### PR TITLE
feat: koda-email MCP server — email via IMAP/SMTP (#133)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           CORE_VER=$(grep '^version' koda-core/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CLI_VER=$(grep '^version' koda-cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           AST_VER=$(grep '^version' koda-ast/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          EMAIL_VER=$(grep '^version' koda-email/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           if [ "$TAG" != "$CORE_VER" ]; then
             echo "::error::Tag v$TAG does not match koda-core version $CORE_VER"
             exit 1
@@ -53,7 +54,11 @@ jobs:
             echo "::error::Tag v$TAG does not match koda-ast version $AST_VER"
             exit 1
           fi
-          echo "✅ Tag v$TAG matches koda-core ($CORE_VER), koda-cli ($CLI_VER), and koda-ast ($AST_VER)"
+          if [ "$TAG" != "$EMAIL_VER" ]; then
+            echo "::error::Tag v$TAG does not match koda-email version $EMAIL_VER"
+            exit 1
+          fi
+          echo "✅ Tag v$TAG matches koda-core ($CORE_VER), koda-cli ($CLI_VER), koda-ast ($AST_VER), and koda-email ($EMAIL_VER)"
 
   build:
     name: Build ${{ matrix.target }}
@@ -86,6 +91,7 @@ jobs:
         run: |
           cargo build --release --target ${{ matrix.target }} -p koda-cli
           cargo build --release --target ${{ matrix.target }} -p koda-ast
+          cargo build --release --target ${{ matrix.target }} -p koda-email
 
       - name: Package (unix)
         if: runner.os != 'Windows'
@@ -93,6 +99,7 @@ jobs:
           mkdir koda-${{ matrix.target }}
           cp target/${{ matrix.target }}/release/koda koda-${{ matrix.target }}/
           cp target/${{ matrix.target }}/release/koda-ast koda-${{ matrix.target }}/
+          cp target/${{ matrix.target }}/release/koda-email koda-${{ matrix.target }}/
           cp README.md LICENSE koda-${{ matrix.target }}/
           tar czf koda-${{ matrix.target }}.tar.gz koda-${{ matrix.target }}
 
@@ -103,6 +110,7 @@ jobs:
           mkdir koda-${{ matrix.target }}
           cp target/${{ matrix.target }}/release/koda.exe koda-${{ matrix.target }}/
           cp target/${{ matrix.target }}/release/koda-ast.exe koda-${{ matrix.target }}/
+          cp target/${{ matrix.target }}/release/koda-email.exe koda-${{ matrix.target }}/
           cp README.md LICENSE koda-${{ matrix.target }}/
           7z a koda-${{ matrix.target }}.zip koda-${{ matrix.target }}/
 
@@ -135,6 +143,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish koda-ast
         run: cargo publish -p koda-ast
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish koda-email
+        run: cargo publish -p koda-email
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -231,6 +243,7 @@ jobs:
             def install
               bin.install "koda"
               bin.install "koda-ast"
+              bin.install "koda-email"
             end
 
             test do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +42,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "allocator-api2"
@@ -101,6 +119,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "async-trait"
@@ -221,6 +248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bufstream"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.5",
+ "stacker",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,7 +368,7 @@ version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -672,6 +715,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +844,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -990,6 +1064,16 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1013,6 +1097,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1054,6 +1144,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1192,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -1310,6 +1417,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "imap"
+version = "3.0.0-alpha.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b81eb9a89c9a40e9d6c670d9b3c4cda734573592bd49b7cd906152c95d9af2"
+dependencies = [
+ "base64",
+ "bufstream",
+ "chrono",
+ "imap-proto",
+ "lazy_static",
+ "native-tls",
+ "nom 7.1.3",
+ "ouroboros",
+ "regex",
+]
+
+[[package]]
+name = "imap-proto"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1f9b30846c3d04371159ef3a0413ce7c1ae0a8c619cd255c60b3d902553f22"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1631,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "koda-email"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "imap",
+ "lettre",
+ "mail-parser",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1662,34 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lettre"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e13e10e8818f8b2a60f52cb127041d388b89f3a96a62be9ceaffa22262fef7f"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chumsky",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "httpdate",
+ "idna",
+ "mime",
+ "native-tls",
+ "nom 8.0.0",
+ "percent-encoding",
+ "quoted_printable",
+ "socket2",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+]
 
 [[package]]
 name = "libc"
@@ -1596,6 +1775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mail-parser"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c3b9e5d8b17faf573330bbc43b37d6e918c0a3bf8a88e7d0a220ebc84af9fc"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1843,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1869,25 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1722,6 +1952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,10 +1973,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "parking"
@@ -1902,6 +2203,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "process-wrap"
 version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +2227,16 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -1979,6 +2303,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "r-efi"
@@ -2753,7 +3083,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2880,6 +3210,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2932,7 +3275,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -2945,7 +3288,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3171,6 +3514,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4288,7 +4641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4299,7 +4652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn",
@@ -4365,6 +4718,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["koda-core", "koda-cli", "koda-ast"]
+members = ["koda-core", "koda-cli", "koda-ast", "koda-email"]
 resolver = "3"
 default-members = ["koda-cli"]
 

--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -24,19 +24,47 @@ pub struct CapabilityEntry {
 }
 
 /// Built-in capability registry — auto-provisionable MCP servers.
-const REGISTRY: &[CapabilityEntry] = &[CapabilityEntry {
-    server_name: "koda-ast",
-    command: "koda-ast",
-    tools: &["AstAnalysis"],
-    description: "Tree-sitter AST analysis for Rust, Python, JS, TS",
-    install_hint: "brew install koda (includes koda-ast) or cargo install koda-ast",
-    tool_definitions: &[(
-        "AstAnalysis",
-        "Read-only AST code analysis. Supports .rs, .py, .js, .ts. \
-         Use action 'analyze_file' for structure summary or 'get_call_graph' with a symbol.",
-        r#"{"type":"object","properties":{"action":{"type":"string","description":"'analyze_file' or 'get_call_graph'"},"file_path":{"type":"string","description":"Path to file"},"symbol":{"type":"string","description":"Symbol for get_call_graph"}},"required":["action","file_path"]}"#,
-    )],
-}];
+const REGISTRY: &[CapabilityEntry] = &[
+    CapabilityEntry {
+        server_name: "koda-ast",
+        command: "koda-ast",
+        tools: &["AstAnalysis"],
+        description: "Tree-sitter AST analysis for Rust, Python, JS, TS",
+        install_hint: "brew install koda (includes koda-ast) or cargo install koda-ast",
+        tool_definitions: &[(
+            "AstAnalysis",
+            "Read-only AST code analysis. Supports .rs, .py, .js, .ts. \
+             Use action 'analyze_file' for structure summary or 'get_call_graph' with a symbol.",
+            r#"{"type":"object","properties":{"action":{"type":"string","description":"'analyze_file' or 'get_call_graph'"},"file_path":{"type":"string","description":"Path to file"},"symbol":{"type":"string","description":"Symbol for get_call_graph"}},"required":["action","file_path"]}"#,
+        )],
+    },
+    CapabilityEntry {
+        server_name: "koda-email",
+        command: "koda-email",
+        tools: &["EmailRead", "EmailSend", "EmailSearch"],
+        description: "Email read/send/search via IMAP/SMTP",
+        install_hint: "brew install koda (includes koda-email) or cargo install koda-email",
+        tool_definitions: &[
+            (
+                "EmailRead",
+                "Read recent emails from INBOX. Returns subject, sender, date, and a text snippet. \
+                 Use 'count' to control how many (default 5, max 20).",
+                r#"{"type":"object","properties":{"count":{"type":"integer","description":"Number of recent emails to fetch (default 5, max 20)"}},"required":[]}"#,
+            ),
+            (
+                "EmailSend",
+                "Send an email via SMTP. Requires 'to' (recipient), 'subject', and 'body'.",
+                r#"{"type":"object","properties":{"to":{"type":"string","description":"Recipient email address"},"subject":{"type":"string","description":"Email subject line"},"body":{"type":"string","description":"Email body text"}},"required":["to","subject","body"]}"#,
+            ),
+            (
+                "EmailSearch",
+                "Search emails in INBOX. Plain text searches subject and body. \
+                 Use 'from:addr' to search by sender, 'subject:text' to search by subject.",
+                r#"{"type":"object","properties":{"query":{"type":"string","description":"Search query. Use 'from:' or 'subject:' prefixes for targeted search."},"max_results":{"type":"integer","description":"Max results (default 10, max 50)"}},"required":["query"]}"#,
+            ),
+        ],
+    },
+];
 
 /// Get tool definitions from all capability registry entries.
 ///
@@ -102,6 +130,24 @@ mod tests {
         assert!(!defs.is_empty());
         let ast = defs.iter().find(|d| d.name == "AstAnalysis");
         assert!(ast.is_some(), "AstAnalysis should be in tool definitions");
+    }
+
+    #[test]
+    fn test_find_email_tools() {
+        for tool_name in &["EmailRead", "EmailSend", "EmailSearch"] {
+            let entry = find_server_for_tool(tool_name);
+            assert!(entry.is_some(), "{tool_name} should be in registry");
+            assert_eq!(entry.unwrap().server_name, "koda-email");
+        }
+    }
+
+    #[test]
+    fn test_tool_definitions_include_email() {
+        let defs = tool_definitions();
+        for name in &["EmailRead", "EmailSend", "EmailSearch"] {
+            let found = defs.iter().find(|d| d.name == *name);
+            assert!(found.is_some(), "{name} should be in tool definitions");
+        }
     }
 
     #[tokio::test]

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "koda-email"
+version = "0.1.2"
+edition = "2024"
+description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
+license = "MIT"
+
+[[bin]]
+name = "koda-email"
+path = "src/main.rs"
+
+[dependencies]
+rmcp = { version = "1.1", features = ["server", "macros", "transport-io"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+schemars = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+imap = "3.0.0-alpha.15"
+lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "smtp-transport"] }
+mail-parser = "0.9"
+
+[dev-dependencies]
+tempfile = "3"

--- a/koda-email/src/config.rs
+++ b/koda-email/src/config.rs
@@ -1,0 +1,85 @@
+//! Email server configuration loaded from environment variables.
+//!
+//! Credentials are expected as:
+//! - KODA_EMAIL_IMAP_HOST, KODA_EMAIL_IMAP_PORT
+//! - KODA_EMAIL_SMTP_HOST, KODA_EMAIL_SMTP_PORT
+//! - KODA_EMAIL_USERNAME, KODA_EMAIL_PASSWORD
+
+use anyhow::{Context, Result};
+
+/// IMAP + SMTP connection settings.
+#[derive(Debug, Clone)]
+pub struct EmailConfig {
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub smtp_host: String,
+    pub smtp_port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+impl EmailConfig {
+    /// Load config from environment variables.
+    ///
+    /// Required: KODA_EMAIL_IMAP_HOST, KODA_EMAIL_USERNAME, KODA_EMAIL_PASSWORD
+    /// Optional: KODA_EMAIL_IMAP_PORT (default 993), KODA_EMAIL_SMTP_HOST,
+    ///           KODA_EMAIL_SMTP_PORT (default 587)
+    pub fn from_env() -> Result<Self> {
+        let imap_host =
+            std::env::var("KODA_EMAIL_IMAP_HOST").context("KODA_EMAIL_IMAP_HOST not set")?;
+        let imap_port = std::env::var("KODA_EMAIL_IMAP_PORT")
+            .unwrap_or_else(|_| "993".to_string())
+            .parse::<u16>()
+            .context("KODA_EMAIL_IMAP_PORT must be a valid port number")?;
+
+        // Default SMTP host: derive from IMAP host (imap.example.com → smtp.example.com)
+        let default_smtp_host = imap_host.replacen("imap", "smtp", 1);
+        let smtp_host = std::env::var("KODA_EMAIL_SMTP_HOST").unwrap_or(default_smtp_host);
+        let smtp_port = std::env::var("KODA_EMAIL_SMTP_PORT")
+            .unwrap_or_else(|_| "587".to_string())
+            .parse::<u16>()
+            .context("KODA_EMAIL_SMTP_PORT must be a valid port number")?;
+
+        let username =
+            std::env::var("KODA_EMAIL_USERNAME").context("KODA_EMAIL_USERNAME not set")?;
+        let password =
+            std::env::var("KODA_EMAIL_PASSWORD").context("KODA_EMAIL_PASSWORD not set")?;
+
+        Ok(Self {
+            imap_host,
+            imap_port,
+            smtp_host,
+            smtp_port,
+            username,
+            password,
+        })
+    }
+
+    /// Human-readable missing-config error with setup instructions.
+    pub fn setup_instructions() -> String {
+        "koda-email requires email credentials via environment variables:\n\n\
+         Required:\n  \
+         KODA_EMAIL_IMAP_HOST=imap.gmail.com\n  \
+         KODA_EMAIL_USERNAME=you@gmail.com\n  \
+         KODA_EMAIL_PASSWORD=your-app-password\n\n\
+         Optional:\n  \
+         KODA_EMAIL_IMAP_PORT=993 (default)\n  \
+         KODA_EMAIL_SMTP_HOST=smtp.gmail.com (derived from IMAP host)\n  \
+         KODA_EMAIL_SMTP_PORT=587 (default)\n\n\
+         For Gmail: use an App Password (Settings → Security → App Passwords).\n\
+         For Outlook: use an App Password or IMAP must be enabled."
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_setup_instructions_not_empty() {
+        let msg = EmailConfig::setup_instructions();
+        assert!(msg.contains("KODA_EMAIL_IMAP_HOST"));
+        assert!(msg.contains("KODA_EMAIL_USERNAME"));
+    }
+}

--- a/koda-email/src/imap_client.rs
+++ b/koda-email/src/imap_client.rs
@@ -1,0 +1,256 @@
+//! IMAP client for reading and searching emails.
+//!
+//! Uses the synchronous `imap` crate with `tokio::task::spawn_blocking`
+//! for async compatibility. Simpler and more battle-tested than async-imap.
+
+use crate::config::EmailConfig;
+use anyhow::{Context, Result};
+
+/// A parsed email summary (subject, sender, date, snippet).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EmailSummary {
+    pub uid: u32,
+    pub subject: String,
+    pub from: String,
+    pub date: String,
+    pub snippet: String,
+}
+
+/// Fetch the last N emails from INBOX.
+pub async fn read_emails(config: &EmailConfig, count: u32) -> Result<Vec<EmailSummary>> {
+    let config = config.clone();
+    tokio::task::spawn_blocking(move || read_emails_sync(&config, count))
+        .await
+        .context("IMAP task panicked")?
+}
+
+/// Search emails by query.
+pub async fn search_emails(
+    config: &EmailConfig,
+    query: &str,
+    max_results: u32,
+) -> Result<Vec<EmailSummary>> {
+    let config = config.clone();
+    let query = query.to_string();
+    tokio::task::spawn_blocking(move || search_emails_sync(&config, &query, max_results))
+        .await
+        .context("IMAP task panicked")?
+}
+
+// ── Synchronous implementations ───────────────────────────────
+
+fn connect(config: &EmailConfig) -> Result<imap::Session<Box<dyn imap::ImapConnection>>> {
+    let client = imap::ClientBuilder::new(&config.imap_host, config.imap_port)
+        .connect()
+        .context("Failed to connect to IMAP server")?;
+    let session = client
+        .login(&config.username, &config.password)
+        .map_err(|e| anyhow::anyhow!("IMAP login failed: {}", e.0))?;
+    Ok(session)
+}
+
+fn read_emails_sync(config: &EmailConfig, count: u32) -> Result<Vec<EmailSummary>> {
+    let mut session = connect(config)?;
+    let mailbox = session.select("INBOX").context("Failed to select INBOX")?;
+
+    let total = mailbox.exists;
+    if total == 0 {
+        session.logout().ok();
+        return Ok(Vec::new());
+    }
+
+    let start = total.saturating_sub(count) + 1;
+    let range = format!("{start}:{total}");
+    let summaries = fetch_messages(&mut session, &range)?;
+
+    session.logout().ok();
+    Ok(summaries)
+}
+
+fn search_emails_sync(
+    config: &EmailConfig,
+    query: &str,
+    max_results: u32,
+) -> Result<Vec<EmailSummary>> {
+    let mut session = connect(config)?;
+    session.select("INBOX").context("Failed to select INBOX")?;
+
+    let search_cmd = build_search_query(query);
+    let uids = session.search(&search_cmd).context("IMAP search failed")?;
+
+    if uids.is_empty() {
+        session.logout().ok();
+        return Ok(Vec::new());
+    }
+
+    // Take last N results (most recent)
+    let mut uid_list: Vec<u32> = uids.into_iter().collect();
+    uid_list.sort();
+    let take = uid_list.len().min(max_results as usize);
+    let selected = &uid_list[uid_list.len() - take..];
+    let range = selected
+        .iter()
+        .map(|u| u.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let summaries = fetch_messages(&mut session, &range)?;
+    session.logout().ok();
+    Ok(summaries)
+}
+
+/// Build an IMAP SEARCH command from a user query.
+///
+/// Supports:
+/// - Plain text → searches subject + body via OR
+/// - "from:user@example.com" → FROM filter
+/// - "subject:keyword" → SUBJECT filter
+fn build_search_query(query: &str) -> String {
+    let q = query.trim();
+
+    if let Some(addr) = q.strip_prefix("from:") {
+        return format!("FROM \"{}\"", addr.trim());
+    }
+    if let Some(subj) = q.strip_prefix("subject:") {
+        return format!("SUBJECT \"{}\"", subj.trim());
+    }
+
+    // Default: search subject OR body
+    format!("OR SUBJECT \"{}\" BODY \"{}\"", q, q)
+}
+
+/// Fetch messages by sequence range and parse into summaries.
+fn fetch_messages(
+    session: &mut imap::Session<Box<dyn imap::ImapConnection>>,
+    range: &str,
+) -> Result<Vec<EmailSummary>> {
+    let fetches = session
+        .fetch(
+            range,
+            "(UID BODY.PEEK[HEADER.FIELDS (FROM SUBJECT DATE)] BODY.PEEK[TEXT]<0.200>)",
+        )
+        .context("Failed to fetch messages")?;
+
+    let mut summaries = Vec::new();
+
+    for fetch in fetches.iter() {
+        let uid = fetch.uid.unwrap_or(0);
+
+        // Parse headers
+        let header_bytes = fetch.header().unwrap_or_default();
+        let header_str = String::from_utf8_lossy(header_bytes);
+
+        let subject = extract_header(&header_str, "Subject");
+        let from = extract_header(&header_str, "From");
+        let date = extract_header(&header_str, "Date");
+
+        // Parse body snippet
+        let body_bytes = fetch.text().unwrap_or_default();
+        let body_raw = String::from_utf8_lossy(body_bytes);
+        let snippet = clean_snippet(&body_raw, 200);
+
+        summaries.push(EmailSummary {
+            uid,
+            subject,
+            from,
+            date,
+            snippet,
+        });
+    }
+
+    // Newest first
+    summaries.reverse();
+    Ok(summaries)
+}
+
+/// Extract a header value from raw header text.
+fn extract_header(headers: &str, name: &str) -> String {
+    let prefix = format!("{name}: ");
+    headers
+        .lines()
+        .find(|line| line.starts_with(&prefix))
+        .map(|line| line[prefix.len()..].trim().to_string())
+        .unwrap_or_else(|| "(unknown)".to_string())
+}
+
+/// Clean a body snippet: strip HTML, collapse whitespace, truncate.
+fn clean_snippet(raw: &str, max_len: usize) -> String {
+    // Strip HTML tags (simple state-machine approach)
+    let mut result = String::new();
+    let mut in_tag = false;
+    for ch in raw.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => result.push(ch),
+            _ => {}
+        }
+    }
+
+    // Collapse whitespace
+    let collapsed: String = result.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    if collapsed.len() > max_len {
+        format!("{}...", &collapsed[..max_len])
+    } else {
+        collapsed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_search_query_plain() {
+        assert_eq!(
+            build_search_query("meeting notes"),
+            "OR SUBJECT \"meeting notes\" BODY \"meeting notes\""
+        );
+    }
+
+    #[test]
+    fn test_build_search_query_from() {
+        assert_eq!(
+            build_search_query("from:alice@example.com"),
+            "FROM \"alice@example.com\""
+        );
+    }
+
+    #[test]
+    fn test_build_search_query_subject() {
+        assert_eq!(
+            build_search_query("subject:quarterly review"),
+            "SUBJECT \"quarterly review\""
+        );
+    }
+
+    #[test]
+    fn test_extract_header() {
+        let headers = "From: alice@example.com\r\nSubject: Hello\r\nDate: Mon, 1 Jan 2024\r\n";
+        assert_eq!(extract_header(headers, "From"), "alice@example.com");
+        assert_eq!(extract_header(headers, "Subject"), "Hello");
+        assert_eq!(extract_header(headers, "Date"), "Mon, 1 Jan 2024");
+        assert_eq!(extract_header(headers, "Missing"), "(unknown)");
+    }
+
+    #[test]
+    fn test_clean_snippet_strips_html() {
+        let raw = "<html><body><p>Hello <b>world</b></p></body></html>";
+        assert_eq!(clean_snippet(raw, 100), "Hello world");
+    }
+
+    #[test]
+    fn test_clean_snippet_truncates() {
+        let raw = "a ".repeat(200);
+        let result = clean_snippet(&raw, 20);
+        assert!(result.len() <= 24); // 20 + "..."
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_clean_snippet_collapses_whitespace() {
+        let raw = "hello    world\n\n  foo";
+        assert_eq!(clean_snippet(raw, 100), "hello world foo");
+    }
+}

--- a/koda-email/src/main.rs
+++ b/koda-email/src/main.rs
@@ -1,0 +1,242 @@
+//! koda-email: MCP server for email read/send/search via IMAP/SMTP.
+//!
+//! Provides `EmailRead`, `EmailSend`, and `EmailSearch` tools via MCP stdio.
+//! Part of the koda ecosystem — auto-provisioned on first use.
+
+mod config;
+mod imap_client;
+mod smtp_client;
+
+use config::EmailConfig;
+use rmcp::{
+    ServerHandler, ServiceExt,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::*,
+    tool, tool_handler, tool_router,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// ── Tool parameter types ───────────────────────────────────────
+
+/// Parameters for EmailRead tool.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct EmailReadParams {
+    /// Number of recent emails to fetch (default: 5, max: 20)
+    #[serde(default = "default_count")]
+    pub count: u32,
+}
+
+/// Parameters for EmailSend tool.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct EmailSendParams {
+    /// Recipient email address
+    pub to: String,
+    /// Email subject line
+    pub subject: String,
+    /// Email body text
+    pub body: String,
+}
+
+/// Parameters for EmailSearch tool.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct EmailSearchParams {
+    /// Search query. Plain text searches subject+body.
+    /// Prefix with "from:" or "subject:" for targeted search.
+    pub query: String,
+    /// Maximum results to return (default: 10)
+    #[serde(default = "default_max_results")]
+    pub max_results: u32,
+}
+
+fn default_count() -> u32 {
+    5
+}
+fn default_max_results() -> u32 {
+    10
+}
+
+// ── MCP Server ───────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct EmailServer {
+    config: Option<EmailConfig>,
+    config_error: Option<String>,
+    tool_router: ToolRouter<Self>,
+}
+
+impl EmailServer {
+    fn new() -> Self {
+        let (config, config_error) = match EmailConfig::from_env() {
+            Ok(c) => (Some(c), None),
+            Err(e) => (None, Some(format!("{e:#}"))),
+        };
+        Self {
+            config,
+            config_error,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    /// Get config or return a setup-instructions error.
+    fn require_config(&self) -> Result<&EmailConfig, rmcp::ErrorData> {
+        self.config.as_ref().ok_or_else(|| {
+            let msg = format!(
+                "Email not configured: {}\n\n{}",
+                self.config_error.as_deref().unwrap_or("unknown error"),
+                EmailConfig::setup_instructions()
+            );
+            rmcp::ErrorData::internal_error(msg, None)
+        })
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for EmailServer {
+    fn get_info(&self) -> ServerInfo {
+        let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
+        info.server_info = Implementation::new("koda-email", env!("CARGO_PKG_VERSION"));
+        info.instructions = Some(
+            "Email server for reading, sending, and searching emails via IMAP/SMTP. \
+             Configure with KODA_EMAIL_* environment variables."
+                .to_string(),
+        );
+        info
+    }
+}
+
+#[tool_router]
+impl EmailServer {
+    /// Read recent emails from your inbox.
+    #[tool(
+        name = "EmailRead",
+        description = "Read recent emails from INBOX. Returns subject, sender, date, and a text snippet for each email. Use 'count' to control how many (default 5, max 20)."
+    )]
+    async fn email_read(
+        &self,
+        params: Parameters<EmailReadParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = self.require_config()?;
+        let count = params.0.count.clamp(1, 20);
+
+        match imap_client::read_emails(config, count).await {
+            Ok(emails) if emails.is_empty() => Ok(CallToolResult::success(vec![Content::text(
+                "No emails found in INBOX.",
+            )])),
+            Ok(emails) => {
+                let output = format_email_list(&emails);
+                Ok(CallToolResult::success(vec![Content::text(output)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error reading emails: {e:#}"
+            ))])),
+        }
+    }
+
+    /// Send an email.
+    #[tool(
+        name = "EmailSend",
+        description = "Send an email via SMTP. Requires 'to' (recipient), 'subject', and 'body'."
+    )]
+    async fn email_send(
+        &self,
+        params: Parameters<EmailSendParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = self.require_config()?;
+        let p = &params.0;
+
+        match smtp_client::send_email(config, &p.to, &p.subject, &p.body).await {
+            Ok(msg) => Ok(CallToolResult::success(vec![Content::text(msg)])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error sending email: {e:#}"
+            ))])),
+        }
+    }
+
+    /// Search emails by query.
+    #[tool(
+        name = "EmailSearch",
+        description = "Search emails in INBOX. Plain text searches subject and body. Use 'from:addr' to search by sender, 'subject:text' to search by subject line."
+    )]
+    async fn email_search(
+        &self,
+        params: Parameters<EmailSearchParams>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let config = self.require_config()?;
+        let p = &params.0;
+        let max = p.max_results.clamp(1, 50);
+
+        match imap_client::search_emails(config, &p.query, max).await {
+            Ok(emails) if emails.is_empty() => Ok(CallToolResult::success(vec![Content::text(
+                format!("No emails found matching: {}", p.query),
+            )])),
+            Ok(emails) => {
+                let output = format!(
+                    "Found {} result(s) for \"{}\":\n\n{}",
+                    emails.len(),
+                    p.query,
+                    format_email_list(&emails)
+                );
+                Ok(CallToolResult::success(vec![Content::text(output)]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error searching emails: {e:#}"
+            ))])),
+        }
+    }
+}
+
+/// Format email summaries for LLM-friendly output.
+fn format_email_list(emails: &[imap_client::EmailSummary]) -> String {
+    emails
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            format!(
+                "{}. [{}] {}\n   From: {}\n   Date: {}\n   {}\n",
+                i + 1,
+                e.uid,
+                e.subject,
+                e.from,
+                e.date,
+                if e.snippet.is_empty() {
+                    "(no preview)".to_string()
+                } else {
+                    e.snippet.clone()
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Handle --version flag
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("koda-email {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    tracing::info!("koda-email MCP server starting...");
+
+    let server = EmailServer::new();
+    if server.config.is_none() {
+        tracing::warn!(
+            "Email credentials not configured. Tools will return setup instructions.\n{}",
+            EmailConfig::setup_instructions()
+        );
+    }
+
+    let service = server.serve(rmcp::transport::io::stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}

--- a/koda-email/src/smtp_client.rs
+++ b/koda-email/src/smtp_client.rs
@@ -1,0 +1,48 @@
+//! SMTP client for sending emails via lettre.
+
+use crate::config::EmailConfig;
+use anyhow::{Context, Result};
+use lettre::{
+    AsyncSmtpTransport, AsyncTransport, Tokio1Executor,
+    message::{Mailbox, MessageBuilder, header::ContentType},
+    transport::smtp::authentication::Credentials,
+};
+
+/// Send an email via SMTP.
+pub async fn send_email(
+    config: &EmailConfig,
+    to: &str,
+    subject: &str,
+    body: &str,
+) -> Result<String> {
+    let from: Mailbox = config
+        .username
+        .parse()
+        .context("Invalid sender email address in KODA_EMAIL_USERNAME")?;
+    let to_addr: Mailbox = to
+        .parse()
+        .context(format!("Invalid recipient email address: {to}"))?;
+
+    let email = MessageBuilder::new()
+        .from(from)
+        .to(to_addr)
+        .subject(subject)
+        .header(ContentType::TEXT_PLAIN)
+        .body(body.to_string())
+        .context("Failed to build email message")?;
+
+    let creds = Credentials::new(config.username.clone(), config.password.clone());
+
+    let mailer = AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.smtp_host)
+        .context("Failed to create SMTP transport")?
+        .port(config.smtp_port)
+        .credentials(creds)
+        .build();
+
+    let response = mailer
+        .send(email)
+        .await
+        .context("Failed to send email via SMTP")?;
+
+    Ok(format!("Email sent to {to} (status: {})", response.code()))
+}


### PR DESCRIPTION
New MCP server for email read/send/search via IMAP/SMTP. Universal — works with any email provider.

**Tools**: EmailRead, EmailSend, EmailSearch
**Auth**: Environment variables (KODA_EMAIL_IMAP_HOST, USERNAME, PASSWORD)
**Pattern**: Same as koda-ast — auto-provisioned, single binary, ships with `brew install koda`

14 new tests. All 267 pass, clippy clean.

Closes #133.