### PR TITLE
refactor: harden engine protocol for event-driven TUI client (#77)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -130,6 +130,9 @@ pub fn engine_event_to_acp(
         EngineEvent::SpinnerStart { .. } => None,
         EngineEvent::SpinnerStop => None,
         EngineEvent::TodoDisplay { .. } => None,
+        EngineEvent::TurnStart { .. } => None,
+        EngineEvent::TurnEnd { .. } => None,
+        EngineEvent::LoopCapReached { .. } => None,
 
         EngineEvent::Info { message } => {
             let cb = acp::ContentBlock::Text(acp::TextContent::new(format!("[info] {message}")));
@@ -243,6 +246,14 @@ impl EngineSink for AcpSink {
             let _ = self
                 .tx
                 .try_send(AcpOutgoing::PermissionRequest { rpc_id, request });
+            return;
+        }
+
+        // Handle loop cap — server always auto-continues
+        if matches!(event, EngineEvent::LoopCapReached { .. }) {
+            let _ = self.cmd_tx.try_send(EngineCommand::LoopDecision {
+                action: koda_core::loop_guard::LoopContinuation::Continue200,
+            });
             return;
         }
 
@@ -476,6 +487,17 @@ mod tests {
                 message: "x".into(),
             },
             EngineEvent::SpinnerStop,
+            EngineEvent::TurnStart {
+                turn_id: "t1".into(),
+            },
+            EngineEvent::TurnEnd {
+                turn_id: "t1".into(),
+                reason: koda_core::engine::event::TurnEndReason::Complete,
+            },
+            EngineEvent::LoopCapReached {
+                cap: 200,
+                recent_tools: vec![],
+            },
         ];
         for event in none_events {
             assert!(

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -690,13 +690,7 @@ pub async fn run(
 
         // Run turn in a scoped block so borrows are released on completion.
         {
-            let turn = session.run_turn(
-                &config,
-                pending_images,
-                &cli_sink,
-                &mut cmd_rx,
-                &crate::app::cli_loop_continue_prompt,
-            );
+            let turn = session.run_turn(&config, pending_images, &cli_sink, &mut cmd_rx);
             tokio::pin!(turn);
 
             loop {
@@ -733,6 +727,17 @@ pub async fn run(
                                     .send(EngineCommand::ApprovalResponse { id, decision })
                                     .await;
                             }
+                            UiEvent::Engine(EngineEvent::LoopCapReached {
+                                cap,
+                                recent_tools,
+                            }) => {
+                                let action = cli_loop_continue_prompt(cap, &recent_tools);
+                                let _ = cmd_tx
+                                    .send(EngineCommand::LoopDecision { action })
+                                    .await;
+                            }
+                            UiEvent::Engine(EngineEvent::TurnStart { .. }) => {}
+                            UiEvent::Engine(EngineEvent::TurnEnd { .. }) => {}
                             UiEvent::Engine(ref event) => {
                                 renderer.render(event.clone());
                             }

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -59,7 +59,6 @@ pub async fn run_headless(
             pending_images,
             &cli_sink,
             &mut cmd_rx,
-            &crate::app::cli_loop_continue_prompt,
         ) => r,
         _ = tokio::signal::ctrl_c() => {
             cancel.cancel();

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -382,13 +382,7 @@ async fn handle_prompt(
     let config = state.config.clone();
     let result = active
         .session
-        .run_turn(
-            &config,
-            None,
-            &sink,
-            &mut cmd_rx,
-            &server_loop_continue_prompt,
-        )
+        .run_turn(&config, None, &sink, &mut cmd_rx)
         .await;
 
     // Drop the sink so the streaming task finishes
@@ -404,14 +398,6 @@ async fn handle_prompt(
     let response = acp::PromptResponse::new(stop_reason);
     let resp = wrap_response(id, acp::AgentResponse::PromptResponse(response));
     send_json(out_tx, &resp).await;
-}
-
-/// Server always continues — no terminal to prompt.
-fn server_loop_continue_prompt(
-    _cap: u32,
-    _recent_names: &[String],
-) -> koda_core::loop_guard::LoopContinuation {
-    koda_core::loop_guard::LoopContinuation::Continue200
 }
 
 // ── Helpers ─────────────────────────────────────────────────

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -134,6 +134,15 @@ impl UiRenderer {
             EngineEvent::StatusUpdate { .. } => {
                 // Status bar updates are a TUI/server concern, not CLI.
             }
+            EngineEvent::TurnStart { .. } => {
+                // Turn lifecycle: handled by the event loop, not the renderer.
+            }
+            EngineEvent::TurnEnd { .. } => {
+                // Turn lifecycle: handled by the event loop, not the renderer.
+            }
+            EngineEvent::LoopCapReached { .. } => {
+                // Loop cap: handled by the event loop, not the renderer.
+            }
             EngineEvent::TodoDisplay { content } => {
                 print!("{}", crate::display::format_todo_display(&content));
             }
@@ -313,6 +322,11 @@ impl EngineSink for CliSink {
                     let _ = cmd_tx.blocking_send(EngineCommand::ApprovalResponse {
                         id: id.clone(),
                         decision,
+                    });
+                } else if matches!(event, EngineEvent::LoopCapReached { .. }) {
+                    // Headless/direct mode: auto-continue
+                    let _ = cmd_tx.blocking_send(EngineCommand::LoopDecision {
+                        action: koda_core::loop_guard::LoopContinuation::Continue200,
                     });
                 } else {
                     renderer.lock().unwrap().render(event);

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -738,13 +738,7 @@ pub async fn run(
 
         // Run turn
         {
-            let turn = session.run_turn(
-                &config,
-                pending_images,
-                &cli_sink,
-                &mut cmd_rx,
-                &cli_loop_continue_prompt,
-            );
+            let turn = session.run_turn(&config, pending_images, &cli_sink, &mut cmd_rx);
             tokio::pin!(turn);
 
             loop {
@@ -778,6 +772,21 @@ pub async fn run(
                                 let _ = cmd_tx
                                     .send(EngineCommand::ApprovalResponse { id, decision })
                                     .await;
+                            }
+                            UiEvent::Engine(EngineEvent::LoopCapReached {
+                                cap,
+                                recent_tools,
+                            }) => {
+                                let action = crate::app::cli_loop_continue_prompt(cap, &recent_tools);
+                                let _ = cmd_tx
+                                    .send(EngineCommand::LoopDecision { action })
+                                    .await;
+                            }
+                            UiEvent::Engine(EngineEvent::TurnStart { .. }) => {
+                                // Future: update status bar to show inference is active
+                            }
+                            UiEvent::Engine(EngineEvent::TurnEnd { .. }) => {
+                                // Future: drain type-ahead queue, update status bar
                             }
                             UiEvent::Engine(ref event) => {
                                 renderer.render(event.clone());
@@ -852,37 +861,4 @@ pub async fn run(
     );
 
     Ok(())
-}
-
-// ── Utilities ─────────────────────────────────────────────────
-
-/// CLI implementation of the loop-continue prompt.
-/// Shows a terminal select widget when the hard cap is hit.
-fn cli_loop_continue_prompt(
-    cap: u32,
-    recent_names: &[String],
-) -> koda_core::loop_guard::LoopContinuation {
-    use koda_core::loop_guard::LoopContinuation;
-
-    println!("\n  \x1b[33m\u{26a0}  Hard cap reached ({cap} iterations).\x1b[0m");
-
-    if !recent_names.is_empty() {
-        println!("  Last tool calls:");
-        for name in recent_names {
-            println!("    \x1b[90m\u{25cf}\x1b[0m {name}");
-        }
-    }
-    println!();
-
-    let options = vec![
-        SelectOption::new("Stop", "End the task here"),
-        SelectOption::new("+50 more", "Continue for 50 more iterations"),
-        SelectOption::new("+200 more", "Continue for 200 more iterations"),
-    ];
-
-    match crate::tui::select("Continue?", &options, 0) {
-        Ok(Some(1)) => LoopContinuation::Continue50,
-        Ok(Some(2)) => LoopContinuation::Continue200,
-        _ => LoopContinuation::Stop,
-    }
 }

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -121,11 +121,38 @@ pub enum EngineEvent {
         context: String,
     },
 
-    /// Spinner/progress indicator.
+    /// Spinner/progress indicator (presentational hint).
+    ///
+    /// Clients may render this as a terminal spinner, a status bar update,
+    /// or ignore it entirely. The ratatui TUI uses the status bar instead.
     SpinnerStart { message: String },
 
-    /// Stop the spinner.
+    /// Stop the spinner (presentational hint).
+    ///
+    /// See `SpinnerStart` — clients may ignore this.
     SpinnerStop,
+
+    // ── Turn lifecycle ─────────────────────────────────────────────────
+    /// An inference turn is starting.
+    ///
+    /// Emitted at the beginning of `inference_loop()`. Clients can use this
+    /// to lock input, start timers, or update status indicators.
+    TurnStart { turn_id: String },
+
+    /// An inference turn has ended.
+    ///
+    /// Emitted when `inference_loop()` completes. Clients can use this to
+    /// unlock input, drain type-ahead queues, or update status.
+    TurnEnd {
+        turn_id: String,
+        reason: TurnEndReason,
+    },
+
+    /// The engine's iteration hard cap was reached.
+    ///
+    /// The client must respond with `EngineCommand::LoopDecision`.
+    /// Until the client responds, the inference loop is paused.
+    LoopCapReached { cap: u32, recent_tools: Vec<String> },
 
     // ── Messages ──────────────────────────────────────────────────────
     /// Display the todo checklist (raw markdown content, client renders).
@@ -141,15 +168,37 @@ pub enum EngineEvent {
     Error { message: String },
 }
 
+/// Why an inference turn ended.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TurnEndReason {
+    /// The LLM produced a final text response (no more tool calls).
+    Complete,
+    /// The user or system cancelled the turn.
+    Cancelled,
+    /// The turn failed with an error.
+    Error { message: String },
+}
+
 // ── Client → Engine ──────────────────────────────────────────────────────
 
 /// Commands sent from the client to the engine.
-/// Not yet consumed outside the engine module — wired in v0.2.0 server mode.
-#[allow(dead_code)]
+///
+/// Currently consumed variants:
+/// - `ApprovalResponse` — during tool confirmation flow
+/// - `Interrupt` — during approval waits and inference streaming
+/// - `LoopDecision` — when iteration hard cap is reached
+///
+/// Future (server mode, v0.2.0):
+/// - `UserPrompt`, `SlashCommand`, `Quit` — defined for wire protocol
+///   completeness but currently handled client-side.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EngineCommand {
     /// User submitted a prompt.
+    ///
+    /// Currently handled client-side. Will be consumed by the engine
+    /// in server mode (v0.2.0) for prompt queuing.
     UserPrompt {
         text: String,
         /// Base64-encoded images attached to the prompt.
@@ -158,6 +207,9 @@ pub enum EngineCommand {
     },
 
     /// User requested interruption of the current operation.
+    ///
+    /// Consumed during approval waits. Also triggers `CancellationToken`
+    /// for streaming interruption.
     Interrupt,
 
     /// Response to an `EngineEvent::ApprovalRequest`.
@@ -167,10 +219,22 @@ pub enum EngineCommand {
         decision: ApprovalDecision,
     },
 
+    /// Response to an `EngineEvent::LoopCapReached`.
+    ///
+    /// Tells the engine whether to continue or stop after hitting
+    /// the iteration hard cap.
+    LoopDecision {
+        action: crate::loop_guard::LoopContinuation,
+    },
+
     /// A slash command from the REPL.
+    ///
+    /// Currently handled client-side. Defined for wire protocol completeness.
     SlashCommand(SlashCommand),
 
     /// User requested to quit the session.
+    ///
+    /// Currently handled client-side. Defined for wire protocol completeness.
     Quit,
 }
 
@@ -402,5 +466,99 @@ mod tests {
         let json = serde_json::to_string(&img).unwrap();
         let deserialized: ImageAttachment = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.mime_type, "image/png");
+    }
+
+    #[test]
+    fn test_turn_lifecycle_roundtrip() {
+        let start = EngineEvent::TurnStart {
+            turn_id: "turn-1".into(),
+        };
+        let json = serde_json::to_string(&start).unwrap();
+        assert!(json.contains("turn_start"));
+        let _: EngineEvent = serde_json::from_str(&json).unwrap();
+
+        let end_complete = EngineEvent::TurnEnd {
+            turn_id: "turn-1".into(),
+            reason: TurnEndReason::Complete,
+        };
+        let json = serde_json::to_string(&end_complete).unwrap();
+        let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            deserialized,
+            EngineEvent::TurnEnd {
+                reason: TurnEndReason::Complete,
+                ..
+            }
+        ));
+
+        let end_error = EngineEvent::TurnEnd {
+            turn_id: "turn-2".into(),
+            reason: TurnEndReason::Error {
+                message: "oops".into(),
+            },
+        };
+        let json = serde_json::to_string(&end_error).unwrap();
+        let _: EngineEvent = serde_json::from_str(&json).unwrap();
+
+        let end_cancelled = EngineEvent::TurnEnd {
+            turn_id: "turn-3".into(),
+            reason: TurnEndReason::Cancelled,
+        };
+        let json = serde_json::to_string(&end_cancelled).unwrap();
+        let _: EngineEvent = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn test_loop_cap_reached_roundtrip() {
+        let event = EngineEvent::LoopCapReached {
+            cap: 200,
+            recent_tools: vec!["Bash".into(), "Edit".into()],
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("loop_cap_reached"));
+        let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            deserialized,
+            EngineEvent::LoopCapReached { cap: 200, .. }
+        ));
+    }
+
+    #[test]
+    fn test_loop_decision_roundtrip() {
+        use crate::loop_guard::LoopContinuation;
+
+        let cmd = EngineCommand::LoopDecision {
+            action: LoopContinuation::Continue50,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let deserialized: EngineCommand = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            deserialized,
+            EngineCommand::LoopDecision {
+                action: LoopContinuation::Continue50
+            }
+        ));
+
+        let cmd_stop = EngineCommand::LoopDecision {
+            action: LoopContinuation::Stop,
+        };
+        let json = serde_json::to_string(&cmd_stop).unwrap();
+        let _: EngineCommand = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn test_turn_end_reason_variants() {
+        let reasons = vec![
+            TurnEndReason::Complete,
+            TurnEndReason::Cancelled,
+            TurnEndReason::Error {
+                message: "failed".into(),
+            },
+        ];
+        for reason in reasons {
+            let json = serde_json::to_string(&reason).unwrap();
+            let roundtripped: TurnEndReason = serde_json::from_str(&json).unwrap();
+            assert_eq!(reason, roundtripped);
+        }
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -36,7 +36,6 @@ pub async fn inference_loop(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
 ) -> Result<()> {
     // When native thinking is active, drop ShareReasoning from tool list
     let has_native_thinking = config.model_settings.thinking_budget.is_some()
@@ -70,11 +69,30 @@ pub async fn inference_loop(
 
     loop {
         if iteration >= hard_cap {
-            let extra = loop_guard::ask_continue_or_stop(
-                hard_cap,
-                &loop_detector.recent_names(),
-                loop_continue_prompt,
-            );
+            let recent = loop_detector.recent_names();
+            sink.emit(EngineEvent::LoopCapReached {
+                cap: hard_cap,
+                recent_tools: recent,
+            });
+
+            // Wait for client decision via EngineCommand::LoopDecision
+            let extra = loop {
+                tokio::select! {
+                    cmd = cmd_rx.recv() => match cmd {
+                        Some(EngineCommand::LoopDecision { action }) => {
+                            break action.extra_iterations();
+                        }
+                        Some(EngineCommand::Interrupt) => {
+                            cancel.cancel();
+                            break 0;
+                        }
+                        None => break 0,
+                        _ => continue,
+                    },
+                    _ = cancel.cancelled() => break 0,
+                }
+            };
+
             if extra == 0 {
                 break Ok(());
             }
@@ -379,7 +397,6 @@ pub async fn inference_loop(
                 &settings.approval.allowed_commands,
                 sink,
                 cancel.clone(),
-                loop_continue_prompt,
             )
             .await?;
         } else {
@@ -395,7 +412,6 @@ pub async fn inference_loop(
                 sink,
                 cancel.clone(),
                 cmd_rx,
-                loop_continue_prompt,
             )
             .await?;
         }
@@ -443,7 +459,6 @@ async fn execute_one_tool(
     allowed_commands: &[String],
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
-    loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
 ) -> (String, String) {
     let result = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
@@ -462,7 +477,6 @@ async fn execute_one_tool(
             cancel.clone(),
             // Sub-agents get a fresh command channel (they auto-approve in all modes)
             &mut mpsc::channel(1).1,
-            loop_continue_prompt,
         )
         .await
         {
@@ -513,7 +527,6 @@ async fn execute_tools_parallel(
     allowed_commands: &[String],
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
-    loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
 ) -> Result<()> {
     // Print all tool call banners upfront
     for tc in tool_calls {
@@ -545,7 +558,6 @@ async fn execute_tools_parallel(
                 allowed_commands,
                 sink,
                 cancel.clone(),
-                loop_continue_prompt,
             )
         })
         .collect();
@@ -585,7 +597,6 @@ async fn execute_tools_sequential(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
 ) -> Result<()> {
     for tc in tool_calls {
         // Check for interrupt before each tool
@@ -732,7 +743,6 @@ async fn execute_tools_sequential(
             &settings.approval.allowed_commands,
             sink,
             cancel.clone(),
-            loop_continue_prompt,
         )
         .await;
         sink.emit(EngineEvent::ToolCallResult {
@@ -768,7 +778,6 @@ async fn execute_sub_agent(
     sink: &dyn crate::engine::EngineSink,
     _cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    _loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"]

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -104,7 +104,8 @@ fn is_mutating_tool(name: &str) -> bool {
 /// Prompt the user when the hard iteration cap is hit.
 ///
 /// Options for continuing after hitting the hard cap.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum LoopContinuation {
     Stop,
     Continue50,

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -9,7 +9,6 @@ use crate::approval::{ApprovalMode, Settings};
 use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
-use crate::loop_guard;
 use crate::providers::{self, ImageData, LlmProvider};
 
 use anyhow::Result;
@@ -55,16 +54,22 @@ impl KodaSession {
 
     /// Run one inference turn: prompt → streaming → tool execution → response.
     ///
-    /// This wraps `inference::inference_loop()` with all the session state.
+    /// Emits `TurnStart` and `TurnEnd` lifecycle events. The loop-cap prompt
+    /// is handled via `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`
+    /// through the `cmd_rx` channel.
     pub async fn run_turn(
         &mut self,
         config: &KodaConfig,
         pending_images: Option<Vec<ImageData>>,
         sink: &dyn EngineSink,
         cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-        loop_continue_prompt: &dyn Fn(u32, &[String]) -> loop_guard::LoopContinuation,
     ) -> Result<()> {
-        crate::inference::inference_loop(
+        let turn_id = uuid::Uuid::new_v4().to_string();
+        sink.emit(crate::engine::EngineEvent::TurnStart {
+            turn_id: turn_id.clone(),
+        });
+
+        let result = crate::inference::inference_loop(
             &self.agent.project_root,
             config,
             &self.db,
@@ -79,9 +84,19 @@ impl KodaSession {
             sink,
             self.cancel.clone(),
             cmd_rx,
-            loop_continue_prompt,
         )
-        .await
+        .await;
+
+        let reason = match &result {
+            Ok(()) if self.cancel.is_cancelled() => crate::engine::event::TurnEndReason::Cancelled,
+            Ok(()) => crate::engine::event::TurnEndReason::Complete,
+            Err(e) => crate::engine::event::TurnEndReason::Error {
+                message: e.to_string(),
+            },
+        };
+        sink.emit(crate::engine::EngineEvent::TurnEnd { turn_id, reason });
+
+        result
     }
 
     /// Replace the provider (e.g., after switching models or providers).

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -99,7 +99,6 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         &sink,
         cancel,
         &mut cmd_rx,
-        &|_, _| koda_core::loop_guard::LoopContinuation::Stop,
     )
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -11,7 +11,6 @@ use koda_core::{
     db::{Database, Role},
     engine::{EngineCommand, EngineEvent, sink::TestSink},
     inference,
-    loop_guard::LoopContinuation,
     providers::{
         ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
         mock::{MockProvider, MockResponse},
@@ -83,7 +82,6 @@ impl Env {
             &sink,
             CancellationToken::new(),
             &mut cmd_rx,
-            &|_, _| LoopContinuation::Stop,
         )
         .await;
 
@@ -255,7 +253,6 @@ async fn test_provider_error_emits_error_event() {
         &sink,
         CancellationToken::new(),
         &mut cmd_rx,
-        &|_, _| LoopContinuation::Stop,
     )
     .await;
 
@@ -369,7 +366,6 @@ async fn test_cancel_during_streaming() {
         &sink,
         cancel,
         &mut cmd_rx,
-        &|_, _| LoopContinuation::Stop,
     )
     .await;
 


### PR DESCRIPTION
## Summary

Fixes #77 — surgical changes to `koda-core`'s `EngineEvent`/`EngineCommand` protocol to make it complete enough for a fully event-driven TUI client. Prerequisite for #78 (full ratatui TUI rewrite).

## Changes

### Gap 1: Turn Lifecycle Events
- **New:** `EngineEvent::TurnStart { turn_id }` / `TurnEnd { turn_id, reason }`
- **New:** `TurnEndReason` enum (`Complete`, `Cancelled`, `Error`)
- Emitted from `session.rs::run_turn()` — wraps the inference loop

### Gap 2: Loop Cap → Event/Command (breaking change to internal API)
- **New:** `EngineEvent::LoopCapReached { cap, recent_tools }`
- **New:** `EngineCommand::LoopDecision { action }`
- **Removed:** `loop_continue_prompt` callback parameter from `inference_loop()`, `run_turn()`, and 5 internal functions
- `LoopContinuation` now derives `Serialize`/`Deserialize`
- Server (`AcpSink`) and headless (`CliSink::Direct`) auto-respond with `Continue200`
- CLI event loops (`app.rs`, `tui_app.rs`) handle via `cmd_tx` channel

### Gap 3: EngineCommand Cleanup
- Removed blanket `#[allow(dead_code)]` from `EngineCommand` enum
- Added per-variant doc comments explaining consumed vs. future variants

### Gap 4: Spinner Documentation
- Added doc comments clarifying `SpinnerStart`/`SpinnerStop` are optional presentational hints

### DRY
- Removed duplicate `cli_loop_continue_prompt` from `tui_app.rs` (reuses `app.rs` version)

## Files changed (12)

| File | What |
|------|------|
| `engine/event.rs` | New events, commands, TurnEndReason, tests |
| `inference.rs` | Remove callback, emit LoopCapReached, await LoopDecision |
| `session.rs` | Emit TurnStart/TurnEnd, remove callback param |
| `loop_guard.rs` | Add Serialize/Deserialize to LoopContinuation |
| `tui_app.rs` | Handle new events, remove duplicate function |
| `app.rs` | Handle new events |
| `sink.rs` | Handle new events in renderer + Direct mode |
| `acp_adapter.rs` | Handle new events, auto-respond to LoopCapReached |
| `server.rs` | Remove callback, remove dead function |
| `headless.rs` | Remove callback param |
| `e2e_test.rs` | Remove callback param |
| `cancel_test.rs` | Remove callback param |

## Test plan

- [x] All tests pass (`cargo test --workspace --features koda-core/test-support`)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New roundtrip tests for TurnStart/TurnEnd, LoopCapReached/LoopDecision, TurnEndReason
- [x] ACP adapter test covers new None-mapped events