### PR TITLE
fix: dropdown select for Tab completion, revert kitty protocol

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -185,7 +185,7 @@ impl InputCompleter {
 ///
 /// An `@` counts as a file reference if it's preceded by whitespace
 /// or is at the start of the input (not an email address).
-fn find_last_at_token(text: &str) -> Option<usize> {
+pub fn find_last_at_token(text: &str) -> Option<usize> {
     for (i, c) in text.char_indices().rev() {
         if c == '@' && (i == 0 || matches!(text.as_bytes()[i - 1], b' ' | b'\n')) {
             return Some(i);

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -142,15 +142,6 @@ type Term = Terminal<CrosstermBackend<std::io::Stdout>>;
 
 fn init_terminal(height: u16) -> Result<Term> {
     crossterm::terminal::enable_raw_mode()?;
-    // Enable kitty keyboard protocol for Shift+Enter detection.
-    // Gracefully ignored by terminals that don't support it.
-    let _ = crossterm::execute!(
-        std::io::stdout(),
-        crossterm::event::PushKeyboardEnhancementFlags(
-            crossterm::event::KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                | crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
-        )
-    );
     let stdout = std::io::stdout();
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::with_options(
@@ -164,10 +155,6 @@ fn init_terminal(height: u16) -> Result<Term> {
 
 fn restore_terminal(terminal: &mut Term, height: u16) {
     let _ = terminal.clear();
-    let _ = crossterm::execute!(
-        std::io::stdout(),
-        crossterm::event::PopKeyboardEnhancementFlags
-    );
     let _ = crossterm::terminal::disable_raw_mode();
     // Erase leftover viewport lines
     print!("\x1b[{}A\x1b[J", height);
@@ -774,7 +761,9 @@ pub async fn run(
             Some(Ok(ev)) = crossterm_events.next() => {
                 if let Event::Key(key) = ev {
                     match (key.code, key.modifiers) {
-                        // Shift+Enter → insert newline (multi-line input)
+                        // Shift+Enter or Alt+Enter → insert newline
+                        // Note: Shift+Enter only works on terminals with kitty
+                        // keyboard protocol. Alt+Enter works everywhere.
                         (KeyCode::Enter, m)
                             if m.contains(KeyModifiers::SHIFT)
                                 || m.contains(KeyModifiers::ALT) =>
@@ -868,50 +857,53 @@ pub async fn run(
                         (KeyCode::Tab, KeyModifiers::NONE) => {
                             let current = textarea.lines().join("\n");
                             if let Some(completed) = completer.complete(&current) {
-                                textarea.select_all();
-                                textarea.cut();
-                                textarea.insert_str(&completed);
-
-                                // Show candidates above viewport if multiple matches
                                 let candidates = completer.candidates();
                                 if candidates.len() > 1 {
-                                    let selected = completer.selected_idx();
-                                    let spans: Vec<Span> = candidates
-                                        .iter()
-                                        .enumerate()
-                                        .flat_map(|(i, c)| {
-                                            let style = if i == selected {
-                                                Style::default()
-                                                    .fg(Color::Cyan)
-                                                    .add_modifier(Modifier::BOLD)
-                                            } else {
-                                                Style::default().fg(Color::DarkGray)
-                                            };
-                                            // Extract just the display name
-                                            let name = c
-                                                .rsplit('/')
-                                                .next()
-                                                .unwrap_or(c)
-                                                .trim_start_matches("/model ")
-                                                .to_string();
-                                            let sep = if i + 1 < candidates.len() {
-                                                "  "
-                                            } else {
-                                                ""
-                                            };
-                                            vec![
-                                                Span::styled(name, style),
-                                                Span::raw(sep.to_string()),
-                                            ]
-                                        })
-                                        .collect();
-                                    let mut line_spans = vec![Span::styled(
-                                        "  Tab: ",
-                                        Style::default().fg(Color::DarkGray),
-                                    )];
-                                    line_spans.extend(spans);
-                                    emit_above(&mut terminal, Line::from(line_spans));
+                                    // Multiple matches — open dropdown select menu
+                                    let options: Vec<crate::select_menu::SelectOption> =
+                                        candidates
+                                            .iter()
+                                            .map(|c| {
+                                                crate::select_menu::SelectOption::new(c, "")
+                                            })
+                                            .collect();
+                                    let initial = completer.selected_idx();
+                                    if let Ok(Some(idx)) =
+                                        crate::select_menu::select_inline(
+                                            &mut terminal,
+                                            "\u{1f4c2} Select",
+                                            &options,
+                                            initial,
+                                        )
+                                    {
+                                        // Reconstruct the full text with the selected match
+                                        let selected = &candidates[idx];
+                                        // Rerun completion logic to build the full text
+                                        let trimmed = current.trim_end();
+                                        let replacement = if trimmed.starts_with('/') {
+                                            selected.clone()
+                                        } else if let Some(at_pos) =
+                                            crate::completer::find_last_at_token(trimmed)
+                                        {
+                                            let prefix = &trimmed[..at_pos];
+                                            format!("{prefix}@{selected}")
+                                        } else {
+                                            selected.clone()
+                                        };
+                                        textarea.select_all();
+                                        textarea.cut();
+                                        textarea.insert_str(&replacement);
+                                    }
+                                    // Reinit terminal after select_inline
+                                    terminal = init_terminal(viewport_height)?;
+                                    crossterm_events = EventStream::new();
+                                } else {
+                                    // Single match — just insert it
+                                    textarea.select_all();
+                                    textarea.cut();
+                                    textarea.insert_str(&completed);
                                 }
+                                completer.reset();
                             }
                         }
                         _ => {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -255,7 +255,7 @@ fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
             Print("\r\n  "),
             SetForegroundColor(Color::DarkGrey),
             Print(
-                "Tips: @file to attach context \u{00b7} Shift+Enter for newline \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel"
+                "Tips: @file to attach context \u{00b7} Alt+Enter for newline \u{00b7} Shift+Tab to cycle mode \u{00b7} Ctrl+C to cancel"
             ),
             ResetColor,
             Print("\r\n"),


### PR DESCRIPTION
### Problem 1: Tab prints a new candidate line every press
The `Tab: file1 file2 file3` line was emitted via `emit_above` on every Tab press, spamming the scrollback.

### Fix: Dropdown select menu
Now when Tab finds multiple matches, it opens the existing `select_inline()` arrow-key menu:
```
📂 Select
  ▸ main.rs
    mod.rs  
    lib.rs
```
- Arrow keys to navigate, Enter to select, Esc to dismiss
- Single-match still completes silently (no menu)
- Works for all three modes: @file, /commands, /model names

### Problem 2: Terminal corruption on exit (`execute: 3u_`)
The kitty keyboard protocol (`PushKeyboardEnhancementFlags`) was leaving escape codes in the terminal buffer on exit. Most Mac terminals don't support this protocol.

### Fix: Revert kitty protocol
Removed `PushKeyboardEnhancementFlags` and `PopKeyboardEnhancementFlags`.
Shift+Enter support is dropped (unreliable). **Alt+Enter** remains the universal newline keybinding.

271 tests pass, clippy clean.