### PR TITLE
feat: Wave 3 — Lazy Tool Loading (#160, #154)

### DIFF
--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -48,7 +48,7 @@ impl KodaAgent {
         }
 
         let tools = ToolRegistry::new(project_root.clone()).with_mcp_registry(mcp_registry.clone());
-        let tool_defs = tools.get_definitions(&config.allowed_tools);
+        let tool_defs = tools.get_definitions_tiered(&config.allowed_tools, config.model_tier);
 
         let semantic_memory = memory::load(&project_root)?;
         let system_prompt = crate::prompt::build_system_prompt_tiered(

--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -43,6 +43,9 @@ pub fn build_system_prompt_tiered(
     if tier != ModelTier::Strong {
         prompt.push_str("\n\n");
         prompt.push_str(include_str!("capabilities.md"));
+    } else {
+        // Strong tier gets compact category hints instead
+        prompt.push_str(&crate::tools::discover::category_hints());
     }
 
     // Auto-generate tool reference from definitions

--- a/koda-core/src/tools/discover.rs
+++ b/koda-core/src/tools/discover.rs
@@ -1,0 +1,203 @@
+//! DiscoverTools — on-demand tool schema injection.
+//!
+//! For Strong-tier models, only core tools + DiscoverTools are loaded upfront.
+//! The model calls `DiscoverTools({ category: "agents" })` to get the full
+//! schemas for a category on demand.
+
+use crate::providers::ToolDefinition;
+use serde_json::json;
+
+/// Tool categories for on-demand discovery.
+const CATEGORIES: &[(&str, &str)] = &[
+    (
+        "agents",
+        "Sub-agent management: InvokeAgent, ListAgents, CreateAgent",
+    ),
+    (
+        "skills",
+        "Expert skill activation: ListSkills, ActivateSkill",
+    ),
+    ("web", "Web content fetching: WebFetch"),
+    ("memory", "Persistent memory: MemoryRead, MemoryWrite"),
+    ("ast", "Code structure analysis: AstAnalysis"),
+    (
+        "email",
+        "Email management: EmailRead, EmailSend, EmailSearch",
+    ),
+];
+
+/// The DiscoverTools tool definition (lightweight, ~50 tokens).
+pub fn definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "DiscoverTools".to_string(),
+        description: "Discover additional tool capabilities by category. \
+            Returns full tool schemas for the requested category."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "enum": ["agents", "skills", "web", "memory", "ast", "email", "all"],
+                    "description": "Category of tools to discover"
+                }
+            },
+            "required": ["category"]
+        }),
+    }
+}
+
+/// Core tool names — always loaded regardless of tier.
+pub const CORE_TOOLS: &[&str] = &[
+    "Read", "Write", "Edit", "Delete", "List", "Grep", "Glob", "Bash",
+];
+
+/// Tool names by category.
+fn tools_in_category(category: &str) -> &'static [&'static str] {
+    match category {
+        "agents" => &["InvokeAgent", "ListAgents", "CreateAgent"],
+        "skills" => &["ListSkills", "ActivateSkill"],
+        "web" => &["WebFetch"],
+        "memory" => &["MemoryRead", "MemoryWrite"],
+        "ast" => &["AstAnalysis"],
+        "email" => &["EmailRead", "EmailSend", "EmailSearch"],
+        _ => &[],
+    }
+}
+
+/// Execute the DiscoverTools tool. Returns JSON schemas as a string.
+pub fn discover(all_defs: &[ToolDefinition], args: &serde_json::Value) -> String {
+    let category = args["category"].as_str().unwrap_or("all");
+
+    if category == "all" {
+        // Return everything that isn't a core tool or DiscoverTools itself
+        let extras: Vec<&ToolDefinition> = all_defs
+            .iter()
+            .filter(|d| !CORE_TOOLS.contains(&d.name.as_str()) && d.name != "DiscoverTools")
+            .collect();
+        return format_tools(&extras);
+    }
+
+    let target_names = tools_in_category(category);
+    if target_names.is_empty() {
+        return format!(
+            "Unknown category: '{category}'. Available: {}",
+            CATEGORIES
+                .iter()
+                .map(|(name, _)| *name)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    let matched: Vec<&ToolDefinition> = all_defs
+        .iter()
+        .filter(|d| target_names.contains(&d.name.as_str()))
+        .collect();
+
+    if matched.is_empty() {
+        format!("No tools found for category '{category}'. They may not be installed.")
+    } else {
+        format_tools(&matched)
+    }
+}
+
+/// Format a list of tool definitions as readable output.
+fn format_tools(tools: &[&ToolDefinition]) -> String {
+    let mut out = String::new();
+    for def in tools {
+        out.push_str(&format!("### {}\n", def.name));
+        out.push_str(&format!("{}\n", def.description));
+        out.push_str(&format!(
+            "Parameters: {}\n\n",
+            serde_json::to_string_pretty(&def.parameters).unwrap_or_default()
+        ));
+    }
+    out
+}
+
+/// Generate category hints for the system prompt (Strong tier).
+pub fn category_hints() -> String {
+    let mut hint = String::from(
+        "\n## Extended Capabilities\n\n\
+         You have additional capabilities available on demand.\n\
+         Call DiscoverTools with a category to unlock them:\n\n",
+    );
+    for (name, desc) in CATEGORIES {
+        hint.push_str(&format!("- **{name}** \u{2014} {desc}\n"));
+    }
+    hint.push_str("\nOnly discover what you need for the current task.\n");
+    hint
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_definition_has_category_enum() {
+        let def = definition();
+        assert_eq!(def.name, "DiscoverTools");
+        let cat = &def.parameters["properties"]["category"];
+        assert!(cat["enum"].is_array());
+    }
+
+    #[test]
+    fn test_discover_all() {
+        let defs = vec![
+            ToolDefinition {
+                name: "Read".into(),
+                description: "Read a file".into(),
+                parameters: json!({}),
+            },
+            ToolDefinition {
+                name: "ListAgents".into(),
+                description: "List agents".into(),
+                parameters: json!({}),
+            },
+        ];
+        let result = discover(&defs, &json!({ "category": "all" }));
+        assert!(result.contains("ListAgents"));
+        assert!(!result.contains("### Read")); // Read is core, excluded
+    }
+
+    #[test]
+    fn test_discover_agents() {
+        let defs = vec![
+            ToolDefinition {
+                name: "InvokeAgent".into(),
+                description: "Invoke a sub-agent".into(),
+                parameters: json!({}),
+            },
+            ToolDefinition {
+                name: "Read".into(),
+                description: "Read a file".into(),
+                parameters: json!({}),
+            },
+        ];
+        let result = discover(&defs, &json!({ "category": "agents" }));
+        assert!(result.contains("InvokeAgent"));
+        assert!(!result.contains("### Read"));
+    }
+
+    #[test]
+    fn test_discover_unknown_category() {
+        let result = discover(&[], &json!({ "category": "bogus" }));
+        assert!(result.contains("Unknown category"));
+    }
+
+    #[test]
+    fn test_category_hints() {
+        let hints = category_hints();
+        assert!(hints.contains("agents"));
+        assert!(hints.contains("skills"));
+        assert!(hints.contains("DiscoverTools"));
+    }
+
+    #[test]
+    fn test_core_tools_list() {
+        assert!(CORE_TOOLS.contains(&"Read"));
+        assert!(CORE_TOOLS.contains(&"Bash"));
+        assert!(!CORE_TOOLS.contains(&"InvokeAgent"));
+    }
+}

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -27,6 +27,7 @@ pub fn normalize_tool_name(name: &str) -> String {
         "listskills" | "list_skills" => "ListSkills".to_string(),
         "activateskill" | "activate_skill" => "ActivateSkill".to_string(),
         "astanalysis" | "ast_analysis" => "AstAnalysis".to_string(),
+        "discovertools" | "discover_tools" | "discover" => "DiscoverTools".to_string(),
         "emailread" | "email_read" => "EmailRead".to_string(),
         "emailsend" | "email_send" => "EmailSend".to_string(),
         "emailsearch" | "email_search" => "EmailSearch".to_string(),
@@ -35,6 +36,7 @@ pub fn normalize_tool_name(name: &str) -> String {
 }
 
 pub mod agent;
+pub mod discover;
 pub mod file_tools;
 pub mod glob_tool;
 pub mod grep;
@@ -102,6 +104,9 @@ impl ToolRegistry {
         for def in skill_tools::definitions() {
             definitions.insert(def.name.clone(), def);
         }
+        // DiscoverTools — lazy loading for Strong tier
+        let discover_def = discover::definition();
+        definitions.insert(discover_def.name.clone(), discover_def);
         // Auto-provisionable MCP tools (registered so the LLM knows they exist)
         for def in crate::mcp::capability_registry::tool_definitions() {
             definitions.insert(def.name.clone(), def);
@@ -139,16 +144,40 @@ impl ToolRegistry {
     /// Get tool definitions, optionally filtered by an allow-list.
     /// Includes MCP tools merged with built-in tools.
     pub fn get_definitions(&self, allowed: &[String]) -> Vec<ToolDefinition> {
-        let mut defs: Vec<ToolDefinition> = if allowed.is_empty() {
-            self.definitions.values().cloned().collect()
-        } else {
+        self.get_definitions_tiered(allowed, crate::model_tier::ModelTier::Standard)
+    }
+
+    /// Get tool definitions with tier-aware filtering.
+    ///
+    /// - **Strong**: core tools + DiscoverTools only (~850 tokens)
+    /// - **Standard**: all tools (~2K tokens, current behavior)
+    /// - **Lite**: all tools (~2K tokens)
+    pub fn get_definitions_tiered(
+        &self,
+        allowed: &[String],
+        tier: crate::model_tier::ModelTier,
+    ) -> Vec<ToolDefinition> {
+        let mut defs: Vec<ToolDefinition> = if !allowed.is_empty() {
+            // Explicit allow-list always wins
             allowed
                 .iter()
                 .filter_map(|name| self.definitions.get(name).cloned())
                 .collect()
+        } else if tier == crate::model_tier::ModelTier::Strong {
+            // Strong tier: core tools + DiscoverTools only
+            self.definitions
+                .values()
+                .filter(|d| {
+                    discover::CORE_TOOLS.contains(&d.name.as_str()) || d.name == "DiscoverTools"
+                })
+                .cloned()
+                .collect()
+        } else {
+            // Standard/Lite: all tools
+            self.definitions.values().cloned().collect()
         };
 
-        // Merge MCP tool definitions (always included, not filtered by allow-list)
+        // Merge MCP tool definitions (always included)
         if let Some(ref mcp) = self.mcp_registry
             && let Ok(registry) = mcp.try_read()
         {
@@ -253,6 +282,12 @@ impl ToolRegistry {
             // Skill tools
             "ListSkills" => Ok(skill_tools::list_skills(&self.skill_registry, &args)),
             "ActivateSkill" => Ok(skill_tools::activate_skill(&self.skill_registry, &args)),
+
+            // Discovery tool
+            "DiscoverTools" => {
+                let all_defs: Vec<ToolDefinition> = self.definitions.values().cloned().collect();
+                Ok(discover::discover(&all_defs, &args))
+            }
 
             "InvokeAgent" => {
                 // Handled externally by the event loop (needs access to config/db).


### PR DESCRIPTION
## Wave 3: DiscoverTools

**DiscoverTools** tool for on-demand schema injection by category
**Tier-aware loading**: Strong gets 9 tools (~850 tok) vs all ~20 (~2000 tok)
**Category hints**: compact system prompt hints for Strong tier

57% reduction in per-turn tool overhead for Strong tier.
291 tests pass. Closes #154.