### PR TITLE
feat: TUI Phase 1 — inline input with tui-textarea + status bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -239,6 +239,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +369,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -484,17 +513,15 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "derive_more",
- "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -626,15 +653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1329,6 +1347,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1389,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1409,6 +1458,7 @@ dependencies = [
  "crossterm",
  "koda-core",
  "once_cell",
+ "ratatui",
  "rustyline",
  "serde",
  "serde_json",
@@ -1420,6 +1470,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "tui-textarea",
 ]
 
 [[package]]
@@ -1506,6 +1557,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1515,12 +1572,6 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1536,6 +1587,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1736,6 +1796,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -2025,6 +2091,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2309,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2229,7 +2329,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2331,7 +2431,7 @@ dependencies = [
  "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
  "utf8parse",
  "windows-sys 0.60.2",
 ]
@@ -2820,6 +2920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,11 +2950,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -2948,7 +3076,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3357,6 +3485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,10 +3552,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -30,15 +30,19 @@ tokio-util = { version = "0.7", features = ["rt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-# TUI / Terminal
-crossterm = "0.29"
+# TUI / Terminal (0.28 required for ratatui 0.29 / tui-textarea 0.7 compatibility)
+crossterm = "0.28"
 
 # Syntax highlighting
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "html", "regex-fancy"] }
 once_cell = "1"
 
-# REPL
+# REPL (legacy, behind --legacy flag)
 rustyline = "17"
+
+# TUI (inline viewport: input + status bar)
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
+tui-textarea = "0.7"
 
 # Logging (subscriber for CLI configuration)
 tracing = "0.1"

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -16,6 +16,8 @@ mod repl;
 mod server;
 mod sink;
 mod tui;
+mod tui_app;
+mod widgets;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -81,6 +83,10 @@ struct Cli {
     /// OpenAI reasoning effort (low, medium, high)
     #[arg(long)]
     reasoning_effort: Option<String>,
+
+    /// Use legacy readline-based input instead of TUI
+    #[arg(long)]
+    legacy: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -235,7 +241,11 @@ async fn main() -> Result<()> {
     };
 
     // Run the main event loop (pass version check handle for post-banner hint)
-    app::run(project_root, config, db, session_id, version_check).await
+    if cli.legacy {
+        app::run(project_root, config, db, session_id, version_check).await
+    } else {
+        tui_app::run(project_root, config, db, session_id, version_check).await
+    }
 }
 
 /// Resolve the headless prompt from -p flag, positional arg, or stdin pipe.

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -1,0 +1,863 @@
+//! TUI-based interactive event loop.
+//!
+//! Replaces the rustyline-based `app.rs` with `ratatui` + `tui-textarea`
+//! for inline input and status bar. All output (`display.rs`, `markdown.rs`)
+//! remains as `println!` to preserve native terminal scrollback.
+//!
+//! Architecture:
+//!   Input phase  -> ratatui Viewport::Inline(2) with tui-textarea + status bar
+//!   Output phase -> viewport cleared, normal println! (unchanged)
+
+use crate::input;
+use crate::repl::{self, ReplAction};
+use crate::sink::{UiEvent, UiRenderer};
+use crate::tui::{self, SelectOption};
+use crate::widgets::status_bar::StatusBar;
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use koda_core::agent::KodaAgent;
+use koda_core::approval::{self, ApprovalMode};
+use koda_core::config::KodaConfig;
+use koda_core::db::{Database, Role};
+use koda_core::engine::{ApprovalDecision, EngineCommand, EngineEvent};
+use koda_core::providers::LlmProvider;
+use koda_core::session::KodaSession;
+use ratatui::{
+    Terminal, TerminalOptions, Viewport,
+    backend::CrosstermBackend,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::sync::mpsc;
+use tui_textarea::TextArea;
+
+/// Height of the inline viewport (input line + status bar).
+const VIEWPORT_HEIGHT: u16 = 2;
+
+// ── Approval helper ──────────────────────────────────────────
+
+fn map_confirmation(c: crate::confirm::Confirmation) -> ApprovalDecision {
+    use crate::confirm::Confirmation;
+    match c {
+        Confirmation::Approved => ApprovalDecision::Approve,
+        Confirmation::Rejected => ApprovalDecision::Reject,
+        Confirmation::RejectedWithFeedback(fb) => {
+            ApprovalDecision::RejectWithFeedback { feedback: fb }
+        }
+        Confirmation::AlwaysAllow => ApprovalDecision::AlwaysAllow,
+    }
+}
+
+// ── Inline TUI input ─────────────────────────────────────────
+
+/// Result from the TUI input loop.
+enum InputResult {
+    /// User submitted text (may be empty).
+    Line(String),
+    /// User pressed Ctrl+D on empty buffer (EOF).
+    Eof,
+}
+
+/// Read user input via ratatui inline viewport with tui-textarea.
+///
+/// This function is blocking — it should be called via `spawn_blocking`.
+/// It creates a temporary ratatui terminal, handles key events, and cleans
+/// up before returning.
+fn read_input(model: &str, shared_mode: &approval::SharedMode) -> Result<InputResult> {
+    crossterm::terminal::enable_raw_mode()?;
+
+    let stdout = std::io::stdout();
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(VIEWPORT_HEIGHT),
+        },
+    )?;
+
+    let mut textarea = TextArea::default();
+    textarea.set_cursor_line_style(Style::default());
+    textarea.set_cursor_style(
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::REVERSED),
+    );
+    textarea.set_placeholder_text("Type a message...");
+    textarea.set_placeholder_style(Style::default().fg(Color::DarkGray));
+
+    let result = input_loop(&mut terminal, &mut textarea, shared_mode, model);
+
+    // Clean up: clear viewport, restore terminal
+    let _ = terminal.clear();
+    drop(terminal);
+    crossterm::terminal::disable_raw_mode()?;
+
+    // Erase the viewport lines left on screen
+    print!("\x1b[{}A\x1b[J", VIEWPORT_HEIGHT);
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+
+    result
+}
+
+/// Inner event loop for tui-textarea input.
+fn input_loop(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    textarea: &mut TextArea,
+    shared_mode: &approval::SharedMode,
+    model: &str,
+) -> Result<InputResult> {
+    loop {
+        let mode = approval::read_mode(shared_mode);
+        let context_pct = koda_core::context::percentage() as u32;
+
+        terminal.draw(|frame| {
+            let area = frame.area();
+            let [input_row, status_row] =
+                Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).areas(area);
+
+            // Prompt icon + textarea
+            let (icon, color) = match mode {
+                ApprovalMode::Plan => ("\u{1f4cb}", Color::Yellow),
+                ApprovalMode::Normal => ("\u{1f43b}", Color::Cyan),
+                ApprovalMode::Yolo => ("\u{26a1}", Color::Red),
+            };
+            let prompt_width: u16 = 4; // emoji(2) + >(1) + space(1)
+            let [prompt_area, text_area] =
+                Layout::horizontal([Constraint::Length(prompt_width), Constraint::Fill(1)])
+                    .areas(input_row);
+
+            frame.render_widget(
+                Paragraph::new(format!("{icon}> ")).style(Style::default().fg(color)),
+                prompt_area,
+            );
+            frame.render_widget(&*textarea, text_area);
+
+            // Status bar
+            frame.render_widget(StatusBar::new(model, mode.label(), context_pct), status_row);
+        })?;
+
+        // Block until next terminal event
+        let ev = event::read()?;
+
+        let handled = if let Event::Key(key) = &ev {
+            match (key.code, key.modifiers) {
+                // Enter → submit
+                (KeyCode::Enter, KeyModifiers::NONE) => {
+                    let text = textarea.lines().join("\n");
+                    return Ok(InputResult::Line(text));
+                }
+                // Esc → clear input
+                (KeyCode::Esc, _) => {
+                    textarea.select_all();
+                    textarea.cut();
+                    true
+                }
+                // Ctrl+C → clear input
+                (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
+                    textarea.select_all();
+                    textarea.cut();
+                    true
+                }
+                // Ctrl+D on empty → EOF
+                (KeyCode::Char('d'), m) if m.contains(KeyModifiers::CONTROL) => {
+                    if textarea.lines().join("").trim().is_empty() {
+                        return Ok(InputResult::Eof);
+                    }
+                    false // let textarea handle delete-forward
+                }
+                // Shift+Tab → cycle approval mode
+                (KeyCode::BackTab, _) => {
+                    approval::cycle_mode(shared_mode);
+                    true
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        if !handled {
+            textarea.input(ev);
+        }
+    }
+}
+
+// ── Main event loop ──────────────────────────────────────────
+
+/// Run the main interactive event loop with TUI input.
+pub async fn run(
+    project_root: PathBuf,
+    mut config: KodaConfig,
+    db: Database,
+    session_id: String,
+    version_check: tokio::task::JoinHandle<Option<String>>,
+) -> Result<()> {
+    // ── Setup (same as app.rs) ───────────────────────────────
+
+    // Restore last-used provider/model if available
+    let settings = koda_core::approval::Settings::load();
+    if let Some(ref last) = settings.last_provider {
+        let ptype =
+            koda_core::config::ProviderType::from_url_or_name("", Some(&last.provider_type));
+        config.provider_type = ptype;
+        config.base_url = last.base_url.clone();
+        config.model = last.model.clone();
+        config.model_settings.model = last.model.clone();
+    }
+
+    let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
+        Arc::new(RwLock::new(crate::commands::create_provider(&config)));
+
+    // Auto-detect the serving model for local providers
+    if config.model == "auto-detect" {
+        let prov = provider.read().await;
+        match prov.list_models().await {
+            Ok(models) if !models.is_empty() => {
+                config.model = models[0].id.clone();
+                config.model_settings.model = config.model.clone();
+                tracing::info!("Auto-detected model: {}", config.model);
+            }
+            Ok(_) => {
+                config.model = "(no model loaded)".to_string();
+                config.model_settings.model = config.model.clone();
+                eprintln!(
+                    "  \x1b[33m\u{26a0} No model loaded in {}.\x1b[0m",
+                    config.provider_type
+                );
+                eprintln!("    Load a model, then use \x1b[36m/model\x1b[0m to select it.");
+            }
+            Err(e) => {
+                config.model = "(connection failed)".to_string();
+                config.model_settings.model = config.model.clone();
+                eprintln!(
+                    "  \x1b[31m\u{2717} Could not connect to {} at {}\x1b[0m",
+                    config.provider_type, config.base_url
+                );
+                tracing::warn!("Auto-detect failed: {e}");
+            }
+        }
+    }
+
+    let recent = db.recent_user_messages(3).await.unwrap_or_default();
+    repl::print_banner(&config, &session_id, &recent);
+
+    // Show update hint if version check completed
+    if let Ok(Some(latest)) = version_check.await {
+        koda_core::version::print_update_hint(&latest);
+    }
+
+    // Build agent (tools, MCP, system prompt) and session
+    let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+    let mut session = KodaSession::new(
+        session_id.clone(),
+        agent.clone(),
+        db,
+        &config,
+        ApprovalMode::Normal,
+    );
+
+    let shared_mode = approval::new_shared_mode(ApprovalMode::Normal);
+
+    // ── Channels ─────────────────────────────────────────────
+
+    // Engine sink -> main loop (UI events)
+    let (ui_tx, mut ui_rx) = mpsc::channel::<UiEvent>(256);
+
+    // Main loop -> engine (approval responses)
+    let (cmd_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(32);
+
+    // ── Event loop ───────────────────────────────────────────
+
+    let mut renderer = UiRenderer::new();
+    let mut pending_command: Option<String> = None;
+    let mut silent_compact_deferred = false;
+
+    loop {
+        // ── Phase 1: Wait for input ──────────────────────────
+
+        let input = if let Some(cmd) = pending_command.take() {
+            cmd
+        } else {
+            let model = config.model.clone();
+            let mode_clone = shared_mode.clone();
+
+            match tokio::task::spawn_blocking(move || read_input(&model, &mode_clone)).await? {
+                Ok(InputResult::Line(text)) => {
+                    // Echo the prompt + input to scrollback
+                    let mode = approval::read_mode(&shared_mode);
+                    let prompt = repl::format_prompt(&config.model, mode);
+                    println!("{prompt}{text}");
+                    text
+                }
+                Ok(InputResult::Eof) => {
+                    println!("\x1b[36m\u{1f43b} Goodbye!\x1b[0m");
+                    break;
+                }
+                Err(e) => {
+                    eprintln!("Input error: {e}");
+                    break;
+                }
+            }
+        };
+
+        let input = input.trim().to_string();
+        if input.is_empty() {
+            continue;
+        }
+
+        // ── Phase 2: Handle slash commands ───────────────────
+
+        if input.starts_with('/') {
+            match repl::handle_command(&input, &config, &provider).await {
+                ReplAction::Quit => {
+                    println!("\x1b[36m\u{1f43b} Goodbye!\x1b[0m");
+                    break;
+                }
+                ReplAction::SwitchModel(model) => {
+                    config.model = model.clone();
+                    config.model_settings.model = model.clone();
+                    let mut s = koda_core::approval::Settings::load();
+                    let _ = s.save_last_provider(
+                        &config.provider_type.to_string(),
+                        &config.base_url,
+                        &config.model,
+                    );
+                    println!("  \x1b[32m\u{2713}\x1b[0m Model set to: \x1b[36m{model}\x1b[0m");
+                    continue;
+                }
+                ReplAction::PickModel => {
+                    let prov = provider.read().await;
+                    match prov.list_models().await {
+                        Ok(models) if models.is_empty() => {
+                            println!(
+                                "  \x1b[33mNo models available from {}\x1b[0m",
+                                prov.provider_name()
+                            );
+                        }
+                        Ok(models) => {
+                            drop(prov);
+                            let current_idx = models
+                                .iter()
+                                .position(|m| m.id == config.model)
+                                .unwrap_or(0);
+                            let options: Vec<SelectOption> = models
+                                .iter()
+                                .map(|m| {
+                                    let desc = if m.id == config.model {
+                                        "\u{25c0} current".to_string()
+                                    } else {
+                                        String::new()
+                                    };
+                                    SelectOption::new(&m.id, desc)
+                                })
+                                .collect();
+                            match tui::select("\u{1f43b} Select a model", &options, current_idx) {
+                                Ok(Some(idx)) => {
+                                    config.model = models[idx].id.clone();
+                                    config.model_settings.model = config.model.clone();
+                                    let mut s = koda_core::approval::Settings::load();
+                                    let _ = s.save_last_provider(
+                                        &config.provider_type.to_string(),
+                                        &config.base_url,
+                                        &config.model,
+                                    );
+                                    println!(
+                                        "  \x1b[32m\u{2713}\x1b[0m Model set to: \x1b[36m{}\x1b[0m",
+                                        config.model
+                                    );
+                                }
+                                Ok(None) => println!("  \x1b[90mCancelled.\x1b[0m"),
+                                Err(e) => println!("  \x1b[31mTUI error: {e}\x1b[0m"),
+                            }
+                        }
+                        Err(e) => println!("  \x1b[31mFailed to list models: {e}\x1b[0m"),
+                    }
+                    continue;
+                }
+                ReplAction::SetupProvider(ptype, base_url) => {
+                    crate::commands::handle_setup_provider(&mut config, &provider, ptype, base_url)
+                        .await;
+                    continue;
+                }
+                ReplAction::PickProvider => {
+                    crate::commands::handle_pick_provider(&mut config, &provider).await;
+                    continue;
+                }
+                ReplAction::ShowHelp => {
+                    let commands = [
+                        ("/agent", "List available sub-agents"),
+                        ("/compact", "Summarize conversation to reclaim context"),
+                        ("/cost", "Show token usage for this session"),
+                        ("/diff", "Show git diff / review / commit message"),
+                        ("/expand", "Show full output of last tool call (/expand N)"),
+                        ("/mcp", "MCP servers: status / add / remove / restart"),
+                        ("/memory", "View/save project & global memory"),
+                        ("/model", "Pick a model interactively"),
+                        ("/provider", "Switch LLM provider"),
+                        ("/sessions", "List/resume/delete sessions"),
+                        ("/trust", "Set approval mode (always / auto / never)"),
+                        ("/verbose", "Toggle full tool output (on/off)"),
+                        ("/exit", "Quit the session"),
+                    ];
+                    let options: Vec<SelectOption> = commands
+                        .iter()
+                        .map(|(cmd, desc)| SelectOption::new(*cmd, *desc))
+                        .collect();
+                    if let Ok(Some(idx)) = tui::select("\u{1f43b} Commands", &options, 0) {
+                        let (cmd, _) = commands[idx];
+                        pending_command = Some(cmd.to_string());
+                    }
+                    println!();
+                    println!(
+                        "  \x1b[90mTips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit\x1b[0m"
+                    );
+                    continue;
+                }
+                ReplAction::ShowCost => {
+                    match session.db.session_token_usage(&session.id).await {
+                        Ok(u) => {
+                            let total = u.prompt_tokens
+                                + u.completion_tokens
+                                + u.cache_read_tokens
+                                + u.cache_creation_tokens;
+                            println!();
+                            println!("  \x1b[1m\u{1f43b} Session Cost\x1b[0m");
+                            println!();
+                            println!("  Prompt tokens:     \x1b[36m{:>8}\x1b[0m", u.prompt_tokens);
+                            println!(
+                                "  Completion tokens: \x1b[36m{:>8}\x1b[0m",
+                                u.completion_tokens
+                            );
+                            if u.cache_read_tokens > 0 {
+                                println!(
+                                    "  Cache read tokens: \x1b[32m{:>8}\x1b[0m",
+                                    u.cache_read_tokens
+                                );
+                            }
+                            if u.cache_creation_tokens > 0 {
+                                println!(
+                                    "  Cache write tokens:\x1b[33m{:>8}\x1b[0m",
+                                    u.cache_creation_tokens
+                                );
+                            }
+                            if u.thinking_tokens > 0 {
+                                println!(
+                                    "  Thinking tokens:   \x1b[35m{:>8}\x1b[0m",
+                                    u.thinking_tokens
+                                );
+                            }
+                            println!("  Total tokens:      \x1b[1m{total:>8}\x1b[0m");
+                            println!("  API calls:         \x1b[90m{:>8}\x1b[0m", u.api_calls);
+                            println!();
+                            println!("  \x1b[90mModel: {}\x1b[0m", config.model);
+                            println!("  \x1b[90mProvider: {}\x1b[0m", config.provider_type);
+                        }
+                        Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
+                    }
+                    continue;
+                }
+                ReplAction::ListSessions => {
+                    match session.db.list_sessions(10, &project_root).await {
+                        Ok(sessions) if sessions.is_empty() => {
+                            println!("  \x1b[90mNo other sessions found.\x1b[0m");
+                        }
+                        Ok(sessions) => {
+                            let current_idx = sessions
+                                .iter()
+                                .position(|s| s.id == session.id)
+                                .unwrap_or(0);
+                            let options: Vec<SelectOption> = sessions
+                                .iter()
+                                .map(|s| {
+                                    let desc = if s.id == session.id {
+                                        format!(
+                                            "{}  {} msgs  {}k tokens  \u{25c0} current",
+                                            s.created_at,
+                                            s.message_count,
+                                            s.total_tokens / 1000
+                                        )
+                                    } else {
+                                        format!(
+                                            "{}  {} msgs  {}k tokens",
+                                            s.created_at,
+                                            s.message_count,
+                                            s.total_tokens / 1000
+                                        )
+                                    };
+                                    SelectOption::new(&s.id[..8], desc)
+                                })
+                                .collect();
+                            match tui::select("\u{1f43b} Sessions", &options, current_idx) {
+                                Ok(Some(idx)) => {
+                                    let target = &sessions[idx];
+                                    if target.id == session.id {
+                                        println!("  \x1b[90mAlready in this session.\x1b[0m");
+                                    } else {
+                                        session.id = target.id.clone();
+                                        println!(
+                                            "  \x1b[32m\u{2713}\x1b[0m Resumed session \x1b[36m{}\x1b[0m  \x1b[90m{}  {} msgs\x1b[0m",
+                                            &target.id[..8],
+                                            target.created_at,
+                                            target.message_count,
+                                        );
+                                    }
+                                }
+                                Ok(None) => println!("  \x1b[90mCancelled.\x1b[0m"),
+                                Err(e) => println!("  \x1b[31mTUI error: {e}\x1b[0m"),
+                            }
+                            println!("  \x1b[90mDelete: /sessions delete <id>\x1b[0m");
+                        }
+                        Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
+                    }
+                    continue;
+                }
+                ReplAction::DeleteSession(ref id) => {
+                    if id == &session.id {
+                        println!("  \x1b[31mCannot delete the current session.\x1b[0m");
+                    } else {
+                        match session.db.list_sessions(100, &project_root).await {
+                            Ok(sessions) => {
+                                let matches: Vec<_> =
+                                    sessions.iter().filter(|s| s.id.starts_with(id)).collect();
+                                match matches.len() {
+                                    0 => println!(
+                                        "  \x1b[31mNo session found matching '{id}'.\x1b[0m"
+                                    ),
+                                    1 => {
+                                        let full_id = &matches[0].id;
+                                        match session.db.delete_session(full_id).await {
+                                            Ok(true) => println!(
+                                                "  \x1b[32m\u{2713}\x1b[0m Deleted session {}",
+                                                &full_id[..8]
+                                            ),
+                                            Ok(false) => {
+                                                println!("  \x1b[31mSession not found.\x1b[0m")
+                                            }
+                                            Err(e) => {
+                                                println!("  \x1b[31mError: {e}\x1b[0m")
+                                            }
+                                        }
+                                    }
+                                    n => println!(
+                                        "  \x1b[31mAmbiguous: '{id}' matches {n} sessions. Be more specific.\x1b[0m"
+                                    ),
+                                }
+                            }
+                            Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
+                        }
+                    }
+                    continue;
+                }
+                ReplAction::ResumeSession(ref id) => {
+                    if session.id.starts_with(id) {
+                        println!("  \x1b[90mAlready in this session.\x1b[0m");
+                    } else {
+                        match session.db.list_sessions(100, &project_root).await {
+                            Ok(sessions) => {
+                                let matches: Vec<_> =
+                                    sessions.iter().filter(|s| s.id.starts_with(id)).collect();
+                                match matches.len() {
+                                    0 => println!(
+                                        "  \x1b[31mNo session found matching '{id}'.\x1b[0m"
+                                    ),
+                                    1 => {
+                                        let target = &matches[0];
+                                        session.id = target.id.clone();
+                                        println!(
+                                            "  \x1b[32m\u{2713}\x1b[0m Resumed session \x1b[36m{}\x1b[0m  \x1b[90m{}  {} msgs\x1b[0m",
+                                            &target.id[..8],
+                                            target.created_at,
+                                            target.message_count,
+                                        );
+                                    }
+                                    n => println!(
+                                        "  \x1b[31mAmbiguous: '{id}' matches {n} sessions. Be more specific.\x1b[0m"
+                                    ),
+                                }
+                            }
+                            Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
+                        }
+                    }
+                    continue;
+                }
+                ReplAction::InjectPrompt(prompt) => {
+                    pending_command = Some(prompt);
+                    continue;
+                }
+                ReplAction::Compact => {
+                    crate::commands::handle_compact(
+                        &session.db,
+                        &session.id,
+                        &config,
+                        &provider,
+                        false,
+                    )
+                    .await;
+                    continue;
+                }
+                ReplAction::McpCommand(ref args) => {
+                    crate::commands::handle_mcp_command(args, &agent.mcp_registry, &project_root)
+                        .await;
+                    continue;
+                }
+                ReplAction::SetTrust(mode_name) => {
+                    let new_mode = if let Some(ref name) = mode_name {
+                        ApprovalMode::parse(name)
+                    } else {
+                        crate::commands::pick_trust_mode(approval::read_mode(&shared_mode))
+                    };
+                    if let Some(m) = new_mode {
+                        approval::set_mode(&shared_mode, m);
+                        println!(
+                            "  \x1b[32m\u{2713}\x1b[0m Trust: \x1b[1m{}\x1b[0m \u{2014} {}",
+                            m.label(),
+                            m.description()
+                        );
+                    } else if let Some(ref name) = mode_name {
+                        println!(
+                            "  \x1b[31m\u{2717}\x1b[0m Unknown trust level '{}'. Use: plan, normal, yolo",
+                            name
+                        );
+                    }
+                    continue;
+                }
+                ReplAction::Expand(n) => {
+                    match renderer.tool_history.get(n) {
+                        Some(record) => {
+                            crate::display::print_tool_output_full(record);
+                        }
+                        None => {
+                            let total = renderer.tool_history.len();
+                            if total == 0 {
+                                println!("  \x1b[90mNo tool outputs recorded yet.\x1b[0m");
+                            } else {
+                                println!(
+                                    "  \x1b[33mNo tool output #{n}. Have {total} recorded (use /expand 1\u{2013}{total}).\x1b[0m"
+                                );
+                            }
+                        }
+                    }
+                    continue;
+                }
+                ReplAction::Verbose(v) => {
+                    renderer.verbose = match v {
+                        Some(val) => val,
+                        None => !renderer.verbose,
+                    };
+                    let state = if renderer.verbose { "on" } else { "off" };
+                    println!("  \x1b[36mVerbose tool output: {state}\x1b[0m");
+                    continue;
+                }
+                ReplAction::Handled => continue,
+                ReplAction::NotACommand => {}
+            }
+        }
+
+        // ── Phase 3: Prepare and run inference turn ──────────
+
+        // Process @file references
+        let processed = input::process_input(&input, &project_root);
+        if !processed.images.is_empty() {
+            for (i, _img) in processed.images.iter().enumerate() {
+                println!("  \x1b[35m\u{1f5bc} Image {}\x1b[0m", i + 1);
+            }
+        }
+
+        let user_message =
+            if let Some(context) = input::format_context_files(&processed.context_files) {
+                if !processed.context_files.is_empty() {
+                    for f in &processed.context_files {
+                        println!("  \x1b[36m\u{1f4ce} {}\x1b[0m", f.path);
+                    }
+                }
+                format!("{}\n\n{context}", processed.prompt)
+            } else {
+                processed.prompt.clone()
+            };
+
+        if let Err(e) = session
+            .db
+            .insert_message(
+                &session.id,
+                &Role::User,
+                Some(&user_message),
+                None,
+                None,
+                None,
+            )
+            .await
+        {
+            tracing::warn!("Failed to persist user message: {e}");
+        }
+
+        let pending_images = if processed.images.is_empty() {
+            None
+        } else {
+            Some(processed.images)
+        };
+
+        // Sync session state
+        session.mode = approval::read_mode(&shared_mode);
+        session.update_provider(&config);
+
+        // Create a channel-forwarding sink for this turn
+        let cli_sink = crate::sink::CliSink::channel(ui_tx.clone());
+
+        // Clone the cancel token so we can trigger it from the Ctrl+C branch
+        let cancel_token = session.cancel.clone();
+
+        // Run turn
+        {
+            let turn = session.run_turn(
+                &config,
+                pending_images,
+                &cli_sink,
+                &mut cmd_rx,
+                &cli_loop_continue_prompt,
+            );
+            tokio::pin!(turn);
+
+            loop {
+                tokio::select! {
+                    result = &mut turn => {
+                        if let Err(e) = result {
+                            println!("\n  \x1b[31m\u{2717} Turn failed: {e}\x1b[0m");
+                        }
+                        break;
+                    }
+                    Some(ui_event) = ui_rx.recv() => {
+                        match ui_event {
+                            UiEvent::Engine(EngineEvent::ApprovalRequest {
+                                id,
+                                tool_name,
+                                detail,
+                                preview,
+                                whitelist_hint,
+                            }) => {
+                                if preview.is_some() {
+                                    renderer.preview_shown = true;
+                                }
+                                let decision = map_confirmation(
+                                    crate::confirm::confirm_tool_action(
+                                        &tool_name,
+                                        &detail,
+                                        preview.as_deref(),
+                                        whitelist_hint.as_deref(),
+                                    ),
+                                );
+                                let _ = cmd_tx
+                                    .send(EngineCommand::ApprovalResponse { id, decision })
+                                    .await;
+                            }
+                            UiEvent::Engine(ref event) => {
+                                renderer.render(event.clone());
+                            }
+                        }
+                    }
+                    _ = tokio::signal::ctrl_c() => {
+                        if crate::interrupt::handle_sigint() {
+                            eprintln!("\n\x1b[31mForce quit.\x1b[0m");
+                            std::process::exit(130);
+                        }
+                        cancel_token.cancel();
+                    }
+                }
+            }
+        }
+
+        // Drain remaining UI events
+        while let Ok(UiEvent::Engine(e)) = ui_rx.try_recv() {
+            renderer.render(e);
+        }
+        renderer.stop_spinner();
+
+        crate::interrupt::reset();
+        session.cancel = tokio_util::sync::CancellationToken::new();
+
+        // Auto-compact when context window gets crowded
+        if config.auto_compact_threshold > 0 {
+            let ctx_pct = koda_core::context::percentage();
+            if ctx_pct >= config.auto_compact_threshold {
+                let pending = session
+                    .db
+                    .has_pending_tool_calls(&session.id)
+                    .await
+                    .unwrap_or(false);
+                if pending {
+                    if !silent_compact_deferred {
+                        println!();
+                        println!(
+                            "  \x1b[33m\u{1f43b} Context at {ctx_pct}% \u{2014} deferring compact (tool calls pending)\x1b[0m"
+                        );
+                        silent_compact_deferred = true;
+                    }
+                } else {
+                    silent_compact_deferred = false;
+                    println!();
+                    println!(
+                        "  \x1b[36m\u{1f43b} Context at {ctx_pct}% \u{2014} auto-compacting...\x1b[0m"
+                    );
+                    crate::commands::handle_compact(
+                        &session.db,
+                        &session.id,
+                        &config,
+                        &provider,
+                        true,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+
+    // Shut down MCP servers
+    {
+        let mut mcp = agent.mcp_registry.write().await;
+        mcp.shutdown();
+    }
+
+    println!(
+        "\n\x1b[90mResume this session with:\n  koda --resume {}\x1b[0m",
+        session.id
+    );
+
+    Ok(())
+}
+
+// ── Utilities ─────────────────────────────────────────────────
+
+/// CLI implementation of the loop-continue prompt.
+/// Shows a terminal select widget when the hard cap is hit.
+fn cli_loop_continue_prompt(
+    cap: u32,
+    recent_names: &[String],
+) -> koda_core::loop_guard::LoopContinuation {
+    use koda_core::loop_guard::LoopContinuation;
+
+    println!("\n  \x1b[33m\u{26a0}  Hard cap reached ({cap} iterations).\x1b[0m");
+
+    if !recent_names.is_empty() {
+        println!("  Last tool calls:");
+        for name in recent_names {
+            println!("    \x1b[90m\u{25cf}\x1b[0m {name}");
+        }
+    }
+    println!();
+
+    let options = vec![
+        SelectOption::new("Stop", "End the task here"),
+        SelectOption::new("+50 more", "Continue for 50 more iterations"),
+        SelectOption::new("+200 more", "Continue for 200 more iterations"),
+    ];
+
+    match crate::tui::select("Continue?", &options, 0) {
+        Ok(Some(1)) => LoopContinuation::Continue50,
+        Ok(Some(2)) => LoopContinuation::Continue200,
+        _ => LoopContinuation::Stop,
+    }
+}

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -1,0 +1,1 @@
+pub mod status_bar;

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -1,0 +1,72 @@
+//! Status bar widget for the inline TUI viewport.
+//!
+//! Shows: model name | approval mode | context usage bar
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::Widget,
+};
+
+pub struct StatusBar<'a> {
+    model: &'a str,
+    mode_label: &'a str,
+    context_pct: u32,
+}
+
+impl<'a> StatusBar<'a> {
+    pub fn new(model: &'a str, mode_label: &'a str, context_pct: u32) -> Self {
+        Self {
+            model,
+            mode_label,
+            context_pct,
+        }
+    }
+}
+
+impl Widget for StatusBar<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let mode_color = match self.mode_label {
+            "plan" => Color::Yellow,
+            "yolo" => Color::Red,
+            _ => Color::Cyan,
+        };
+
+        let bar_width: u32 = 10;
+        let filled = (self.context_pct * bar_width / 100).min(bar_width);
+        let empty = bar_width - filled;
+        let ctx_color = if self.context_pct >= 90 {
+            Color::Red
+        } else if self.context_pct >= 75 {
+            Color::Yellow
+        } else {
+            Color::DarkGray
+        };
+
+        let line = Line::from(vec![
+            Span::styled(
+                format!(" {} ", self.model),
+                Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled("\u{2502}", Style::default().fg(Color::Rgb(60, 60, 60))),
+            Span::styled(
+                format!(" {} ", self.mode_label),
+                Style::default().fg(mode_color),
+            ),
+            Span::styled("\u{2502}", Style::default().fg(Color::Rgb(60, 60, 60))),
+            Span::styled(
+                format!(
+                    " {}{} {}%",
+                    "\u{2588}".repeat(filled as usize),
+                    "\u{2591}".repeat(empty as usize),
+                    self.context_pct,
+                ),
+                Style::default().fg(ctx_color),
+            ),
+        ]);
+
+        line.render(area, buf);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the TUI redesign (#70): replaces `rustyline` with `ratatui` `Viewport::Inline(2)` + `tui-textarea` for REPL input, plus a status bar.

- **New input**: `tui-textarea` in a 2-line inline viewport (input line + status bar)
- **Status bar**: shows model name, approval mode (plan/normal/yolo), and context usage meter
- **Key bindings**: Enter (submit), Esc/Ctrl+C (clear), Ctrl+D (exit), Shift+Tab (cycle approval mode)
- **`--legacy` flag**: falls back to the old rustyline-based input for safety
- **No output changes**: all `println!` rendering (display.rs, markdown.rs, sink.rs) is untouched
- **No core changes**: `koda-core` is completely untouched

### New files
- `koda-cli/src/tui_app.rs` — ratatui event loop (parallel to `app.rs`)
- `koda-cli/src/widgets/mod.rs` + `status_bar.rs` — inline status bar widget

### Changed files
- `koda-cli/Cargo.toml` — add ratatui 0.29, tui-textarea 0.7; downgrade crossterm 0.29→0.28 for compatibility
- `koda-cli/src/main.rs` — add `--legacy` flag, wire up `tui_app::run()`

### Architecture
```
Normal terminal output (println!)     ← Scrollback preserved
  ├── Tool banners, markdown, diffs   ← Existing display.rs / markdown.rs
  └── All EngineEvent rendering       ← Existing UiRenderer

┌─ ratatui Viewport::Inline(2) ──────┐
│ 🐻> input text here_                │ ← tui-textarea widget
│ model │ normal │ ████░░ 5%          │ ← Status bar widget
└──────────────────────────────────────┘
```

## Test plan

- [x] `cargo test --workspace --features koda-core/test-support` — all 351 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] Manual: `cargo run -p koda-cli` — verify TUI input renders, typing works, Enter submits
- [ ] Manual: `cargo run -p koda-cli -- --legacy` — verify rustyline fallback works
- [ ] Manual: verify Shift+Tab cycles mode in status bar
- [ ] Manual: verify Ctrl+D exits, Esc/Ctrl+C clears input
- [ ] Manual: verify slash commands (/help, /model, /cost) work through TUI input

Closes #70 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)