### PR TITLE
docs: v0.1.2 release — updated docs, version bump, Tab fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-03-06
+
+### Added
+- **Inline TUI** — ratatui `Viewport::Inline` with persistent input + status bar ([#70](https://github.com/lijunzh/koda/issues/70))
+  - Type-ahead during inference (input queued while model runs)
+  - Inline approval widget (arrow-key approve/reject/feedback)
+  - Status bar: model name, approval mode, context meter (`████░░ 5%`), elapsed time
+  - Dynamic viewport expansion: input area grows with multi-line text (2–10 rows)
+  - Paste detection: multi-line paste enters text mode instead of submitting
+- **Streaming markdown renderer** — headers, **bold**, *italic*, `code`, fenced blocks with syntax highlighting, lists, blockquotes, horizontal rules
+- **Tab completion** — three modes:
+  - Slash commands: `/d` + Tab → dropdown select (`/diff`, `/diff commit`, `/diff review`)
+  - `@file` paths: `@src/m` + Tab → dropdown with filesystem walking (case-insensitive)
+  - `/model` names: `/model gpt` + Tab → dropdown with substring matching
+- **Compaction module** — `koda-core::compact` with pure logic, zero UI deps. Shared by TUI and headless modes
+- **Alt+Enter** for multi-line input (Shift+Enter on terminals with kitty protocol)
+
+### Fixed
+- **TUI auto-compaction** — was calling `println!` inside raw mode, corrupting the viewport
+- **API key echoing** — onboarding now uses `rpassword` for silent input
+- **Path traversal in @file** — `@../../etc/passwd` now blocked by `safe_resolve_path()`
+- **Select menu cleanup** — leftover menu items no longer linger after `/provider`, `/model`
+- **Rendering path consistency** — all slash commands use crossterm; approval widget fixed
+- **Event clone in hot path** — `TextDelta` events no longer cloned during streaming
+- **Lock poisoning** — `runtime_env` recovers gracefully instead of panicking
+- **Raw mode RAII guard** — `select_menu` restores terminal on panic
+
+### Changed
+- **Legacy cleanup** — deleted ~550 lines of dead code (`commands.rs`, old `handle_compact`, ANSI helpers)
+- **DRY style helpers** — `ok_msg`/`err_msg`/`dim_msg`/`warn_msg` shared from `tui_output.rs`
+- **Dropped rustyline** — replaced by `tui-textarea` widget
+
+### Removed
+- `app.rs` (864 lines) — legacy rustyline event loop
+- `display.rs` (922 lines) — legacy terminal output formatting
+- `markdown.rs` (564 lines) — legacy ANSI markdown renderer (replaced by `md_render.rs`)
+- `confirm.rs` (104 lines) — legacy confirmation prompts
+
+### Testing
+- 284 tests across `koda-core` and `koda-cli`
+- New: 12 compaction tests (7 unit + 2 E2E + skip/boundary), 12 markdown tests, 19 completer tests, 2 path traversal tests
+
 ## [0.1.1] - 2026-03-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Koda is a high-performance AI coding agent built in Rust (edition 2024). Two-crate workspace:
 - `koda-core` (library) — pure engine with zero terminal deps
-- `koda-cli` (binary `koda`) — CLI frontend
+- `koda-cli` (binary `koda`) — CLI frontend with ratatui TUI
 
-See [DESIGN.md](DESIGN.md) for architectural decisions. See [#57](https://github.com/lijunzh/koda/issues/57) for the TUI migration plan (v0.1.2).
+See [DESIGN.md](DESIGN.md) for architectural decisions. See [#70](https://github.com/lijunzh/koda/issues/70) for the TUI design.
 
 ## Build & Development Commands
 
@@ -32,12 +32,13 @@ cargo doc --workspace --no-deps          # Build docs
 ```
 koda/
 ├── Cargo.toml              # Workspace root
-├── koda-core/              # Engine library
+├── koda-core/              # Engine library (zero terminal deps)
 │   ├── src/
 │   │   ├── lib.rs          # Crate root
 │   │   ├── agent.rs        # KodaAgent (shared config: tools, prompt, MCP)
 │   │   ├── session.rs      # KodaSession (per-conversation: DB, provider, settings)
 │   │   ├── inference.rs    # Streaming inference loop + tool execution
+│   │   ├── compact.rs      # Session compaction (summarize old messages)
 │   │   ├── approval.rs     # Approval modes + bash command safety classification
 │   │   ├── context.rs      # Context window token tracking
 │   │   ├── keystore.rs     # Secure API key storage (~/.config/koda/keys.toml, 0600)
@@ -47,38 +48,53 @@ koda/
 │   │   ├── runtime_env.rs  # Thread-safe runtime env for API keys
 │   │   ├── version.rs      # Background version checker (queries crates.io)
 │   │   ├── engine/         # EngineEvent, EngineCommand, EngineSink trait
-│   │   ├── providers/      # LLM providers (Anthropic, Gemini, OpenAI-compat)
+│   │   ├── providers/      # LLM providers (Anthropic, Gemini, OpenAI-compat, mock)
 │   │   ├── tools/          # Built-in tools (Bash, Read, Write, Edit, etc.)
-│   │   ├── mcp/            # MCP client
-│   │   ├── db.rs           # SQLite persistence
+│   │   ├── mcp/            # MCP client (registry, config, stdio transport)
+│   │   ├── db.rs           # SQLite persistence (WAL mode, parameterized queries)
 │   │   └── config.rs       # Agent/provider config
 │   └── tests/              # Engine integration tests
 ├── koda-cli/               # CLI binary
 │   ├── src/
-│   │   ├── lib.rs          # Crate root (exports acp_adapter)
 │   │   ├── main.rs         # CLI entry point (clap)
-│   │   ├── app.rs          # Application entry points (REPL + headless dispatch)
-│   │   ├── server.rs       # ACP server over stdio JSON-RPC (koda server --stdio)
-│   │   ├── acp_adapter.rs  # ACP protocol adapter (EngineEvent → ACP messages, approval flow)
-│   │   ├── headless.rs     # Single-prompt headless mode
-│   │   ├── repl.rs         # Slash command handling (/model, /provider, /help, /quit)
-│   │   ├── commands.rs     # /compact, /mcp, /provider, /trust handlers
-│   │   ├── confirm.rs      # User confirmation UI for dangerous operations
-│   │   ├── input.rs        # rustyline Helper: slash-command + @file completions
-│   │   ├── interrupt.rs    # Ctrl+C double-tap graceful cancellation
-│   │   ├── onboarding.rs   # First-run wizard (provider + API key setup)
-│   │   ├── tui.rs          # Arrow-key interactive selection menus (approval, /model, /help)
-│   │   ├── sink.rs         # CliSink (EngineEvent → terminal rendering, inline spinner)
-│   │   ├── display.rs      # Terminal output formatting
+│   │   ├── tui_app.rs      # Main TUI event loop (ratatui Viewport::Inline)
+│   │   ├── tui_render.rs   # EngineEvent → ratatui Line/Span rendering
+│   │   ├── tui_commands.rs # Slash command dispatch (/help, /model, /sessions, etc.)
+│   │   ├── tui_wizards.rs  # Interactive wizards (/provider, /compact, /mcp, /agent)
+│   │   ├── tui_output.rs   # Output bridge: emit_line (ratatui) + write_line (crossterm)
+│   │   ├── md_render.rs    # Streaming markdown → ratatui renderer
+│   │   ├── completer.rs    # Tab completion (/commands, @files, /model names)
+│   │   ├── diff_render.rs  # Diff preview → ratatui renderer (syntax highlighted)
 │   │   ├── highlight.rs    # Syntax highlighting via syntect
-│   │   └── markdown.rs     # Streaming markdown renderer
+│   │   ├── select_menu.rs  # Arrow-key selection menus (standalone + inline)
+│   │   ├── commands.rs     # Provider factory (create_provider)
+│   │   ├── repl.rs         # Slash command parsing + provider/model lists
+│   │   ├── input.rs        # @file reference processing + image loading
+│   │   ├── headless.rs     # Single-prompt headless mode
+│   │   ├── headless_sink.rs# HeadlessSink (println-based, auto-approve)
+│   │   ├── sink.rs         # CliSink (channel forwarding for TUI)
+│   │   ├── server.rs       # ACP server over stdio JSON-RPC
+│   │   ├── acp_adapter.rs  # ACP protocol adapter
+│   │   ├── onboarding.rs   # First-run wizard (provider + API key setup)
+│   │   ├── interrupt.rs    # Ctrl+C double-tap graceful cancellation
+│   │   ├── tool_history.rs # Tool output history for /expand
+│   │   ├── lib.rs          # Crate root (exports acp_adapter)
+│   │   └── widgets/        # TUI widgets
+│   │       ├── approval.rs # Inline approval prompt (approve/reject/feedback)
+│   │       ├── status_bar.rs# Model, mode, context meter, elapsed time
+│   │       └── text_input.rs# Inline text input (masked for API keys)
 │   └── tests/              # CLI integration tests
 └── DESIGN.md               # Architecture decisions
 ```
 
 ### Core Event Loop
 
-`main.rs` → `app.rs` (REPL) → `KodaSession::run_turn()` → `inference_loop()` (streaming LLM + tools)
+`main.rs` → `tui_app.rs` (TUI event loop) → `KodaSession::run_turn()` → `inference_loop()` (streaming LLM + tools)
+
+The TUI uses `ratatui::Viewport::Inline` for a persistent input bar + status bar at the bottom.
+Engine output is rendered above the viewport via `insert_before()`. Slash commands use
+crossterm direct writes (`write_line()`). These two rendering paths must never be mixed
+within a single operation.
 
 The engine communicates through `EngineEvent` (output) and `EngineCommand` (input) enums.
 Approval flows through async channels: engine emits `ApprovalRequest`, client sends `ApprovalResponse`.
@@ -88,7 +104,7 @@ Approval flows through async channels: engine emits `ApprovalRequest`, client se
 - **`KodaAgent`** — Shared resources (tools, system prompt, MCP). `Arc`-shareable.
 - **`KodaSession`** — Per-conversation state (DB, provider, settings). Has `run_turn()`.
 - **`EngineSink`** — Trait with single method: `fn emit(&self, event: EngineEvent)`.
-- **`CliSink`** — CLI implementation. Renders events to terminal + sends approval responses via channel.
+- **`CliSink`** — Channel-forwarding sink. Sends events to the TUI event loop via `UiEvent`.
 
 ### Provider System (`koda-core/src/providers/`)
 
@@ -103,7 +119,10 @@ Tools use PascalCase names. `mod.rs` has the registry, dispatcher, and `safe_res
 - Error handling: `anyhow::Result<T>` with `.context()`
 - All I/O is async (`tokio`)
 - Tool names: PascalCase; module names: snake_case
-- `koda-core` has zero terminal deps (no crossterm, no rustyline)
+- `koda-core` has zero terminal deps (no crossterm, no ratatui)
+- Two rendering paths in koda-cli (never mix within one operation):
+  - `emit_line()` / `emit_above()` — ratatui `insert_before()` for engine output
+  - `write_line()` — crossterm direct writes for slash commands
 - Engine → client: `EngineSink::emit(EngineEvent)`
 - Client → engine: `mpsc::Receiver<EngineCommand>`
 - Cancellation: `tokio_util::sync::CancellationToken`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,7 @@
 # Koda Design Decisions
 
 This document captures architectural decisions and their rationale.
-For the TUI migration plan (v0.1.2), see [#57](https://github.com/lijunzh/koda/issues/57).
+For the TUI architecture (v0.1.2), see [#70](https://github.com/lijunzh/koda/issues/70).
 For workspace structure and developer docs, see [CLAUDE.md](CLAUDE.md).
 
 ## Vision

--- a/README.md
+++ b/README.md
@@ -83,23 +83,21 @@ Koda natively understands the structure of your codebase using embedded `tree-si
 | `/trust` | Switch approval mode (plan/normal/yolo) |
 | `/exit` | Quit Koda |
 
-**Tips:** `@file` to attach context · `Shift+Tab` to cycle trust mode · `Esc` to clear input
+**Tips:** `@file` to attach context · Tab to autocomplete · `Shift+Tab` to cycle trust mode · `Alt+Enter` for multi-line
 
 ### Keyboard Shortcuts
 
 | Key | Context | Action |
 |-----|---------|--------|
+| **Tab** | At prompt | Autocomplete (`/commands`, `@files`, `/model names`) |
+| **Alt+Enter** | At prompt | Insert newline (multi-line input) |
 | **Ctrl+C** | During inference | Cancel the current turn |
 | **Ctrl+C ×2** | During inference | Force quit Koda |
-| **Ctrl+C** | At prompt (empty) | Exit Koda |
 | **Ctrl+C** | At prompt (with text) | Clear the line |
 | **Esc** | At prompt | Clear the line |
 | **Shift+Tab** | At prompt | Cycle trust mode (plan → normal → yolo) |
-| **Ctrl+D** | At prompt | Exit Koda |
-
-> **Note:** Input is not accepted while the model is running. Wait for the turn
-> to complete, then type your next message. Type-ahead during inference is planned
-> for v0.1.2 via a TUI framework migration ([#57](https://github.com/lijunzh/koda/issues/57)).
+| **Ctrl+D** | At prompt (empty) | Exit Koda |
+| **↑/↓** | At prompt | Browse command history |
 
 ## MCP (Model Context Protocol)
 
@@ -150,7 +148,7 @@ over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
 ## Development
 
 ```bash
-cargo test --workspace        # Run all 372 tests
+cargo test --workspace --features koda-core/test-support  # Run all 284 tests
 cargo clippy --workspace      # Lint
 cargo run -p koda-cli         # Run locally
 ```

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"

--- a/koda-cli/src/select_menu.rs
+++ b/koda-cli/src/select_menu.rs
@@ -82,9 +82,11 @@ pub fn select_inline(
                 KeyCode::Up => {
                     selected = selected.saturating_sub(1);
                 }
-                KeyCode::Down => {
+                KeyCode::Down | KeyCode::Tab => {
                     if selected + 1 < options.len() {
                         selected += 1;
+                    } else {
+                        selected = 0; // wrap around
                     }
                 }
                 KeyCode::Enter => {

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -571,7 +571,18 @@ pub async fn run(
                                                 (KeyCode::BackTab, _) => {
                                                     approval::cycle_mode(&shared_mode);
                                                 }
+                                                (KeyCode::Tab, KeyModifiers::NONE) => {
+                                                    // Silent Tab completion during inference
+                                                    // (no dropdown — would block the event loop)
+                                                    let current = textarea.lines().join("\n");
+                                                    if let Some(completed) = completer.complete(&current) {
+                                                        textarea.select_all();
+                                                        textarea.cut();
+                                                        textarea.insert_str(&completed);
+                                                    }
+                                                }
                                                 _ => {
+                                                    completer.reset();
                                                     textarea.input(Event::Key(key));
                                                 }
                                             }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"


### PR DESCRIPTION
### Docs & Version
- Bumped `Cargo.toml` versions: 0.1.1 → 0.1.2
- Full CHANGELOG entry for v0.1.2
- README: updated keyboard shortcuts, test count, removed stale type-ahead note
- DESIGN.md: updated TUI reference
- CLAUDE.md: complete file tree rewrite (old files deleted, new TUI modules added)

### Bug Fixes
1. **Tab cycles in dropdown** — Tab now works as Down arrow in select menus (wraps around)
2. **Tab completion during type-ahead** — works during inference with silent cycling (no dropdown to avoid blocking)

284 tests pass, clippy clean.