### PR TITLE
ci: build, publish, and install koda-ast alongside koda-cli (#151)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/v}"
           CORE_VER=$(grep '^version' koda-core/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CLI_VER=$(grep '^version' koda-cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          AST_VER=$(grep '^version' koda-ast/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           if [ "$TAG" != "$CORE_VER" ]; then
             echo "::error::Tag v$TAG does not match koda-core version $CORE_VER"
             exit 1
@@ -48,7 +49,11 @@ jobs:
             echo "::error::Tag v$TAG does not match koda-cli version $CLI_VER"
             exit 1
           fi
-          echo "✅ Tag v$TAG matches koda-core ($CORE_VER) and koda-cli ($CLI_VER)"
+          if [ "$TAG" != "$AST_VER" ]; then
+            echo "::error::Tag v$TAG does not match koda-ast version $AST_VER"
+            exit 1
+          fi
+          echo "✅ Tag v$TAG matches koda-core ($CORE_VER), koda-cli ($CLI_VER), and koda-ast ($AST_VER)"
 
   build:
     name: Build ${{ matrix.target }}
@@ -78,13 +83,16 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }} -p koda-cli
+        run: |
+          cargo build --release --target ${{ matrix.target }} -p koda-cli
+          cargo build --release --target ${{ matrix.target }} -p koda-ast
 
       - name: Package (unix)
         if: runner.os != 'Windows'
         run: |
           mkdir koda-${{ matrix.target }}
           cp target/${{ matrix.target }}/release/koda koda-${{ matrix.target }}/
+          cp target/${{ matrix.target }}/release/koda-ast koda-${{ matrix.target }}/
           cp README.md LICENSE koda-${{ matrix.target }}/
           tar czf koda-${{ matrix.target }}.tar.gz koda-${{ matrix.target }}
 
@@ -94,6 +102,7 @@ jobs:
         run: |
           mkdir koda-${{ matrix.target }}
           cp target/${{ matrix.target }}/release/koda.exe koda-${{ matrix.target }}/
+          cp target/${{ matrix.target }}/release/koda-ast.exe koda-${{ matrix.target }}/
           cp README.md LICENSE koda-${{ matrix.target }}/
           7z a koda-${{ matrix.target }}.zip koda-${{ matrix.target }}/
 
@@ -122,6 +131,10 @@ jobs:
         run: sleep 30
       - name: Publish koda-cli
         run: cargo publish -p koda-cli
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish koda-ast
+        run: cargo publish -p koda-ast
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -217,10 +230,12 @@ jobs:
 
             def install
               bin.install "koda"
+              bin.install "koda-ast"
             end
 
             test do
               assert_match "koda", shell_output("#{bin}/koda --version")
+              assert_match "koda-ast", shell_output("#{bin}/koda-ast --version 2>&1", 1)
             end
           end
           FORMULA

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "petgraph",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-ast/src/main.rs
+++ b/koda-ast/src/main.rs
@@ -109,6 +109,12 @@ impl AstServer {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Handle --version flag
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("koda-ast {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()

--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -29,7 +29,7 @@ const REGISTRY: &[CapabilityEntry] = &[CapabilityEntry {
     command: "koda-ast",
     tools: &["AstAnalysis"],
     description: "Tree-sitter AST analysis for Rust, Python, JS, TS",
-    install_hint: "cargo install koda-ast",
+    install_hint: "brew install koda (includes koda-ast) or cargo install koda-ast",
     tool_definitions: &[(
         "AstAnalysis",
         "Read-only AST code analysis. Supports .rs, .py, .js, .ts. \


### PR DESCRIPTION
Ships koda-ast in the same release archive as koda-cli. One `brew install koda` installs both.

- Build both binaries for all 5 targets
- Include in release archives + Homebrew formula
- Publish to crates.io
- Version sync + --version flag

Closes #151.