### PR TITLE
feat: /sessions uses inline dropdown — Phase 4 of #230

### DIFF
--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -93,6 +93,8 @@ type SlashDropdown =
 type ModelDropdown = crate::widgets::dropdown::DropdownState<crate::widgets::model_menu::ModelItem>;
 type ProviderDropdown =
     crate::widgets::dropdown::DropdownState<crate::widgets::provider_menu::ProviderItem>;
+type SessionDropdown =
+    crate::widgets::dropdown::DropdownState<crate::widgets::session_menu::SessionItem>;
 
 /// What's currently shown in the `menu_area` below the status bar.
 /// Only one menu can be active at a time.
@@ -105,6 +107,8 @@ enum MenuContent {
     Model(ModelDropdown),
     /// Provider picker dropdown (`/provider` with no args).
     Provider(ProviderDropdown),
+    /// Session picker dropdown (`/sessions` with no args).
+    Session(SessionDropdown),
 }
 
 impl MenuContent {
@@ -165,6 +169,10 @@ fn draw_viewport(
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
         MenuContent::Provider(dd) => {
+            let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::Session(dd) => {
             let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
@@ -559,6 +567,59 @@ pub async fn run(
                                 }
                             }
                             menu = MenuContent::Provider(dd);
+                            continue;
+                        }
+
+                        // Intercept /sessions (no args) — open inline dropdown
+                        if input.trim() == "/sessions" {
+                            match session.db.list_sessions(10, &project_root).await {
+                                Ok(sessions) if !sessions.is_empty() => {
+                                    let items: Vec<crate::widgets::session_menu::SessionItem> =
+                                        sessions
+                                            .iter()
+                                            .map(|s| crate::widgets::session_menu::SessionItem {
+                                                id: s.id.clone(),
+                                                short_id: s.id[..8.min(s.id.len())].to_string(),
+                                                created_at: s.created_at.clone(),
+                                                message_count: s.message_count,
+                                                total_tokens: s.total_tokens,
+                                                is_current: s.id == session.id,
+                                            })
+                                            .collect();
+                                    let mut dd = crate::widgets::dropdown::DropdownState::new(
+                                        items,
+                                        "\u{1f43b} Sessions",
+                                    );
+                                    // Pre-select current session
+                                    if let Some(idx) = dd.filtered.iter().position(|s| s.is_current)
+                                    {
+                                        dd.selected = idx;
+                                        let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
+                                        if idx >= max_vis {
+                                            dd.scroll_offset = idx + 1 - max_vis;
+                                        }
+                                    }
+                                    menu = MenuContent::Session(dd);
+                                }
+                                Ok(_) => {
+                                    emit_above(
+                                        &mut terminal,
+                                        Line::styled(
+                                            "  No other sessions found.",
+                                            Style::default().fg(Color::DarkGray),
+                                        ),
+                                    );
+                                }
+                                Err(e) => {
+                                    emit_above(
+                                        &mut terminal,
+                                        Line::styled(
+                                            format!("  \u{2717} Error: {e}"),
+                                            Style::default().fg(Color::Red),
+                                        ),
+                                    );
+                                }
+                            }
                             continue;
                         }
 
@@ -1000,6 +1061,7 @@ pub async fn run(
                                 MenuContent::Slash(dd) => dd.up(),
                                 MenuContent::Model(dd) => dd.up(),
                                 MenuContent::Provider(dd) => dd.up(),
+                                MenuContent::Session(dd) => dd.up(),
                                 MenuContent::None => {}
                             }
                             continue;
@@ -1008,6 +1070,7 @@ pub async fn run(
                                 MenuContent::Slash(dd) => dd.down(),
                                 MenuContent::Model(dd) => dd.down(),
                                 MenuContent::Provider(dd) => dd.down(),
+                                MenuContent::Session(dd) => dd.down(),
                                 MenuContent::None => {}
                             }
                             continue;
@@ -1075,6 +1138,37 @@ pub async fn run(
                                             terminal = init_terminal(viewport_height)?;
                                         }
                                         continue;
+                                    }
+                                    MenuContent::Session(dd) => {
+                                        if let Some(item) = dd.selected_item() {
+                                            if item.is_current {
+                                                emit_above(
+                                                    &mut terminal,
+                                                    Line::styled(
+                                                        "  Already in this session.",
+                                                        Style::default().fg(Color::DarkGray),
+                                                    ),
+                                                );
+                                            } else {
+                                                let target_id = item.id.clone();
+                                                let short = &item.short_id;
+                                                session.id = target_id;
+                                                emit_above(
+                                                    &mut terminal,
+                                                    Line::from(vec![
+                                                        Span::styled(
+                                                            "  \u{2714} ",
+                                                            Style::default().fg(Color::Green),
+                                                        ),
+                                                        Span::raw("Resumed session "),
+                                                        Span::styled(
+                                                            short.to_string(),
+                                                            Style::default().fg(Color::Cyan),
+                                                        ),
+                                                    ]),
+                                                );
+                                            }
+                                        }
                                     }
                                     MenuContent::None => {}
                                 }

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -2,6 +2,7 @@ pub mod approval;
 pub mod dropdown;
 pub mod model_menu;
 pub mod provider_menu;
+pub mod session_menu;
 pub mod slash_menu;
 pub mod status_bar;
 pub mod text_input;

--- a/koda-cli/src/widgets/session_menu.rs
+++ b/koda-cli/src/widgets/session_menu.rs
@@ -1,0 +1,71 @@
+//! Session picker dropdown — thin wrapper around the generic dropdown.
+//!
+//! Appears when the user types `/sessions` with no args.
+
+use super::dropdown::DropdownItem;
+
+/// A session item for the dropdown.
+#[derive(Clone, Debug)]
+pub struct SessionItem {
+    pub id: String,
+    pub short_id: String,
+    pub created_at: String,
+    pub message_count: i64,
+    pub total_tokens: i64,
+    pub is_current: bool,
+}
+
+impl DropdownItem for SessionItem {
+    fn label(&self) -> &str {
+        &self.short_id
+    }
+    fn description(&self) -> String {
+        let mut desc = format!(
+            "{}  {} msgs  {}k tok",
+            self.created_at,
+            self.message_count,
+            self.total_tokens / 1000
+        );
+        if self.is_current {
+            desc.push_str(" \u{25c0} current");
+        }
+        desc
+    }
+    fn matches_filter(&self, filter: &str) -> bool {
+        let f = filter.to_lowercase();
+        self.id.to_lowercase().contains(&f) || self.created_at.to_lowercase().contains(&f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_shows_marker() {
+        let item = SessionItem {
+            id: "abc12345".into(),
+            short_id: "abc12345".into(),
+            created_at: "2026-03-08".into(),
+            message_count: 5,
+            total_tokens: 12000,
+            is_current: true,
+        };
+        assert!(item.description().contains('\u{25c0}'));
+    }
+
+    #[test]
+    fn filter_by_id_and_date() {
+        let item = SessionItem {
+            id: "abc12345".into(),
+            short_id: "abc12345".into(),
+            created_at: "2026-03-08".into(),
+            message_count: 5,
+            total_tokens: 12000,
+            is_current: false,
+        };
+        assert!(item.matches_filter("abc"));
+        assert!(item.matches_filter("2026"));
+        assert!(!item.matches_filter("xyz"));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4 of #230: Convert `/sessions` from blocking `select_inline` to reactive ratatui dropdown.

## What it looks like

```
─── 🐻 ─
⚡> /sessions
────────────────────────────────
model │ auto │ 0%
  🐻 Sessions
  › abc12345  2026-03-08  12 msgs  45k tok  ◀ current
    def67890  2026-03-07   8 msgs  23k tok
    ...
```

Type to filter by session ID or date. Arrow keys navigate, Enter resumes, Esc cancels.

## New files

- `widgets/session_menu.rs` — `SessionItem` implementing `DropdownItem` (76 lines, 2 tests)

## Testing

- 161 tests pass
- `cargo clippy -D warnings` clean

All dropdown conversions complete! Remaining #230 work: approval widget + text input widget for Pattern 2 wizards.

Part of #230
