### PR TITLE
chore: finalize v0.1.1 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-03-05
+
 ### Added
+- **Async REPL event loop** — readline runs on a dedicated OS thread; inference, UI rendering, and approval prompts run concurrently via `tokio::select!`
+- **Tool output expand/collapse** — `/expand N` reprints full output; `/verbose` toggles persistent expansion
 - **TodoRead tool** — read and display task lists from the database
+- **Todo list display** — active tasks shown after each turn with highlighting
 - **Dev workflow guidance** — system prompt teaches best practices for development workflows
 - **Pre-confirmation diff previews** — see exactly what Edit/Write/Delete will change before approving
 - **Redundant diff skip** — suppress post-execution diff when preview was already shown
-- **Async REPL event loop** — readline runs on a dedicated OS thread; inference, UI rendering, and approval prompts run concurrently via `tokio::select!`
-- **Tool output expand/collapse** — `/expand N` reprints full output; `/verbose` toggles persistent expansion
+- **Persist provider/model** — last-used provider and model restored on startup
+- **Diff background colors** — colored diff output with smarter shell error display
+- **Interactive session resume** — `/sessions` shows an arrow-key picker to switch sessions mid-REPL
+- **Session recovery** — orphaned tool calls from interrupted sessions are cleaned up on resume
+
+### Fixed
+- **Panic on multi-byte chars** — think_tag_filter no longer panics on emoji/CJK in thinking blocks
+- **AstAnalysis approval** — now correctly classified as read-only (was requiring confirmation in Normal mode)
+- **REPL survives inference errors** — API failures print an error and return to prompt instead of exiting
+- **Improved TodoWrite prompts** — more reliable tool usage by small models
+
+### Changed
+- **rmcp** upgraded from 0.16 to 1.1
 
 ### Removed
-- **Bottom bar / ANSI scroll regions** — reverted due to fundamental incompatibility with terminal scrollback. Users could not scroll back to the latest output after scrolling up during inference. See [#57](https://github.com/lijunzh/koda/issues/57) for the TUI migration plan.
+- **Bottom bar / ANSI scroll regions** — reverted due to fundamental incompatibility with terminal scrollback. See [#57](https://github.com/lijunzh/koda/issues/57) for the TUI migration plan.
 
 ### Known Limitations
 - **No type-ahead during inference** — input is not accepted while the model is running. Planned for v0.1.2 via a TUI framework migration ([#57](https://github.com/lijunzh/koda/issues/57)).
+
+### Testing
+- 372 tests across `koda-core` and `koda-cli`
 
 ## [0.1.0] - 2026-03-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ See [DESIGN.md](DESIGN.md) for architectural decisions. See [#57](https://github
 ```bash
 cargo build                              # Debug build
 cargo build --release -p koda-cli        # Release build
-cargo test --workspace                   # Run all 370 tests
+cargo test --workspace                   # Run all 372 tests
 cargo test -p koda-core                  # Engine tests only
 cargo test -p koda-cli                   # CLI tests only
 cargo test -p koda-core --test perf_test # Run a specific test file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
 ## Development
 
 ```bash
-cargo test --workspace        # Run all 370 tests
+cargo test --workspace        # Run all 372 tests
 cargo clippy --workspace      # Lint
 cargo run -p koda-cli         # Run locally
 ```

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.0" }
+koda-core = { path = "../koda-core", version = "0.1.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -9,21 +9,30 @@ mod repl_commands {
     fn dispatch(input: &str) -> &'static str {
         let parts: Vec<&str> = input.splitn(2, ' ').collect();
         let cmd = parts[0];
+        let arg = parts.get(1).copied().unwrap_or("");
 
         match cmd {
             "/exit" => "Quit",
-            "/model" if parts.len() > 1 => "SwitchModel",
+            "/model" if !arg.is_empty() => "SwitchModel",
             "/model" => "PickModel",
-            "/provider" if parts.len() > 1 => "SetupProvider",
+            "/provider" if !arg.is_empty() => "SetupProvider",
             "/provider" => "PickProvider",
             "/help" => "ShowHelp",
             "/cost" => "ShowCost",
-            "/trust" if parts.len() > 1 => "SetTrust",
+            "/trust" if !arg.is_empty() => "SetTrust",
             "/trust" => "PickTrust",
-            "/diff" if parts.len() > 1 => "InjectPrompt_or_Handled",
+            "/diff" if !arg.is_empty() => "InjectPrompt_or_Handled",
             "/diff" => "Handled",
-            "/sessions" if parts.len() > 1 && parts[1].starts_with("delete ") => "DeleteSession",
+            "/sessions" if arg.starts_with("delete ") => "DeleteSession",
+            "/sessions" if arg.starts_with("resume ") => "ResumeSession",
+            "/sessions"
+                if !arg.is_empty() && arg.chars().all(|c| c.is_ascii_hexdigit() || c == '-') =>
+            {
+                "ResumeSession"
+            }
             "/sessions" => "ListSessions",
+            "/expand" => "Expand",
+            "/verbose" => "Verbose",
             "/memory" => "Handled",
 
             "/compact" => "Compact",
@@ -55,6 +64,10 @@ mod repl_commands {
         assert_eq!(dispatch("/diff commit"), "InjectPrompt_or_Handled");
         assert_eq!(dispatch("/sessions"), "ListSessions");
         assert_eq!(dispatch("/sessions delete abc123"), "DeleteSession");
+        assert_eq!(dispatch("/sessions resume abc123"), "ResumeSession");
+        assert_eq!(dispatch("/sessions abc12345"), "ResumeSession");
+        assert_eq!(dispatch("/expand"), "Expand");
+        assert_eq!(dispatch("/verbose"), "Verbose");
         assert_eq!(dispatch("/memory"), "Handled");
         assert_eq!(dispatch("/memory add test"), "Handled");
         assert_eq!(dispatch("/memory global test"), "Handled");
@@ -222,6 +235,8 @@ mod display_regression {
         ("ListAgents", "Tool"),
         ("CreateAgent", "Create"),
         ("TodoWrite", "Todo"),
+        ("TodoRead", "Todo"),
+        ("AstAnalysis", "AST"),
     ];
 
     fn tool_label(name: &str) -> &'static str {
@@ -238,7 +253,8 @@ mod display_regression {
             "MemoryRead" | "MemoryWrite" => "Memory",
             "InvokeAgent" => "Agent",
             "CreateAgent" => "Create",
-            "TodoWrite" => "Todo",
+            "TodoWrite" | "TodoRead" => "Todo",
+            "AstAnalysis" => "AST",
             _ => "Tool",
         }
     }
@@ -263,8 +279,8 @@ mod display_regression {
     fn test_tool_count() {
         assert_eq!(
             KNOWN_TOOLS.len(),
-            16,
-            "Expected 16 known tools (update this test when adding tools)"
+            18,
+            "Expected 18 known tools (update this test when adding tools)"
         );
     }
 }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -5,9 +5,10 @@ Refer to this when the user asks "what can you do?" or about features.
 ### Commands (user types these in the REPL)
 
 /help — command palette | /agent — list sub-agents | /compact — reclaim context
-/cost — token usage | /diff — git diff/review/commit | /mcp — MCP server management
-/memory — persistent memory | /model — switch model | /provider — switch provider
-/sessions — manage sessions | /trust — plan/normal/yolo | /exit — quit
+/cost — token usage | /diff — git diff/review/commit | /expand — show full tool output
+/mcp — MCP server management | /memory — persistent memory | /model — switch model
+/provider — switch provider | /sessions — resume/delete sessions (interactive picker)
+/trust — plan/normal/yolo | /verbose — toggle full tool output | /exit — quit
 
 ### Input
 


### PR DESCRIPTION
## Summary

Final release preparation for v0.1.1.

- Bump `koda-core` and `koda-cli` versions from 0.1.0 → 0.1.1
- Complete CHANGELOG with 6 missing items (panic fix, rmcp upgrade, diff colors, todo display, persist provider, session resume)
- Update test counts in README and CLAUDE.md (370 → 372)
- Update capabilities.md with `/expand`, `/verbose`, `/sessions` picker
- Create E2E test infrastructure issue (#60) for v0.1.2

## Checklist

- [x] All 372 tests pass
- [x] clippy clean, fmt clean, docs build
- [x] CHANGELOG covers all 15 commits since v0.1.0
- [x] Crate versions bumped
- [x] Security audit reviewed (2 transitive advisories, zero risk — see PR description)

### Security notes

- **RUSTSEC-2023-0071 (rsa)**: Medium severity, from `sqlx-mysql` transitive dep. We use SQLite only — `sqlx-mysql` is never invoked. No fix available upstream.
- **RUSTSEC-2025-0141 (bincode)**: Unmaintained warning, from `syntect` transitive dep. No vulnerability, just a maintenance advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)