### PR TITLE
refactor: structured diff preview with syntax highlighting (#68)

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -700,7 +700,7 @@ pub async fn run(
                                     crate::confirm::confirm_tool_action(
                                         &tool_name,
                                         &detail,
-                                        preview.as_deref(),
+                                        preview.as_ref(),
                                         whitelist_hint.as_deref(),
                                     ),
                                 );

--- a/koda-cli/src/confirm.rs
+++ b/koda-cli/src/confirm.rs
@@ -32,7 +32,7 @@ pub enum Confirmation {
 pub fn confirm_tool_action(
     _tool_name: &str,
     detail: &str,
-    preview: Option<&str>,
+    preview: Option<&koda_core::preview::DiffPreview>,
     whitelist_hint: Option<&str>,
 ) -> Confirmation {
     // Show the action details
@@ -40,9 +40,10 @@ pub fn confirm_tool_action(
     println!("  \x1b[90m{detail}\x1b[0m");
 
     // Show diff preview if available
-    if let Some(preview_text) = preview {
+    if let Some(preview) = preview {
         println!();
-        for line in preview_text.lines() {
+        let rendered = crate::diff_render::render(preview);
+        for line in rendered.lines() {
             println!("  {line}");
         }
     }

--- a/koda-cli/src/diff_render.rs
+++ b/koda-cli/src/diff_render.rs
@@ -1,0 +1,352 @@
+//! Diff preview renderer with syntax highlighting and word-level diffs.
+//!
+//! Takes structured [`DiffPreview`] data from koda-core and produces
+//! ANSI-colored terminal output with:
+//! - Dark background tint for line-level diffs (red removed, green added)
+//! - Brighter background for the changed words within a line
+//! - Syntax highlighting (foreground colors via syntect)
+
+use crate::highlight::CodeHighlighter;
+use koda_core::preview::{
+    DeleteDirPreview, DeleteFilePreview, DiffPreview, EditPreview, WriteOverwritePreview,
+    WritePreview,
+};
+
+const LINE_RED: &str = "\x1b[48;2;80;0;0m"; // dark red bg — removed line
+const LINE_GREEN: &str = "\x1b[48;2;0;60;0m"; // dark green bg — added line
+const WORD_RED: &str = "\x1b[48;2;130;15;15m"; // brighter red — changed word
+const WORD_GREEN: &str = "\x1b[48;2;15;100;15m"; // brighter green — changed word
+const DIM: &str = "\x1b[90m";
+const RESET: &str = "\x1b[0m";
+
+/// Render a [`DiffPreview`] as ANSI-colored terminal output.
+pub fn render(preview: &DiffPreview) -> String {
+    match preview {
+        DiffPreview::Edit(edit) => render_edit(edit),
+        DiffPreview::WriteNew(w) => render_write_new(w),
+        DiffPreview::WriteOverwrite(w) => render_write_overwrite(w),
+        DiffPreview::DeleteFile(d) => render_delete_file(d),
+        DiffPreview::DeleteDir(d) => render_delete_dir(d),
+        DiffPreview::FileNotYetExists => format!("{DIM}(file does not exist yet){RESET}"),
+        DiffPreview::PathNotFound => format!("{DIM}(path does not exist){RESET}"),
+    }
+}
+
+fn render_edit(edit: &EditPreview) -> String {
+    let ext = std::path::Path::new(&edit.path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+
+    let mut lines = Vec::new();
+
+    for r in &edit.replacements {
+        if r.total > 1 {
+            lines.push(format!(
+                "{DIM}── replacement {}/{} ──{RESET}",
+                r.index + 1,
+                r.total
+            ));
+        }
+
+        let pair_count = r.old_lines.len().min(r.new_lines.len());
+        let mut hl_old = CodeHighlighter::new(ext);
+        let mut hl_new = CodeHighlighter::new(ext);
+
+        // Paired lines: intra-line word highlighting + syntax
+        for j in 0..pair_count {
+            let (pre_bytes, suf_bytes_old, suf_bytes_new) =
+                common_prefix_suffix(&r.old_lines[j], &r.new_lines[j]);
+
+            let old_hl = highlight_for_diff(&mut hl_old, &r.old_lines[j]);
+            let new_hl = highlight_for_diff(&mut hl_new, &r.new_lines[j]);
+
+            let changed_end_old = r.old_lines[j].len() - suf_bytes_old;
+            let changed_end_new = r.new_lines[j].len() - suf_bytes_new;
+
+            let old_rendered =
+                inject_word_highlight(&old_hl, pre_bytes, changed_end_old, LINE_RED, WORD_RED);
+            let new_rendered =
+                inject_word_highlight(&new_hl, pre_bytes, changed_end_new, LINE_GREEN, WORD_GREEN);
+
+            lines.push(format!(
+                "{LINE_RED}{:>4} -\t{old_rendered}{RESET}",
+                r.start_line + j
+            ));
+            lines.push(format!(
+                "{LINE_GREEN}{:>4} +\t{new_rendered}{RESET}",
+                r.start_line + j
+            ));
+        }
+
+        // Remaining old lines (pure deletions)
+        for (j, line) in r.old_lines.iter().enumerate().skip(pair_count) {
+            let hl = highlight_for_diff(&mut hl_old, line);
+            lines.push(format!("{LINE_RED}{:>4} -\t{hl}{RESET}", r.start_line + j,));
+        }
+
+        // Remaining new lines (pure additions)
+        for (j, line) in r.new_lines.iter().enumerate().skip(pair_count) {
+            let hl = highlight_for_diff(&mut hl_new, line);
+            lines.push(format!(
+                "{LINE_GREEN}{:>4} +\t{hl}{RESET}",
+                r.start_line + j,
+            ));
+        }
+    }
+
+    if edit.truncated_count > 0 {
+        lines.push(format!(
+            "{DIM}... and {} more replacement(s){RESET}",
+            edit.truncated_count
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_write_new(w: &WritePreview) -> String {
+    let mut lines = vec![format!(
+        "{DIM}New file: {} lines ({} bytes){RESET}",
+        w.line_count, w.byte_count
+    )];
+    for line in &w.first_lines {
+        lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
+    }
+    if w.truncated {
+        lines.push(format!(
+            "{DIM}... +{} more lines{RESET}",
+            w.line_count - w.first_lines.len()
+        ));
+    }
+    lines.join("\n")
+}
+
+fn render_write_overwrite(w: &WriteOverwritePreview) -> String {
+    let mut lines = vec![format!(
+        "{DIM}Overwriting {} lines ({} bytes) → {} lines ({} bytes){RESET}",
+        w.old_line_count, w.old_byte_count, w.new_line_count, w.new_byte_count
+    )];
+    for line in &w.first_lines {
+        lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
+    }
+    if w.truncated {
+        lines.push(format!(
+            "{DIM}... +{} more lines{RESET}",
+            w.new_line_count - w.first_lines.len()
+        ));
+    }
+    lines.join("\n")
+}
+
+fn render_delete_file(d: &DeleteFilePreview) -> String {
+    format!(
+        "{LINE_RED}Removing {} lines ({} bytes){RESET}",
+        d.line_count, d.byte_count
+    )
+}
+
+fn render_delete_dir(d: &DeleteDirPreview) -> String {
+    if d.recursive {
+        format!("{LINE_RED}Removing directory and all contents{RESET}")
+    } else {
+        format!("{LINE_RED}Removing empty directory{RESET}")
+    }
+}
+
+// ── Syntax highlighting helpers ───────────────────────────────
+
+/// Syntax-highlight a line for diff display.
+///
+/// Strips the trailing `\x1b[0m` that [`CodeHighlighter::highlight_line`]
+/// appends, because the caller manages reset/background itself.
+fn highlight_for_diff(hl: &mut CodeHighlighter, line: &str) -> String {
+    let output = hl.highlight_line(line);
+    output
+        .strip_suffix("\x1b[0m")
+        .unwrap_or(&output)
+        .to_string()
+}
+
+// ── Intra-line word diff ──────────────────────────────────────
+
+/// Walk `syntect_output` (foreground ANSI codes interleaved with raw text)
+/// and inject word-level background at the raw byte offsets
+/// `changed_start..changed_end`.
+///
+/// syntect only emits `\x1b[38;2;…m` (foreground), so our background
+/// codes persist through them. We switch from `line_bg` to `word_bg` at
+/// the changed region and back.
+fn inject_word_highlight(
+    syntect_output: &str,
+    changed_start: usize,
+    changed_end: usize,
+    line_bg: &str,
+    word_bg: &str,
+) -> String {
+    if changed_start >= changed_end {
+        return syntect_output.to_string();
+    }
+
+    let mut result = String::with_capacity(syntect_output.len() + 64);
+    let mut raw_bytes = 0usize;
+    let mut in_word = false;
+    let mut chars = syntect_output.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            // Consume the ANSI escape sequence without advancing raw_bytes
+            result.push(ch);
+            for ec in chars.by_ref() {
+                result.push(ec);
+                if ec == 'm' {
+                    break;
+                }
+            }
+        } else {
+            if !in_word && raw_bytes == changed_start {
+                result.push_str(word_bg);
+                in_word = true;
+            }
+            if in_word && raw_bytes == changed_end {
+                result.push_str(line_bg);
+                in_word = false;
+            }
+            result.push(ch);
+            raw_bytes += ch.len_utf8();
+        }
+    }
+
+    if in_word {
+        result.push_str(line_bg);
+    }
+
+    result
+}
+
+/// Find byte lengths of the common prefix and suffix between two strings.
+///
+/// Returns `(prefix_bytes, suffix_bytes_old, suffix_bytes_new)`.
+fn common_prefix_suffix(old: &str, new: &str) -> (usize, usize, usize) {
+    let prefix_chars = old
+        .chars()
+        .zip(new.chars())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let prefix_bytes = old
+        .char_indices()
+        .nth(prefix_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(old.len());
+
+    let old_rest: Vec<char> = old[prefix_bytes..].chars().collect();
+    let new_rest: Vec<char> = new[prefix_bytes..].chars().collect();
+
+    let suffix_chars = old_rest
+        .iter()
+        .rev()
+        .zip(new_rest.iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let suffix_bytes_old: usize = old_rest
+        .iter()
+        .rev()
+        .take(suffix_chars)
+        .map(|c| c.len_utf8())
+        .sum();
+    let suffix_bytes_new: usize = new_rest
+        .iter()
+        .rev()
+        .take(suffix_chars)
+        .map(|c| c.len_utf8())
+        .sum();
+
+    (prefix_bytes, suffix_bytes_old, suffix_bytes_new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use koda_core::preview::{EditPreview, ReplacementPreview};
+
+    #[test]
+    fn test_render_edit_has_syntax_and_word_highlight() {
+        let preview = DiffPreview::Edit(EditPreview {
+            path: "test.rs".into(),
+            replacements: vec![ReplacementPreview {
+                index: 0,
+                total: 1,
+                start_line: 2,
+                old_lines: vec!["println!(\"hello\");".into()],
+                new_lines: vec!["println!(\"world\");".into()],
+            }],
+            truncated_count: 0,
+        });
+        let rendered = render(&preview);
+
+        // Line numbers present
+        assert!(
+            rendered.contains("2 -\t"),
+            "should have line number for removed"
+        );
+        assert!(
+            rendered.contains("2 +\t"),
+            "should have line number for added"
+        );
+
+        // Line-level backgrounds
+        assert!(rendered.contains(LINE_RED), "removed line background");
+        assert!(rendered.contains(LINE_GREEN), "added line background");
+
+        // Word-level highlights for the changed region
+        assert!(
+            rendered.contains(WORD_RED),
+            "changed word highlight in removed"
+        );
+        assert!(
+            rendered.contains(WORD_GREEN),
+            "changed word highlight in added"
+        );
+
+        // Syntax highlighting: .rs extension → syntect should add foreground codes
+        assert!(
+            rendered.contains("\x1b[38;2;"),
+            "should have syntect foreground colors"
+        );
+    }
+
+    #[test]
+    fn test_inject_word_highlight_no_change() {
+        let result = inject_word_highlight("hello world", 5, 5, LINE_RED, WORD_RED);
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_inject_word_highlight_with_change() {
+        let result = inject_word_highlight("hello world", 0, 5, LINE_RED, WORD_RED);
+        assert!(result.contains(WORD_RED));
+        assert!(result.contains(LINE_RED));
+        assert!(result.contains("hello"));
+    }
+
+    #[test]
+    fn test_common_prefix_suffix_basic() {
+        let (pre, suf_old, suf_new) = common_prefix_suffix("hello world", "hello earth");
+        assert_eq!(pre, 6); // "hello " is common
+        assert_eq!(suf_old, 0);
+        assert_eq!(suf_new, 0);
+    }
+
+    #[test]
+    fn test_common_prefix_suffix_with_suffix() {
+        let (pre, suf_old, suf_new) =
+            common_prefix_suffix("println!(\"hello\");", "println!(\"world\");");
+        // Common prefix: "println!("
+        assert_eq!(pre, 10);
+        // Common suffix: ");"  — wait, actually `");` (3 bytes)
+        assert_eq!(suf_old, 3);
+        assert_eq!(suf_new, 3);
+    }
+}

--- a/koda-cli/src/diff_render.rs
+++ b/koda-cli/src/diff_render.rs
@@ -12,10 +12,10 @@ use koda_core::preview::{
     WritePreview,
 };
 
-const LINE_RED: &str = "\x1b[48;2;80;0;0m"; // dark red bg — removed line
-const LINE_GREEN: &str = "\x1b[48;2;0;60;0m"; // dark green bg — added line
-const WORD_RED: &str = "\x1b[48;2;130;15;15m"; // brighter red — changed word
-const WORD_GREEN: &str = "\x1b[48;2;15;100;15m"; // brighter green — changed word
+const LINE_RED: &str = "\x1b[48;2;50;0;0m"; // dark red bg — removed line
+const LINE_GREEN: &str = "\x1b[48;2;0;35;0m"; // dark green bg — added line
+const WORD_RED: &str = "\x1b[48;2;100;0;0m"; // brighter red — changed word
+const WORD_GREEN: &str = "\x1b[48;2;0;70;0m"; // brighter green — changed word
 const DIM: &str = "\x1b[90m";
 const RESET: &str = "\x1b[0m";
 

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -5,6 +5,7 @@
 mod app;
 mod commands;
 mod confirm;
+mod diff_render;
 mod display;
 mod headless;
 mod highlight;

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -124,8 +124,9 @@ impl UiRenderer {
                 preview,
             } => {
                 println!("  \x1b[33m\u{1f4cb} Would execute: {detail}\x1b[0m");
-                if let Some(preview_text) = preview {
-                    for line in preview_text.lines() {
+                if let Some(ref preview) = preview {
+                    let rendered = crate::diff_render::render(preview);
+                    for line in rendered.lines() {
                         println!("  {line}");
                     }
                 }
@@ -296,7 +297,7 @@ impl EngineSink for CliSink {
                     let decision = match confirm::confirm_tool_action(
                         tool_name,
                         detail,
-                        preview.as_deref(),
+                        preview.as_ref(),
                         whitelist_hint.as_deref(),
                     ) {
                         Confirmation::Approved => ApprovalDecision::Approve,

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -746,7 +746,7 @@ pub async fn run(
                                     crate::confirm::confirm_tool_action(
                                         &tool_name,
                                         &detail,
-                                        preview.as_deref(),
+                                        preview.as_ref(),
                                         whitelist_hint.as_deref(),
                                     ),
                                 );

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -86,8 +86,8 @@ pub enum EngineEvent {
         tool_name: String,
         /// Human-readable description of the action.
         detail: String,
-        /// Optional diff preview or action preview.
-        preview: Option<String>,
+        /// Structured diff preview (rendered by the client).
+        preview: Option<crate::preview::DiffPreview>,
         /// If set, the client can offer an "Always allow" option for this pattern.
         whitelist_hint: Option<String>,
     },
@@ -96,7 +96,7 @@ pub enum EngineEvent {
     ActionBlocked {
         tool_name: String,
         detail: String,
-        preview: Option<String>,
+        preview: Option<crate::preview::DiffPreview>,
     },
 
     // ── Session metadata ──────────────────────────────────────────────

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -634,16 +634,15 @@ async fn execute_tools_sequential(
                 // Execute without asking
             }
             ToolApproval::Blocked => {
-                // Plan mode: show what would happen, don't execute
+                // Plan mode: emit ActionBlocked event, let the client render it
                 let detail = tools::describe_action(&tc.function_name, &parsed_args);
                 let diff_preview =
                     preview::compute(&tc.function_name, &parsed_args, project_root).await;
-                println!("  \x1b[33m\u{1f4cb} Would execute: {detail}\x1b[0m");
-                if let Some(ref preview_text) = diff_preview {
-                    for line in preview_text.lines() {
-                        println!("  {line}");
-                    }
-                }
+                sink.emit(EngineEvent::ActionBlocked {
+                    tool_name: tc.function_name.clone(),
+                    detail: detail.clone(),
+                    preview: diff_preview,
+                });
                 db.insert_message(
                     session_id,
                     &Role::Tool,
@@ -683,7 +682,7 @@ async fn execute_tools_sequential(
                     &cancel,
                     &tc.function_name,
                     &detail,
-                    diff_preview.as_deref(),
+                    diff_preview,
                     whitelist_hint.as_deref(),
                 )
                 .await
@@ -897,7 +896,13 @@ async fn execute_sub_agent(
                 }
                 ToolApproval::Blocked => {
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                    println!("  \x1b[33m\u{1f4cb} Would execute: {detail}\x1b[0m");
+                    let diff_preview =
+                        preview::compute(&tc.function_name, &parsed_args, project_root).await;
+                    sink.emit(EngineEvent::ActionBlocked {
+                        tool_name: tc.function_name.clone(),
+                        detail,
+                        preview: diff_preview,
+                    });
                     "[plan mode] Action described but not executed.".to_string()
                 }
                 ToolApproval::NeedsConfirmation => {
@@ -926,7 +931,7 @@ async fn execute_sub_agent(
                         &sub_cancel,
                         &tc.function_name,
                         &detail,
-                        diff_preview.as_deref(),
+                        diff_preview,
                         whitelist_hint.as_deref(),
                     )
                     .await
@@ -1071,7 +1076,7 @@ async fn request_approval(
     cancel: &CancellationToken,
     tool_name: &str,
     detail: &str,
-    preview: Option<&str>,
+    preview: Option<crate::preview::DiffPreview>,
     whitelist_hint: Option<&str>,
 ) -> Option<ApprovalDecision> {
     let approval_id = uuid::Uuid::new_v4().to_string();
@@ -1079,7 +1084,7 @@ async fn request_approval(
         id: approval_id.clone(),
         tool_name: tool_name.to_string(),
         detail: detail.to_string(),
-        preview: preview.map(|s| s.to_string()),
+        preview,
         whitelist_hint: whitelist_hint.map(|s| s.to_string()),
     });
 

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -91,11 +91,11 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         for j in 0..pair_count {
             let (old_content, new_content) = intra_line_diff(old_line_vec[j], new_line_vec[j]);
             lines.push(format!(
-                "{LINE_RED}{:>4} -{old_content}{RESET}",
+                "{LINE_RED}{:>4} - {old_content}{RESET}",
                 start_line + j
             ));
             lines.push(format!(
-                "{LINE_GREEN}{:>4} +{new_content}{RESET}",
+                "{LINE_GREEN}{:>4} + {new_content}{RESET}",
                 start_line + j
             ));
             total_lines += 2;
@@ -104,7 +104,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining old lines (pure deletions without a new counterpart)
         for j in pair_count..old_line_vec.len() {
             lines.push(format!(
-                "{LINE_RED}{:>4} -{}{RESET}",
+                "{LINE_RED}{:>4} - {}{RESET}",
                 start_line + j,
                 old_line_vec[j]
             ));
@@ -114,7 +114,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining new lines (pure additions without an old counterpart)
         for j in pair_count..new_line_vec.len() {
             lines.push(format!(
-                "{LINE_GREEN}{:>4} +{}{RESET}",
+                "{LINE_GREEN}{:>4} + {}{RESET}",
                 start_line + j,
                 new_line_vec[j]
             ));
@@ -245,7 +245,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
         // Show first few lines of new content as preview
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+{line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+ {line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -261,7 +261,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
 
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+{line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+ {line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -339,11 +339,11 @@ mod tests {
         assert!(text.contains("world"));
         // Line number for println! on line 2
         assert!(
-            text.contains("2 -"),
+            text.contains("2 - "),
             "should show line number for removed line"
         );
         assert!(
-            text.contains("2 +"),
+            text.contains("2 + "),
             "should show line number for added line"
         );
         // Line-level dark background colors

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -6,8 +6,10 @@
 use crate::tools::safe_resolve_path;
 use std::path::Path;
 
-const GREEN: &str = "\x1b[42m"; // green background
-const RED: &str = "\x1b[41m"; // red background
+const LINE_RED: &str = "\x1b[48;5;52m"; // dark red background — removed line
+const LINE_GREEN: &str = "\x1b[48;5;22m"; // dark green background — added line
+const WORD_RED: &str = "\x1b[48;5;88m"; // brighter red — changed words in removed line
+const WORD_GREEN: &str = "\x1b[48;5;28m"; // brighter green — changed words in added line
 const DIM: &str = "\x1b[90m";
 const RESET: &str = "\x1b[0m";
 
@@ -30,7 +32,8 @@ pub async fn compute(
     }
 }
 
-/// Preview for Edit tool: show each replacement as old (red) → new (green) with line numbers.
+/// Preview for Edit tool: show each replacement as old (red) → new (green) with line numbers
+/// and intra-line word highlighting for the changed region.
 async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<String> {
     // Handle both flat args {"path", "replacements"} and nested {"payload": {"file_path", "replacements"}}
     let inner = args.get("payload").unwrap_or(args);
@@ -80,12 +83,41 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
             ));
         }
 
-        for (j, line) in old_str.lines().enumerate() {
-            lines.push(format!("{RED}{:>4} -{line}{RESET}", start_line + j));
+        let old_line_vec: Vec<&str> = old_str.lines().collect();
+        let new_line_vec: Vec<&str> = new_str.lines().collect();
+        let pair_count = old_line_vec.len().min(new_line_vec.len());
+
+        // Paired lines: render with intra-line word highlighting
+        for j in 0..pair_count {
+            let (old_content, new_content) = intra_line_diff(old_line_vec[j], new_line_vec[j]);
+            lines.push(format!(
+                "{LINE_RED}{:>4} -{old_content}{RESET}",
+                start_line + j
+            ));
+            lines.push(format!(
+                "{LINE_GREEN}{:>4} +{new_content}{RESET}",
+                start_line + j
+            ));
+            total_lines += 2;
+        }
+
+        // Remaining old lines (pure deletions without a new counterpart)
+        for j in pair_count..old_line_vec.len() {
+            lines.push(format!(
+                "{LINE_RED}{:>4} -{}{RESET}",
+                start_line + j,
+                old_line_vec[j]
+            ));
             total_lines += 1;
         }
-        for (j, line) in new_str.lines().enumerate() {
-            lines.push(format!("{GREEN}{:>4} +{line}{RESET}", start_line + j));
+
+        // Remaining new lines (pure additions without an old counterpart)
+        for j in pair_count..new_line_vec.len() {
+            lines.push(format!(
+                "{LINE_GREEN}{:>4} +{}{RESET}",
+                start_line + j,
+                new_line_vec[j]
+            ));
             total_lines += 1;
         }
 
@@ -108,6 +140,81 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
     }
 
     Some(lines.join("\n"))
+}
+
+/// Compute intra-line diff content for a pair of lines.
+///
+/// Returns `(old_content, new_content)` with word-level highlight escapes
+/// embedded. The caller wraps each in the line-level background + RESET.
+fn intra_line_diff(old_line: &str, new_line: &str) -> (String, String) {
+    let (pre_bytes, suf_bytes_old, suf_bytes_new) = common_prefix_suffix(old_line, new_line);
+
+    let old_prefix = &old_line[..pre_bytes];
+    let old_changed = &old_line[pre_bytes..old_line.len() - suf_bytes_old];
+    let old_suffix = &old_line[old_line.len() - suf_bytes_old..];
+
+    let new_prefix = &new_line[..pre_bytes];
+    let new_changed = &new_line[pre_bytes..new_line.len() - suf_bytes_new];
+    let new_suffix = &new_line[new_line.len() - suf_bytes_new..];
+
+    let old_content = if old_changed.is_empty() {
+        format!("{old_prefix}{old_suffix}")
+    } else {
+        format!("{old_prefix}{WORD_RED}{old_changed}{LINE_RED}{old_suffix}")
+    };
+
+    let new_content = if new_changed.is_empty() {
+        format!("{new_prefix}{new_suffix}")
+    } else {
+        format!("{new_prefix}{WORD_GREEN}{new_changed}{LINE_GREEN}{new_suffix}")
+    };
+
+    (old_content, new_content)
+}
+
+/// Find the byte lengths of the common prefix and suffix shared by `old` and `new`.
+///
+/// Returns `(prefix_bytes, suffix_bytes_old, suffix_bytes_new)`.
+/// Because the prefix chars are identical in both strings, `prefix_bytes` is
+/// the same for both. The suffix may differ in byte length for multi-byte chars.
+fn common_prefix_suffix(old: &str, new: &str) -> (usize, usize, usize) {
+    let prefix_chars = old
+        .chars()
+        .zip(new.chars())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let prefix_bytes = old
+        .char_indices()
+        .nth(prefix_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(old.len());
+
+    // Compute suffix only within the remaining part after the prefix
+    let old_rest: Vec<char> = old[prefix_bytes..].chars().collect();
+    let new_rest: Vec<char> = new[prefix_bytes..].chars().collect();
+
+    let suffix_chars = old_rest
+        .iter()
+        .rev()
+        .zip(new_rest.iter().rev())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let suffix_bytes_old: usize = old_rest
+        .iter()
+        .rev()
+        .take(suffix_chars)
+        .map(|c| c.len_utf8())
+        .sum();
+    let suffix_bytes_new: usize = new_rest
+        .iter()
+        .rev()
+        .take(suffix_chars)
+        .map(|c| c.len_utf8())
+        .sum();
+
+    (prefix_bytes, suffix_bytes_old, suffix_bytes_new)
 }
 
 /// Preview for Write tool: show new-file summary or overwrite diff.
@@ -138,7 +245,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
         // Show first few lines of new content as preview
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{GREEN}+{line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+{line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -154,7 +261,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
 
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{GREEN}+{line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+{line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -186,7 +293,7 @@ async fn preview_delete(args: &serde_json::Value, project_root: &Path) -> Option
             .map(|c| c.lines().count())
             .unwrap_or(0);
         Some(format!(
-            "{RED}Removing {line_count} lines ({size} bytes){RESET}"
+            "{LINE_RED}Removing {line_count} lines ({size} bytes){RESET}"
         ))
     } else if meta.is_dir() {
         let recursive = args
@@ -194,9 +301,11 @@ async fn preview_delete(args: &serde_json::Value, project_root: &Path) -> Option
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         if recursive {
-            Some(format!("{RED}Removing directory and all contents{RESET}"))
+            Some(format!(
+                "{LINE_RED}Removing directory and all contents{RESET}"
+            ))
         } else {
-            Some(format!("{RED}Removing empty directory{RESET}"))
+            Some(format!("{LINE_RED}Removing empty directory{RESET}"))
         }
     } else {
         None
@@ -237,14 +346,23 @@ mod tests {
             text.contains("2 +"),
             "should show line number for added line"
         );
-        // Must use background colors
+        // Line-level dark background colors
         assert!(
-            text.contains("\x1b[41m"),
-            "removed lines should use red background"
+            text.contains(LINE_RED),
+            "removed lines should use dark red background"
         );
         assert!(
-            text.contains("\x1b[42m"),
-            "added lines should use green background"
+            text.contains(LINE_GREEN),
+            "added lines should use dark green background"
+        );
+        // Intra-line word highlights: "hello" vs "world" are the changed words
+        assert!(
+            text.contains(WORD_RED),
+            "changed word in removed line should be highlighted"
+        );
+        assert!(
+            text.contains(WORD_GREEN),
+            "changed word in added line should be highlighted"
         );
     }
 

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -91,11 +91,11 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         for j in 0..pair_count {
             let (old_content, new_content) = intra_line_diff(old_line_vec[j], new_line_vec[j]);
             lines.push(format!(
-                "{LINE_RED}{:>4} -  {old_content}{RESET}",
+                "{LINE_RED}{:>4} -\t{old_content}{RESET}",
                 start_line + j
             ));
             lines.push(format!(
-                "{LINE_GREEN}{:>4} +  {new_content}{RESET}",
+                "{LINE_GREEN}{:>4} +\t{new_content}{RESET}",
                 start_line + j
             ));
             total_lines += 2;
@@ -104,7 +104,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining old lines (pure deletions without a new counterpart)
         for j in pair_count..old_line_vec.len() {
             lines.push(format!(
-                "{LINE_RED}{:>4} -  {}{RESET}",
+                "{LINE_RED}{:>4} -\t{}{RESET}",
                 start_line + j,
                 old_line_vec[j]
             ));
@@ -114,7 +114,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining new lines (pure additions without an old counterpart)
         for j in pair_count..new_line_vec.len() {
             lines.push(format!(
-                "{LINE_GREEN}{:>4} +  {}{RESET}",
+                "{LINE_GREEN}{:>4} +\t{}{RESET}",
                 start_line + j,
                 new_line_vec[j]
             ));
@@ -245,7 +245,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
         // Show first few lines of new content as preview
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+  {line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -261,7 +261,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
 
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+  {line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -339,11 +339,11 @@ mod tests {
         assert!(text.contains("world"));
         // Line number for println! on line 2
         assert!(
-            text.contains("2 -  "),
+            text.contains("2 -\t"),
             "should show line number for removed line"
         );
         assert!(
-            text.contains("2 +  "),
+            text.contains("2 +\t"),
             "should show line number for added line"
         );
         // Line-level dark background colors

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -91,11 +91,11 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         for j in 0..pair_count {
             let (old_content, new_content) = intra_line_diff(old_line_vec[j], new_line_vec[j]);
             lines.push(format!(
-                "{LINE_RED}{:>4} - {old_content}{RESET}",
+                "{LINE_RED}{:>4} -  {old_content}{RESET}",
                 start_line + j
             ));
             lines.push(format!(
-                "{LINE_GREEN}{:>4} + {new_content}{RESET}",
+                "{LINE_GREEN}{:>4} +  {new_content}{RESET}",
                 start_line + j
             ));
             total_lines += 2;
@@ -104,7 +104,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining old lines (pure deletions without a new counterpart)
         for j in pair_count..old_line_vec.len() {
             lines.push(format!(
-                "{LINE_RED}{:>4} - {}{RESET}",
+                "{LINE_RED}{:>4} -  {}{RESET}",
                 start_line + j,
                 old_line_vec[j]
             ));
@@ -114,7 +114,7 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         // Remaining new lines (pure additions without an old counterpart)
         for j in pair_count..new_line_vec.len() {
             lines.push(format!(
-                "{LINE_GREEN}{:>4} + {}{RESET}",
+                "{LINE_GREEN}{:>4} +  {}{RESET}",
                 start_line + j,
                 new_line_vec[j]
             ));
@@ -245,7 +245,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
         // Show first few lines of new content as preview
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+ {line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+  {line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -261,7 +261,7 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
 
         let preview_count = line_count.min(8);
         for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+ {line}{RESET}"));
+            lines.push(format!("{LINE_GREEN}+  {line}{RESET}"));
         }
         if line_count > 8 {
             lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
@@ -339,11 +339,11 @@ mod tests {
         assert!(text.contains("world"));
         // Line number for println! on line 2
         assert!(
-            text.contains("2 - "),
+            text.contains("2 -  "),
             "should show line number for removed line"
         );
         assert!(
-            text.contains("2 + "),
+            text.contains("2 +  "),
             "should show line number for added line"
         );
         // Line-level dark background colors

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -102,21 +102,16 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         }
 
         // Remaining old lines (pure deletions without a new counterpart)
-        for j in pair_count..old_line_vec.len() {
-            lines.push(format!(
-                "{LINE_RED}{:>4} -\t{}{RESET}",
-                start_line + j,
-                old_line_vec[j]
-            ));
+        for (j, line) in old_line_vec.iter().enumerate().skip(pair_count) {
+            lines.push(format!("{LINE_RED}{:>4} -\t{line}{RESET}", start_line + j,));
             total_lines += 1;
         }
 
         // Remaining new lines (pure additions without an old counterpart)
-        for j in pair_count..new_line_vec.len() {
+        for (j, line) in new_line_vec.iter().enumerate().skip(pair_count) {
             lines.push(format!(
-                "{LINE_GREEN}{:>4} +\t{}{RESET}",
+                "{LINE_GREEN}{:>4} +\t{line}{RESET}",
                 start_line + j,
-                new_line_vec[j]
             ));
             total_lines += 1;
         }

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -6,8 +6,8 @@
 use crate::tools::safe_resolve_path;
 use std::path::Path;
 
-const GREEN: &str = "\x1b[32m"; // green foreground
-const RED: &str = "\x1b[31m"; // red foreground
+const GREEN: &str = "\x1b[42m"; // green background
+const RED: &str = "\x1b[41m"; // red background
 const DIM: &str = "\x1b[90m";
 const RESET: &str = "\x1b[0m";
 
@@ -237,17 +237,15 @@ mod tests {
             text.contains("2 +"),
             "should show line number for added line"
         );
-        // Must use foreground colors, not background fills
+        // Must use background colors
         assert!(
-            text.contains("\x1b[31m"),
-            "removed lines should use red foreground"
+            text.contains("\x1b[41m"),
+            "removed lines should use red background"
         );
         assert!(
-            text.contains("\x1b[32m"),
-            "added lines should use green foreground"
+            text.contains("\x1b[42m"),
+            "added lines should use green background"
         );
-        assert!(!text.contains("\x1b[41"), "must not use red background");
-        assert!(!text.contains("\x1b[42"), "must not use green background");
     }
 
     #[tokio::test]

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -6,8 +6,8 @@
 use crate::tools::safe_resolve_path;
 use std::path::Path;
 
-const GREEN: &str = "\x1b[42;30m"; // green background, black text
-const RED: &str = "\x1b[41;37m"; // red background, white text
+const GREEN: &str = "\x1b[32m"; // green foreground
+const RED: &str = "\x1b[31m"; // red foreground
 const DIM: &str = "\x1b[90m";
 const RESET: &str = "\x1b[0m";
 
@@ -30,7 +30,7 @@ pub async fn compute(
     }
 }
 
-/// Preview for Edit tool: show each replacement as old (red) → new (green).
+/// Preview for Edit tool: show each replacement as old (red) → new (green) with line numbers.
 async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<String> {
     // Handle both flat args {"path", "replacements"} and nested {"payload": {"file_path", "replacements"}}
     let inner = args.get("payload").unwrap_or(args);
@@ -41,11 +41,12 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
         .and_then(|v| v.as_str())?;
     let replacements = inner.get("replacements")?.as_array()?;
 
-    // Verify file exists
+    // Verify file exists and read content for line number computation
     let resolved = safe_resolve_path(project_root, path_str).ok()?;
     if !resolved.exists() {
         return Some(format!("{DIM}(file does not exist yet){RESET}"));
     }
+    let file_content = tokio::fs::read_to_string(&resolved).await.ok()?;
 
     let mut lines = Vec::new();
     let mut total_lines = 0usize;
@@ -57,6 +58,20 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
+        // Find the 1-based starting line number of old_str in the file.
+        // Count newlines before the match position (not lines(), which
+        // includes the partial line at byte_pos and over-counts by 1).
+        let start_line = file_content
+            .find(old_str)
+            .map(|byte_pos| {
+                file_content[..byte_pos]
+                    .bytes()
+                    .filter(|&b| b == b'\n')
+                    .count()
+                    + 1
+            })
+            .unwrap_or(1);
+
         if replacements.len() > 1 {
             lines.push(format!(
                 "{DIM}── replacement {}/{} ──{RESET}",
@@ -65,12 +80,12 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
             ));
         }
 
-        for line in old_str.lines() {
-            lines.push(format!("{RED}-{line}{RESET}"));
+        for (j, line) in old_str.lines().enumerate() {
+            lines.push(format!("{RED}{:>4} -{line}{RESET}", start_line + j));
             total_lines += 1;
         }
-        for line in new_str.lines() {
-            lines.push(format!("{GREEN}+{line}{RESET}"));
+        for (j, line) in new_str.lines().enumerate() {
+            lines.push(format!("{GREEN}{:>4} +{line}{RESET}", start_line + j));
             total_lines += 1;
         }
 
@@ -213,6 +228,26 @@ mod tests {
         let text = preview.unwrap();
         assert!(text.contains("hello"));
         assert!(text.contains("world"));
+        // Line number for println! on line 2
+        assert!(
+            text.contains("2 -"),
+            "should show line number for removed line"
+        );
+        assert!(
+            text.contains("2 +"),
+            "should show line number for added line"
+        );
+        // Must use foreground colors, not background fills
+        assert!(
+            text.contains("\x1b[31m"),
+            "removed lines should use red foreground"
+        );
+        assert!(
+            text.contains("\x1b[32m"),
+            "added lines should use green foreground"
+        );
+        assert!(!text.contains("\x1b[41"), "must not use red background");
+        assert!(!text.contains("\x1b[42"), "must not use green background");
     }
 
     #[tokio::test]

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -6,10 +6,10 @@
 use crate::tools::safe_resolve_path;
 use std::path::Path;
 
-const LINE_RED: &str = "\x1b[48;5;52m"; // dark red background — removed line
-const LINE_GREEN: &str = "\x1b[48;5;22m"; // dark green background — added line
-const WORD_RED: &str = "\x1b[48;5;88m"; // brighter red — changed words in removed line
-const WORD_GREEN: &str = "\x1b[48;5;28m"; // brighter green — changed words in added line
+const LINE_RED: &str = "\x1b[48;2;80;0;0m"; // dark red background — removed line
+const LINE_GREEN: &str = "\x1b[48;2;0;60;0m"; // dark green background — added line
+const WORD_RED: &str = "\x1b[48;2;150;20;20m"; // brighter red — changed words in removed line
+const WORD_GREEN: &str = "\x1b[48;2;20;120;20m"; // brighter green — changed words in added line
 const DIM: &str = "\x1b[90m";
 const RESET: &str = "\x1b[0m";
 

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -1,29 +1,98 @@
 //! Pre-confirmation diff previews for destructive tool operations.
 //!
-//! Computes a colored diff preview before the user confirms an Edit or Write,
-//! so they can make an informed decision instead of approving blind.
+//! Computes **structured** preview data before the user confirms an Edit,
+//! Write, or Delete.  The actual rendering (colors, syntax highlighting)
+//! is the client's responsibility — koda-core never emits ANSI codes.
 
 use crate::tools::safe_resolve_path;
 use std::path::Path;
 
-const LINE_RED: &str = "\x1b[48;2;80;0;0m"; // dark red background — removed line
-const LINE_GREEN: &str = "\x1b[48;2;0;60;0m"; // dark green background — added line
-const WORD_RED: &str = "\x1b[48;2;150;20;20m"; // brighter red — changed words in removed line
-const WORD_GREEN: &str = "\x1b[48;2;20;120;20m"; // brighter green — changed words in added line
-const DIM: &str = "\x1b[90m";
-const RESET: &str = "\x1b[0m";
-
-/// Maximum diff lines to show before truncating.
+/// Maximum diff lines before truncation.
 const MAX_PREVIEW_LINES: usize = 40;
 
-/// Compute a diff preview for a tool action, if applicable.
+/// Maximum first-lines in Write previews.
+const MAX_WRITE_PREVIEW_LINES: usize = 8;
+
+// ── Data types ────────────────────────────────────────────────
+
+/// Structured diff preview produced by the engine.
 ///
-/// Returns `None` for tools that don't need a preview (Read, List, Grep, etc.).
+/// Clients render this however they want (ANSI, HTML, plain text, …).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind")]
+pub enum DiffPreview {
+    Edit(EditPreview),
+    WriteNew(WritePreview),
+    WriteOverwrite(WriteOverwritePreview),
+    DeleteFile(DeleteFilePreview),
+    DeleteDir(DeleteDirPreview),
+    FileNotYetExists,
+    PathNotFound,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EditPreview {
+    /// File path (as given in the tool args).
+    pub path: String,
+    /// Per-replacement data.
+    pub replacements: Vec<ReplacementPreview>,
+    /// Number of replacements omitted due to truncation.
+    pub truncated_count: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReplacementPreview {
+    /// 0-based index of this replacement.
+    pub index: usize,
+    /// Total number of replacements in the Edit call.
+    pub total: usize,
+    /// 1-based line number where `old_str` starts in the file.
+    pub start_line: usize,
+    /// Lines of the old (removed) text.
+    pub old_lines: Vec<String>,
+    /// Lines of the new (added) text.
+    pub new_lines: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WritePreview {
+    pub line_count: usize,
+    pub byte_count: usize,
+    pub first_lines: Vec<String>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WriteOverwritePreview {
+    pub old_line_count: usize,
+    pub old_byte_count: usize,
+    pub new_line_count: usize,
+    pub new_byte_count: usize,
+    pub first_lines: Vec<String>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeleteFilePreview {
+    pub line_count: usize,
+    pub byte_count: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DeleteDirPreview {
+    pub recursive: bool,
+}
+
+// ── Compute ───────────────────────────────────────────────────
+
+/// Compute a structured diff preview for a tool action.
+///
+/// Returns `None` for tools that don't need a preview.
 pub async fn compute(
     tool_name: &str,
     args: &serde_json::Value,
     project_root: &Path,
-) -> Option<String> {
+) -> Option<DiffPreview> {
     match tool_name {
         "Edit" => preview_edit(args, project_root).await,
         "Write" => preview_write(args, project_root).await,
@@ -32,27 +101,23 @@ pub async fn compute(
     }
 }
 
-/// Preview for Edit tool: show each replacement as old (red) → new (green) with line numbers
-/// and intra-line word highlighting for the changed region.
-async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<String> {
-    // Handle both flat args {"path", "replacements"} and nested {"payload": {"file_path", "replacements"}}
+async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<DiffPreview> {
     let inner = args.get("payload").unwrap_or(args);
-
     let path_str = inner
         .get("path")
         .or(inner.get("file_path"))
         .and_then(|v| v.as_str())?;
     let replacements = inner.get("replacements")?.as_array()?;
 
-    // Verify file exists and read content for line number computation
     let resolved = safe_resolve_path(project_root, path_str).ok()?;
     if !resolved.exists() {
-        return Some(format!("{DIM}(file does not exist yet){RESET}"));
+        return Some(DiffPreview::FileNotYetExists);
     }
     let file_content = tokio::fs::read_to_string(&resolved).await.ok()?;
 
-    let mut lines = Vec::new();
+    let mut previews = Vec::new();
     let mut total_lines = 0usize;
+    let mut truncated_count = 0usize;
 
     for (i, replacement) in replacements.iter().enumerate() {
         let old_str = replacement.get("old_str")?.as_str()?;
@@ -61,9 +126,6 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        // Find the 1-based starting line number of old_str in the file.
-        // Count newlines before the match position (not lines(), which
-        // includes the partial line at byte_pos and over-counts by 1).
         let start_line = file_content
             .find(old_str)
             .map(|byte_pos| {
@@ -75,147 +137,33 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<S
             })
             .unwrap_or(1);
 
-        if replacements.len() > 1 {
-            lines.push(format!(
-                "{DIM}── replacement {}/{} ──{RESET}",
-                i + 1,
-                replacements.len()
-            ));
-        }
+        let old_lines: Vec<String> = old_str.lines().map(String::from).collect();
+        let new_lines: Vec<String> = new_str.lines().map(String::from).collect();
+        total_lines += old_lines.len() + new_lines.len();
 
-        let old_line_vec: Vec<&str> = old_str.lines().collect();
-        let new_line_vec: Vec<&str> = new_str.lines().collect();
-        let pair_count = old_line_vec.len().min(new_line_vec.len());
-
-        // Paired lines: render with intra-line word highlighting
-        for j in 0..pair_count {
-            let (old_content, new_content) = intra_line_diff(old_line_vec[j], new_line_vec[j]);
-            lines.push(format!(
-                "{LINE_RED}{:>4} -\t{old_content}{RESET}",
-                start_line + j
-            ));
-            lines.push(format!(
-                "{LINE_GREEN}{:>4} +\t{new_content}{RESET}",
-                start_line + j
-            ));
-            total_lines += 2;
-        }
-
-        // Remaining old lines (pure deletions without a new counterpart)
-        for (j, line) in old_line_vec.iter().enumerate().skip(pair_count) {
-            lines.push(format!("{LINE_RED}{:>4} -\t{line}{RESET}", start_line + j,));
-            total_lines += 1;
-        }
-
-        // Remaining new lines (pure additions without an old counterpart)
-        for (j, line) in new_line_vec.iter().enumerate().skip(pair_count) {
-            lines.push(format!(
-                "{LINE_GREEN}{:>4} +\t{line}{RESET}",
-                start_line + j,
-            ));
-            total_lines += 1;
-        }
+        previews.push(ReplacementPreview {
+            index: i,
+            total: replacements.len(),
+            start_line,
+            old_lines,
+            new_lines,
+        });
 
         if total_lines > MAX_PREVIEW_LINES {
-            let remaining = replacements.len() - i - 1;
-            if remaining > 0 {
-                lines.push(format!(
-                    "{DIM}... and {remaining} more replacement(s){RESET}"
-                ));
-            }
+            truncated_count = replacements.len() - i - 1;
             break;
         }
     }
 
-    // Truncate if too many lines
-    if lines.len() > MAX_PREVIEW_LINES {
-        lines.truncate(MAX_PREVIEW_LINES);
-        let hidden = total_lines - MAX_PREVIEW_LINES;
-        lines.push(format!("{DIM}... +{hidden} more lines{RESET}"));
-    }
-
-    Some(lines.join("\n"))
+    Some(DiffPreview::Edit(EditPreview {
+        path: path_str.to_string(),
+        replacements: previews,
+        truncated_count,
+    }))
 }
 
-/// Compute intra-line diff content for a pair of lines.
-///
-/// Returns `(old_content, new_content)` with word-level highlight escapes
-/// embedded. The caller wraps each in the line-level background + RESET.
-fn intra_line_diff(old_line: &str, new_line: &str) -> (String, String) {
-    let (pre_bytes, suf_bytes_old, suf_bytes_new) = common_prefix_suffix(old_line, new_line);
-
-    let old_prefix = &old_line[..pre_bytes];
-    let old_changed = &old_line[pre_bytes..old_line.len() - suf_bytes_old];
-    let old_suffix = &old_line[old_line.len() - suf_bytes_old..];
-
-    let new_prefix = &new_line[..pre_bytes];
-    let new_changed = &new_line[pre_bytes..new_line.len() - suf_bytes_new];
-    let new_suffix = &new_line[new_line.len() - suf_bytes_new..];
-
-    let old_content = if old_changed.is_empty() {
-        format!("{old_prefix}{old_suffix}")
-    } else {
-        format!("{old_prefix}{WORD_RED}{old_changed}{LINE_RED}{old_suffix}")
-    };
-
-    let new_content = if new_changed.is_empty() {
-        format!("{new_prefix}{new_suffix}")
-    } else {
-        format!("{new_prefix}{WORD_GREEN}{new_changed}{LINE_GREEN}{new_suffix}")
-    };
-
-    (old_content, new_content)
-}
-
-/// Find the byte lengths of the common prefix and suffix shared by `old` and `new`.
-///
-/// Returns `(prefix_bytes, suffix_bytes_old, suffix_bytes_new)`.
-/// Because the prefix chars are identical in both strings, `prefix_bytes` is
-/// the same for both. The suffix may differ in byte length for multi-byte chars.
-fn common_prefix_suffix(old: &str, new: &str) -> (usize, usize, usize) {
-    let prefix_chars = old
-        .chars()
-        .zip(new.chars())
-        .take_while(|(a, b)| a == b)
-        .count();
-
-    let prefix_bytes = old
-        .char_indices()
-        .nth(prefix_chars)
-        .map(|(i, _)| i)
-        .unwrap_or(old.len());
-
-    // Compute suffix only within the remaining part after the prefix
-    let old_rest: Vec<char> = old[prefix_bytes..].chars().collect();
-    let new_rest: Vec<char> = new[prefix_bytes..].chars().collect();
-
-    let suffix_chars = old_rest
-        .iter()
-        .rev()
-        .zip(new_rest.iter().rev())
-        .take_while(|(a, b)| a == b)
-        .count();
-
-    let suffix_bytes_old: usize = old_rest
-        .iter()
-        .rev()
-        .take(suffix_chars)
-        .map(|c| c.len_utf8())
-        .sum();
-    let suffix_bytes_new: usize = new_rest
-        .iter()
-        .rev()
-        .take(suffix_chars)
-        .map(|c| c.len_utf8())
-        .sum();
-
-    (prefix_bytes, suffix_bytes_old, suffix_bytes_new)
-}
-
-/// Preview for Write tool: show new-file summary or overwrite diff.
-async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<String> {
+async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<DiffPreview> {
     let inner = args.get("payload").unwrap_or(args);
-
     let path_str = inner
         .get("path")
         .or(inner.get("file_path"))
@@ -225,51 +173,35 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
 
     let content_lines: Vec<&str> = content.lines().collect();
     let line_count = content_lines.len();
+    let preview_count = line_count.min(MAX_WRITE_PREVIEW_LINES);
+    let first_lines: Vec<String> = content_lines[..preview_count]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let truncated = line_count > MAX_WRITE_PREVIEW_LINES;
 
     if resolved.exists() {
-        // Overwrite: show what's being replaced
         let existing = tokio::fs::read_to_string(&resolved).await.ok()?;
-        let existing_lines = existing.lines().count();
-        let existing_bytes = existing.len();
-
-        let mut lines = vec![format!(
-            "{DIM}Overwriting {existing_lines} lines ({existing_bytes} bytes) → {line_count} lines ({} bytes){RESET}",
-            content.len()
-        )];
-
-        // Show first few lines of new content as preview
-        let preview_count = line_count.min(8);
-        for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
-        }
-        if line_count > 8 {
-            lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
-        }
-
-        Some(lines.join("\n"))
+        Some(DiffPreview::WriteOverwrite(WriteOverwritePreview {
+            old_line_count: existing.lines().count(),
+            old_byte_count: existing.len(),
+            new_line_count: line_count,
+            new_byte_count: content.len(),
+            first_lines,
+            truncated,
+        }))
     } else {
-        // New file: show first few lines
-        let mut lines = vec![format!(
-            "{DIM}New file: {line_count} lines ({} bytes){RESET}",
-            content.len()
-        )];
-
-        let preview_count = line_count.min(8);
-        for line in &content_lines[..preview_count] {
-            lines.push(format!("{LINE_GREEN}+\t{line}{RESET}"));
-        }
-        if line_count > 8 {
-            lines.push(format!("{DIM}... +{} more lines{RESET}", line_count - 8));
-        }
-
-        Some(lines.join("\n"))
+        Some(DiffPreview::WriteNew(WritePreview {
+            line_count,
+            byte_count: content.len(),
+            first_lines,
+            truncated,
+        }))
     }
 }
 
-/// Preview for Delete tool: show file/dir size info.
-async fn preview_delete(args: &serde_json::Value, project_root: &Path) -> Option<String> {
+async fn preview_delete(args: &serde_json::Value, project_root: &Path) -> Option<DiffPreview> {
     let inner = args.get("payload").unwrap_or(args);
-
     let path_str = inner
         .get("path")
         .or(inner.get("file_path"))
@@ -277,35 +209,31 @@ async fn preview_delete(args: &serde_json::Value, project_root: &Path) -> Option
     let resolved = safe_resolve_path(project_root, path_str).ok()?;
 
     if !resolved.exists() {
-        return Some(format!("{DIM}(path does not exist){RESET}"));
+        return Some(DiffPreview::PathNotFound);
     }
 
     let meta = tokio::fs::metadata(&resolved).await.ok()?;
     if meta.is_file() {
-        let size = meta.len();
         let line_count = tokio::fs::read_to_string(&resolved)
             .await
             .map(|c| c.lines().count())
             .unwrap_or(0);
-        Some(format!(
-            "{LINE_RED}Removing {line_count} lines ({size} bytes){RESET}"
-        ))
+        Some(DiffPreview::DeleteFile(DeleteFilePreview {
+            line_count,
+            byte_count: meta.len(),
+        }))
     } else if meta.is_dir() {
         let recursive = args
             .get("recursive")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        if recursive {
-            Some(format!(
-                "{LINE_RED}Removing directory and all contents{RESET}"
-            ))
-        } else {
-            Some(format!("{LINE_RED}Removing empty directory{RESET}"))
-        }
+        Some(DiffPreview::DeleteDir(DeleteDirPreview { recursive }))
     } else {
         None
     }
 }
+
+// ── Tests ─────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
@@ -328,37 +256,17 @@ mod tests {
         });
 
         let preview = compute("Edit", &args, tmp.path()).await;
-        assert!(preview.is_some());
-        let text = preview.unwrap();
-        assert!(text.contains("hello"));
-        assert!(text.contains("world"));
-        // Line number for println! on line 2
-        assert!(
-            text.contains("2 -\t"),
-            "should show line number for removed line"
-        );
-        assert!(
-            text.contains("2 +\t"),
-            "should show line number for added line"
-        );
-        // Line-level dark background colors
-        assert!(
-            text.contains(LINE_RED),
-            "removed lines should use dark red background"
-        );
-        assert!(
-            text.contains(LINE_GREEN),
-            "added lines should use dark green background"
-        );
-        // Intra-line word highlights: "hello" vs "world" are the changed words
-        assert!(
-            text.contains(WORD_RED),
-            "changed word in removed line should be highlighted"
-        );
-        assert!(
-            text.contains(WORD_GREEN),
-            "changed word in added line should be highlighted"
-        );
+        let preview = preview.expect("should produce a preview");
+        match preview {
+            DiffPreview::Edit(edit) => {
+                assert_eq!(edit.replacements.len(), 1);
+                let r = &edit.replacements[0];
+                assert_eq!(r.start_line, 2);
+                assert_eq!(r.old_lines, vec!["println!(\"hello\");"]);
+                assert_eq!(r.new_lines, vec!["println!(\"world\");"]);
+            }
+            other => panic!("expected Edit preview, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -370,9 +278,7 @@ mod tests {
         });
 
         let preview = compute("Write", &args, tmp.path()).await;
-        assert!(preview.is_some());
-        let text = preview.unwrap();
-        assert!(text.contains("New file"));
+        assert!(matches!(preview, Some(DiffPreview::WriteNew(_))));
     }
 
     #[tokio::test]
@@ -387,9 +293,7 @@ mod tests {
         });
 
         let preview = compute("Write", &args, tmp.path()).await;
-        assert!(preview.is_some());
-        let text = preview.unwrap();
-        assert!(text.contains("Overwriting"));
+        assert!(matches!(preview, Some(DiffPreview::WriteOverwrite(_))));
     }
 
     #[tokio::test]
@@ -403,9 +307,7 @@ mod tests {
         });
 
         let preview = compute("Delete", &args, tmp.path()).await;
-        assert!(preview.is_some());
-        let text = preview.unwrap();
-        assert!(text.contains("Removing"));
+        assert!(matches!(preview, Some(DiffPreview::DeleteFile(_))));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #68 — architectural refactor of the diff preview system plus visual improvements.

**Before**: `koda-core/preview.rs` generated ANSI-colored strings directly (violating the zero-terminal-deps principle). No syntax highlighting, wrong colors (background fills spanning full terminal width), no line numbers.

**After**: Clean separation between engine data and client rendering:

### koda-core (structured data, zero ANSI codes)
- `preview.rs` returns a `DiffPreview` enum with structured data (line numbers, old/new lines, truncation info)
- `EngineEvent::ApprovalRequest` and `ActionBlocked` carry `Option<DiffPreview>` instead of `Option<String>`
- `inference.rs` emits `ActionBlocked` via `sink.emit()` instead of direct `println!`
- Removed syntect/once_cell from koda-core Cargo.toml (not needed in engine)

### koda-cli (rendering with syntax highlighting)
- **NEW `diff_render.rs`**: renders `DiffPreview` with:
  - Dark RGB background tint for line-level diffs (red `rgb(80,0,0)` / green `rgb(0,60,0)`)
  - Brighter background for the actual changed words within a line (`rgb(130,15,15)` / `rgb(15,100,15)`)
  - Syntax highlighting via syntect (foreground colors derived from file extension)
  - Line numbers (right-aligned 4 chars) and tab spacing
  - `inject_word_highlight()` walks syntect's foreground escape codes and overlays word-level backgrounds at the correct raw byte offsets
- `confirm.rs`, `sink.rs`, `app.rs`, `tui_app.rs` updated to pass `DiffPreview` by ref

## Test plan

- [x] `koda-core::preview` tests verify structured data (line numbers, old/new lines, variant matching)
- [x] `koda-cli::diff_render` tests verify ANSI rendering: line backgrounds, word highlights, syntect foreground codes, common prefix/suffix computation
- [x] Full workspace test suite passes (390 tests, `cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Manual testing with `test_preview.py` in koda REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)