### PR TITLE
refactor: remove all ANSI codes and direct I/O from koda-core (#75)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -129,6 +129,7 @@ pub fn engine_event_to_acp(
         EngineEvent::Footer { .. } => None,
         EngineEvent::SpinnerStart { .. } => None,
         EngineEvent::SpinnerStop => None,
+        EngineEvent::TodoDisplay { .. } => None,
 
         EngineEvent::Info { message } => {
             let cb = acp::ContentBlock::Text(acp::TextContent::new(format!("[info] {message}")));

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -158,12 +158,37 @@ pub async fn run(
     repl::print_banner(&config, &session_id, &recent);
 
     // Show update hint if version check completed
-    if let Ok(Some(latest)) = version_check.await {
-        koda_core::version::print_update_hint(&latest);
+    if let Ok(Some(latest)) = version_check.await
+        && let Some((current, latest)) = koda_core::version::update_available(&latest)
+    {
+        let crate_name = koda_core::version::crate_name();
+        println!(
+            "  \x1b[90m\u{2728} Update available: \x1b[0m\x1b[36m{current}\x1b[0m\x1b[90m \u{2192} \x1b[0m\x1b[32m{latest}\x1b[0m\x1b[90m  (cargo install {crate_name})\x1b[0m"
+        );
+        println!();
     }
 
     // Build agent (tools, MCP, system prompt) and session
     let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+
+    // Render MCP connection statuses
+    if !agent.mcp_statuses.is_empty() {
+        println!(
+            "  \x1b[36m\u{1f50c} Connecting to {} MCP server(s)...\x1b[0m",
+            agent.mcp_statuses.len()
+        );
+        for (name, result) in &agent.mcp_statuses {
+            match result {
+                Ok(tool_count) => {
+                    println!("  \x1b[32m\u{2713}\x1b[0m {name} — {tool_count} tool(s)");
+                }
+                Err(msg) => {
+                    println!("  \x1b[31m\u{2717}\x1b[0m {name} — {msg}");
+                }
+            }
+        }
+        println!();
+    }
     let mut session = KodaSession::new(
         session_id.clone(),
         agent.clone(),

--- a/koda-cli/src/display.rs
+++ b/koda-cli/src/display.rs
@@ -763,6 +763,61 @@ pub fn print_tool_output_compact(tool_name: &str, output: &str) {
     }
 }
 
+/// Format a todo checklist for CLI display with colored checkboxes.
+///
+/// Takes the raw markdown checklist content from the engine.
+pub fn format_todo_display(content: &str) -> String {
+    let items = koda_core::tools::todo::parse_todo_items(content);
+    let mut output = String::new();
+    output.push_str("  \x1b[1m\u{1f4cb} Todo\x1b[0m\n");
+
+    for (indent, status, text) in &items {
+        let pad = if *indent > 0 { "    " } else { "  " };
+        match *status {
+            "done" => {
+                output.push_str(&format!(
+                    "{pad}\x1b[32m\u{2714}\x1b[0m \x1b[9m\x1b[90m{text}\x1b[0m\n"
+                ));
+            }
+            "active" => {
+                output.push_str(&format!(
+                    "{pad}\x1b[33m\u{25a0}\x1b[0m \x1b[1m{text}\x1b[0m\n"
+                ));
+            }
+            "pending" => {
+                output.push_str(&format!(
+                    "{pad}\x1b[90m\u{25a1}\x1b[0m \x1b[90m{text}\x1b[0m\n"
+                ));
+            }
+            _ => {
+                output.push_str(&format!("{pad}{text}\n"));
+            }
+        }
+    }
+
+    output
+}
+
+/// Format agent list for CLI display with colors.
+pub fn format_agents_list(agents: &[(String, String, String)]) -> String {
+    if agents.is_empty() {
+        return "No sub-agents configured.".to_string();
+    }
+
+    let lines: Vec<String> = agents
+        .iter()
+        .map(|(name, description, source)| {
+            let tag = match source.as_str() {
+                "user" => " \x1b[90m[user]\x1b[0m",
+                "project" => " \x1b[90m[project]\x1b[0m",
+                _ => "",
+            };
+            format!("  \x1b[36m{name}\x1b[0m \u{2014} {description}{tag}")
+        })
+        .collect();
+    lines.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -162,11 +162,12 @@ pub async fn handle_command(
 
         "/agent" => {
             let project_root = std::env::current_dir().unwrap_or_default();
-            let listing = koda_core::tools::agent::list_agents(&project_root);
+            let agents = koda_core::tools::agent::list_agents(&project_root);
+            let listing = crate::display::format_agents_list(&agents);
             println!();
             println!("  \x1b[1m\u{1f43b} Sub-Agents\x1b[0m");
             println!();
-            if listing.contains("No ") {
+            if agents.is_empty() {
                 println!("  \x1b[90m{listing}\x1b[0m");
             } else {
                 println!("{listing}");

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -134,6 +134,9 @@ impl UiRenderer {
             EngineEvent::StatusUpdate { .. } => {
                 // Status bar updates are a TUI/server concern, not CLI.
             }
+            EngineEvent::TodoDisplay { content } => {
+                print!("{}", crate::display::format_todo_display(&content));
+            }
             EngineEvent::Footer {
                 prompt_tokens,
                 completion_tokens,

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -247,12 +247,37 @@ pub async fn run(
     repl::print_banner(&config, &session_id, &recent);
 
     // Show update hint if version check completed
-    if let Ok(Some(latest)) = version_check.await {
-        koda_core::version::print_update_hint(&latest);
+    if let Ok(Some(latest)) = version_check.await
+        && let Some((current, latest)) = koda_core::version::update_available(&latest)
+    {
+        let crate_name = koda_core::version::crate_name();
+        println!(
+            "  \x1b[90m\u{2728} Update available: \x1b[0m\x1b[36m{current}\x1b[0m\x1b[90m \u{2192} \x1b[0m\x1b[32m{latest}\x1b[0m\x1b[90m  (cargo install {crate_name})\x1b[0m"
+        );
+        println!();
     }
 
     // Build agent (tools, MCP, system prompt) and session
     let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
+
+    // Render MCP connection statuses
+    if !agent.mcp_statuses.is_empty() {
+        println!(
+            "  \x1b[36m\u{1f50c} Connecting to {} MCP server(s)...\x1b[0m",
+            agent.mcp_statuses.len()
+        );
+        for (name, result) in &agent.mcp_statuses {
+            match result {
+                Ok(tool_count) => {
+                    println!("  \x1b[32m\u{2713}\x1b[0m {name} — {tool_count} tool(s)");
+                }
+                Err(msg) => {
+                    println!("  \x1b[31m\u{2717}\x1b[0m {name} — {msg}");
+                }
+            }
+        }
+        println!();
+    }
     let mut session = KodaSession::new(
         session_id.clone(),
         agent.clone(),

--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -19,6 +19,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// MCP server connection status entry (for client rendering).
+pub type McpStatus = (String, Result<usize, String>);
+
 /// Shared agent resources. Immutable after construction.
 ///
 /// Create once, share via `Arc<KodaAgent>` across sessions and sub-agents.
@@ -28,6 +31,8 @@ pub struct KodaAgent {
     pub tool_defs: Vec<ToolDefinition>,
     pub system_prompt: String,
     pub mcp_registry: Arc<RwLock<McpRegistry>>,
+    /// MCP server connection results from init (for client rendering).
+    pub mcp_statuses: Vec<McpStatus>,
 }
 
 impl KodaAgent {
@@ -36,9 +41,10 @@ impl KodaAgent {
     /// Initializes tools, MCP servers, system prompt, and tool definitions.
     pub async fn new(config: &KodaConfig, project_root: PathBuf) -> Result<Self> {
         let mcp_registry = Arc::new(RwLock::new(McpRegistry::new()));
+        let mcp_statuses;
         {
             let mut mcp = mcp_registry.write().await;
-            mcp.start_from_config(&project_root).await;
+            mcp_statuses = mcp.start_from_config(&project_root).await;
         }
 
         let tools = ToolRegistry::new(project_root.clone()).with_mcp_registry(mcp_registry.clone());
@@ -58,6 +64,7 @@ impl KodaAgent {
             tool_defs,
             system_prompt,
             mcp_registry,
+            mcp_statuses,
         })
     }
 }

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -128,6 +128,9 @@ pub enum EngineEvent {
     SpinnerStop,
 
     // ── Messages ──────────────────────────────────────────────────────
+    /// Display the todo checklist (raw markdown content, client renders).
+    TodoDisplay { content: String },
+
     /// Informational message (not from the LLM).
     Info { message: String },
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -136,7 +136,7 @@ pub async fn inference_loop(
 
         // Stream the response
         sink.emit(EngineEvent::SpinnerStart {
-            message: "\u{1f36f} Thinking...".into(),
+            message: "Thinking...".into(),
         });
 
         let mut rx = tokio::select! {
@@ -306,9 +306,9 @@ pub async fn inference_loop(
         // If no tool calls, we already streamed the response — done
         if tool_calls.is_empty() {
             if made_tool_calls && full_text.trim().is_empty() {
-                println!(
-                    "\n  \x1b[33m\u{26a0} Model produced an empty response after tool use — it may have given up mid-task. Try rephrasing or switching to a more capable model.\x1b[0m"
-                );
+                sink.emit(EngineEvent::Warn {
+                    message: "Model produced an empty response after tool use — it may have given up mid-task. Try rephrasing or switching to a more capable model.".into(),
+                });
             }
             total_prompt_tokens += usage.prompt_tokens;
             total_completion_tokens += usage.completion_tokens;
@@ -325,52 +325,32 @@ pub async fn inference_loop(
 
             let total_elapsed = loop_start.elapsed();
             let total_secs = total_elapsed.as_secs_f64();
-            let time_str = format_duration(total_elapsed);
             let rate = if total_secs > 0.0 && display_tokens > 0 {
                 display_tokens as f64 / total_secs
             } else {
                 0.0
             };
 
-            let ctx = crate::context::format_footer();
-            let ctx_part = if ctx.is_empty() {
-                String::new()
-            } else {
-                format!(" \u{00b7} {ctx}")
-            };
-
-            // Build enriched footer parts
-            let mut parts = Vec::new();
-            if total_prompt_tokens > 0 {
-                let prompt_k = format_token_count(total_prompt_tokens);
-                parts.push(format!("in: {prompt_k}"));
-            }
-            if display_tokens > 0 {
-                parts.push(format!("out: {display_tokens}"));
-            }
-            parts.push(time_str);
-            if display_tokens > 0 {
-                parts.push(format!("{rate:.0} t/s"));
-            }
-            if total_cache_read_tokens > 0 {
-                let cache_k = format_token_count(total_cache_read_tokens);
-                parts.push(format!("cache: {cache_k} read"));
-            }
-            if total_thinking_tokens > 0 {
-                let think_k = format_token_count(total_thinking_tokens);
-                parts.push(format!("thinking: {think_k}"));
-            }
-
-            let footer = parts.join(" \u{00b7} ");
+            let context = crate::context::format_footer();
 
             // Show todo at end only if no tool calls were made this turn
             // (if tools ran, TodoWrite already rendered inline when called)
             if !made_tool_calls && let Ok(Some(todo_content)) = db.get_todo(session_id).await {
-                println!();
-                print!("{}", crate::tools::todo::format_todo_display(&todo_content));
+                sink.emit(EngineEvent::TodoDisplay {
+                    content: todo_content,
+                });
             }
 
-            println!("\n\x1b[90m{footer}{ctx_part}\x1b[0m\n");
+            sink.emit(EngineEvent::Footer {
+                prompt_tokens: total_prompt_tokens,
+                completion_tokens: total_completion_tokens,
+                cache_read_tokens: total_cache_read_tokens,
+                thinking_tokens: total_thinking_tokens,
+                total_chars: total_char_count,
+                elapsed_ms: total_elapsed.as_millis() as u64,
+                rate,
+                context,
+            });
 
             return Ok(());
         }
@@ -423,10 +403,12 @@ pub async fn inference_loop(
         // Loop detection: same tool+args repeated REPEAT_THRESHOLD times → stop immediately.
         if let Some(fp) = loop_detector.record(&tool_calls) {
             let culprit = fp.split(':').next().unwrap_or("unknown");
-            println!(
-                "\n  \x1b[31m\u{26a0}  Loop detected: '{culprit}' is repeating with identical arguments.\
-                \n  Stopping to avoid wasted work. Rephrase the task or check for ambiguity.\x1b[0m"
-            );
+            sink.emit(EngineEvent::Warn {
+                message: format!(
+                    "Loop detected: '{culprit}' is repeating with identical arguments. \
+                     Stopping to avoid wasted work. Rephrase the task or check for ambiguity."
+                ),
+            });
             break Ok(());
         }
 
@@ -503,8 +485,9 @@ async fn execute_one_tool(
                     format!("Failed to save todo: {e}")
                 } else {
                     // Show updated todo immediately
-                    println!();
-                    print!("{}", crate::tools::todo::format_todo_display(&content));
+                    sink.emit(EngineEvent::TodoDisplay {
+                        content: content.clone(),
+                    });
                     "Todo list updated.".to_string()
                 }
             }
@@ -543,7 +526,9 @@ async fn execute_tools_parallel(
     }
 
     let count = tool_calls.len();
-    println!("\n  \x1b[36m\u{1f43b} Running {count} tools in parallel...\x1b[0m");
+    sink.emit(EngineEvent::Info {
+        message: format!("Running {count} tools in parallel..."),
+    });
 
     // Launch all tool calls concurrently
     let futures: Vec<_> = tool_calls
@@ -694,9 +679,11 @@ async fn execute_tools_sequential(
                             if let Err(e) = settings.add_allowed_command(pattern) {
                                 tracing::warn!("Failed to save whitelist: {e}");
                             } else {
-                                println!(
-                                    "  \x1b[32m\u{2713}\x1b[0m Added '\x1b[1m{pattern}\x1b[0m' to always-allowed commands"
-                                );
+                                sink.emit(EngineEvent::Info {
+                                    message: format!(
+                                        "Added '{pattern}' to always-allowed commands"
+                                    ),
+                                });
                             }
                         }
                         // Fall through to execute
@@ -966,10 +953,12 @@ async fn execute_sub_agent(
         }
     }
 
-    println!(
-        "  \x1b[33m\u{26a0}  Sub-agent '{agent_name}' hit its iteration limit ({MAX_SUB_AGENT_LIMIT}). Returning partial result.\x1b[0m",
-        MAX_SUB_AGENT_LIMIT = loop_guard::MAX_SUB_AGENT_ITERATIONS
-    );
+    sink.emit(EngineEvent::Warn {
+        message: format!(
+            "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
+            loop_guard::MAX_SUB_AGENT_ITERATIONS
+        ),
+    });
     Ok("(sub-agent reached maximum iterations)".to_string())
 }
 

--- a/koda-core/src/mcp/registry.rs
+++ b/koda-core/src/mcp/registry.rs
@@ -30,41 +30,35 @@ impl McpRegistry {
 
     /// Load configs from `.mcp.json` files and connect to all servers.
     /// Logs errors for servers that fail to connect but doesn't abort.
-    pub async fn start_from_config(&mut self, project_root: &Path) {
+    ///
+    /// Returns a list of `(name, result)` status entries for the client to render.
+    pub async fn start_from_config(
+        &mut self,
+        project_root: &Path,
+    ) -> Vec<(String, Result<usize, String>)> {
         let configs = config::load_mcp_configs(project_root);
         if configs.is_empty() {
-            return;
+            return Vec::new();
         }
 
-        println!(
-            "  \x1b[36m\u{1f50c} Connecting to {} MCP server(s)...\x1b[0m",
-            configs.len()
-        );
+        let mut statuses = Vec::new();
 
         for (name, server_config) in configs {
             match McpClient::connect(name.clone(), server_config).await {
                 Ok(client) => {
                     let tool_count = client.tool_definitions().len();
-                    println!(
-                        "  \x1b[32m\u{2713}\x1b[0m {} — {} tool(s)",
-                        name, tool_count
-                    );
+                    statuses.push((name.clone(), Ok(tool_count)));
                     self.servers.insert(name, client);
                 }
                 Err(e) => {
-                    println!(
-                        "  \x1b[31m\u{2717}\x1b[0m {} — {}",
-                        name,
-                        format_error_short(&e)
-                    );
+                    let msg = format_error_short(&e);
                     tracing::error!("Failed to connect MCP server '{name}': {e:#}");
+                    statuses.push((name, Err(msg)));
                 }
             }
         }
 
-        if !self.servers.is_empty() {
-            println!();
-        }
+        statuses
     }
 
     /// Connect a single new server and add it to the registry.

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -144,11 +144,9 @@ pub fn build_http_client() -> reqwest::Client {
         .map(|v| v == "1" || v == "true")
         .unwrap_or(false);
     if accept_invalid_certs {
-        eprintln!(
-            "  \x1b[33m\u{26a0} WARNING: TLS certificate validation is DISABLED (KODA_ACCEPT_INVALID_CERTS=1)\x1b[0m"
+        tracing::warn!(
+            "TLS certificate validation disabled! API keys and conversation data may be intercepted."
         );
-        eprintln!("    API keys and conversation data may be intercepted.");
-        tracing::warn!("TLS certificate validation disabled!");
     }
     builder = builder.danger_accept_invalid_certs(accept_invalid_certs);
 

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -242,30 +242,21 @@ fn user_agents_dir() -> Result<PathBuf, std::env::VarError> {
         .join("agents"))
 }
 
-/// Format agent list for display (used by /agent command and ListAgents tool).
-pub fn list_agents(project_root: &Path) -> String {
-    let agents = discover_all_agents(project_root);
-
-    if agents.is_empty() {
-        return "No sub-agents configured.".to_string();
-    }
-
-    let lines: Vec<String> = agents
-        .iter()
+/// Return agent list data for display (used by /agent command and ListAgents tool).
+///
+/// Returns a list of `(name, description, source)` tuples.
+/// The client is responsible for formatting/coloring.
+pub fn list_agents(project_root: &Path) -> Vec<(String, String, String)> {
+    discover_all_agents(project_root)
+        .into_iter()
         .map(|a| {
-            let tag = match a.source {
-                "built-in" => "",
-                "user" => " \x1b[90m[user]\x1b[0m",
-                "project" => " \x1b[90m[project]\x1b[0m",
-                _ => "",
-            };
-            format!(
-                "  \x1b[36m{}\x1b[0m \u{2014} {}{}",
-                a.name, a.description, tag
+            (
+                a.name.to_string(),
+                a.description.to_string(),
+                a.source.to_string(),
             )
         })
-        .collect();
-    lines.join("\n")
+        .collect()
 }
 
 /// Format detailed agent list (for ListAgents with detail=true, used by CreateAgent workflow).
@@ -341,22 +332,22 @@ mod tests {
     #[test]
     fn test_list_agents_includes_builtins() {
         let dir = TempDir::new().unwrap();
-        // Even with no agents/ directory, built-ins are always available
         let result = list_agents(dir.path());
+        let names: Vec<&str> = result.iter().map(|(n, _, _)| n.as_str()).collect();
         assert!(
-            result.contains("reviewer"),
+            names.contains(&"reviewer"),
             "Should include built-in reviewer"
         );
         assert!(
-            result.contains("security"),
+            names.contains(&"security"),
             "Should include built-in security"
         );
         assert!(
-            result.contains("testgen"),
+            names.contains(&"testgen"),
             "Should include built-in testgen"
         );
         assert!(
-            result.contains("releaser"),
+            names.contains(&"releaser"),
             "Should include built-in releaser"
         );
     }
@@ -365,7 +356,8 @@ mod tests {
     fn test_list_agents_excludes_default() {
         let dir = TempDir::new().unwrap();
         let result = list_agents(dir.path());
-        assert!(!result.contains("default"), "Should exclude default agent");
+        let names: Vec<&str> = result.iter().map(|(n, _, _)| n.as_str()).collect();
+        assert!(!names.contains(&"default"), "Should exclude default agent");
     }
 
     #[test]
@@ -373,15 +365,16 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let agents_dir = dir.path().join("agents");
         std::fs::create_dir(&agents_dir).unwrap();
-        // Override the built-in reviewer with a project-local one
         std::fs::write(
             agents_dir.join("reviewer.json"),
             r#"{"name":"reviewer","system_prompt":"You are a custom project reviewer. Your job is to do project-specific reviews."}"#,
         ).unwrap();
         let result = list_agents(dir.path());
-        assert!(result.contains("reviewer"));
-        assert!(
-            result.contains("[project]"),
+        let reviewer = result.iter().find(|(n, _, _)| n == "reviewer");
+        assert!(reviewer.is_some());
+        assert_eq!(
+            reviewer.unwrap().2,
+            "project",
             "Project agent should be tagged"
         );
     }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -216,7 +216,22 @@ impl ToolRegistry {
                 if detail {
                     Ok(agent::list_agents_detail(&self.project_root))
                 } else {
-                    Ok(agent::list_agents(&self.project_root))
+                    let agents = agent::list_agents(&self.project_root);
+                    if agents.is_empty() {
+                        Ok("No sub-agents configured.".to_string())
+                    } else {
+                        let lines: Vec<String> = agents
+                            .iter()
+                            .map(|(name, desc, source)| {
+                                if source == "built-in" {
+                                    format!("  {name} — {desc}")
+                                } else {
+                                    format!("  {name} — {desc} [{source}]")
+                                }
+                            })
+                            .collect();
+                        Ok(lines.join("\n"))
+                    }
                 }
             }
             "CreateAgent" => Ok(agent::create_agent(&self.project_root, &args)),
@@ -345,7 +360,7 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
                 .or(args.get("cmd"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("?");
-            format!("\x1b[1m{cmd}\x1b[0m")
+            cmd.to_string()
         }
         "Delete" => {
             let path = args
@@ -358,9 +373,9 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             if recursive {
-                format!("Delete directory (recursive): \x1b[1m{path}\x1b[0m")
+                format!("Delete directory (recursive): {path}")
             } else {
-                format!("Delete: \x1b[1m{path}\x1b[0m")
+                format!("Delete: {path}")
             }
         }
         "Write" => {
@@ -374,9 +389,9 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             if overwrite {
-                format!("Overwrite file: \x1b[1m{path}\x1b[0m")
+                format!("Overwrite file: {path}")
             } else {
-                format!("Create file: \x1b[1m{path}\x1b[0m")
+                format!("Create file: {path}")
             }
         }
         "Edit" => {
@@ -392,11 +407,11 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
                     .and_then(|v| v.as_str())
                     .unwrap_or("?")
             };
-            format!("Edit file: \x1b[1m{path}\x1b[0m")
+            format!("Edit file: {path}")
         }
         "WebFetch" => {
             let url = args.get("url").and_then(|v| v.as_str()).unwrap_or("?");
-            format!("Fetch URL: \x1b[1m{url}\x1b[0m")
+            format!("Fetch URL: {url}")
         }
         _ => format!("Execute: {tool_name}"),
     }

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -44,63 +44,46 @@ pub fn definitions() -> Vec<ToolDefinition> {
     ]
 }
 
-/// Format a todo list for CLI display with visual checkboxes.
-pub fn format_todo_display(content: &str) -> String {
-    let mut output = String::new();
-    output.push_str("  \x1b[1m\u{1f4cb} Todo\x1b[0m\n");
-
+/// Parse a todo list into structured items for client rendering.
+///
+/// Returns a list of `(indent_level, status, text)` tuples where
+/// status is `"done"`, `"active"` (first pending), `"pending"`, or `"text"`.
+pub fn parse_todo_items(content: &str) -> Vec<(usize, &'static str, String)> {
     // Find the first unchecked item to highlight as "active"
     let first_pending = content.lines().position(|l| {
         let t = l.trim();
         t.starts_with("- [ ] ") || t.starts_with("  - [ ] ")
     });
 
+    let mut items = Vec::new();
+
     for (i, line) in content.lines().enumerate() {
-        let trimmed = line.trim();
         let is_active = Some(i) == first_pending;
 
-        if let Some(task) = trimmed
-            .strip_prefix("- [x] ")
-            .or_else(|| trimmed.strip_prefix("- [X] "))
-        {
-            // Done: green check + strikethrough
-            output.push_str(&format!(
-                "  \x1b[32m\u{2714}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
-            ));
-        } else if let Some(task) = trimmed.strip_prefix("- [ ] ") {
-            if is_active {
-                // Active: bold white square + bold text
-                output.push_str(&format!("  \x1b[33m\u{25a0}\x1b[0m \x1b[1m{task}\x1b[0m\n"));
-            } else {
-                // Pending: dim square
-                output.push_str(&format!(
-                    "  \x1b[90m\u{25a1}\x1b[0m \x1b[90m{task}\x1b[0m\n"
-                ));
-            }
-        } else if let Some(task) = trimmed
+        // Check nested (indented) patterns first, before trimming
+        if let Some(task) = line
             .strip_prefix("  - [x] ")
-            .or_else(|| trimmed.strip_prefix("  - [X] "))
+            .or_else(|| line.strip_prefix("  - [X] "))
         {
-            // Nested done
-            output.push_str(&format!(
-                "    \x1b[32m\u{2714}\x1b[0m \x1b[9m\x1b[90m{task}\x1b[0m\n"
-            ));
-        } else if let Some(task) = trimmed.strip_prefix("  - [ ] ") {
-            if is_active {
-                output.push_str(&format!(
-                    "    \x1b[33m\u{25a0}\x1b[0m \x1b[1m{task}\x1b[0m\n"
-                ));
-            } else {
-                output.push_str(&format!(
-                    "    \x1b[90m\u{25a1}\x1b[0m \x1b[90m{task}\x1b[0m\n"
-                ));
-            }
-        } else if !trimmed.is_empty() {
-            output.push_str(&format!("  {trimmed}\n"));
+            items.push((1, "done", task.to_string()));
+        } else if let Some(task) = line.strip_prefix("  - [ ] ") {
+            let status = if is_active { "active" } else { "pending" };
+            items.push((1, status, task.to_string()));
+        } else if let Some(task) = line
+            .trim()
+            .strip_prefix("- [x] ")
+            .or_else(|| line.trim().strip_prefix("- [X] "))
+        {
+            items.push((0, "done", task.to_string()));
+        } else if let Some(task) = line.trim().strip_prefix("- [ ] ") {
+            let status = if is_active { "active" } else { "pending" };
+            items.push((0, status, task.to_string()));
+        } else if !line.trim().is_empty() {
+            items.push((0, "text", line.trim().to_string()));
         }
     }
 
-    output
+    items
 }
 
 /// Extract the content string from tool arguments.
@@ -123,16 +106,15 @@ mod tests {
     }
 
     #[test]
-    fn test_format_todo_display() {
+    fn test_parse_todo_items() {
         let content =
             "- [x] Setup project\n- [ ] Write tests\n  - [ ] Unit tests\n  - [x] Integration tests";
-        let output = format_todo_display(content);
-        // Should contain visual checkmarks
-        assert!(output.contains("Todo"));
-        assert!(output.contains("Setup project"));
-        assert!(output.contains("Write tests"));
-        assert!(output.contains("Unit tests"));
-        assert!(output.contains("Integration tests"));
+        let items = parse_todo_items(content);
+        assert_eq!(items.len(), 4);
+        assert_eq!(items[0], (0, "done", "Setup project".into()));
+        assert_eq!(items[1], (0, "active", "Write tests".into())); // first pending = active
+        assert_eq!(items[2], (1, "pending", "Unit tests".into()));
+        assert_eq!(items[3], (1, "done", "Integration tests".into()));
     }
 
     #[test]

--- a/koda-core/src/version.rs
+++ b/koda-core/src/version.rs
@@ -15,15 +15,20 @@ pub fn spawn_version_check() -> tokio::task::JoinHandle<Option<String>> {
     tokio::spawn(async move { check_latest_version().await })
 }
 
-/// Print the update hint if a newer version was found.
-pub fn print_update_hint(latest: &str) {
+/// Check whether `latest` is newer than the current version.
+/// Returns `Some((current, latest))` if an update is available.
+pub fn update_available(latest: &str) -> Option<(&'static str, String)> {
     let current = env!("CARGO_PKG_VERSION");
     if latest != current && is_newer(latest, current) {
-        println!(
-            "  \x1b[90m\u{2728} Update available: \x1b[0m\x1b[36m{current}\x1b[0m\x1b[90m \u{2192} \x1b[0m\x1b[32m{latest}\x1b[0m\x1b[90m  (cargo install {CRATE_NAME})\x1b[0m"
-        );
-        println!();
+        Some((current, latest.to_string()))
+    } else {
+        None
     }
+}
+
+/// The crate name, useful for building install commands.
+pub fn crate_name() -> &'static str {
+    CRATE_NAME
 }
 
 /// Query crates.io for the latest version.


### PR DESCRIPTION
## Summary

Fixes #75 — removes all 15 violations of the client-server separation principle from `koda-core`.

After this change, `koda-core` has **zero** `println!`, `eprintln!`, `print!`, ANSI escape codes, or Unicode UI characters in production code. All presentation logic lives in `koda-cli`.

## Changes by file

### koda-core (engine — now terminal-agnostic)

| File | Violations | Fix |
|------|-----------|-----|
| `inference.rs` | 8 — direct println with ANSI + emoji for warnings, footer, todo, parallel status, whitelist confirmation | All replaced with `sink.emit(EngineEvent::Warn/Info/Footer/TodoDisplay)` |
| `tools/todo.rs` | `format_todo_display()` with embedded ANSI | Replaced with `parse_todo_items()` → `Vec<(indent, status, text)>` |
| `mcp/registry.rs` | 4 — direct println for connection status | `start_from_config()` now returns `Vec<(name, Result<usize, String>)>` |
| `version.rs` | `print_update_hint()` with ANSI | Replaced with `update_available()` → `Option<(current, latest)>` |
| `providers/mod.rs` | `eprintln!` TLS warning with ANSI | Removed (kept existing `tracing::warn!`) |
| `tools/agent.rs` | `list_agents()` returning ANSI string | Now returns `Vec<(name, desc, source)>` |
| `tools/mod.rs` | `describe_action()` with `\x1b[1m` bold | Removed ANSI codes (plain text) |
| `engine/event.rs` | — | Added `TodoDisplay { content }` variant |
| `agent.rs` | — | Stores `mcp_statuses` for client rendering |

### koda-cli (rendering — all ANSI lives here)

| File | Change |
|------|--------|
| `display.rs` | Added `format_todo_display()` and `format_agents_list()` |
| `sink.rs` | Added `TodoDisplay` handler |
| `app.rs` / `tui_app.rs` | Render MCP statuses and version hint |
| `repl.rs` | Use `format_agents_list()` for `/agent` command |
| `acp_adapter.rs` | Added `TodoDisplay` match arm |

## Test plan

- [x] All 390 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] Grep confirms zero ANSI/println in koda-core production code
- [x] `EngineEvent::Footer` now actually emitted (was dead code before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)