### PR TITLE
perf: token efficiency — trim descriptions, cap results, remove stale injection (#141)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -85,16 +85,7 @@ pub async fn inference_loop(
             hard_cap += extra;
         }
 
-        // Build system message with current todo (if any)
-        let system_with_todo = match db.get_todo(session_id).await.unwrap_or(None) {
-            Some(todo) => format!(
-                "{base_system_prompt}\n\n## Current Task List\n\
-                 You are tracking these tasks. Update with TodoWrite as you make progress.\n\
-                 {todo}"
-            ),
-            None => base_system_prompt.clone(),
-        };
-        let system_message = ChatMessage::text("system", &system_with_todo);
+        let system_message = ChatMessage::text("system", &base_system_prompt);
 
         // Assemble context with sliding window
         let history = db.load_context(session_id, available).await?;

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -19,6 +19,27 @@ use std::path::Path;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+/// Maximum tool result size stored in conversation history.
+/// Larger results are truncated to keep context usage bounded.
+const MAX_TOOL_RESULT_CHARS: usize = 10_000;
+
+/// Truncate a tool result for storage in conversation history.
+fn truncate_for_history(output: &str) -> String {
+    if output.len() <= MAX_TOOL_RESULT_CHARS {
+        return output.to_string();
+    }
+    // Find a safe char boundary
+    let mut end = MAX_TOOL_RESULT_CHARS;
+    while end > 0 && !output.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!(
+        "{}\n\n[...truncated {} chars. Re-read the file if you need the full content.]",
+        &output[..end],
+        output.len() - end
+    )
+}
+
 pub(crate) fn can_parallelize(
     tool_calls: &[ToolCall],
     mode: ApprovalMode,
@@ -133,10 +154,11 @@ pub(crate) async fn execute_tools_parallel(
             name: tool_calls[i].function_name.clone(),
             output: result.clone(),
         });
+        let stored = truncate_for_history(&result);
         db.insert_message(
             session_id,
             &Role::Tool,
-            Some(&result),
+            Some(&stored),
             None,
             Some(&tc_id),
             None,
@@ -314,10 +336,11 @@ pub(crate) async fn execute_tools_sequential(
             output: result.clone(),
         });
 
+        let stored = truncate_for_history(&result);
         db.insert_message(
             session_id,
             &Role::Tool,
-            Some(&result),
+            Some(&stored),
             None,
             Some(&tc.id),
             None,

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -38,15 +38,14 @@ pub fn definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "ListAgents".to_string(),
-            description: "List all available sub-agents (built-in, user, and project). \
-                Use detail=true to see full system prompts (useful as templates before CreateAgent)."
+            description: "List available sub-agents. Use detail=true to see system prompts."
                 .to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
                     "detail": {
                         "type": "boolean",
-                        "description": "If true, show full system prompts for each agent (use as templates for CreateAgent)"
+                        "description": "Show full system prompts"
                     }
                 }
             }),
@@ -69,12 +68,12 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     },
                     "system_prompt": {
                         "type": "string",
-                        "description": "The agent's system prompt. Should include: identity/mindset, process steps, output format with severity dots, scope limits, and what NOT to do."
+                        "description": "Full system prompt for the agent"
                     },
                     "allowed_tools": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Tools this agent can use. Read-only agents: [Read,List,Grep,Glob]. Agents that modify code: add Write,Edit,Bash. Empty [] means all tools."
+                        "description": "Tools this agent can use. Empty [] = all tools."
                     }
                 },
                 "required": ["name", "system_prompt"]

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -13,9 +13,7 @@ use std::path::Path;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "Glob".to_string(),
-        description: "Find files by glob pattern (e.g. '**/*.rs', 'src/**/*.test.ts'). \
-            Returns matching file paths relative to the project root. \
-            Use this to discover files by extension or naming convention."
+        description: "Find files by glob pattern (e.g. '**/*.rs'). Returns relative paths."
             .to_string(),
         parameters: json!({
             "type": "object",

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -16,10 +16,8 @@ const MAX_MATCHES: usize = 100;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "Grep".to_string(),
-        description: "Recursively search for a text pattern across files. \
-            Respects .gitignore. Returns matching file paths, line numbers, and content. \
-            Results are capped at 100 matches. If too many results, narrow the search \
-            pattern or scope to a subdirectory."
+        description: "Recursively search for text across files (respects .gitignore). \
+            Capped at 100 matches."
             .to_string(),
         parameters: json!({
             "type": "object",

--- a/koda-core/src/tools/skill_tools.rs
+++ b/koda-core/src/tools/skill_tools.rs
@@ -11,9 +11,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
             name: "ListSkills".to_string(),
-            description: "List available skills (curated expertise modules). \
-                Skills inject specialized knowledge into your context — \
-                use them for reviews, audits, and domain-specific tasks."
+            description: "List available skills (expertise modules for reviews, audits, etc.)."
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -28,9 +26,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "ActivateSkill".to_string(),
-            description: "Activate a skill to get expert instructions for a specific task. \
-                Use this for code review, security audit, and other structured analyses. \
-                The skill's instructions will guide your approach — follow them carefully."
+            description: "Activate a skill for expert instructions. Follow the returned guidance."
                 .to_string(),
             parameters: json!({
                 "type": "object",

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -14,9 +14,7 @@ const DEFAULT_TIMEOUT_SECS: u64 = 15;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "WebFetch".to_string(),
-        description: "Fetch content from a URL. Returns the page text with HTML tags stripped. \
-            Useful for reading documentation, APIs, or any public web page."
-            .to_string(),
+        description: "Fetch content from a URL (HTML stripped to text).".to_string(),
         parameters: json!({
             "type": "object",
             "properties": {

--- a/koda-core/tests/token_audit.rs
+++ b/koda-core/tests/token_audit.rs
@@ -1,0 +1,55 @@
+//! Token audit: dump tool definitions for analysis.
+
+use std::path::PathBuf;
+
+#[test]
+fn dump_tool_definitions_for_audit() {
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("."));
+    let defs = registry.get_definitions(&[]); // empty = all tools
+
+    let mut total_chars = 0;
+    let mut entries: Vec<(String, usize, usize)> = Vec::new();
+
+    for def in &defs {
+        let desc_chars = def.description.len();
+        let param_chars = serde_json::to_string(&def.parameters).unwrap().len();
+        total_chars += desc_chars + param_chars;
+        entries.push((def.name.clone(), desc_chars, param_chars));
+    }
+
+    entries.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)));
+
+    eprintln!(
+        "\n{:<20} {:>10} {:>10} {:>10}",
+        "Tool", "Desc", "Params", "Total"
+    );
+    eprintln!("{}", "-".repeat(55));
+    for (name, desc, params) in &entries {
+        eprintln!(
+            "{:<20} {:>10} {:>10} {:>10}",
+            name,
+            desc,
+            params,
+            desc + params
+        );
+    }
+    eprintln!("{}", "-".repeat(55));
+    eprintln!(
+        "{:<20} {:>10} {:>10} {:>10}",
+        "TOTAL",
+        entries.iter().map(|e| e.1).sum::<usize>(),
+        entries.iter().map(|e| e.2).sum::<usize>(),
+        total_chars
+    );
+    eprintln!("Estimated tokens: ~{}", total_chars / 4);
+    eprintln!("Tool count: {}", defs.len());
+    eprintln!();
+
+    // Also dump the full JSON for detailed review
+    let json = serde_json::to_string_pretty(&defs).unwrap();
+    eprintln!(
+        "Full JSON size: {} chars, ~{} tokens",
+        json.len(),
+        json.len() / 4
+    );
+}


### PR DESCRIPTION
Three optimizations targeting per-turn token usage:

1. **Remove stale todo injection** — still injecting into system prompt even after TodoWrite was deleted
2. **Trim tool descriptions** — 11k→10k chars in tool definitions (~234 tokens/turn)
3. **Cap tool results at 10k chars** — large file reads were stored verbatim and replayed every turn

Adds `token_audit.rs` test for ongoing measurement. All 420+ tests pass.

Addresses #141.