### PR TITLE
feat(koda-ast): expand language support — fixes #164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,37 +12,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [0.1.3] - 2026-03-06
 
 ### Added
-- **Model-adaptive architecture** — `ModelTier` enum (Strong/Standard/Lite) auto-detected from model name + provider ([#158](https://github.com/lijunzh/koda/issues/158))
+- **Model-adaptive architecture** — `ModelTier` enum (Strong/Standard/Lite) auto-detected from model name + provider
   - Strong: minimal prompts, lazy tool loading, parallel execution, 90% auto-compact
   - Standard: full prompts, all tools, 80% auto-compact (backward compatible)
   - Lite: verbose prompts, sequential execution, 70% auto-compact, 50 iteration cap
   - CLI override: `--model-tier strong|standard|lite`
   - Agent config: `"model_tier": "strong"` in JSON
   - Displayed in status bar: `claude-sonnet-4-6 [Strong]`
-- **Context window auto-detection** — maps model name to actual context size ([#149](https://github.com/lijunzh/koda/issues/149))
+- **Context window auto-detection** — maps model name to actual context size
   - Opus: 32K → 200K, Gemini 2.5: 32K → 1M, GPT-4o: 32K → 128K
   - Eliminates premature compaction (Opus was using 16% of available context)
 - **Rate limit retry** — exponential backoff (2/4/8/16/32s) for 429 errors, up to 5 retries
-- **DiscoverTools** tool — on-demand tool schema injection by category ([#154](https://github.com/lijunzh/koda/issues/154))
+- **DiscoverTools** tool — on-demand tool schema injection by category (agents, skills, web, memory, ast, email)
   - Strong tier loads 9 core tools + DiscoverTools (~850 tokens vs ~2000)
   - 57% reduction in per-turn tool overhead for Strong tier
-- **RecallContext** tool — search or recall older conversation turns from history
-- **Task phase state machine** — auto-detects Understanding → Planning → Executing → Verifying → Reporting ([#156](https://github.com/lijunzh/koda/issues/156))
+- **RecallContext** tool — search or recall older conversation turns that scrolled out of the sliding window
+- **Task phase state machine** — auto-detects Understanding → Planning → Executing → Verifying → Reporting
 - **Intent classifier** — rule-based task classification with agent/skill suggestions (zero LLM cost)
+  - "write tests" → testgen, "find all uses" → scout, "review" → review skill
 - **Built-in scout agent** — read-only codebase explorer (Read, List, Grep, Glob), max 10 iterations
 - **Built-in planner agent** — strategic task decomposition (read-only), max 5 iterations
 - **Built-in verifier agent** — quality verification (Bash, Read, Grep), max 8 iterations
-- **Sub-agent model routing** — sub-agents respect their own provider/model when explicitly set ([#159](https://github.com/lijunzh/koda/issues/159))
+- **Sub-agent model routing** — sub-agents respect their own provider/model when explicitly set
 - **Plan-before-execute** — system prompt instructs planning for >3-step tasks
+- **Self-review instruction** — verify feasibility before executing multi-step plans
 - **koda-email MCP server** — email read/send/search via IMAP/SMTP (any provider)
 
 ### Fixed
-- **Thinking tokens in cost** — now included at output rate (Opus was underreporting by 2-3x)
-- **Token estimation** — calibrated chars/3.5 heuristic (was chars/4)
-- **`__INVOKE_AGENT__` sentinel removed** — no more magic strings ([#122](https://github.com/lijunzh/koda/issues/122))
+- **Thinking tokens in cost** — `estimate_turn_cost()` now includes thinking tokens at output rate. Opus with extended thinking budget no longer underreports cost by 2-3x.
+- **Token estimation calibration** — chars/3.5 heuristic (was chars/4) for better accuracy with code
+- **`__INVOKE_AGENT__` sentinel removed** — InvokeAgent handled at dispatch level, no more magic strings
+- **Email tool normalizer mappings** — EmailRead/Send/Search properly normalized from lowercase
 
 ### Testing
 - 489 tests across 4 crates (up from 284 in v0.1.2)
+- New: model tier tests, context window tests, rate limit tests, DiscoverTools tests, RecallContext tests, task phase tests, intent classifier tests, email MCP integration tests
 
 ## [0.1.2] - 2026-03-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,11 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
@@ -3742,6 +3747,56 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,7 +135,8 @@ accordingly.
 
 **Rationale**: One-size-fits-all wastes tokens on strong models (verbose prompts
 they don't need) and confuses weak models (terse instructions they can't follow).
-The tiered system adapts automatically.
+Competitor analysis showed Claude Code, Goose, and Aider all adapt behavior to
+model capability, but none do it as explicitly as a tiered system.
 
 **How it works**:
 - `ModelTier::from_model_name()` auto-detects from model name + provider
@@ -153,29 +154,44 @@ Anthropic prompt cache hit rates. Tier is determined at session start, not per-t
 No API call required — pure lookup table.
 
 **Rationale**: The previous hardcoded 32K default meant Opus users were using
-16% of their available context, triggering premature compaction. Auto-detection
-is the single highest-impact change in v0.1.3.
+16% of their available context, triggering premature compaction that lost
+information. Auto-detection is the single highest-impact change in v0.1.3.
+
+**Fallback**: Unknown models get 128K (generous but safe). Local models
+("auto-detect") get 4K (conservative). Agent config can always override.
 
 ### 10. Lazy Tool Loading with DiscoverTools (v0.1.3)
 
-**Decision**: Strong-tier models get only 9 tools upfront. Everything else is
-discoverable on demand by category.
+**Decision**: Strong-tier models get only 9 tools (8 core + DiscoverTools)
+upfront. Everything else is discoverable on demand by category.
 
-**Rationale**: 20+ tool schemas cost ~2000 tokens/turn. Core tools handle 90%+
-of turns. DiscoverTools costs ~50 tokens for the schema + ~80 for category hints.
-Net savings: ~57% reduction in per-turn tool overhead for Strong tier.
+**Rationale**: 20+ tool schemas cost ~2000 tokens/turn. Core tools (Read, Write,
+Edit, etc.) handle 90%+ of turns. Agents, skills, memory, web, AST, and email
+tools are situational. DiscoverTools costs ~50 tokens for the schema + ~80 tokens
+for category hints in the system prompt.
+
+**Net savings**: ~57% reduction in per-turn tool overhead for Strong tier.
+Standard and Lite tiers still get all tools (they need the explicit schemas).
 
 ### 11. Rate Limit Retry (v0.1.3)
 
 **Decision**: Exponential backoff retry for 429/rate-limit errors. Up to 5
 attempts with delays of 2, 4, 8, 16, 32 seconds.
 
+**Rationale**: Long sessions with Opus hit rate limits regularly. Previously,
+a 429 killed the session. Now the user sees a countdown and the request
+automatically retries.
+
 ### 12. Sub-Agent Model Routing (v0.1.3)
 
 **Decision**: Sub-agents respect their own provider/model config when
 explicitly set. The parent's base_url is only inherited if the sub-agent
-uses the same provider. This enables cheap models for grunt work while
-expensive models handle reasoning.
+uses the same provider.
+
+**Rationale**: The biggest cost lever — expensive models think, cheap models
+grunt. A scout on Gemini Flash costs 1/20th of Opus for codebase exploration.
+The parent's Anthropic prompt cache is unaffected because sub-agents make
+independent API calls to potentially different providers.
 
 ## References
 

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -23,6 +23,11 @@ tree-sitter-rust = "0.24.0"
 tree-sitter-python = "0.25.0"
 tree-sitter-javascript = "0.25.0"
 tree-sitter-typescript = "0.23.2"
+tree-sitter-go = "0.23.4"
+tree-sitter-java = "0.23.5"
+tree-sitter-c = "0.24.1"
+tree-sitter-cpp = "0.23.4"
+tree-sitter-bash = "0.23.3"
 petgraph = "0.8"
 
 [dev-dependencies]

--- a/koda-ast/src/ast.rs
+++ b/koda-ast/src/ast.rs
@@ -43,14 +43,68 @@ pub fn get_call_graph(file_path: &Path, symbol: &str) -> Result<String> {
     format_graph_output(symbol, callers, callees)
 }
 
+/// Language-specific AST node type names for structure analysis.
+struct LangNodeTypes {
+    func_type: &'static str,
+    class_type: &'static str,
+    func_name_field: &'static str,
+    class_name_field: &'static str,
+}
+
+impl LangNodeTypes {
+    fn for_extension(ext: &str) -> Self {
+        match ext {
+            "rs" => Self::new("function_item", "struct_item", "name", "name"),
+            "py" | "pyi" | "pyw" => {
+                Self::new("function_definition", "class_definition", "name", "name")
+            }
+            "js" | "jsx" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" => {
+                Self::new("function_declaration", "class_declaration", "name", "name")
+            }
+            "go" => Self::new("function_declaration", "type_declaration", "name", "name"),
+            "java" => Self::new("method_declaration", "class_declaration", "name", "name"),
+            "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" => Self::new(
+                "function_definition",
+                "struct_specifier",
+                "declarator",
+                "name",
+            ),
+            "sh" | "bash" => Self::new("function_definition", "", "name", "name"),
+            _ => Self::new("", "", "", ""),
+        }
+    }
+
+    fn new(
+        func_type: &'static str,
+        class_type: &'static str,
+        func_name_field: &'static str,
+        class_name_field: &'static str,
+    ) -> Self {
+        Self {
+            func_type,
+            class_type,
+            func_name_field,
+            class_name_field,
+        }
+    }
+}
+
 fn get_language(extension: &str) -> Result<tree_sitter::Language> {
     match extension {
         "rs" => Ok(tree_sitter_rust::LANGUAGE.into()),
-        "py" => Ok(tree_sitter_python::LANGUAGE.into()),
-        "js" => Ok(tree_sitter_javascript::LANGUAGE.into()),
-        "ts" => Ok(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "py" | "pyi" | "pyw" => Ok(tree_sitter_python::LANGUAGE.into()),
+        "js" | "jsx" | "mjs" | "cjs" => Ok(tree_sitter_javascript::LANGUAGE.into()),
+        "ts" | "mts" | "cts" => Ok(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        "tsx" => Ok(tree_sitter_typescript::LANGUAGE_TSX.into()),
+        "go" => Ok(tree_sitter_go::LANGUAGE.into()),
+        "java" => Ok(tree_sitter_java::LANGUAGE.into()),
+        "c" | "h" => Ok(tree_sitter_c::LANGUAGE.into()),
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => Ok(tree_sitter_cpp::LANGUAGE.into()),
+        "sh" | "bash" => Ok(tree_sitter_bash::LANGUAGE.into()),
         _ => Err(anyhow::anyhow!(
-            "Unsupported file type '.{extension}'. Supports: .rs, .py, .js, .ts"
+            "Unsupported file type '.{extension}'. Supports: .rs, .py, .pyi, .pyw, \
+             .js, .jsx, .mjs, .cjs, .ts, .mts, .cts, .tsx, .go, .java, \
+             .c, .h, .cpp, .cc, .cxx, .hpp, .hh, .sh, .bash"
         )),
     }
 }
@@ -63,25 +117,11 @@ fn analyze_file_structure(
     let mut output = String::from("### AST Structure Summary\n\n");
     let mut cursor = tree.root_node().walk();
 
-    let (func_type, class_type, name_field) = match extension {
-        "rs" => ("function_item", "struct_item", "name"),
-        "py" => ("function_definition", "class_definition", "name"),
-        "js" | "ts" => ("function_declaration", "class_declaration", "name"),
-        _ => ("", "", ""),
-    };
-
+    let types = LangNodeTypes::for_extension(extension);
     let mut funcs = Vec::new();
     let mut classes = Vec::new();
 
-    traverse_structure(
-        &mut cursor,
-        source,
-        func_type,
-        class_type,
-        name_field,
-        &mut funcs,
-        &mut classes,
-    );
+    traverse_structure(&mut cursor, source, &types, &mut funcs, &mut classes);
 
     if !classes.is_empty() {
         output.push_str("**Classes / Structs:**\n");
@@ -105,26 +145,26 @@ fn analyze_file_structure(
 fn traverse_structure(
     cursor: &mut tree_sitter::TreeCursor,
     source: &[u8],
-    func_type: &str,
-    class_type: &str,
-    name_field: &str,
+    types: &LangNodeTypes,
     funcs: &mut Vec<String>,
     classes: &mut Vec<String>,
 ) {
     let node = cursor.node();
     let kind = node.kind();
 
-    if kind == func_type {
-        if let Some(name_node) = node.child_by_field_name(name_field)
+    if kind == types.func_type {
+        if let Some(name_node) = node.child_by_field_name(types.func_name_field)
             && let Ok(name) = std::str::from_utf8(&source[name_node.byte_range()])
         {
+            // For C/C++ declarator, strip parameter list
+            let clean_name = name.split('(').next().unwrap_or(name).trim();
             funcs.push(format!(
-                "- `{name}` (Line {})",
+                "- `{clean_name}` (Line {})",
                 name_node.start_position().row + 1
             ));
         }
-    } else if kind == class_type
-        && let Some(name_node) = node.child_by_field_name(name_field)
+    } else if kind == types.class_type
+        && let Some(name_node) = node.child_by_field_name(types.class_name_field)
         && let Ok(name) = std::str::from_utf8(&source[name_node.byte_range()])
     {
         classes.push(format!(
@@ -134,13 +174,9 @@ fn traverse_structure(
     }
 
     if cursor.goto_first_child() {
-        traverse_structure(
-            cursor, source, func_type, class_type, name_field, funcs, classes,
-        );
+        traverse_structure(cursor, source, types, funcs, classes);
         while cursor.goto_next_sibling() {
-            traverse_structure(
-                cursor, source, func_type, class_type, name_field, funcs, classes,
-            );
+            traverse_structure(cursor, source, types, funcs, classes);
         }
         cursor.goto_parent();
     }
@@ -199,9 +235,18 @@ fn walk_call_graph(
     let mut next_caller = current_caller.clone();
 
     // Detect function definitions
-    let is_func = (extension == "rs" && kind == "function_item")
-        || (extension == "py" && kind == "function_definition")
-        || ((extension == "js" || extension == "ts") && kind == "function_declaration");
+    let is_func = match extension {
+        "rs" => kind == "function_item",
+        "py" | "pyi" | "pyw" => kind == "function_definition",
+        "js" | "jsx" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" => {
+            kind == "function_declaration"
+        }
+        "go" => kind == "function_declaration",
+        "java" => kind == "method_declaration",
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" => kind == "function_definition",
+        "sh" | "bash" => kind == "function_definition",
+        _ => false,
+    };
 
     if is_func
         && let Some(name_node) = node.child_by_field_name("name")
@@ -214,10 +259,33 @@ fn walk_call_graph(
             .or_insert_with(|| graph.add_node(name_str));
     }
 
+    // For C/C++ the function name is in the "declarator" field
+    if is_func
+        && matches!(extension, "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh")
+        && let Some(decl_node) = node.child_by_field_name("declarator")
+        && let Ok(name) = std::str::from_utf8(&source[decl_node.byte_range()])
+    {
+        // Strip parameter list if present (e.g. "main(int argc, ...)" -> "main")
+        let name_str = name.split('(').next().unwrap_or(name).trim().to_string();
+        if !name_str.is_empty() {
+            next_caller = Some(name_str.clone());
+            node_indices
+                .entry(name_str.clone())
+                .or_insert_with(|| graph.add_node(name_str));
+        }
+    }
+
     // Detect function calls
-    let is_call = (extension == "rs" && kind == "call_expression")
-        || (extension == "py" && kind == "call")
-        || ((extension == "js" || extension == "ts") && kind == "call_expression");
+    let is_call = match extension {
+        "rs" => kind == "call_expression",
+        "py" | "pyi" | "pyw" => kind == "call",
+        "js" | "jsx" | "mjs" | "cjs" | "ts" | "mts" | "cts" | "tsx" => kind == "call_expression",
+        "go" => kind == "call_expression",
+        "java" => kind == "method_invocation",
+        "c" | "h" | "cpp" | "cc" | "cxx" | "hpp" | "hh" => kind == "call_expression",
+        "sh" | "bash" => kind == "command",
+        _ => false,
+    };
 
     if let Some(caller) = &current_caller
         && is_call
@@ -314,8 +382,8 @@ mod tests {
 
     #[test]
     fn test_unsupported_extension() {
-        let mut tmp = tempfile::NamedTempFile::with_suffix(".go").unwrap();
-        write!(tmp, "package main").unwrap();
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".xyz").unwrap();
+        write!(tmp, "some random content").unwrap();
         let result = analyze_file(tmp.path());
         assert!(result.is_err());
     }
@@ -328,6 +396,100 @@ mod tests {
         assert!(
             result.contains("helper"),
             "Should find helper as callee: {result}"
+        );
+    }
+
+    #[test]
+    fn test_analyze_go_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".go").unwrap();
+        write!(tmp, "package main\n\nfunc main() {{}}\nfunc helper() {{}}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("main"), "Should find main: {result}");
+        assert!(result.contains("helper"), "Should find helper: {result}");
+    }
+
+    #[test]
+    fn test_analyze_java_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".java").unwrap();
+        write!(
+            tmp,
+            "public class Main {{\n  public void hello() {{}}\n  public void world() {{}}\n}}"
+        )
+        .unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("Main"), "Should find class Main: {result}");
+        assert!(result.contains("hello"), "Should find hello: {result}");
+        assert!(result.contains("world"), "Should find world: {result}");
+    }
+
+    #[test]
+    fn test_analyze_c_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".c").unwrap();
+        write!(tmp, "int main() {{ return 0; }}\nvoid helper() {{}}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("main"), "Should find main: {result}");
+        assert!(result.contains("helper"), "Should find helper: {result}");
+    }
+
+    #[test]
+    fn test_analyze_cpp_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".cpp").unwrap();
+        write!(
+            tmp,
+            "struct Config {{\n  int x;\n}};\nint main() {{ return 0; }}"
+        )
+        .unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(
+            result.contains("Config"),
+            "Should find struct Config: {result}"
+        );
+        assert!(result.contains("main"), "Should find main: {result}");
+    }
+
+    #[test]
+    fn test_analyze_bash_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".sh").unwrap();
+        write!(tmp, "#!/bin/bash\nmy_func() {{\n  echo hello\n}}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("my_func"), "Should find my_func: {result}");
+    }
+
+    #[test]
+    fn test_analyze_jsx_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".jsx").unwrap();
+        write!(tmp, "function App() {{ return null; }}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("App"), "Should find App: {result}");
+    }
+
+    #[test]
+    fn test_analyze_tsx_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".tsx").unwrap();
+        write!(tmp, "function Widget() {{ return null; }}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(result.contains("Widget"), "Should find Widget: {result}");
+    }
+
+    #[test]
+    fn test_analyze_pyi_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".pyi").unwrap();
+        write!(tmp, "def stub_func() -> None: ...").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(
+            result.contains("stub_func"),
+            "Should find stub_func: {result}"
+        );
+    }
+
+    #[test]
+    fn test_analyze_mjs_file() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".mjs").unwrap();
+        write!(tmp, "function esModule() {{}}").unwrap();
+        let result = analyze_file(tmp.path()).unwrap();
+        assert!(
+            result.contains("esModule"),
+            "Should find esModule: {result}"
         );
     }
 }

--- a/koda-ast/src/main.rs
+++ b/koda-ast/src/main.rs
@@ -49,8 +49,9 @@ impl ServerHandler for AstServer {
         let mut info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build());
         info.server_info = Implementation::new("koda-ast", env!("CARGO_PKG_VERSION"));
         info.instructions = Some(
-            "AST analysis server for Rust, Python, JavaScript, and TypeScript. \
-             Use AstAnalysis tool with action 'analyze_file' or 'get_call_graph'."
+            "AST analysis server for Rust, Python, JavaScript, TypeScript, Go, Java, \
+             C/C++, and Bash. Use AstAnalysis tool with action 'analyze_file' or \
+             'get_call_graph'."
                 .to_string(),
         );
         info
@@ -62,7 +63,7 @@ impl AstServer {
     /// Read-only AST code analysis for Rust, Python, JavaScript, TypeScript.
     #[tool(
         name = "AstAnalysis",
-        description = "Read-only AST code analysis. Use 'analyze_file' for functions/classes/structs summary, or 'get_call_graph' with a symbol name to find callers and callees. Supports .rs, .py, .js, .ts files."
+        description = "Read-only AST code analysis. Use 'analyze_file' for functions/classes/structs summary, or 'get_call_graph' with a symbol name to find callers and callees. Supports .rs, .py, .pyi, .pyw, .js, .jsx, .mjs, .cjs, .ts, .mts, .cts, .tsx, .go, .java, .c, .h, .cpp, .cc, .cxx, .hpp, .hh, .sh, .bash files."
     )]
     async fn ast_analysis(
         &self,


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #164 — expanding `koda-ast` language support.

### What changed

**New Tier 1 languages:**
| Language | Crate | Version |
|----------|-------|---------|
| Go | `tree-sitter-go` | 0.23.4 |
| Java | `tree-sitter-java` | 0.23.5 |
| C | `tree-sitter-c` | 0.24.1 |
| C++ | `tree-sitter-cpp` | 0.23.4 |
| Bash | `tree-sitter-bash` | 0.23.3 |

**Fixed missing file extensions:**
- `.jsx`, `.mjs`, `.cjs` → JavaScript
- `.tsx` → TypeScript TSX (uses `LANGUAGE_TSX`)
- `.mts`, `.cts` → TypeScript
- `.pyi`, `.pyw` → Python

**Code changes:**
- `get_language()` — expanded extension → grammar mapping
- `analyze_file_structure()` — added node type mappings per language; refactored to use separate `func_name_field`/`class_name_field` (needed for C/C++ where functions use `declarator` but structs use `name`)
- `walk_call_graph()` — expanded function definition and call expression detection for all new languages; added C/C++ declarator handling
- Updated MCP server description to list all supported file types

**Tests:** 13 unit tests + 4 integration tests all pass. Added tests for Go, Java, C, C++, Bash, JSX, TSX, `.pyi`, and `.mjs`.

### What's NOT in this PR (future phases per #164)
- Tier 2 languages (Ruby, PHP, Kotlin, Swift, Scala)
- Method extraction within classes
- Import/dependency analysis
- Multi-file analysis
- Cargo features for optional grammars

Closes #164