### PR TITLE
feat: native TUI for all slash commands + rendering architecture (#84, #91)

### DIFF
--- a/koda-cli/src/commands.rs
+++ b/koda-cli/src/commands.rs
@@ -177,6 +177,7 @@ pub(crate) async fn handle_compact(
 // ── MCP command handler ──────────────────────────────────────
 
 /// Handle `/mcp` subcommands: status, add, remove, restart.
+#[allow(dead_code)] // Replaced by tui_wizards::handle_mcp
 pub(crate) async fn handle_mcp_command(
     args: &str,
     mcp_registry: &Arc<tokio::sync::RwLock<koda_core::mcp::McpRegistry>>,

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -19,6 +19,7 @@ mod tui_app;
 mod tui_commands;
 mod tui_output;
 mod tui_render;
+mod tui_wizards;
 mod widgets;
 
 use anyhow::{Context, Result};

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -32,6 +32,8 @@ pub enum ReplAction {
     Expand(usize),
     /// Toggle verbose tool output (None = toggle, Some = set)
     Verbose(Option<bool>),
+    /// List available sub-agents
+    ListAgents,
     Handled,
     NotACommand,
 }
@@ -160,40 +162,7 @@ pub async fn handle_command(
             _ => ReplAction::Verbose(None), // toggle
         },
 
-        "/agent" => {
-            let project_root = std::env::current_dir().unwrap_or_default();
-            let agents = koda_core::tools::agent::list_agents(&project_root);
-            let listing = if agents.is_empty() {
-                "No sub-agents configured.".to_string()
-            } else {
-                agents
-                    .iter()
-                    .map(|(name, desc, source)| {
-                        let tag = match source.as_str() {
-                            "user" => " \x1b[90m[user]\x1b[0m",
-                            "project" => " \x1b[90m[project]\x1b[0m",
-                            _ => "",
-                        };
-                        format!("  \x1b[36m{name}\x1b[0m \u{2014} {desc}{tag}")
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            };
-            println!();
-            println!("  \x1b[1m\u{1f43b} Sub-Agents\x1b[0m");
-            println!();
-            if agents.is_empty() {
-                println!("  \x1b[90m{listing}\x1b[0m");
-            } else {
-                println!("{listing}");
-            }
-            println!();
-            println!("  \x1b[90mAsk Koda to invoke them, or use koda --agent <name>\x1b[0m");
-            println!(
-                "  \x1b[90mNeed a specialist? Ask Koda to create one for recurring tasks\x1b[0m"
-            );
-            ReplAction::Handled
-        }
+        "/agent" => ReplAction::ListAgents,
 
         "/sessions" => match arg {
             Some(sub) if sub.starts_with("delete ") => {

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -34,6 +34,11 @@ pub enum ReplAction {
     Verbose(Option<bool>),
     /// List available sub-agents
     ListAgents,
+    /// Show git diff summary
+    ShowDiff,
+    /// Memory management command
+    MemoryCommand(Option<String>),
+    #[allow(dead_code)]
     Handled,
     NotACommand,
 }
@@ -74,78 +79,21 @@ pub async fn handle_command(
             None => ReplAction::SetTrust(None),
         },
 
-        "/diff" => {
-            // Run git diff
-            let output = std::process::Command::new("git")
-                .args(["diff", "--stat"])
-                .output();
-
-            let diff_stat = match output {
-                Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
-                Ok(o) => {
-                    let err = String::from_utf8_lossy(&o.stderr);
-                    println!("  \x1b[31mGit error: {err}\x1b[0m");
-                    return ReplAction::Handled;
-                }
-                Err(e) => {
-                    println!("  \x1b[31mFailed to run git: {e}\x1b[0m");
-                    return ReplAction::Handled;
-                }
-            };
-
-            if diff_stat.trim().is_empty() {
-                // Try staged changes
-                let staged = std::process::Command::new("git")
-                    .args(["diff", "--cached", "--stat"])
-                    .output()
-                    .ok()
-                    .and_then(|o| {
-                        if o.status.success() {
-                            let s = String::from_utf8_lossy(&o.stdout).to_string();
-                            if s.trim().is_empty() { None } else { Some(s) }
-                        } else {
-                            None
-                        }
-                    });
-
-                if staged.is_none() {
-                    println!("  \x1b[90mNo uncommitted changes.\x1b[0m");
-                    return ReplAction::Handled;
-                }
+        "/diff" => match arg {
+            Some("review") => {
+                let full_diff = get_git_diff();
+                ReplAction::InjectPrompt(format!(
+                    "Review these uncommitted changes. Point out bugs, improvements, and concerns:\n\n```diff\n{full_diff}\n```"
+                ))
             }
-
-            match arg {
-                Some("review") => {
-                    // Get full diff for LLM review
-                    let full_diff = get_git_diff();
-                    ReplAction::InjectPrompt(format!(
-                        "Review these uncommitted changes. Point out bugs, improvements, and concerns:\n\n```diff\n{full_diff}\n```"
-                    ))
-                }
-                Some("commit") => {
-                    // Get full diff for commit message generation
-                    let full_diff = get_git_diff();
-                    ReplAction::InjectPrompt(format!(
-                        "Write a conventional commit message for these changes. Use the format: type: description\n\nInclude a body with bullet points for each logical change.\n\n```diff\n{full_diff}\n```"
-                    ))
-                }
-                _ => {
-                    // Just show the summary
-                    println!();
-                    println!("  \x1b[1m\u{1f43b} Uncommitted Changes\x1b[0m");
-                    println!();
-                    for line in diff_stat.lines() {
-                        println!("  \x1b[90m{line}\x1b[0m");
-                    }
-                    println!();
-                    println!(
-                        "  \x1b[90m/diff review   \u{2014} ask Koda to review the changes\x1b[0m"
-                    );
-                    println!("  \x1b[90m/diff commit   \u{2014} generate a commit message\x1b[0m");
-                    ReplAction::Handled
-                }
+            Some("commit") => {
+                let full_diff = get_git_diff();
+                ReplAction::InjectPrompt(format!(
+                    "Write a conventional commit message for these changes. Use the format: type: description\n\nInclude a body with bullet points for each logical change.\n\n```diff\n{full_diff}\n```"
+                ))
             }
-        }
+            _ => ReplAction::ShowDiff,
+        },
 
         "/compact" => ReplAction::Compact,
 
@@ -180,58 +128,7 @@ pub async fn handle_command(
             _ => ReplAction::ListSessions,
         },
 
-        "/memory" => {
-            let project_root = std::env::current_dir().unwrap_or_default();
-            match arg {
-                Some(text) if text.starts_with("global ") => {
-                    let entry = text.strip_prefix("global ").unwrap().trim();
-                    if entry.is_empty() {
-                        println!("  Usage: /memory global <text>");
-                    } else {
-                        match koda_core::memory::append_global(entry) {
-                            Ok(()) => println!("  \x1b[32m\u{2713}\x1b[0m Saved to global memory"),
-                            Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
-                        }
-                    }
-                }
-                Some(text) if text.starts_with("add ") => {
-                    let entry = text.strip_prefix("add ").unwrap().trim();
-                    if entry.is_empty() {
-                        println!("  Usage: /memory add <text>");
-                    } else {
-                        match koda_core::memory::append(&project_root, entry) {
-                            Ok(()) => println!(
-                                "  \x1b[32m\u{2713}\x1b[0m Saved to project memory (MEMORY.md)"
-                            ),
-                            Err(e) => println!("  \x1b[31mError: {e}\x1b[0m"),
-                        }
-                    }
-                }
-                _ => {
-                    // Show current memory status
-                    let active = koda_core::memory::active_project_file(&project_root);
-                    println!();
-                    println!("  \x1b[1m\u{1f43b} Memory\x1b[0m");
-                    println!();
-                    match active {
-                        Some(f) => println!("  Project: \x1b[36m{f}\x1b[0m"),
-                        None => println!(
-                            "  Project: \x1b[90m(none — will create MEMORY.md on first write)\x1b[0m"
-                        ),
-                    }
-                    println!("  Global:  \x1b[36m~/.config/koda/memory.md\x1b[0m");
-                    println!();
-                    println!("  Commands:");
-                    println!("    /memory add <text>      Save to project MEMORY.md");
-                    println!("    /memory global <text>   Save to global memory");
-                    println!();
-                    println!(
-                        "  \x1b[90mTip: the LLM can also call MemoryWrite to save insights automatically.\x1b[0m"
-                    );
-                }
-            }
-            ReplAction::Handled
-        }
+        "/memory" => ReplAction::MemoryCommand(arg.map(|s| s.to_string())),
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/select_menu.rs
+++ b/koda-cli/src/select_menu.rs
@@ -79,15 +79,16 @@ pub fn select_inline(
                     }
                 }
                 KeyCode::Enter => {
-                    clear_inline(&mut stdout, total_lines)?;
+                    // Move cursor past menu — content stays in scrollback
+                    move_past_menu(&mut stdout, title, options, selected, total_lines)?;
                     return Ok(Some(selected));
                 }
                 KeyCode::Esc => {
-                    clear_inline(&mut stdout, total_lines)?;
+                    move_past_menu(&mut stdout, title, options, selected, total_lines)?;
                     return Ok(None);
                 }
                 KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                    clear_inline(&mut stdout, total_lines)?;
+                    move_past_menu(&mut stdout, title, options, selected, total_lines)?;
                     return Ok(None);
                 }
                 _ => {}
@@ -194,12 +195,21 @@ fn clear_lines(stdout: &mut io::Stdout, lines: usize) -> io::Result<()> {
 
 // ── Inline renderer (cursor movement, no \n) ─────────────────
 
-fn clear_inline(stdout: &mut io::Stdout, total_lines: usize) -> io::Result<()> {
-    for _ in 0..total_lines {
-        execute!(stdout, Clear(ClearType::CurrentLine), cursor::MoveDown(1))?;
-    }
-    // Don't move back up — leave cursor at the viewport position
-    // so subsequent insert_before() calls work correctly.
+/// Re-render the final selection state and move cursor below the menu.
+/// Menu content stays in scrollback (like Claude Code).
+fn move_past_menu(
+    stdout: &mut io::Stdout,
+    title: &str,
+    options: &[SelectOption],
+    selected: usize,
+    total_lines: usize,
+) -> io::Result<()> {
+    // Re-render so the final selected state is in scrollback
+    render_inline(stdout, title, options, selected)?;
+    // Cursor is at menu top after render_inline; move to bottom
+    execute!(stdout, cursor::MoveDown(total_lines as u16 - 1))?;
+    // One more \n to position at the line after the menu
+    execute!(stdout, Print("\r\n"))?;
     stdout.flush()?;
     Ok(())
 }

--- a/koda-cli/src/select_menu.rs
+++ b/koda-cli/src/select_menu.rs
@@ -198,7 +198,8 @@ fn clear_inline(stdout: &mut io::Stdout, total_lines: usize) -> io::Result<()> {
     for _ in 0..total_lines {
         execute!(stdout, Clear(ClearType::CurrentLine), cursor::MoveDown(1))?;
     }
-    execute!(stdout, cursor::MoveUp(total_lines as u16))?;
+    // Don't move back up — leave cursor at the viewport position
+    // so subsequent insert_before() calls work correctly.
     stdout.flush()?;
     Ok(())
 }

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -355,6 +355,22 @@ pub async fn run(
                                     terminal = init_terminal()?;
                                     crossterm_events = EventStream::new();
                                 }
+                                // Force viewport redraw to resync after crossterm writes
+                                let mode = approval::read_mode(&shared_mode);
+                                let ctx = koda_core::context::percentage() as u32;
+                                terminal.draw(|f| {
+                                    draw_viewport(
+                                        f,
+                                        &textarea,
+                                        &config.model,
+                                        mode,
+                                        ctx,
+                                        tui_state,
+                                        input_queue.len(),
+                                        inference_start.map(|s| s.elapsed().as_secs()).unwrap_or(0),
+                                        renderer.last_turn_stats.as_ref(),
+                                    );
+                                })?;
                             }
                             SlashAction::Quit => {
                                 tui_output::emit_line(

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -1,20 +1,40 @@
 //! TUI-based interactive event loop with persistent inline viewport.
 //!
-//! Architecture:
-//!   - Terminal stays in raw mode for the entire session
-//!   - `Viewport::Inline(2)` with `scrolling-regions` is always rendered
-//!   - Output scrolls above the viewport via `terminal.insert_before()`
-//!   - Input is always active — type-ahead queues submissions during inference
+//! # Rendering Architecture
+//!
+//! Two rendering systems coexist, bridged by terminal re-initialization:
+//!
+//! ## 1. Engine output — ratatui `insert_before()`
+//!
+//! LLM streaming, tool calls, diffs, and approval prompts render as
+//! native `ratatui::text::Line`/`Span` via `tui_output::emit_line()`.
+//! Content scrolls into terminal scrollback above the viewport.
+//!
+//! ## 2. Slash commands — crossterm direct writes
+//!
+//! `/model`, `/help`, `/provider`, etc. render via `tui_output::write_line()`
+//! which writes styled content directly to stdout with `\r\n` line endings.
+//! Interactive select menus (`select_inline`) use crossterm cursor movement
+//! for in-place arrow-key navigation.
+//!
+//! ## Bridge: `init_terminal()` resync
+//!
+//! After every slash command, we create a fresh `Terminal` with
+//! `Viewport::Inline(2)`. This anchors the viewport at the current
+//! cursor position — wherever crossterm left it — eliminating stale
+//! cursor tracking. No raw mode toggle needed.
 //!
 //! ```text
-//! Normal terminal scrollback            ← via insert_before()
-//!   ├── Tool banners, markdown, diffs
-//!   └── All EngineEvent rendering
-//!
-//! ┌─ ratatui Viewport::Inline(2) ──────────────────────────┐
-//! │ 🐻> user types here even during inference_              │
+//! ┌─ scrollback ────────────────────────────────────────────┐
+//! │ Engine output via insert_before() (ratatui Line/Span)   │
+//! │ Slash command output via write_line() (crossterm)       │
+//! │ Select menus via select_inline() (crossterm)            │
+//! ├─────────────────────────────────────────────────────────┤
+//! │ ← init_terminal() resyncs viewport here →              │
+//! ├─ ratatui Viewport::Inline(2) ──────────────────────────┤
+//! │ \u{1f43b}> user types here even during inference_              │
 //! │ model │ normal │ ████░░ 5%                             │
-//! └────────────────────────────────────────────────────────┘
+//! └─────────────────────────────────────────────────────────┘
 //! ```
 
 use crate::input;

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -349,28 +349,10 @@ pub async fn run(
 
                         match action {
                             SlashAction::Continue => {
-                                // Re-init terminal if a legacy command disabled raw mode
-                                if !crossterm::terminal::is_raw_mode_enabled().unwrap_or(true) {
-                                    crossterm::terminal::enable_raw_mode()?;
-                                    terminal = init_terminal()?;
-                                    crossterm_events = EventStream::new();
-                                }
-                                // Force viewport redraw to resync after crossterm writes
-                                let mode = approval::read_mode(&shared_mode);
-                                let ctx = koda_core::context::percentage() as u32;
-                                terminal.draw(|f| {
-                                    draw_viewport(
-                                        f,
-                                        &textarea,
-                                        &config.model,
-                                        mode,
-                                        ctx,
-                                        tui_state,
-                                        input_queue.len(),
-                                        inference_start.map(|s| s.elapsed().as_secs()).unwrap_or(0),
-                                        renderer.last_turn_stats.as_ref(),
-                                    );
-                                })?;
+                                // Re-init terminal to resync viewport with cursor
+                                // position after crossterm direct writes.
+                                terminal = init_terminal()?;
+                                crossterm_events = EventStream::new();
                             }
                             SlashAction::Quit => {
                                 tui_output::emit_line(

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -229,13 +229,26 @@ async fn handle_pick_model(
 }
 
 fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
-    // Show tips first, before the interactive menu
-    tui_output::emit_blank(terminal);
-    dim_msg(
-        terminal,
-        "Tips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit".into(),
-    );
-    tui_output::emit_blank(terminal);
+    // Emit tips via crossterm (same rendering system as select_inline)
+    // so cursor math stays consistent — no insert_before here.
+    {
+        use crossterm::{
+            execute,
+            style::{Color, Print, ResetColor, SetForegroundColor},
+        };
+        let mut stdout = std::io::stdout();
+        execute!(
+            stdout,
+            Print("\r\n  "),
+            SetForegroundColor(Color::DarkGrey),
+            Print(
+                "Tips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit"
+            ),
+            ResetColor,
+            Print("\r\n"),
+        )
+        .ok();
+    }
 
     let commands = [
         ("/agent", "List available sub-agents"),

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -159,6 +159,10 @@ pub async fn handle_slash_command(
             );
             SlashAction::Continue
         }
+        ReplAction::ListAgents => {
+            crate::tui_wizards::handle_list_agents(terminal, project_root);
+            SlashAction::Continue
+        }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
     }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -163,6 +163,14 @@ pub async fn handle_slash_command(
             crate::tui_wizards::handle_list_agents(terminal, project_root);
             SlashAction::Continue
         }
+        ReplAction::ShowDiff => {
+            crate::tui_wizards::handle_diff(terminal);
+            SlashAction::Continue
+        }
+        ReplAction::MemoryCommand(ref arg) => {
+            crate::tui_wizards::handle_memory(terminal, arg.as_deref(), project_root);
+            SlashAction::Continue
+        }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
     }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -229,6 +229,14 @@ async fn handle_pick_model(
 }
 
 fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
+    // Show tips first, before the interactive menu
+    tui_output::emit_blank(terminal);
+    dim_msg(
+        terminal,
+        "Tips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit".into(),
+    );
+    tui_output::emit_blank(terminal);
+
     let commands = [
         ("/agent", "List available sub-agents"),
         ("/compact", "Summarize conversation to reclaim context"),
@@ -252,11 +260,6 @@ fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
         let (cmd, _) = commands[idx];
         *pending_command = Some(cmd.to_string());
     }
-    tui_output::emit_blank(terminal);
-    dim_msg(
-        terminal,
-        "Tips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit".into(),
-    );
 }
 
 async fn handle_cost(terminal: &mut Term, session: &KodaSession, config: &KodaConfig) {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -108,6 +108,22 @@ pub async fn handle_slash_command(
         }
         ReplAction::ShowHelp => {
             handle_help(terminal, pending_command);
+            // If /help selected a command, execute it right away
+            if let Some(cmd) = pending_command.take() {
+                return Box::pin(handle_slash_command(
+                    terminal,
+                    &cmd,
+                    config,
+                    provider,
+                    session,
+                    shared_mode,
+                    renderer,
+                    project_root,
+                    agent,
+                    pending_command,
+                ))
+                .await;
+            }
             SlashAction::Continue
         }
         ReplAction::ShowCost => {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -89,7 +89,7 @@ pub async fn handle_slash_command(
         ReplAction::SwitchModel(model) => {
             config.model = model.clone();
             config.model_settings.model = model.clone();
-            save_provider(config);
+            crate::tui_wizards::save_provider(config);
             ok_msg(terminal, format!("Model set to: {model}"));
             SlashAction::Continue
         }
@@ -98,14 +98,12 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
         ReplAction::SetupProvider(ptype, base_url) => {
-            run_legacy_command(terminal, || async {
-                crate::commands::handle_setup_provider(config, provider, ptype, base_url).await;
-            })
-            .await;
+            crate::tui_wizards::handle_setup_provider(terminal, config, provider, ptype, base_url)
+                .await;
             SlashAction::Continue
         }
         ReplAction::PickProvider => {
-            handle_pick_provider(terminal, config, provider).await;
+            crate::tui_wizards::handle_pick_provider(terminal, config, provider).await;
             SlashAction::Continue
         }
         ReplAction::ShowHelp => {
@@ -133,19 +131,11 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
         ReplAction::Compact => {
-            run_legacy_command(terminal, || async {
-                crate::commands::handle_compact(&session.db, &session.id, config, provider, false)
-                    .await;
-            })
-            .await;
+            crate::tui_wizards::handle_compact(terminal, session, config, provider).await;
             SlashAction::Continue
         }
         ReplAction::McpCommand(ref args) => {
-            let args = args.clone();
-            run_legacy_command(terminal, || async {
-                crate::commands::handle_mcp_command(&args, &agent.mcp_registry, project_root).await;
-            })
-            .await;
+            crate::tui_wizards::handle_mcp(terminal, args, &agent.mcp_registry, project_root).await;
             SlashAction::Continue
         }
         ReplAction::SetTrust(mode_name) => {
@@ -215,7 +205,7 @@ async fn handle_pick_model(
                 Ok(Some(idx)) => {
                     config.model = models[idx].id.clone();
                     config.model_settings.model = config.model.clone();
-                    save_provider(config);
+                    crate::tui_wizards::save_provider(config);
                     ok_msg(terminal, format!("Model set to: {}", config.model));
                 }
                 Ok(None) => dim_msg(terminal, "Cancelled.".into()),
@@ -473,7 +463,7 @@ fn handle_trust(
     let new_mode = if let Some(ref name) = mode_name {
         ApprovalMode::parse(name)
     } else {
-        pick_trust_inline(terminal, approval::read_mode(shared_mode))
+        crate::tui_wizards::pick_trust_inline(terminal, approval::read_mode(shared_mode))
     };
     if let Some(m) = new_mode {
         approval::set_mode(shared_mode, m);
@@ -530,105 +520,4 @@ fn handle_expand(terminal: &mut Term, renderer: &TuiRenderer, n: usize) {
             }
         }
     }
-}
-
-// ── Legacy command shim ─────────────────────────────────────
-//
-// Commands that haven't been migrated to native TUI yet (/provider setup,
-// /compact, /mcp) still use println!. We temporarily exit raw mode,
-// clear the viewport, run the command, then re-init the terminal.
-// The caller in tui_app.rs must re-init the terminal after these.
-
-async fn run_legacy_command<F, Fut>(terminal: &mut Term, f: F)
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = ()>,
-{
-    let _ = terminal.clear();
-    let _ = crossterm::terminal::disable_raw_mode();
-    print!("\x1b[2A\x1b[J");
-    let _ = std::io::Write::flush(&mut std::io::stdout());
-
-    f().await;
-
-    println!();
-}
-
-// ── Provider picker (native select, legacy setup) ───────────
-
-async fn handle_pick_provider(
-    terminal: &mut Term,
-    config: &mut KodaConfig,
-    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
-) {
-    let providers = crate::repl::PROVIDERS;
-    let current_idx = providers
-        .iter()
-        .position(|(key, _, _)| {
-            koda_core::config::ProviderType::from_url_or_name("", Some(key)) == config.provider_type
-        })
-        .unwrap_or(0);
-    let options: Vec<SelectOption> = providers
-        .iter()
-        .map(|(_, name, url)| SelectOption::new(*name, *url))
-        .collect();
-
-    let idx = match select_menu::select_inline(
-        terminal,
-        "\u{1f43b} Select a provider",
-        &options,
-        current_idx,
-    ) {
-        Ok(Some(idx)) => idx,
-        Ok(None) => {
-            dim_msg(terminal, "Cancelled.".into());
-            return;
-        }
-        Err(e) => {
-            err_msg(terminal, format!("TUI error: {e}"));
-            return;
-        }
-    };
-
-    let (key, _, _) = providers[idx];
-    let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
-    let base_url = ptype.default_base_url().to_string();
-
-    // Provider setup wizard uses println! — run in legacy mode
-    run_legacy_command(terminal, || async {
-        crate::commands::handle_setup_provider(config, provider, ptype, base_url).await;
-    })
-    .await;
-}
-
-// ── Trust picker (native TUI) ───────────────────────────────
-
-fn pick_trust_inline(terminal: &mut Term, current: ApprovalMode) -> Option<ApprovalMode> {
-    use ApprovalMode::*;
-    let modes = [Plan, Normal, Yolo];
-    let options: Vec<SelectOption> = modes
-        .iter()
-        .map(|m| {
-            let label = match m {
-                Plan => "\u{1f4cb} plan",
-                Normal => "\u{1f43b} normal",
-                Yolo => "\u{26a1} yolo",
-            };
-            SelectOption::new(label, m.description())
-        })
-        .collect();
-    let initial = modes.iter().position(|m| *m == current).unwrap_or(1);
-    match select_menu::select_inline(terminal, "\u{1f43b} Trust level", &options, initial) {
-        Ok(Some(idx)) => Some(modes[idx]),
-        _ => None,
-    }
-}
-
-fn save_provider(config: &KodaConfig) {
-    let mut s = koda_core::approval::Settings::load();
-    let _ = s.save_last_provider(
-        &config.provider_type.to_string(),
-        &config.base_url,
-        &config.model,
-    );
 }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -1,6 +1,6 @@
 //! Slash command handler for the TUI event loop.
 //!
-//! All output rendered through `tui_output::emit_line()` with native
+//! All output rendered through `tui_output::write_line(&)` with native
 //! ratatui `Line`/`Span` styling. Stays in raw mode.
 
 use crate::repl::ReplAction;
@@ -29,7 +29,11 @@ pub enum SlashAction {
     Quit,
 }
 
-// ── Style helpers ────────────────────────────────────────────
+// ── Style helpers (crossterm direct writes) ─────────────────
+//
+// All slash command output goes through write_line/write_blank
+// (crossterm \r\n), NOT insert_before. This avoids cursor conflicts
+// with select_inline which also uses crossterm.
 
 const DIM: Style = Style::new().fg(Color::DarkGray);
 const ERR: Style = Style::new().fg(Color::Red);
@@ -38,40 +42,34 @@ const CYAN: Style = Style::new().fg(Color::Cyan);
 const WARN: Style = Style::new().fg(Color::Yellow);
 const BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
 
-fn ok_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![Span::styled("  \u{2713} ", OK), Span::raw(msg)]),
-    );
+fn ok_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{2713} ", OK),
+        Span::raw(msg),
+    ]));
 }
 
-fn err_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::styled("  \u{2717} ", ERR),
-            Span::styled(msg, ERR),
-        ]),
-    );
+fn err_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{2717} ", ERR),
+        Span::styled(msg, ERR),
+    ]));
 }
 
-fn dim_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(terminal, Line::styled(format!("  {msg}"), DIM));
+fn dim_msg(msg: String) {
+    tui_output::write_line(&Line::styled(format!("  {msg}"), DIM));
 }
 
-fn warn_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::styled("  \u{26a0} ", WARN),
-            Span::styled(msg, WARN),
-        ]),
-    );
+fn warn_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{26a0} ", WARN),
+        Span::styled(msg, WARN),
+    ]));
 }
 
 // ── Main handler ────────────────────────────────────────────
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, unused_variables)]
 pub async fn handle_slash_command(
     terminal: &mut Term,
     input: &str,
@@ -90,7 +88,7 @@ pub async fn handle_slash_command(
             config.model = model.clone();
             config.model_settings.model = model.clone();
             crate::tui_wizards::save_provider(config);
-            ok_msg(terminal, format!("Model set to: {model}"));
+            ok_msg(format!("Model set to: {model}"));
             SlashAction::Continue
         }
         ReplAction::PickModel => {
@@ -169,10 +167,10 @@ pub async fn handle_slash_command(
                 None => !renderer.verbose,
             };
             let state = if renderer.verbose { "on" } else { "off" };
-            tui_output::emit_line(
-                terminal,
-                Line::styled(format!("  Verbose tool output: {state}"), CYAN),
-            );
+            tui_output::write_line(&Line::styled(
+                format!("  Verbose tool output: {state}"),
+                CYAN,
+            ));
             SlashAction::Continue
         }
         ReplAction::ListAgents => {
@@ -194,6 +192,7 @@ pub async fn handle_slash_command(
 
 // ── Sub-handlers ───────────────────────────────────────────
 
+#[allow(unused_variables)]
 async fn handle_pick_model(
     terminal: &mut Term,
     config: &mut KodaConfig,
@@ -202,10 +201,7 @@ async fn handle_pick_model(
     let prov = provider.read().await;
     match prov.list_models().await {
         Ok(models) if models.is_empty() => {
-            warn_msg(
-                terminal,
-                format!("No models available from {}", prov.provider_name()),
-            );
+            warn_msg(format!("No models available from {}", prov.provider_name()));
         }
         Ok(models) => {
             drop(prov);
@@ -234,16 +230,17 @@ async fn handle_pick_model(
                     config.model = models[idx].id.clone();
                     config.model_settings.model = config.model.clone();
                     crate::tui_wizards::save_provider(config);
-                    ok_msg(terminal, format!("Model set to: {}", config.model));
+                    ok_msg(format!("Model set to: {}", config.model));
                 }
-                Ok(None) => dim_msg(terminal, "Cancelled.".into()),
-                Err(e) => err_msg(terminal, format!("TUI error: {e}")),
+                Ok(None) => dim_msg("Cancelled.".into()),
+                Err(e) => err_msg(format!("TUI error: {e}")),
             }
         }
-        Err(e) => err_msg(terminal, format!("Failed to list models: {e}")),
+        Err(e) => err_msg(format!("Failed to list models: {e}")),
     }
 }
 
+#[allow(unused_variables)]
 fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
     // Emit tips via crossterm (same rendering system as select_inline)
     // so cursor math stays consistent — no insert_before here.
@@ -291,16 +288,17 @@ fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
     }
 }
 
-async fn handle_cost(terminal: &mut Term, session: &KodaSession, config: &KodaConfig) {
+#[allow(unused_variables)]
+async fn handle_cost(_terminal: &mut Term, session: &KodaSession, config: &KodaConfig) {
     match session.db.session_token_usage(&session.id).await {
         Ok(u) => {
             let total = u.prompt_tokens
                 + u.completion_tokens
                 + u.cache_read_tokens
                 + u.cache_creation_tokens;
-            tui_output::emit_blank(terminal);
-            tui_output::emit_line(terminal, Line::styled("  \u{1f43b} Session Cost", BOLD));
-            tui_output::emit_blank(terminal);
+            tui_output::write_blank();
+            tui_output::write_line(&Line::styled("  \u{1f43b} Session Cost", BOLD));
+            tui_output::write_blank();
 
             let mut rows = vec![
                 ("Prompt tokens:", format!("{:>8}", u.prompt_tokens), CYAN),
@@ -335,22 +333,20 @@ async fn handle_cost(terminal: &mut Term, session: &KodaSession, config: &KodaCo
             rows.push(("API calls:", format!("{:>8}", u.api_calls), DIM));
 
             for (label, value, style) in &rows {
-                tui_output::emit_line(
-                    terminal,
-                    Line::from(vec![
-                        Span::raw(format!("  {label:<21}")),
-                        Span::styled(value, *style),
-                    ]),
-                );
+                tui_output::write_line(&Line::from(vec![
+                    Span::raw(format!("  {label:<21}")),
+                    Span::styled(value, *style),
+                ]));
             }
-            tui_output::emit_blank(terminal);
-            dim_msg(terminal, format!("Model: {}", config.model));
-            dim_msg(terminal, format!("Provider: {}", config.provider_type));
+            tui_output::write_blank();
+            dim_msg(format!("Model: {}", config.model));
+            dim_msg(format!("Provider: {}", config.provider_type));
         }
-        Err(e) => err_msg(terminal, format!("Error: {e}")),
+        Err(e) => err_msg(format!("Error: {e}")),
     }
 }
 
+#[allow(unused_variables)]
 async fn handle_list_sessions(
     terminal: &mut Term,
     session: &mut KodaSession,
@@ -358,7 +354,7 @@ async fn handle_list_sessions(
 ) {
     match session.db.list_sessions(10, project_root).await {
         Ok(sessions) if sessions.is_empty() => {
-            dim_msg(terminal, "No other sessions found.".into());
+            dim_msg("No other sessions found.".into());
         }
         Ok(sessions) => {
             let current_idx = sessions
@@ -391,35 +387,30 @@ async fn handle_list_sessions(
                 Ok(Some(idx)) => {
                     let target = &sessions[idx];
                     if target.id == session.id {
-                        dim_msg(terminal, "Already in this session.".into());
+                        dim_msg("Already in this session.".into());
                     } else {
                         session.id = target.id.clone();
-                        tui_output::emit_line(
-                            terminal,
-                            Line::from(vec![
-                                Span::styled("  \u{2713} ", OK),
-                                Span::raw("Resumed session "),
-                                Span::styled(&target.id[..8], CYAN),
-                                Span::styled(
-                                    format!(
-                                        "  {}  {} msgs",
-                                        target.created_at, target.message_count
-                                    ),
-                                    DIM,
-                                ),
-                            ]),
-                        );
+                        tui_output::write_line(&Line::from(vec![
+                            Span::styled("  \u{2713} ", OK),
+                            Span::raw("Resumed session "),
+                            Span::styled(&target.id[..8], CYAN),
+                            Span::styled(
+                                format!("  {}  {} msgs", target.created_at, target.message_count),
+                                DIM,
+                            ),
+                        ]));
                     }
                 }
-                Ok(None) => dim_msg(terminal, "Cancelled.".into()),
-                Err(e) => err_msg(terminal, format!("TUI error: {e}")),
+                Ok(None) => dim_msg("Cancelled.".into()),
+                Err(e) => err_msg(format!("TUI error: {e}")),
             }
-            dim_msg(terminal, "Delete: /sessions delete <id>".into());
+            dim_msg("Delete: /sessions delete <id>".into());
         }
-        Err(e) => err_msg(terminal, format!("Error: {e}")),
+        Err(e) => err_msg(format!("Error: {e}")),
     }
 }
 
+#[allow(unused_variables)]
 async fn handle_delete_session(
     terminal: &mut Term,
     session: &KodaSession,
@@ -427,34 +418,32 @@ async fn handle_delete_session(
     project_root: &std::path::Path,
 ) {
     if id == session.id {
-        err_msg(terminal, "Cannot delete the current session.".into());
+        err_msg("Cannot delete the current session.".into());
     } else {
         match session.db.list_sessions(100, project_root).await {
             Ok(sessions) => {
                 let matches: Vec<_> = sessions.iter().filter(|s| s.id.starts_with(id)).collect();
                 match matches.len() {
-                    0 => err_msg(terminal, format!("No session found matching '{id}'.")),
+                    0 => err_msg(format!("No session found matching '{id}'.")),
                     1 => {
                         let full_id = &matches[0].id;
                         match session.db.delete_session(full_id).await {
-                            Ok(true) => {
-                                ok_msg(terminal, format!("Deleted session {}", &full_id[..8]))
-                            }
-                            Ok(false) => err_msg(terminal, "Session not found.".into()),
-                            Err(e) => err_msg(terminal, format!("Error: {e}")),
+                            Ok(true) => ok_msg(format!("Deleted session {}", &full_id[..8])),
+                            Ok(false) => err_msg("Session not found.".into()),
+                            Err(e) => err_msg(format!("Error: {e}")),
                         }
                     }
-                    n => err_msg(
-                        terminal,
-                        format!("Ambiguous: '{id}' matches {n} sessions. Be more specific."),
-                    ),
+                    n => err_msg(format!(
+                        "Ambiguous: '{id}' matches {n} sessions. Be more specific."
+                    )),
                 }
             }
-            Err(e) => err_msg(terminal, format!("Error: {e}")),
+            Err(e) => err_msg(format!("Error: {e}")),
         }
     }
 }
 
+#[allow(unused_variables)]
 async fn handle_resume_session(
     terminal: &mut Term,
     session: &mut KodaSession,
@@ -462,43 +451,37 @@ async fn handle_resume_session(
     project_root: &std::path::Path,
 ) {
     if session.id.starts_with(id) {
-        dim_msg(terminal, "Already in this session.".into());
+        dim_msg("Already in this session.".into());
     } else {
         match session.db.list_sessions(100, project_root).await {
             Ok(sessions) => {
                 let matches: Vec<_> = sessions.iter().filter(|s| s.id.starts_with(id)).collect();
                 match matches.len() {
-                    0 => err_msg(terminal, format!("No session found matching '{id}'.")),
+                    0 => err_msg(format!("No session found matching '{id}'.")),
                     1 => {
                         let target = &matches[0];
                         session.id = target.id.clone();
-                        tui_output::emit_line(
-                            terminal,
-                            Line::from(vec![
-                                Span::styled("  \u{2713} ", OK),
-                                Span::raw("Resumed session "),
-                                Span::styled(&target.id[..8], CYAN),
-                                Span::styled(
-                                    format!(
-                                        "  {}  {} msgs",
-                                        target.created_at, target.message_count
-                                    ),
-                                    DIM,
-                                ),
-                            ]),
-                        );
+                        tui_output::write_line(&Line::from(vec![
+                            Span::styled("  \u{2713} ", OK),
+                            Span::raw("Resumed session "),
+                            Span::styled(&target.id[..8], CYAN),
+                            Span::styled(
+                                format!("  {}  {} msgs", target.created_at, target.message_count),
+                                DIM,
+                            ),
+                        ]));
                     }
-                    n => err_msg(
-                        terminal,
-                        format!("Ambiguous: '{id}' matches {n} sessions. Be more specific."),
-                    ),
+                    n => err_msg(format!(
+                        "Ambiguous: '{id}' matches {n} sessions. Be more specific."
+                    )),
                 }
             }
-            Err(e) => err_msg(terminal, format!("Error: {e}")),
+            Err(e) => err_msg(format!("Error: {e}")),
         }
     }
 }
 
+#[allow(unused_variables)]
 fn handle_trust(
     terminal: &mut Term,
     mode_name: Option<String>,
@@ -511,56 +494,44 @@ fn handle_trust(
     };
     if let Some(m) = new_mode {
         approval::set_mode(shared_mode, m);
-        tui_output::emit_line(
-            terminal,
-            Line::from(vec![
-                Span::styled("  \u{2713} ", OK),
-                Span::raw("Trust: "),
-                Span::styled(m.label(), BOLD),
-                Span::raw(format!(" \u{2014} {}", m.description())),
-            ]),
-        );
+        tui_output::write_line(&Line::from(vec![
+            Span::styled("  \u{2713} ", OK),
+            Span::raw("Trust: "),
+            Span::styled(m.label(), BOLD),
+            Span::raw(format!(" \u{2014} {}", m.description())),
+        ]));
     } else if let Some(ref name) = mode_name {
-        err_msg(
-            terminal,
-            format!("Unknown trust level '{name}'. Use: plan, normal, yolo"),
-        );
+        err_msg(format!(
+            "Unknown trust level '{name}'. Use: plan, normal, yolo"
+        ));
     }
 }
 
+#[allow(unused_variables)]
 fn handle_expand(terminal: &mut Term, renderer: &TuiRenderer, n: usize) {
     match renderer.tool_history.get(n) {
         Some(record) => {
-            tui_output::emit_blank(terminal);
-            tui_output::emit_line(
-                terminal,
-                Line::from(vec![
-                    Span::styled(format!("  \u{1f50d} Expand: {}", record.tool_name), BOLD),
-                    Span::styled(format!(" ({} lines)", record.output.lines().count()), DIM),
-                ]),
-            );
+            tui_output::write_blank();
+            tui_output::write_line(&Line::from(vec![
+                Span::styled(format!("  \u{1f50d} Expand: {}", record.tool_name), BOLD),
+                Span::styled(format!(" ({} lines)", record.output.lines().count()), DIM),
+            ]));
             for line in record.output.lines() {
-                tui_output::emit_line(
-                    terminal,
-                    Line::from(vec![
-                        Span::styled("  \u{2502} ", DIM),
-                        Span::raw(line.to_string()),
-                    ]),
-                );
+                tui_output::write_line(&Line::from(vec![
+                    Span::styled("  \u{2502} ", DIM),
+                    Span::raw(line.to_string()),
+                ]));
             }
-            tui_output::emit_blank(terminal);
+            tui_output::write_blank();
         }
         None => {
             let total = renderer.tool_history.len();
             if total == 0 {
-                dim_msg(terminal, "No tool outputs recorded yet.".into());
+                dim_msg("No tool outputs recorded yet.".into());
             } else {
-                warn_msg(
-                    terminal,
-                    format!(
-                        "No tool output #{n}. Have {total} recorded (use /expand 1\u{2013}{total})."
-                    ),
-                );
+                warn_msg(format!(
+                    "No tool output #{n}. Have {total} recorded (use /expand 1\u{2013}{total})."
+                ));
             }
         }
     }

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -46,7 +46,7 @@ pub fn emit_blank(terminal: &mut Term) {
     emit_line(terminal, Line::raw(""));
 }
 
-// ── Style constants ─────────────────────────────────────────────
+// ── Style constants ─────────────────────────────────────────
 // Centralized color palette for the TUI renderer.
 
 pub const DIM: Style = Style::new().fg(Color::DarkGray);
@@ -58,3 +58,72 @@ pub const GREEN: Style = Style::new().fg(Color::Green);
 pub const MAGENTA: Style = Style::new().fg(Color::Magenta);
 pub const ORANGE: Style = Style::new().fg(Color::Rgb(255, 165, 0));
 pub const AMBER: Style = Style::new().fg(Color::Rgb(255, 191, 0));
+
+// ── Direct crossterm output (for slash commands) ───────────────
+//
+// Slash commands use these instead of `emit_line()` to avoid mixing
+// `insert_before()` with crossterm cursor management (select menus).
+// After a slash command completes, `terminal.draw()` resyncs the viewport.
+
+/// Write a styled `Line` directly to stdout via crossterm.
+///
+/// Uses `\r\n` for line endings (raw mode). No `insert_before()` —
+/// all slash command output should use this to stay in one rendering system.
+pub fn write_line(line: &Line<'_>) {
+    use crossterm::{
+        execute,
+        style::{Attribute, Print, ResetColor, SetAttribute, SetForegroundColor},
+    };
+    use std::io::Write;
+
+    let mut stdout = std::io::stdout();
+    execute!(stdout, Print("\r")).ok();
+    for span in &line.spans {
+        // Apply foreground color
+        if let Some(cc) = span.style.fg.and_then(ratatui_to_crossterm_color) {
+            execute!(stdout, SetForegroundColor(cc)).ok();
+        }
+        // Apply bold
+        if span.style.add_modifier.contains(Modifier::BOLD) {
+            execute!(stdout, SetAttribute(Attribute::Bold)).ok();
+        }
+        execute!(stdout, Print(&*span.content)).ok();
+        // Reset after each span
+        if span.style.fg.is_some() || !span.style.add_modifier.is_empty() {
+            execute!(stdout, ResetColor, SetAttribute(Attribute::Reset)).ok();
+        }
+    }
+    execute!(stdout, Print("\r\n")).ok();
+    stdout.flush().ok();
+}
+
+/// Write a blank line directly to stdout.
+pub fn write_blank() {
+    use crossterm::{execute, style::Print};
+    let mut stdout = std::io::stdout();
+    execute!(stdout, Print("\r\n")).ok();
+}
+
+fn ratatui_to_crossterm_color(c: Color) -> Option<crossterm::style::Color> {
+    use crossterm::style::Color as CC;
+    Some(match c {
+        Color::Black => CC::Black,
+        Color::Red => CC::DarkRed,
+        Color::Green => CC::DarkGreen,
+        Color::Yellow => CC::DarkYellow,
+        Color::Blue => CC::DarkBlue,
+        Color::Magenta => CC::DarkMagenta,
+        Color::Cyan => CC::DarkCyan,
+        Color::Gray => CC::Grey,
+        Color::DarkGray => CC::DarkGrey,
+        Color::LightRed => CC::Red,
+        Color::LightGreen => CC::Green,
+        Color::LightYellow => CC::Yellow,
+        Color::LightBlue => CC::Blue,
+        Color::LightMagenta => CC::Magenta,
+        Color::LightCyan => CC::Cyan,
+        Color::White => CC::White,
+        Color::Rgb(r, g, b) => CC::Rgb { r, g, b },
+        _ => return None,
+    })
+}

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -1,8 +1,13 @@
-//! Output bridge: native ratatui types → `insert_before()`.
+//! Output bridge for the TUI.
 //!
-//! All rendering produces `ratatui::text::Line` / `Text` directly.
-//! This module provides helpers for writing styled content above
-//! the persistent inline viewport.
+//! Two rendering paths (see `tui_app.rs` for full architecture):
+//!
+//! - **`emit_line()`** — ratatui `insert_before()` for engine output
+//!   (LLM streaming, tool calls, diffs). Managed by ratatui.
+//!
+//! - **`write_line()`** — crossterm direct writes for slash commands.
+//!   Uses `\r\n` line endings in raw mode. After slash commands,
+//!   `tui_app` calls `init_terminal()` to resync the viewport.
 
 use ratatui::{
     Terminal,

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -1,7 +1,7 @@
 //! Native TUI wizard handlers for /provider, /compact, /mcp, /trust.
 //!
 //! Extracted from tui_commands.rs to keep files under 600 lines.
-//! All output rendered through tui_output::emit_line().
+//! All output rendered through tui_output::write_line(&).
 
 use crate::select_menu::{self, SelectOption};
 use crate::tui_output;
@@ -28,36 +28,31 @@ const CYAN: Style = Style::new().fg(Color::Cyan);
 const WARN: Style = Style::new().fg(Color::Yellow);
 const BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
 
-fn ok_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![Span::styled("  \u{2713} ", OK), Span::raw(msg)]),
-    );
+fn ok_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{2713} ", OK),
+        Span::raw(msg),
+    ]));
 }
-fn err_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::styled("  \u{2717} ", ERR),
-            Span::styled(msg, ERR),
-        ]),
-    );
+fn err_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{2717} ", ERR),
+        Span::styled(msg, ERR),
+    ]));
 }
-fn dim_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(terminal, Line::styled(format!("  {msg}"), DIM));
+fn dim_msg(msg: String) {
+    tui_output::write_line(&Line::styled(format!("  {msg}"), DIM));
 }
-fn warn_msg(terminal: &mut Term, msg: String) {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::styled("  \u{26a0} ", WARN),
-            Span::styled(msg, WARN),
-        ]),
-    );
+fn warn_msg(msg: String) {
+    tui_output::write_line(&Line::from(vec![
+        Span::styled("  \u{26a0} ", WARN),
+        Span::styled(msg, WARN),
+    ]));
 }
 
 // ── Provider (native TUI) ───────────────────────────────────
 
+#[allow(unused_variables)]
 pub(crate) async fn handle_pick_provider(
     terminal: &mut Term,
     config: &mut KodaConfig,
@@ -83,11 +78,11 @@ pub(crate) async fn handle_pick_provider(
     ) {
         Ok(Some(idx)) => idx,
         Ok(None) => {
-            dim_msg(terminal, "Cancelled.".into());
+            dim_msg("Cancelled.".into());
             return;
         }
         Err(e) => {
-            err_msg(terminal, format!("TUI error: {e}"));
+            err_msg(format!("TUI error: {e}"));
             return;
         }
     };
@@ -98,6 +93,7 @@ pub(crate) async fn handle_pick_provider(
     handle_setup_provider(terminal, config, provider, ptype, base_url).await;
 }
 
+#[allow(unused_variables)]
 pub(crate) async fn handle_setup_provider(
     terminal: &mut Term,
     config: &mut KodaConfig,
@@ -121,26 +117,26 @@ pub(crate) async fn handle_setup_provider(
                 config.provider_type
             )
         } else {
-            warn_msg(terminal, format!("{env_name} is not set."));
+            warn_msg(format!("{env_name} is not set."));
             format!("Paste your {} API key: ", config.provider_type)
         };
 
         let key = crate::widgets::text_input::read_line(terminal, &prompt, true);
         if key.is_empty() {
             if !is_same_provider {
-                err_msg(terminal, "No key provided, provider not changed.".into());
+                err_msg("No key provided, provider not changed.".into());
                 return;
             }
         } else {
             koda_core::runtime_env::set(env_name, &key);
             let masked = koda_core::keystore::mask_key(&key);
-            ok_msg(terminal, format!("{env_name} set to {masked}"));
+            ok_msg(format!("{env_name} set to {masked}"));
             if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
                 store.set(env_name, &key);
                 if let Err(e) = store.save() {
-                    warn_msg(terminal, format!("Could not persist key: {e}"));
+                    warn_msg(format!("Could not persist key: {e}"));
                 } else if let Ok(path) = koda_core::keystore::KeyStore::keys_path() {
-                    ok_msg(terminal, format!("Saved to {}", path.display()));
+                    ok_msg(format!("Saved to {}", path.display()));
                 }
             }
         }
@@ -153,11 +149,11 @@ pub(crate) async fn handle_setup_provider(
         } else {
             config.base_url = default_url.to_string();
         }
-        ok_msg(terminal, format!("URL set to {}", config.base_url));
+        ok_msg(format!("URL set to {}", config.base_url));
     }
 
     *provider.write().await = crate::commands::create_provider(config);
-    ok_msg(terminal, format!("Provider: {}", config.provider_type));
+    ok_msg(format!("Provider: {}", config.provider_type));
     save_provider(config);
 
     // Verify connection
@@ -168,28 +164,22 @@ pub(crate) async fn handle_setup_provider(
                 config.model = first.id.clone();
                 config.model_settings.model = config.model.clone();
             }
-            ok_msg(terminal, "Connection verified! Available models:".into());
+            ok_msg("Connection verified! Available models:".into());
             for m in &models {
                 let marker = if m.id == config.model {
                     " \u{25c0} selected"
                 } else {
                     ""
                 };
-                tui_output::emit_line(
-                    terminal,
-                    Line::from(vec![
-                        Span::raw(format!("      {}", m.id)),
-                        Span::styled(marker, OK),
-                    ]),
-                );
+                tui_output::write_line(&Line::from(vec![
+                    Span::raw(format!("      {}", m.id)),
+                    Span::styled(marker, OK),
+                ]));
             }
         }
         Err(e) => {
-            warn_msg(terminal, format!("Could not verify connection: {e}"));
-            dim_msg(
-                terminal,
-                format!("Model set to: {} (unverified)", config.model),
-            );
+            warn_msg(format!("Could not verify connection: {e}"));
+            dim_msg(format!("Model set to: {} (unverified)", config.model));
         }
     }
 }
@@ -198,6 +188,7 @@ pub(crate) async fn handle_setup_provider(
 
 const COMPACT_PRESERVE_COUNT: usize = 4;
 
+#[allow(unused_variables)]
 pub(crate) async fn handle_compact(
     terminal: &mut Term,
     session: &KodaSession,
@@ -207,10 +198,7 @@ pub(crate) async fn handle_compact(
     use koda_core::providers::ChatMessage;
 
     if let Ok(true) = session.db.has_pending_tool_calls(&session.id).await {
-        warn_msg(
-            terminal,
-            "Tool calls are still pending — deferring compact.".into(),
-        );
+        warn_msg("Tool calls are still pending — deferring compact.".into());
         return;
     }
 
@@ -221,33 +209,27 @@ pub(crate) async fn handle_compact(
     {
         Ok(msgs) => msgs,
         Err(e) => {
-            err_msg(terminal, format!("Error loading conversation: {e}"));
+            err_msg(format!("Error loading conversation: {e}"));
             return;
         }
     };
 
     if history.len() < 4 {
-        dim_msg(
-            terminal,
-            format!(
-                "Conversation is too short to compact ({} messages).",
-                history.len()
-            ),
-        );
+        dim_msg(format!(
+            "Conversation is too short to compact ({} messages).",
+            history.len()
+        ));
         return;
     }
 
-    tui_output::emit_line(
-        terminal,
-        Line::styled(
-            format!(
-                "  \u{1f43b} Compacting {} messages (preserving last {})...",
-                history.len(),
-                COMPACT_PRESERVE_COUNT
-            ),
-            CYAN,
+    tui_output::write_line(&Line::styled(
+        format!(
+            "  \u{1f43b} Compacting {} messages (preserving last {})...",
+            history.len(),
+            COMPACT_PRESERVE_COUNT
         ),
-    );
+        CYAN,
+    ));
 
     // Build conversation text for summarization
     let mut conversation_text = String::new();
@@ -294,7 +276,7 @@ pub(crate) async fn handle_compact(
     let response = match prov.chat(&messages, &[], &config.model_settings).await {
         Ok(r) => r,
         Err(e) => {
-            err_msg(terminal, format!("Failed to generate summary: {e}"));
+            err_msg(format!("Failed to generate summary: {e}"));
             return;
         }
     };
@@ -302,10 +284,7 @@ pub(crate) async fn handle_compact(
     let summary = match response.content {
         Some(text) if !text.trim().is_empty() => text,
         _ => {
-            err_msg(
-                terminal,
-                "LLM returned an empty summary. Aborting compact.".into(),
-            );
+            err_msg("LLM returned an empty summary. Aborting compact.".into());
             return;
         }
     };
@@ -319,21 +298,18 @@ pub(crate) async fn handle_compact(
     {
         Ok(deleted) => {
             let summary_tokens = summary.len() / 4;
-            ok_msg(
-                terminal,
-                format!("Compacted {deleted} messages → ~{summary_tokens} tokens"),
-            );
-            dim_msg(
-                terminal,
-                "Conversation context has been summarized. Continue as normal!".into(),
-            );
+            ok_msg(format!(
+                "Compacted {deleted} messages → ~{summary_tokens} tokens"
+            ));
+            dim_msg("Conversation context has been summarized. Continue as normal!".into());
         }
-        Err(e) => err_msg(terminal, format!("Failed to compact session: {e}")),
+        Err(e) => err_msg(format!("Failed to compact session: {e}")),
     }
 }
 
 // ── MCP (native TUI) ───────────────────────────────────────
 
+#[allow(unused_variables)]
 pub(crate) async fn handle_mcp(
     terminal: &mut Term,
     args: &str,
@@ -347,55 +323,42 @@ pub(crate) async fn handle_mcp(
         "" | "status" => {
             let registry = mcp_registry.read().await;
             let servers = registry.server_info();
-            tui_output::emit_blank(terminal);
+            tui_output::write_blank();
             if servers.is_empty() {
-                dim_msg(terminal, "No MCP servers connected.".into());
-                dim_msg(
-                    terminal,
-                    "Add servers via .mcp.json or /mcp add <name> <command> [args...]".into(),
-                );
+                dim_msg("No MCP servers connected.".into());
+                dim_msg("Add servers via .mcp.json or /mcp add <name> <command> [args...]".into());
             } else {
-                tui_output::emit_line(terminal, Line::styled("  \u{1f50c} MCP Servers", BOLD));
-                tui_output::emit_blank(terminal);
+                tui_output::write_line(&Line::styled("  \u{1f50c} MCP Servers", BOLD));
+                tui_output::write_blank();
                 for server in &servers {
                     let cmd = if server.args.is_empty() {
                         server.command.clone()
                     } else {
                         format!("{} {}", server.command, server.args.join(" "))
                     };
-                    tui_output::emit_line(
-                        terminal,
-                        Line::from(vec![
-                            Span::styled("  \u{25cf} ", OK),
-                            Span::styled(&server.name, BOLD),
-                            Span::raw(format!(" \u{2014} {} tool(s)", server.tool_count)),
-                        ]),
-                    );
-                    dim_msg(terminal, format!("    {cmd}"));
+                    tui_output::write_line(&Line::from(vec![
+                        Span::styled("  \u{25cf} ", OK),
+                        Span::styled(&server.name, BOLD),
+                        Span::raw(format!(" \u{2014} {} tool(s)", server.tool_count)),
+                    ]));
+                    dim_msg(format!("    {cmd}"));
                     for tool_name in &server.tool_names {
-                        tui_output::emit_line(
-                            terminal,
-                            Line::from(vec![
-                                Span::styled("    \u{2022} ", CYAN),
-                                Span::raw(tool_name.clone()),
-                            ]),
-                        );
+                        tui_output::write_line(&Line::from(vec![
+                            Span::styled("    \u{2022} ", CYAN),
+                            Span::raw(tool_name.clone()),
+                        ]));
                     }
                 }
             }
-            tui_output::emit_blank(terminal);
+            tui_output::write_blank();
         }
 
         "add" => {
             let rest = args.strip_prefix("add").unwrap_or("").trim();
             let add_parts: Vec<&str> = rest.splitn(2, ' ').collect();
             if add_parts.len() < 2 {
-                warn_msg(
-                    terminal,
-                    "Usage: /mcp add <name> <command> [args...]".into(),
-                );
+                warn_msg("Usage: /mcp add <name> <command> [args...]".into());
                 dim_msg(
-                    terminal,
                     "Example: /mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /tmp".into(),
                 );
                 return;
@@ -415,14 +378,14 @@ pub(crate) async fn handle_mcp(
             if let Err(e) =
                 koda_core::mcp::config::save_server_to_project(project_root, &name, &config)
             {
-                err_msg(terminal, format!("Failed to save config: {e}"));
+                err_msg(format!("Failed to save config: {e}"));
                 return;
             }
 
-            tui_output::emit_line(
-                terminal,
-                Line::styled(format!("  \u{1f50c} Connecting to '{name}'..."), CYAN),
-            );
+            tui_output::write_line(&Line::styled(
+                format!("  \u{1f50c} Connecting to '{name}'..."),
+                CYAN,
+            ));
             let mut registry = mcp_registry.write().await;
             match registry.add_server(name.clone(), config).await {
                 Ok(()) => {
@@ -432,27 +395,26 @@ pub(crate) async fn handle_mcp(
                         .find(|s| s.name == name)
                         .map(|s| s.tool_count)
                         .unwrap_or(0);
-                    ok_msg(
-                        terminal,
-                        format!("Added '{name}' ({tool_count} tools). Saved to .mcp.json"),
-                    );
+                    ok_msg(format!(
+                        "Added '{name}' ({tool_count} tools). Saved to .mcp.json"
+                    ));
                 }
-                Err(e) => err_msg(terminal, format!("Failed to connect: {e}")),
+                Err(e) => err_msg(format!("Failed to connect: {e}")),
             }
         }
 
         "remove" => {
             let name = args.strip_prefix("remove").unwrap_or("").trim();
             if name.is_empty() {
-                warn_msg(terminal, "Usage: /mcp remove <name>".into());
+                warn_msg("Usage: /mcp remove <name>".into());
                 return;
             }
             let mut registry = mcp_registry.write().await;
             if registry.remove_server(name) {
                 let _ = koda_core::mcp::config::remove_server_from_project(project_root, name);
-                ok_msg(terminal, format!("Removed MCP server '{name}'"));
+                ok_msg(format!("Removed MCP server '{name}'"));
             } else {
-                err_msg(terminal, format!("MCP server '{name}' not found"));
+                err_msg(format!("MCP server '{name}' not found"));
             }
         }
 
@@ -460,41 +422,42 @@ pub(crate) async fn handle_mcp(
             let name = args.strip_prefix("restart").unwrap_or("").trim();
             let mut registry = mcp_registry.write().await;
             if name.is_empty() {
-                tui_output::emit_line(
-                    terminal,
-                    Line::styled("  \u{1f50c} Restarting all MCP servers...", CYAN),
-                );
+                tui_output::write_line(&Line::styled(
+                    "  \u{1f50c} Restarting all MCP servers...",
+                    CYAN,
+                ));
                 registry.restart_all(project_root).await;
-                ok_msg(terminal, "Done".into());
+                ok_msg("Done".into());
             } else {
-                tui_output::emit_line(
-                    terminal,
-                    Line::styled(format!("  \u{1f50c} Restarting '{name}'..."), CYAN),
-                );
+                tui_output::write_line(&Line::styled(
+                    format!("  \u{1f50c} Restarting '{name}'..."),
+                    CYAN,
+                ));
                 match registry.restart_server(name, project_root).await {
-                    Ok(()) => ok_msg(terminal, format!("Restarted '{name}'")),
-                    Err(e) => err_msg(terminal, format!("Failed: {e}")),
+                    Ok(()) => ok_msg(format!("Restarted '{name}'")),
+                    Err(e) => err_msg(format!("Failed: {e}")),
                 }
             }
         }
 
         other => {
-            warn_msg(terminal, format!("Unknown MCP command: {other}"));
-            dim_msg(terminal, "Usage: /mcp [status|add|remove|restart]".into());
+            warn_msg(format!("Unknown MCP command: {other}"));
+            dim_msg("Usage: /mcp [status|add|remove|restart]".into());
         }
     }
 }
 
 // ── Agents (native TUI) ──────────────────────────────────
 
+#[allow(unused_variables)]
 pub(crate) fn handle_list_agents(terminal: &mut Term, project_root: &std::path::Path) {
     let agents = koda_core::tools::agent::list_agents(project_root);
-    tui_output::emit_blank(terminal);
-    tui_output::emit_line(terminal, Line::styled("  \u{1f43b} Sub-Agents", BOLD));
-    tui_output::emit_blank(terminal);
+    tui_output::write_blank();
+    tui_output::write_line(&Line::styled("  \u{1f43b} Sub-Agents", BOLD));
+    tui_output::write_blank();
 
     if agents.is_empty() {
-        dim_msg(terminal, "No sub-agents configured.".into());
+        dim_msg("No sub-agents configured.".into());
     } else {
         for (name, desc, source) in &agents {
             let tag = match source.as_str() {
@@ -502,30 +465,22 @@ pub(crate) fn handle_list_agents(terminal: &mut Term, project_root: &std::path::
                 "project" => " [project]",
                 _ => "",
             };
-            tui_output::emit_line(
-                terminal,
-                Line::from(vec![
-                    Span::styled(format!("  {name}"), CYAN),
-                    Span::raw(format!(" \u{2014} {desc}")),
-                    Span::styled(tag, DIM),
-                ]),
-            );
+            tui_output::write_line(&Line::from(vec![
+                Span::styled(format!("  {name}"), CYAN),
+                Span::raw(format!(" \u{2014} {desc}")),
+                Span::styled(tag, DIM),
+            ]));
         }
     }
 
-    tui_output::emit_blank(terminal);
-    dim_msg(
-        terminal,
-        "Ask Koda to invoke them, or use koda --agent <name>".into(),
-    );
-    dim_msg(
-        terminal,
-        "Need a specialist? Ask Koda to create one for recurring tasks".into(),
-    );
+    tui_output::write_blank();
+    dim_msg("Ask Koda to invoke them, or use koda --agent <name>".into());
+    dim_msg("Need a specialist? Ask Koda to create one for recurring tasks".into());
 }
 
 // ── Diff (native TUI) ────────────────────────────────────
 
+#[allow(unused_variables)]
 pub(crate) fn handle_diff(terminal: &mut Term) {
     let output = std::process::Command::new("git")
         .args(["diff", "--stat"])
@@ -535,11 +490,11 @@ pub(crate) fn handle_diff(terminal: &mut Term) {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
         Ok(o) => {
             let err = String::from_utf8_lossy(&o.stderr);
-            err_msg(terminal, format!("Git error: {err}"));
+            err_msg(format!("Git error: {err}"));
             return;
         }
         Err(e) => {
-            err_msg(terminal, format!("Failed to run git: {e}"));
+            err_msg(format!("Failed to run git: {e}"));
             return;
         }
     };
@@ -568,32 +523,24 @@ pub(crate) fn handle_diff(terminal: &mut Term) {
     } else if let Some(s) = staged_stat {
         s
     } else {
-        dim_msg(terminal, "No uncommitted changes.".into());
+        dim_msg("No uncommitted changes.".into());
         return;
     };
 
-    tui_output::emit_blank(terminal);
-    tui_output::emit_line(
-        terminal,
-        Line::styled("  \u{1f43b} Uncommitted Changes", BOLD),
-    );
-    tui_output::emit_blank(terminal);
+    tui_output::write_blank();
+    tui_output::write_line(&Line::styled("  \u{1f43b} Uncommitted Changes", BOLD));
+    tui_output::write_blank();
     for line in stat.lines() {
-        dim_msg(terminal, line.to_string());
+        dim_msg(line.to_string());
     }
-    tui_output::emit_blank(terminal);
-    dim_msg(
-        terminal,
-        "/diff review   \u{2014} ask Koda to review the changes".into(),
-    );
-    dim_msg(
-        terminal,
-        "/diff commit   \u{2014} generate a commit message".into(),
-    );
+    tui_output::write_blank();
+    dim_msg("/diff review   \u{2014} ask Koda to review the changes".into());
+    dim_msg("/diff commit   \u{2014} generate a commit message".into());
 }
 
 // ── Memory (native TUI) ───────────────────────────────────
 
+#[allow(unused_variables)]
 pub(crate) fn handle_memory(
     terminal: &mut Term,
     arg: Option<&str>,
@@ -603,60 +550,49 @@ pub(crate) fn handle_memory(
         Some(text) if text.starts_with("global ") => {
             let entry = text.strip_prefix("global ").unwrap().trim();
             if entry.is_empty() {
-                warn_msg(terminal, "Usage: /memory global <text>".into());
+                warn_msg("Usage: /memory global <text>".into());
             } else {
                 match koda_core::memory::append_global(entry) {
-                    Ok(()) => ok_msg(terminal, "Saved to global memory".into()),
-                    Err(e) => err_msg(terminal, format!("Error: {e}")),
+                    Ok(()) => ok_msg("Saved to global memory".into()),
+                    Err(e) => err_msg(format!("Error: {e}")),
                 }
             }
         }
         Some(text) if text.starts_with("add ") => {
             let entry = text.strip_prefix("add ").unwrap().trim();
             if entry.is_empty() {
-                warn_msg(terminal, "Usage: /memory add <text>".into());
+                warn_msg("Usage: /memory add <text>".into());
             } else {
                 match koda_core::memory::append(project_root, entry) {
-                    Ok(()) => ok_msg(terminal, "Saved to project memory (MEMORY.md)".into()),
-                    Err(e) => err_msg(terminal, format!("Error: {e}")),
+                    Ok(()) => ok_msg("Saved to project memory (MEMORY.md)".into()),
+                    Err(e) => err_msg(format!("Error: {e}")),
                 }
             }
         }
         _ => {
             let active = koda_core::memory::active_project_file(project_root);
-            tui_output::emit_blank(terminal);
-            tui_output::emit_line(terminal, Line::styled("  \u{1f43b} Memory", BOLD));
-            tui_output::emit_blank(terminal);
+            tui_output::write_blank();
+            tui_output::write_line(&Line::styled("  \u{1f43b} Memory", BOLD));
+            tui_output::write_blank();
             match active {
-                Some(f) => tui_output::emit_line(
-                    terminal,
-                    Line::from(vec![Span::raw("  Project: "), Span::styled(f, CYAN)]),
-                ),
-                None => dim_msg(
-                    terminal,
-                    "Project: (none \u{2014} will create MEMORY.md on first write)".into(),
-                ),
+                Some(f) => tui_output::write_line(&Line::from(vec![
+                    Span::raw("  Project: "),
+                    Span::styled(f, CYAN),
+                ])),
+                None => {
+                    dim_msg("Project: (none \u{2014} will create MEMORY.md on first write)".into())
+                }
             }
-            tui_output::emit_line(
-                terminal,
-                Line::from(vec![
-                    Span::raw("  Global:  "),
-                    Span::styled("~/.config/koda/memory.md", CYAN),
-                ]),
-            );
-            tui_output::emit_blank(terminal);
-            dim_msg(terminal, "Commands:".into());
+            tui_output::write_line(&Line::from(vec![
+                Span::raw("  Global:  "),
+                Span::styled("~/.config/koda/memory.md", CYAN),
+            ]));
+            tui_output::write_blank();
+            dim_msg("Commands:".into());
+            dim_msg("  /memory add <text>      Save to project MEMORY.md".into());
+            dim_msg("  /memory global <text>   Save to global memory".into());
+            tui_output::write_blank();
             dim_msg(
-                terminal,
-                "  /memory add <text>      Save to project MEMORY.md".into(),
-            );
-            dim_msg(
-                terminal,
-                "  /memory global <text>   Save to global memory".into(),
-            );
-            tui_output::emit_blank(terminal);
-            dim_msg(
-                terminal,
                 "Tip: the LLM can also call MemoryWrite to save insights automatically.".into(),
             );
         }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -524,6 +524,145 @@ pub(crate) fn handle_list_agents(terminal: &mut Term, project_root: &std::path::
     );
 }
 
+// ── Diff (native TUI) ────────────────────────────────────
+
+pub(crate) fn handle_diff(terminal: &mut Term) {
+    let output = std::process::Command::new("git")
+        .args(["diff", "--stat"])
+        .output();
+
+    let diff_stat = match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).to_string(),
+        Ok(o) => {
+            let err = String::from_utf8_lossy(&o.stderr);
+            err_msg(terminal, format!("Git error: {err}"));
+            return;
+        }
+        Err(e) => {
+            err_msg(terminal, format!("Failed to run git: {e}"));
+            return;
+        }
+    };
+
+    // Check unstaged + staged
+    let has_unstaged = !diff_stat.trim().is_empty();
+    let staged_stat = if !has_unstaged {
+        std::process::Command::new("git")
+            .args(["diff", "--cached", "--stat"])
+            .output()
+            .ok()
+            .and_then(|o| {
+                if o.status.success() {
+                    let s = String::from_utf8_lossy(&o.stdout).to_string();
+                    if s.trim().is_empty() { None } else { Some(s) }
+                } else {
+                    None
+                }
+            })
+    } else {
+        None
+    };
+
+    let stat = if has_unstaged {
+        diff_stat
+    } else if let Some(s) = staged_stat {
+        s
+    } else {
+        dim_msg(terminal, "No uncommitted changes.".into());
+        return;
+    };
+
+    tui_output::emit_blank(terminal);
+    tui_output::emit_line(
+        terminal,
+        Line::styled("  \u{1f43b} Uncommitted Changes", BOLD),
+    );
+    tui_output::emit_blank(terminal);
+    for line in stat.lines() {
+        dim_msg(terminal, line.to_string());
+    }
+    tui_output::emit_blank(terminal);
+    dim_msg(
+        terminal,
+        "/diff review   \u{2014} ask Koda to review the changes".into(),
+    );
+    dim_msg(
+        terminal,
+        "/diff commit   \u{2014} generate a commit message".into(),
+    );
+}
+
+// ── Memory (native TUI) ───────────────────────────────────
+
+pub(crate) fn handle_memory(
+    terminal: &mut Term,
+    arg: Option<&str>,
+    project_root: &std::path::Path,
+) {
+    match arg {
+        Some(text) if text.starts_with("global ") => {
+            let entry = text.strip_prefix("global ").unwrap().trim();
+            if entry.is_empty() {
+                warn_msg(terminal, "Usage: /memory global <text>".into());
+            } else {
+                match koda_core::memory::append_global(entry) {
+                    Ok(()) => ok_msg(terminal, "Saved to global memory".into()),
+                    Err(e) => err_msg(terminal, format!("Error: {e}")),
+                }
+            }
+        }
+        Some(text) if text.starts_with("add ") => {
+            let entry = text.strip_prefix("add ").unwrap().trim();
+            if entry.is_empty() {
+                warn_msg(terminal, "Usage: /memory add <text>".into());
+            } else {
+                match koda_core::memory::append(project_root, entry) {
+                    Ok(()) => ok_msg(terminal, "Saved to project memory (MEMORY.md)".into()),
+                    Err(e) => err_msg(terminal, format!("Error: {e}")),
+                }
+            }
+        }
+        _ => {
+            let active = koda_core::memory::active_project_file(project_root);
+            tui_output::emit_blank(terminal);
+            tui_output::emit_line(terminal, Line::styled("  \u{1f43b} Memory", BOLD));
+            tui_output::emit_blank(terminal);
+            match active {
+                Some(f) => tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![Span::raw("  Project: "), Span::styled(f, CYAN)]),
+                ),
+                None => dim_msg(
+                    terminal,
+                    "Project: (none \u{2014} will create MEMORY.md on first write)".into(),
+                ),
+            }
+            tui_output::emit_line(
+                terminal,
+                Line::from(vec![
+                    Span::raw("  Global:  "),
+                    Span::styled("~/.config/koda/memory.md", CYAN),
+                ]),
+            );
+            tui_output::emit_blank(terminal);
+            dim_msg(terminal, "Commands:".into());
+            dim_msg(
+                terminal,
+                "  /memory add <text>      Save to project MEMORY.md".into(),
+            );
+            dim_msg(
+                terminal,
+                "  /memory global <text>   Save to global memory".into(),
+            );
+            tui_output::emit_blank(terminal);
+            dim_msg(
+                terminal,
+                "Tip: the LLM can also call MemoryWrite to save insights automatically.".into(),
+            );
+        }
+    }
+}
+
 // ── Trust picker (native TUI) ───────────────────────────────
 
 pub(crate) fn pick_trust_inline(

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -485,6 +485,45 @@ pub(crate) async fn handle_mcp(
     }
 }
 
+// ── Agents (native TUI) ──────────────────────────────────
+
+pub(crate) fn handle_list_agents(terminal: &mut Term, project_root: &std::path::Path) {
+    let agents = koda_core::tools::agent::list_agents(project_root);
+    tui_output::emit_blank(terminal);
+    tui_output::emit_line(terminal, Line::styled("  \u{1f43b} Sub-Agents", BOLD));
+    tui_output::emit_blank(terminal);
+
+    if agents.is_empty() {
+        dim_msg(terminal, "No sub-agents configured.".into());
+    } else {
+        for (name, desc, source) in &agents {
+            let tag = match source.as_str() {
+                "user" => " [user]",
+                "project" => " [project]",
+                _ => "",
+            };
+            tui_output::emit_line(
+                terminal,
+                Line::from(vec![
+                    Span::styled(format!("  {name}"), CYAN),
+                    Span::raw(format!(" \u{2014} {desc}")),
+                    Span::styled(tag, DIM),
+                ]),
+            );
+        }
+    }
+
+    tui_output::emit_blank(terminal);
+    dim_msg(
+        terminal,
+        "Ask Koda to invoke them, or use koda --agent <name>".into(),
+    );
+    dim_msg(
+        terminal,
+        "Need a specialist? Ask Koda to create one for recurring tasks".into(),
+    );
+}
+
 // ── Trust picker (native TUI) ───────────────────────────────
 
 pub(crate) fn pick_trust_inline(

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -1,0 +1,521 @@
+//! Native TUI wizard handlers for /provider, /compact, /mcp, /trust.
+//!
+//! Extracted from tui_commands.rs to keep files under 600 lines.
+//! All output rendered through tui_output::emit_line().
+
+use crate::select_menu::{self, SelectOption};
+use crate::tui_output;
+
+use koda_core::approval::ApprovalMode;
+use koda_core::config::KodaConfig;
+use koda_core::providers::LlmProvider;
+use koda_core::session::KodaSession;
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+type Term = Terminal<CrosstermBackend<std::io::Stdout>>;
+
+const DIM: Style = Style::new().fg(Color::DarkGray);
+const ERR: Style = Style::new().fg(Color::Red);
+const OK: Style = Style::new().fg(Color::Green);
+const CYAN: Style = Style::new().fg(Color::Cyan);
+const WARN: Style = Style::new().fg(Color::Yellow);
+const BOLD: Style = Style::new().add_modifier(Modifier::BOLD);
+
+fn ok_msg(terminal: &mut Term, msg: String) {
+    tui_output::emit_line(
+        terminal,
+        Line::from(vec![Span::styled("  \u{2713} ", OK), Span::raw(msg)]),
+    );
+}
+fn err_msg(terminal: &mut Term, msg: String) {
+    tui_output::emit_line(
+        terminal,
+        Line::from(vec![
+            Span::styled("  \u{2717} ", ERR),
+            Span::styled(msg, ERR),
+        ]),
+    );
+}
+fn dim_msg(terminal: &mut Term, msg: String) {
+    tui_output::emit_line(terminal, Line::styled(format!("  {msg}"), DIM));
+}
+fn warn_msg(terminal: &mut Term, msg: String) {
+    tui_output::emit_line(
+        terminal,
+        Line::from(vec![
+            Span::styled("  \u{26a0} ", WARN),
+            Span::styled(msg, WARN),
+        ]),
+    );
+}
+
+// ── Provider (native TUI) ───────────────────────────────────
+
+pub(crate) async fn handle_pick_provider(
+    terminal: &mut Term,
+    config: &mut KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+) {
+    let providers = crate::repl::PROVIDERS;
+    let current_idx = providers
+        .iter()
+        .position(|(key, _, _)| {
+            koda_core::config::ProviderType::from_url_or_name("", Some(key)) == config.provider_type
+        })
+        .unwrap_or(0);
+    let options: Vec<SelectOption> = providers
+        .iter()
+        .map(|(_, name, url)| SelectOption::new(*name, *url))
+        .collect();
+
+    let idx = match select_menu::select_inline(
+        terminal,
+        "\u{1f43b} Select a provider",
+        &options,
+        current_idx,
+    ) {
+        Ok(Some(idx)) => idx,
+        Ok(None) => {
+            dim_msg(terminal, "Cancelled.".into());
+            return;
+        }
+        Err(e) => {
+            err_msg(terminal, format!("TUI error: {e}"));
+            return;
+        }
+    };
+
+    let (key, _, _) = providers[idx];
+    let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
+    let base_url = ptype.default_base_url().to_string();
+    handle_setup_provider(terminal, config, provider, ptype, base_url).await;
+}
+
+pub(crate) async fn handle_setup_provider(
+    terminal: &mut Term,
+    config: &mut KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+    ptype: koda_core::config::ProviderType,
+    base_url: String,
+) {
+    let env_name = ptype.env_key_name();
+    let key_missing = ptype.requires_api_key() && !koda_core::runtime_env::is_set(env_name);
+    let is_same_provider = ptype == config.provider_type;
+
+    config.provider_type = ptype.clone();
+    config.base_url = base_url;
+    config.model = ptype.default_model().to_string();
+    config.model_settings.model = config.model.clone();
+
+    if key_missing || (is_same_provider && ptype.requires_api_key()) {
+        let prompt = if is_same_provider {
+            format!(
+                "Update {} API key (enter to keep current): ",
+                config.provider_type
+            )
+        } else {
+            warn_msg(terminal, format!("{env_name} is not set."));
+            format!("Paste your {} API key: ", config.provider_type)
+        };
+
+        let key = crate::widgets::text_input::read_line(terminal, &prompt, true);
+        if key.is_empty() {
+            if !is_same_provider {
+                err_msg(terminal, "No key provided, provider not changed.".into());
+                return;
+            }
+        } else {
+            koda_core::runtime_env::set(env_name, &key);
+            let masked = koda_core::keystore::mask_key(&key);
+            ok_msg(terminal, format!("{env_name} set to {masked}"));
+            if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
+                store.set(env_name, &key);
+                if let Err(e) = store.save() {
+                    warn_msg(terminal, format!("Could not persist key: {e}"));
+                } else if let Ok(path) = koda_core::keystore::KeyStore::keys_path() {
+                    ok_msg(terminal, format!("Saved to {}", path.display()));
+                }
+            }
+        }
+    } else if !ptype.requires_api_key() {
+        let default_url = ptype.default_base_url();
+        let prompt = format!("Enter {} URL (enter for {}): ", ptype, default_url);
+        let url = crate::widgets::text_input::read_line(terminal, &prompt, false);
+        if !url.is_empty() {
+            config.base_url = url;
+        } else {
+            config.base_url = default_url.to_string();
+        }
+        ok_msg(terminal, format!("URL set to {}", config.base_url));
+    }
+
+    *provider.write().await = crate::commands::create_provider(config);
+    ok_msg(terminal, format!("Provider: {}", config.provider_type));
+    save_provider(config);
+
+    // Verify connection
+    let prov = provider.read().await;
+    match prov.list_models().await {
+        Ok(models) => {
+            if let Some(first) = models.first() {
+                config.model = first.id.clone();
+                config.model_settings.model = config.model.clone();
+            }
+            ok_msg(terminal, "Connection verified! Available models:".into());
+            for m in &models {
+                let marker = if m.id == config.model {
+                    " \u{25c0} selected"
+                } else {
+                    ""
+                };
+                tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![
+                        Span::raw(format!("      {}", m.id)),
+                        Span::styled(marker, OK),
+                    ]),
+                );
+            }
+        }
+        Err(e) => {
+            warn_msg(terminal, format!("Could not verify connection: {e}"));
+            dim_msg(
+                terminal,
+                format!("Model set to: {} (unverified)", config.model),
+            );
+        }
+    }
+}
+
+// ── Compact (native TUI) ────────────────────────────────────
+
+const COMPACT_PRESERVE_COUNT: usize = 4;
+
+pub(crate) async fn handle_compact(
+    terminal: &mut Term,
+    session: &KodaSession,
+    config: &KodaConfig,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+) {
+    use koda_core::providers::ChatMessage;
+
+    if let Ok(true) = session.db.has_pending_tool_calls(&session.id).await {
+        warn_msg(
+            terminal,
+            "Tool calls are still pending — deferring compact.".into(),
+        );
+        return;
+    }
+
+    let history = match session
+        .db
+        .load_context(&session.id, config.max_context_tokens)
+        .await
+    {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            err_msg(terminal, format!("Error loading conversation: {e}"));
+            return;
+        }
+    };
+
+    if history.len() < 4 {
+        dim_msg(
+            terminal,
+            format!(
+                "Conversation is too short to compact ({} messages).",
+                history.len()
+            ),
+        );
+        return;
+    }
+
+    tui_output::emit_line(
+        terminal,
+        Line::styled(
+            format!(
+                "  \u{1f43b} Compacting {} messages (preserving last {})...",
+                history.len(),
+                COMPACT_PRESERVE_COUNT
+            ),
+            CYAN,
+        ),
+    );
+
+    // Build conversation text for summarization
+    let mut conversation_text = String::new();
+    for msg in &history {
+        let role = msg.role.as_str();
+        if let Some(ref content) = msg.content {
+            let truncated: String = content.chars().take(2000).collect();
+            conversation_text.push_str(&format!("[{role}]: {truncated}\n\n"));
+        }
+        if let Some(ref tool_calls) = msg.tool_calls {
+            let truncated: String = tool_calls.chars().take(500).collect();
+            conversation_text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
+        }
+    }
+    if conversation_text.len() > 20_000 {
+        let mut end = 20_000;
+        while end > 0 && !conversation_text.is_char_boundary(end) {
+            end -= 1;
+        }
+        conversation_text.truncate(end);
+        conversation_text.push_str("\n\n[...truncated for summarization...]");
+    }
+
+    let summary_prompt = format!(
+        "Summarize the conversation below. This summary will replace the older messages \
+         so an AI assistant can continue the session seamlessly.\n\
+         \n\
+         Preserve ALL of the following:\n\
+         1. **User Intent** — Every goal, request, and requirement.\n\
+         2. **Key Decisions** — Decisions made and their rationale.\n\
+         3. **Files & Code** — Every file created, modified, or deleted.\n\
+         4. **Errors & Fixes** — Bugs encountered and how they were resolved.\n\
+         5. **Current State** — What is working, what has been tested.\n\
+         6. **Pending Tasks** — Anything unfinished or deferred.\n\
+         7. **Next Step** — Only if clearly stated or implied.\n\
+         \n\
+         Use concise bullet points. Do not add new ideas.\n\
+         \n\
+         ---\n\n{conversation_text}"
+    );
+
+    let messages = vec![ChatMessage::text("user", &summary_prompt)];
+    let prov = provider.read().await;
+    let response = match prov.chat(&messages, &[], &config.model_settings).await {
+        Ok(r) => r,
+        Err(e) => {
+            err_msg(terminal, format!("Failed to generate summary: {e}"));
+            return;
+        }
+    };
+
+    let summary = match response.content {
+        Some(text) if !text.trim().is_empty() => text,
+        _ => {
+            err_msg(
+                terminal,
+                "LLM returned an empty summary. Aborting compact.".into(),
+            );
+            return;
+        }
+    };
+
+    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
+
+    match session
+        .db
+        .compact_session(&session.id, &compact_message, COMPACT_PRESERVE_COUNT)
+        .await
+    {
+        Ok(deleted) => {
+            let summary_tokens = summary.len() / 4;
+            ok_msg(
+                terminal,
+                format!("Compacted {deleted} messages → ~{summary_tokens} tokens"),
+            );
+            dim_msg(
+                terminal,
+                "Conversation context has been summarized. Continue as normal!".into(),
+            );
+        }
+        Err(e) => err_msg(terminal, format!("Failed to compact session: {e}")),
+    }
+}
+
+// ── MCP (native TUI) ───────────────────────────────────────
+
+pub(crate) async fn handle_mcp(
+    terminal: &mut Term,
+    args: &str,
+    mcp_registry: &Arc<RwLock<koda_core::mcp::McpRegistry>>,
+    project_root: &std::path::Path,
+) {
+    let parts: Vec<&str> = args.splitn(3, ' ').collect();
+    let sub = parts.first().map(|s| s.trim()).unwrap_or("");
+
+    match sub {
+        "" | "status" => {
+            let registry = mcp_registry.read().await;
+            let servers = registry.server_info();
+            tui_output::emit_blank(terminal);
+            if servers.is_empty() {
+                dim_msg(terminal, "No MCP servers connected.".into());
+                dim_msg(
+                    terminal,
+                    "Add servers via .mcp.json or /mcp add <name> <command> [args...]".into(),
+                );
+            } else {
+                tui_output::emit_line(terminal, Line::styled("  \u{1f50c} MCP Servers", BOLD));
+                tui_output::emit_blank(terminal);
+                for server in &servers {
+                    let cmd = if server.args.is_empty() {
+                        server.command.clone()
+                    } else {
+                        format!("{} {}", server.command, server.args.join(" "))
+                    };
+                    tui_output::emit_line(
+                        terminal,
+                        Line::from(vec![
+                            Span::styled("  \u{25cf} ", OK),
+                            Span::styled(&server.name, BOLD),
+                            Span::raw(format!(" \u{2014} {} tool(s)", server.tool_count)),
+                        ]),
+                    );
+                    dim_msg(terminal, format!("    {cmd}"));
+                    for tool_name in &server.tool_names {
+                        tui_output::emit_line(
+                            terminal,
+                            Line::from(vec![
+                                Span::styled("    \u{2022} ", CYAN),
+                                Span::raw(tool_name.clone()),
+                            ]),
+                        );
+                    }
+                }
+            }
+            tui_output::emit_blank(terminal);
+        }
+
+        "add" => {
+            let rest = args.strip_prefix("add").unwrap_or("").trim();
+            let add_parts: Vec<&str> = rest.splitn(2, ' ').collect();
+            if add_parts.len() < 2 {
+                warn_msg(
+                    terminal,
+                    "Usage: /mcp add <name> <command> [args...]".into(),
+                );
+                dim_msg(
+                    terminal,
+                    "Example: /mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /tmp".into(),
+                );
+                return;
+            }
+            let name = add_parts[0].to_string();
+            let cmd_parts: Vec<&str> = add_parts[1].split_whitespace().collect();
+            let command = cmd_parts[0].to_string();
+            let cmd_args: Vec<String> = cmd_parts[1..].iter().map(|s| s.to_string()).collect();
+
+            let config = koda_core::mcp::config::McpServerConfig {
+                command,
+                args: cmd_args,
+                env: std::collections::HashMap::new(),
+                timeout: None,
+            };
+
+            if let Err(e) =
+                koda_core::mcp::config::save_server_to_project(project_root, &name, &config)
+            {
+                err_msg(terminal, format!("Failed to save config: {e}"));
+                return;
+            }
+
+            tui_output::emit_line(
+                terminal,
+                Line::styled(format!("  \u{1f50c} Connecting to '{name}'..."), CYAN),
+            );
+            let mut registry = mcp_registry.write().await;
+            match registry.add_server(name.clone(), config).await {
+                Ok(()) => {
+                    let tool_count = registry
+                        .server_info()
+                        .iter()
+                        .find(|s| s.name == name)
+                        .map(|s| s.tool_count)
+                        .unwrap_or(0);
+                    ok_msg(
+                        terminal,
+                        format!("Added '{name}' ({tool_count} tools). Saved to .mcp.json"),
+                    );
+                }
+                Err(e) => err_msg(terminal, format!("Failed to connect: {e}")),
+            }
+        }
+
+        "remove" => {
+            let name = args.strip_prefix("remove").unwrap_or("").trim();
+            if name.is_empty() {
+                warn_msg(terminal, "Usage: /mcp remove <name>".into());
+                return;
+            }
+            let mut registry = mcp_registry.write().await;
+            if registry.remove_server(name) {
+                let _ = koda_core::mcp::config::remove_server_from_project(project_root, name);
+                ok_msg(terminal, format!("Removed MCP server '{name}'"));
+            } else {
+                err_msg(terminal, format!("MCP server '{name}' not found"));
+            }
+        }
+
+        "restart" => {
+            let name = args.strip_prefix("restart").unwrap_or("").trim();
+            let mut registry = mcp_registry.write().await;
+            if name.is_empty() {
+                tui_output::emit_line(
+                    terminal,
+                    Line::styled("  \u{1f50c} Restarting all MCP servers...", CYAN),
+                );
+                registry.restart_all(project_root).await;
+                ok_msg(terminal, "Done".into());
+            } else {
+                tui_output::emit_line(
+                    terminal,
+                    Line::styled(format!("  \u{1f50c} Restarting '{name}'..."), CYAN),
+                );
+                match registry.restart_server(name, project_root).await {
+                    Ok(()) => ok_msg(terminal, format!("Restarted '{name}'")),
+                    Err(e) => err_msg(terminal, format!("Failed: {e}")),
+                }
+            }
+        }
+
+        other => {
+            warn_msg(terminal, format!("Unknown MCP command: {other}"));
+            dim_msg(terminal, "Usage: /mcp [status|add|remove|restart]".into());
+        }
+    }
+}
+
+// ── Trust picker (native TUI) ───────────────────────────────
+
+pub(crate) fn pick_trust_inline(
+    terminal: &mut Term,
+    current: ApprovalMode,
+) -> Option<ApprovalMode> {
+    use ApprovalMode::*;
+    let modes = [Plan, Normal, Yolo];
+    let options: Vec<SelectOption> = modes
+        .iter()
+        .map(|m| {
+            let label = match m {
+                Plan => "\u{1f4cb} plan",
+                Normal => "\u{1f43b} normal",
+                Yolo => "\u{26a1} yolo",
+            };
+            SelectOption::new(label, m.description())
+        })
+        .collect();
+    let initial = modes.iter().position(|m| *m == current).unwrap_or(1);
+    match select_menu::select_inline(terminal, "\u{1f43b} Trust level", &options, initial) {
+        Ok(Some(idx)) => Some(modes[idx]),
+        _ => None,
+    }
+}
+
+pub(crate) fn save_provider(config: &KodaConfig) {
+    let mut s = koda_core::approval::Settings::load();
+    let _ = s.save_last_provider(
+        &config.provider_type.to_string(),
+        &config.base_url,
+        &config.model,
+    );
+}

--- a/koda-cli/src/widgets/text_input.rs
+++ b/koda-cli/src/widgets/text_input.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // Will be used when provider setup is migrated to native TUI
 //! Inline text input widget for the TUI.
 //!
 //! Renders a prompt above the viewport, reads character-by-character


### PR DESCRIPTION
## Summary

All slash commands render natively — zero legacy shims, zero raw mode toggling.

### Rendering Architecture

Two systems bridged by terminal re-init:

```
┌─ scrollback ──────────────────────────────────────────────┐
│ Engine output via insert_before() (ratatui Line/Span)     │
│ Slash command output via write_line() (crossterm)         │
│ Select menus via select_inline() (crossterm)              │
├───────────────────────────────────────────────────────────┤
│ ← init_terminal() resyncs viewport here →                │
├─ ratatui Viewport::Inline(2) ────────────────────────────┤
│ 🐻> input                                                │
│ model │ normal │ ████░░ 5%                               │
└───────────────────────────────────────────────────────────┘
```

### New files
- `tui_wizards.rs` — native handlers for /provider, /compact, /mcp, /agent, /diff, /memory, /trust
- `widgets/text_input.rs` — inline text input (API key entry)

### Key changes
- `tui_output.rs`: added `write_line()` / `write_blank()` — crossterm direct writes for slash commands
- `select_menu.rs`: `select_inline()` + `move_past_menu()` — menu stays in scrollback
- `tui_app.rs`: `init_terminal()` after every slash command resyncs viewport
- `repl.rs`: added `ListAgents`, `ShowDiff`, `MemoryCommand` variants — zero println in handlers

### /agent fix (#91)
Moved /agent from `repl.rs` (println! with ANSI) to `tui_wizards::handle_list_agents()` with native Line/Span rendering. Added `ReplAction::ListAgents` variant so the TUI event loop handles rendering instead of repl.rs printing directly.

### All commands native ✅
```
/model ✅  /help    ✅  /sessions ✅  /trust   ✅
/cost  ✅  /expand  ✅  /verbose  ✅  /exit    ✅  
/provider ✅  /compact ✅  /mcp  ✅  /agent   ✅
/diff  ✅  /memory  ✅
```

## Test plan
- [x] All tests pass
- [x] Clippy clean
- [x] Fmt clean

Closes #91
Fixes #84