### PR TITLE
fix: cargo run defaults to koda-cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["koda-core", "koda-cli", "koda-ast"]
 resolver = "3"
+default-members = ["koda-cli"]
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Sets `default-members = ["koda-cli"]` so `cargo run` works without `-p`.