### PR TITLE
docs: evolve philosophy to thin core + auto-provisioned MCP

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,14 +46,34 @@ mode is optional for external clients.
 messages, tool calls with permissions, and status updates — exactly what
 Koda needs. Adopting ACP gives us Zed integration for free.
 
-### 3. Single Binary Philosophy
+### 3. Extensibility: Thin Core + Auto-Provisioned MCP
 
-**Decision**: `cargo install koda-cli` gives you everything. No separate
-server process required for normal usage.
+**Decision**: The core binary contains only essential tools (file ops, shell,
+search, web fetch, memory, agents). Domain-specific capabilities (AST analysis,
+email, calendar, browser) are delivered as MCP servers, auto-installed on demand.
 
-**Rationale**: Koda's core value is zero-config simplicity. The CLI client
-talks to the engine via in-process `tokio::mpsc` channels. Server mode is
-opt-in (`koda server`) for external clients.
+**Principle evolution**:
+- **v0.1.x**: Single binary, everything compiled in.
+- **v0.2.x**: Thin core + auto-provisioned capabilities.
+
+"Everything just works" no longer means "everything compiled into one binary."
+It means "everything auto-provisioned with zero user config." The user
+experience is identical — zero friction — but the implementation scales to
+domains beyond coding.
+
+**How it works**: When the LLM calls a tool that isn't built-in, koda checks
+an MCP capability registry, auto-installs the matching server, connects it,
+and retries — transparently. The user sees a brief spinner on first use;
+subsequent calls are instant.
+
+**Rationale**: As koda expands to email, calendar, and knowledge management,
+compiling every integration into one binary creates bloat. The MCP protocol
+is the contract; the implementation language and deployment model are details.
+AST analysis is the pilot for this pattern (see [#113](https://github.com/lijunzh/koda/issues/113)).
+
+**MCP server language**: Default to Rust (`cargo binstall`) for koda-maintained
+servers. Use Node/Python when critical libraries only exist in those ecosystems.
+See [#123](https://github.com/lijunzh/koda/issues/123) for tradeoff analysis.
 
 ### 4. Async Approval Flow
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,22 @@ Single compiled binary. Multi-provider LLM support. Zero runtime dependencies.
 
 ## Philosophy
 
-**Koda is a personal coding agent.** It's built for a single developer at a keyboard,
-not for enterprise teams or platform integrations. This focus drives every design decision:
+**Koda is a personal AI assistant.** Coding is the starting point, but the platform
+will expand to support email, calendar, knowledge management, and more — all
+powered by the same engine. This focus drives every design decision:
 
-- **Single binary, zero runtime deps.** `cargo install koda-cli` and you're done.
-  No Node.js, no Python, no Docker. Works offline with local models (LM Studio)
-  or online with cloud providers.
-- **Built-in tools for the core coding loop.** File ops, search, shell, web fetch,
-  memory, and agents are compiled in — always available, zero latency, zero config.
-- **MCP for everything else.** Need GitHub API, databases, Slack? Connect external
-  MCP servers via `.mcp.json`. Koda stays lean; the ecosystem handles the long tail.
-- **Ask Koda what it can do.** Just ask — "what can you do?" or "what tools do you
-  have?" Koda's capabilities are embedded in its system prompt, so it can always
-  describe its own tools, commands, and features accurately.
+- **Everything just works.** `cargo install koda-cli` and you're done.
+  No Node.js, no Python, no Docker. Core tools (file ops, search, shell, web
+  fetch, memory, agents) are compiled in — always available, zero config.
+- **Auto-provisioned capabilities.** Beyond the core, koda auto-installs
+  MCP servers on demand. Ask about your email? Koda installs the email
+  integration transparently. You never configure plumbing.
+- **MCP is the extension model.** Need GitHub API, databases, Slack? Connect
+  external MCP servers via `.mcp.json`, or let koda auto-discover them.
+  Koda stays lean; the ecosystem handles the long tail.
+- **Ask Koda what it can do.** Just ask — "what can you do?" Koda's
+  capabilities are embedded in its system prompt, so it can always describe
+  its own tools, commands, and features accurately.
 
 ## Install
 


### PR DESCRIPTION
Documents the principle evolution from v0.1.x (everything compiled in) to v0.2.x (thin core + auto-provisioned MCP).

### Changes
- **README**: Koda is a 'personal AI assistant', not just 'coding agent'. Auto-provisioned capabilities bullet added.
- **DESIGN.md §3**: 'Single Binary Philosophy' → 'Thin Core + Auto-Provisioned MCP' with rationale.
- **Issue #113**: Rewritten from 'evaluate MCP extraction' to 'auto-provisioned MCP architecture with AST as pilot'.
- **Issue #123**: Comment added with npx vs Rust MCP tradeoff analysis and monorepo workspace recommendation.