### PR TITLE
docs: interaction system design decisions (DESIGN.md §14-15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ koda/
 │   │   ├── lib.rs          # Crate root (exports acp_adapter)
 │   │   └── widgets/        # TUI widgets
 │   │       ├── approval.rs # Inline approval prompt (approve/reject/feedback)
+│   │       ├── slash_menu.rs# Slash command dropdown (ratatui-native, see DESIGN.md §14)
 │   │       ├── status_bar.rs# Model, mode, context meter, elapsed time
 │   │       └── text_input.rs# Inline text input (masked for API keys)
 │   └── tests/              # CLI integration tests
@@ -133,10 +134,23 @@ koda/
 
 `main.rs` → `tui_app.rs` (TUI event loop) → `KodaSession::run_turn()` → `inference_loop()` (streaming LLM + tools)
 
-The TUI uses `ratatui::Viewport::Inline` for a persistent input bar + status bar at the bottom.
+The TUI uses `ratatui::Viewport::Inline` with a fixed 12-line viewport.
 Engine output is rendered above the viewport via `insert_before()`. Slash commands use
 crossterm direct writes (`write_line()`). These two rendering paths must never be mixed
 within a single operation.
+
+**Viewport layout** (see DESIGN.md §14):
+```
+[output scrollback]          ← insert_before()
+─── 🐻 ─                        ← separator
+⚡> input                      ← fixed position, sized to content
+──────────────────────────────
+model │ auto │ 0%               ← status bar (hugs input)
+[menu_area]                    ← dropdown / approval / wizard (Min(0))
+```
+
+All interactive UI renders in `menu_area`. The prompt and status bar never move.
+See DESIGN.md §14 for the interaction system design and competitive analysis.
 
 The engine communicates through `EngineEvent` (output) and `EngineCommand` (input) enums.
 Approval flows through async channels: engine emits `ApprovalRequest`, client sends `ApprovalResponse`.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -224,6 +224,69 @@ compatible with Claude Code. Teams using both tools get one file, not two.
 approval mode) remains a valid future feature but is orthogonal to project
 rules and should be tracked separately.
 
+### 14. Interaction System — Inline, Never Fullscreen (v0.1.4)
+
+**Decision**: All interactive UI (dropdowns, approvals, wizards) renders in a
+fixed `menu_area` below the status bar inside the ratatui viewport. The
+conversation is always visible. No fullscreen takeover, ever.
+
+**Principle**: *The conversation is the primary surface. Interactions happen
+within it, not on top of it.* This is the common thread across Claude Code
+and Codex. Goose's stepped wizards and Code Puppy's fullscreen forms violate
+this — users find them tedious and disorienting.
+
+**Viewport layout** (established in [#229](https://github.com/lijunzh/koda/pull/229)):
+```
+[LLM output in terminal scrollback]   ← always visible
+─── 🐻 ─
+⚡> input                              ← fixed, never moves
+────────────────────────────────
+model │ auto │ 0%                      ← fixed, hugs input
+  [menu_area]                          ← dropdown / approval / wizard
+  [empty when inactive]                ← looks like terminal bottom
+```
+
+Input + status bar form a fixed “center of mass” panel. The 12-line viewport
+never resizes for menus. Menu content appears below the status bar and
+disappears on dismiss.
+
+**Three interaction patterns**, all sharing `menu_area`:
+
+| Pattern | Widget | Examples |
+|---------|--------|----------|
+| 1a. Select | `DropdownState<T>` with type-to-filter, scroll | `/model`, `/provider`, `/` commands, `@file` |
+| 1b. Confirm | Compact approval + optional diff preview | Tool approval, file edits |
+| 2. Multi-step | Sequential inline prompts with compact trail | `/provider` setup, `/mcp add`, onboarding |
+
+**Key architectural decisions**:
+- Per-command state machine enums (`ProviderWizard`, `McpAddWizard`), not a
+  generic wizard framework — only 3 commands need multi-step flows (YAGNI)
+- Shared `WizardView { trail, active_widget }` for rendering; command-specific
+  logic in typed enums with exhaustive `match`
+- Power-user escape hatch: positional args skip the wizard entirely
+  (`/provider anthropic sk-ant-xxx` → zero prompts)
+- Keystore eliminates repeat wizards — most provider switches are instant
+- Shared `validate_and_build` between wizard completion and positional parser (DRY)
+- No “go back” in v0.2 — Esc to cancel and restart is fine for 2–4 step flows
+
+**Competitive analysis and detailed design**: [#230](https://github.com/lijunzh/koda/issues/230)
+**Implementation (slash dropdown)**: [#229](https://github.com/lijunzh/koda/pull/229)
+
+### 15. No `?` Help Overlay — The Dropdown Is Help (v0.1.4)
+
+**Decision**: Removed the `?` keyboard shortcut overlay and `/help` command.
+The slash dropdown with descriptions IS the help system.
+
+**Rationale**: Three overlapping discovery mechanisms (`?` overlay, `/help`
+modal, `/` auto-dropdown) created redundant complexity and viewport resize
+bugs. The auto-dropdown on `/` shows all commands with descriptions — that
+is help. Keyboard shortcuts moved to the startup banner header.
+
+**Code removed**: `widgets/help_overlay.rs` (96 lines), `handle_help()`,
+`show_help` state, and all associated viewport resize logic.
+
+**Implementation**: [#229](https://github.com/lijunzh/koda/pull/229)
+
 ## References
 
 - [ACP (Agent Client Protocol)](https://www.npmjs.com/package/@agentclientprotocol/sdk)

--- a/koda-cli/src/widgets/slash_menu.rs
+++ b/koda-cli/src/widgets/slash_menu.rs
@@ -9,7 +9,7 @@ use ratatui::{
     text::{Line, Span},
 };
 
-// Warm palette (matches help_overlay and separator)
+// Warm palette (matches separator)
 const DIM: Style = Style::new().fg(Color::Rgb(124, 111, 100));
 const SELECTED_CMD: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const UNSELECTED_CMD: Style = Style::new().fg(Color::Rgb(124, 111, 100));


### PR DESCRIPTION
## Summary

Documents the UX design research and architectural decisions for koda's interaction system. DESIGN.md serves as a **decision index** — concise rationale with links to the detailed discussions in GitHub issues/PRs.

## What's documented

### §14 — Interaction System: Inline, Never Fullscreen

> *The conversation is the primary surface. Interactions happen within it, not on top of it.*

- **Competitive analysis**: Claude Code (inline, non-blocking), Codex (config-file-first), Goose (stepped wizards, tedious), Code Puppy (fullscreen, blocks everything), Aider (zero widgets)
- **Viewport layout**: fixed 12-line viewport, input+status as fixed panel, `menu_area` below for all interactive content
- **Three interaction patterns**, all sharing `menu_area`:
  - 1a. Dropdown (`DropdownState<T>`) for `/model`, `/provider`, `/` commands
  - 1b. Confirm with preview for tool approval, file edits
  - 2. Sequential inline prompts for `/provider` setup, `/mcp add`, onboarding
- **Per-command state machines** (`ProviderWizard`, `McpAddWizard`), not generic wizard engine (YAGNI for 3 commands)
- **Power-user escape hatch**: positional args skip wizard (`/provider anthropic sk-ant-xxx` = zero prompts)
- **Shared validation** between wizard and positional parser (DRY)
- **No go-back in v0.2**: Esc to restart is fine for 2-4 step flows

### §15 — No `?` Help Overlay

The `/` auto-dropdown with descriptions IS help. Three overlapping mechanisms (`?`, `/help`, `/` dropdown) collapsed to one. Keyboard shortcuts moved to startup banner.

## Also updated

- **CLAUDE.md**: viewport layout diagram, `slash_menu.rs` in widget listing, reference to DESIGN.md §14

## Links
- Detailed design + competitive analysis: #230
- Implementation (slash dropdown): #229 (merged)
- Original issue: #227 (closed)
