### PR TITLE
feat(acp): adapter + sink (text/thought chunks)

### DIFF
--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -53,7 +53,7 @@ anyhow = "1"
 
 # Base64 encoding (for image input)
 base64 = "0.22"
-agent-client-protocol-schema = { version = "0.10", features = ["unstable_session_model", "unstable_session_list"] }
+agent-client-protocol-schema = { version = "0.10.8", features = ["unstable_session_model", "unstable_session_list", "unstable"] }
 tokio-tungstenite = "0.26"
 
 [dev-dependencies]

--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -1,0 +1,90 @@
+use agent_client_protocol_schema as acp;
+use koda_core::engine::EngineEvent;
+use koda_core::engine::sink::EngineSink;
+use tokio::sync::mpsc;
+
+/// Translates an internal `EngineEvent` to an ACP `SessionNotification`.
+pub fn engine_event_to_acp(
+    event: &EngineEvent,
+    session_id: &str,
+) -> Option<acp::SessionNotification> {
+    match event {
+        EngineEvent::TextDelta { text } => {
+            let cb = acp::ContentBlock::Text(acp::TextContent::new(text.clone()));
+            Some(acp::SessionNotification::new(
+                session_id.to_string(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(cb)),
+            ))
+        }
+        EngineEvent::TextDone => None,
+        EngineEvent::ThinkingStart => None,
+        EngineEvent::ThinkingDelta { text } => {
+            let cb = acp::ContentBlock::Text(acp::TextContent::new(text.clone()));
+            Some(acp::SessionNotification::new(
+                session_id.to_string(),
+                acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(cb)),
+            ))
+        }
+        EngineEvent::ThinkingDone => None,
+        EngineEvent::ResponseStart => None,
+        EngineEvent::ToolCallStart { .. } => None, // Not implementing complex tool calls yet to keep compilation clean
+        EngineEvent::ToolCallResult { .. } => None,
+        EngineEvent::SubAgentStart { .. } => None,
+        EngineEvent::SubAgentEnd { .. } => None,
+        EngineEvent::ApprovalRequest { .. } => None,
+        EngineEvent::ActionBlocked { .. } => None,
+        EngineEvent::StatusUpdate { .. } => None,
+        EngineEvent::Footer { .. } => None,
+        EngineEvent::SpinnerStart { .. } => None,
+        EngineEvent::SpinnerStop => None,
+        EngineEvent::Info { .. } => None,
+        EngineEvent::Warn { .. } => None,
+        EngineEvent::Error { .. } => None,
+    }
+}
+
+pub struct AcpSink {
+    session_id: String,
+    tx: mpsc::Sender<acp::SessionNotification>,
+}
+
+impl AcpSink {
+    pub fn new(session_id: String, tx: mpsc::Sender<acp::SessionNotification>) -> Self {
+        Self { session_id, tx }
+    }
+}
+
+impl EngineSink for AcpSink {
+    fn emit(&self, event: EngineEvent) {
+        if let Some(notification) = engine_event_to_acp(&event, &self.session_id) {
+            let _ = self.tx.try_send(notification);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_text_delta() {
+        let event = EngineEvent::TextDelta {
+            text: "hello".into(),
+        };
+        let acp = engine_event_to_acp(&event, "session-1").unwrap();
+
+        assert_eq!(acp.session_id, "session-1".to_string().into());
+        match acp.update {
+            acp::SessionUpdate::AgentMessageChunk(chunk) => {
+                let block = chunk.content;
+                match block {
+                    acp::ContentBlock::Text(text_content) => {
+                        assert_eq!(text_content.text, "hello");
+                    }
+                    _ => panic!("Expected text block"),
+                }
+            }
+            _ => panic!("Expected AgentMessageChunk"),
+        }
+    }
+}

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod acp_adapter;


### PR DESCRIPTION
## Summary

- Add `AcpSink` implementing `EngineSink` trait to forward `EngineEvent`s as ACP `SessionNotification`s via `mpsc::Sender`
- Add `engine_event_to_acp()` mapping function: `TextDelta` → `AgentMessageChunk`, `ThinkingDelta` → `AgentThoughtChunk`
- Bump `agent-client-protocol-schema` to `0.10.8` with `"unstable"` feature

Contributes to #21 (Phase 4: ACP server)

## Why

We need a stable translation layer between our internal engine events (koda-core) and the external ACP schema (agent-client-protocol-schema). This keeps protocol churn out of the engine and isolates ACP-specific decisions to koda-cli.

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace` passes (348 tests, including new `test_text_delta`)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

## Context & Related Issues
- Legacy plan: lijunzh/koda-agent#50 (client-server migration plan)
- Server vision: lijunzh/koda-agent#38
- Gap analysis: lijunzh/koda-agent#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)