### PR TITLE
fix: Ctrl+N/P history navigation + approval window positioning (#134, #135)

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -622,48 +622,46 @@ pub async fn run(
                                                 if preview.is_some() {
                                                     renderer.preview_shown = true;
                                                 }
-                                                // Inline approval — stays in raw mode
+                                                // Inline approval — uses crossterm direct writes
                                                 let decision = crate::widgets::approval::prompt_approval(
-                                                    &mut terminal,
                                                     &tool_name,
                                                     &detail,
                                                     preview.as_ref(),
                                                     whitelist_hint.as_deref(),
                                                 );
+                                                // Resync ratatui viewport after crossterm writes
+                                                crossterm_events = EventStream::new();
+                                                terminal = init_terminal(viewport_height)?;
                                                 let _ = cmd_tx
                                                     .send(EngineCommand::ApprovalResponse { id, decision })
                                                     .await;
                                             }
                                             UiEvent::Engine(EngineEvent::LoopCapReached { cap, recent_tools }) => {
-                                                // Show cap info above viewport
-                                                tui_output::emit_blank(&mut terminal);
-                                                tui_output::emit_line(
-                                                    &mut terminal,
-                                                    Line::from(vec![
-                                                        Span::raw("  "),
-                                                        Span::styled(
-                                                            format!("\u{26a0} Hard cap reached ({cap} iterations)"),
-                                                            Style::default().fg(Color::Yellow),
-                                                        ),
-                                                    ]),
-                                                );
+                                                // Show cap info via crossterm (matches approval widget path)
+                                                tui_output::write_blank();
+                                                tui_output::write_line(&Line::from(vec![
+                                                    Span::raw("  "),
+                                                    Span::styled(
+                                                        format!("\u{26a0} Hard cap reached ({cap} iterations)"),
+                                                        Style::default().fg(Color::Yellow),
+                                                    ),
+                                                ]));
                                                 for name in &recent_tools {
-                                                    tui_output::emit_line(
-                                                        &mut terminal,
-                                                        Line::from(vec![
-                                                            Span::raw("    "),
-                                                            Span::styled(format!("\u{25cf} {name}"), Style::default().fg(Color::DarkGray)),
-                                                        ]),
-                                                    );
+                                                    tui_output::write_line(&Line::from(vec![
+                                                        Span::raw("    "),
+                                                        Span::styled(format!("\u{25cf} {name}"), Style::default().fg(Color::DarkGray)),
+                                                    ]));
                                                 }
                                                 // Use approval widget for continue/stop
                                                 let decision = crate::widgets::approval::prompt_approval(
-                                                    &mut terminal,
                                                     "LoopCap",
                                                     "Continue running?",
                                                     None,
                                                     None,
                                                 );
+                                                // Resync ratatui viewport after crossterm writes
+                                                crossterm_events = EventStream::new();
+                                                terminal = init_terminal(viewport_height)?;
                                                 let action = match decision {
                                                     ApprovalDecision::Approve => koda_core::loop_guard::LoopContinuation::Continue200,
                                                     _ => koda_core::loop_guard::LoopContinuation::Stop,

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -852,7 +852,8 @@ pub async fn run(
                                 }
                             }
                         }
-                        (KeyCode::Up, KeyModifiers::NONE) => {
+                        (KeyCode::Up, KeyModifiers::NONE)
+                        | (KeyCode::Char('p'), KeyModifiers::CONTROL) => {
                             if !history.is_empty() {
                                 let idx = match history_idx {
                                     None => history.len() - 1,
@@ -864,7 +865,8 @@ pub async fn run(
                                 textarea.insert_str(&history[idx]);
                             }
                         }
-                        (KeyCode::Down, KeyModifiers::NONE) => {
+                        (KeyCode::Down, KeyModifiers::NONE)
+                        | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
                             if let Some(idx) = history_idx {
                                 if idx + 1 < history.len() {
                                     history_idx = Some(idx + 1);

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -46,11 +46,6 @@ pub fn emit_line(terminal: &mut Term, line: Line<'_>) {
     emit_lines(terminal, &[line]);
 }
 
-/// Write a blank line above the viewport.
-pub fn emit_blank(terminal: &mut Term) {
-    emit_line(terminal, Line::raw(""));
-}
-
 // ── Style constants ─────────────────────────────────────────
 // Centralized color palette for the TUI renderer.
 

--- a/koda-cli/src/widgets/approval.rs
+++ b/koda-cli/src/widgets/approval.rs
@@ -1,8 +1,11 @@
 //! Inline approval widget for the TUI.
 //!
-//! Renders approval prompt + options above the viewport using
-//! `insert_before()` for permanent content, then crossterm styled
-//! output for the in-place selection menu.
+//! Renders the entire approval prompt using crossterm direct writes
+//! (`write_line()`), avoiding ratatui `insert_before()`. This keeps
+//! cursor tracking consistent so the interactive options menu renders
+//! at the correct position. The caller must reinitialize the terminal
+//! after this widget returns to resync ratatui's viewport.
+//!
 //! Stays in raw mode the entire time — no mode switching.
 
 use crate::tui_output;
@@ -10,42 +13,37 @@ use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use koda_core::engine::ApprovalDecision;
 use koda_core::preview::DiffPreview;
 use ratatui::{
-    Terminal,
-    backend::CrosstermBackend,
     style::{Color, Style},
     text::{Line, Span},
 };
 use std::io::Write;
 
-type Term = Terminal<CrosstermBackend<std::io::Stdout>>;
-
 /// Run an inline approval prompt. Returns the user's decision.
 ///
-/// Renders the prompt above the viewport and handles arrow-key
-/// navigation entirely within raw mode.
+/// Uses crossterm direct writes for all output (detail, diff, options).
+/// The caller must reinitialize the terminal afterwards to resync
+/// ratatui's viewport tracking.
 pub fn prompt_approval(
-    terminal: &mut Term,
     _tool_name: &str,
     detail: &str,
     preview: Option<&DiffPreview>,
     whitelist_hint: Option<&str>,
 ) -> ApprovalDecision {
-    // Show detail above viewport
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled(detail.to_string(), Style::default().fg(Color::DarkGray)),
-        ]),
-    );
+    // Show detail via crossterm (not ratatui insert_before)
+    tui_output::write_line(&Line::from(vec![
+        Span::raw("  "),
+        Span::styled(detail.to_string(), Style::default().fg(Color::DarkGray)),
+    ]));
 
     // Show diff preview if available
     if let Some(preview) = preview {
-        tui_output::emit_blank(terminal);
+        tui_output::write_blank();
         let diff_lines = crate::diff_render::render_lines(preview);
-        tui_output::emit_lines(terminal, &diff_lines);
+        for line in &diff_lines {
+            tui_output::write_line(line);
+        }
     }
-    tui_output::emit_blank(terminal);
+    tui_output::write_blank();
 
     // Build options
     let mut options = vec![
@@ -58,11 +56,9 @@ pub fn prompt_approval(
     }
 
     // Scroll terminal to make room for the options menu.
-    // After emit_line()/insert_before(), the cursor sits inside the ratatui
-    // viewport (the status/input bar at the bottom). We print newlines to
-    // push the viewport down, then move the cursor back up so the crossterm
-    // options render in the space we just created — immediately above the
-    // viewport rather than overlapping it.
+    // The cursor is at a known position after write_line(). We print
+    // newlines to push content up, then move back so the crossterm
+    // options render in the space we just created.
     {
         let total_lines = (options.len() + 2) as u16; // title + options + hint
         let mut stdout = std::io::stdout();
@@ -75,29 +71,29 @@ pub fn prompt_approval(
 
     // Render options and run selection loop
     let mut selected: usize = 0;
-    render_options(terminal, &options, selected);
+    render_options(&options, selected);
 
     loop {
         if let Ok(Event::Key(key)) = event::read() {
             match (key.code, key.modifiers) {
                 (KeyCode::Up, _) => {
                     selected = selected.saturating_sub(1);
-                    render_options(terminal, &options, selected);
+                    render_options(&options, selected);
                 }
                 (KeyCode::Down, _) => {
                     if selected + 1 < options.len() {
                         selected += 1;
                     }
-                    render_options(terminal, &options, selected);
+                    render_options(&options, selected);
                 }
                 (KeyCode::Enter, _) => {
-                    clear_options(terminal, &options);
+                    clear_options(&options);
                     return match selected {
                         0 => ApprovalDecision::Approve,
                         1 => ApprovalDecision::Reject,
                         2 => {
                             // Feedback: get text from user inline
-                            let feedback = read_feedback_inline(terminal);
+                            let feedback = read_feedback_inline();
                             if feedback.is_empty() {
                                 ApprovalDecision::Reject
                             } else {
@@ -109,11 +105,11 @@ pub fn prompt_approval(
                     };
                 }
                 (KeyCode::Esc, _) => {
-                    clear_options(terminal, &options);
+                    clear_options(&options);
                     return ApprovalDecision::Reject;
                 }
                 (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
-                    clear_options(terminal, &options);
+                    clear_options(&options);
                     return ApprovalDecision::Reject;
                 }
                 _ => {}
@@ -122,14 +118,16 @@ pub fn prompt_approval(
     }
 }
 
-fn render_options(_terminal: &mut Term, options: &[(&str, &str)], selected: usize) {
+fn render_options(options: &[(&str, &str)], selected: usize) {
     use crossterm::{
         cursor, execute,
         style::{Attribute, Color as CColor, Print, ResetColor, SetAttribute, SetForegroundColor},
         terminal::{Clear, ClearType},
     };
     let mut stdout = std::io::stdout();
-    let height = (options.len() + 2) as u16; // title + options + hint
+    // After rendering: title MoveDown + N option MoveDowns = N+1 moves.
+    // Hint has no MoveDown. To return cursor to the title line: MoveUp(N+1).
+    let move_back = (options.len() + 1) as u16;
 
     // Title
     execute!(
@@ -174,7 +172,7 @@ fn render_options(_terminal: &mut Term, options: &[(&str, &str)], selected: usiz
         }
     }
 
-    // Hint
+    // Hint (no MoveDown — cursor stays on this line)
     execute!(
         stdout,
         Clear(ClearType::CurrentLine),
@@ -182,13 +180,13 @@ fn render_options(_terminal: &mut Term, options: &[(&str, &str)], selected: usiz
         SetForegroundColor(CColor::DarkGrey),
         Print("\u{2191}/\u{2193} navigate  enter select  esc cancel"),
         ResetColor,
-        cursor::MoveUp(height),
+        cursor::MoveUp(move_back),
     )
     .ok();
     stdout.flush().ok();
 }
 
-fn clear_options(_terminal: &mut Term, options: &[(&str, &str)]) {
+fn clear_options(options: &[(&str, &str)]) {
     use crossterm::{
         cursor, execute,
         terminal::{Clear, ClearType},
@@ -200,25 +198,20 @@ fn clear_options(_terminal: &mut Term, options: &[(&str, &str)]) {
     }
     execute!(stdout, cursor::MoveUp(total_lines as u16)).ok();
     stdout.flush().ok();
-    // Use write_blank (crossterm) not emit_blank (ratatui) since we're
-    // in the crossterm rendering path for the options menu.
     tui_output::write_blank();
 }
 
 /// Read feedback text inline (in raw mode).
-fn read_feedback_inline(terminal: &mut Term) -> String {
+fn read_feedback_inline() -> String {
     use crossterm::{cursor, style::Print};
 
-    tui_output::emit_line(
-        terminal,
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled(
-                "\u{276f} Tell koda what to change: ",
-                Style::default().fg(Color::Green),
-            ),
-        ]),
-    );
+    tui_output::write_line(&Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "\u{276f} Tell koda what to change: ",
+            Style::default().fg(Color::Green),
+        ),
+    ]));
 
     let mut buf = String::new();
     let mut stdout = std::io::stdout();

--- a/koda-cli/src/widgets/approval.rs
+++ b/koda-cli/src/widgets/approval.rs
@@ -57,6 +57,22 @@ pub fn prompt_approval(
         options.push(("\u{1f513} Always allow", "Auto-approve from now on"));
     }
 
+    // Scroll terminal to make room for the options menu.
+    // After emit_line()/insert_before(), the cursor sits inside the ratatui
+    // viewport (the status/input bar at the bottom). We print newlines to
+    // push the viewport down, then move the cursor back up so the crossterm
+    // options render in the space we just created — immediately above the
+    // viewport rather than overlapping it.
+    {
+        let total_lines = (options.len() + 2) as u16; // title + options + hint
+        let mut stdout = std::io::stdout();
+        for _ in 0..total_lines {
+            crossterm::execute!(stdout, crossterm::style::Print("\n")).ok();
+        }
+        crossterm::execute!(stdout, crossterm::cursor::MoveUp(total_lines)).ok();
+        stdout.flush().ok();
+    }
+
     // Render options and run selection loop
     let mut selected: usize = 0;
     render_options(terminal, &options, selected);


### PR DESCRIPTION
## What changed

### Ctrl+N/Ctrl+P for command history (#134)
Added `Ctrl+P` (previous) and `Ctrl+N` (next) as aliases for Up/Down arrow keys when navigating command history. This matches standard readline/emacs-style keybindings.

### Approval window rendering position (#135)
Fixed the approval options menu rendering inside the ratatui viewport area (overlapping the status/input bar) instead of immediately above it.

**Root cause:** After `insert_before()` calls emit the approval header, the cursor sits at the viewport row. The crossterm-based options menu then wrote over the viewport.

**Fix:** Scroll the terminal to make room for the options menu before rendering, then move the cursor back up — matching the pattern used by `select_inline()`.

## Testing
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace --features koda-core/test-support` ✅

Closes #134
Closes #135