### PR TITLE
test: inference error-recovery tests (rate limit + context overflow)

### DIFF
--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -26,6 +26,10 @@ pub enum MockResponse {
     ToolCalls(Vec<ToolCall>),
     /// Simulate a provider error.
     Error(String),
+    /// Simulate a rate limit (429) error.
+    RateLimit,
+    /// Simulate a context overflow error.
+    ContextOverflow,
 }
 
 impl MockResponse {
@@ -75,6 +79,10 @@ impl MockProvider {
                     MockResponse::tool_call(tool, args)
                 } else if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
                     MockResponse::Error(err.to_string())
+                } else if v.get("rate_limit").is_some() {
+                    MockResponse::RateLimit
+                } else if v.get("context_overflow").is_some() {
+                    MockResponse::ContextOverflow
                 } else {
                     MockResponse::Text(v.to_string())
                 }
@@ -113,6 +121,12 @@ impl LlmProvider for MockProvider {
                 usage: TokenUsage::default(),
             }),
             MockResponse::Error(msg) => Err(anyhow::anyhow!(msg)),
+            MockResponse::RateLimit => {
+                Err(anyhow::anyhow!("LLM API returned 429: Too Many Requests"))
+            }
+            MockResponse::ContextOverflow => Err(anyhow::anyhow!(
+                "LLM API returned 400: prompt is too long, maximum context length exceeded"
+            )),
         }
     }
 
@@ -125,8 +139,17 @@ impl LlmProvider for MockProvider {
         let response = self.next_response();
 
         // Error responses fail at the call site, not inside the stream.
-        if let MockResponse::Error(msg) = response {
-            return Err(anyhow::anyhow!(msg));
+        match &response {
+            MockResponse::Error(msg) => return Err(anyhow::anyhow!("{msg}")),
+            MockResponse::RateLimit => {
+                return Err(anyhow::anyhow!("LLM API returned 429: Too Many Requests"));
+            }
+            MockResponse::ContextOverflow => {
+                return Err(anyhow::anyhow!(
+                    "LLM API returned 400: prompt is too long, maximum context length exceeded"
+                ));
+            }
+            _ => {}
         }
 
         let (tx, rx) = mpsc::channel(32);
@@ -157,7 +180,9 @@ impl LlmProvider for MockProvider {
                         }))
                         .await;
                 }
-                MockResponse::Error(_) => unreachable!(),
+                MockResponse::Error(_)
+                | MockResponse::RateLimit
+                | MockResponse::ContextOverflow => unreachable!(),
             }
         });
 

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -1,0 +1,229 @@
+//! Tests for inference loop error recovery paths.
+//!
+//! Exercises rate-limit retry (429 → backoff → success) and context-overflow
+//! recovery (overflow → compact → retry → success).
+
+use koda_core::{
+    approval::{ApprovalMode, Settings},
+    config::{KodaConfig, ProviderType},
+    db::{Database, Role},
+    engine::{EngineCommand, EngineEvent, sink::TestSink},
+    inference,
+    providers::mock::{MockProvider, MockResponse},
+    tools::ToolRegistry,
+};
+use std::path::PathBuf;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// ── Test harness ──────────────────────────────────────────────
+
+struct Env {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+    db: Database,
+    session_id: String,
+    config: KodaConfig,
+    tools: ToolRegistry,
+}
+
+impl Env {
+    async fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let db = Database::init(&root, &root).await.unwrap();
+        let session_id = db.create_session("test-agent", &root).await.unwrap();
+        let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
+        let tools = ToolRegistry::new(root.clone(), config.max_context_tokens);
+        Self {
+            _tmp: tmp,
+            root,
+            db,
+            session_id,
+            config,
+            tools,
+        }
+    }
+
+    fn tool_defs(&self) -> Vec<koda_core::providers::ToolDefinition> {
+        self.tools.get_definitions(&[])
+    }
+
+    async fn insert_message(&self, role: &Role, text: &str) {
+        self.db
+            .insert_message(&self.session_id, role, Some(text), None, None, None)
+            .await
+            .unwrap();
+    }
+
+    /// Run inference and return (result, events).
+    async fn run(&self, provider: &MockProvider) -> (anyhow::Result<()>, Vec<EngineEvent>) {
+        let sink = TestSink::new();
+        let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+        let mut settings = Settings::load();
+        let tool_defs = self.tool_defs();
+
+        let result = inference::inference_loop(
+            &self.root,
+            &self.config,
+            &self.db,
+            &self.session_id,
+            "You are a test assistant.",
+            provider,
+            &self.tools,
+            &tool_defs,
+            None,
+            ApprovalMode::Auto,
+            &mut settings,
+            &sink,
+            CancellationToken::new(),
+            &mut cmd_rx,
+        )
+        .await;
+
+        (result, sink.events())
+    }
+}
+
+// ── Rate limit retry tests ───────────────────────────────────
+
+#[tokio::test]
+async fn test_rate_limit_single_retry_recovers() {
+    let env = Env::new().await;
+    env.insert_message(&Role::User, "hello").await;
+
+    // First call: 429, second call: success
+    let provider = MockProvider::new(vec![
+        MockResponse::RateLimit,
+        MockResponse::Text("recovered after rate limit".into()),
+    ]);
+
+    let (result, events) = env.run(&provider).await;
+    assert!(result.is_ok(), "should recover: {:?}", result.err());
+
+    // Should have a warning about rate limiting
+    let has_rate_warn = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Warn { message } if message.contains("Rate limited")
+        )
+    });
+    assert!(has_rate_warn, "expected rate limit warning in events");
+
+    // Response should be persisted
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("recovered after rate limit"),
+        "DB should contain recovered response: {last}"
+    );
+}
+
+#[tokio::test]
+async fn test_rate_limit_exhausted_returns_error() {
+    let env = Env::new().await;
+    env.insert_message(&Role::User, "hello").await;
+
+    // All 5 retries fail with rate limit
+    let provider = MockProvider::new(vec![
+        MockResponse::RateLimit,
+        MockResponse::RateLimit,
+        MockResponse::RateLimit,
+        MockResponse::RateLimit,
+        MockResponse::RateLimit,
+    ]);
+
+    let (result, _events) = env.run(&provider).await;
+    assert!(result.is_err(), "should fail after exhausting retries");
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(
+        err.contains("429") || err.contains("Too Many Requests"),
+        "error should mention rate limit: {err}"
+    );
+}
+
+// ── Context overflow recovery tests ──────────────────────────
+
+#[tokio::test]
+async fn test_context_overflow_compacts_and_retries() {
+    let env = Env::new().await;
+
+    // Need >= 4 messages in history for compaction to proceed.
+    env.insert_message(&Role::User, "first question").await;
+    env.insert_message(&Role::Assistant, "first answer").await;
+    env.insert_message(&Role::User, "second question").await;
+    env.insert_message(&Role::Assistant, "second answer").await;
+    env.insert_message(&Role::User, "third question that overflows")
+        .await;
+
+    // Response sequence:
+    // 1. chat_stream() → ContextOverflow (triggers recovery)
+    // 2. chat() → compaction summary (non-streaming)
+    // 3. chat_stream() → success (retry after compaction)
+    let provider = MockProvider::new(vec![
+        MockResponse::ContextOverflow,
+        MockResponse::Text("Summary: user asked three questions.".into()),
+        MockResponse::Text("recovered after compaction".into()),
+    ]);
+
+    let (result, events) = env.run(&provider).await;
+    assert!(result.is_ok(), "should recover: {:?}", result.err());
+
+    // Should have a warning about context overflow
+    let has_overflow_warn = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Warn { message } if message.contains("context overflow")
+                || message.contains("Context overflow")
+                || message.contains("overflow")
+        )
+    });
+    assert!(
+        has_overflow_warn,
+        "expected overflow warning in events: {events:?}"
+    );
+
+    // Should have compaction info
+    let has_compact_info = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Info { message } if message.contains("Compacted")
+        )
+    });
+    assert!(
+        has_compact_info,
+        "expected compaction info in events: {events:?}"
+    );
+
+    // Response should be persisted
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("recovered after compaction"),
+        "DB should contain recovered response: {last}"
+    );
+}
+
+#[tokio::test]
+async fn test_context_overflow_too_few_messages_fails() {
+    let env = Env::new().await;
+
+    // Only 1 message — compaction will skip (TooShort), recovery fails.
+    env.insert_message(&Role::User, "hello").await;
+
+    let provider = MockProvider::new(vec![MockResponse::ContextOverflow]);
+
+    let (result, _events) = env.run(&provider).await;
+    assert!(result.is_err(), "should fail when compaction can't help");
+    let err = format!("{:#}", result.unwrap_err());
+    assert!(
+        err.contains("context overflow") || err.contains("too long"),
+        "error should mention overflow: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds E2E tests for the two highest-risk untested error recovery paths in `inference.rs`, as flagged by the QA pre-release review (#215 P0-4).

## Changes

### New mock variants (`providers/mock.rs`)

- `MockResponse::RateLimit` — returns `429 Too Many Requests`
- `MockResponse::ContextOverflow` — returns `400: prompt is too long`

Both work in `chat()` (non-streaming) and `chat_stream()` (streaming), and are supported by `from_env()` JSON parsing (`{"rate_limit": true}`, `{"context_overflow": true}`).

### New test file (`tests/inference_recovery_test.rs`)

| Test | Scenario | Asserts |
|------|----------|---------|
| `test_rate_limit_single_retry_recovers` | 429 → backoff → success | Recovery succeeds, rate limit warning emitted, response persisted to DB |
| `test_rate_limit_exhausted_returns_error` | 5× 429 → fail | Error propagated with rate limit message |
| `test_context_overflow_compacts_and_retries` | overflow → compact → retry → success | Recovery succeeds, overflow warning + compaction info emitted, response persisted |
| `test_context_overflow_too_few_messages_fails` | overflow with 1 msg → fail | Error propagated (compaction skipped: TooShort) |

## Testing

- All 4 new tests pass (including the rate limit test which exercises real `tokio::time::sleep` backoff)
- Full workspace: all tests pass
- Clippy clean, fmt clean