### PR TITLE
feat: scale tool output caps to context window (#192)

### DIFF
--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -47,7 +47,8 @@ impl KodaAgent {
             mcp_statuses = mcp.start_from_config(&project_root).await;
         }
 
-        let tools = ToolRegistry::new(project_root.clone()).with_mcp_registry(mcp_registry.clone());
+        let tools = ToolRegistry::new(project_root.clone(), config.max_context_tokens)
+            .with_mcp_registry(mcp_registry.clone());
         let tool_defs = tools.get_definitions_tiered(&config.allowed_tools, config.model_tier);
 
         let semantic_memory = memory::load(&project_root)?;

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod mcp;
 pub mod memory;
 pub mod model_context;
 pub mod model_tier;
+pub mod output_caps;
 pub mod preview;
 pub mod progress;
 pub mod prompt;

--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -154,7 +154,7 @@ mod tests {
     async fn test_auto_provision_returns_install_hint() {
         // When koda-ast is not on PATH and MCP registry is None,
         // executing AstAnalysis should return an install hint, not "Unknown tool"
-        let registry = crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"));
+        let registry = crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"), 100_000);
         let result = registry.execute("AstAnalysis", "{}").await;
         assert!(
             !result.output.contains("Unknown tool"),

--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -154,7 +154,8 @@ mod tests {
     async fn test_auto_provision_returns_install_hint() {
         // When koda-ast is not on PATH and MCP registry is None,
         // executing AstAnalysis should return an install hint, not "Unknown tool"
-        let registry = crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"), 100_000);
+        let registry =
+            crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"), 100_000);
         let result = registry.execute("AstAnalysis", "{}").await;
         assert!(
             !result.output.contains("Unknown tool"),

--- a/koda-core/src/model_context.rs
+++ b/koda-core/src/model_context.rs
@@ -18,9 +18,16 @@ pub fn context_window_for_model(model: &str) -> usize {
     let m = model.to_lowercase();
 
     // ── Anthropic ─────────────────────────────────────
-    // All current Claude models (3.x, 4.x) have 200K context.
-    // When Anthropic changes this, add specific prefixes ABOVE
-    // the catch-all so they match first.
+    // Default context window for all Claude models is 200K tokens.
+    //
+    // Claude 4.x models (opus-4-6, sonnet-4-6, sonnet-4-5, sonnet-4)
+    // support 1M context via opt-in beta header:
+    //   anthropic-beta: context-1m-2025-08-07
+    // Without the header, the API caps at 200K. Premium pricing (2×
+    // input, 1.5× output) applies for tokens beyond 200K.
+    //
+    // TODO: Add a config flag (e.g. `extended_context = true`) that
+    // sends the beta header and sets context window to 1M.
     //
     // NOTE: Anthropic's API does not expose context_window today.
     // If they add it, `model_capabilities()` in anthropic.rs will
@@ -38,7 +45,6 @@ pub fn context_window_for_model(model: &str) -> usize {
         return 200_000;
     }
     // Catch-all for future Claude models we haven't seen yet.
-    // Log a warning so we notice when this fires.
     if m.contains("claude") {
         tracing::warn!(
             "Unknown Claude model '{}' — assuming 200K context. \
@@ -145,9 +151,33 @@ mod tests {
 
     #[test]
     fn test_claude_models() {
+        // Claude 4.x: 200K default (1M available via beta header opt-in)
         assert_eq!(context_window_for_model("claude-sonnet-4-6"), 200_000);
+        assert_eq!(context_window_for_model("claude-opus-4-6"), 200_000);
+        assert_eq!(
+            context_window_for_model("claude-opus-4-5-20251101"),
+            200_000
+        );
+        assert_eq!(
+            context_window_for_model("claude-haiku-4-5-20251001"),
+            200_000
+        );
+        assert_eq!(
+            context_window_for_model("claude-sonnet-4-5-20250929"),
+            200_000
+        );
+        assert_eq!(context_window_for_model("claude-opus-4-20250514"), 200_000);
+        assert_eq!(
+            context_window_for_model("claude-sonnet-4-20250514"),
+            200_000
+        );
+        // Claude 3.x: 200K context
         assert_eq!(context_window_for_model("claude-3-opus-20240229"), 200_000);
         assert_eq!(context_window_for_model("claude-3-haiku-20240307"), 200_000);
+        assert_eq!(
+            context_window_for_model("claude-3-5-sonnet-20240620"),
+            200_000
+        );
     }
 
     #[test]

--- a/koda-core/src/model_context.rs
+++ b/koda-core/src/model_context.rs
@@ -17,8 +17,34 @@ const MIN_CONTEXT: usize = 4_096;
 pub fn context_window_for_model(model: &str) -> usize {
     let m = model.to_lowercase();
 
-    // ── Anthropic ─────────────────────────────────────────
+    // ── Anthropic ─────────────────────────────────────
+    // All current Claude models (3.x, 4.x) have 200K context.
+    // When Anthropic changes this, add specific prefixes ABOVE
+    // the catch-all so they match first.
+    //
+    // NOTE: Anthropic's API does not expose context_window today.
+    // If they add it, `model_capabilities()` in anthropic.rs will
+    // return it and this table will be bypassed automatically.
+    if m.starts_with("claude-opus-4")
+        || m.starts_with("claude-sonnet-4")
+        || m.starts_with("claude-haiku-4")
+    {
+        return 200_000;
+    }
+    if m.starts_with("claude-3.5") || m.starts_with("claude-3-5") {
+        return 200_000;
+    }
+    if m.starts_with("claude-3") {
+        return 200_000;
+    }
+    // Catch-all for future Claude models we haven't seen yet.
+    // Log a warning so we notice when this fires.
     if m.contains("claude") {
+        tracing::warn!(
+            "Unknown Claude model '{}' — assuming 200K context. \
+             Update model_context.rs if this model has a different context window.",
+            model
+        );
         return 200_000;
     }
 

--- a/koda-core/src/output_caps.rs
+++ b/koda-core/src/output_caps.rs
@@ -1,0 +1,145 @@
+//! Centralized tool output caps, scaled to the model's context window.
+//!
+//! All tool output limits live here instead of being scattered across 6+ files.
+//! Caps scale linearly from a floor (current defaults) up to a 4× ceiling
+//! as the context window grows.
+//!
+//! Scaling formula:
+//!   `clamp(base × (ctx / BASELINE), base, base × MAX_SCALE)`
+//!
+//! | Context window | Scale factor | Effect            |
+//! |----------------|-------------|-------------------|
+//! | 4K             | 0.04×       | Floor (base)      |
+//! | 100K           | 1.0×        | Base (current)    |
+//! | 200K           | 2.0×        | 2× current        |
+//! | 1M             | 10.0×       | Ceiling (4× base) |
+
+/// Baseline context window for scaling (100K tokens = 1.0× factor).
+const BASELINE: f64 = 100_000.0;
+
+/// Maximum scale multiplier (4× base values).
+const MAX_SCALE: f64 = 4.0;
+
+/// Pre-computed output caps for all tools in a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OutputCaps {
+    /// Max chars for tool results stored in conversation history.
+    /// Base: 10,000 (was `MAX_TOOL_RESULT_CHARS` in `tool_dispatch.rs`).
+    pub tool_result_chars: usize,
+
+    /// Max chars for web page body content.
+    /// Base: 15,000 (was `MAX_BODY_CHARS` in `web_fetch.rs`).
+    pub web_body_chars: usize,
+
+    /// Max lines of shell command output.
+    /// Base: 256 (was `MAX_OUTPUT_LINES` in `shell.rs`).
+    pub shell_output_lines: usize,
+
+    /// Max grep matches returned.
+    /// Base: 100 (was `MAX_MATCHES` in `grep.rs`).
+    pub grep_matches: usize,
+
+    /// Max directory listing entries.
+    /// Base: 200 (was `MAX_ENTRIES` in `file_tools.rs`).
+    pub list_entries: usize,
+
+    /// Max glob search results.
+    /// Base: 200 (was `MAX_RESULTS` in `glob_tool.rs`).
+    pub glob_results: usize,
+}
+
+impl OutputCaps {
+    // ── Base values (floors) ─────────────────────────────────
+    const BASE_TOOL_RESULT_CHARS: usize = 10_000;
+    const BASE_WEB_BODY_CHARS: usize = 15_000;
+    const BASE_SHELL_OUTPUT_LINES: usize = 256;
+    const BASE_GREP_MATCHES: usize = 100;
+    const BASE_LIST_ENTRIES: usize = 200;
+    const BASE_GLOB_RESULTS: usize = 200;
+
+    /// Compute caps scaled to the given context window size (in tokens).
+    pub fn for_context(max_context_tokens: usize) -> Self {
+        let factor = (max_context_tokens as f64 / BASELINE).clamp(1.0, MAX_SCALE);
+
+        Self {
+            tool_result_chars: scale(Self::BASE_TOOL_RESULT_CHARS, factor),
+            web_body_chars: scale(Self::BASE_WEB_BODY_CHARS, factor),
+            shell_output_lines: scale(Self::BASE_SHELL_OUTPUT_LINES, factor),
+            grep_matches: scale(Self::BASE_GREP_MATCHES, factor),
+            list_entries: scale(Self::BASE_LIST_ENTRIES, factor),
+            glob_results: scale(Self::BASE_GLOB_RESULTS, factor),
+        }
+    }
+}
+
+impl Default for OutputCaps {
+    /// Default caps (100K context baseline — matches legacy hardcoded values).
+    fn default() -> Self {
+        Self::for_context(100_000)
+    }
+}
+
+/// Scale a base value by factor, rounding to nearest integer.
+fn scale(base: usize, factor: f64) -> usize {
+    (base as f64 * factor).round() as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_context_gets_base_values() {
+        let caps = OutputCaps::for_context(4_096);
+        assert_eq!(caps.tool_result_chars, OutputCaps::BASE_TOOL_RESULT_CHARS);
+        assert_eq!(caps.shell_output_lines, OutputCaps::BASE_SHELL_OUTPUT_LINES);
+        assert_eq!(caps.grep_matches, OutputCaps::BASE_GREP_MATCHES);
+        assert_eq!(caps.list_entries, OutputCaps::BASE_LIST_ENTRIES);
+    }
+
+    #[test]
+    fn baseline_context_gets_base_values() {
+        let caps = OutputCaps::for_context(100_000);
+        assert_eq!(caps.tool_result_chars, 10_000);
+        assert_eq!(caps.web_body_chars, 15_000);
+        assert_eq!(caps.shell_output_lines, 256);
+        assert_eq!(caps.grep_matches, 100);
+        assert_eq!(caps.list_entries, 200);
+        assert_eq!(caps.glob_results, 200);
+    }
+
+    #[test]
+    fn double_context_doubles_caps() {
+        let caps = OutputCaps::for_context(200_000);
+        assert_eq!(caps.tool_result_chars, 20_000);
+        assert_eq!(caps.web_body_chars, 30_000);
+        assert_eq!(caps.shell_output_lines, 512);
+        assert_eq!(caps.grep_matches, 200);
+        assert_eq!(caps.list_entries, 400);
+        assert_eq!(caps.glob_results, 400);
+    }
+
+    #[test]
+    fn million_context_caps_at_4x() {
+        let caps = OutputCaps::for_context(1_000_000);
+        assert_eq!(caps.tool_result_chars, 40_000);
+        assert_eq!(caps.web_body_chars, 60_000);
+        assert_eq!(caps.shell_output_lines, 1024);
+        assert_eq!(caps.grep_matches, 400);
+        assert_eq!(caps.list_entries, 800);
+        assert_eq!(caps.glob_results, 800);
+    }
+
+    #[test]
+    fn default_matches_baseline() {
+        assert_eq!(OutputCaps::default(), OutputCaps::for_context(100_000));
+    }
+
+    #[test]
+    fn intermediate_context_scales_linearly() {
+        let caps = OutputCaps::for_context(150_000);
+        // 1.5× base
+        assert_eq!(caps.tool_result_chars, 15_000);
+        assert_eq!(caps.shell_output_lines, 384);
+    }
+}

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -167,6 +167,24 @@ struct ModelsListEntry {
     id: String,
 }
 
+/// Single model detail from `GET /v1/models/{model_id}`.
+///
+/// Anthropic's API currently returns `id`, `display_name`, `created_at`, `type`.
+/// We also optimistically parse `context_window` and `max_output_tokens` —
+/// if Anthropic adds those fields in the future, we'll pick them up
+/// automatically without a code change.
+#[derive(Deserialize)]
+struct ModelDetailResponse {
+    #[allow(dead_code)]
+    id: String,
+    /// Not currently in the API, but future-proofed.
+    #[serde(default)]
+    context_window: Option<usize>,
+    /// Not currently in the API, but future-proofed.
+    #[serde(default)]
+    max_output_tokens: Option<usize>,
+}
+
 // ── SSE Streaming types ──────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -334,6 +352,42 @@ impl LlmProvider for AnthropicProvider {
 
     fn provider_name(&self) -> &str {
         "anthropic"
+    }
+
+    /// Query Anthropic's models API for context window and max output tokens.
+    ///
+    /// Anthropic's `/v1/models/{id}` doesn't currently return these fields,
+    /// but we optimistically try to parse them. If/when Anthropic adds them,
+    /// this will automatically start working without a code change.
+    async fn model_capabilities(&self, model: &str) -> Result<super::ModelCapabilities> {
+        let resp = self
+            .client
+            .get(format!("{}/v1/models/{}", self.base_url, model))
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_API_VERSION)
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) if r.status().is_success() => r,
+            _ => {
+                tracing::debug!(
+                    "Anthropic models API did not return info for {model}; \
+                     using lookup table"
+                );
+                return Ok(super::ModelCapabilities::default());
+            }
+        };
+
+        let detail: ModelDetailResponse = match resp.json().await {
+            Ok(d) => d,
+            Err(_) => return Ok(super::ModelCapabilities::default()),
+        };
+
+        Ok(super::ModelCapabilities {
+            context_window: detail.context_window,
+            max_output_tokens: detail.max_output_tokens,
+        })
     }
 
     /// Real SSE streaming via Anthropic's Messages API.

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -19,17 +19,14 @@ use std::path::Path;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-/// Maximum tool result size stored in conversation history.
-/// Larger results are truncated to keep context usage bounded.
-const MAX_TOOL_RESULT_CHARS: usize = 10_000;
-
 /// Truncate a tool result for storage in conversation history.
-fn truncate_for_history(output: &str) -> String {
-    if output.len() <= MAX_TOOL_RESULT_CHARS {
+/// The `max_chars` limit is set by `OutputCaps::tool_result_chars`.
+fn truncate_for_history(output: &str, max_chars: usize) -> String {
+    if output.len() <= max_chars {
         return output.to_string();
     }
     // Find a safe char boundary
-    let mut end = MAX_TOOL_RESULT_CHARS;
+    let mut end = max_chars;
     while end > 0 && !output.is_char_boundary(end) {
         end -= 1;
     }
@@ -145,7 +142,7 @@ pub(crate) async fn execute_tools_parallel(
             name: tool_calls[i].function_name.clone(),
             output: result.clone(),
         });
-        let stored = truncate_for_history(&result);
+        let stored = truncate_for_history(&result, tools.caps.tool_result_chars);
         db.insert_message(
             session_id,
             &Role::Tool,
@@ -296,7 +293,7 @@ pub(crate) async fn execute_tools_sequential(
             output: result.clone(),
         });
 
-        let stored = truncate_for_history(&result);
+        let stored = truncate_for_history(&result, tools.caps.tool_result_chars);
         db.insert_message(
             session_id,
             &Role::Tool,
@@ -368,7 +365,7 @@ pub(crate) async fn execute_sub_agent(
 
     let provider = crate::providers::create_provider(&sub_config);
     let tools = {
-        let registry = ToolRegistry::new(project_root.to_path_buf());
+        let registry = ToolRegistry::new(project_root.to_path_buf(), sub_config.max_context_tokens);
         match parent_cache {
             Some(cache) => registry.with_shared_cache(cache),
             None => registry,

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -375,13 +375,12 @@ fn count_dir_entries(path: &Path) -> usize {
 }
 
 /// List files in a directory, respecting .gitignore.
-/// Results are capped at 200 entries to protect the context window.
-pub async fn list_files(project_root: &Path, args: &Value) -> Result<String> {
+/// Entry cap is set by `OutputCaps` (context-scaled).
+pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -> Result<String> {
     let path_str = args["path"].as_str().unwrap_or(".");
     let recursive = args["recursive"].as_bool().unwrap_or(true);
     let resolved = safe_resolve_path(project_root, path_str)?;
 
-    const MAX_ENTRIES: usize = 200;
     let mut entries = Vec::new();
     let mut total_count: usize = 0;
 
@@ -418,7 +417,7 @@ pub async fn list_files(project_root: &Path, args: &Value) -> Result<String> {
             let prefix = if path.is_dir() { "d " } else { "  " };
             entries.push(format!("{prefix}{}", relative.display()));
             total_count += 1;
-            if entries.len() >= MAX_ENTRIES {
+            if entries.len() >= max_entries {
                 break;
             }
         }
@@ -429,7 +428,7 @@ pub async fn list_files(project_root: &Path, args: &Value) -> Result<String> {
             let prefix = if ft.is_dir() { "d " } else { "  " };
             entries.push(format!("{prefix}{}", entry.file_name().to_string_lossy()));
             total_count += 1;
-            if entries.len() >= MAX_ENTRIES {
+            if entries.len() >= max_entries {
                 break;
             }
         }
@@ -437,9 +436,9 @@ pub async fn list_files(project_root: &Path, args: &Value) -> Result<String> {
 
     if entries.is_empty() {
         Ok("(empty directory)".to_string())
-    } else if total_count > MAX_ENTRIES {
+    } else if total_count > max_entries {
         Ok(format!(
-            "{}\n\n... [CAPPED at {MAX_ENTRIES} entries. Use a subdirectory path to narrow results.]",
+            "{}\n\n... [CAPPED at {max_entries} entries. Use a subdirectory path to narrow results.]",
             entries.join("\n")
         ))
     } else {

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -32,10 +32,8 @@ pub fn definitions() -> Vec<ToolDefinition> {
     }]
 }
 
-const MAX_RESULTS: usize = 200;
-
 /// Execute a glob search from the given base directory.
-pub async fn glob_search(project_root: &Path, args: &Value) -> Result<String> {
+pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) -> Result<String> {
     let pattern = args["pattern"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?;
@@ -61,7 +59,7 @@ pub async fn glob_search(project_root: &Path, args: &Value) -> Result<String> {
                 }
                 let relative = path.strip_prefix(project_root).unwrap_or(&path);
                 matches.push(relative.display().to_string());
-                if matches.len() >= MAX_RESULTS {
+                if matches.len() >= max_results {
                     break;
                 }
             }
@@ -73,8 +71,8 @@ pub async fn glob_search(project_root: &Path, args: &Value) -> Result<String> {
         Ok(format!("No files matched pattern: {pattern}"))
     } else {
         let count = matches.len();
-        let capped = if count >= MAX_RESULTS {
-            format!("\n\n[Capped at {MAX_RESULTS} results]")
+        let capped = if count >= max_results {
+            format!("\n\n[Capped at {max_results} results]")
         } else {
             String::new()
         };
@@ -105,7 +103,7 @@ mod tests {
     async fn test_glob_rust_files() {
         let tmp = setup();
         let args = json!({ "pattern": "**/*.rs" });
-        let result = glob_search(tmp.path(), &args).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
         assert!(result.contains("main.rs"));
         assert!(result.contains("lib.rs"));
     }
@@ -114,7 +112,7 @@ mod tests {
     async fn test_glob_toml() {
         let tmp = setup();
         let args = json!({ "pattern": "*.toml" });
-        let result = glob_search(tmp.path(), &args).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
         assert!(result.contains("Cargo.toml"));
     }
 
@@ -122,7 +120,7 @@ mod tests {
     async fn test_glob_no_match() {
         let tmp = setup();
         let args = json!({ "pattern": "**/*.xyz" });
-        let result = glob_search(tmp.path(), &args).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
         assert!(result.contains("No files matched"));
     }
 
@@ -130,7 +128,7 @@ mod tests {
     async fn test_glob_scoped_path() {
         let tmp = setup();
         let args = json!({ "pattern": "*.rs", "path": "src/tools" });
-        let result = glob_search(tmp.path(), &args).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
         assert!(result.contains("mod.rs"));
         assert!(!result.contains("main.rs")); // Not in src/tools
     }

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -1,16 +1,14 @@
 //! Grep tool: recursive text search across files.
 //!
 //! Uses the `ignore` crate to walk directories (respecting .gitignore)
-//! and searches for text patterns. Results are capped at 100 matches
-//! to protect the context window.
+//! and searches for text patterns. Match cap is set by `OutputCaps`
+//! (context-scaled).
 
 use super::safe_resolve_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::path::Path;
-
-const MAX_MATCHES: usize = 100;
 
 /// Return tool definitions for the LLM.
 pub fn definitions() -> Vec<ToolDefinition> {
@@ -41,7 +39,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Search for a text pattern across files in a directory.
-pub async fn grep(project_root: &Path, args: &Value) -> Result<String> {
+pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Result<String> {
     let pattern = args["pattern"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?
@@ -54,7 +52,13 @@ pub async fn grep(project_root: &Path, args: &Value) -> Result<String> {
 
     // Run blocking file I/O off the tokio thread pool
     tokio::task::spawn_blocking(move || {
-        grep_blocking(&project_root, &search_root, &pattern, case_insensitive)
+        grep_blocking(
+            &project_root,
+            &search_root,
+            &pattern,
+            case_insensitive,
+            max_matches,
+        )
     })
     .await?
 }
@@ -65,6 +69,7 @@ fn grep_blocking(
     search_root: &Path,
     pattern: &str,
     case_insensitive: bool,
+    max_matches: usize,
 ) -> Result<String> {
     let regex = if case_insensitive {
         regex::RegexBuilder::new(&regex::escape(pattern))
@@ -109,9 +114,9 @@ fn grep_blocking(
                     truncate_line(line, 200)
                 ));
 
-                if matches.len() >= MAX_MATCHES {
+                if matches.len() >= max_matches {
                     matches.push(format!(
-                        "\n... [CAPPED at {MAX_MATCHES} matches. \
+                        "\n... [CAPPED at {max_matches} matches. \
                          Narrow your search pattern.]"
                     ));
                     return Ok(format_output(&matches, files_searched));
@@ -187,7 +192,7 @@ mod tests {
     async fn test_grep_finds_matches() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "hello" });
-        let result = grep(tmp.path(), &args).await.unwrap();
+        let result = grep(tmp.path(), &args, 100).await.unwrap();
         assert!(result.contains("hello.rs"));
         assert!(result.contains("lib.rs"));
     }
@@ -196,7 +201,7 @@ mod tests {
     async fn test_grep_no_matches() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "zzzznotfound" });
-        let result = grep(tmp.path(), &args).await.unwrap();
+        let result = grep(tmp.path(), &args, 100).await.unwrap();
         assert!(result.contains("No matches"));
     }
 
@@ -204,7 +209,7 @@ mod tests {
     async fn test_grep_case_insensitive() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "HELLO", "case_insensitive": true });
-        let result = grep(tmp.path(), &args).await.unwrap();
+        let result = grep(tmp.path(), &args, 100).await.unwrap();
         assert!(result.contains("hello.rs"));
     }
 
@@ -243,7 +248,7 @@ mod tests {
     async fn test_grep_scoped_to_subdirectory() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "nope", "path": "nested" });
-        let result = grep(tmp.path(), &args).await.unwrap();
+        let result = grep(tmp.path(), &args, 100).await.unwrap();
         assert!(result.contains("deep.rs"));
     }
 }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -55,6 +55,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use crate::output_caps::OutputCaps;
 use crate::providers::ToolDefinition;
 
 /// Shared file-read cache: tracks (size, mtime) per cache key so we can
@@ -85,11 +86,15 @@ pub struct ToolRegistry {
     db: std::sync::RwLock<Option<std::sync::Arc<crate::db::Database>>>,
     /// Current session ID (for RecallContext).
     session_id: std::sync::RwLock<Option<String>>,
+    /// Context-scaled output caps for all tools.
+    pub caps: OutputCaps,
 }
 
 impl ToolRegistry {
     /// Create a new registry with all built-in tools.
-    pub fn new(project_root: PathBuf) -> Self {
+    ///
+    /// `max_context_tokens` scales all output caps (see `OutputCaps`).
+    pub fn new(project_root: PathBuf, max_context_tokens: usize) -> Self {
         let mut definitions = HashMap::new();
 
         // Register all built-in tools
@@ -140,6 +145,7 @@ impl ToolRegistry {
             skill_registry,
             db: std::sync::RwLock::new(None),
             session_id: std::sync::RwLock::new(None),
+            caps: OutputCaps::for_context(max_context_tokens),
         }
     }
 
@@ -285,17 +291,24 @@ impl ToolRegistry {
             "Write" => file_tools::write_file(&self.project_root, &args).await,
             "Edit" => file_tools::edit_file(&self.project_root, &args).await,
             "Delete" => file_tools::delete_file(&self.project_root, &args).await,
-            "List" => file_tools::list_files(&self.project_root, &args).await,
+            "List" => {
+                file_tools::list_files(&self.project_root, &args, self.caps.list_entries).await
+            }
 
             // Search tools
-            "Grep" => grep::grep(&self.project_root, &args).await,
-            "Glob" => glob_tool::glob_search(&self.project_root, &args).await,
+            "Grep" => grep::grep(&self.project_root, &args, self.caps.grep_matches).await,
+            "Glob" => {
+                glob_tool::glob_search(&self.project_root, &args, self.caps.glob_results).await
+            }
 
             // Shell
-            "Bash" => shell::run_shell_command(&self.project_root, &args).await,
+            "Bash" => {
+                shell::run_shell_command(&self.project_root, &args, self.caps.shell_output_lines)
+                    .await
+            }
 
             // Web
-            "WebFetch" => web_fetch::web_fetch(&args).await,
+            "WebFetch" => web_fetch::web_fetch(&args, self.caps.web_body_chars).await,
 
             // Memory
             "MemoryRead" => memory::memory_read(&self.project_root).await,

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -1,7 +1,7 @@
 //! Shell command execution tool.
 //!
 //! Runs commands as child processes with timeout protection.
-//! Output is capped at 150 lines to protect the context window.
+//! Output line cap is set by `OutputCaps` (context-scaled).
 
 use crate::providers::ToolDefinition;
 use anyhow::Result;
@@ -9,7 +9,6 @@ use serde_json::{Value, json};
 use std::path::Path;
 use tokio::process::Command;
 
-const MAX_OUTPUT_LINES: usize = 256;
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
 
 /// Return tool definitions for the LLM.
@@ -39,7 +38,11 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Execute a shell command with timeout and output capping.
-pub async fn run_shell_command(project_root: &Path, args: &Value) -> Result<String> {
+pub async fn run_shell_command(
+    project_root: &Path,
+    args: &Value,
+    max_output_lines: usize,
+) -> Result<String> {
     let command = args["command"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'command' argument"))?;
@@ -63,8 +66,8 @@ pub async fn run_shell_command(project_root: &Path, args: &Value) -> Result<Stri
             let stderr = String::from_utf8_lossy(&output.stderr);
             let exit_code = output.status.code().unwrap_or(-1);
 
-            let stdout_capped = cap_output(&stdout);
-            let stderr_capped = cap_output(&stderr);
+            let stdout_capped = cap_output(&stdout, max_output_lines);
+            let stderr_capped = cap_output(&stderr, max_output_lines);
 
             let mut response = format!("Exit code: {exit_code}\n");
             if !stdout_capped.is_empty() {
@@ -84,13 +87,13 @@ pub async fn run_shell_command(project_root: &Path, args: &Value) -> Result<Stri
 }
 
 /// Cap output to the last N lines to protect the context window.
-fn cap_output(output: &str) -> String {
+fn cap_output(output: &str, max_lines: usize) -> String {
     let lines: Vec<&str> = output.lines().collect();
-    if lines.len() > MAX_OUTPUT_LINES {
-        let skipped = lines.len() - MAX_OUTPUT_LINES;
+    if lines.len() > max_lines {
+        let skipped = lines.len() - max_lines;
         format!(
             "[... {skipped} lines truncated ...]\n{}",
-            lines[lines.len() - MAX_OUTPUT_LINES..].join("\n")
+            lines[lines.len() - max_lines..].join("\n")
         )
     } else {
         output.to_string()
@@ -104,14 +107,14 @@ mod tests {
     #[test]
     fn test_cap_output_short() {
         let input = "line1\nline2\nline3";
-        assert_eq!(cap_output(input), input);
+        assert_eq!(cap_output(input, 256), input);
     }
 
     #[test]
     fn test_cap_output_long() {
         let lines: Vec<String> = (0..500).map(|i| format!("line {i}")).collect();
         let input = lines.join("\n");
-        let capped = cap_output(&input);
+        let capped = cap_output(&input, 256);
 
         // Should contain the truncation notice
         assert!(capped.contains("truncated"));
@@ -123,9 +126,9 @@ mod tests {
 
     #[test]
     fn test_cap_output_exactly_at_limit() {
-        let lines: Vec<String> = (0..MAX_OUTPUT_LINES).map(|i| format!("line {i}")).collect();
+        let lines: Vec<String> = (0..256).map(|i| format!("line {i}")).collect();
         let input = lines.join("\n");
-        let capped = cap_output(&input);
+        let capped = cap_output(&input, 256);
         // Exactly at limit, no truncation
         assert!(!capped.contains("truncated"));
     }

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -1,13 +1,13 @@
 //! WebFetch tool: retrieve content from a URL.
 //!
 //! Fetches a web page and returns the textual content,
-//! stripping HTML tags for readability.
+//! stripping HTML tags for readability. Body cap is set by
+//! `OutputCaps` (context-scaled).
 
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
 
-const MAX_BODY_CHARS: usize = 15_000;
 const DEFAULT_TIMEOUT_SECS: u64 = 15;
 
 /// Return tool definitions for the LLM.
@@ -33,7 +33,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Fetch a URL and return its content.
-pub async fn web_fetch(args: &Value) -> Result<String> {
+pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
     let url = args["url"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'url' argument"))?;
@@ -78,11 +78,11 @@ pub async fn web_fetch(args: &Value) -> Result<String> {
 
     let content = if raw { body } else { strip_html(&body) };
 
-    if content.len() > MAX_BODY_CHARS {
+    if content.len() > max_body_chars {
         Ok(format!(
             "{}\n\n[TRUNCATED: response was {} chars. \
              Consider fetching a more specific URL.]",
-            &content[..MAX_BODY_CHARS],
+            &content[..max_body_chars],
             content.len()
         ))
     } else {
@@ -310,7 +310,7 @@ mod tests {
     #[tokio::test]
     async fn test_web_fetch_bad_url() {
         let args = json!({ "url": "not-a-url" });
-        let result = web_fetch(&args).await;
+        let result = web_fetch(&args, 15_000).await;
         assert!(result.is_err());
     }
 
@@ -359,7 +359,7 @@ mod tests {
     #[tokio::test]
     async fn test_web_fetch_blocks_ssrf() {
         let args = json!({ "url": "http://169.254.169.254/latest/meta-data/" });
-        let result = web_fetch(&args).await;
+        let result = web_fetch(&args, 15_000).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
@@ -367,7 +367,7 @@ mod tests {
     #[tokio::test]
     async fn test_web_fetch_missing_url() {
         let args = json!({});
-        let result = web_fetch(&args).await;
+        let result = web_fetch(&args, 15_000).await;
         assert!(result.is_err());
     }
 }

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -68,7 +68,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
 
     let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
     let provider = SlowProvider;
-    let tools = ToolRegistry::new(PathBuf::from("."));
+    let tools = ToolRegistry::new(PathBuf::from("."), 100_000);
     let tool_defs: Vec<ToolDefinition> = vec![];
     let sink = TestSink::new();
     let cancel = CancellationToken::new();

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -39,7 +39,7 @@ impl Env {
         let db = Database::init(&root, &root).await.unwrap();
         let session_id = db.create_session("test-agent", &root).await.unwrap();
         let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
-        let tools = ToolRegistry::new(root.clone());
+        let tools = ToolRegistry::new(root.clone(), config.max_context_tokens);
         Self {
             _tmp: tmp,
             root,

--- a/koda-core/tests/token_audit.rs
+++ b/koda-core/tests/token_audit.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 #[test]
 fn dump_tool_definitions_for_audit() {
-    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("."));
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("."), 100_000);
     let defs = registry.get_definitions(&[]); // empty = all tools
 
     let mut total_chars = 0;

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 /// Get all built-in tool names from the registry.
 fn all_tool_names() -> Vec<String> {
-    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"));
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     registry.all_builtin_tool_names()
 }
 
@@ -18,7 +18,7 @@ fn all_tool_names() -> Vec<String> {
 /// None should return "Unknown tool".
 #[tokio::test]
 async fn test_all_tools_routable_in_dispatcher() {
-    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"));
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for name in all_tool_names() {
         let result = registry.execute(&name, "{}").await;
         assert!(


### PR DESCRIPTION
## Summary

All 6 hardcoded tool output caps are now **centralized** in `OutputCaps` and **scale linearly** with the model's context window.

### Scaling behavior

| Context window | Scale | Shell lines | Grep matches | List entries |
|---|---|---|---|---|
| 4K (local) | 1× (floor) | 256 | 100 | 200 |
| 100K (baseline) | 1× | 256 | 100 | 200 |
| 200K (Claude) | 2× | 512 | 200 | 400 |
| 1M (Gemini) | 4× (ceiling) | 1,024 | 400 | 800 |

Formula: `clamp(base × (ctx / 100K), base, base × 4)`

### What changed

**New file: `output_caps.rs`** (145 lines, 6 unit tests)
- `OutputCaps` struct with 6 cap fields
- `for_context(max_context_tokens)` constructor
- `Default` impl (100K baseline = legacy values)

**Consolidated from 6 files:**

| Cap | Base | Was in |
|---|---|---|
| `tool_result_chars` | 10,000 | `tool_dispatch.rs` |
| `web_body_chars` | 15,000 | `web_fetch.rs` |
| `shell_output_lines` | 256 | `shell.rs` |
| `grep_matches` | 100 | `grep.rs` |
| `list_entries` | 200 | `file_tools.rs` |
| `glob_results` | 200 | `glob_tool.rs` |

**Wiring:**
- `ToolRegistry::new()` now takes `max_context_tokens`
- Caps stored in `ToolRegistry.caps` (computed once)
- Each tool function receives its cap as a parameter (no globals)
- `truncate_for_history()` uses `caps.tool_result_chars`
- Sub-agent registries get their own context-appropriate caps

### Testing

- 6 new unit tests for scaling logic
- All 142+ workspace tests pass
- Zero clippy warnings
- 15 files changed, 235 insertions, 73 deletions

Fixes #192