### PR TITLE
chore: finalize v0.1.0 release prep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,7 +207,7 @@ jobs:
             end
 
             test do
-              assert_match "koda-cli", shell_output("#{bin}/koda --version")
+              assert_match "koda", shell_output("#{bin}/koda --version")
             end
           end
           FORMULA

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-03-04
+
 First release of `koda-core` and `koda-cli` as separate crates.
-See [#21](https://github.com/lijunzh/koda/issues/21) for the v0.1.0 release plan.
 
 ### Architecture
 - **Workspace split**: `koda-agent` (single crate) → `koda-core` (library) + `koda-cli` (binary)
@@ -22,6 +23,12 @@ See [#21](https://github.com/lijunzh/koda/issues/21) for the v0.1.0 release plan
 - **KodaAgent**: Shared, immutable agent resources (tools, prompt, MCP registry). `Arc`-shareable
 - **KodaSession**: Per-conversation state (DB, provider, settings, cancel token). `run_turn()` replaces 15-parameter `inference_loop()` call
 
+### Added
+- **ACP server** (`koda server --stdio`): JSON-RPC server over stdio implementing the Agent Client Protocol for editor integration (Zed, VS Code, etc.)
+  - Full ACP lifecycle: Initialize → Authenticate → NewSession → Prompt (streaming) → Cancel
+  - All 19 EngineEvent variants mapped to ACP protocol messages
+  - Bidirectional approval flow over JSON-RPC
+
 ### Testing
-- 347 tests across `koda-core` and `koda-cli`
+- 360 tests across `koda-core` and `koda-cli`
 - All CI checks passing: `cargo fmt`, `clippy -D warnings`, `test`, `doc`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ See [DESIGN.md](DESIGN.md) for architectural decisions. See [#21](https://github
 ```bash
 cargo build                              # Debug build
 cargo build --release -p koda-cli        # Release build
-cargo test --workspace                   # Run all 347 tests
+cargo test --workspace                   # Run all 360 tests
 cargo test -p koda-core                  # Engine tests only
 cargo test -p koda-cli                   # CLI tests only
 cargo test -p koda-core --test perf_test # Run a specific test file
@@ -55,8 +55,11 @@ koda/
 │   └── tests/              # Engine integration tests
 ├── koda-cli/               # CLI binary
 │   ├── src/
+│   │   ├── lib.rs          # Crate root (exports acp_adapter)
 │   │   ├── main.rs         # CLI entry point (clap)
 │   │   ├── app.rs          # Application entry points (REPL + headless dispatch)
+│   │   ├── server.rs       # ACP server over stdio JSON-RPC (koda server --stdio)
+│   │   ├── acp_adapter.rs  # ACP protocol adapter (EngineEvent → ACP messages, approval flow)
 │   │   ├── headless.rs     # Single-prompt headless mode
 │   │   ├── repl.rs         # Slash command handling (/model, /provider, /help, /quit)
 │   │   ├── commands.rs     # /compact, /mcp, /provider, /trust handlers
@@ -115,6 +118,7 @@ Tools use PascalCase names. `mod.rs` has the registry, dispatcher, and `safe_res
 - `tests/capabilities_test.rs` — capabilities.md freshness
 
 **koda-cli** (unit + integration):
-- Unit tests in `src/` modules
+- Unit tests in `src/` modules (notably `acp_adapter.rs`)
 - `tests/cli_test.rs` — binary subprocess invocation
 - `tests/regression_test.rs` — REPL dispatch, input processing
+- `tests/server_test.rs` — ACP server integration tests (spawn subprocess, JSON-RPC lifecycle)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,9 +15,7 @@ and knowledge management — all powered by the same engine.
 ```bash
 koda                      # Auto-starts embedded engine + CLI client (default)
 koda -p "fix the bug"     # Headless mode (direct engine, no server)
-koda server               # Standalone server for external clients
-koda server --port 9999   # Server on custom port
-koda connect <url>        # CLI client connecting to a remote engine
+koda server --stdio       # ACP server over stdio (for editor integration)
 ```
 
 ## Design Decisions

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
 ## Development
 
 ```bash
-cargo test --workspace        # Run all 347 tests
+cargo test --workspace        # Run all 360 tests
 cargo clippy --workspace      # Lint
 cargo run -p koda-cli         # Run locally
 ```


### PR DESCRIPTION
## Summary
- Mark `CHANGELOG.md` `[0.1.0]` with release date 2026-03-04 and add ACP server to release notes
- Fix Homebrew formula test assertion: `koda --version` outputs `koda 0.1.0`, not `koda-cli`

## Test plan
- [ ] CI passes
- [ ] After merge: push `v0.1.0` tag to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)