### PR TITLE
docs: comprehensive v0.1.3 documentation — README, DESIGN, CHANGELOG, CLAUDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-03-06
+
+### Added
+- **Model-adaptive architecture** — `ModelTier` enum (Strong/Standard/Lite) auto-detected from model name + provider ([#158](https://github.com/lijunzh/koda/issues/158))
+  - Strong: minimal prompts, lazy tool loading, parallel execution, 90% auto-compact
+  - Standard: full prompts, all tools, 80% auto-compact (backward compatible)
+  - Lite: verbose prompts, sequential execution, 70% auto-compact, 50 iteration cap
+  - CLI override: `--model-tier strong|standard|lite`
+  - Agent config: `"model_tier": "strong"` in JSON
+  - Displayed in status bar: `claude-sonnet-4-6 [Strong]`
+- **Context window auto-detection** — maps model name to actual context size ([#149](https://github.com/lijunzh/koda/issues/149))
+  - Opus: 32K → 200K, Gemini 2.5: 32K → 1M, GPT-4o: 32K → 128K
+  - Eliminates premature compaction (Opus was using 16% of available context)
+- **Rate limit retry** — exponential backoff (2/4/8/16/32s) for 429 errors, up to 5 retries
+- **DiscoverTools** tool — on-demand tool schema injection by category ([#154](https://github.com/lijunzh/koda/issues/154))
+  - Strong tier loads 9 core tools + DiscoverTools (~850 tokens vs ~2000)
+  - 57% reduction in per-turn tool overhead for Strong tier
+- **RecallContext** tool — search or recall older conversation turns from history
+- **Task phase state machine** — auto-detects Understanding → Planning → Executing → Verifying → Reporting ([#156](https://github.com/lijunzh/koda/issues/156))
+- **Intent classifier** — rule-based task classification with agent/skill suggestions (zero LLM cost)
+- **Built-in scout agent** — read-only codebase explorer (Read, List, Grep, Glob), max 10 iterations
+- **Built-in planner agent** — strategic task decomposition (read-only), max 5 iterations
+- **Built-in verifier agent** — quality verification (Bash, Read, Grep), max 8 iterations
+- **Sub-agent model routing** — sub-agents respect their own provider/model when explicitly set ([#159](https://github.com/lijunzh/koda/issues/159))
+- **Plan-before-execute** — system prompt instructs planning for >3-step tasks
+- **koda-email MCP server** — email read/send/search via IMAP/SMTP (any provider)
+
+### Fixed
+- **Thinking tokens in cost** — now included at output rate (Opus was underreporting by 2-3x)
+- **Token estimation** — calibrated chars/3.5 heuristic (was chars/4)
+- **`__INVOKE_AGENT__` sentinel removed** — no more magic strings ([#122](https://github.com/lijunzh/koda/issues/122))
+
+### Testing
+- 489 tests across 4 crates (up from 284 in v0.1.2)
+
 ## [0.1.2] - 2026-03-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,16 @@ koda/
 │   │   ├── keystore.rs     # Secure API key storage (~/.config/koda/keys.toml, 0600)
 │   │   ├── loop_guard.rs   # Loop detection + iteration hard-cap
 │   │   ├── memory.rs       # Semantic memory (global + project tiers → system prompt)
+│   │   ├── model_context.rs# Model → context window size lookup table
+│   │   ├── model_tier.rs   # ModelTier enum (Strong/Standard/Lite) + auto-detection
+│   │   ├── intent.rs       # Rule-based intent classifier (task → agent/skill)
+│   │   ├── task_phase.rs   # Task phase state machine (Understanding→Verifying)
 │   │   ├── preview.rs      # Pre-confirmation diff previews for Edit/Write
 │   │   ├── runtime_env.rs  # Thread-safe runtime env for API keys
 │   │   ├── version.rs      # Background version checker (queries crates.io)
 │   │   ├── engine/         # EngineEvent, EngineCommand, EngineSink trait
 │   │   ├── providers/      # LLM providers (Anthropic, Gemini, OpenAI-compat, mock)
-│   │   ├── tools/          # Built-in tools (Bash, Read, Write, Edit, etc.)
+│   │   ├── tools/          # Built-in tools (Bash, Read, Write, Edit, DiscoverTools, RecallContext, etc.)
 │   │   ├── mcp/            # MCP client (registry, config, capability_registry)
 │   │   ├── db.rs           # SQLite persistence (WAL mode, parameterized queries)
 │   │   └── config.rs       # Agent/provider config

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -116,16 +116,66 @@ not via a `Tool` trait with dynamic dispatch.
 **Rationale**: Rust's exhaustive matching catches missing tool handlers at compile
 time — adding a tool without a match arm is a compile error. A `HashMap<String, Box<dyn Tool>>`
 would move this to a runtime error. The match statement works well at the current
-scale (~15 tools).
+scale (~20 tools).
 
-**Known tech debt**: Three tools (`InvokeAgent`, `TodoWrite`, `TodoRead`) return
-sentinel strings (`"__INVOKE_AGENT__"`) because they need DB/session access that
-the registry doesn't have. A `ToolContext` struct would fix this. Tracked in
-[#122](https://github.com/lijunzh/koda/issues/122).
+**v0.1.3 update**: The `__INVOKE_AGENT__` sentinel was removed. InvokeAgent is now
+handled at the dispatch level (`tool_dispatch.rs`) before reaching the registry.
+RecallContext uses an optional `db` + `session_id` on the ToolRegistry, set via
+`.with_session()`. No more sentinel strings anywhere.
 
 **Future trigger**: When tool additions become frequent enough that editing 3
 locations per tool (definitions, match arm, module import) is a bottleneck,
 convert to a `Tool` trait + `ToolContext`. Do both together, not piecemeal.
+
+### 8. Model-Adaptive Architecture (v0.1.3)
+
+**Decision**: Koda classifies models into three tiers (Strong/Standard/Lite)
+and adapts system prompts, tool loading, loop limits, and parallel execution
+accordingly.
+
+**Rationale**: One-size-fits-all wastes tokens on strong models (verbose prompts
+they don't need) and confuses weak models (terse instructions they can't follow).
+The tiered system adapts automatically.
+
+**How it works**:
+- `ModelTier::from_model_name()` auto-detects from model name + provider
+- `build_system_prompt_tiered()` adjusts verbosity per tier
+- `get_definitions_tiered()` loads core-only tools for Strong (+ DiscoverTools)
+- `ModelTier::allows_parallel_tools()` gates parallel execution
+- CLI `--model-tier` flag and agent JSON `"model_tier"` field for overrides
+
+**Key constraint**: The system prompt must be stable within a session to preserve
+Anthropic prompt cache hit rates. Tier is determined at session start, not per-turn.
+
+### 9. Context Window Auto-Detection (v0.1.3)
+
+**Decision**: `model_context.rs` maps model names to context window sizes.
+No API call required — pure lookup table.
+
+**Rationale**: The previous hardcoded 32K default meant Opus users were using
+16% of their available context, triggering premature compaction. Auto-detection
+is the single highest-impact change in v0.1.3.
+
+### 10. Lazy Tool Loading with DiscoverTools (v0.1.3)
+
+**Decision**: Strong-tier models get only 9 tools upfront. Everything else is
+discoverable on demand by category.
+
+**Rationale**: 20+ tool schemas cost ~2000 tokens/turn. Core tools handle 90%+
+of turns. DiscoverTools costs ~50 tokens for the schema + ~80 for category hints.
+Net savings: ~57% reduction in per-turn tool overhead for Strong tier.
+
+### 11. Rate Limit Retry (v0.1.3)
+
+**Decision**: Exponential backoff retry for 429/rate-limit errors. Up to 5
+attempts with delays of 2, 4, 8, 16, 32 seconds.
+
+### 12. Sub-Agent Model Routing (v0.1.3)
+
+**Decision**: Sub-agents respect their own provider/model config when
+explicitly set. The parent's base_url is only inherited if the sub-agent
+uses the same provider. This enables cheap models for grunt work while
+expensive models handle reasoning.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -42,26 +42,30 @@ On first run, an onboarding wizard guides you through provider and API key setup
 ```bash
 koda                              # Interactive REPL (auto-detects LM Studio)
 koda --provider anthropic         # Use a cloud provider
+koda --model-tier strong          # Override auto-detected tier
 koda -p "fix the bug in auth.rs"  # Headless one-shot
 echo "explain this" | koda        # Piped input
 ```
 
 ## Features
 
-- **17 built-in tools** — file ops, search, shell, web fetch, memory, agents, task tracking, AST analysis
+- **20+ built-in tools** — file ops, search, shell, web fetch, memory, agents, AST analysis, email, context recall
 - **MCP support** — connect to any [MCP server](https://modelcontextprotocol.io) via `.mcp.json` (same format as Claude Code / Cursor)
-- **6 LLM providers** — LM Studio, OpenAI, Anthropic, Gemini, Groq, Grok
-- **5 embedded agents** — default, code reviewer, security auditor, test writer, release engineer
+- **14 LLM providers** — LM Studio, OpenAI, Anthropic, Gemini, Groq, Grok, Ollama, DeepSeek, Mistral, MiniMax, OpenRouter, Together, Fireworks, vLLM
+- **6 built-in agents** — default, test writer, release engineer, codebase scout, planner, verifier
+- **Model-adaptive** — auto-detects model tier (Strong/Standard/Lite) and adjusts prompts, tool loading, and parameters
+- **Lazy tool loading** — Strong models get 9 core tools; discover more on demand via `DiscoverTools`
+- **Smart context** — auto-detects context window (200K for Opus, 1M for Gemini), rate limit retry with backoff, auto-compact
 - **Approval modes** — plan (read-only) / normal (smart confirm) / yolo (auto-approve) via `/trust`
 - **Diff preview** — see exactly what changes before approving Edit, Write, Delete
 - **Loop detection** — catches repeated tool calls with configurable iteration caps
 - **Parallel execution** — concurrent tool calls and sub-agent orchestration
-- **Smart context** — auto-compact (configurable threshold), sliding window, prompt caching (Anthropic)
 - **Extended thinking** — structured thinking block display with configurable budgets
 - **Image analysis** — `@image.png` or drag-and-drop for multi-modal input
 - **Git integration** — `/diff` review, commit message generation
 - **Headless mode** — `koda -p "prompt"` with JSON output for CI/CD
 - **Persistent memory** — project (`MEMORY.md`) and global (`~/.config/koda/memory.md`)
+- **Cost tracking** — per-turn and per-session cost estimation including thinking tokens
 
 ### 🌳 AST Code Analysis
 
@@ -130,16 +134,90 @@ User-level servers go in `~/.config/koda/mcp.json` (merged, project overrides).
 
 ## Architecture
 
-Koda is a Cargo workspace with two crates:
+Koda is a Cargo workspace with four crates:
 
 ```
 koda/
-├── koda-core/    # Engine library (providers, tools, inference, DB) — zero terminal deps
-└── koda-cli/     # CLI binary (REPL, display, approval UI)
+├── koda-core/     # Engine library (providers, tools, inference, DB) — zero terminal deps
+├── koda-cli/      # CLI binary (REPL, display, approval UI)
+├── koda-ast/      # MCP server: tree-sitter AST analysis
+└── koda-email/    # MCP server: email via IMAP/SMTP
 ```
 
 The engine communicates through `EngineEvent` (output) and `EngineCommand` (input) enums
 over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
+
+### Model-Adaptive Architecture
+
+Koda auto-detects your model's capabilities and adapts its behavior:
+
+| Tier | Models | Behavior |
+|------|--------|----------|
+| **Strong** | Opus, Sonnet, GPT-4o, o-series, Gemini 2.5 Pro | Minimal prompts, lazy tool loading, parallel execution |
+| **Standard** | Flash, DeepSeek, Mistral Large, Llama 70B | Full prompts, all tools, balanced |
+| **Lite** | Local models, 7B/8B, Flash Lite | Verbose prompts, sequential execution, lower loop caps |
+
+Override with `--model-tier strong|standard|lite` or `"model_tier": "strong"` in agent config.
+
+## Getting the Most Out of Koda
+
+### Use the right model tier
+
+Koda auto-detects your model's tier, but you can override it:
+
+```bash
+koda --model-tier strong    # Minimal prompts, lazy tools (saves ~57% token overhead)
+koda --model-tier lite      # Verbose prompts, step-by-step guidance for small models
+```
+
+The status bar shows your current tier: `claude-sonnet-4-6 [Strong]`
+
+### Delegate with sub-agents
+
+Koda ships with specialized agents. Use them for focused tasks:
+
+| Agent | Purpose | Tools |
+|-------|---------|-------|
+| **scout** | Codebase exploration (read-only) | Read, List, Grep, Glob |
+| **testgen** | Test generation | All tools |
+| **planner** | Task decomposition (read-only) | Read, List, Grep, Glob |
+| **verifier** | Quality verification | Read, Grep, Bash |
+| **releaser** | Release engineering | All tools |
+
+Koda's intent classifier suggests agents automatically: "find all uses of X" → scout, "write tests" → testgen.
+
+Sub-agents can run on different models for cost optimization:
+```json
+// agents/scout.json — use cheap model for exploration
+{
+  "name": "scout",
+  "provider": "gemini",
+  "model": "gemini-2.5-flash",
+  "allowed_tools": ["Read", "List", "Grep", "Glob"],
+  "max_iterations": 10
+}
+```
+
+### Context window management
+
+Koda auto-detects your model's context window and manages it:
+
+| Model | Context | Auto-compact at |
+|-------|---------|----------------|
+| Claude Opus/Sonnet | 200K tokens | 90% (Strong) |
+| Gemini 2.5 | 1M tokens | 80% (Standard) |
+| GPT-4o | 128K tokens | 90% (Strong) |
+| Local models | 4K–128K | 70% (Lite) |
+
+Use `/compact` manually, or let auto-compact handle it. The `/cost` command shows token usage and estimated cost.
+
+### Save tokens with DiscoverTools
+
+Strong-tier models load only core tools (Read, Write, Edit, etc.) by default. When the model needs agents, skills, or other capabilities, it calls `DiscoverTools` to load them on demand — saving ~57% per-turn tool overhead.
+
+### Recall older context
+
+If context was dropped from the sliding window, the model can use `RecallContext` to search or retrieve specific turns from conversation history.
 
 ## Documentation
 
@@ -151,7 +229,7 @@ over async channels. See [DESIGN.md](DESIGN.md) for architectural decisions.
 ## Development
 
 ```bash
-cargo test --workspace --features koda-core/test-support  # Run all 284 tests
+cargo test --workspace --features koda-core/test-support  # Run all 489 tests
 cargo clippy --workspace      # Lint
 cargo run -p koda-cli         # Run locally
 ```

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -5,7 +5,7 @@ Refer to this when the user asks "what can you do?" or about features.
 ### Commands (user types these in the REPL)
 
 /help — command palette | /agent — list sub-agents | /compact — reclaim context
-/cost — token usage | /diff — git diff/review/commit | /expand — show full tool output
+/cost — token usage & cost | /diff — git diff/review/commit | /expand — show full tool output
 /mcp — MCP server management | /memory — persistent memory | /model — switch model
 /provider — switch provider | /sessions — resume/delete sessions (interactive picker)
 /trust — plan/normal/yolo | /verbose — toggle full tool output | /exit — quit
@@ -15,6 +15,21 @@ Refer to this when the user asks "what can you do?" or about features.
 - `@file.rs` attaches file context, `@image.png` for multi-modal analysis
 - Piped input: `echo "explain" | koda` or `koda -p "prompt"` for headless/CI
 
+### Model Tiers
+
+Koda auto-adapts to your model. Override with `--model-tier strong|standard|lite`.
+- Strong (Opus, GPT-4o): minimal prompts, lazy tools, parallel execution
+- Standard (Flash, Mistral): full prompts, all tools
+- Lite (local models): verbose prompts, step-by-step, sequential
+
+### Built-in Agents
+
+- **scout** — read-only codebase exploration
+- **testgen** — test generation
+- **planner** — task decomposition
+- **verifier** — quality verification
+- **releaser** — release engineering
+
 ### Memory
 
 - Project: `MEMORY.md` (also reads `CLAUDE.md`, `AGENTS.md`) | Global: `~/.config/koda/memory.md`
@@ -23,3 +38,4 @@ Refer to this when the user asks "what can you do?" or about features.
 
 External tool servers configured in `.mcp.json` (project) or `~/.config/koda/mcp.json` (global).
 MCP tools appear with namespaced names like `github.create_issue`.
+Auto-provisioned: `koda-ast` (AST analysis), `koda-email` (email via IMAP/SMTP).


### PR DESCRIPTION
Full documentation update so users know how to take advantage of v0.1.3.

### For users (README):
- **'Getting the Most Out of Koda'** section with practical guidance on model tiers, sub-agent delegation, context management, and token savings
- Updated feature list, architecture diagram, and test count

### For developers (DESIGN):
- 6 new architectural decision records (#8-#12) covering ModelTier, context auto-detection, DiscoverTools, rate limit retry, and model routing

### For the agent itself (capabilities.md):
- Koda can now explain model tiers, list built-in agents, and describe auto-provisioned MCP servers when asked 'what can you do?'

All 489 tests pass.