### PR TITLE
feat: query model capabilities from provider API (fixes #185, Gemini truncation)

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -269,6 +269,27 @@ pub async fn run(
         }
     }
 
+    // Query actual model capabilities from the provider API.
+    // This overrides the hardcoded context window with the real value.
+    if config.model != "(no model loaded)" && config.model != "(connection failed)" {
+        let prov = provider.read().await;
+        match prov.model_capabilities(&config.model).await {
+            Ok(caps) if caps.context_window.is_some() || caps.max_output_tokens.is_some() => {
+                config.apply_provider_capabilities(&caps);
+            }
+            Ok(_) => {
+                tracing::debug!(
+                    "Provider did not report capabilities for {}; using lookup table ({}k tokens)",
+                    config.model,
+                    config.max_context_tokens / 1000
+                );
+            }
+            Err(e) => {
+                tracing::debug!("Could not query model capabilities: {e:#}");
+            }
+        }
+    }
+
     // Print banner BEFORE entering raw mode
     let recent = db.recent_user_messages(3).await.unwrap_or_default();
     repl::print_banner(&config, &session_id, &recent);

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -59,6 +59,13 @@ pub async fn handle_slash_command(
             config.model = model.clone();
             config.model_settings.model = model.clone();
             config.recalculate_model_derived();
+            // Query actual capabilities from the API
+            {
+                let prov = provider.read().await;
+                if let Ok(caps) = prov.model_capabilities(&model).await {
+                    config.apply_provider_capabilities(&caps);
+                }
+            }
             crate::tui_wizards::save_provider(config);
             ok_msg(format!("Model set to: {model}"));
             SlashAction::Continue
@@ -212,6 +219,13 @@ async fn handle_pick_model(
                     config.model = models[idx].id.clone();
                     config.model_settings.model = config.model.clone();
                     config.recalculate_model_derived();
+                    // Query actual capabilities from the API (re-acquire lock)
+                    {
+                        let prov = provider.read().await;
+                        if let Ok(caps) = prov.model_capabilities(&config.model).await {
+                            config.apply_provider_capabilities(&caps);
+                        }
+                    }
                     crate::tui_wizards::save_provider(config);
                     ok_msg(format!("Model set to: {}", config.model));
                 }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -142,6 +142,10 @@ pub(crate) async fn handle_setup_provider(
                 config.model_settings.model = config.model.clone();
                 config.recalculate_model_derived();
             }
+            // Query actual capabilities from the API
+            if let Ok(caps) = prov.model_capabilities(&config.model).await {
+                config.apply_provider_capabilities(&caps);
+            }
             ok_msg("Connection verified! Available models:".into());
             for m in &models {
                 let marker = if m.id == config.model {

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -452,6 +452,8 @@ impl KodaConfig {
     ///
     /// Call this whenever `self.model` or `self.provider_type` changes to keep
     /// context window, tier, and iteration defaults in sync with the new model.
+    /// Uses the hardcoded lookup table as a synchronous fallback.
+    /// For API-sourced values, call `apply_provider_capabilities` after this.
     pub fn recalculate_model_derived(&mut self) {
         let new_ctx = crate::model_context::context_window_for_model(&self.model);
         self.max_context_tokens = new_ctx;
@@ -460,6 +462,26 @@ impl KodaConfig {
         self.model_tier = ModelTier::from_model_name(&self.model, &self.provider_type);
         self.max_iterations = self.model_tier.default_max_iterations();
         self.auto_compact_threshold = self.model_tier.default_auto_compact_threshold();
+    }
+
+    /// Apply capabilities queried from the provider API.
+    ///
+    /// Overrides the hardcoded context window and max output tokens with
+    /// values reported by the provider. Call this after `recalculate_model_derived`
+    /// when you have access to the provider.
+    pub fn apply_provider_capabilities(&mut self, caps: &crate::providers::ModelCapabilities) {
+        if let Some(ctx) = caps.context_window {
+            self.max_context_tokens = ctx;
+            self.model_settings.max_context_tokens = ctx;
+            tracing::info!("Context window from API: {} tokens for {}", ctx, self.model);
+        }
+        if let Some(max_out) = caps.max_output_tokens {
+            // Only override if not explicitly set by the user/agent config
+            if self.model_settings.max_tokens.is_none() {
+                self.model_settings.max_tokens = Some(max_out as u32);
+                tracing::info!("Max output tokens from API: {} for {}", max_out, self.model);
+            }
+        }
     }
 
     /// Built-in agent configs, embedded at compile time.

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -9,8 +9,8 @@
 //! - SSE streaming via `streamGenerateContent?alt=sse`
 
 use super::{
-    ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, TokenUsage, ToolCall,
-    ToolDefinition,
+    ChatMessage, LlmProvider, LlmResponse, ModelCapabilities, ModelInfo, StreamChunk, TokenUsage,
+    ToolCall, ToolDefinition,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -253,6 +253,12 @@ struct GeminiModelInfo {
     name: String,
     #[serde(default)]
     supported_generation_methods: Vec<String>,
+    /// Max input tokens (reported by the Gemini models API).
+    #[serde(default)]
+    input_token_limit: Option<usize>,
+    /// Max output tokens (reported by the Gemini models API).
+    #[serde(default)]
+    output_token_limit: Option<usize>,
 }
 
 // ── Implementation ───────────────────────────────────────────
@@ -352,6 +358,34 @@ impl LlmProvider for GeminiProvider {
 
     fn provider_name(&self) -> &str {
         "gemini"
+    }
+
+    async fn model_capabilities(&self, model: &str) -> Result<ModelCapabilities> {
+        let resp = self
+            .client
+            .get(format!(
+                "{}/v1beta/models/{}?key={}",
+                self.base_url, model, self.api_key
+            ))
+            .send()
+            .await
+            .context("Failed to query Gemini model info")?;
+
+        if !resp.status().is_success() {
+            return Ok(ModelCapabilities::default());
+        }
+
+        let info: GeminiModelInfo = resp.json().await.unwrap_or(GeminiModelInfo {
+            name: model.to_string(),
+            supported_generation_methods: vec![],
+            input_token_limit: None,
+            output_token_limit: None,
+        });
+
+        Ok(ModelCapabilities {
+            context_window: info.input_token_limit,
+            max_output_tokens: info.output_token_limit,
+        })
     }
 
     async fn chat_stream(

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -98,6 +98,15 @@ pub struct ModelInfo {
     pub owned_by: Option<String>,
 }
 
+/// Model capabilities queried from the provider API.
+#[derive(Debug, Clone, Default)]
+pub struct ModelCapabilities {
+    /// Maximum context window in tokens (input + output).
+    pub context_window: Option<usize>,
+    /// Maximum output tokens the model supports.
+    pub max_output_tokens: Option<usize>,
+}
+
 /// Build a reqwest client with proper proxy configuration.
 ///
 /// - Reads HTTPS_PROXY / HTTP_PROXY from env
@@ -188,6 +197,15 @@ pub trait LlmProvider: Send + Sync {
 
     /// List available models from the provider.
     async fn list_models(&self) -> Result<Vec<ModelInfo>>;
+
+    /// Query model capabilities (context window, max output tokens) from the API.
+    ///
+    /// Returns `Ok(caps)` with whatever the provider reports. Fields are `None`
+    /// when the API doesn't expose them. Callers should fall back to the
+    /// hardcoded lookup table for any `None` fields.
+    async fn model_capabilities(&self, _model: &str) -> Result<ModelCapabilities> {
+        Ok(ModelCapabilities::default())
+    }
 
     /// Provider display name (for UI).
     fn provider_name(&self) -> &str;

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -496,8 +496,56 @@ impl LlmProvider for OpenAiCompatProvider {
     fn provider_name(&self) -> &str {
         "openai-compat"
     }
+
+    async fn model_capabilities(&self, model: &str) -> Result<super::ModelCapabilities> {
+        // Try LM Studio / Ollama extended endpoint first (/api/v0/models)
+        // which returns max_context_length per model.
+        let base = self.base_url.trim_end_matches("/v1");
+        if let Ok(caps) = self.query_local_capabilities(base, model).await
+            && caps.context_window.is_some()
+        {
+            return Ok(caps);
+        }
+        Ok(super::ModelCapabilities::default())
+    }
 }
 
+impl OpenAiCompatProvider {
+    /// Query LM Studio / Ollama extended model info for context window.
+    async fn query_local_capabilities(
+        &self,
+        base: &str,
+        model: &str,
+    ) -> Result<super::ModelCapabilities> {
+        let resp = self
+            .client
+            .get(format!("{base}/api/v0/models"))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Ok(super::ModelCapabilities::default());
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+        let models = body["data"].as_array();
+
+        if let Some(models) = models {
+            for m in models {
+                let id = m["id"].as_str().unwrap_or_default();
+                if id == model {
+                    let ctx = m["max_context_length"].as_u64().map(|v| v as usize);
+                    return Ok(super::ModelCapabilities {
+                        context_window: ctx,
+                        max_output_tokens: None,
+                    });
+                }
+            }
+        }
+
+        Ok(super::ModelCapabilities::default())
+    }
+}
 /// Convert OpenAI usage response to our TokenUsage, extracting reasoning_tokens.
 fn usage_from_response(u: &UsageResponse) -> TokenUsage {
     TokenUsage {


### PR DESCRIPTION
## Summary

Fixes #185 and Gemini output truncation.

Instead of guessing context windows from model names via a hardcoded lookup table, koda now **queries the provider API** for actual model capabilities. The lookup table remains as a synchronous fallback.

## Problem

1. **LM Studio**: User set context to 262,144 in LM Studio, but koda guessed 32k from the model name `qwen3.5-122b-a10b` → request exceeded the "assumed" context → LM Studio error: `n_keep (8250) >= n_ctx (4096)`
2. **Gemini**: Output truncated at ~30 lines because `maxOutputTokens` defaulted to 8,192 instead of using the model's actual output limit (e.g., 65,536 for flash models)

## Solution

### New `ModelCapabilities` struct + `model_capabilities()` trait method

```rust
pub struct ModelCapabilities {
    pub context_window: Option<usize>,
    pub max_output_tokens: Option<usize>,
}
```

Added to `LlmProvider` trait with a default no-op. Providers override it to query their API.

### Provider implementations

| Provider | API Endpoint | Fields Used |
|---|---|---|
| **Gemini** | `GET /v1beta/models/{model}` | `inputTokenLimit`, `outputTokenLimit` |
| **OpenAI-compat** (LM Studio, Ollama) | `GET /api/v0/models` | `max_context_length` per model |
| **Anthropic** | (default no-op) | Falls back to hardcoded 200k |
| **Others** | (default no-op) | Falls back to lookup table |

### Config integration

`KodaConfig::apply_provider_capabilities()` overrides hardcoded values with API-reported ones. Called:
- At startup (after provider creation + auto-detect)
- On `/provider` switch
- On `/model` switch and `/model <name>`

### Precedence

```
API-reported value  >  hardcoded lookup table  >  MIN_CONTEXT (4096)
```

If the API reports capabilities, they always win. The hardcoded table is only used when the API returns nothing (with a debug log warning).

## Changes

| File | What |
|---|---|
| `providers/mod.rs` | `ModelCapabilities` struct + trait method |
| `providers/gemini.rs` | Query `/v1beta/models/{model}` for limits |
| `providers/openai_compat.rs` | Query `/api/v0/models` for LM Studio context |
| `config.rs` | `apply_provider_capabilities()` method |
| `tui_app.rs` | Query caps at startup |
| `tui_commands.rs` | Query caps on `/model` switch |
| `tui_wizards.rs` | Query caps on `/provider` switch |

## Testing

- All 114 tests pass
- Manually verified LM Studio `/api/v0/models` returns `max_context_length`
