### PR TITLE
fix: clear leftover select menu lines after selection

### DIFF
--- a/koda-cli/src/select_menu.rs
+++ b/koda-cli/src/select_menu.rs
@@ -210,6 +210,8 @@ fn move_past_menu(
     execute!(stdout, cursor::MoveDown(total_lines as u16 - 1))?;
     // One more \n to position at the line after the menu
     execute!(stdout, Print("\r\n"))?;
+    // Clear everything below cursor so leftover menu lines don't linger
+    execute!(stdout, Clear(ClearType::FromCursorDown))?;
     stdout.flush()?;
     Ok(())
 }


### PR DESCRIPTION
### Problem
After selecting a provider in `/provider`, leftover menu items (Fireworks, vLLM, etc.) remained visible below the cursor. The subsequent wizard output (URL prompt, model list) mixed with the old menu options.

### Root Cause
`move_past_menu()` moved the cursor past the menu but didn't clear the lines below it. The old crossterm-rendered menu options were still in the terminal buffer.

### Fix
One line: `Clear(ClearType::FromCursorDown)` after positioning the cursor past the menu.

This fixes all `select_inline()` users: `/provider`, `/model`, `/help`, `/trust`, and the new Tab completion dropdown.

271 tests pass, clippy clean.