### PR TITLE
feat: show mode change notification on Shift+Tab

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -863,7 +863,25 @@ pub async fn run(
                             }
                         }
                         (KeyCode::BackTab, _) => {
-                            approval::cycle_mode(&shared_mode);
+                            let new_mode = approval::cycle_mode(&shared_mode);
+                            let (icon, desc) = match new_mode {
+                                ApprovalMode::Plan => ("\u{1f4cb}", "read-only"),
+                                ApprovalMode::Normal => ("\u{1f43b}", "confirm dangerous"),
+                                ApprovalMode::Yolo => ("\u{26a1}", "auto-approve all"),
+                            };
+                            emit_above(
+                                &mut terminal,
+                                Line::from(vec![
+                                    Span::styled(
+                                        format!("  {icon} Mode: {} ", new_mode.label()),
+                                        Style::default().fg(Color::Cyan),
+                                    ),
+                                    Span::styled(
+                                        format!("\u{2014} {desc}"),
+                                        Style::default().fg(Color::DarkGray),
+                                    ),
+                                ]),
+                            );
                         }
                         (KeyCode::Tab, KeyModifiers::NONE) => {
                             let current = textarea.lines().join("\n");


### PR DESCRIPTION
When Shift+Tab cycles the approval mode, a brief notification appears above the viewport:

```
  📋 Mode: plan — read-only
  🐻 Mode: normal — confirm dangerous
  ⚡ Mode: yolo — auto-approve all
```

This teaches users the Shift+Tab shortcut naturally without requiring them to discover it via `/help`.

**Design decision:** `/trust` stays as-is — it's useful for discoverability (`/help` lists it) and for direct mode selection by name (`/trust yolo`). Same pattern as Claude Code keeping both CLI flags and UI controls.

During inference, mode changes are silent — the status bar update is enough.

284 tests pass, clippy clean.