### PR TITLE
fix: restore block-art bear logo lost in #207 merge conflict

### DIFF
--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -235,9 +235,15 @@ mod tests {
     fn banner_contains_bear_face() {
         let lines = build_banner_lines("m", "p", "~", &[]);
         let text = lines_to_text(&lines);
-        assert!(text.contains("▞▀▚"), "Banner should contain block-art bear ears");
+        assert!(
+            text.contains("▞▀▚"),
+            "Banner should contain block-art bear ears"
+        );
         // Block-art bear line 3: chin
-        assert!(text.contains("▀▄▄▄▄▄▄▀"), "Banner should contain block-art bear chin");
+        assert!(
+            text.contains("▀▄▄▄▄▄▄▀"),
+            "Banner should contain block-art bear chin"
+        );
     }
 
     #[test]

--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -13,12 +13,12 @@ use ratatui::{
 
 // ── Banner ───────────────────────────────────────────────
 
-/// Build the compact 3-line header (replaces the old boxed banner).
+/// Build the compact 3-line header with block-art bear.
 ///
 /// ```text
-///  ʕ·ᴥ·ʔ  Koda v0.1.3
-///          gpt-4o · openai
-///          ~/repo/koda
+///  ▞▀▚▄▄▞▀▚  Koda v0.1.3
+///  ▌·▐▀▌·▐   gpt-4o · openai
+///  ▀▄▄▄▄▄▄▀  ~/repo/koda
 /// ```
 pub fn build_banner_lines(
     model: &str,
@@ -27,27 +27,30 @@ pub fn build_banner_lines(
     _recent_activity: &[String],
 ) -> Vec<Line<'static>> {
     let ver = env!("CARGO_PKG_VERSION");
-    let bear = "ʕ·ᴥ·ʔ";
-    // Indent to align with the bear face width + spacing
-    let indent = " ".repeat(bear.len() + 3); // "ʕ·ᴥ·ʔ" + "  "
+
+    // 3-line block-art bear (quadrant style).
+    // Each line is 8 visual columns wide.
+    const BEAR: [&str; 3] = ["▞▀▚▄▄▞▀▚", "▌·▐▀▌·▐ ", "▀▄▄▄▄▄▄▀"];
 
     vec![
-        // Line 1: bear face + name + version
+        // Line 1: bear ears + name + version
         Line::from(vec![
-            Span::styled(format!(" {bear}"), WARM_ACCENT),
+            Span::styled(format!(" {}", BEAR[0]), WARM_ACCENT),
             Span::raw("  "),
             Span::styled(format!("Koda v{ver}"), WARM_TITLE),
         ]),
-        // Line 2: model · provider
+        // Line 2: bear face + model · provider
         Line::from(vec![
-            Span::raw(format!(" {indent}")),
+            Span::styled(format!(" {}", BEAR[1]), WARM_ACCENT),
+            Span::raw("  "),
             Span::styled(model.to_string(), WARM_INFO),
             Span::styled(" · ", WARM_MUTED),
             Span::styled(provider.to_string(), WARM_MUTED),
         ]),
-        // Line 3: cwd
+        // Line 3: bear chin + cwd
         Line::from(vec![
-            Span::raw(format!(" {indent}")),
+            Span::styled(format!(" {}", BEAR[2]), WARM_ACCENT),
+            Span::raw("  "),
             Span::styled(cwd.to_string(), DIM),
         ]),
     ]
@@ -232,7 +235,9 @@ mod tests {
     fn banner_contains_bear_face() {
         let lines = build_banner_lines("m", "p", "~", &[]);
         let text = lines_to_text(&lines);
-        assert!(text.contains("ʕ·ᴥ·ʔ"), "Banner should contain bear face");
+        assert!(text.contains("▞▀▚"), "Banner should contain block-art bear ears");
+        // Block-art bear line 3: chin
+        assert!(text.contains("▀▄▄▄▄▄▄▀"), "Banner should contain block-art bear chin");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The 3-line block-art bear header (design E) was lost during the conflict resolution of the `feat/203-header-redesign` merge into main (#207).

The merge replaced the block-art bear:
```
 ▞▀▚▄▄▞▀▚  Koda v0.1.3
 ▌·▐▀▌·▐   gpt-4o · openai
 ▀▄▄▄▄▄▄▀  ~/repo/koda
```

...with the old kaomoji bear `ʕ·ᴥ·ʔ`.

## Fix

Recovered the block-art `BEAR` constant from commit `4670180` (the original Phase 4 commit on the feature branch). Updated the test assertion to match.

## Note

This is why we should use rebase instead of merge — merge conflict resolution silently dropped the design E logo without failing any tests (the test only checked for `ʕ·ᴥ·ʔ` which was in the base branch).

Closes the bear logo portion of #207.