### PR TITLE
release: v0.1.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,5 +288,5 @@ See `koda-ast/tests/mcp_integration_test.rs` for the reference implementation.
 4. Add `--version` flag to `main()`
 5. Write MCP integration tests in `tests/mcp_integration_test.rs`
 6. Update `release.yml`: version verify, build, package, publish, Homebrew
-7. Sync version with workspace (currently 0.1.2)
+7. Sync version with workspace (currently 0.1.3)
 8. Update this file (claude.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.2" }
+koda-core = { path = "../koda-core", version = "0.1.3" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.3

Bumps all 4 crate versions from `0.1.2` → `0.1.3`.

**589 tests passing** | **Clippy clean** | **0 doc warnings** | **29 closed issues**

Closes #215

---

### Highlights

#### Intelligent Token Management & Model-Adaptive Architecture
- Observe-and-adapt tier system with decoupled limits (#186)
- Query model capabilities from provider API (#185, #187)
- Context-on-demand + structured progress tracking (#169)
- Lazy tool loading — DiscoverTools for on-demand schema injection (#167)
- Model-routed sub-agents — right-size the model to the task phase (#168)
- Cheap compaction, per-agent cost tracking, priority retention (#177)
- Scale tool output caps to context window (#192, #204)
- Claude 1M extended context via virtual -long model names (#205, #206)

#### Security
- TLS bypass scoped to localhost only (#215)
- Remove curl/wget from bash safety auto-approve list (#215)

#### Streaming Robustness
- Generalized stream tag filter: thinking, tool call, and special token handling for 6+ OpenAI-compat providers (#214)
- Fix stale `</think>` tag handling across turn boundaries (#191)
- Fix inference terminated prematurely (#189)

#### UX & TUI
- Redesigned startup header — warm colors, separator, help overlay (#203)
- Mode simplification — Auto/Strict/Safe (#180)
- Per-turn cost display, fuzzy @file, /undo (#129)
- Syntax highlighting for Read and Grep tool output (#136)
- Fix terminal resize ghost prompt lines (#194)
- Fix context window at 152% on startup (#182)
- Ctrl+J/K vim-style navigation (#130)
- Ctrl+N/P history navigation fix (#134, #135)

#### MCP & Tools
- koda-email MCP server — email via IMAP/SMTP (#133, #161)
- Auto-provisioned MCP — koda-ast extraction + capability registry (#128)
- Skill system — ActivateSkill/ListSkills (#127)
- Sub-agent efficiency — result caching & parallel execution (#208)

#### Testing
- Inference error-recovery tests: rate limit + context overflow (#215)
- Automated smoke tests for TUI + headless (#183, #202)
- MCP integration tests for koda-email (#162)
- Fix flaky E2E tests — env var race condition (#211)

#### Refactoring
- Extract tool_dispatch.rs, bash_safety.rs, prompt.rs from inference.rs (#116)
- Data-driven ProviderType, remove dead code (#116, #210)

---

### Pre-Release Review (4 agents)

| Agent | Verdict |
|-------|---------|
| code-reviewer | 🟢 Ship |
| qa-expert | 🟢 Ship (P0 tests added) |
| security-auditor | 🟢 Ship (TLS + curl fixed) |
| rust-programmer | 🟢 Ship |

### Merge & Tag

After merging this PR:
```bash
git tag v0.1.3
git push origin v0.1.3
```