### PR TITLE
feat: /provider uses inline dropdown — Phase 3 of #230

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -91,6 +91,8 @@ enum TuiState {
 type SlashDropdown =
     crate::widgets::dropdown::DropdownState<crate::widgets::slash_menu::SlashCommand>;
 type ModelDropdown = crate::widgets::dropdown::DropdownState<crate::widgets::model_menu::ModelItem>;
+type ProviderDropdown =
+    crate::widgets::dropdown::DropdownState<crate::widgets::provider_menu::ProviderItem>;
 
 /// What's currently shown in the `menu_area` below the status bar.
 /// Only one menu can be active at a time.
@@ -101,6 +103,8 @@ enum MenuContent {
     Slash(SlashDropdown),
     /// Model picker dropdown (`/model` with no args).
     Model(ModelDropdown),
+    /// Provider picker dropdown (`/provider` with no args).
+    Provider(ProviderDropdown),
 }
 
 impl MenuContent {
@@ -157,6 +161,10 @@ fn draw_viewport(
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
         MenuContent::Model(dd) => {
+            let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::Provider(dd) => {
             let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
@@ -517,6 +525,40 @@ pub async fn run(
                                     );
                                 }
                             }
+                            continue;
+                        }
+
+                        // Intercept /provider (no args) — open inline dropdown
+                        if input.trim() == "/provider" {
+                            let providers = crate::repl::PROVIDERS;
+                            let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
+                                .iter()
+                                .map(|(key, name, desc)| {
+                                    crate::widgets::provider_menu::ProviderItem {
+                                        key,
+                                        name,
+                                        description: desc,
+                                        is_current:
+                                            koda_core::config::ProviderType::from_url_or_name(
+                                                "",
+                                                Some(key),
+                                            ) == config.provider_type,
+                                    }
+                                })
+                                .collect();
+                            let mut dd = crate::widgets::dropdown::DropdownState::new(
+                                items,
+                                "\u{1f43b} Select a provider",
+                            );
+                            // Pre-select current provider
+                            if let Some(idx) = dd.filtered.iter().position(|p| p.is_current) {
+                                dd.selected = idx;
+                                let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
+                                if idx >= max_vis {
+                                    dd.scroll_offset = idx + 1 - max_vis;
+                                }
+                            }
+                            menu = MenuContent::Provider(dd);
                             continue;
                         }
 
@@ -957,6 +999,7 @@ pub async fn run(
                             match &mut menu {
                                 MenuContent::Slash(dd) => dd.up(),
                                 MenuContent::Model(dd) => dd.up(),
+                                MenuContent::Provider(dd) => dd.up(),
                                 MenuContent::None => {}
                             }
                             continue;
@@ -964,6 +1007,7 @@ pub async fn run(
                             match &mut menu {
                                 MenuContent::Slash(dd) => dd.down(),
                                 MenuContent::Model(dd) => dd.down(),
+                                MenuContent::Provider(dd) => dd.down(),
                                 MenuContent::None => {}
                             }
                             continue;
@@ -1000,6 +1044,37 @@ pub async fn run(
                                             );
                                             renderer.model = model_id;
                                         }
+                                    }
+                                    MenuContent::Provider(dd) => {
+                                        if let Some(item) = dd.selected_item() {
+                                            let key = item.key;
+                                            let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
+                                            let base_url = ptype.default_base_url().to_string();
+                                            // Close the dropdown first
+                                            menu = MenuContent::None;
+                                            // Delegate to the existing setup flow
+                                            // (handles API key prompt, connection verify, etc.)
+                                            crate::tui_wizards::handle_setup_provider(
+                                                &mut terminal,
+                                                &mut config,
+                                                &provider,
+                                                ptype,
+                                                base_url,
+                                            )
+                                            .await;
+                                            // Refresh after provider change
+                                            renderer.model = config.model.clone();
+                                            let prov = provider.read().await;
+                                            if let Ok(models) = prov.list_models().await {
+                                                completer.set_model_names(
+                                                    models.iter().map(|m| m.id.clone()).collect(),
+                                                );
+                                            }
+                                            // Reinit terminal after crossterm writes from setup
+                                            crossterm_events = EventStream::new();
+                                            terminal = init_terminal(viewport_height)?;
+                                        }
+                                        continue;
                                     }
                                     MenuContent::None => {}
                                 }

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -1,6 +1,7 @@
 pub mod approval;
 pub mod dropdown;
 pub mod model_menu;
+pub mod provider_menu;
 pub mod slash_menu;
 pub mod status_bar;
 pub mod text_input;

--- a/koda-cli/src/widgets/provider_menu.rs
+++ b/koda-cli/src/widgets/provider_menu.rs
@@ -1,0 +1,68 @@
+//! Provider picker dropdown — thin wrapper around the generic dropdown.
+//!
+//! Appears when the user types `/provider` with no args.
+//! After selection, the provider setup flow continues with API key input.
+
+use super::dropdown::DropdownItem;
+
+/// A provider item for the dropdown.
+#[derive(Clone, Debug)]
+pub struct ProviderItem {
+    /// Internal key (e.g. "anthropic", "openai").
+    pub key: &'static str,
+    /// Display name (e.g. "Anthropic", "OpenAI").
+    pub name: &'static str,
+    /// Short description (e.g. "Claude Sonnet, Opus").
+    pub description: &'static str,
+    /// Whether this is the currently active provider.
+    pub is_current: bool,
+}
+
+impl DropdownItem for ProviderItem {
+    fn label(&self) -> &str {
+        self.name
+    }
+    fn description(&self) -> String {
+        let mut desc = self.description.to_string();
+        if self.is_current {
+            desc.push_str(" \u{25c0} current");
+        }
+        desc
+    }
+    fn matches_filter(&self, filter: &str) -> bool {
+        let f = filter.to_lowercase();
+        self.name.to_lowercase().contains(&f)
+            || self.key.to_lowercase().contains(&f)
+            || self.description.to_lowercase().contains(&f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_shows_marker() {
+        let item = ProviderItem {
+            key: "anthropic",
+            name: "Anthropic",
+            description: "Claude Sonnet, Opus",
+            is_current: true,
+        };
+        assert!(item.description().contains('\u{25c0}'));
+    }
+
+    #[test]
+    fn filter_matches_key_name_desc() {
+        let item = ProviderItem {
+            key: "anthropic",
+            name: "Anthropic",
+            description: "Claude Sonnet, Opus",
+            is_current: false,
+        };
+        assert!(item.matches_filter("anth"));
+        assert!(item.matches_filter("Claude"));
+        assert!(item.matches_filter("opus"));
+        assert!(!item.matches_filter("gemini"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 of #230: Convert `/provider` (no args) from blocking `select_inline` modal to reactive ratatui dropdown.

## How it works

1. Type `/provider` → inline dropdown appears with all 14 providers
2. Type to filter (searches name, key, AND description — e.g. "claude" finds Anthropic)
3. Arrow keys / Ctrl+J/K navigate, Enter selects, Esc cancels
4. After selection → delegates to existing `handle_setup_provider` for API key flow
5. `/provider <name>` still works as direct setup (no dropdown)

## New files

- `widgets/provider_menu.rs` — `ProviderItem` implementing `DropdownItem` (68 lines, 2 tests)

## Architecture

- `MenuContent::Provider` variant added (same pattern as Model/Slash)
- All Up/Down/Enter/Esc handlers updated for Provider
- After provider selection, the API key prompt still uses the existing crossterm `text_input` (Pattern 2 wizard will convert this later)

## Testing

- 159 tests pass
- `cargo clippy -D warnings` clean

Part of #230
