### PR TITLE
feat: skip redundant post-execution diff when preview was shown

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -609,6 +609,10 @@ pub async fn run(
                                 preview,
                                 whitelist_hint,
                             }) => {
+                                // Track that a preview was shown for this tool
+                                if preview.is_some() {
+                                    renderer.preview_shown = true;
+                                }
                                 // Readline thread is paused — stdin is free for TUI.
                                 let decision = map_confirmation(
                                     crate::confirm::confirm_tool_action(

--- a/koda-cli/src/display.rs
+++ b/koda-cli/src/display.rs
@@ -721,6 +721,36 @@ pub fn print_tool_output_full(record: &ToolOutputRecord) {
     println!();
 }
 
+/// Print a compact summary for tool output when the preview was already shown.
+pub fn print_tool_output_compact(tool_name: &str, output: &str) {
+    let border_color = match tool_name {
+        "Write" | "Edit" | "MemoryWrite" => AMBER,
+        "Delete" => CRIMSON,
+        _ => DIM,
+    };
+
+    // Count additions and removals from diff output
+    let additions = output
+        .lines()
+        .filter(|l| l.starts_with('+') && !l.starts_with("+++"))
+        .count();
+    let removals = output
+        .lines()
+        .filter(|l| l.starts_with('-') && !l.starts_with("---"))
+        .count();
+
+    if additions > 0 || removals > 0 {
+        println!(
+            "{CONTENT_INDENT}{border_color}│{RESET} {DIM}\x1b[32m+{additions}\x1b[0m {DIM}\x1b[31m-{removals}{RESET}"
+        );
+    } else {
+        let line_count = output.lines().count();
+        println!(
+            "{CONTENT_INDENT}{border_color}│{RESET} {DIM}\u{2714} Done ({line_count} lines){RESET}"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -28,6 +28,8 @@ pub(crate) struct UiRenderer {
     pub verbose: bool,
     /// Buffer for streaming thinking deltas (rendered line-by-line).
     think_buf: String,
+    /// Set when an ApprovalRequest with a preview was shown; cleared on next ToolCallResult.
+    pub preview_shown: bool,
 }
 
 impl UiRenderer {
@@ -38,6 +40,7 @@ impl UiRenderer {
             tool_history: crate::display::ToolOutputHistory::new(),
             verbose: false,
             think_buf: String::new(),
+            preview_shown: false,
         }
     }
 
@@ -93,13 +96,19 @@ impl UiRenderer {
                 output,
             } => {
                 self.tool_history.push(&name, &output);
-                if self.verbose {
+                let is_diff_tool =
+                    matches!(name.as_str(), "Write" | "Edit" | "Delete" | "MemoryWrite");
+                if self.preview_shown && is_diff_tool {
+                    // Preview was already shown before confirmation — show compact summary
+                    crate::display::print_tool_output_compact(&name, &output);
+                } else if self.verbose {
                     if let Some(record) = self.tool_history.get(1) {
                         crate::display::print_tool_output_full(record);
                     }
                 } else {
                     crate::display::print_tool_output(&name, &output);
                 }
+                self.preview_shown = false;
             }
             EngineEvent::SubAgentStart { agent_name } => {
                 crate::display::print_sub_agent_start(&agent_name);


### PR DESCRIPTION
Closes #40

In Normal mode, Edit/Write/Delete diffs were shown twice:
1. Preview before confirmation prompt
2. Full diff again after execution

Now: if a preview was shown, the post-execution output shows a compact summary instead:
```
│ +3 -1
```

In Yolo mode (no confirmation = no preview), the full diff is still shown — it's the only chance to see changes.

### Implementation
- `preview_shown` flag in `UiRenderer` (set on `ApprovalRequest` with preview, cleared on `ToolCallResult`)
- `print_tool_output_compact()` in `display.rs` — counts +/- lines from diff output
- 3 files changed, 44 insertions, 1 deletion

Tests ✅ | fmt ✅ | clippy ✅