### PR TITLE
fix: case-insensitive @file completion + Shift+Enter for newlines

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -210,7 +210,8 @@ fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
                 return None;
             }
 
-            if !name.starts_with(file_prefix) {
+            let lower_prefix = file_prefix.to_lowercase();
+            if !name.to_lowercase().starts_with(&lower_prefix) {
                 return None;
             }
 
@@ -351,6 +352,21 @@ mod tests {
         let mut c = InputCompleter::new(tmp.path().to_path_buf());
         let result = c.complete("@");
         assert_eq!(result, Some("@visible.rs".to_string()));
+    }
+
+    #[test]
+    fn test_at_file_case_insensitive() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("Makefile"), "").unwrap();
+        fs::write(tmp.path().join("README.md"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        let result = c.complete("@make");
+        assert_eq!(result, Some("@Makefile".to_string()));
+
+        c.reset();
+        let result = c.complete("@read");
+        assert_eq!(result, Some("@README.md".to_string()));
     }
 
     #[test]

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -761,8 +761,11 @@ pub async fn run(
             Some(Ok(ev)) = crossterm_events.next() => {
                 if let Event::Key(key) = ev {
                     match (key.code, key.modifiers) {
-                        // Alt+Enter → insert newline (multi-line input)
-                        (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
+                        // Shift+Enter → insert newline (multi-line input)
+                        (KeyCode::Enter, m)
+                            if m.contains(KeyModifiers::SHIFT)
+                                || m.contains(KeyModifiers::ALT) =>
+                        {
                             textarea.insert_newline();
                         }
                         (KeyCode::Enter, KeyModifiers::NONE) => {


### PR DESCRIPTION
Two quick UX fixes:

### 1. Case-insensitive @file completion
`@make` + Tab → `@Makefile`, `@read` + Tab → `@README.md`

### 2. Shift+Enter for newlines
More natural than Alt+Enter — matches Slack, Teams, Discord convention.
Alt+Enter still works as a fallback.

270 tests pass (+1 case-insensitive test), clippy clean.