### PR TITLE
feat: Claude 1M extended context via virtual -1m model names (#205)

### DIFF
--- a/koda-core/src/model_context.rs
+++ b/koda-core/src/model_context.rs
@@ -23,15 +23,26 @@ pub fn context_window_for_model(model: &str) -> usize {
     // Claude 4.x models (opus-4-6, sonnet-4-6, sonnet-4-5, sonnet-4)
     // support 1M context via opt-in beta header:
     //   anthropic-beta: context-1m-2025-08-07
-    // Without the header, the API caps at 200K. Premium pricing (2×
-    // input, 1.5× output) applies for tokens beyond 200K.
-    //
-    // TODO: Add a config flag (e.g. `extended_context = true`) that
-    // sends the beta header and sets context window to 1M.
-    //
-    // NOTE: Anthropic's API does not expose context_window today.
-    // If they add it, `model_capabilities()` in anthropic.rs will
-    // return it and this table will be bypassed automatically.
+    // Virtual "-1m" suffix (e.g. claude-sonnet-4-6-1m) selects the
+    // extended context variant. Only eligible models get 1M;
+    // ineligible models with -1m fall through to their normal 200K.
+    if m.ends_with("-1m") && m.contains("claude") {
+        let base = &m[..m.len() - 3]; // strip "-1m"
+        if base.starts_with("claude-opus-4-6")
+            || base.starts_with("claude-sonnet-4-6")
+            || base.starts_with("claude-sonnet-4-5")
+            || base.starts_with("claude-sonnet-4-2")
+            || base.starts_with("claude-sonnet-4")
+        {
+            return 1_000_000;
+        }
+        // Ineligible model with -1m suffix — fall through to 200K
+        tracing::warn!(
+            "Model '{}' does not support 1M extended context; using 200K.",
+            model
+        );
+        return 200_000;
+    }
     if m.starts_with("claude-opus-4")
         || m.starts_with("claude-sonnet-4")
         || m.starts_with("claude-haiku-4")
@@ -176,6 +187,38 @@ mod tests {
         assert_eq!(context_window_for_model("claude-3-haiku-20240307"), 200_000);
         assert_eq!(
             context_window_for_model("claude-3-5-sonnet-20240620"),
+            200_000
+        );
+    }
+
+    #[test]
+    fn test_claude_1m_virtual_models() {
+        // Eligible models with -1m suffix get 1M
+        assert_eq!(context_window_for_model("claude-sonnet-4-6-1m"), 1_000_000);
+        assert_eq!(context_window_for_model("claude-opus-4-6-1m"), 1_000_000);
+        assert_eq!(
+            context_window_for_model("claude-sonnet-4-5-20250929-1m"),
+            1_000_000
+        );
+        assert_eq!(
+            context_window_for_model("claude-sonnet-4-20250514-1m"),
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn test_claude_1m_ineligible_models() {
+        // Ineligible models with -1m suffix stay at 200K
+        assert_eq!(
+            context_window_for_model("claude-opus-4-5-20251101-1m"),
+            200_000
+        );
+        assert_eq!(
+            context_window_for_model("claude-haiku-4-5-20251001-1m"),
+            200_000
+        );
+        assert_eq!(
+            context_window_for_model("claude-3-opus-20240229-1m"),
             200_000
         );
     }

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -16,6 +16,62 @@ use serde::{Deserialize, Serialize};
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 const ANTHROPIC_BETA_FEATURES: &str = "prompt-caching-2024-07-31";
 
+/// Beta header value for 1M extended context.
+/// See: https://docs.anthropic.com/en/docs/about-claude/models#extended-context
+const EXTENDED_CONTEXT_BETA: &str = "context-1m-2025-08-07";
+
+/// Virtual model name suffix that opts into 1M extended context.
+const EXTENDED_CONTEXT_SUFFIX: &str = "-1m";
+
+/// Models eligible for 1M extended context (per Anthropic docs).
+/// Only Claude 4.6 family and Sonnet 4.5/4.0 support the beta header.
+const EXTENDED_CONTEXT_ELIGIBLE: &[&str] = &[
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-2", // dated variant
+    "claude-sonnet-4",
+];
+
+/// Check whether a base model ID (without `-1m` suffix) is eligible
+/// for 1M extended context.
+fn is_extended_context_eligible(base_model: &str) -> bool {
+    let m = base_model.to_lowercase();
+    EXTENDED_CONTEXT_ELIGIBLE
+        .iter()
+        .any(|prefix| m.starts_with(prefix))
+}
+
+/// Strip the `-1m` suffix from a virtual model name, returning the
+/// real API model ID and whether extended context was requested.
+/// Returns an error message if the model isn't eligible for 1M.
+fn resolve_model(model: &str) -> (&str, bool) {
+    if let Some(base) = model.strip_suffix(EXTENDED_CONTEXT_SUFFIX) {
+        if is_extended_context_eligible(base) {
+            (base, true)
+        } else {
+            tracing::warn!(
+                "Model '{}' does not support 1M extended context. \
+                 Using standard 200K context.",
+                model
+            );
+            (base, false)
+        }
+    } else {
+        (model, false)
+    }
+}
+
+/// Build the `anthropic-beta` header value, appending the extended
+/// context beta flag when requested.
+fn beta_header(extended_context: bool) -> String {
+    if extended_context {
+        format!("{ANTHROPIC_BETA_FEATURES},{EXTENDED_CONTEXT_BETA}")
+    } else {
+        ANTHROPIC_BETA_FEATURES.to_string()
+    }
+}
+
 pub struct AnthropicProvider {
     client: reqwest::Client,
     base_url: String,
@@ -233,7 +289,7 @@ impl LlmProvider for AnthropicProvider {
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
     ) -> Result<LlmResponse> {
-        let model = &settings.model;
+        let (api_model, extended_ctx) = resolve_model(&settings.model);
         // Extract system prompt (Anthropic puts it at the top level)
         let system = messages
             .iter()
@@ -246,7 +302,7 @@ impl LlmProvider for AnthropicProvider {
         let api_tools = Self::build_cached_tools(tools);
 
         let request = MessagesRequest {
-            model: model.to_string(),
+            model: api_model.to_string(),
             max_tokens: settings.max_tokens.unwrap_or(16384),
             system,
             messages: api_messages,
@@ -258,7 +314,7 @@ impl LlmProvider for AnthropicProvider {
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_API_VERSION)
-            .header("anthropic-beta", ANTHROPIC_BETA_FEATURES)
+            .header("anthropic-beta", beta_header(extended_ctx))
             .json(&request)
             .send()
             .await
@@ -340,14 +396,27 @@ impl LlmProvider for AnthropicProvider {
             .await
             .context("Failed to parse Anthropic models response")?;
 
-        Ok(list_resp
+        let mut models: Vec<ModelInfo> = list_resp
             .data
             .into_iter()
             .map(|m| ModelInfo {
                 id: m.id,
                 owned_by: Some("anthropic".to_string()),
             })
-            .collect())
+            .collect();
+
+        // Append virtual "-1m" variants for eligible models
+        let extended: Vec<ModelInfo> = models
+            .iter()
+            .filter(|m| is_extended_context_eligible(&m.id))
+            .map(|m| ModelInfo {
+                id: format!("{}-1m", m.id),
+                owned_by: m.owned_by.clone(),
+            })
+            .collect();
+        models.extend(extended);
+
+        Ok(models)
     }
 
     fn provider_name(&self) -> &str {
@@ -397,7 +466,7 @@ impl LlmProvider for AnthropicProvider {
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
     ) -> Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
-        let model = &settings.model;
+        let (api_model, extended_ctx) = resolve_model(&settings.model);
         let system = messages
             .iter()
             .find(|m| m.role == "system")
@@ -411,7 +480,7 @@ impl LlmProvider for AnthropicProvider {
 
         // Build request body with stream: true
         let mut body = serde_json::json!({
-            "model": model,
+            "model": api_model,
             "max_tokens": max_tokens,
             "stream": true,
             "messages": serde_json::to_value(&api_messages)?,
@@ -447,7 +516,7 @@ impl LlmProvider for AnthropicProvider {
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_API_VERSION)
-            .header("anthropic-beta", ANTHROPIC_BETA_FEATURES)
+            .header("anthropic-beta", beta_header(extended_ctx))
             .json(&body)
             .send()
             .await
@@ -925,5 +994,71 @@ mod tests {
         assert_eq!(cached.len(), 1);
         // Single tool should have cache_control (it's both first and last)
         assert_eq!(cached[0]["cache_control"]["type"], "ephemeral");
+    }
+
+    // ── Extended context (1M) tests ────────────────────────
+
+    #[test]
+    fn test_resolve_model_standard() {
+        let (model, ext) = resolve_model("claude-sonnet-4-6");
+        assert_eq!(model, "claude-sonnet-4-6");
+        assert!(!ext);
+    }
+
+    #[test]
+    fn test_resolve_model_1m_eligible() {
+        let (model, ext) = resolve_model("claude-sonnet-4-6-1m");
+        assert_eq!(model, "claude-sonnet-4-6");
+        assert!(ext);
+
+        let (model, ext) = resolve_model("claude-opus-4-6-1m");
+        assert_eq!(model, "claude-opus-4-6");
+        assert!(ext);
+
+        let (model, ext) = resolve_model("claude-sonnet-4-5-20250929-1m");
+        assert_eq!(model, "claude-sonnet-4-5-20250929");
+        assert!(ext);
+
+        let (model, ext) = resolve_model("claude-sonnet-4-20250514-1m");
+        assert_eq!(model, "claude-sonnet-4-20250514");
+        assert!(ext);
+    }
+
+    #[test]
+    fn test_resolve_model_1m_ineligible() {
+        // Opus 4.5, Haiku — not eligible, should get ext=false
+        let (model, ext) = resolve_model("claude-opus-4-5-20251101-1m");
+        assert_eq!(model, "claude-opus-4-5-20251101");
+        assert!(!ext);
+
+        let (model, ext) = resolve_model("claude-haiku-4-5-20251001-1m");
+        assert_eq!(model, "claude-haiku-4-5-20251001");
+        assert!(!ext);
+    }
+
+    #[test]
+    fn test_is_eligible() {
+        assert!(is_extended_context_eligible("claude-sonnet-4-6"));
+        assert!(is_extended_context_eligible("claude-opus-4-6"));
+        assert!(is_extended_context_eligible("claude-sonnet-4-5-20250929"));
+        assert!(is_extended_context_eligible("claude-sonnet-4-20250514"));
+
+        assert!(!is_extended_context_eligible("claude-opus-4-5-20251101"));
+        assert!(!is_extended_context_eligible("claude-haiku-4-5-20251001"));
+        assert!(!is_extended_context_eligible("claude-3-opus-20240229"));
+    }
+
+    #[test]
+    fn test_beta_header_standard() {
+        let header = beta_header(false);
+        assert_eq!(header, ANTHROPIC_BETA_FEATURES);
+        assert!(!header.contains("context-1m"));
+    }
+
+    #[test]
+    fn test_beta_header_extended() {
+        let header = beta_header(true);
+        assert!(header.contains(ANTHROPIC_BETA_FEATURES));
+        assert!(header.contains(EXTENDED_CONTEXT_BETA));
     }
 }


### PR DESCRIPTION
## Summary

Users can now select `claude-sonnet-4-6-1m` from the `/model` picker to opt into 1M extended context. Everything is automatic — no config flags needed.

### How it works

```
/model
  claude-sonnet-4-6       ← 200K context (default)
  claude-sonnet-4-6-1m    ← 1M context (premium pricing)
  claude-opus-4-6         ← 200K context
  claude-opus-4-6-1m      ← 1M context
  ...
```

When `-1m` is selected:
1. Suffix stripped → API sees `claude-sonnet-4-6`
2. Beta header added → `anthropic-beta: prompt-caching-2024-07-31,context-1m-2025-08-07`
3. Context window set to 1M → OutputCaps scales to 4× automatically

### Eligible models (per Anthropic docs)

| Model | 1M eligible |
|---|---|
| claude-opus-4-6 | ✅ |
| claude-sonnet-4-6 | ✅ |
| claude-sonnet-4-5 | ✅ |
| claude-sonnet-4 | ✅ |
| claude-opus-4-5 | ❌ |
| claude-haiku-4-5 | ❌ |
| claude-3.x | ❌ |

Ineligible models with `-1m` suffix silently fall back to 200K with a `tracing::warn()`.

### Pricing impact
Beyond 200K tokens: 2× input, 1.5× output. Under 200K: normal rates even with header.

### New tests (8)
- `resolve_model` standard / eligible / ineligible
- `is_extended_context_eligible` allowlist
- `beta_header` standard / extended
- `context_window_for_model` 1M eligible / ineligible

### Files changed
- `anthropic.rs`: +151 lines (resolve_model, eligibility, beta_header, list_models)
- `model_context.rs`: +44 lines (-1m suffix handling + tests)

All 330 koda-core tests pass, zero warnings.

Fixes #205