### PR TITLE
feat: Wave 4 — Model-Routed Sub-Agents (#160, #159, #122)

### DIFF
--- a/koda-core/agents/scout.json
+++ b/koda-core/agents/scout.json
@@ -1,0 +1,9 @@
+{
+    "name": "scout",
+    "system_prompt": "You are Scout, a fast codebase explorer. Your job is to read files, search for patterns, and report findings back. Be thorough but concise. Report file paths, line numbers, and relevant snippets. Do NOT modify any files.",
+    "allowed_tools": ["Read", "List", "Grep", "Glob"],
+    "max_iterations": 10,
+    "model": null,
+    "base_url": null,
+    "provider": null
+}

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -452,6 +452,7 @@ impl KodaConfig {
         ("default", include_str!("../agents/default.json")),
         ("testgen", include_str!("../agents/testgen.json")),
         ("releaser", include_str!("../agents/releaser.json")),
+        ("scout", include_str!("../agents/scout.json")),
     ];
 
     /// Try to load a built-in (embedded) agent by name.

--- a/koda-core/src/intent.rs
+++ b/koda-core/src/intent.rs
@@ -1,0 +1,197 @@
+//! Rule-based intent classifier.
+//!
+//! Classifies user messages into task intents and suggests
+//! appropriate skills or agents. Zero LLM cost.
+
+/// Classified intent of a user message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskIntent {
+    /// Simple question or explanation request.
+    Question,
+    /// Code exploration (read, search, understand).
+    Explore,
+    /// Code modification (edit, write, refactor).
+    Modify,
+    /// Test generation.
+    TestGen,
+    /// Code review or analysis.
+    Review,
+    /// Build, run, or deploy.
+    Build,
+    /// Complex multi-step task.
+    Complex,
+}
+
+/// Optional suggestion to surface to the user.
+#[derive(Debug, Clone)]
+pub struct IntentSuggestion {
+    pub intent: TaskIntent,
+    /// Suggested skill or agent name (if applicable).
+    pub suggestion: Option<String>,
+    /// Short explanation for the suggestion.
+    pub reason: Option<String>,
+}
+
+/// Classify a user message into an intent.
+pub fn classify_intent(msg: &str) -> IntentSuggestion {
+    let lower = msg.to_lowercase();
+    let words: Vec<&str> = lower.split_whitespace().collect();
+
+    // Test generation
+    if matches_any(
+        &lower,
+        &[
+            "write tests",
+            "add tests",
+            "generate tests",
+            "test coverage",
+            "unit test",
+        ],
+    ) {
+        return IntentSuggestion {
+            intent: TaskIntent::TestGen,
+            suggestion: Some("testgen".into()),
+            reason: Some("The testgen agent specializes in test generation.".into()),
+        };
+    }
+
+    // Code review
+    if matches_any(&lower, &["review", "code review", "audit", "check quality"]) {
+        return IntentSuggestion {
+            intent: TaskIntent::Review,
+            suggestion: None,
+            reason: Some("Try the /review skill for expert code review.".into()),
+        };
+    }
+
+    // Build/run
+    if matches_any(&lower, &["build", "compile", "deploy", "run tests", "make"]) {
+        return IntentSuggestion {
+            intent: TaskIntent::Build,
+            suggestion: None,
+            reason: None,
+        };
+    }
+
+    // Simple question
+    if words.len() < 10
+        && matches_any(
+            &lower,
+            &[
+                "what is", "what are", "how do", "explain", "why ", "show me", "tell me",
+            ],
+        )
+    {
+        return IntentSuggestion {
+            intent: TaskIntent::Question,
+            suggestion: None,
+            reason: None,
+        };
+    }
+
+    // Exploration
+    if matches_any(
+        &lower,
+        &[
+            "find", "search", "look for", "where is", "list all", "show all", "scan",
+        ],
+    ) {
+        return IntentSuggestion {
+            intent: TaskIntent::Explore,
+            suggestion: Some("scout".into()),
+            reason: Some("The scout agent is optimized for codebase exploration.".into()),
+        };
+    }
+
+    // Modification
+    if matches_any(
+        &lower,
+        &[
+            "refactor",
+            "rename",
+            "fix bug",
+            "add feature",
+            "implement",
+            "change",
+            "update",
+            "modify",
+            "rewrite",
+        ],
+    ) {
+        return IntentSuggestion {
+            intent: TaskIntent::Modify,
+            suggestion: None,
+            reason: None,
+        };
+    }
+
+    // Long messages are likely complex
+    if words.len() > 30 {
+        return IntentSuggestion {
+            intent: TaskIntent::Complex,
+            suggestion: None,
+            reason: None,
+        };
+    }
+
+    IntentSuggestion {
+        intent: TaskIntent::Modify,
+        suggestion: None,
+        reason: None,
+    }
+}
+
+/// Check if the text contains any of the patterns.
+fn matches_any(text: &str, patterns: &[&str]) -> bool {
+    patterns.iter().any(|p| text.contains(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_test_generation() {
+        let r = classify_intent("write tests for the auth module");
+        assert_eq!(r.intent, TaskIntent::TestGen);
+        assert_eq!(r.suggestion.as_deref(), Some("testgen"));
+    }
+
+    #[test]
+    fn test_classify_review() {
+        let r = classify_intent("review this PR");
+        assert_eq!(r.intent, TaskIntent::Review);
+    }
+
+    #[test]
+    fn test_classify_question() {
+        let r = classify_intent("what is this function doing?");
+        assert_eq!(r.intent, TaskIntent::Question);
+    }
+
+    #[test]
+    fn test_classify_exploration() {
+        let r = classify_intent("find all uses of DatabaseConfig");
+        assert_eq!(r.intent, TaskIntent::Explore);
+        assert_eq!(r.suggestion.as_deref(), Some("scout"));
+    }
+
+    #[test]
+    fn test_classify_build() {
+        let r = classify_intent("build and run tests");
+        assert_eq!(r.intent, TaskIntent::Build);
+    }
+
+    #[test]
+    fn test_classify_modification() {
+        let r = classify_intent("refactor the payment module");
+        assert_eq!(r.intent, TaskIntent::Modify);
+    }
+
+    #[test]
+    fn test_classify_complex_long_message() {
+        let msg = "I need you to ".to_string() + &"word ".repeat(30) + "and more";
+        let r = classify_intent(&msg);
+        assert_eq!(r.intent, TaskIntent::Complex);
+    }
+}

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod db;
 pub mod engine;
 pub mod inference;
 pub mod inference_helpers;
+pub mod intent;
 pub mod keystore;
 pub mod loop_guard;
 pub mod mcp;

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -380,7 +380,13 @@ pub(crate) async fn execute_sub_agent(
 
     let sub_config = crate::config::KodaConfig::load(project_root, agent_name)
         .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
-    let sub_config = sub_config.with_overrides(Some(parent_config.base_url.clone()), None, None);
+    // Only inherit parent's base_url if the sub-agent doesn't have its own
+    // provider/model explicitly configured (respect agent-level routing).
+    let sub_config = if sub_config.provider_type == parent_config.provider_type {
+        sub_config.with_overrides(Some(parent_config.base_url.clone()), None, None)
+    } else {
+        sub_config
+    };
 
     let sub_session = match session_id {
         Some(id) => id,

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -375,8 +375,8 @@ mod tests {
         let builtins: Vec<_> = agents.iter().filter(|a| a.source == "built-in").collect();
         assert_eq!(
             builtins.len(),
-            2,
-            "Expected 2 built-in agents (testgen, releaser), got {}",
+            3,
+            "Expected 3 built-in agents (testgen, releaser, scout), got {}",
             builtins.len()
         );
         let names: Vec<_> = builtins.iter().map(|a| a.name.as_str()).collect();

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -290,9 +290,10 @@ impl ToolRegistry {
             }
 
             "InvokeAgent" => {
-                // Handled externally by the event loop (needs access to config/db).
+                // Handled by tool_dispatch.rs before reaching here.
+                // This branch should not be reached in normal flow.
                 return ToolResult {
-                    output: "__INVOKE_AGENT__".to_string(),
+                    output: "InvokeAgent is handled by the inference loop.".to_string(),
                 };
             }
 


### PR DESCRIPTION
## Wave 4: Model Routing

**Sub-agent routing**: respects per-agent provider/model config
**Scout agent**: built-in read-only codebase explorer
**Intent classifier**: rule-based task classification with agent/skill suggestions
**Sentinel cleanup**: eliminated `__INVOKE_AGENT__` anti-pattern

298 tests pass. Closes #159 P1, #122 S1, #156 P2.