### PR TITLE
fix(db): inject config_dir into Database::init to fix concurrent-test DB lock

### DIFF
--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
                 cli.thinking_budget,
                 cli.reasoning_effort,
             );
-        let db = koda_core::db::Database::init(&project_root).await?;
+        let db = koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;
         let session_id = match cli.session {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,
@@ -168,7 +168,7 @@ async fn main() -> Result<()> {
         );
 
     // Initialize database
-    let db = koda_core::db::Database::init(&project_root).await?;
+    let db = koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;
 
     // Load or create session
     let session_id = match cli.session {

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -124,7 +124,8 @@ async fn main() -> Result<()> {
                 cli.thinking_budget,
                 cli.reasoning_effort,
             );
-        let db = koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;
+        let db =
+            koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;
         let session_id = match cli.session {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,

--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -69,7 +69,7 @@ pub struct Database {
 }
 
 /// Get the koda config directory (~/.config/koda/).
-fn config_dir() -> Result<std::path::PathBuf> {
+pub fn config_dir() -> Result<std::path::PathBuf> {
     let base = std::env::var("XDG_CONFIG_HOME")
         .ok()
         .map(std::path::PathBuf::from)
@@ -91,24 +91,28 @@ pub fn db_dir() -> Result<std::path::PathBuf> {
 
 impl Database {
     /// Initialize the database, run migrations, and enable WAL mode.
-    /// The database lives in `~/.config/koda/db/koda.db`.
-    pub async fn init(project_root: &Path) -> Result<Self> {
-        let db_dir = db_dir()?;
+    ///
+    /// `koda_config_dir` is the koda configuration directory (e.g. `~/.config/koda`).
+    /// The database lives in `<koda_config_dir>/db/koda.db`.
+    ///
+    /// Production callers should pass `db::config_dir()?`; tests pass a temp dir.
+    pub async fn init(project_root: &Path, koda_config_dir: &Path) -> Result<Self> {
+        let db_dir = koda_config_dir.join("db");
         std::fs::create_dir_all(&db_dir)
             .with_context(|| format!("Failed to create DB dir: {}", db_dir.display()))?;
 
         let db_path = db_dir.join("koda.db");
 
-        // Migrate old `~/.config/koda/koda.db` to the new `db/` folder if needed
-        let old_db_path = config_dir()?.join("koda.db");
+        // Migrate old `<koda_config_dir>/koda.db` to the new `db/` folder if needed
+        let old_db_path = koda_config_dir.join("koda.db");
         if old_db_path.exists() && !db_path.exists() {
             tracing::info!("Migrating koda.db to new db/ directory");
             if let Err(e) = std::fs::rename(&old_db_path, &db_path) {
                 tracing::warn!("Failed to move old koda.db to db/ folder: {}", e);
             }
             // Also try to move WAL files if they exist
-            let old_wal = config_dir()?.join("koda.db-wal");
-            let old_shm = config_dir()?.join("koda.db-shm");
+            let old_wal = koda_config_dir.join("koda.db-wal");
+            let old_shm = koda_config_dir.join("koda.db-shm");
             if old_wal.exists() {
                 let _ = std::fs::rename(old_wal, db_dir.join("koda.db-wal"));
             }

--- a/koda-core/tests/perf_test.rs
+++ b/koda-core/tests/perf_test.rs
@@ -16,9 +16,7 @@ mod db_perf {
     #[tokio::test]
     async fn test_load_context_500_messages_under_1s() {
         let tmp = TempDir::new().unwrap();
-        // Database::init needs HOME for config_dir resolution
-        unsafe { std::env::set_var("HOME", tmp.path()) };
-        let db = Database::init(tmp.path()).await.unwrap();
+        let db = Database::init(tmp.path(), tmp.path()).await.unwrap();
         let session_id = db.create_session("test", tmp.path()).await.unwrap();
 
         // Insert 500 messages
@@ -49,8 +47,7 @@ mod db_perf {
     #[tokio::test]
     async fn test_insert_message_under_50ms() {
         let tmp = TempDir::new().unwrap();
-        unsafe { std::env::set_var("HOME", tmp.path()) };
-        let db = Database::init(tmp.path()).await.unwrap();
+        let db = Database::init(tmp.path(), tmp.path()).await.unwrap();
         let session_id = db.create_session("test", tmp.path()).await.unwrap();
 
         let start = Instant::now();


### PR DESCRIPTION
## Problem

`test_insert_message_under_50ms` (and intermittently `test_load_context_500_messages_under_1s`) were failing in CI with:
`error returned from database: (code: 5) database is locked`

### Root cause (Architectural flaw)

`Database::init()` was implicitly coupled to the global `HOME` env var via `config_dir()`, completely ignoring the `project_root` parameter when resolving the database path. This made it inherently untestable without `unsafe` env-var mutation.

When tokio runs the perf tests **concurrently**, they race each other to overwrite `HOME`:
1. Test A sets `HOME=/tmp/aaa`
2. Test B sets `HOME=/tmp/bbb`
3. Test A tries to open `/tmp/bbb/.config/koda/db/koda.db` — **same file as Test B**
4. SQLite WAL lock → 💥

## Fix (Dependency Injection)

Refactored `Database::init()` to take the `config_dir` explicitly instead of sniffing the environment. 

Production code (`main.rs`) now resolves `config_dir()` once and passes it down.
Tests now pass their `TempDir` directly — **no more unsafe environment mutation, no more locks.**

Zen of Python: *Explicit is better than implicit.*