### PR TITLE
chore: bump rmcp from 0.16 to 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "d2cb14cb9278a12eae884c9f3c0cfeca2cc28f361211206424a1d7abed95f090"
 dependencies = [
  "async-trait",
  "base64",
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "6a02ea81d9482b07e1fe156ac7cf98b6823d51fb84531936a5e1cbb4eec31ad5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -60,7 +60,7 @@ anyhow = "1"
 async-trait = "0.1"
 
 # MCP (Model Context Protocol) client
-rmcp = { version = "0.16", features = ["client", "transport-child-process"] }
+rmcp = { version = "1.1", features = ["client", "transport-child-process"] }
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
 
 # AST analysis

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -8,7 +8,7 @@ use rmcp::{
     ClientHandler, RoleClient, ServiceExt,
     model::{
         CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation,
-        PaginatedRequestParams, ProtocolVersion, Tool as McpTool,
+        ProtocolVersion, Tool as McpTool,
     },
     service::RunningService,
     transport::TokioChildProcess,
@@ -33,19 +33,11 @@ impl ClientHandler for KodaClientHandler {
     // Notifications (progress, logging) are silently handled by rmcp defaults.
 
     fn get_info(&self) -> ClientInfo {
-        ClientInfo {
-            meta: None,
-            protocol_version: ProtocolVersion::V_2025_03_26,
-            capabilities: ClientCapabilities::builder().build(),
-            client_info: Implementation {
-                name: "koda".to_string(),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                icons: None,
-                title: None,
-                description: None,
-                website_url: None,
-            },
-        }
+        let mut info = ClientInfo::default();
+        info.protocol_version = ProtocolVersion::V_2025_03_26;
+        info.capabilities = ClientCapabilities::builder().build();
+        info.client_info = Implementation::new("koda", env!("CARGO_PKG_VERSION"));
+        info
     }
 }
 
@@ -96,10 +88,7 @@ impl McpClient {
 
         // Discover available tools via the Peer high-level API
         let tools_result = service
-            .list_tools(Some(PaginatedRequestParams {
-                meta: None,
-                cursor: None,
-            }))
+            .list_tools(Default::default())
             .await
             .map_err(|e| anyhow::anyhow!("Failed to list tools from '{name}': {e}"))?;
 
@@ -142,12 +131,10 @@ impl McpClient {
                 })?)
             };
 
-        let params = CallToolRequestParams {
-            meta: None,
-            task: None,
-            name: tool_name.to_string().into(),
-            arguments: args,
-        };
+        let mut params = CallToolRequestParams::new(tool_name.to_string());
+        if let Some(args) = args {
+            params = params.with_arguments(args);
+        }
 
         let result = self
             .service


### PR DESCRIPTION
## Summary

Bumps `rmcp` (MCP client) from **0.16.0** → **1.1.0** (major version).

### Breaking changes handled

`rmcp` v1.x marks most model structs as `#[non_exhaustive]`, so struct literal construction from external crates no longer compiles. Migrated to:

- `Implementation::new(name, version)` builder
- `ClientInfo::default()` + field mutation
- `CallToolRequestParams::new(name).with_arguments(args)`
- `Default::default()` for `PaginatedRequestParams`

### Testing

- `cargo check` ✅
- Full test suite passes ✅ (all 49 tests)
- `cargo update` run to pick up latest compatible transitive deps