### PR TITLE
feat: v0.1.3 UX polish — per-turn cost, fuzzy @file, /undo (#112)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -196,8 +196,8 @@ pub fn find_last_at_token(text: &str) -> Option<usize> {
 
 /// List filesystem paths matching a partial path relative to project_root.
 ///
-/// Given partial `"src/m"`, lists files in `project_root/src/` starting with `m`.
-/// Given partial `"src/"`, lists all files in `project_root/src/`.
+/// Uses fuzzy subsequence matching: `@mrs` matches `main.rs`, `@ctml` matches `Cargo.toml`.
+/// Prefix matches rank higher than fuzzy matches.
 /// Directories get a trailing `/` to encourage further completion.
 fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
     let (dir_part, file_prefix) = match partial.rfind('/') {
@@ -220,18 +220,15 @@ fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
         Err(_) => return Vec::new(),
     };
 
-    let mut matches: Vec<String> = entries
+    let lower_prefix = file_prefix.to_lowercase();
+
+    let mut scored: Vec<(i32, String)> = entries
         .filter_map(|e| e.ok())
         .filter_map(|entry| {
             let name = entry.file_name().to_string_lossy().to_string();
 
             // Skip hidden files and common noise
             if name.starts_with('.') {
-                return None;
-            }
-
-            let lower_prefix = file_prefix.to_lowercase();
-            if !name.to_lowercase().starts_with(&lower_prefix) {
                 return None;
             }
 
@@ -247,17 +244,74 @@ fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
                 return None;
             }
 
+            let lower_name = name.to_lowercase();
+            let score = fuzzy_score(&lower_prefix, &lower_name)?;
+
             let path = if is_dir {
                 format!("{dir_part}{name}/")
             } else {
                 format!("{dir_part}{name}")
             };
-            Some(path)
+            Some((score, path))
         })
         .collect();
 
-    matches.sort();
-    matches
+    // Sort by score (higher = better match), then alphabetically
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(&b.1)));
+    scored.into_iter().map(|(_, path)| path).collect()
+}
+
+/// Fuzzy subsequence scoring.
+///
+/// Returns `Some(score)` if all chars of `query` appear in `target` in order.
+/// Higher score = better match.
+///
+/// Scoring:
+/// - Prefix match: +100
+/// - Consecutive chars: +10 each
+/// - Char after separator (`_`, `-`, `.`, `/`): +5
+/// - Base: +1 per matched char
+fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
+    if query.is_empty() {
+        return Some(0);
+    }
+
+    let query_chars: Vec<char> = query.chars().collect();
+    let target_chars: Vec<char> = target.chars().collect();
+
+    let mut qi = 0;
+    let mut score: i32 = 0;
+    let mut prev_match_pos: Option<usize> = None;
+
+    for (ti, &tc) in target_chars.iter().enumerate() {
+        if qi < query_chars.len() && tc == query_chars[qi] {
+            score += 1;
+
+            // Bonus: prefix match
+            if qi == 0 && ti == 0 {
+                score += 100;
+            }
+
+            // Bonus: consecutive match
+            if prev_match_pos == Some(ti - 1) {
+                score += 10;
+            }
+
+            // Bonus: after separator
+            if ti > 0 && matches!(target_chars[ti - 1], '_' | '-' | '.' | '/') {
+                score += 5;
+            }
+
+            prev_match_pos = Some(ti);
+            qi += 1;
+        }
+    }
+
+    if qi == query_chars.len() {
+        Some(score)
+    } else {
+        None // Not all query chars matched
+    }
 }
 
 #[cfg(test)]
@@ -483,5 +537,61 @@ mod tests {
         // Attempt path traversal — should return no matches
         let result = c.complete("@../../etc/");
         assert!(result.is_none(), "traversal should be blocked");
+    }
+
+    // ── Fuzzy matching tests ────────────────────────────────
+
+    #[test]
+    fn test_fuzzy_score_basic() {
+        // Exact prefix → high score
+        assert!(fuzzy_score("main", "main.rs").unwrap() > 100);
+        // Subsequence match
+        assert!(fuzzy_score("mrs", "main.rs").is_some());
+        // No match
+        assert!(fuzzy_score("xyz", "main.rs").is_none());
+    }
+
+    #[test]
+    fn test_fuzzy_score_prefix_wins() {
+        let prefix = fuzzy_score("ma", "main.rs").unwrap();
+        let fuzzy = fuzzy_score("ma", "format.rs").unwrap();
+        assert!(prefix > fuzzy, "prefix {prefix} should beat fuzzy {fuzzy}");
+    }
+
+    #[test]
+    fn test_fuzzy_at_file() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("main.rs"), "").unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "").unwrap();
+        fs::write(tmp.path().join("config.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        // "mrs" → should fuzzy-match main.rs (m...r.s)
+        let result = c.complete("@mrs");
+        assert_eq!(result, Some("@main.rs".to_string()));
+    }
+
+    #[test]
+    fn test_fuzzy_cargo_toml() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("Cargo.toml"), "").unwrap();
+        fs::write(tmp.path().join("config.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        // "ctml" → fuzzy-match Cargo.toml (c...t..m.l)
+        let result = c.complete("@ctml");
+        assert_eq!(result, Some("@Cargo.toml".to_string()));
+    }
+
+    #[test]
+    fn test_fuzzy_prefix_ranked_first() {
+        let tmp = tempdir().unwrap();
+        fs::write(tmp.path().join("main.rs"), "").unwrap();
+        fs::write(tmp.path().join("format.rs"), "").unwrap();
+
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        // "m" → main.rs should come before format.rs (prefix match wins)
+        let result = c.complete("@m");
+        assert_eq!(result, Some("@main.rs".to_string()));
     }
 }

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -23,6 +23,7 @@ const SLASH_COMMANDS: &[&str] = &[
     "/provider",
     "/sessions",
     "/trust",
+    "/undo",
     "/verbose",
 ];
 
@@ -293,7 +294,7 @@ fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
             }
 
             // Bonus: consecutive match
-            if prev_match_pos == Some(ti - 1) {
+            if ti > 0 && prev_match_pos == Some(ti - 1) {
                 score += 10;
             }
 

--- a/koda-cli/src/cost.rs
+++ b/koda-cli/src/cost.rs
@@ -1,0 +1,205 @@
+//! Per-turn cost estimation based on model and provider.
+//!
+//! Pricing is best-effort — returns None for unknown models.
+//! Prices are per million tokens (as of March 2025).
+
+/// Pricing per million tokens.
+struct ModelPrice {
+    input: f64,
+    output: f64,
+    /// Cache read discount (multiplier, e.g. 0.1 = 90% cheaper).
+    cache_read: f64,
+}
+
+/// Estimate cost for a single turn.
+///
+/// Returns None if the model isn't in our pricing table.
+pub fn estimate_turn_cost(
+    model: &str,
+    prompt_tokens: i64,
+    completion_tokens: i64,
+    cache_read_tokens: i64,
+) -> Option<f64> {
+    let price = lookup_price(model)?;
+
+    let billable_input = (prompt_tokens - cache_read_tokens).max(0);
+    let cached = cache_read_tokens.max(0);
+
+    let input_cost = billable_input as f64 * price.input / 1_000_000.0;
+    let cache_cost = cached as f64 * price.input * price.cache_read / 1_000_000.0;
+    let output_cost = completion_tokens as f64 * price.output / 1_000_000.0;
+
+    Some(input_cost + cache_cost + output_cost)
+}
+
+fn lookup_price(model: &str) -> Option<ModelPrice> {
+    // Normalize: lowercase, strip version suffixes for matching.
+    let m = model.to_lowercase();
+
+    // Anthropic
+    if m.contains("claude-3-5-sonnet") || m.contains("claude-sonnet-4") {
+        return Some(ModelPrice {
+            input: 3.0,
+            output: 15.0,
+            cache_read: 0.1,
+        });
+    }
+    if m.contains("claude-3-5-haiku") || m.contains("claude-haiku-4") {
+        return Some(ModelPrice {
+            input: 0.80,
+            output: 4.0,
+            cache_read: 0.1,
+        });
+    }
+    if m.contains("claude-3-opus") || m.contains("claude-opus-4") {
+        return Some(ModelPrice {
+            input: 15.0,
+            output: 75.0,
+            cache_read: 0.1,
+        });
+    }
+
+    // OpenAI
+    if m.contains("gpt-4o-mini") {
+        return Some(ModelPrice {
+            input: 0.15,
+            output: 0.60,
+            cache_read: 0.5,
+        });
+    }
+    if m.contains("gpt-4o") {
+        return Some(ModelPrice {
+            input: 2.50,
+            output: 10.0,
+            cache_read: 0.5,
+        });
+    }
+    if m.contains("o3-mini") {
+        return Some(ModelPrice {
+            input: 1.10,
+            output: 4.40,
+            cache_read: 0.5,
+        });
+    }
+    if m.contains("o3") && !m.contains("o3-mini") {
+        return Some(ModelPrice {
+            input: 10.0,
+            output: 40.0,
+            cache_read: 0.5,
+        });
+    }
+    if m.contains("o1-mini") {
+        return Some(ModelPrice {
+            input: 1.10,
+            output: 4.40,
+            cache_read: 0.5,
+        });
+    }
+    if m.contains("o1") && !m.contains("o1-mini") {
+        return Some(ModelPrice {
+            input: 15.0,
+            output: 60.0,
+            cache_read: 0.5,
+        });
+    }
+
+    // Google Gemini
+    if m.contains("gemini-2.0-flash") || m.contains("gemini-2.5-flash") {
+        return Some(ModelPrice {
+            input: 0.075,
+            output: 0.30,
+            cache_read: 1.0,
+        });
+    }
+    if m.contains("gemini-2.5-pro") || m.contains("gemini-1.5-pro") {
+        return Some(ModelPrice {
+            input: 1.25,
+            output: 5.0,
+            cache_read: 1.0,
+        });
+    }
+
+    // DeepSeek
+    if m.contains("deepseek-chat") || m.contains("deepseek-v3") {
+        return Some(ModelPrice {
+            input: 0.27,
+            output: 1.10,
+            cache_read: 0.1,
+        });
+    }
+    if m.contains("deepseek-reasoner") {
+        return Some(ModelPrice {
+            input: 0.55,
+            output: 2.19,
+            cache_read: 0.1,
+        });
+    }
+
+    // Groq (free tier / very cheap)
+    if m.contains("llama") && m.contains("groq") {
+        return Some(ModelPrice {
+            input: 0.05,
+            output: 0.08,
+            cache_read: 1.0,
+        });
+    }
+
+    // Mistral
+    if m.contains("mistral-large") {
+        return Some(ModelPrice {
+            input: 2.0,
+            output: 6.0,
+            cache_read: 1.0,
+        });
+    }
+
+    // Local models — free
+    if m.contains("auto-detect") || m.contains("local") {
+        return Some(ModelPrice {
+            input: 0.0,
+            output: 0.0,
+            cache_read: 1.0,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claude_sonnet_cost() {
+        let cost = estimate_turn_cost("claude-sonnet-4-6", 1000, 500, 0).unwrap();
+        // 1000 * 3.0/1M + 500 * 15.0/1M = 0.003 + 0.0075 = 0.0105
+        assert!((cost - 0.0105).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_cache_discount() {
+        let cost = estimate_turn_cost("claude-sonnet-4-6", 1000, 500, 800).unwrap();
+        // billable_input = 200, cached = 800
+        // 200 * 3.0/1M + 800 * 3.0 * 0.1/1M + 500 * 15.0/1M
+        // = 0.0006 + 0.00024 + 0.0075 = 0.00834
+        assert!((cost - 0.00834).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_unknown_model() {
+        assert!(estimate_turn_cost("unknown-model-42", 1000, 500, 0).is_none());
+    }
+
+    #[test]
+    fn test_local_model_free() {
+        let cost = estimate_turn_cost("auto-detect", 10000, 5000, 0).unwrap();
+        assert_eq!(cost, 0.0);
+    }
+
+    #[test]
+    fn test_gpt4o_cost() {
+        let cost = estimate_turn_cost("gpt-4o", 10000, 1000, 0).unwrap();
+        // 10000 * 2.5/1M + 1000 * 10.0/1M = 0.025 + 0.01 = 0.035
+        assert!((cost - 0.035).abs() < 0.001);
+    }
+}

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -4,6 +4,7 @@
 
 mod commands;
 mod completer;
+mod cost;
 mod diff_render;
 mod headless;
 mod headless_sink;

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -38,6 +38,8 @@ pub enum ReplAction {
     ShowDiff,
     /// Memory management command
     MemoryCommand(Option<String>),
+    /// Undo last turn's file mutations
+    Undo,
     #[allow(dead_code)]
     Handled,
     NotACommand,
@@ -129,6 +131,8 @@ pub async fn handle_command(
         },
 
         "/memory" => ReplAction::MemoryCommand(arg.map(|s| s.to_string())),
+
+        "/undo" => ReplAction::Undo,
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -687,6 +687,11 @@ pub async fn run(
                         crate::interrupt::reset();
                         session.cancel = tokio_util::sync::CancellationToken::new();
 
+                        // Commit undo snapshots for this turn
+                        if let Ok(mut undo) = agent.tools.undo.lock() {
+                            undo.commit_turn();
+                        }
+
                         // Drain remaining UI events
                         while let Ok(UiEvent::Engine(e)) = ui_rx.try_recv() {
                             renderer.render_to_terminal(e, &mut terminal);

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -332,6 +332,7 @@ pub async fn run(
     // ── State ────────────────────────────────────────────────
 
     let mut renderer = TuiRenderer::new();
+    renderer.model = config.model.clone();
     let mut tui_state = TuiState::Idle;
     let mut input_queue: VecDeque<String> = VecDeque::new();
     let mut pending_command: Option<String> = None;
@@ -441,6 +442,8 @@ pub async fn run(
                                         models.iter().map(|m| m.id.clone()).collect(),
                                     );
                                 }
+                                // Sync model name for cost estimation
+                                renderer.model = config.model.clone();
                             }
                             SlashAction::Quit => {
                                 tui_output::emit_line(

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -99,6 +99,16 @@ pub async fn handle_slash_command(
             handle_cost(terminal, session, config).await;
             SlashAction::Continue
         }
+        ReplAction::Undo => {
+            match agent.tools.undo.lock() {
+                Ok(mut undo) => match undo.undo() {
+                    Some(summary) => ok_msg(summary),
+                    None => warn_msg("Nothing to undo.".to_string()),
+                },
+                Err(e) => err_msg(format!("Undo error: {e}")),
+            }
+            SlashAction::Continue
+        }
         ReplAction::ListSessions => {
             handle_list_sessions(terminal, session, project_root).await;
             SlashAction::Continue
@@ -246,6 +256,7 @@ fn handle_help(terminal: &mut Term, pending_command: &mut Option<String>) {
         ("/provider", "Switch LLM provider"),
         ("/sessions", "List/resume/delete sessions"),
         ("/trust", "Set approval mode (always / auto / never)"),
+        ("/undo", "Undo last turn's file changes"),
         ("/verbose", "Toggle full tool output (on/off)"),
         ("/exit", "Quit the session"),
     ];

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -23,6 +23,8 @@ pub struct TuiRenderer {
     pub verbose: bool,
     /// Last turn stats for status bar display.
     pub last_turn_stats: Option<TurnStats>,
+    /// Current model name (for cost estimation).
+    pub model: String,
     /// Buffer for streaming text deltas (flushed line-by-line).
     text_buf: String,
     /// Buffer for streaming thinking deltas.
@@ -43,6 +45,7 @@ impl TuiRenderer {
             tool_history: crate::tool_history::ToolOutputHistory::new(),
             verbose: false,
             last_turn_stats: None,
+            model: String::new(),
             text_buf: String::new(),
             think_buf: String::new(),
             preview_shown: false,
@@ -196,7 +199,9 @@ impl TuiRenderer {
                 }
             }
             EngineEvent::Footer {
+                prompt_tokens,
                 completion_tokens,
+                cache_read_tokens,
                 total_chars,
                 elapsed_ms,
                 rate,
@@ -207,10 +212,19 @@ impl TuiRenderer {
                 } else {
                     (total_chars / 4) as i64
                 };
+                let cost_usd = crate::cost::estimate_turn_cost(
+                    &self.model,
+                    prompt_tokens,
+                    completion_tokens,
+                    cache_read_tokens,
+                );
                 self.last_turn_stats = Some(TurnStats {
+                    tokens_in: prompt_tokens,
                     tokens_out,
+                    cache_read: cache_read_tokens,
                     elapsed_ms,
                     rate,
+                    cost_usd,
                 });
             }
             EngineEvent::SpinnerStart { .. } | EngineEvent::SpinnerStop => {

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -24,9 +24,15 @@ pub struct StatusBar<'a> {
 /// Stats from the most recent inference turn.
 #[derive(Debug, Clone, Default)]
 pub struct TurnStats {
+    #[allow(dead_code)]
+    pub tokens_in: i64,
     pub tokens_out: i64,
+    #[allow(dead_code)]
+    pub cache_read: i64,
     pub elapsed_ms: u64,
     pub rate: f64,
+    /// Estimated cost in USD (None if model pricing unknown).
+    pub cost_usd: Option<f64>,
 }
 
 impl<'a> StatusBar<'a> {
@@ -133,10 +139,17 @@ impl Widget for StatusBar<'_> {
             } else {
                 format!("{}ms", stats.elapsed_ms)
             };
+
+            let cost_str = match stats.cost_usd {
+                Some(c) if c < 0.01 => " · <$0.01".to_string(),
+                Some(c) => format!(" · ${c:.2}"),
+                None => String::new(),
+            };
+
             spans.push(Span::styled(
                 format!(
-                    " {} tok \u{00b7} {} \u{00b7} {:.0} t/s ",
-                    stats.tokens_out, time, stats.rate
+                    " {} tok · {} · {:.0} t/s{} ",
+                    stats.tokens_out, time, stats.rate, cost_str
                 ),
                 Style::default().fg(Color::DarkGray),
             ));

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -26,4 +26,5 @@ pub mod runtime_env;
 pub mod session;
 pub mod tool_dispatch;
 pub mod tools;
+pub mod undo;
 pub mod version;

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -63,6 +63,8 @@ pub struct ToolRegistry {
     read_cache: std::sync::Mutex<HashMap<String, (u64, SystemTime)>>,
     /// Connected MCP servers providing additional tools.
     mcp_registry: Option<std::sync::Arc<tokio::sync::RwLock<crate::mcp::McpRegistry>>>,
+    /// Undo stack for file mutations.
+    pub undo: std::sync::Mutex<crate::undo::UndoStack>,
 }
 
 impl ToolRegistry {
@@ -104,6 +106,7 @@ impl ToolRegistry {
             definitions,
             read_cache: std::sync::Mutex::new(HashMap::new()),
             mcp_registry: None,
+            undo: std::sync::Mutex::new(crate::undo::UndoStack::new()),
         }
     }
 
@@ -178,6 +181,17 @@ impl ToolRegistry {
             "Executing tool: {name} with args: [{} chars]",
             arguments.len()
         );
+
+        // Snapshot file before mutation (for /undo)
+        if let Some(file_path) = crate::undo::is_mutating_tool(name)
+            .then(|| crate::undo::extract_file_path(name, &args))
+            .flatten()
+        {
+            let resolved = self.project_root.join(&file_path);
+            if let Ok(mut undo) = self.undo.lock() {
+                undo.snapshot(&resolved);
+            }
+        }
 
         let result = match name {
             // File tools

--- a/koda-core/src/undo.rs
+++ b/koda-core/src/undo.rs
@@ -1,0 +1,256 @@
+//! Undo stack for file mutations.
+//!
+//! Snapshots file contents before Write/Edit/Delete tool execution.
+//! Each turn's mutations are grouped into a single undo entry.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// A snapshot of file states before a turn's mutations.
+#[derive(Debug, Clone)]
+pub struct UndoEntry {
+    /// Map of absolute path → previous content (None = file didn't exist).
+    files: HashMap<PathBuf, Option<Vec<u8>>>,
+}
+
+/// Stack of undo entries, one per turn.
+#[derive(Debug, Default)]
+pub struct UndoStack {
+    entries: Vec<UndoEntry>,
+    /// Accumulates snapshots for the current (in-progress) turn.
+    pending: HashMap<PathBuf, Option<Vec<u8>>>,
+}
+
+impl UndoStack {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot a file before mutation. Call before Write/Edit/Delete.
+    ///
+    /// Only snapshots the first time per file per turn (preserves original state).
+    pub fn snapshot(&mut self, path: &Path) {
+        let abs = match std::fs::canonicalize(path) {
+            Ok(p) => p,
+            Err(_) => path.to_path_buf(), // File doesn't exist yet
+        };
+
+        // Only snapshot the first mutation per file per turn
+        if self.pending.contains_key(&abs) {
+            return;
+        }
+
+        let content = std::fs::read(&abs).ok();
+        self.pending.insert(abs, content);
+    }
+
+    /// Finalize the current turn's snapshots into an undo entry.
+    ///
+    /// Call at the end of each inference turn (after all tool calls complete).
+    /// Does nothing if no mutations were snapshotted.
+    pub fn commit_turn(&mut self) {
+        if self.pending.is_empty() {
+            return;
+        }
+        self.entries.push(UndoEntry {
+            files: std::mem::take(&mut self.pending),
+        });
+    }
+
+    /// Undo the last turn's file mutations.
+    ///
+    /// Returns a summary of what was restored, or None if nothing to undo.
+    pub fn undo(&mut self) -> Option<String> {
+        let entry = self.entries.pop()?;
+        let mut restored = Vec::new();
+
+        for (path, original) in &entry.files {
+            match original {
+                Some(content) => {
+                    if let Err(e) = std::fs::write(path, content) {
+                        restored.push(format!("  ❌ {} (write failed: {e})", path.display()));
+                    } else {
+                        restored.push(format!("  ↩ {} (restored)", path.display()));
+                    }
+                }
+                None => {
+                    // File didn't exist before — delete it
+                    if let Err(e) = std::fs::remove_file(path) {
+                        restored.push(format!("  ❌ {} (delete failed: {e})", path.display()));
+                    } else {
+                        restored.push(format!(
+                            "  ↩ {} (removed — was newly created)",
+                            path.display()
+                        ));
+                    }
+                }
+            }
+        }
+
+        restored.sort();
+        Some(format!(
+            "Undid {} file(s) from last turn:\n{}",
+            entry.files.len(),
+            restored.join("\n")
+        ))
+    }
+
+    /// How many turns can be undone.
+    pub fn depth(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Check if a tool name is a file-mutating tool that should be snapshotted.
+pub fn is_mutating_tool(name: &str) -> bool {
+    matches!(name, "Write" | "Edit" | "Delete" | "Overwrite")
+}
+
+/// Extract the target file path from tool arguments.
+pub fn extract_file_path(name: &str, args: &serde_json::Value) -> Option<String> {
+    match name {
+        "Write" | "Edit" | "Delete" | "Overwrite" => args
+            .get("file_path")
+            .or_else(|| args.get("path"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (UndoStack, TempDir) {
+        (UndoStack::new(), TempDir::new().unwrap())
+    }
+
+    #[test]
+    fn test_undo_restores_overwritten_file() {
+        let (mut stack, tmp) = setup();
+        let path = tmp.path().join("test.txt");
+        std::fs::write(&path, "original").unwrap();
+
+        // Snapshot before mutation
+        stack.snapshot(&path);
+        std::fs::write(&path, "modified").unwrap();
+        stack.commit_turn();
+
+        // Undo
+        let result = stack.undo();
+        assert!(result.is_some());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "original");
+    }
+
+    #[test]
+    fn test_undo_removes_newly_created_file() {
+        let (mut stack, tmp) = setup();
+        let path = tmp.path().join("new.txt");
+
+        // Snapshot before creation (file doesn't exist)
+        stack.snapshot(&path);
+        std::fs::write(&path, "created").unwrap();
+        stack.commit_turn();
+
+        // Undo
+        stack.undo();
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_undo_empty_stack() {
+        let mut stack = UndoStack::new();
+        assert!(stack.undo().is_none());
+    }
+
+    #[test]
+    fn test_multiple_files_per_turn() {
+        let (mut stack, tmp) = setup();
+        let a = tmp.path().join("a.txt");
+        let b = tmp.path().join("b.txt");
+        std::fs::write(&a, "aaa").unwrap();
+        std::fs::write(&b, "bbb").unwrap();
+
+        stack.snapshot(&a);
+        stack.snapshot(&b);
+        std::fs::write(&a, "AAA").unwrap();
+        std::fs::write(&b, "BBB").unwrap();
+        stack.commit_turn();
+
+        stack.undo();
+        assert_eq!(std::fs::read_to_string(&a).unwrap(), "aaa");
+        assert_eq!(std::fs::read_to_string(&b).unwrap(), "bbb");
+    }
+
+    #[test]
+    fn test_only_first_snapshot_per_file_per_turn() {
+        let (mut stack, tmp) = setup();
+        let path = tmp.path().join("test.txt");
+        std::fs::write(&path, "v1").unwrap();
+
+        stack.snapshot(&path); // Captures "v1"
+        std::fs::write(&path, "v2").unwrap();
+        stack.snapshot(&path); // Should NOT overwrite snapshot
+        std::fs::write(&path, "v3").unwrap();
+        stack.commit_turn();
+
+        stack.undo();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v1");
+    }
+
+    #[test]
+    fn test_multi_turn_undo() {
+        let (mut stack, tmp) = setup();
+        let path = tmp.path().join("test.txt");
+        std::fs::write(&path, "v1").unwrap();
+
+        // Turn 1
+        stack.snapshot(&path);
+        std::fs::write(&path, "v2").unwrap();
+        stack.commit_turn();
+
+        // Turn 2
+        stack.snapshot(&path);
+        std::fs::write(&path, "v3").unwrap();
+        stack.commit_turn();
+
+        assert_eq!(stack.depth(), 2);
+
+        // Undo turn 2
+        stack.undo();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v2");
+
+        // Undo turn 1
+        stack.undo();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "v1");
+    }
+
+    #[test]
+    fn test_is_mutating_tool() {
+        assert!(is_mutating_tool("Write"));
+        assert!(is_mutating_tool("Edit"));
+        assert!(is_mutating_tool("Delete"));
+        assert!(!is_mutating_tool("Read"));
+        assert!(!is_mutating_tool("Grep"));
+        assert!(!is_mutating_tool("Bash"));
+    }
+
+    #[test]
+    fn test_extract_file_path() {
+        let args = serde_json::json!({"file_path": "src/main.rs"});
+        assert_eq!(
+            extract_file_path("Write", &args),
+            Some("src/main.rs".into())
+        );
+        assert_eq!(extract_file_path("Read", &args), None);
+    }
+
+    #[test]
+    fn test_no_commit_if_no_snapshots() {
+        let mut stack = UndoStack::new();
+        stack.commit_turn(); // Nothing pending
+        assert_eq!(stack.depth(), 0);
+    }
+}


### PR DESCRIPTION
Three user-facing improvements that close the UX gap with Claude Code.

### 1. Per-turn cost display in status bar
After each inference turn, the status bar shows estimated cost:
```
42 tok · 1.2s · 35 t/s · $0.03
```
- Pricing table for popular models (Anthropic, OpenAI, Gemini, DeepSeek, Mistral)
- Cache read discounts applied (Anthropic 90%, OpenAI 50%)
- Unknown models show tokens only (no cost estimate)
- 5 unit tests

### 2. Fuzzy @file completion
`@mrs` → `main.rs`, `@ctml` → `Cargo.toml`
- Subsequence matching with scoring (prefix > consecutive > separator > base)
- Prefix matches always rank first
- All existing tests pass unchanged + 5 new fuzzy tests

### 3. /undo command
Reverts last turn's file changes:
- Snapshots file contents before Write/Edit/Delete tool execution
- Per-turn grouping (undo restores all files from one turn)
- Multi-turn stack (undo repeatedly to go further back)
- Newly created files removed on undo, deleted files restored
- 9 unit tests

### Test results
- All 380+ tests pass
- Clippy clean
- `cargo fmt` clean

Closes #112