### PR TITLE
fix: surface full error chain in TUI error messages (#139)

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -559,7 +559,7 @@ pub async fn run(
                                                 Line::from(vec![
                                                     ratatui::text::Span::raw("  "),
                                                     ratatui::text::Span::styled(
-                                                        format!("\u{2717} Turn failed: {e}"),
+                                                        format!("\u{2717} Turn failed: {e:#}"),
                                                         Style::default().fg(Color::Red),
                                                     ),
                                                 ]),
@@ -760,7 +760,9 @@ pub async fn run(
                                             emit_above(
                                                 &mut terminal,
                                                 Line::styled(
-                                                    format!("  \u{2717} Auto-compact failed: {e}"),
+                                                    format!(
+                                                        "  \u{2717} Auto-compact failed: {e:#}"
+                                                    ),
                                                     Style::default().fg(Color::Red),
                                                 ),
                                             );

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -196,7 +196,7 @@ pub(crate) async fn handle_compact(
                 "Conversation is too short to compact ({n} messages)."
             ));
         }
-        Err(e) => err_msg(format!("Compact failed: {e}")),
+        Err(e) => err_msg(format!("Compact failed: {e:#}")),
     }
 }
 


### PR DESCRIPTION
Changed `{e}` to `{e:#}` for anyhow errors. Now shows the full chain instead of just the outermost context.

Before: `✗ Turn failed: LLM inference failed`
After: `✗ Turn failed: LLM inference failed: Anthropic API returned 429: {...}`

Closes #139.