### PR TITLE
feat: generic DropdownState<T> widget — Phase 1 of #230

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -86,6 +86,11 @@ enum TuiState {
     Inferring,
 }
 
+// ── Type aliases ─────────────────────────────────────────
+
+type SlashDropdown =
+    crate::widgets::dropdown::DropdownState<crate::widgets::slash_menu::SlashCommand>;
+
 // ── Viewport drawing ─────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -100,7 +105,7 @@ fn draw_viewport(
     queue_len: usize,
     elapsed_secs: u64,
     last_turn: Option<&crate::widgets::status_bar::TurnStats>,
-    slash_menu: Option<&crate::widgets::slash_menu::SlashMenuState>,
+    slash_menu: Option<&SlashDropdown>,
 ) {
     let area = frame.area();
 
@@ -367,7 +372,7 @@ pub async fn run(
     let mut pending_command: Option<String> = None;
     let mut silent_compact_deferred = false;
     let mut should_quit = false;
-    let mut slash_menu: Option<crate::widgets::slash_menu::SlashMenuState> = None;
+    let mut slash_menu: Option<SlashDropdown> = None;
     let mut inference_start: Option<std::time::Instant> = None;
     let mut history: Vec<String> = load_history();
     let mut history_idx: Option<usize> = None; // None = not browsing history
@@ -880,8 +885,10 @@ pub async fn run(
                                 continue;
                             }
                             KeyCode::Enter => {
-                                if let Some(ref menu) = slash_menu {
-                                    let cmd = menu.selected_command().to_string();
+                                if let Some(ref menu) = slash_menu
+                                    && let Some(item) = menu.selected_item()
+                                {
+                                    let cmd = item.command.to_string();
                                     textarea.select_all();
                                     textarea.cut();
                                     textarea.insert_str(&cmd);
@@ -1059,7 +1066,7 @@ pub async fn run(
                             let after_input = textarea.lines().join("\n");
                             let trimmed_after = after_input.trim_end();
                             if trimmed_after.starts_with('/') && !trimmed_after.contains(' ') {
-                                slash_menu = crate::widgets::slash_menu::SlashMenuState::from_input(
+                                slash_menu = crate::widgets::slash_menu::from_input(
                                     crate::completer::SLASH_COMMANDS,
                                     trimmed_after,
                                 );

--- a/koda-cli/src/widgets/dropdown.rs
+++ b/koda-cli/src/widgets/dropdown.rs
@@ -1,0 +1,317 @@
+//! Generic dropdown widget — rendered inside the ratatui viewport.
+//!
+//! Reusable dropdown with type-to-filter, scroll, and fixed-height
+//! rendering. Used by slash commands, `/model`, `/provider`, etc.
+//!
+//! See DESIGN.md §14 for the interaction system design.
+
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+// ── Styles ────────────────────────────────────────────
+
+const DIM: Style = Style::new().fg(Color::Rgb(124, 111, 100));
+const SELECTED: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+const UNSELECTED: Style = Style::new().fg(Color::Rgb(124, 111, 100));
+const DESC: Style = Style::new().fg(Color::Rgb(198, 165, 106));
+const HINT: Style = Style::new().fg(Color::Rgb(124, 111, 100));
+
+/// Max visible items in the dropdown (scroll for more).
+pub const MAX_VISIBLE: usize = 6;
+
+// ── Trait ────────────────────────────────────────────
+
+/// Trait for items that can be displayed in a dropdown.
+pub trait DropdownItem: Clone {
+    /// Primary label shown in the list.
+    fn label(&self) -> &str;
+    /// Optional description shown after the label.
+    fn description(&self) -> String;
+    /// Whether this item matches a filter string.
+    fn matches_filter(&self, filter: &str) -> bool;
+}
+
+// ── Built-in item types ────────────────────────────────
+
+/// Simple label+description pair (for static command lists, providers, etc.).
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // Used in Phase 2 (/model, /provider conversions)
+pub struct SimpleItem {
+    pub label: String,
+    pub description: String,
+}
+
+impl SimpleItem {
+    #[allow(dead_code)] // Used in Phase 2
+    pub fn new(label: impl Into<String>, desc: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            description: desc.into(),
+        }
+    }
+}
+
+impl DropdownItem for SimpleItem {
+    fn label(&self) -> &str {
+        &self.label
+    }
+    fn description(&self) -> String {
+        self.description.clone()
+    }
+    fn matches_filter(&self, filter: &str) -> bool {
+        let lower = self.label.to_lowercase();
+        let filter_lower = filter.to_lowercase();
+        lower.contains(&filter_lower)
+    }
+}
+
+// ── State ────────────────────────────────────────────
+
+/// Generic dropdown state. Owns the filtered item list, selection,
+/// and scroll offset. Type parameter `T` must implement `DropdownItem`.
+#[derive(Clone)]
+pub struct DropdownState<T: DropdownItem> {
+    /// All items (unfiltered source).
+    all_items: Vec<T>,
+    /// Currently visible items after filtering.
+    pub filtered: Vec<T>,
+    /// Index into `filtered`.
+    pub selected: usize,
+    /// Scroll offset for the visible window.
+    pub scroll_offset: usize,
+    /// Title shown above the dropdown.
+    pub title: String,
+}
+
+impl<T: DropdownItem> DropdownState<T> {
+    /// Create a new dropdown with the given items and title.
+    pub fn new(items: Vec<T>, title: impl Into<String>) -> Self {
+        let filtered = items.clone();
+        Self {
+            all_items: items,
+            filtered,
+            selected: 0,
+            scroll_offset: 0,
+            title: title.into(),
+        }
+    }
+
+    /// Apply a filter string. Resets selection to 0.
+    /// Returns `false` if no items match (caller can dismiss).
+    pub fn apply_filter(&mut self, filter: &str) -> bool {
+        self.filtered = self
+            .all_items
+            .iter()
+            .filter(|item| item.matches_filter(filter))
+            .cloned()
+            .collect();
+        self.selected = 0;
+        self.scroll_offset = 0;
+        !self.filtered.is_empty()
+    }
+
+    /// Move selection up.
+    pub fn up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+        if self.selected < self.scroll_offset {
+            self.scroll_offset = self.selected;
+        }
+    }
+
+    /// Move selection down (wraps around).
+    pub fn down(&mut self) {
+        if self.selected + 1 < self.filtered.len() {
+            self.selected += 1;
+        } else {
+            self.selected = 0;
+            self.scroll_offset = 0;
+        }
+        let visible = MAX_VISIBLE.min(self.filtered.len());
+        if self.selected >= self.scroll_offset + visible {
+            self.scroll_offset = self.selected + 1 - visible;
+        }
+    }
+
+    /// Get the currently selected item, if any.
+    pub fn selected_item(&self) -> Option<&T> {
+        self.filtered.get(self.selected)
+    }
+
+    /// Check if the dropdown has any items to show.
+    #[allow(dead_code)] // Used in Phase 2
+    pub fn is_empty(&self) -> bool {
+        self.filtered.is_empty()
+    }
+}
+
+// ── Rendering ─────────────────────────────────────────
+
+/// Build dropdown lines for rendering in the viewport.
+/// Always returns exactly `MAX_VISIBLE + 2` lines (fixed height).
+pub fn build_dropdown_lines<T: DropdownItem>(state: &DropdownState<T>) -> Vec<Line<'static>> {
+    let visible = MAX_VISIBLE.min(state.filtered.len());
+    let end = (state.scroll_offset + visible).min(state.filtered.len());
+    let window = &state.filtered[state.scroll_offset..end];
+    let has_above = state.scroll_offset > 0;
+    let has_below = end < state.filtered.len();
+
+    let mut lines = Vec::with_capacity(MAX_VISIBLE + 2);
+
+    // Title with scroll indicator
+    let title = if has_above {
+        format!("  {} \u{25b2} more", state.title)
+    } else {
+        format!("  {}", state.title)
+    };
+    lines.push(Line::from(Span::styled(title, DIM)));
+
+    // Visible options
+    for (i, item) in window.iter().enumerate() {
+        let absolute_idx = state.scroll_offset + i;
+        let is_selected = absolute_idx == state.selected;
+        let label = item.label().to_string();
+        let desc = item.description();
+        let mut spans = Vec::with_capacity(4);
+
+        if is_selected {
+            spans.push(Span::styled(
+                "  \u{203a} ",
+                Style::default().fg(Color::Cyan),
+            ));
+            spans.push(Span::styled(label, SELECTED));
+        } else {
+            spans.push(Span::raw("    "));
+            spans.push(Span::styled(label, UNSELECTED));
+        }
+        if !desc.is_empty() {
+            spans.push(Span::styled(format!("  {desc}"), DESC));
+        }
+
+        lines.push(Line::from(spans));
+    }
+
+    // Pad empty slots to maintain fixed height
+    for _ in visible..MAX_VISIBLE {
+        lines.push(Line::from(""));
+    }
+
+    // Hint with scroll indicator
+    let hint = if has_below {
+        "  \u{2191}/\u{2193} navigate \u{00b7} enter select \u{00b7} esc cancel  \u{25bc} more"
+    } else {
+        "  \u{2191}/\u{2193} navigate \u{00b7} enter select \u{00b7} esc cancel"
+    };
+    lines.push(Line::from(Span::styled(hint, HINT)));
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_items() -> Vec<SimpleItem> {
+        vec![
+            SimpleItem::new("/agent", "Agents"),
+            SimpleItem::new("/compact", "Compact"),
+            SimpleItem::new("/cost", "Cost"),
+            SimpleItem::new("/diff", "Diff"),
+            SimpleItem::new("/exit", "Quit"),
+            SimpleItem::new("/expand", "Expand"),
+            SimpleItem::new("/mcp", "MCP"),
+            SimpleItem::new("/model", "Pick model"),
+        ]
+    }
+
+    #[test]
+    fn new_contains_all() {
+        let dd = DropdownState::new(test_items(), "Test");
+        assert_eq!(dd.filtered.len(), 8);
+        assert_eq!(dd.selected, 0);
+    }
+
+    #[test]
+    fn filter_narrows() {
+        let mut dd = DropdownState::new(test_items(), "Test");
+        assert!(dd.apply_filter("/m"));
+        assert_eq!(dd.filtered.len(), 2); // /mcp, /model
+        assert_eq!(dd.filtered[0].label(), "/mcp");
+    }
+
+    #[test]
+    fn filter_no_match() {
+        let mut dd = DropdownState::new(test_items(), "Test");
+        assert!(!dd.apply_filter("/z"));
+        assert!(dd.is_empty());
+    }
+
+    #[test]
+    fn filter_case_insensitive() {
+        let mut dd = DropdownState::new(test_items(), "Test");
+        assert!(dd.apply_filter("/MCP"));
+        assert_eq!(dd.filtered.len(), 1);
+    }
+
+    #[test]
+    fn navigation() {
+        let mut dd = DropdownState::new(test_items(), "Test");
+        assert_eq!(dd.selected_item().unwrap().label(), "/agent");
+        dd.down();
+        assert_eq!(dd.selected_item().unwrap().label(), "/compact");
+        for _ in 0..6 {
+            dd.down();
+        }
+        assert_eq!(dd.selected_item().unwrap().label(), "/model");
+        dd.down(); // wraps
+        assert_eq!(dd.selected_item().unwrap().label(), "/agent");
+        dd.up(); // saturates at 0
+        assert_eq!(dd.selected_item().unwrap().label(), "/agent");
+    }
+
+    #[test]
+    fn scroll_indicators() {
+        let dd = DropdownState::new(test_items(), "Test");
+        let lines = build_dropdown_lines(&dd);
+        // 8 items, 6 visible → should have ▼ more
+        let hint: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(hint.contains('\u{25bc}'), "should show scroll-down: {hint}");
+    }
+
+    #[test]
+    fn fixed_height() {
+        let dd = DropdownState::new(test_items(), "Test");
+        let lines = build_dropdown_lines(&dd);
+        assert_eq!(lines.len(), 8); // title + 6 slots + hint
+
+        // Filtered to 2 items — still 8 lines
+        let mut dd2 = DropdownState::new(test_items(), "Test");
+        dd2.apply_filter("/e");
+        let lines = build_dropdown_lines(&dd2);
+        assert_eq!(lines.len(), 8);
+    }
+
+    #[test]
+    fn selected_marker() {
+        let dd = DropdownState::new(test_items(), "Test");
+        let lines = build_dropdown_lines(&dd);
+        let first: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(first.contains('\u{203a}'), "got: {first}");
+        let second: String = lines[2].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!second.contains('\u{203a}'), "got: {second}");
+    }
+
+    #[test]
+    fn selected_item_empty() {
+        let mut dd = DropdownState::new(test_items(), "Test");
+        dd.apply_filter("/zzz");
+        assert!(dd.selected_item().is_none());
+    }
+}

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -1,4 +1,5 @@
 pub mod approval;
+pub mod dropdown;
 pub mod slash_menu;
 pub mod status_bar;
 pub mod text_input;

--- a/koda-cli/src/widgets/slash_menu.rs
+++ b/koda-cli/src/widgets/slash_menu.rs
@@ -1,142 +1,54 @@
-//! Inline slash command menu — rendered inside the ratatui viewport.
+//! Slash command dropdown — thin wrapper around the generic dropdown.
 //!
 //! Appears when the user types `/` in an empty input. Filters live
-//! as the user continues typing. Fully reactive — no crossterm
-//! direct writes, no terminal reinit needed.
+//! as the user continues typing.
 
-use ratatui::{
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-};
+use super::dropdown::{self, DropdownItem, DropdownState};
+use ratatui::text::Line;
 
-// Warm palette (matches separator)
-const DIM: Style = Style::new().fg(Color::Rgb(124, 111, 100));
-const SELECTED_CMD: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
-const UNSELECTED_CMD: Style = Style::new().fg(Color::Rgb(124, 111, 100));
-const DESC: Style = Style::new().fg(Color::Rgb(198, 165, 106));
-const HINT: Style = Style::new().fg(Color::Rgb(124, 111, 100));
-
-/// Max visible items in the dropdown (scroll for more).
-const MAX_VISIBLE: usize = 6;
-
-/// State for the active slash command menu.
-#[derive(Clone)]
-pub struct SlashMenuState {
-    /// Currently matching commands: (command, description).
-    pub filtered: Vec<(&'static str, &'static str)>,
-    /// Index of the highlighted option.
-    pub selected: usize,
-    /// Scroll offset for the visible window.
-    pub scroll_offset: usize,
+/// A slash command item.
+#[derive(Clone, Debug)]
+pub struct SlashCommand {
+    pub command: &'static str,
+    pub description: &'static str,
 }
 
-impl SlashMenuState {
-    /// Create a new menu state by filtering commands against input.
-    /// Returns `None` if no commands match.
-    pub fn from_input(
-        commands: &'static [(&'static str, &'static str)],
-        input: &str,
-    ) -> Option<Self> {
-        let filtered: Vec<_> = commands
-            .iter()
-            .filter(|(cmd, _)| cmd.starts_with(input))
-            .copied()
-            .collect();
-        if filtered.is_empty() {
-            None
-        } else {
-            Some(Self {
-                filtered,
-                selected: 0,
-                scroll_offset: 0,
-            })
-        }
+impl DropdownItem for SlashCommand {
+    fn label(&self) -> &str {
+        self.command
     }
-
-    /// Move selection up.
-    pub fn up(&mut self) {
-        self.selected = self.selected.saturating_sub(1);
-        // Keep selected in visible window
-        if self.selected < self.scroll_offset {
-            self.scroll_offset = self.selected;
-        }
+    fn description(&self) -> String {
+        self.description.to_string()
     }
-
-    /// Move selection down (wraps around).
-    pub fn down(&mut self) {
-        if self.selected + 1 < self.filtered.len() {
-            self.selected += 1;
-        } else {
-            self.selected = 0;
-            self.scroll_offset = 0;
-        }
-        // Keep selected in visible window
-        let visible = MAX_VISIBLE.min(self.filtered.len());
-        if self.selected >= self.scroll_offset + visible {
-            self.scroll_offset = self.selected + 1 - visible;
-        }
-    }
-
-    /// Get the currently selected command string.
-    pub fn selected_command(&self) -> &'static str {
-        self.filtered[self.selected].0
+    fn matches_filter(&self, filter: &str) -> bool {
+        self.command.starts_with(filter)
     }
 }
 
-/// Build the slash menu as `Vec<Line>` for rendering in the viewport.
-/// Always returns exactly `MAX_VISIBLE + 2` lines (fixed height).
-pub fn build_menu_lines(state: &SlashMenuState) -> Vec<Line<'static>> {
-    let visible = MAX_VISIBLE.min(state.filtered.len());
-    let end = (state.scroll_offset + visible).min(state.filtered.len());
-    let window = &state.filtered[state.scroll_offset..end];
-    let has_above = state.scroll_offset > 0;
-    let has_below = end < state.filtered.len();
-
-    let mut lines = Vec::with_capacity(MAX_VISIBLE + 2);
-
-    // Title with scroll indicator
-    let title = if has_above {
-        "  \u{1f43b} Commands  \u{25b2} more"
+/// Create a slash menu dropdown from the command list and current input.
+/// Returns `None` if no commands match.
+pub fn from_input(
+    commands: &'static [(&'static str, &'static str)],
+    input: &str,
+) -> Option<DropdownState<SlashCommand>> {
+    let items: Vec<SlashCommand> = commands
+        .iter()
+        .map(|(cmd, desc)| SlashCommand {
+            command: cmd,
+            description: desc,
+        })
+        .collect();
+    let mut dd = DropdownState::new(items, "\u{1f43b} Commands");
+    if dd.apply_filter(input) {
+        Some(dd)
     } else {
-        "  \u{1f43b} Commands"
-    };
-    lines.push(Line::from(Span::styled(title, DIM)));
-
-    // Visible options
-    for (i, (cmd, desc)) in window.iter().enumerate() {
-        let absolute_idx = state.scroll_offset + i;
-        let is_selected = absolute_idx == state.selected;
-        let mut spans = Vec::with_capacity(4);
-
-        if is_selected {
-            spans.push(Span::styled(
-                "  \u{203a} ",
-                Style::default().fg(Color::Cyan),
-            ));
-            spans.push(Span::styled(*cmd, SELECTED_CMD));
-        } else {
-            spans.push(Span::raw("    "));
-            spans.push(Span::styled(*cmd, UNSELECTED_CMD));
-        }
-        spans.push(Span::styled(format!("  {desc}"), DESC));
-
-        lines.push(Line::from(spans));
+        None
     }
+}
 
-    // Pad empty slots to maintain fixed height
-    for _ in visible..MAX_VISIBLE {
-        lines.push(Line::from(""));
-    }
-
-    // Hint with scroll indicator
-    let hint = if has_below {
-        "  \u{2191}/\u{2193} navigate \u{00b7} enter select \u{00b7} esc cancel  \u{25bc} more"
-    } else {
-        "  \u{2191}/\u{2193} navigate \u{00b7} enter select \u{00b7} esc cancel"
-    };
-    lines.push(Line::from(Span::styled(hint, HINT)));
-
-    lines
+/// Build lines for rendering. Delegates to the generic dropdown renderer.
+pub fn build_menu_lines(state: &DropdownState<SlashCommand>) -> Vec<Line<'static>> {
+    dropdown::build_dropdown_lines(state)
 }
 
 #[cfg(test)]
@@ -156,79 +68,25 @@ mod tests {
 
     #[test]
     fn from_input_all() {
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/").unwrap();
+        let state = from_input(TEST_COMMANDS, "/").unwrap();
         assert_eq!(state.filtered.len(), 8);
-        assert_eq!(state.selected, 0);
     }
 
     #[test]
     fn from_input_filtered() {
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/m").unwrap();
-        assert_eq!(state.filtered.len(), 2); // /mcp, /model
-        assert_eq!(state.filtered[0].0, "/mcp");
+        let state = from_input(TEST_COMMANDS, "/m").unwrap();
+        assert_eq!(state.filtered.len(), 2);
+        assert_eq!(state.filtered[0].command, "/mcp");
     }
 
     #[test]
     fn from_input_no_match() {
-        assert!(SlashMenuState::from_input(TEST_COMMANDS, "/z").is_none());
+        assert!(from_input(TEST_COMMANDS, "/z").is_none());
     }
 
     #[test]
-    fn navigation() {
-        let mut state = SlashMenuState::from_input(TEST_COMMANDS, "/").unwrap();
-        assert_eq!(state.selected_command(), "/agent");
-        state.down();
-        assert_eq!(state.selected_command(), "/compact");
-        // Go to end
-        for _ in 0..6 {
-            state.down();
-        }
-        assert_eq!(state.selected_command(), "/model");
-        state.down(); // wraps
-        assert_eq!(state.selected_command(), "/agent");
-        state.up(); // saturates at 0
-        assert_eq!(state.selected_command(), "/agent");
-    }
-
-    #[test]
-    fn scroll_indicator() {
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/").unwrap();
-        let lines = build_menu_lines(&state);
-        // 8 items, 6 visible → should have ▼ more on hint
-        let hint: String = lines
-            .last()
-            .unwrap()
-            .spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect();
-        assert!(
-            hint.contains('\u{25bc}'),
-            "should show scroll-down indicator: {hint}"
-        );
-    }
-
-    #[test]
-    fn build_lines_count_always_fixed() {
-        // Full list
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/").unwrap();
-        let lines = build_menu_lines(&state);
-        assert_eq!(lines.len(), 8); // title + 6 slots + hint
-        // Filtered to 2 items — still 8 lines (4 blank padding)
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/e").unwrap();
-        let lines = build_menu_lines(&state);
-        assert_eq!(lines.len(), 8);
-    }
-
-    #[test]
-    fn build_lines_selected_marker() {
-        let state = SlashMenuState::from_input(TEST_COMMANDS, "/").unwrap();
-        let lines = build_menu_lines(&state);
-        // First option should have the › marker
-        let first_opt: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(first_opt.contains('\u{203a}'), "got: {first_opt}");
-        // Second option should NOT
-        let second_opt: String = lines[2].spans.iter().map(|s| s.content.as_ref()).collect();
-        assert!(!second_opt.contains('\u{203a}'), "got: {second_opt}");
+    fn selected_command() {
+        let state = from_input(TEST_COMMANDS, "/").unwrap();
+        assert_eq!(state.selected_item().unwrap().command, "/agent");
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #230: Extract the generic `DropdownState<T>` widget from `SlashMenuState`.

This is the foundation for converting `/model`, `/provider`, `/sessions`, and `@file` completion to the same inline dropdown pattern (see DESIGN.md §14).

## What changed

| File | Before | After |
|------|--------|-------|
| `widgets/dropdown.rs` | — | **New**: `DropdownState<T>`, `DropdownItem` trait, `SimpleItem`, `build_dropdown_lines()` |
| `widgets/slash_menu.rs` | 230 lines (all logic inline) | 95 lines (thin wrapper implementing `DropdownItem` for `SlashCommand`) |
| `tui_app.rs` | `SlashMenuState` | `SlashDropdown` type alias |

## The `DropdownItem` trait

```rust
pub trait DropdownItem: Clone {
    fn label(&self) -> &str;              // primary text
    fn description(&self) -> String;       // secondary text
    fn matches_filter(&self, filter: &str) -> bool;  // type-to-filter
}
```

Any type implementing this trait gets: scrollable dropdown, type-to-filter, fixed-height rendering, scroll indicators. Zero additional widget code needed.

## Testing

- 154 tests pass (109 unit + 45 integration)
- 9 new tests for the generic dropdown
- `cargo clippy -D warnings` clean
- `cargo fmt --all --check` clean

## Next: Phase 2

Convert `/model` to use `DropdownState<ModelItem>` with type-to-filter across 100+ models.

Part of #230
