### PR TITLE
feat: paste detection for multi-line input (#95)

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -751,24 +751,43 @@ pub async fn run(
                             textarea.insert_newline();
                         }
                         (KeyCode::Enter, KeyModifiers::NONE) => {
-                            let text = textarea.lines().join("\n");
-                            if !text.trim().is_empty() {
-                                textarea.select_all();
-                                textarea.cut();
-                                history.push(text.clone());
-                                save_history(&history);
-                                history_idx = None;
-                                let mode = approval::read_mode(&shared_mode);
-                                let icon = match mode {
-                                    ApprovalMode::Plan => "\u{1f4cb}",
-                                    ApprovalMode::Normal => "\u{1f43b}",
-                                    ApprovalMode::Yolo => "\u{26a1}",
-                                };
-                                emit_above(&mut terminal, Line::from(vec![
-                                    Span::styled(format!("{icon}> "), Style::default().fg(Color::Cyan)),
-                                    Span::raw(text.clone()),
-                                ]));
-                                pending_command = Some(text);
+                            // Paste detection: peek ahead for more input.
+                            // If characters arrive within 30ms, it's a paste —
+                            // insert newline instead of submitting.
+                            let is_paste = tokio::time::timeout(
+                                std::time::Duration::from_millis(30),
+                                crossterm_events.next(),
+                            )
+                            .await;
+
+                            match is_paste {
+                                Ok(Some(Ok(Event::Key(next_key)))) => {
+                                    // More input arrived quickly — it's a paste
+                                    textarea.insert_newline();
+                                    textarea.input(Event::Key(next_key));
+                                }
+                                _ => {
+                                    // Timeout or no event — real Enter, submit
+                                    let text = textarea.lines().join("\n");
+                                    if !text.trim().is_empty() {
+                                        textarea.select_all();
+                                        textarea.cut();
+                                        history.push(text.clone());
+                                        save_history(&history);
+                                        history_idx = None;
+                                        let mode = approval::read_mode(&shared_mode);
+                                        let icon = match mode {
+                                            ApprovalMode::Plan => "\u{1f4cb}",
+                                            ApprovalMode::Normal => "\u{1f43b}",
+                                            ApprovalMode::Yolo => "\u{26a1}",
+                                        };
+                                        emit_above(&mut terminal, Line::from(vec![
+                                            Span::styled(format!("{icon}> "), Style::default().fg(Color::Cyan)),
+                                            Span::raw(text.clone()),
+                                        ]));
+                                        pending_command = Some(text);
+                                    }
+                                }
                             }
                         }
                         (KeyCode::Up, KeyModifiers::NONE) => {


### PR DESCRIPTION
Addresses item 4 of #95.

### Problem
Pasting multi-line text submits the first line immediately and loses the rest.

### Solution
After receiving Enter, peek ahead for 30ms using `tokio::time::timeout`. If more characters arrive within that window, it's a paste — insert a newline instead of submitting. Combined with dynamic viewport expansion (#97), pasted text fills the growing textarea naturally.

### How it works
```
User presses Enter → wait 30ms for more input
  ├─ Timeout (no more input) → real Enter, submit the text
  └─ More chars arrive → paste detected, insert newline + process char
```

265 tests pass, clippy clean.