### PR TITLE
feat: @file path Tab completion (#95)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -1,10 +1,13 @@
-//! Slash command completion for the TUI input.
+//! Tab completion for TUI input.
 //!
-//! When the user types `/` and presses Tab, this module cycles
-//! through matching command names.
+//! Handles two completion modes:
+//! - **Slash commands**: `/d` → `/diff`, `/diff commit`, `/diff review`
+//! - **@file paths**: `explain @src/m` → `explain @src/main.rs`
+
+use std::path::{Path, PathBuf};
 
 /// All known slash commands.
-pub const SLASH_COMMANDS: &[&str] = &[
+const SLASH_COMMANDS: &[&str] = &[
     "/agent",
     "/compact",
     "/cost",
@@ -23,44 +26,69 @@ pub const SLASH_COMMANDS: &[&str] = &[
     "/verbose",
 ];
 
-/// Tab-completion state tracker.
-pub struct SlashCompleter {
-    /// Current matches for the prefix.
-    matches: Vec<&'static str>,
+/// Unified Tab-completion for slash commands and @file paths.
+pub struct InputCompleter {
+    /// Current completion matches.
+    matches: Vec<String>,
     /// Index into `matches` for cycling.
     idx: usize,
-    /// The original prefix the user typed.
-    prefix: String,
+    /// The token being completed (to detect changes).
+    token: String,
+    /// Project root for @file path resolution.
+    project_root: PathBuf,
 }
 
-impl SlashCompleter {
-    pub fn new() -> Self {
+impl InputCompleter {
+    pub fn new(project_root: PathBuf) -> Self {
         Self {
             matches: Vec::new(),
             idx: 0,
-            prefix: String::new(),
+            token: String::new(),
+            project_root,
         }
     }
 
-    /// Attempt to complete the given input.
+    /// Attempt to complete the current input text.
     ///
-    /// Returns `Some(completed_text)` if there's a match, `None` otherwise.
-    /// Repeated calls with the same prefix cycle through matches.
-    pub fn complete(&mut self, current_text: &str) -> Option<&'static str> {
-        if !current_text.starts_with('/') {
-            self.reset();
-            return None;
+    /// Returns `Some(replacement_text)` with the full input line replaced,
+    /// or `None` if no completion is available.
+    /// Repeated calls cycle through matches.
+    pub fn complete(&mut self, current_text: &str) -> Option<String> {
+        let trimmed = current_text.trim_end();
+
+        // Slash command completion: input starts with /
+        if trimmed.starts_with('/') {
+            return self.complete_slash(trimmed);
         }
 
-        let trimmed = current_text.trim();
+        // @file completion: find the last @token in the input
+        if let Some(at_pos) = find_last_at_token(trimmed) {
+            let partial = &trimmed[at_pos + 1..]; // after @
+            let prefix = &trimmed[..at_pos]; // everything before @
+            return self.complete_file(prefix, partial);
+        }
 
-        // If prefix changed, rebuild matches
-        if trimmed != self.prefix && !self.matches.contains(&trimmed) {
-            self.prefix = trimmed.to_string();
+        self.reset();
+        None
+    }
+
+    /// Reset completion state (call on non-Tab keystrokes).
+    pub fn reset(&mut self) {
+        self.matches.clear();
+        self.idx = 0;
+        self.token.clear();
+    }
+
+    // ── Slash command completion ─────────────────────────────
+
+    fn complete_slash(&mut self, trimmed: &str) -> Option<String> {
+        // Rebuild matches if the token changed
+        if trimmed != self.token && !self.matches.iter().any(|m| m == trimmed) {
+            self.token = trimmed.to_string();
             self.matches = SLASH_COMMANDS
                 .iter()
                 .filter(|cmd| cmd.starts_with(trimmed) && **cmd != trimmed)
-                .copied()
+                .map(|s| s.to_string())
                 .collect();
             self.idx = 0;
         }
@@ -69,26 +97,123 @@ impl SlashCompleter {
             return None;
         }
 
-        let result = self.matches[self.idx];
+        let result = self.matches[self.idx].clone();
         self.idx = (self.idx + 1) % self.matches.len();
         Some(result)
     }
 
-    /// Reset completion state (called when input changes non-Tab).
-    pub fn reset(&mut self) {
-        self.matches.clear();
-        self.idx = 0;
-        self.prefix.clear();
+    // ── @file path completion ────────────────────────────────
+
+    fn complete_file(&mut self, prefix: &str, partial: &str) -> Option<String> {
+        let token_key = format!("@{partial}");
+
+        // Rebuild matches if the partial path changed
+        if token_key != self.token && !self.matches.iter().any(|m| m == &token_key) {
+            self.token = token_key;
+            self.matches = list_path_matches(&self.project_root, partial);
+            self.idx = 0;
+        }
+
+        if self.matches.is_empty() {
+            return None;
+        }
+
+        let path = &self.matches[self.idx];
+        self.idx = (self.idx + 1) % self.matches.len();
+
+        // Rebuild full input: prefix + @completed_path
+        Some(format!("{prefix}@{path}"))
     }
+}
+
+// ── Helpers ─────────────────────────────────────────────────
+
+/// Find the byte position of the last `@` that starts a file reference.
+///
+/// An `@` counts as a file reference if it's preceded by whitespace
+/// or is at the start of the input (not an email address).
+fn find_last_at_token(text: &str) -> Option<usize> {
+    for (i, c) in text.char_indices().rev() {
+        if c == '@' && (i == 0 || text.as_bytes()[i - 1] == b' ') {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// List filesystem paths matching a partial path relative to project_root.
+///
+/// Given partial `"src/m"`, lists files in `project_root/src/` starting with `m`.
+/// Given partial `"src/"`, lists all files in `project_root/src/`.
+/// Directories get a trailing `/` to encourage further completion.
+fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
+    let (dir_part, file_prefix) = match partial.rfind('/') {
+        Some(pos) => (&partial[..=pos], &partial[pos + 1..]),
+        None => ("", partial),
+    };
+
+    let search_dir = if dir_part.is_empty() {
+        project_root.to_path_buf()
+    } else {
+        project_root.join(dir_part)
+    };
+
+    let entries = match std::fs::read_dir(&search_dir) {
+        Ok(entries) => entries,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut matches: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter_map(|entry| {
+            let name = entry.file_name().to_string_lossy().to_string();
+
+            // Skip hidden files and common noise
+            if name.starts_with('.') {
+                return None;
+            }
+
+            if !name.starts_with(file_prefix) {
+                return None;
+            }
+
+            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+
+            // Skip build artifacts / deps
+            if is_dir
+                && matches!(
+                    name.as_str(),
+                    "target" | "node_modules" | "__pycache__" | ".git"
+                )
+            {
+                return None;
+            }
+
+            let path = if is_dir {
+                format!("{dir_part}{name}/")
+            } else {
+                format!("{dir_part}{name}")
+            };
+            Some(path)
+        })
+        .collect();
+
+    matches.sort();
+    matches
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    // ── Slash command tests ─────────────────────────────────
 
     #[test]
     fn test_complete_slash_d() {
-        let mut c = SlashCompleter::new();
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
         let first = c.complete("/d");
         assert!(first.is_some());
         assert!(first.unwrap().starts_with("/d"));
@@ -96,30 +221,119 @@ mod tests {
 
     #[test]
     fn test_complete_cycles() {
-        let mut c = SlashCompleter::new();
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
         let a = c.complete("/d");
         let b = c.complete("/d");
-        // /diff, /diff commit, /diff review are matches
         assert!(a.is_some());
         assert!(b.is_some());
     }
 
     #[test]
     fn test_no_match() {
-        let mut c = SlashCompleter::new();
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
         assert!(c.complete("/zzz").is_none());
     }
 
     #[test]
-    fn test_non_slash_returns_none() {
-        let mut c = SlashCompleter::new();
+    fn test_non_slash_no_at_returns_none() {
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
         assert!(c.complete("hello").is_none());
     }
 
     #[test]
     fn test_exact_match_no_complete() {
-        let mut c = SlashCompleter::new();
-        // "/exit" is an exact match, no further completion
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
         assert!(c.complete("/exit").is_none());
+    }
+
+    // ── @file completion tests ───────────────────────────────
+
+    #[test]
+    fn test_at_file_completes() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("main.rs"), "fn main() {}").unwrap();
+        fs::write(tmp.path().join("mod.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("explain @m");
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.starts_with("explain @m"), "got: {text}");
+        assert!(
+            text.contains("main.rs") || text.contains("mod.rs"),
+            "got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_at_file_in_subdir() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+        fs::write(tmp.path().join("src/lib.rs"), "").unwrap();
+        fs::write(tmp.path().join("src/main.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("@src/l");
+        assert_eq!(result, Some("@src/lib.rs".to_string()));
+    }
+
+    #[test]
+    fn test_at_file_dir_gets_trailing_slash() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("src")).unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("@s");
+        assert_eq!(result, Some("@src/".to_string()));
+    }
+
+    #[test]
+    fn test_at_file_cycles() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("alpha.rs"), "").unwrap();
+        fs::write(tmp.path().join("beta.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let a = c.complete("@");
+        let b = c.complete("@");
+        assert!(a.is_some());
+        assert!(b.is_some());
+        assert_ne!(a, b, "should cycle through different files");
+    }
+
+    #[test]
+    fn test_at_file_skips_hidden() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join(".hidden"), "").unwrap();
+        fs::write(tmp.path().join("visible.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("@");
+        assert_eq!(result, Some("@visible.rs".to_string()));
+    }
+
+    #[test]
+    fn test_at_file_preserves_prefix_text() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("config.toml"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("review this @c");
+        assert_eq!(result, Some("review this @config.toml".to_string()));
+    }
+
+    // ── Helper tests ────────────────────────────────────────
+
+    #[test]
+    fn test_find_last_at_token() {
+        assert_eq!(find_last_at_token("@file"), Some(0));
+        assert_eq!(find_last_at_token("explain @file"), Some(8));
+        assert_eq!(find_last_at_token("email@domain"), None); // no space before @
+        assert_eq!(find_last_at_token("a @b @c"), Some(5)); // last @
+        assert_eq!(find_last_at_token("no at here"), None);
     }
 }

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -295,7 +295,7 @@ pub async fn run(
     let mut inference_start: Option<std::time::Instant> = None;
     let mut history: Vec<String> = load_history();
     let mut history_idx: Option<usize> = None; // None = not browsing history
-    let mut completer = crate::completer::SlashCompleter::new();
+    let mut completer = crate::completer::InputCompleter::new(project_root.clone());
 
     // Crossterm event stream for async key capture
     let mut crossterm_events = EventStream::new();


### PR DESCRIPTION
Addresses item 1 of #95.

Type `explain @src/m` + Tab → `explain @src/main.rs`

### Changes
- Refactored `SlashCompleter` → `InputCompleter` (unified completer)
- Added @file path completion with filesystem walking
- Directories complete with trailing `/`
- Skips hidden files and build artifacts (`target/`, `node_modules/`)
- Preserves prefix text, cycles matches, finds last @token
- 13 unit tests (7 new @file + 5 slash + 1 helper)

265 tests pass, clippy clean.