### PR TITLE
fix: remove mode change scrollback spam on Shift+Tab

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -863,25 +863,8 @@ pub async fn run(
                             }
                         }
                         (KeyCode::BackTab, _) => {
-                            let new_mode = approval::cycle_mode(&shared_mode);
-                            let (icon, desc) = match new_mode {
-                                ApprovalMode::Plan => ("\u{1f4cb}", "read-only"),
-                                ApprovalMode::Normal => ("\u{1f43b}", "confirm dangerous"),
-                                ApprovalMode::Yolo => ("\u{26a1}", "auto-approve all"),
-                            };
-                            emit_above(
-                                &mut terminal,
-                                Line::from(vec![
-                                    Span::styled(
-                                        format!("  {icon} Mode: {} ", new_mode.label()),
-                                        Style::default().fg(Color::Cyan),
-                                    ),
-                                    Span::styled(
-                                        format!("\u{2014} {desc}"),
-                                        Style::default().fg(Color::DarkGray),
-                                    ),
-                                ]),
-                            );
+                            approval::cycle_mode(&shared_mode);
+                            // Status bar updates on next draw — no scrollback noise
                         }
                         (KeyCode::Tab, KeyModifiers::NONE) => {
                             let current = textarea.lines().join("\n");


### PR DESCRIPTION
### Problem
Every Shift+Tab press added a permanent line to scrollback:
```
  ⚡ Mode: yolo — auto-approve all
  📋 Mode: plan — read-only
  🐻 Mode: normal — confirm dangerous
  ⚡ Mode: yolo — auto-approve all
```

### Fix
Removed the `emit_above` notification. The status bar already updates instantly on mode change — that's the right feedback mechanism. Discoverability comes from `/help` which shows `Shift+Tab to cycle mode`.

**Lesson learned:** `emit_above` is for permanent output (LLM responses, tool results). Transient state changes belong in the status bar.

284 tests pass, clippy clean.