### PR TITLE
fix: handle terminal resize events to prevent ghost prompt lines (#194)

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -581,7 +581,11 @@ pub async fn run(
                                         break;
                                     }
                                     Some(Ok(ev)) = crossterm_events.next() => {
-                                        if let Event::Key(key) = ev {
+                                        if let Event::Resize(_, _) = ev {
+                                            // Terminal resized during inference — reinit viewport
+                                            // to prevent ghost prompt lines.
+                                            terminal = init_terminal(viewport_height)?;
+                                        } else if let Event::Key(key) = ev {
                                             match (key.code, key.modifiers) {
                                                 (KeyCode::Enter, KeyModifiers::NONE) => {
                                                     let text = textarea.lines().join("\n");
@@ -815,7 +819,10 @@ pub async fn run(
 
         tokio::select! {
             Some(Ok(ev)) = crossterm_events.next() => {
-                if let Event::Key(key) = ev {
+                if let Event::Resize(_, _) = ev {
+                    // Terminal resized while idle — reinit viewport.
+                    terminal = init_terminal(viewport_height)?;
+                } else if let Event::Key(key) = ev {
                     match (key.code, key.modifiers) {
                         // Shift+Enter or Alt+Enter → insert newline
                         // Note: Shift+Enter only works on terminals with kitty


### PR DESCRIPTION
## Bug

Resizing the terminal during inference (or while idle) produced stacked ghost prompt lines:

```
⏳>  Type a message...
⏳>  Type a message...
⏳>  Type a message...
```

## Root cause

Both event loops (`select!` branches) only matched `Event::Key`:

```rust
if let Event::Key(key) = ev { ... }
```

`Event::Resize(w, h)` was silently dropped. The ratatui inline viewport kept its old dimensions, causing the prompt to be redrawn at incorrect positions.

## Fix

Added `Event::Resize` handling in both loops — reinitializes the terminal viewport to reset cursor positioning:

```rust
if let Event::Resize(_, _) = ev {
    terminal = init_terminal(viewport_height)?;
} else if let Event::Key(key) = ev {
    ...
}
```

Two sites:
1. **Inference loop** (~line 583) — resize during LLM streaming
2. **Idle loop** (~line 820) — resize while waiting for user input

## Testing

- Build + clippy clean
- Full test suite passes (128 tests)
- Manual: resize terminal during inference → no ghost lines

Fixes #194