### PR TITLE
fix: Shift+Enter support + Tab completion candidate list

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -84,6 +84,22 @@ impl InputCompleter {
         None
     }
 
+    /// Get the current completion candidates (for display in the TUI).
+    /// Returns the raw match values (without the `/model ` or `@` prefix context).
+    pub fn candidates(&self) -> &[String] {
+        &self.matches
+    }
+
+    /// Get the index of the currently selected candidate.
+    pub fn selected_idx(&self) -> usize {
+        // idx points to the *next* one, so the current selection is idx - 1
+        if self.idx == 0 && !self.matches.is_empty() {
+            self.matches.len() - 1
+        } else {
+            self.idx.saturating_sub(1)
+        }
+    }
+
     /// Reset completion state (call on non-Tab keystrokes).
     pub fn reset(&mut self) {
         self.matches.clear();

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -142,6 +142,15 @@ type Term = Terminal<CrosstermBackend<std::io::Stdout>>;
 
 fn init_terminal(height: u16) -> Result<Term> {
     crossterm::terminal::enable_raw_mode()?;
+    // Enable kitty keyboard protocol for Shift+Enter detection.
+    // Gracefully ignored by terminals that don't support it.
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::PushKeyboardEnhancementFlags(
+            crossterm::event::KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+                | crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+        )
+    );
     let stdout = std::io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::with_options(
@@ -155,6 +164,10 @@ fn init_terminal(height: u16) -> Result<Term> {
 
 fn restore_terminal(terminal: &mut Term, height: u16) {
     let _ = terminal.clear();
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::PopKeyboardEnhancementFlags
+    );
     let _ = crossterm::terminal::disable_raw_mode();
     // Erase leftover viewport lines
     print!("\x1b[{}A\x1b[J", height);
@@ -857,7 +870,48 @@ pub async fn run(
                             if let Some(completed) = completer.complete(&current) {
                                 textarea.select_all();
                                 textarea.cut();
-                                textarea.insert_str(completed);
+                                textarea.insert_str(&completed);
+
+                                // Show candidates above viewport if multiple matches
+                                let candidates = completer.candidates();
+                                if candidates.len() > 1 {
+                                    let selected = completer.selected_idx();
+                                    let spans: Vec<Span> = candidates
+                                        .iter()
+                                        .enumerate()
+                                        .flat_map(|(i, c)| {
+                                            let style = if i == selected {
+                                                Style::default()
+                                                    .fg(Color::Cyan)
+                                                    .add_modifier(Modifier::BOLD)
+                                            } else {
+                                                Style::default().fg(Color::DarkGray)
+                                            };
+                                            // Extract just the display name
+                                            let name = c
+                                                .rsplit('/')
+                                                .next()
+                                                .unwrap_or(c)
+                                                .trim_start_matches("/model ")
+                                                .to_string();
+                                            let sep = if i + 1 < candidates.len() {
+                                                "  "
+                                            } else {
+                                                ""
+                                            };
+                                            vec![
+                                                Span::styled(name, style),
+                                                Span::raw(sep.to_string()),
+                                            ]
+                                        })
+                                        .collect();
+                                    let mut line_spans = vec![Span::styled(
+                                        "  Tab: ",
+                                        Style::default().fg(Color::DarkGray),
+                                    )];
+                                    line_spans.extend(spans);
+                                    emit_above(&mut terminal, Line::from(line_spans));
+                                }
                             }
                         }
                         _ => {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -255,7 +255,7 @@ fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
             Print("\r\n  "),
             SetForegroundColor(Color::DarkGrey),
             Print(
-                "Tips: @file to attach context \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel \u{00b7} Ctrl+D to exit"
+                "Tips: @file to attach context \u{00b7} Shift+Enter for newline \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel"
             ),
             ResetColor,
             Print("\r\n"),


### PR DESCRIPTION
### 1. Shift+Enter for newlines
Enables the kitty keyboard protocol via `PushKeyboardEnhancementFlags` so crossterm can distinguish Shift+Enter from plain Enter. Gracefully ignored by terminals that don't support it (Terminal.app, older iTerm2). **Alt+Enter still works everywhere as fallback.**

Supported terminals: kitty, WezTerm, foot, Alacritty (recent), iTerm2 (with kitty protocol enabled).

### 2. Tab completion shows candidates
When multiple matches exist, shows them above the viewport with the current selection highlighted:

```
  Tab: main.rs  mod.rs  lib.rs
🐻> explain @m_
```

Works for all three completion modes: slash commands, @file paths, and /model names.

270 tests pass, clippy clean.