### PR TITLE
fix: auto-provisioned MCP — inject tool definitions into LLM

### DIFF
--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -4,6 +4,7 @@
 //! when a tool call arrives for a tool that isn't built-in.
 
 use crate::mcp::config::McpServerConfig;
+use crate::providers::ToolDefinition;
 
 /// An entry in the capability registry.
 #[derive(Debug, Clone)]
@@ -18,6 +19,8 @@ pub struct CapabilityEntry {
     pub description: &'static str,
     /// Install command hint (shown if binary not found).
     pub install_hint: &'static str,
+    /// Tool definition for the LLM (so it knows to call the tool).
+    pub tool_definitions: &'static [(&'static str, &'static str, &'static str)], // (name, description, params_json)
 }
 
 /// Built-in capability registry — auto-provisionable MCP servers.
@@ -27,7 +30,33 @@ const REGISTRY: &[CapabilityEntry] = &[CapabilityEntry {
     tools: &["AstAnalysis"],
     description: "Tree-sitter AST analysis for Rust, Python, JS, TS",
     install_hint: "cargo install koda-ast",
+    tool_definitions: &[(
+        "AstAnalysis",
+        "Read-only AST code analysis. Supports .rs, .py, .js, .ts. \
+         Use action 'analyze_file' for structure summary or 'get_call_graph' with a symbol.",
+        r#"{"type":"object","properties":{"action":{"type":"string","description":"'analyze_file' or 'get_call_graph'"},"file_path":{"type":"string","description":"Path to file"},"symbol":{"type":"string","description":"Symbol for get_call_graph"}},"required":["action","file_path"]}"#,
+    )],
 }];
+
+/// Get tool definitions from all capability registry entries.
+///
+/// These are injected into the LLM's tool list so it knows auto-provisionable
+/// tools exist, even before the MCP server is connected.
+pub fn tool_definitions() -> Vec<ToolDefinition> {
+    REGISTRY
+        .iter()
+        .flat_map(|entry| {
+            entry
+                .tool_definitions
+                .iter()
+                .map(|(name, desc, params)| ToolDefinition {
+                    name: name.to_string(),
+                    description: desc.to_string(),
+                    parameters: serde_json::from_str(params).unwrap_or_default(),
+                })
+        })
+        .collect()
+}
 
 /// Look up which MCP server provides a given tool name.
 pub fn find_server_for_tool(tool_name: &str) -> Option<&'static CapabilityEntry> {
@@ -65,5 +94,31 @@ mod tests {
     #[test]
     fn test_unknown_tool() {
         assert!(find_server_for_tool("UnknownTool123").is_none());
+    }
+
+    #[test]
+    fn test_tool_definitions_include_ast() {
+        let defs = tool_definitions();
+        assert!(!defs.is_empty());
+        let ast = defs.iter().find(|d| d.name == "AstAnalysis");
+        assert!(ast.is_some(), "AstAnalysis should be in tool definitions");
+    }
+
+    #[tokio::test]
+    async fn test_auto_provision_returns_install_hint() {
+        // When koda-ast is not on PATH and MCP registry is None,
+        // executing AstAnalysis should return an install hint, not "Unknown tool"
+        let registry = crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"));
+        let result = registry.execute("AstAnalysis", "{}").await;
+        assert!(
+            !result.output.contains("Unknown tool"),
+            "Should not return 'Unknown tool', got: {}",
+            result.output
+        );
+        assert!(
+            result.output.contains("koda-ast"),
+            "Should mention koda-ast server, got: {}",
+            result.output
+        );
     }
 }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -26,6 +26,7 @@ pub fn normalize_tool_name(name: &str) -> String {
         "invokeagent" | "invoke_agent" => "InvokeAgent".to_string(),
         "listskills" | "list_skills" => "ListSkills".to_string(),
         "activateskill" | "activate_skill" => "ActivateSkill".to_string(),
+        "astanalysis" | "ast_analysis" => "AstAnalysis".to_string(),
         _ => name.to_string(), // pass through unknown names (e.g., MCP tools)
     }
 }
@@ -96,6 +97,10 @@ impl ToolRegistry {
             definitions.insert(def.name.clone(), def);
         }
         for def in skill_tools::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        // Auto-provisionable MCP tools (registered so the LLM knows they exist)
+        for def in crate::mcp::capability_registry::tool_definitions() {
             definitions.insert(def.name.clone(), def);
         }
 
@@ -252,18 +257,6 @@ impl ToolRegistry {
                     output: "__INVOKE_AGENT__".to_string(),
                 };
             }
-            "TodoWrite" => {
-                // Handled externally by the event loop (needs access to db/session_id).
-                return ToolResult {
-                    output: "__TODO_WRITE__".to_string(),
-                };
-            }
-            "TodoRead" => {
-                // Handled externally by the event loop (needs access to db/session_id).
-                return ToolResult {
-                    output: "__TODO_READ__".to_string(),
-                };
-            }
 
             other => {
                 // Auto-provision: check capability registry for MCP servers
@@ -321,6 +314,15 @@ impl ToolRegistry {
                                 ),
                             };
                         }
+                    } else {
+                        // MCP registry not available (e.g., test mode)
+                        return ToolResult {
+                            output: format!(
+                                "Tool '{}' is available via the '{}' MCP server.\n\
+                                 Install: {}",
+                                other, entry.server_name, entry.install_hint
+                            ),
+                        };
                     }
                 }
                 Err(anyhow::anyhow!("Unknown tool: {other}"))

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -12,8 +12,9 @@ fn all_tool_names() -> Vec<String> {
 }
 
 /// Every tool must be routable in the dispatcher.
-/// Tools handled externally (InvokeAgent, TodoWrite, TodoRead) return
-/// sentinel strings; all others return real results or errors.
+/// Tools handled externally (InvokeAgent) return sentinel strings.
+/// Auto-provisioned tools (from capability registry) return install hints
+/// when the server binary isn't available.
 /// None should return "Unknown tool".
 #[tokio::test]
 async fn test_all_tools_routable_in_dispatcher() {


### PR DESCRIPTION
**Bug**: AstAnalysis was removed from tool definitions when extracted to koda-ast. The LLM never knew the tool existed, so auto-provision never triggered.

**Fix**: Capability registry now contributes tool definitions. Also removed stale TodoWrite/TodoRead sentinels and added 2 new tests for auto-provision behavior.

All 420+ tests pass.