### PR TITLE
feat: todo list display after each turn

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -355,7 +355,14 @@ pub async fn inference_loop(
             }
 
             let footer = parts.join(" \u{00b7} ");
-            println!("\n\n\x1b[90m{footer}{ctx_part}\x1b[0m\n");
+            println!("\n\n\x1b[90m{footer}{ctx_part}\x1b[0m");
+
+            // Show todo progress if a todo list exists for this session
+            if let Ok(Some(todo_content)) = db.get_todo(session_id).await {
+                println!();
+                print!("{}", crate::tools::todo::format_todo_display(&todo_content));
+            }
+            println!();
 
             return Ok(());
         }
@@ -480,10 +487,6 @@ async fn execute_one_tool(
                 if let Err(e) = db.set_todo(session_id, &content).await {
                     format!("Failed to save todo: {e}")
                 } else {
-                    // Render the todo visually for the user
-                    let display = crate::tools::todo::format_todo_display(&content);
-                    println!();
-                    println!("{display}");
                     "Todo list updated.".to_string()
                 }
             }

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -34,34 +34,58 @@ pub fn definitions() -> Vec<ToolDefinition> {
 pub fn format_todo_display(content: &str) -> String {
     let mut output = String::new();
     output.push_str("  \x1b[1m\u{1f4cb} Todo\x1b[0m\n");
-    output.push_str("  \x1b[90m\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\x1b[0m\n");
 
-    for line in content.lines() {
+    // Find the first unchecked item to highlight as "active"
+    let first_pending = content.lines().position(|l| {
+        let t = l.trim();
+        t.starts_with("- [ ] ") || t.starts_with("  - [ ] ")
+    });
+
+    for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
+        let is_active = Some(i) == first_pending;
+
         if let Some(task) = trimmed
             .strip_prefix("- [x] ")
             .or_else(|| trimmed.strip_prefix("- [X] "))
         {
+            // Done: green check + strikethrough
             output.push_str(&format!(
-                "  \x1b[32m\u{2705}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
+                "  \x1b[32m\u{2714}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
             ));
         } else if let Some(task) = trimmed.strip_prefix("- [ ] ") {
-            output.push_str(&format!("  \x1b[90m\u{2b1c}\x1b[0m {task}\n"));
+            if is_active {
+                // Active: bold white square + bold text
+                output.push_str(&format!("  \x1b[33m\u{25a0}\x1b[0m \x1b[1m{task}\x1b[0m\n"));
+            } else {
+                // Pending: dim square
+                output.push_str(&format!(
+                    "  \x1b[90m\u{25a1}\x1b[0m \x1b[90m{task}\x1b[0m\n"
+                ));
+            }
         } else if let Some(task) = trimmed
             .strip_prefix("  - [x] ")
             .or_else(|| trimmed.strip_prefix("  - [X] "))
         {
+            // Nested done
             output.push_str(&format!(
-                "    \x1b[32m\u{2705}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
+                "    \x1b[32m\u{2714}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
             ));
         } else if let Some(task) = trimmed.strip_prefix("  - [ ] ") {
-            output.push_str(&format!("    \x1b[90m\u{2b1c}\x1b[0m {task}\n"));
+            if is_active {
+                output.push_str(&format!(
+                    "    \x1b[33m\u{25a0}\x1b[0m \x1b[1m{task}\x1b[0m\n"
+                ));
+            } else {
+                output.push_str(&format!(
+                    "    \x1b[90m\u{25a1}\x1b[0m \x1b[90m{task}\x1b[0m\n"
+                ));
+            }
         } else if !trimmed.is_empty() {
             output.push_str(&format!("  {trimmed}\n"));
         }
     }
 
-    output.push_str("  \x1b[90m\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\u{2504}\x1b[0m");
     output
 }
 


### PR DESCRIPTION
## Summary

PR B from the UX roadmap: render the todo list at the bottom of each inference turn.

### Changes

**Todo display at turn end** (`inference.rs`):
- After the footer stats line, check if a todo exists for the session
- If yes, render it with `format_todo_display()`
- Removed the redundant mid-turn `println!` in the TodoWrite handler (was causing double rendering)

**Active task highlighting** (`todo.rs`):
- First unchecked item: bold **■** marker in amber + bold text (the "current" task)
- Remaining pending: dim □ + dim text
- Done items: green ✔ with strikethrough
- Removed dotted border lines for cleaner look

### Visual

After each turn:
```
in: 5k · out: 200 · 10s · 20 t/s · context: 8k/32k (25%)

📋 Todo
  ✔ ~~Setup project~~
  ■ Write tests
  □ Deploy to staging
```

### Testing
- `cargo test` ✅ (all tests pass)
- `cargo fmt --check` ✅