### PR TITLE
feat: persist last-used provider and model across sessions

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -110,6 +110,17 @@ pub async fn run(
     session_id: String,
     version_check: tokio::task::JoinHandle<Option<String>>,
 ) -> Result<()> {
+    // Restore last-used provider/model if available
+    let settings = koda_core::approval::Settings::load();
+    if let Some(ref last) = settings.last_provider {
+        let ptype =
+            koda_core::config::ProviderType::from_url_or_name("", Some(&last.provider_type));
+        config.provider_type = ptype;
+        config.base_url = last.base_url.clone();
+        config.model = last.model.clone();
+        config.model_settings.model = last.model.clone();
+    }
+
     let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
         Arc::new(RwLock::new(crate::commands::create_provider(&config)));
 
@@ -256,6 +267,13 @@ pub async fn run(
                 ReplAction::SwitchModel(model) => {
                     config.model = model.clone();
                     config.model_settings.model = model.clone();
+                    // Persist for next startup
+                    let mut s = koda_core::approval::Settings::load();
+                    let _ = s.save_last_provider(
+                        &config.provider_type.to_string(),
+                        &config.base_url,
+                        &config.model,
+                    );
                     println!("  \x1b[32m\u{2713}\x1b[0m Model set to: \x1b[36m{model}\x1b[0m");
                     continue;
                 }
@@ -291,6 +309,12 @@ pub async fn run(
                                 Ok(Some(idx)) => {
                                     config.model = models[idx].id.clone();
                                     config.model_settings.model = config.model.clone();
+                                    let mut s = koda_core::approval::Settings::load();
+                                    let _ = s.save_last_provider(
+                                        &config.provider_type.to_string(),
+                                        &config.base_url,
+                                        &config.model,
+                                    );
                                     println!(
                                         "  \x1b[32m\u{2713}\x1b[0m Model set to: \x1b[36m{}\x1b[0m",
                                         config.model

--- a/koda-cli/src/commands.rs
+++ b/koda-cli/src/commands.rs
@@ -397,6 +397,14 @@ pub(crate) async fn handle_setup_provider(
         config.provider_type
     );
 
+    // Persist for next startup
+    let mut s = koda_core::approval::Settings::load();
+    let _ = s.save_last_provider(
+        &config.provider_type.to_string(),
+        &config.base_url,
+        &config.model,
+    );
+
     let prov = provider.read().await;
     match prov.list_models().await {
         Ok(models) => {

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -595,6 +595,16 @@ pub fn extract_whitelist_pattern(command: &str) -> String {
 pub struct Settings {
     #[serde(default)]
     pub approval: ApprovalSettings,
+    /// Last-used provider/model, restored on next startup.
+    #[serde(default)]
+    pub last_provider: Option<LastProvider>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LastProvider {
+    pub provider_type: String,
+    pub base_url: String,
+    pub model: String,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -633,6 +643,21 @@ impl Settings {
             self.save()?;
         }
         Ok(())
+    }
+
+    /// Save the last-used provider/model for restoration on next startup.
+    pub fn save_last_provider(
+        &mut self,
+        provider_type: &str,
+        base_url: &str,
+        model: &str,
+    ) -> anyhow::Result<()> {
+        self.last_provider = Some(LastProvider {
+            provider_type: provider_type.to_string(),
+            base_url: base_url.to_string(),
+            model: model.to_string(),
+        });
+        self.save()
     }
 
     fn settings_path() -> Option<PathBuf> {


### PR DESCRIPTION
Closes #39

Adds `LastProvider` to `Settings` (`~/.config/koda/settings.toml`).

- **Startup**: restores `provider_type`, `base_url`, and `model` from settings
- **`/model`**: saves the new model immediately
- **`/provider`**: saves the new provider + model immediately
- **First run**: falls back to `config.toml` defaults (no settings file yet)

3 files changed: `approval.rs` (LastProvider struct + save helper), `app.rs` (restore on startup + save on model pick), `commands.rs` (save on provider switch).

Tests pass ✅ | fmt ✅ | clippy ✅