### PR TITLE
fix: URL prompt renders on dirty line after /provider menu

### DIFF
--- a/koda-cli/src/widgets/text_input.rs
+++ b/koda-cli/src/widgets/text_input.rs
@@ -21,14 +21,14 @@ type Term = Terminal<CrosstermBackend<std::io::Stdout>>;
 /// character. Returns the trimmed input, or empty string on Esc.
 ///
 /// If `mask` is true, input is shown as `*` characters (for API keys).
-pub fn read_line(terminal: &mut Term, prompt: &str, mask: bool) -> String {
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled(prompt, Style::default().fg(Color::Cyan)),
-        ]),
-    );
+pub fn read_line(_terminal: &mut Term, prompt: &str, mask: bool) -> String {
+    // Use write_line (crossterm direct) not emit_line (ratatui insert_before)
+    // because this is called during slash commands where the ratatui viewport
+    // is desynced after select_inline.
+    tui_output::write_line(&Line::from(vec![
+        Span::raw("  "),
+        Span::styled(prompt.to_string(), Style::default().fg(Color::Cyan)),
+    ]));
 
     let mut buf = String::new();
     let mut stdout = std::io::stdout();


### PR DESCRIPTION
### Problem
After selecting a provider in `/provider`, the URL prompt appeared on a dirty line with leftover content:
```
aasdaflm-studio URL (enter for http://localhost:1234/v1):
```

### Root Cause
`text_input::read_line` used `emit_line()` (ratatui's `insert_before()`) to render the prompt. During slash commands, the ratatui viewport is **desynced** after `select_inline()` writes directly with crossterm. The `insert_before()` rendered at the wrong cursor position.

### Fix
Switch `text_input::read_line` from `emit_line()` (ratatui) to `write_line()` (crossterm direct). All other slash command output already uses `write_line` — `text_input` was the only one still mixing rendering paths.

271 tests pass, clippy clean.