### PR TITLE
docs: clean up DESIGN, README, CHANGELOG, CLAUDE for fresh start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,24 @@ All notable changes to Koda are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-> **Lineage:** This project continues from [`koda-agent`](https://github.com/lijunzh/koda-agent) (archived).
+> **Lineage:** This project continues from [`koda-agent`](https://github.com/lijunzh/koda-agent) (archived at v0.1.5).
 > Versions v0.1.0–v0.1.5 of `koda-agent` are documented in that repository's CHANGELOG.
 
 ## [Unreleased]
 
 First release of `koda-core` and `koda-cli` as separate crates.
+See [#21](https://github.com/lijunzh/koda/issues/21) for the v0.1.0 release plan.
 
 ### Architecture
-- **Workspace split**: Single `koda-agent` crate → `koda-core` (library) + `koda-cli` (binary)
+- **Workspace split**: `koda-agent` (single crate) → `koda-core` (library) + `koda-cli` (binary)
   - `koda-core`: pure engine with zero terminal dependencies
   - `koda-cli`: CLI frontend, produces the `koda` binary
   - `cargo install koda-cli` replaces `cargo install koda-agent`
-- **Channel-based approval**: Approval flows through async `EngineEvent::ApprovalRequest` + `EngineCommand::ApprovalResponse` over `tokio::mpsc` channels — works over any transport
-- **CancellationToken**: Replaces global `AtomicBool` interrupt flag. Proper per-session cancellation
-- **KodaAgent**: Shared, immutable agent resources (tools, system prompt, MCP registry). `Arc`-shareable for parallel sub-agents
+- **Channel-based approval**: Async `EngineEvent::ApprovalRequest` / `EngineCommand::ApprovalResponse` over `tokio::mpsc` channels — transport-agnostic
+- **CancellationToken**: Replaces global `AtomicBool` interrupt flag
+- **KodaAgent**: Shared, immutable agent resources (tools, prompt, MCP registry). `Arc`-shareable
 - **KodaSession**: Per-conversation state (DB, provider, settings, cancel token). `run_turn()` replaces 15-parameter `inference_loop()` call
 
-### Still TODO before v0.1.0
-- [ ] Phase 4: ACP server (`koda server` subcommand)
-- [ ] Phase 5: Remote CLI client (`koda connect`)
-- [ ] Fix `version.rs` to check `koda-cli` on crates.io
-- [ ] Update homebrew formula test assertion
-- [ ] CI/CD: verify dual crate publishing pipeline
-
 ### Testing
-- 347 tests across `koda-core/tests/` and `koda-cli/tests/`
-- All CI checks passing: cargo fmt, clippy -D warnings, test, doc
+- 347 tests across `koda-core` and `koda-cli`
+- All CI checks passing: `cargo fmt`, `clippy -D warnings`, `test`, `doc`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Koda is a high-performance AI coding agent built in Rust (edition 2024). Published as two crates:
+Koda is a high-performance AI coding agent built in Rust (edition 2024). Two-crate workspace:
 - `koda-core` (library) — pure engine with zero terminal deps
 - `koda-cli` (binary `koda`) — CLI frontend
 
-v0.1.x is an intentional prototype testing feasibility. v0.2.0 will add server mode (ACP protocol).
+See [DESIGN.md](DESIGN.md) for architectural decisions. See [#21](https://github.com/lijunzh/koda/issues/21) for the v0.1.0 release plan.
 
 ## Build & Development Commands
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,38 +1,14 @@
-# Koda Architecture Design
+# Koda Design Decisions
 
-## Overview
-
-Koda is evolving from a single-binary CLI coding agent into a **server-backed personal AI platform**. This document captures the architectural decisions, design rationale, and implementation plan.
+This document captures architectural decisions and their rationale.
+For the current release plan, see [#21](https://github.com/lijunzh/koda/issues/21).
+For workspace structure and developer docs, see [CLAUDE.md](CLAUDE.md).
 
 ## Vision
 
-Koda is a personal AI assistant. Coding is the starting point, but the platform will expand to support email, messaging, calendar, reminders, documentation, and knowledge management — all powered by the same engine.
-
-## Architecture
-
-```
-koda/
-├── Cargo.toml              # Workspace root
-├── koda-core/              # LIBRARY — engine, zero terminal deps
-│   ├── src/
-│   │   ├── agent.rs        # KodaAgent (shared: tools, prompt, MCP)
-│   │   ├── session.rs      # KodaSession (per-turn: DB, provider, cancel)
-│   │   ├── inference.rs    # Streaming inference loop
-│   │   ├── engine/         # EngineEvent, EngineCommand, EngineSink
-│   │   ├── providers/      # LLM providers
-│   │   ├── tools/          # Built-in tools
-│   │   └── ...             # DB, config, MCP, memory, approval
-│   └── tests/              # Engine integration tests
-└── koda-cli/               # BINARY — CLI + future ACP server
-    ├── src/
-    │   ├── main.rs         # CLI entry point
-    │   ├── app.rs          # Interactive REPL
-    │   ├── headless.rs     # Headless mode
-    │   ├── commands.rs     # Slash command handlers
-    │   ├── sink.rs         # CliSink (events → terminal)
-    │   └── ...             # display, markdown, confirm, input
-    └── tests/              # CLI integration tests
-```
+Koda is a personal AI assistant. Coding is the starting point, but the platform
+will expand to support email, messaging, calendar, reminders, documentation,
+and knowledge management — all powered by the same engine.
 
 ## Execution Modes
 
@@ -48,127 +24,58 @@ koda connect <url>        # CLI client connecting to a remote engine
 
 ### 1. Engine as a Library, Not a Process
 
-**Decision**: The engine is a Rust library crate with zero IO. It communicates exclusively through `EngineEvent` (output) and `EngineCommand` (input) enums.
+**Decision**: The engine is a Rust library crate (`koda-core`) with zero IO.
+It communicates exclusively through `EngineEvent` (output) and `EngineCommand`
+(input) enums. See `koda-core/src/engine/event.rs` for the protocol definition.
 
-**Rationale**: Studied four Rust projects:
-- **xi-editor**: Used stdio JSON-RPC. Discontinued. Lesson: protocol becomes bottleneck when core and frontend are separate processes.
-- **Zed**: Keeps `agent` (engine) and `agent_ui` (rendering) as separate crates in the same binary. Engine has zero UI imports.
+**Rationale**: Studied four projects:
+- **xi-editor**: Used stdio JSON-RPC. Discontinued. Lesson: protocol becomes
+  bottleneck when core and frontend are separate processes.
+- **Zed**: Keeps `agent` (engine) and `agent_ui` (rendering) as separate crates
+  in the same binary. Engine has zero UI imports.
 - **Goose**: Rust engine + ACP server + multiple frontends (Electron, Ink TUI, CLI).
 - **Neovim**: C core + msgpack-RPC. Terminal TUI is just one client.
 
-**Zed's approach wins**: engine and primary client in the same binary. Server mode is optional for external clients.
+**Zed's approach wins**: engine and primary client in the same binary. Server
+mode is optional for external clients.
 
 ### 2. ACP (Agent Client Protocol)
 
 **Decision**: Koda's server mode will speak ACP.
 
-**Rationale**: Both Zed and Goose independently converged on ACP (`@agentclientprotocol/sdk`). ACP defines session management, streaming messages, tool calls with permissions, and status updates — exactly what Koda needs. Adopting ACP gives us Zed integration for free.
+**Rationale**: Both Zed and Goose independently converged on ACP
+(`@agentclientprotocol/sdk`). ACP defines session management, streaming
+messages, tool calls with permissions, and status updates — exactly what
+Koda needs. Adopting ACP gives us Zed integration for free.
 
 ### 3. Single Binary Philosophy
 
-**Decision**: `cargo install koda-cli` gives you everything. No separate server process required for normal usage.
+**Decision**: `cargo install koda-cli` gives you everything. No separate
+server process required for normal usage.
 
-**Rationale**: Koda's core value is zero-config simplicity. The CLI client talks to the engine via in-process `tokio::mpsc` channels. Server mode is opt-in (`koda server`) for external clients.
+**Rationale**: Koda's core value is zero-config simplicity. The CLI client
+talks to the engine via in-process `tokio::mpsc` channels. Server mode is
+opt-in (`koda server`) for external clients.
 
 ### 4. Async Approval Flow
 
-**Decision**: Tool approval is an async request/response, not a blocking function call.
+**Decision**: Tool approval is an async request/response, not a blocking
+function call.
 
-**Rationale**: The current `confirm::confirm_tool_action()` blocks the inference loop to show a terminal select widget. In server mode, the approval decision comes from a remote client. The engine must emit `EngineEvent::ApprovalRequest` and await `EngineCommand::ApprovalResponse`.
+**Rationale**: In server mode, the approval decision comes from a remote
+client. The engine emits `EngineEvent::ApprovalRequest` and awaits
+`EngineCommand::ApprovalResponse` — works identically over in-process
+channels or network transport.
 
 ### 5. Database Evolution
 
-**Decision**: Keep SQLite for v0.2.0. Introduce a `Persistence` trait so the backend can be swapped later.
+**Decision**: Keep SQLite for now. Introduce a `Persistence` trait so the
+backend can be swapped later.
 
-**Rationale**: SQLite is excellent for conversations, sessions, and AST cache. But email, calendar, documents, and knowledge graphs may require full-text search (FTS5), vector embeddings, graph relationships, or multi-device sync. The trait boundary lets us evolve without rewriting.
-
-## Protocol: EngineEvent / EngineCommand
-
-### EngineEvent (Engine → Client)
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum EngineEvent {
-    // Streaming LLM output
-    TextDelta { text: String },
-    TextDone,
-    ThinkingStart,
-    ThinkingDelta { text: String },
-    ThinkingDone,
-    ResponseStart,
-
-    // Tool execution
-    ToolCallStart { id: String, name: String, args: Value },
-    ToolCallResult { id: String, output: String, success: bool },
-
-    // Interactive
-    ApprovalRequest { id: String, tool: String, detail: String, preview: Option<String> },
-
-    // Session metadata
-    StatusUpdate { model: String, context_pct: f64, mode: String },
-    Footer { tokens: i64, time_ms: u64, rate: f64, context: String },
-    Info(String),
-    Warn(String),
-    Error(String),
-}
-```
-
-### EngineCommand (Client → Engine)
-
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum EngineCommand {
-    UserPrompt { text: String, images: Vec<ImageData> },
-    Interrupt,
-    ApprovalResponse { id: String, decision: ApprovalDecision },
-    Command(SlashCommand),
-    Quit,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum ApprovalDecision {
-    Approve,
-    Reject,
-    RejectWithFeedback(String),
-    AlwaysAllow,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "cmd", rename_all = "snake_case")]
-enum SlashCommand {
-    Compact,
-    SwitchModel { model: String },
-    SwitchProvider { provider: String },
-    ListSessions,
-    DeleteSession { id: String },
-    SetTrust { mode: String },
-    McpCommand { args: String },
-    Cost,
-    Memory { action: Option<String> },
-}
-```
-
-## Implementation Phases
-
-### v0.1.x — Prototype (complete)
-Intentional simplified prototype to test feasibility:
-- Engine extraction: `EngineEvent`/`EngineCommand` protocol types
-- Workspace split: `koda-core` (lib) + `koda-cli` (bin)
-- Channel-based approval (async, transport-agnostic)
-- `KodaAgent`/`KodaSession` structs
-- 347 tests, clippy clean
-
-### v0.2.0 — Server Architecture (in progress)
-See [#50](https://github.com/lijunzh/koda/issues/50) for the detailed plan:
-- Phase 4: ACP server (`koda server` subcommand)
-- Phase 5: Remote CLI client (`koda connect`)
-
-### v0.2.x — External Clients
-- VS Code extension
-- Zed agent panel integration
-- Desktop app
+**Rationale**: SQLite is excellent for conversations, sessions, and AST cache.
+But email, calendar, documents, and knowledge graphs may require full-text
+search (FTS5), vector embeddings, graph relationships, or multi-device sync.
+The trait boundary lets us evolve without rewriting.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Single compiled binary. Multi-provider LLM support. Zero runtime dependencies.
 **Koda is a personal coding agent.** It's built for a single developer at a keyboard,
 not for enterprise teams or platform integrations. This focus drives every design decision:
 
-- **Single binary, zero runtime deps.** `cargo install` and you're done. No Node.js,
-  no Python, no Docker. Works offline with local models (LM Studio) or online with
-  cloud providers.
+- **Single binary, zero runtime deps.** `cargo install koda-cli` and you're done.
+  No Node.js, no Python, no Docker. Works offline with local models (LM Studio)
+  or online with cloud providers.
 - **Built-in tools for the core coding loop.** File ops, search, shell, web fetch,
   memory, and agents are compiled in — always available, zero latency, zero config.
 - **MCP for everything else.** Need GitHub API, databases, Slack? Connect external
@@ -28,7 +28,7 @@ cargo install koda-cli
 
 # From source
 git clone https://github.com/lijunzh/koda.git
-cd koda && cargo build --release
+cd koda && cargo build --release -p koda-cli
 # Binary is at target/release/koda
 ```
 
@@ -43,29 +43,12 @@ koda -p "fix the bug in auth.rs"  # Headless one-shot
 echo "explain this" | koda        # Piped input
 ```
 
-## What's Inside
+## Features
 
-- **17 built-in tools** — file ops, search, shell, web fetch, memory, agents, task tracking, and AST analysis
+- **17 built-in tools** — file ops, search, shell, web fetch, memory, agents, task tracking, AST analysis
 - **MCP support** — connect to any [MCP server](https://modelcontextprotocol.io) via `.mcp.json` (same format as Claude Code / Cursor)
 - **6 LLM providers** — LM Studio, OpenAI, Anthropic, Gemini, Groq, Grok
 - **5 embedded agents** — default, code reviewer, security auditor, test writer, release engineer
-
-### 🌳 AST Code Analysis
-Koda natively understands the structure of your codebase using embedded `tree-sitter` parsers.
-- **Built-in Languages:** Rust, Python, JavaScript, and TypeScript. Koda can instantly extract functions, classes, and generate call graphs (who calls what) without guessing.
-- **Extending with MCP:** To keep Koda's binary blazingly fast and lightweight, we restrict built-in parsers to the "Big 4" languages. Need AST support for Go, C++, or Java? Simply connect a community Tree-sitter MCP server via your `.mcp.json`!
-
-### 🏗️ Architecture
-
-Koda v0.1.x is an **intentional prototype** — a simplified, single-user CLI agent
-designed to test the feasibility of a Rust-based AI coding assistant. It prioritizes
-speed of iteration over architectural purity.
-
-v0.2.0 will evolve Koda into a **server-backed platform** (see [DESIGN.md](DESIGN.md)):
-- **`koda-core`** — pure Rust engine library with zero terminal deps
-- **`koda-cli`** — the CLI frontend (and future ACP server)
-- Workspace split complete: `EngineEvent`/`EngineCommand` protocol, `KodaAgent`/`KodaSession` structs
-- **ACP Server** — planned for v0.2.0, enabling VS Code, desktop apps, and Zed to connect
 - **Approval modes** — plan (read-only) / normal (smart confirm) / yolo (auto-approve) via `/trust`
 - **Diff preview** — see exactly what changes before approving Edit, Write, Delete
 - **Loop detection** — catches repeated tool calls with configurable iteration caps
@@ -76,6 +59,12 @@ v0.2.0 will evolve Koda into a **server-backed platform** (see [DESIGN.md](DESIG
 - **Git integration** — `/diff` review, commit message generation
 - **Headless mode** — `koda -p "prompt"` with JSON output for CI/CD
 - **Persistent memory** — project (`MEMORY.md`) and global (`~/.config/koda/memory.md`)
+
+### 🌳 AST Code Analysis
+
+Koda natively understands the structure of your codebase using embedded `tree-sitter` parsers.
+- **Built-in languages:** Rust, Python, JavaScript, TypeScript — instant function/class extraction and call graphs.
+- **Extending with MCP:** Need Go, C++, or Java? Connect a community Tree-sitter MCP server via `.mcp.json`.
 
 ## REPL Commands
 
@@ -122,26 +111,32 @@ namespaced names (e.g. `github.create_issue`). Manage at runtime with `/mcp`.
 
 User-level servers go in `~/.config/koda/mcp.json` (merged, project overrides).
 
+## Architecture
+
+Koda is a Cargo workspace with two crates:
+
+```
+koda/
+├── koda-core/    # Engine library (providers, tools, inference, DB) — zero terminal deps
+└── koda-cli/     # CLI binary (REPL, display, approval UI)
+```
+
+The engine communicates through `EngineEvent` (output) and `EngineCommand` (input) enums
+over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
+
 ## Documentation
 
-- **[DESIGN.md](DESIGN.md)** — Architecture, design principles, technical stack
+- **[DESIGN.md](DESIGN.md)** — Design decisions and rationale
 - **[CHANGELOG.md](CHANGELOG.md)** — Release history
-- **[GitHub Issues](https://github.com/lijunzh/koda/issues)** — Roadmap and feature backlog
+- **[CLAUDE.md](CLAUDE.md)** — Developer guide for AI assistants
+- **[GitHub Issues](https://github.com/lijunzh/koda/issues)** — Roadmap and release tracking
 
 ## Development
 
 ```bash
-cargo test --workspace      # Run all 347 tests
-cargo clippy --workspace    # Lint
-cargo run -p koda-cli       # Run locally
-```
-
-### Workspace Structure
-
-```
-koda/
-├── koda-core/    # Engine library (providers, tools, inference, DB)
-└── koda-cli/     # CLI binary (REPL, display, approval UI)
+cargo test --workspace        # Run all 347 tests
+cargo clippy --workspace      # Lint
+cargo run -p koda-cli         # Run locally
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Trim documentation for the fresh-start koda repo. Each doc now has a single clear purpose:

| Doc | Purpose |
|-----|---------|
| `DESIGN.md` | **Why** — design decisions + rationale |
| `README.md` | **What** — user-facing features + install |
| `CLAUDE.md` | **How** — developer guide for AI assistants |
| `CHANGELOG.md` | **When** — release history |

## Changes

**DESIGN.md** (−104 lines)
- Removed duplicated file tree (lives in CLAUDE.md)
- Removed protocol enum listings (source of truth is `engine/event.rs`)
- Removed implementation phases (tracked in #21)
- Kept: vision, execution modes, 5 design decisions with rationale, references

**README.md**
- Removed "intentional prototype" / v0.2.0 forward-looking language
- Flattened architecture section into features
- Fixed `cargo build` command to target `koda-cli`
- Added CLAUDE.md to documentation section

**CHANGELOG.md**
- Removed inline TODO checklist (tracked in #21)
- Tightened to architecture changes only

**CLAUDE.md**
- Removed prototype framing
- Added links to DESIGN.md and #21

Closes no issues — prep for #21.