### PR TITLE
test: end-to-end test infrastructure with mock provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace
+      - run: cargo test --workspace --features koda-core/test-support
 
   doc:
     name: Docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,15 +110,41 @@ Tools use PascalCase names. `mod.rs` has the registry, dispatcher, and `safe_res
 
 ## Test Structure
 
-**koda-core** (unit + integration):
-- Unit tests co-located in `src/` modules
-- `tests/file_tools_test.rs` — path safety, file CRUD
-- `tests/new_tools_test.rs` — glob, tool naming
-- `tests/perf_test.rs` — DB, grep, markdown throughput
-- `tests/capabilities_test.rs` — capabilities.md freshness
+### Running tests
 
-**koda-cli** (unit + integration):
-- Unit tests in `src/` modules (notably `acp_adapter.rs`)
-- `tests/cli_test.rs` — binary subprocess invocation
-- `tests/regression_test.rs` — REPL dispatch, input processing
-- `tests/server_test.rs` — ACP server integration tests (spawn subprocess, JSON-RPC lifecycle)
+```bash
+# CI suite (all tests including E2E with mock provider)
+cargo test --workspace --features koda-core/test-support
+
+# Live smoke tests (requires LM Studio running locally)
+KODA_TEST_LMSTUDIO=1 cargo test -p koda-cli --test smoke_test -- --ignored
+```
+
+The `test-support` feature gates `MockProvider` and `TestSink` — they are excluded
+from production builds to keep `koda-core`'s public API clean.
+
+### Test tiers
+
+**Unit tests** — co-located in `src/` modules, no feature flag needed:
+```bash
+cargo test -p koda-core   # runs unit tests only (no E2E)
+```
+
+**E2E tests** (mock provider, CI) — require `test-support` feature:
+- `koda-core/tests/e2e_test.rs` — full inference loop with real tools in sandboxed temp dirs
+- `koda-core/tests/cancel_test.rs` — Ctrl+C interruption during inference
+
+**Integration tests** — no feature flag needed:
+- `koda-core/tests/file_tools_test.rs` — path safety, file CRUD
+- `koda-core/tests/new_tools_test.rs` — glob, tool naming
+- `koda-core/tests/perf_test.rs` — DB, grep, markdown throughput
+- `koda-core/tests/capabilities_test.rs` — capabilities.md freshness
+
+**CLI tests** — no feature flag needed:
+- `koda-cli/tests/cli_test.rs` — binary subprocess invocation
+- `koda-cli/tests/regression_test.rs` — REPL dispatch, input processing
+- `koda-cli/tests/server_test.rs` — ACP server integration (JSON-RPC lifecycle)
+
+**Live smoke tests** (`#[ignore]`, local only):
+- `koda-cli/tests/smoke_test.rs` — headless prompt, tool use, session resume against LM Studio
+- Gated by `KODA_TEST_LMSTUDIO=1` env var; never runs in CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ See [DESIGN.md](DESIGN.md) for architectural decisions. See [#57](https://github
 ```bash
 cargo build                              # Debug build
 cargo build --release -p koda-cli        # Release build
-cargo test --workspace                   # Run all 372 tests
-cargo test -p koda-core                  # Engine tests only
-cargo test -p koda-cli                   # CLI tests only
-cargo test -p koda-core --test perf_test # Run a specific test file
+cargo test --workspace --features koda-core/test-support  # Run all tests (incl. E2E)
+cargo test -p koda-core --features test-support          # Engine tests only
+cargo test -p koda-cli                                   # CLI tests only
+cargo test -p koda-core --test perf_test                 # Run a specific test file
 cargo fmt --all                          # Format all crates
 cargo fmt --all --check                  # Check formatting (CI enforced)
 cargo clippy --workspace -- -D warnings  # Lint (CI enforced)

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -55,4 +55,6 @@ tokio-tungstenite = "0.28"
 
 [dev-dependencies]
 tempfile = "3"
+koda-core = { path = "../koda-core", features = ["test-support"] }
+serde_json = "1"
 

--- a/koda-cli/tests/smoke_test.rs
+++ b/koda-cli/tests/smoke_test.rs
@@ -1,0 +1,176 @@
+//! Live smoke tests against a running LM Studio instance.
+//!
+//! Gated by `KODA_TEST_LMSTUDIO=1` environment variable.
+//! These tests are `#[ignore]` by default — run them with:
+//!
+//!   KODA_TEST_LMSTUDIO=1 cargo test -p koda-cli --test smoke_test -- --ignored
+
+use std::process::Command;
+
+fn koda_bin() -> String {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // test binary name
+    path.pop(); // deps/
+    path.push("koda");
+    path.to_string_lossy().to_string()
+}
+
+fn lmstudio_available() -> bool {
+    std::env::var("KODA_TEST_LMSTUDIO").is_ok()
+}
+
+#[test]
+#[ignore]
+fn test_headless_prompt_returns_response() {
+    if !lmstudio_available() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let output = Command::new(koda_bin())
+        .args([
+            "-p",
+            "Reply with only the word 'hello'",
+            "--provider",
+            "lmstudio",
+            "--output-format",
+            "json",
+            "--project-root",
+        ])
+        .arg(tmp.path())
+        // Isolate config/DB so this doesn't interfere with real sessions.
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .output()
+        .expect("Failed to run koda");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Find the JSON object in stdout (skip any non-JSON lines like banners)
+    let json_str = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("No JSON in stdout.\nstdout: {stdout}\nstderr: {stderr}"));
+
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .unwrap_or_else(|e| panic!("Invalid JSON: {e}\nline: {json_str}\nstderr: {stderr}"));
+
+    assert_eq!(
+        json["success"], true,
+        "Expected success.\nJSON: {json}\nstderr: {stderr}"
+    );
+    let response = json["response"].as_str().unwrap_or("");
+    assert!(
+        !response.is_empty(),
+        "Response should not be empty.\nJSON: {json}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_headless_tool_use() {
+    if !lmstudio_available() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a file for the model to read
+    std::fs::write(tmp.path().join("hello.txt"), "test content 12345").unwrap();
+
+    let output = Command::new(koda_bin())
+        .args([
+            "-p",
+            "Read the file hello.txt and tell me what it contains. Be brief.",
+            "--provider",
+            "lmstudio",
+            "--output-format",
+            "json",
+            "--project-root",
+        ])
+        .arg(tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .output()
+        .expect("Failed to run koda");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let json_str = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("No JSON in stdout.\nstdout: {stdout}\nstderr: {stderr}"));
+
+    let json: serde_json::Value = serde_json::from_str(json_str)
+        .unwrap_or_else(|e| panic!("Invalid JSON: {e}\nline: {json_str}\nstderr: {stderr}"));
+
+    assert_eq!(
+        json["success"], true,
+        "Expected success.\nJSON: {json}\nstderr: {stderr}"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_headless_session_resume() {
+    if !lmstudio_available() {
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Run first prompt — capture session ID from JSON output.
+    let output1 = Command::new(koda_bin())
+        .args([
+            "-p",
+            "Say 'alpha'",
+            "--provider",
+            "lmstudio",
+            "--output-format",
+            "json",
+            "--project-root",
+        ])
+        .arg(tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .output()
+        .expect("Failed to run koda (turn 1)");
+
+    let stdout1 = String::from_utf8_lossy(&output1.stdout);
+    let json1_str = stdout1
+        .lines()
+        .find(|l| l.trim_start().starts_with('{'))
+        .expect("No JSON in turn 1");
+    let json1: serde_json::Value = serde_json::from_str(json1_str).expect("Bad JSON turn 1");
+    let session_id = json1["session_id"].as_str().expect("No session_id in JSON");
+
+    // Run second prompt resuming the same session.
+    let output2 = Command::new(koda_bin())
+        .args([
+            "-p",
+            "Say 'beta'",
+            "--provider",
+            "lmstudio",
+            "--output-format",
+            "json",
+            "--resume",
+            session_id,
+            "--project-root",
+        ])
+        .arg(tmp.path())
+        .env("XDG_CONFIG_HOME", tmp.path())
+        .output()
+        .expect("Failed to run koda (turn 2)");
+
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    let stderr2 = String::from_utf8_lossy(&output2.stderr);
+
+    let json2_str = stdout2
+        .lines()
+        .find(|l| l.trim_start().starts_with('{'))
+        .unwrap_or_else(|| panic!("No JSON in turn 2.\nstdout: {stdout2}\nstderr: {stderr2}"));
+    let json2: serde_json::Value = serde_json::from_str(json2_str).expect("Bad JSON turn 2");
+
+    assert_eq!(json2["success"], true);
+    assert_eq!(
+        json2["session_id"].as_str().unwrap(),
+        session_id,
+        "Resumed session should keep the same ID"
+    );
+}

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -71,8 +71,23 @@ tree-sitter-python = "0.25.0"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-typescript = "0.23.2"
 
+[features]
+test-support = []
+
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
 regex = "1"
 ignore = "0.4"
+anyhow = "1"
+async-trait = "0.1"
+
+# Integration tests that need mock infrastructure.
+# Run with: cargo test -p koda-core --features test-support
+[[test]]
+name = "e2e_test"
+required-features = ["test-support"]
+
+[[test]]
+name = "cancel_test"
+required-features = ["test-support"]

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -20,13 +20,13 @@ pub trait EngineSink: Send + Sync {
 }
 
 /// A sink that collects events into a Vec for testing.
-#[allow(dead_code)]
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Default)]
 pub struct TestSink {
     events: std::sync::Mutex<Vec<EngineEvent>>,
 }
 
-#[allow(dead_code)]
+#[cfg(any(test, feature = "test-support"))]
 impl TestSink {
     pub fn new() -> Self {
         Self::default()
@@ -48,6 +48,7 @@ impl TestSink {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl EngineSink for TestSink {
     fn emit(&self, event: EngineEvent) {
         self.events.lock().unwrap().push(event);

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -1,0 +1,223 @@
+//! Mock LLM provider for testing.
+//!
+//! Returns scripted responses so tests can exercise the full inference loop
+//! without a real LLM. Responses are consumed in FIFO order.
+
+use super::{
+    ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, TokenUsage, ToolCall,
+    ToolDefinition,
+};
+use crate::config::ModelSettings;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::mpsc;
+
+static MOCK_CALL_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+/// A scripted response for the mock provider.
+#[derive(Debug, Clone)]
+pub enum MockResponse {
+    /// Stream text content back as the LLM response.
+    Text(String),
+    /// Return one or more tool calls.
+    ToolCalls(Vec<ToolCall>),
+    /// Simulate a provider error.
+    Error(String),
+}
+
+impl MockResponse {
+    /// Convenience: create a single tool call response.
+    pub fn tool_call(name: &str, args: serde_json::Value) -> Self {
+        let id = format!(
+            "mock_call_{}",
+            MOCK_CALL_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        MockResponse::ToolCalls(vec![ToolCall {
+            id,
+            function_name: name.to_string(),
+            arguments: serde_json::to_string(&args).unwrap(),
+            thought_signature: None,
+        }])
+    }
+}
+
+/// A mock LLM provider that returns scripted responses.
+///
+/// Responses are consumed in FIFO order. Panics if exhausted.
+pub struct MockProvider {
+    responses: Mutex<Vec<MockResponse>>,
+}
+
+impl MockProvider {
+    pub fn new(responses: Vec<MockResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+
+    fn next_response(&self) -> MockResponse {
+        let mut responses = self.responses.lock().unwrap();
+        assert!(
+            !responses.is_empty(),
+            "MockProvider: no more scripted responses"
+        );
+        responses.remove(0)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for MockProvider {
+    async fn chat(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: &[ToolDefinition],
+        _settings: &ModelSettings,
+    ) -> Result<LlmResponse> {
+        match self.next_response() {
+            MockResponse::Text(text) => Ok(LlmResponse {
+                content: Some(text),
+                tool_calls: vec![],
+                usage: TokenUsage::default(),
+            }),
+            MockResponse::ToolCalls(calls) => Ok(LlmResponse {
+                content: None,
+                tool_calls: calls,
+                usage: TokenUsage::default(),
+            }),
+            MockResponse::Error(msg) => Err(anyhow::anyhow!(msg)),
+        }
+    }
+
+    async fn chat_stream(
+        &self,
+        _messages: &[ChatMessage],
+        _tools: &[ToolDefinition],
+        _settings: &ModelSettings,
+    ) -> Result<mpsc::Receiver<StreamChunk>> {
+        let response = self.next_response();
+
+        // Error responses fail at the call site, not inside the stream.
+        if let MockResponse::Error(msg) = response {
+            return Err(anyhow::anyhow!(msg));
+        }
+
+        let (tx, rx) = mpsc::channel(32);
+
+        tokio::spawn(async move {
+            match response {
+                MockResponse::Text(text) => {
+                    // Stream in small chunks to simulate real streaming.
+                    for chunk in text.as_bytes().chunks(20) {
+                        let s = String::from_utf8_lossy(chunk).to_string();
+                        let _ = tx.send(StreamChunk::TextDelta(s)).await;
+                    }
+                    let _ = tx
+                        .send(StreamChunk::Done(TokenUsage {
+                            prompt_tokens: 10,
+                            completion_tokens: text.len() as i64 / 4,
+                            ..Default::default()
+                        }))
+                        .await;
+                }
+                MockResponse::ToolCalls(calls) => {
+                    let _ = tx.send(StreamChunk::ToolCalls(calls)).await;
+                    let _ = tx
+                        .send(StreamChunk::Done(TokenUsage {
+                            prompt_tokens: 10,
+                            completion_tokens: 5,
+                            ..Default::default()
+                        }))
+                        .await;
+                }
+                MockResponse::Error(_) => unreachable!(),
+            }
+        });
+
+        Ok(rx)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        Ok(vec![ModelInfo {
+            id: "mock-model".to_string(),
+            owned_by: Some("test".to_string()),
+        }])
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_text_response() {
+        let provider = MockProvider::new(vec![MockResponse::Text("hello".into())]);
+        let rx = provider
+            .chat_stream(
+                &[],
+                &[],
+                &ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio),
+            )
+            .await
+            .unwrap();
+
+        let chunks: Vec<_> = collect_chunks(rx).await;
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, StreamChunk::TextDelta(_)))
+        );
+        assert!(chunks.iter().any(|c| matches!(c, StreamChunk::Done(_))));
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_response() {
+        let provider = MockProvider::new(vec![MockResponse::tool_call(
+            "Bash",
+            serde_json::json!({"command": "echo hi"}),
+        )]);
+        let rx = provider
+            .chat_stream(
+                &[],
+                &[],
+                &ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio),
+            )
+            .await
+            .unwrap();
+
+        let chunks: Vec<_> = collect_chunks(rx).await;
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, StreamChunk::ToolCalls(_)))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_error_response() {
+        let provider = MockProvider::new(vec![MockResponse::Error("boom".into())]);
+        let result = provider
+            .chat_stream(
+                &[],
+                &[],
+                &ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio),
+            )
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("boom"));
+    }
+
+    async fn collect_chunks(mut rx: mpsc::Receiver<StreamChunk>) -> Vec<StreamChunk> {
+        let mut chunks = Vec::new();
+        while let Some(chunk) = rx.recv().await {
+            chunks.push(chunk);
+        }
+        chunks
+    }
+}

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -7,6 +7,9 @@ pub mod gemini;
 pub mod openai_compat;
 pub mod think_tag_filter;
 
+#[cfg(any(test, feature = "test-support"))]
+pub mod mock;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -189,10 +189,10 @@ async fn test_read_tool_in_sandbox() {
 
     // Tool result should contain the file content
     let tool_result = events.iter().find_map(|e| {
-        if let EngineEvent::ToolCallResult { output, name, .. } = e {
-            if name == "Read" {
-                return Some(output.clone());
-            }
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "Read"
+        {
+            return Some(output.clone());
         }
         None
     });
@@ -406,10 +406,10 @@ async fn test_glob_tool_in_sandbox() {
     let events = env.run_inference(&provider).await;
 
     let tool_result = events.iter().find_map(|e| {
-        if let EngineEvent::ToolCallResult { output, name, .. } = e {
-            if name == "Glob" {
-                return Some(output.clone());
-            }
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "Glob"
+        {
+            return Some(output.clone());
         }
         None
     });

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -1,0 +1,420 @@
+//! End-to-end tests: mock provider → inference loop → real tools → DB persistence.
+//!
+//! These tests exercise the full engine pipeline without a real LLM.
+//! All file operations happen in isolated temp directories.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use koda_core::{
+    approval::{ApprovalMode, Settings},
+    config::{KodaConfig, ModelSettings, ProviderType},
+    db::{Database, Role},
+    engine::{EngineCommand, EngineEvent, sink::TestSink},
+    inference,
+    loop_guard::LoopContinuation,
+    providers::{
+        ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
+        mock::{MockProvider, MockResponse},
+    },
+    tools::ToolRegistry,
+};
+use std::path::PathBuf;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// ── Test harness ──────────────────────────────────────────────
+
+struct Env {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+    db: Database,
+    session_id: String,
+    config: KodaConfig,
+    tools: ToolRegistry,
+}
+
+impl Env {
+    async fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let db = Database::init(&root, &root).await.unwrap();
+        let session_id = db.create_session("test-agent", &root).await.unwrap();
+        let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
+        let tools = ToolRegistry::new(root.clone());
+        Self {
+            _tmp: tmp,
+            root,
+            db,
+            session_id,
+            config,
+            tools,
+        }
+    }
+
+    fn tool_defs(&self) -> Vec<koda_core::providers::ToolDefinition> {
+        self.tools.get_definitions(&[])
+    }
+
+    async fn insert_user_message(&self, text: &str) {
+        self.db
+            .insert_message(&self.session_id, &Role::User, Some(text), None, None, None)
+            .await
+            .unwrap();
+    }
+
+    async fn run_inference(&self, provider: &MockProvider) -> Vec<EngineEvent> {
+        let sink = TestSink::new();
+        let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+        let mut settings = Settings::load();
+        let tool_defs = self.tool_defs();
+
+        let result = inference::inference_loop(
+            &self.root,
+            &self.config,
+            &self.db,
+            &self.session_id,
+            "You are a test assistant.",
+            provider,
+            &self.tools,
+            &tool_defs,
+            None,
+            ApprovalMode::Yolo,
+            &mut settings,
+            &sink,
+            CancellationToken::new(),
+            &mut cmd_rx,
+            &|_, _| LoopContinuation::Stop,
+        )
+        .await;
+
+        assert!(result.is_ok(), "inference_loop failed: {:?}", result.err());
+        sink.events()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_text_response_streams_and_persists() {
+    let env = Env::new().await;
+    env.insert_user_message("say hello").await;
+
+    let provider = MockProvider::new(vec![MockResponse::Text("Hello, world!".into())]);
+    let events = env.run_inference(&provider).await;
+
+    // Should have streaming text events
+    let text_deltas: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, EngineEvent::TextDelta { .. }))
+        .collect();
+    assert!(!text_deltas.is_empty(), "expected TextDelta events");
+    assert!(
+        events.iter().any(|e| matches!(e, EngineEvent::TextDone)),
+        "expected TextDone"
+    );
+
+    // Should have persisted to DB
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("Hello, world!"),
+        "DB should contain response: {last}"
+    );
+}
+
+#[tokio::test]
+async fn test_tool_call_executes_and_returns() {
+    let env = Env::new().await;
+    env.insert_user_message("run echo").await;
+
+    // Mock: first call returns a Bash tool call, second returns final text.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("Bash", serde_json::json!({"command": "echo hello"})),
+        MockResponse::Text("Done! The command printed hello.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Should have tool call start + result events
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EngineEvent::ToolCallStart { name, .. } if name == "Bash")),
+        "expected ToolCallStart for Bash"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EngineEvent::ToolCallResult { name, .. } if name == "Bash")),
+        "expected ToolCallResult for Bash"
+    );
+
+    // Should end with text response
+    assert!(
+        events.iter().any(|e| matches!(e, EngineEvent::TextDone)),
+        "expected TextDone after tool execution"
+    );
+
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("Done!"),
+        "DB should contain final response: {last}"
+    );
+}
+
+#[tokio::test]
+async fn test_read_tool_in_sandbox() {
+    let env = Env::new().await;
+
+    // Create a file in the sandbox for the Read tool to find.
+    let test_file = env.root.join("test_data.txt");
+    std::fs::write(&test_file, "sandbox content here").unwrap();
+
+    env.insert_user_message("read the file").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"path": test_file.to_string_lossy()}),
+        ),
+        MockResponse::Text("The file contains sandbox content.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Tool result should contain the file content
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e {
+            if name == "Read" {
+                return Some(output.clone());
+            }
+        }
+        None
+    });
+    assert!(
+        tool_result.is_some(),
+        "expected Read tool result in events: {events:?}"
+    );
+    assert!(
+        tool_result.unwrap().contains("sandbox content here"),
+        "Read tool should return file content"
+    );
+}
+
+#[tokio::test]
+async fn test_write_tool_creates_file_in_sandbox() {
+    let env = Env::new().await;
+    env.insert_user_message("create a file").await;
+
+    let target = env.root.join("created.txt");
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Write",
+            serde_json::json!({
+                "path": target.to_string_lossy(),
+                "content": "hello from mock"
+            }),
+        ),
+        MockResponse::Text("File created.".into()),
+    ]);
+    env.run_inference(&provider).await;
+
+    assert!(target.exists(), "Write tool should create the file");
+    let content = std::fs::read_to_string(&target).unwrap();
+    assert_eq!(content, "hello from mock");
+}
+
+#[tokio::test]
+async fn test_provider_error_emits_error_event() {
+    let env = Env::new().await;
+    env.insert_user_message("trigger error").await;
+
+    let provider = MockProvider::new(vec![MockResponse::Error("API rate limit".into())]);
+    let sink = TestSink::new();
+    let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+    let mut settings = Settings::load();
+    let tool_defs = env.tool_defs();
+
+    let result = inference::inference_loop(
+        &env.root,
+        &env.config,
+        &env.db,
+        &env.session_id,
+        "You are a test assistant.",
+        &provider,
+        &env.tools,
+        &tool_defs,
+        None,
+        ApprovalMode::Yolo,
+        &mut settings,
+        &sink,
+        CancellationToken::new(),
+        &mut cmd_rx,
+        &|_, _| LoopContinuation::Stop,
+    )
+    .await;
+
+    // Provider error should propagate as an Err (wrapped by inference_loop)
+    assert!(result.is_err(), "expected error from provider failure");
+    let err = result.unwrap_err();
+    let chain = format!("{err:?}"); // debug format shows full error chain
+    assert!(
+        chain.contains("API rate limit"),
+        "error chain should contain provider message, got: {chain}"
+    );
+}
+
+#[tokio::test]
+async fn test_session_history_persists_across_turns() {
+    let env = Env::new().await;
+
+    // Turn 1
+    env.insert_user_message("first question").await;
+    let provider1 = MockProvider::new(vec![MockResponse::Text("first answer".into())]);
+    env.run_inference(&provider1).await;
+
+    // Turn 2
+    env.insert_user_message("second question").await;
+    let provider2 = MockProvider::new(vec![MockResponse::Text("second answer".into())]);
+    env.run_inference(&provider2).await;
+
+    // Verify both messages are in the DB
+    let messages = env.db.load_context(&env.session_id, 100_000).await.unwrap();
+
+    let contents: Vec<String> = messages.iter().filter_map(|m| m.content.clone()).collect();
+
+    assert!(
+        contents.iter().any(|c| c.contains("first question")),
+        "history should contain first user message"
+    );
+    assert!(
+        contents.iter().any(|c| c.contains("first answer")),
+        "history should contain first assistant response"
+    );
+    assert!(
+        contents.iter().any(|c| c.contains("second question")),
+        "history should contain second user message"
+    );
+    assert!(
+        contents.iter().any(|c| c.contains("second answer")),
+        "history should contain second assistant response"
+    );
+}
+
+#[tokio::test]
+async fn test_cancel_during_streaming() {
+    let env = Env::new().await;
+    env.insert_user_message("hello").await;
+
+    struct HangingProvider;
+
+    #[async_trait]
+    impl LlmProvider for HangingProvider {
+        async fn chat(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &ModelSettings,
+        ) -> Result<LlmResponse> {
+            unreachable!()
+        }
+        async fn chat_stream(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &ModelSettings,
+        ) -> Result<mpsc::Receiver<StreamChunk>> {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            unreachable!()
+        }
+        async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+            Ok(vec![])
+        }
+        fn provider_name(&self) -> &str {
+            "hanging"
+        }
+    }
+
+    let sink = TestSink::new();
+    let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+    let mut settings = Settings::load();
+    let tool_defs = env.tool_defs();
+    let cancel = CancellationToken::new();
+
+    // Cancel after 100ms
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancel_clone.cancel();
+    });
+
+    let start = std::time::Instant::now();
+    let result = inference::inference_loop(
+        &env.root,
+        &env.config,
+        &env.db,
+        &env.session_id,
+        "You are a test assistant.",
+        &HangingProvider,
+        &env.tools,
+        &tool_defs,
+        None,
+        ApprovalMode::Yolo,
+        &mut settings,
+        &sink,
+        cancel,
+        &mut cmd_rx,
+        &|_, _| LoopContinuation::Stop,
+    )
+    .await;
+
+    let elapsed = start.elapsed();
+    assert!(result.is_ok(), "cancel should be graceful");
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "should cancel quickly, took {elapsed:?}"
+    );
+    assert!(
+        sink.events()
+            .iter()
+            .any(|e| matches!(e, EngineEvent::Warn { message } if message == "Interrupted")),
+        "should emit Interrupted warning"
+    );
+}
+
+#[tokio::test]
+async fn test_glob_tool_in_sandbox() {
+    let env = Env::new().await;
+
+    // Create some files for Glob to find
+    let src_dir = env.root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("main.rs"), "fn main() {}").unwrap();
+    std::fs::write(src_dir.join("lib.rs"), "pub mod foo;").unwrap();
+
+    env.insert_user_message("find rust files").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("Glob", serde_json::json!({"pattern": "src/*.rs"})),
+        MockResponse::Text("Found 2 Rust files.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e {
+            if name == "Glob" {
+                return Some(output.clone());
+            }
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected Glob tool result");
+    let output = tool_result.unwrap();
+    assert!(output.contains("main.rs"), "Glob should find main.rs");
+    assert!(output.contains("lib.rs"), "Glob should find lib.rs");
+}


### PR DESCRIPTION
## Summary

- **MockProvider** in `koda-core/src/providers/mock.rs` — implements `LlmProvider` with scripted FIFO responses (text, tool calls, errors). Behind `test-support` feature flag for clean public API.
- **TestSink** and MockProvider gated with `#[cfg(any(test, feature = "test-support"))]` — compiled for unit tests (`test` cfg) and integration/CLI tests (feature flag), excluded from production builds.
- **8 core E2E tests** in `koda-core/tests/e2e_test.rs` — text streaming, Bash/Read/Write/Glob tool execution in sandboxed temp dirs, provider error propagation, multi-turn history persistence, Ctrl+C cancellation.
- **3 live smoke tests** in `koda-cli/tests/smoke_test.rs` — `#[ignore]` + `KODA_TEST_LMSTUDIO=1` gated. Test headless prompt, tool use, and session resume against a real LM Studio instance.
- **CI updated** to `cargo test --workspace --features koda-core/test-support`

Closes #60

## Test plan
- [x] All 8 E2E tests pass locally
- [x] Full workspace test suite passes (0 failures)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --features koda-core/test-support -- -D warnings` clean
- [x] Production build (`cargo build --workspace`) excludes mock/TestSink
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)