### PR TITLE
chore: simplify CI/CD workflows for faster iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,23 @@ permissions:
   contents: write
 
 jobs:
-  # Gate: run the full CI suite before building release artifacts.
-  ci:
-    name: CI
-    uses: ./.github/workflows/ci.yml
+  # Gate: verify CI already passed on this commit (no re-run).
+  check-ci:
+    name: Verify CI Passed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI status for this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&status=success&per_page=1" \
+            --jq '.total_count')
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::No successful CI run found for commit ${{ github.sha }}"
+            exit 1
+          fi
+          echo "CI passed for commit ${{ github.sha }}"
 
   # Verify that the git tag matches the workspace version.
   verify-version:
@@ -39,7 +52,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.target }}
-    needs: [ci, verify-version]
+    needs: [check-ci, verify-version]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- **CI**: Drop Windows and macOS from the test matrix (Linux only). macOS is covered by local dev testing; Windows compile correctness is verified by the release build matrix.
- **Release**: Remove the redundant full CI re-run gate. Replace with a lightweight `check-ci` job that queries the GitHub API to confirm CI already passed on the tagged commit SHA — no duplicate work, same safety guarantee (main is branch-protected).

## Result

- PR CI is faster (1 platform instead of 3)
- Release triggers immediately after tag push, gates on prior CI pass rather than re-running it

## Test plan
- [ ] Verify CI passes on this PR (Linux only)
- [ ] Confirm release workflow logic looks correct (no re-run, SHA check gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)