### PR TITLE
fix: v0.1.2 release blockers — TUI corruption, security, tests (#92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,6 +1429,7 @@ dependencies = [
  "koda-core",
  "once_cell",
  "ratatui",
+ "rpassword",
  "serde",
  "serde_json",
  "syntect",
@@ -2211,6 +2212,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2240,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -54,6 +54,7 @@ base64 = "0.22"
 agent-client-protocol-schema = { version = "0.11", features = ["unstable_session_model", "unstable_session_list", "unstable"] }
 tokio-tungstenite = "0.28"
 futures-util = "0.3.32"
+rpassword = "7.4.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/koda-cli/src/commands.rs
+++ b/koda-cli/src/commands.rs
@@ -5,14 +5,10 @@
 use crate::select_menu::SelectOption;
 use koda_core::approval::ApprovalMode;
 use koda_core::config::{KodaConfig, ProviderType};
-use koda_core::db::Database;
 use koda_core::providers::LlmProvider;
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
-
-/// Number of recent messages to preserve during compaction.
-const COMPACT_PRESERVE_COUNT: usize = 4;
 
 // ── Raw stdin input ──────────────────────────────────────────
 
@@ -25,153 +21,6 @@ fn read_line_raw(prompt: &str) -> anyhow::Result<String> {
     let mut line = String::new();
     std::io::stdin().read_line(&mut line)?;
     Ok(line.trim().to_string())
-}
-
-// ── Compact handler ───────────────────────────────────────────
-
-/// Compact the conversation by summarizing history via the LLM.
-/// When `silent` is true (auto-compact), suppresses the "too short" message.
-///
-/// Improvements over v1:
-/// - Preserves the most recent messages (Fix 1)
-/// - Inserts summary as `system` role, not `user` (Fix 3)
-/// - Adds a continuation instruction for the LLM (Fix 2)
-/// - Checks for pending tool calls before proceeding (Fix 5)
-/// - Uses a structured summarization prompt (Fix 6)
-pub(crate) async fn handle_compact(
-    db: &Database,
-    session_id: &str,
-    config: &KodaConfig,
-    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
-    silent: bool,
-) {
-    use koda_core::providers::ChatMessage;
-
-    // Fix 5: Defer compaction if tool calls are pending
-    if let Ok(true) = db.has_pending_tool_calls(session_id).await {
-        if !silent {
-            println!("  \x1b[33mTool calls are still pending — deferring compact.\x1b[0m");
-        }
-        return;
-    }
-
-    // Load current conversation
-    let history = match db.load_context(session_id, config.max_context_tokens).await {
-        Ok(msgs) => msgs,
-        Err(e) => {
-            if !silent {
-                println!("  \x1b[31mError loading conversation: {e}\x1b[0m");
-            }
-            return;
-        }
-    };
-
-    if history.len() < 4 {
-        if !silent {
-            println!(
-                "  \x1b[90mConversation is too short to compact ({} messages).\x1b[0m",
-                history.len()
-            );
-        }
-        return;
-    }
-
-    // Format the conversation for summarization
-    let mut conversation_text = String::new();
-    for msg in &history {
-        let role = msg.role.as_str();
-        if let Some(ref content) = msg.content {
-            // Cap individual messages to avoid blowing the summary prompt
-            let truncated: String = content.chars().take(2000).collect();
-            conversation_text.push_str(&format!("[{role}]: {truncated}\n\n"));
-        }
-        if let Some(ref tool_calls) = msg.tool_calls {
-            let truncated: String = tool_calls.chars().take(500).collect();
-            conversation_text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
-        }
-    }
-
-    // Cap total conversation text
-    if conversation_text.len() > 20_000 {
-        let mut end = 20_000;
-        while end > 0 && !conversation_text.is_char_boundary(end) {
-            end -= 1;
-        }
-        conversation_text.truncate(end);
-        conversation_text.push_str("\n\n[...truncated for summarization...]");
-    }
-
-    println!();
-    println!(
-        "  \x1b[36m\u{1f43b} Compacting {} messages (preserving last {})...\x1b[0m",
-        history.len(),
-        COMPACT_PRESERVE_COUNT,
-    );
-
-    // Fix 6: Structured summarization prompt preserving code-relevant context
-    let summary_prompt = format!(
-        "Summarize the conversation below. This summary will replace the older messages \
-         so an AI assistant can continue the session seamlessly.\n\
-         \n\
-         Preserve ALL of the following — do NOT omit any section:\n\
-         \n\
-         1. **User Intent** — Every goal, request, and requirement the user stated.\n\
-         2. **Key Decisions** — Decisions made and their rationale.\n\
-         3. **Files & Code** — Every file created, modified, or deleted. Include file paths, \n\
-            key function/struct names, and the purpose of each change.\n\
-         4. **Errors & Fixes** — Bugs encountered, error messages, and how they were resolved.\n\
-         5. **Current State** — What is working, what has been tested, what the project \n\
-            looks like right now.\n\
-         6. **Pending Tasks** — Anything unfinished or explicitly deferred.\n\
-         7. **Next Step** — Only if one was clearly stated or implied.\n\
-         \n\
-         Use concise bullet points. Do not add new ideas or suggestions.\n\
-         \n\
-         ---\n\n{conversation_text}"
-    );
-
-    let messages = vec![ChatMessage::text("user", &summary_prompt)];
-
-    // Call the LLM for the summary (no tools, no streaming)
-    let prov = provider.read().await;
-    let response = match prov.chat(&messages, &[], &config.model_settings).await {
-        Ok(r) => r,
-        Err(e) => {
-            println!("  \x1b[31mFailed to generate summary: {e}\x1b[0m");
-            return;
-        }
-    };
-
-    let summary = match response.content {
-        Some(text) if !text.trim().is_empty() => text,
-        _ => {
-            println!("  \x1b[31mLLM returned an empty summary. Aborting compact.\x1b[0m");
-            return;
-        }
-    };
-
-    // Fix 3: Summary is wrapped clearly for the LLM context (inserted as system role in DB)
-    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
-
-    // Fix 1: Preserve recent messages; Fix 2 & 3: DB inserts system + assistant continuation
-    match db
-        .compact_session(session_id, &compact_message, COMPACT_PRESERVE_COUNT)
-        .await
-    {
-        Ok(deleted) => {
-            let summary_tokens = summary.len() / 4;
-            println!(
-                "  \x1b[32m\u{2713}\x1b[0m Compacted {deleted} messages → ~{summary_tokens} tokens"
-            );
-            println!(
-                "  \x1b[90mConversation context has been summarized. Continue as normal!\x1b[0m"
-            );
-        }
-        Err(e) => {
-            println!("  \x1b[31mFailed to compact session: {e}\x1b[0m");
-        }
-    }
-    println!();
 }
 
 // ── MCP command handler ──────────────────────────────────────

--- a/koda-cli/src/onboarding.rs
+++ b/koda-cli/src/onboarding.rs
@@ -99,30 +99,32 @@ pub fn run_wizard() -> Option<ProviderType> {
             let _ = std::io::Write::flush(&mut std::io::stdout());
 
             let mut key = String::new();
-            if std::io::stdin().read_line(&mut key).is_ok() {
-                let key = key.trim();
-                if !key.is_empty() {
-                    // Save to keystore
-                    match KeyStore::load() {
-                        Ok(mut store) => {
-                            store.set(env_key, key);
-                            if let Err(e) = store.save() {
-                                println!("  \x1b[31mFailed to save key: {e}\x1b[0m");
-                            } else {
-                                // Also inject into current process
-                                koda_core::runtime_env::set(env_key, key);
-                                println!(
-                                    "  \x1b[32m\u{2713}\x1b[0m Saved to \x1b[36m~/.config/koda/keys.toml\x1b[0m"
-                                );
-                            }
+            // Use rpassword to avoid echoing the API key to the terminal
+            if let Ok(k) = rpassword::read_password() {
+                key = k;
+            }
+            let key = key.trim();
+            if !key.is_empty() {
+                // Save to keystore
+                match KeyStore::load() {
+                    Ok(mut store) => {
+                        store.set(env_key, key);
+                        if let Err(e) = store.save() {
+                            println!("  \x1b[31mFailed to save key: {e}\x1b[0m");
+                        } else {
+                            // Also inject into current process
+                            koda_core::runtime_env::set(env_key, key);
+                            println!(
+                                "  \x1b[32m\u{2713}\x1b[0m Saved to \x1b[36m~/.config/koda/keys.toml\x1b[0m"
+                            );
                         }
-                        Err(e) => println!("  \x1b[31mFailed to load keystore: {e}\x1b[0m"),
                     }
-                } else {
-                    println!(
-                        "  \x1b[90mSkipped. Set {env_key} in your environment or use /provider later.\x1b[0m"
-                    );
+                    Err(e) => println!("  \x1b[31mFailed to load keystore: {e}\x1b[0m"),
                 }
+            } else {
+                println!(
+                    "  \x1b[90mSkipped. Set {env_key} in your environment or use /provider later.\x1b[0m"
+                );
             }
         }
     } else {

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -649,14 +649,38 @@ pub async fn run(
                                             ),
                                         ]),
                                     );
-                                    crate::commands::handle_compact(
+                                    match koda_core::compact::compact_session(
                                         &session.db,
                                         &session.id,
-                                        &config,
+                                        config.max_context_tokens,
+                                        &config.model_settings,
                                         &provider,
-                                        true,
                                     )
-                                    .await;
+                                    .await
+                                    {
+                                        Ok(Ok(result)) => {
+                                            emit_above(
+                                                &mut terminal,
+                                                Line::styled(
+                                                    format!(
+                                                        "  \u{2713} Compacted {} messages \u{2192} ~{} tokens",
+                                                        result.deleted, result.summary_tokens
+                                                    ),
+                                                    Style::default().fg(Color::Green),
+                                                ),
+                                            );
+                                        }
+                                        Ok(Err(_skip)) => {} // silently skip
+                                        Err(e) => {
+                                            emit_above(
+                                                &mut terminal,
+                                                Line::styled(
+                                                    format!("  \u{2717} Auto-compact failed: {e}"),
+                                                    Style::default().fg(Color::Red),
+                                                ),
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -186,124 +186,42 @@ pub(crate) async fn handle_setup_provider(
 
 // ── Compact (native TUI) ────────────────────────────────────
 
-const COMPACT_PRESERVE_COUNT: usize = 4;
-
 #[allow(unused_variables)]
 pub(crate) async fn handle_compact(
-    terminal: &mut Term,
+    _terminal: &mut Term,
     session: &KodaSession,
     config: &KodaConfig,
     provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
 ) {
-    use koda_core::providers::ChatMessage;
+    use koda_core::compact::{self, CompactSkip};
 
-    if let Ok(true) = session.db.has_pending_tool_calls(&session.id).await {
-        warn_msg("Tool calls are still pending — deferring compact.".into());
-        return;
-    }
+    tui_output::write_line(&Line::styled("  \u{1f43b} Compacting...", CYAN));
 
-    let history = match session
-        .db
-        .load_context(&session.id, config.max_context_tokens)
-        .await
+    match compact::compact_session(
+        &session.db,
+        &session.id,
+        config.max_context_tokens,
+        &config.model_settings,
+        provider,
+    )
+    .await
     {
-        Ok(msgs) => msgs,
-        Err(e) => {
-            err_msg(format!("Error loading conversation: {e}"));
-            return;
-        }
-    };
-
-    if history.len() < 4 {
-        dim_msg(format!(
-            "Conversation is too short to compact ({} messages).",
-            history.len()
-        ));
-        return;
-    }
-
-    tui_output::write_line(&Line::styled(
-        format!(
-            "  \u{1f43b} Compacting {} messages (preserving last {})...",
-            history.len(),
-            COMPACT_PRESERVE_COUNT
-        ),
-        CYAN,
-    ));
-
-    // Build conversation text for summarization
-    let mut conversation_text = String::new();
-    for msg in &history {
-        let role = msg.role.as_str();
-        if let Some(ref content) = msg.content {
-            let truncated: String = content.chars().take(2000).collect();
-            conversation_text.push_str(&format!("[{role}]: {truncated}\n\n"));
-        }
-        if let Some(ref tool_calls) = msg.tool_calls {
-            let truncated: String = tool_calls.chars().take(500).collect();
-            conversation_text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
-        }
-    }
-    if conversation_text.len() > 20_000 {
-        let mut end = 20_000;
-        while end > 0 && !conversation_text.is_char_boundary(end) {
-            end -= 1;
-        }
-        conversation_text.truncate(end);
-        conversation_text.push_str("\n\n[...truncated for summarization...]");
-    }
-
-    let summary_prompt = format!(
-        "Summarize the conversation below. This summary will replace the older messages \
-         so an AI assistant can continue the session seamlessly.\n\
-         \n\
-         Preserve ALL of the following:\n\
-         1. **User Intent** — Every goal, request, and requirement.\n\
-         2. **Key Decisions** — Decisions made and their rationale.\n\
-         3. **Files & Code** — Every file created, modified, or deleted.\n\
-         4. **Errors & Fixes** — Bugs encountered and how they were resolved.\n\
-         5. **Current State** — What is working, what has been tested.\n\
-         6. **Pending Tasks** — Anything unfinished or deferred.\n\
-         7. **Next Step** — Only if clearly stated or implied.\n\
-         \n\
-         Use concise bullet points. Do not add new ideas.\n\
-         \n\
-         ---\n\n{conversation_text}"
-    );
-
-    let messages = vec![ChatMessage::text("user", &summary_prompt)];
-    let prov = provider.read().await;
-    let response = match prov.chat(&messages, &[], &config.model_settings).await {
-        Ok(r) => r,
-        Err(e) => {
-            err_msg(format!("Failed to generate summary: {e}"));
-            return;
-        }
-    };
-
-    let summary = match response.content {
-        Some(text) if !text.trim().is_empty() => text,
-        _ => {
-            err_msg("LLM returned an empty summary. Aborting compact.".into());
-            return;
-        }
-    };
-
-    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
-
-    match session
-        .db
-        .compact_session(&session.id, &compact_message, COMPACT_PRESERVE_COUNT)
-        .await
-    {
-        Ok(deleted) => {
-            let summary_tokens = summary.len() / 4;
+        Ok(Ok(result)) => {
             ok_msg(format!(
-                "Compacted {deleted} messages → ~{summary_tokens} tokens"
+                "Compacted {} messages \u{2192} ~{} tokens",
+                result.deleted, result.summary_tokens
             ));
             dim_msg("Conversation context has been summarized. Continue as normal!".into());
         }
-        Err(e) => err_msg(format!("Failed to compact session: {e}")),
+        Ok(Err(CompactSkip::PendingToolCalls)) => {
+            warn_msg("Tool calls are still pending \u{2014} deferring compact.".into());
+        }
+        Ok(Err(CompactSkip::TooShort(n))) => {
+            dim_msg(format!(
+                "Conversation is too short to compact ({n} messages)."
+            ));
+        }
+        Err(e) => err_msg(format!("Compact failed: {e}")),
     }
 }
 

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -1,0 +1,117 @@
+//! Session compaction — summarize old messages to reclaim context.
+//!
+//! Pure logic, zero UI dependencies. Returns structured results
+//! for the caller (TUI or headless) to render however it likes.
+
+use crate::db::Database;
+use crate::providers::{ChatMessage, LlmProvider};
+use anyhow::{Result, bail};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Number of recent messages to keep verbatim during compaction.
+pub const COMPACT_PRESERVE_COUNT: usize = 4;
+
+/// Result of a successful compaction.
+pub struct CompactResult {
+    /// Number of messages deleted from the database.
+    pub deleted: usize,
+    /// Estimated tokens in the summary.
+    pub summary_tokens: usize,
+}
+
+/// Why compaction was skipped (not an error, just a precondition).
+pub enum CompactSkip {
+    PendingToolCalls,
+    TooShort(usize),
+}
+
+/// Attempt to compact a session.
+///
+/// Returns `Ok(Ok(result))` on success, `Ok(Err(skip))` if a
+/// precondition prevented compaction, or `Err(e)` on failure.
+pub async fn compact_session(
+    db: &Database,
+    session_id: &str,
+    max_context_tokens: usize,
+    model_settings: &crate::config::ModelSettings,
+    provider: &Arc<RwLock<Box<dyn LlmProvider>>>,
+) -> Result<std::result::Result<CompactResult, CompactSkip>> {
+    // Check preconditions
+    if db.has_pending_tool_calls(session_id).await.unwrap_or(false) {
+        return Ok(Err(CompactSkip::PendingToolCalls));
+    }
+
+    let history = db.load_context(session_id, max_context_tokens).await?;
+
+    if history.len() < 4 {
+        return Ok(Err(CompactSkip::TooShort(history.len())));
+    }
+
+    // Build conversation text for summarization
+    let conversation_text = build_conversation_text(&history);
+
+    let summary_prompt = format!(
+        "Summarize the conversation below. This summary will replace the older messages \
+         so an AI assistant can continue the session seamlessly.\n\
+         \n\
+         Preserve ALL of the following:\n\
+         1. **User Intent** — Every goal, request, and requirement.\n\
+         2. **Key Decisions** — Decisions made and their rationale.\n\
+         3. **Files & Code** — Every file created, modified, or deleted.\n\
+         4. **Errors & Fixes** — Bugs encountered and how they were resolved.\n\
+         5. **Current State** — What is working, what has been tested.\n\
+         6. **Pending Tasks** — Anything unfinished or deferred.\n\
+         7. **Next Step** — Only if clearly stated or implied.\n\
+         \n\
+         Use concise bullet points. Do not add new ideas.\n\
+         \n\
+         ---\n\n{conversation_text}"
+    );
+
+    let messages = vec![ChatMessage::text("user", &summary_prompt)];
+    let prov = provider.read().await;
+    let response = prov.chat(&messages, &[], model_settings).await?;
+
+    let summary = match response.content {
+        Some(text) if !text.trim().is_empty() => text,
+        _ => bail!("LLM returned an empty summary"),
+    };
+
+    let compact_message = format!("[Compacted conversation summary]\n\n{summary}");
+    let deleted = db
+        .compact_session(session_id, &compact_message, COMPACT_PRESERVE_COUNT)
+        .await?;
+
+    Ok(Ok(CompactResult {
+        deleted,
+        summary_tokens: summary.len() / 4,
+    }))
+}
+
+/// Format conversation history into a single string for the summarizer.
+fn build_conversation_text(history: &[crate::db::Message]) -> String {
+    let mut text = String::new();
+    for msg in history {
+        let role = msg.role.as_str();
+        if let Some(ref content) = msg.content {
+            let truncated: String = content.chars().take(2000).collect();
+            text.push_str(&format!("[{role}]: {truncated}\n\n"));
+        }
+        if let Some(ref tool_calls) = msg.tool_calls {
+            let truncated: String = tool_calls.chars().take(500).collect();
+            text.push_str(&format!("[{role} tool_calls]: {truncated}\n\n"));
+        }
+    }
+    // Cap total text
+    const MAX_TEXT: usize = 20_000;
+    if text.len() > MAX_TEXT {
+        let mut end = MAX_TEXT;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+        text.push_str("\n\n[...truncated for summarization...]");
+    }
+    text
+}

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -13,6 +13,7 @@ use tokio::sync::RwLock;
 pub const COMPACT_PRESERVE_COUNT: usize = 4;
 
 /// Result of a successful compaction.
+#[derive(Debug)]
 pub struct CompactResult {
     /// Number of messages deleted from the database.
     pub deleted: usize,
@@ -21,6 +22,7 @@ pub struct CompactResult {
 }
 
 /// Why compaction was skipped (not an error, just a precondition).
+#[derive(Debug)]
 pub enum CompactSkip {
     PendingToolCalls,
     TooShort(usize),

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod agent;
 pub mod approval;
+pub mod compact;
 pub mod config;
 pub mod context;
 pub mod db;

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -414,3 +414,130 @@ async fn test_glob_tool_in_sandbox() {
     assert!(output.contains("main.rs"), "Glob should find main.rs");
     assert!(output.contains("lib.rs"), "Glob should find lib.rs");
 }
+
+// ── Compaction E2E ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_compact_session_summarizes_and_reduces_messages() {
+    use koda_core::compact;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let env = Env::new().await;
+
+    // Stuff 10 user/assistant message pairs into the session
+    for i in 0..10 {
+        env.db
+            .insert_message(
+                &env.session_id,
+                &Role::User,
+                Some(&format!("User message {i} about implementing feature X")),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        env.db
+            .insert_message(
+                &env.session_id,
+                &Role::Assistant,
+                Some(&format!(
+                    "Assistant response {i}: I've made the changes to file_{i}.rs"
+                )),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Verify we have 20 messages
+    let before = env.db.load_context(&env.session_id, 100_000).await.unwrap();
+    assert_eq!(before.len(), 20);
+
+    // Create a mock provider that returns a summary
+    let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
+        Arc::new(RwLock::new(Box::new(MockProvider::new(vec![
+            MockResponse::Text("Summary: User implemented feature X across 10 files.".into()),
+        ]))));
+
+    // Run compaction
+    let result = compact::compact_session(
+        &env.db,
+        &env.session_id,
+        100_000,
+        &env.config.model_settings,
+        &provider,
+    )
+    .await
+    .unwrap();
+
+    // Should succeed
+    let compact_result = result.unwrap();
+    assert!(compact_result.deleted > 0, "should have deleted messages");
+    assert!(
+        compact_result.summary_tokens > 0,
+        "should have summary tokens"
+    );
+
+    // Verify message count decreased
+    let after = env.db.load_context(&env.session_id, 100_000).await.unwrap();
+    assert!(
+        after.len() < before.len(),
+        "message count should decrease after compaction: {} < {}",
+        after.len(),
+        before.len()
+    );
+
+    // Verify the summary is in the history
+    let has_summary = after.iter().any(|m| {
+        m.content
+            .as_deref()
+            .unwrap_or("")
+            .contains("Compacted conversation summary")
+    });
+    assert!(has_summary, "should contain compaction summary message");
+}
+
+#[tokio::test]
+async fn test_compact_skips_short_conversation() {
+    use koda_core::compact::{self, CompactSkip};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let env = Env::new().await;
+
+    // Only 2 messages — too short
+    env.insert_user_message("hello").await;
+    env.db
+        .insert_message(
+            &env.session_id,
+            &Role::Assistant,
+            Some("hi"),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
+        Arc::new(RwLock::new(Box::new(MockProvider::new(vec![]))));
+
+    let result = compact::compact_session(
+        &env.db,
+        &env.session_id,
+        100_000,
+        &env.config.model_settings,
+        &provider,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        matches!(result, Err(CompactSkip::TooShort(2))),
+        "should skip compaction for short conversations"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes all 4 items from #92.

### 1. TUI Corruption (Blocker) ✅
- **New:** `koda-core/src/compact.rs` — pure logic, zero UI deps
  - `compact_session()` returns `Result<Result<CompactResult, CompactSkip>>`
- `tui_app.rs`: auto-compact renders via `emit_above()` (ratatui)
- `tui_wizards.rs`: `/compact` renders via `write_line()` (crossterm)
- **Deleted:** `commands::handle_compact` (147 lines of legacy `println!` code)

### 2. API Key Echoing (Security) ✅
- `onboarding.rs`: replaced `stdin().read_line()` with `rpassword::read_password()`
- API keys are no longer echoed to the terminal during setup

### 3. Compaction E2E Tests ✅
- `test_compact_session_summarizes_and_reduces_messages`: full happy path
- `test_compact_skips_short_conversation`: precondition check

### 4. Legacy Cleanup ✅
- Deleted `commands::handle_compact` and `COMPACT_PRESERVE_COUNT`
- Removed unused `Database` import

## Test Results
- **245 tests pass** (was 243 — added 2 compaction tests)
- Clippy clean, fmt clean

Closes #92