### PR TITLE
feat: Wave 2 — Model Tiers (#160, #158)

### DIFF
--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -89,6 +89,10 @@ struct Cli {
     /// OpenAI reasoning effort (low, medium, high)
     #[arg(long)]
     reasoning_effort: Option<String>,
+
+    /// Override model tier (strong, standard, lite)
+    #[arg(long, value_parser = ["strong", "standard", "lite"])]
+    model_tier: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -136,7 +140,8 @@ async fn main() -> Result<()> {
                             cli.temperature,
                             cli.thinking_budget,
                             cli.reasoning_effort.clone(),
-                        );
+                        )
+                        .with_tier_override(cli.model_tier.as_deref());
                     server::run_stdio_server(project_root, config).await?;
                 } else {
                     eprintln!("WebSocket server (--port {port}) not yet implemented. Use --stdio.");
@@ -188,7 +193,8 @@ async fn main() -> Result<()> {
                 cli.temperature,
                 cli.thinking_budget,
                 cli.reasoning_effort,
-            );
+            )
+            .with_tier_override(cli.model_tier.as_deref());
         let db =
             koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;
         let session_id = match cli.session {
@@ -231,7 +237,8 @@ async fn main() -> Result<()> {
             cli.temperature,
             cli.thinking_budget,
             cli.reasoning_effort,
-        );
+        )
+        .with_tier_override(cli.model_tier.as_deref());
 
     // Initialize database
     let db = koda_core::db::Database::init(&project_root, &koda_core::db::config_dir()?).await?;

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -93,6 +93,7 @@ fn draw_viewport(
     frame: &mut ratatui::Frame,
     textarea: &TextArea,
     model: &str,
+    tier_label: &str,
     mode: ApprovalMode,
     context_pct: u32,
     state: TuiState,
@@ -123,7 +124,7 @@ fn draw_viewport(
     frame.render_widget(textarea, text_area);
 
     // Status bar
-    let mut sb = StatusBar::new(model, mode.label(), context_pct);
+    let mut sb = StatusBar::new(model, tier_label, mode.label(), context_pct);
     if queue_len > 0 {
         sb = sb.with_queue(queue_len);
     }
@@ -364,6 +365,7 @@ pub async fn run(
             f,
             &textarea,
             &config.model,
+            config.model_tier.label(),
             mode,
             ctx,
             tui_state,
@@ -542,6 +544,7 @@ pub async fn run(
                                         f,
                                         &textarea,
                                         &config.model,
+                                        config.model_tier.label(),
                                         mode,
                                         ctx,
                                         tui_state,
@@ -788,6 +791,7 @@ pub async fn run(
                 f,
                 &textarea,
                 &config.model,
+                config.model_tier.label(),
                 mode,
                 ctx,
                 tui_state,

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -12,6 +12,7 @@ use ratatui::{
 
 pub struct StatusBar<'a> {
     model: &'a str,
+    tier_label: &'a str,
     mode_label: &'a str,
     context_pct: u32,
     queue_len: usize,
@@ -36,9 +37,10 @@ pub struct TurnStats {
 }
 
 impl<'a> StatusBar<'a> {
-    pub fn new(model: &'a str, mode_label: &'a str, context_pct: u32) -> Self {
+    pub fn new(model: &'a str, tier_label: &'a str, mode_label: &'a str, context_pct: u32) -> Self {
         Self {
             model,
+            tier_label,
             mode_label,
             context_pct,
             queue_len: 0,
@@ -86,6 +88,10 @@ impl Widget for StatusBar<'_> {
             Span::styled(
                 format!(" {} ", self.model),
                 Style::default().fg(Color::DarkGray),
+            ),
+            Span::styled(
+                format!("[{}]", self.tier_label),
+                Style::default().fg(Color::Rgb(100, 100, 100)),
             ),
             Span::styled("\u{2502}", Style::default().fg(Color::Rgb(60, 60, 60))),
             Span::styled(

--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -51,11 +51,12 @@ impl KodaAgent {
         let tool_defs = tools.get_definitions(&config.allowed_tools);
 
         let semantic_memory = memory::load(&project_root)?;
-        let system_prompt = crate::prompt::build_system_prompt(
+        let system_prompt = crate::prompt::build_system_prompt_tiered(
             &config.system_prompt,
             &semantic_memory,
             &config.agents_dir,
             &tool_defs,
+            config.model_tier,
         );
 
         Ok(Self {

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -10,6 +10,7 @@ pub struct ProviderMeta {
     pub env_key: &'static str,
     pub api_key: bool,
 }
+use crate::model_tier::ModelTier;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
@@ -274,6 +275,9 @@ pub struct AgentConfig {
     pub max_iterations: Option<u32>,
     #[serde(default)]
     pub auto_compact_threshold: Option<usize>,
+    /// Override the auto-detected model tier.
+    #[serde(default)]
+    pub model_tier: Option<ModelTier>,
 }
 
 /// Runtime configuration assembled from CLI args, env vars, and agent JSON.
@@ -291,6 +295,8 @@ pub struct KodaConfig {
     pub max_iterations: u32,
     /// Context usage percentage (0-100) that triggers auto-compact. 0 = disabled.
     pub auto_compact_threshold: usize,
+    /// Model capability tier (auto-detected or overridden).
+    pub model_tier: ModelTier,
 }
 
 impl KodaConfig {
@@ -353,11 +359,17 @@ impl KodaConfig {
             settings.reasoning_effort = Some(re.clone());
         }
 
+        let model_tier = agent
+            .model_tier
+            .unwrap_or_else(|| ModelTier::from_model_name(&model, &provider_type));
+
         let max_iterations = agent
             .max_iterations
-            .unwrap_or(crate::loop_guard::MAX_ITERATIONS_DEFAULT);
+            .unwrap_or_else(|| model_tier.default_max_iterations());
 
-        let auto_compact_threshold = agent.auto_compact_threshold.unwrap_or(80);
+        let auto_compact_threshold = agent
+            .auto_compact_threshold
+            .unwrap_or_else(|| model_tier.default_auto_compact_threshold());
 
         Ok(Self {
             agent_name: agent.name,
@@ -371,6 +383,7 @@ impl KodaConfig {
             model_settings: settings,
             max_iterations,
             auto_compact_threshold,
+            model_tier,
         })
     }
 
@@ -421,6 +434,18 @@ impl KodaConfig {
         self
     }
 
+    /// Override the auto-detected model tier.
+    pub fn with_tier_override(mut self, tier_str: Option<&str>) -> Self {
+        if let Some(t) = tier_str {
+            self.model_tier = match t {
+                "strong" => ModelTier::Strong,
+                "lite" => ModelTier::Lite,
+                _ => ModelTier::Standard,
+            };
+        }
+        self
+    }
+
     /// Built-in agent configs, embedded at compile time.
     /// These are always available regardless of disk state.
     const BUILTIN_AGENTS: &[(&str, &str)] = &[
@@ -454,6 +479,7 @@ impl KodaConfig {
         let model = provider_type.default_model().to_string();
         let model_settings = ModelSettings::defaults_for(&model, &provider_type);
         let max_context_tokens = model_settings.max_context_tokens;
+        let model_tier = ModelTier::from_model_name(&model, &provider_type);
         Self {
             agent_name: "test".to_string(),
             system_prompt: "You are a test agent.".to_string(),
@@ -466,6 +492,7 @@ impl KodaConfig {
             model_settings,
             max_iterations: crate::loop_guard::MAX_ITERATIONS_DEFAULT,
             auto_compact_threshold: 80,
+            model_tier,
         }
     }
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -485,7 +485,9 @@ pub async fn inference_loop(
         made_tool_calls = true;
 
         // Execute tool calls — parallelize when possible
+        // (Lite tier models must use sequential to avoid confusion)
         if tool_calls.len() > 1
+            && config.model_tier.allows_parallel_tools()
             && can_parallelize(&tool_calls, mode, &settings.approval.allowed_commands)
         {
             execute_tools_parallel(

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod loop_guard;
 pub mod mcp;
 pub mod memory;
 pub mod model_context;
+pub mod model_tier;
 pub mod preview;
 pub mod prompt;
 pub mod providers;

--- a/koda-core/src/model_tier.rs
+++ b/koda-core/src/model_tier.rs
@@ -1,0 +1,208 @@
+//! Model capability tiers.
+//!
+//! Classifies models into Strong/Standard/Lite tiers based on name and
+//! provider. Each tier gets different system prompts, tool loading
+//! strategies, loop limits, and inference parameters.
+
+use crate::config::ProviderType;
+
+/// Model capability tier — determines prompt verbosity, tool loading,
+/// and inference parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelTier {
+    /// Frontier models: excellent reasoning, tool use, intent inference.
+    /// Can work with minimal prompts and discover tools on demand.
+    Strong,
+    /// Capable models: good reasoning, reliable tool use.
+    /// Need standard prompts but handle some ambiguity.
+    Standard,
+    /// Smaller/cheaper models: basic tool use, need explicit instructions.
+    /// Require all schemas upfront, step-by-step guidance.
+    Lite,
+}
+
+impl ModelTier {
+    /// Auto-detect tier from model name and provider.
+    pub fn from_model_name(model: &str, provider: &ProviderType) -> Self {
+        let m = model.to_lowercase();
+
+        // Strong tier — frontier models
+        if m.contains("opus")
+            || m.contains("sonnet")
+            || (m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4"))
+            || m.starts_with("gpt-4o")
+            || m.starts_with("gpt-4.1")
+            || m.contains("gemini-2.5-pro")
+            || m.contains("deepseek-r1")
+            || m.contains("grok-3")
+        {
+            return Self::Strong;
+        }
+
+        // Lite tier — small/local models
+        if m.contains("lite")
+            || m.contains("nano")
+            || m.contains("-8b")
+            || m.contains("-7b")
+            || m.contains("-3b")
+            || m.contains("-1b")
+            || m == "auto-detect"
+            || matches!(
+                provider,
+                ProviderType::LMStudio | ProviderType::Ollama | ProviderType::Vllm
+            )
+        {
+            return Self::Lite;
+        }
+
+        // Everything else is Standard
+        Self::Standard
+    }
+
+    /// Default max iterations for the inference loop.
+    pub fn default_max_iterations(self) -> u32 {
+        match self {
+            Self::Strong => 200,
+            Self::Standard => 200,
+            Self::Lite => 50,
+        }
+    }
+
+    /// Default auto-compact threshold (percentage).
+    pub fn default_auto_compact_threshold(self) -> usize {
+        match self {
+            Self::Strong => 90,
+            Self::Standard => 80,
+            Self::Lite => 70,
+        }
+    }
+
+    /// Whether parallel tool execution is allowed.
+    pub fn allows_parallel_tools(self) -> bool {
+        match self {
+            Self::Strong | Self::Standard => true,
+            Self::Lite => false,
+        }
+    }
+
+    /// Display label for status bar.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Strong => "Strong",
+            Self::Standard => "Standard",
+            Self::Lite => "Lite",
+        }
+    }
+}
+
+impl std::fmt::Display for ModelTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.label())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strong_models() {
+        let p = ProviderType::Anthropic;
+        assert_eq!(
+            ModelTier::from_model_name("claude-opus-4-6", &p),
+            ModelTier::Strong
+        );
+        assert_eq!(
+            ModelTier::from_model_name("claude-sonnet-4-6", &p),
+            ModelTier::Strong
+        );
+
+        let p = ProviderType::OpenAI;
+        assert_eq!(ModelTier::from_model_name("gpt-4o", &p), ModelTier::Strong);
+        assert_eq!(
+            ModelTier::from_model_name("gpt-4o-mini", &p),
+            ModelTier::Strong
+        );
+        assert_eq!(ModelTier::from_model_name("o3-mini", &p), ModelTier::Strong);
+        assert_eq!(ModelTier::from_model_name("o1", &p), ModelTier::Strong);
+        assert_eq!(ModelTier::from_model_name("gpt-4.1", &p), ModelTier::Strong);
+
+        let p = ProviderType::Gemini;
+        assert_eq!(
+            ModelTier::from_model_name("gemini-2.5-pro", &p),
+            ModelTier::Strong
+        );
+
+        let p = ProviderType::Grok;
+        assert_eq!(ModelTier::from_model_name("grok-3", &p), ModelTier::Strong);
+    }
+
+    #[test]
+    fn test_standard_models() {
+        assert_eq!(
+            ModelTier::from_model_name("gemini-2.5-flash", &ProviderType::Gemini),
+            ModelTier::Standard
+        );
+        assert_eq!(
+            ModelTier::from_model_name("gemini-2.0-flash", &ProviderType::Gemini),
+            ModelTier::Standard
+        );
+        assert_eq!(
+            ModelTier::from_model_name("deepseek-chat", &ProviderType::DeepSeek),
+            ModelTier::Standard
+        );
+        assert_eq!(
+            ModelTier::from_model_name("mistral-large-latest", &ProviderType::Mistral),
+            ModelTier::Standard
+        );
+        assert_eq!(
+            ModelTier::from_model_name("llama-3.3-70b-versatile", &ProviderType::Groq),
+            ModelTier::Standard
+        );
+    }
+
+    #[test]
+    fn test_lite_models() {
+        assert_eq!(
+            ModelTier::from_model_name("auto-detect", &ProviderType::LMStudio),
+            ModelTier::Lite
+        );
+        assert_eq!(
+            ModelTier::from_model_name("auto-detect", &ProviderType::Ollama),
+            ModelTier::Lite
+        );
+        assert_eq!(
+            ModelTier::from_model_name("llama-3-8b", &ProviderType::Groq),
+            ModelTier::Lite
+        );
+        assert_eq!(
+            ModelTier::from_model_name("gemini-flash-lite", &ProviderType::Gemini),
+            ModelTier::Lite
+        );
+        assert_eq!(
+            ModelTier::from_model_name("qwen-2.5-7b", &ProviderType::Ollama),
+            ModelTier::Lite
+        );
+    }
+
+    #[test]
+    fn test_tier_defaults() {
+        assert_eq!(ModelTier::Strong.default_max_iterations(), 200);
+        assert_eq!(ModelTier::Standard.default_max_iterations(), 200);
+        assert_eq!(ModelTier::Lite.default_max_iterations(), 50);
+
+        assert_eq!(ModelTier::Strong.default_auto_compact_threshold(), 90);
+        assert_eq!(ModelTier::Lite.default_auto_compact_threshold(), 70);
+
+        assert!(ModelTier::Strong.allows_parallel_tools());
+        assert!(!ModelTier::Lite.allows_parallel_tools());
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", ModelTier::Strong), "Strong");
+        assert_eq!(format!("{}", ModelTier::Standard), "Standard");
+        assert_eq!(format!("{}", ModelTier::Lite), "Lite");
+    }
+}

--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -2,6 +2,7 @@
 //!
 //! Builds the system prompt from agent config, memory, and available tools.
 
+use crate::model_tier::ModelTier;
 use std::path::Path;
 
 pub fn build_system_prompt(
@@ -9,6 +10,23 @@ pub fn build_system_prompt(
     semantic_memory: &str,
     agents_dir: &Path,
     tool_defs: &[crate::providers::ToolDefinition],
+) -> String {
+    build_system_prompt_tiered(
+        base_prompt,
+        semantic_memory,
+        agents_dir,
+        tool_defs,
+        ModelTier::Standard,
+    )
+}
+
+/// Build system prompt with tier-aware verbosity.
+pub fn build_system_prompt_tiered(
+    base_prompt: &str,
+    semantic_memory: &str,
+    agents_dir: &Path,
+    tool_defs: &[crate::providers::ToolDefinition],
+    tier: ModelTier,
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -21,21 +39,39 @@ pub fn build_system_prompt(
          feasible with the information you have.\n",
     );
 
-    // Embed the capabilities reference (REPL features, not tools)
-    prompt.push_str("\n\n");
-    prompt.push_str(include_str!("capabilities.md"));
+    // Embed the capabilities reference — Strong tier skips it (can discover)
+    if tier != ModelTier::Strong {
+        prompt.push_str("\n\n");
+        prompt.push_str(include_str!("capabilities.md"));
+    }
 
     // Auto-generate tool reference from definitions
     if !tool_defs.is_empty() {
         prompt.push_str("\n### Available Tools\n\n");
         for def in tool_defs {
-            // First sentence of description only (keep it concise)
-            let short_desc = def
-                .description
-                .split('.')
-                .next()
-                .unwrap_or(&def.description);
-            prompt.push_str(&format!("- **{}**: {}\n", def.name, short_desc));
+            let desc = match tier {
+                ModelTier::Strong => {
+                    // First sentence only (concise)
+                    def.description
+                        .split('.')
+                        .next()
+                        .unwrap_or(&def.description)
+                        .to_string()
+                }
+                ModelTier::Lite => {
+                    // Full description for weak models
+                    def.description.clone()
+                }
+                ModelTier::Standard => {
+                    // First sentence
+                    def.description
+                        .split('.')
+                        .next()
+                        .unwrap_or(&def.description)
+                        .to_string()
+                }
+            };
+            prompt.push_str(&format!("- **{}**: {}\n", def.name, desc));
         }
     }
 


### PR DESCRIPTION
## Wave 2: Model-Adaptive Behavior

**ModelTier** enum: Strong/Standard/Lite auto-detected from model name
**Tiered prompts**: Strong skips capabilities.md, Lite gets full descriptions
**Tiered parameters**: loop limits, auto-compact thresholds, parallel tools
**User override**: `--model-tier strong` CLI flag + agent config JSON
**Status bar**: shows `claude-sonnet-4-6 [Strong]`

285 tests pass. Closes #158.