### PR TITLE
fix: update mode emojis to match semantics

### DIFF
--- a/koda-cli/src/headless_sink.rs
+++ b/koda-cli/src/headless_sink.rs
@@ -67,7 +67,7 @@ impl EngineSink for HeadlessSink {
             EngineEvent::ActionBlocked {
                 detail, preview, ..
             } => {
-                eprintln!("\x1b[33m  \u{1f4cb} Would execute: {detail}\x1b[0m");
+                eprintln!("\x1b[33m  \u{1f50d} Would execute: {detail}\x1b[0m");
                 if let Some(ref p) = preview {
                     let rendered = crate::diff_render::render(p);
                     for line in rendered.lines() {

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -281,8 +281,8 @@ pub fn format_prompt(model: &str, mode: koda_core::approval::ApprovalMode) -> St
     };
     // Mode embedded in logo: [Koda 🐻] / [Koda 📋] / [Koda ⚡]
     let (logo_icon, logo_color) = match mode {
-        koda_core::approval::ApprovalMode::Safe => ("\u{1f4cb}", "\x1b[33m"),
-        koda_core::approval::ApprovalMode::Strict => ("\u{1f43b}", "\x1b[36m"),
+        koda_core::approval::ApprovalMode::Safe => ("\u{1f50d}", "\x1b[33m"),
+        koda_core::approval::ApprovalMode::Strict => ("\u{1f512}", "\x1b[36m"),
         koda_core::approval::ApprovalMode::Auto => ("\u{26a1}", "\x1b[32m"),
     };
     let mode_label = mode.label();

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -108,8 +108,8 @@ fn draw_viewport(
     // Prompt icon + textarea
     let (icon, color) = match (state, mode) {
         (TuiState::Inferring, _) => ("\u{23f3}", Color::DarkGray), // ⏳ during inference
-        (_, ApprovalMode::Safe) => ("📋", Color::Yellow),
-        (_, ApprovalMode::Strict) => ("🐻", Color::Cyan),
+        (_, ApprovalMode::Safe) => ("🔍", Color::Yellow),
+        (_, ApprovalMode::Strict) => ("🔒", Color::Cyan),
         (_, ApprovalMode::Auto) => ("⚡", Color::Green),
     };
     let prompt_width: u16 = 4;
@@ -408,8 +408,8 @@ pub async fn run(
                 // Echo queued input above viewport
                 let mode = approval::read_mode(&shared_mode);
                 let icon = match mode {
-                    ApprovalMode::Safe => "📋",
-                    ApprovalMode::Strict => "🐻",
+                    ApprovalMode::Safe => "🔍",
+                    ApprovalMode::Strict => "🔒",
                     ApprovalMode::Auto => "⚡",
                 };
                 emit_above(
@@ -866,8 +866,8 @@ pub async fn run(
                                         history_idx = None;
                                         let mode = approval::read_mode(&shared_mode);
                                         let icon = match mode {
-                                            ApprovalMode::Safe => "📋",
-                                            ApprovalMode::Strict => "🐻",
+                                            ApprovalMode::Safe => "🔍",
+                                            ApprovalMode::Strict => "🔒",
                                             ApprovalMode::Auto => "⚡",
                                         };
                                         emit_above(&mut terminal, Line::from(vec![

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -200,7 +200,7 @@ impl TuiRenderer {
                     terminal,
                     Line::from(vec![
                         Span::raw("  "),
-                        Span::styled(format!("\u{1f4cb} Would execute: {detail}"), YELLOW),
+                        Span::styled(format!("\u{1f50d} Would execute: {detail}"), YELLOW),
                     ]),
                 );
                 if let Some(preview) = preview {


### PR DESCRIPTION
Quick follow-up to #198 — the mode emojis were leftover from the old plan/normal/yolo naming.

| Mode | Before | After | Why |
|---|---|---|---|
| Auto | ⚡ | ⚡ | Already perfect |
| Strict | 🐻 | 🔒 | Lock = needs your key to proceed |
| Safe | 📋 | 🔍 | Magnifier = look but don't touch |

4 files, pure emoji swap.