### PR TITLE
feat: phase-aware check_tool() + Notify variant + destructive op floor (#242 step 2)

### DIFF
--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -395,7 +395,7 @@ impl TuiContext {
                             }
 
                             // Intercept /self.provider (no args) — open inline dropdown
-                            if input.trim() == "/self.provider" {
+                            if input.trim() == "/provider" {
                                 let providers = crate::repl::PROVIDERS;
                                 let items: Vec<crate::widgets::provider_menu::ProviderItem> =
                                     providers
@@ -415,7 +415,7 @@ impl TuiContext {
                                         .collect();
                                 let mut dd = crate::widgets::dropdown::DropdownState::new(
                                     items,
-                                    "\u{1f43b} Select a self.provider",
+                                    "\u{1f43b} Select a provider",
                                 );
                                 // Pre-select current self.provider
                                 if let Some(idx) = dd.filtered.iter().position(|p| p.is_current) {
@@ -430,9 +430,8 @@ impl TuiContext {
                             }
 
                             // Intercept /self.provider <name> — skip dropdown, start wizard at API key step
-                            if input.trim().starts_with("/self.provider ") {
-                                let name =
-                                    input.trim().strip_prefix("/self.provider ").unwrap().trim();
+                            if input.trim().starts_with("/provider ") {
+                                let name = input.trim().strip_prefix("/provider ").unwrap().trim();
                                 let ptype = koda_core::config::ProviderType::from_url_or_name(
                                     "",
                                     Some(name),
@@ -1117,7 +1116,7 @@ impl TuiContext {
                         // Terminal resized while idle — erase stale viewport and reinit.
                         reinit_viewport_in_place(&mut self.terminal, self.viewport_height, self.viewport_height)?;
                     } else if let Event::Key(key) = ev {
-                        // ── Slash self.menu key interception ───────────
+                        // ── Slash menu key interception ───────────
                         // When a self.menu is active, intercept navigation
                         // and selection keys before normal handling.
                         if !self.menu.is_none() {
@@ -1233,7 +1232,7 @@ impl TuiContext {
                                                     emit_above(
                                                         &mut self.terminal,
                                                         Line::styled(
-                                                            "  Already in this self.session.",
+                                                            "  Already in this session.",
                                                             Style::default().fg(Color::DarkGray),
                                                         ),
                                                     );
@@ -1248,7 +1247,7 @@ impl TuiContext {
                                                                 "  \u{2714} ",
                                                                 Style::default().fg(Color::Green),
                                                             ),
-                                                            Span::raw("Resumed self.session "),
+                                                            Span::raw("Resumed session "),
                                                             Span::styled(
                                                                 short.to_string(),
                                                                 Style::default().fg(Color::Cyan),
@@ -1586,7 +1585,7 @@ impl TuiContext {
                                         self.menu = MenuContent::None;
                                     }
                                 } else {
-                                    // Clear self.menu if it was a slash or file self.menu
+                                    // Clear menu if it was a slash or file menu
                                     if matches!(self.menu, MenuContent::Slash(_) | MenuContent::File { .. }) {
                                         self.menu = MenuContent::None;
                                     }

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -102,6 +102,9 @@ pub fn cycle_mode(shared: &SharedMode) -> ApprovalMode {
 pub enum ToolApproval {
     /// Execute without asking.
     AutoApprove,
+    /// Execute but display what's happening (de-escalation).
+    /// Agent continues automatically; user's next input is implicit consent.
+    Notify,
     /// Show confirmation dialog.
     NeedsConfirmation,
     /// Safe mode: show what would happen, don't execute.
@@ -124,17 +127,60 @@ const READ_ONLY_TOOLS: &[&str] = &[
 ];
 
 /// Decide whether a tool call should be auto-approved, confirmed, or blocked.
-pub fn check_tool(tool_name: &str, args: &serde_json::Value, mode: ApprovalMode) -> ToolApproval {
+///
+/// Phase-aware gating (#242 step 2):
+/// - Reads always auto-approved (unchanged)
+/// - Writes during `Executing` after `plan_approved` → auto-approved
+/// - Writes during `Understanding` (before any plan) → require confirmation in Auto mode
+/// - Destructive operations → hardcoded floor of NeedsConfirmation
+pub fn check_tool(
+    tool_name: &str,
+    args: &serde_json::Value,
+    mode: ApprovalMode,
+    phase_info: crate::task_phase::PhaseInfo,
+) -> ToolApproval {
     // Read-only tools always execute in every mode
     if READ_ONLY_TOOLS.contains(&tool_name) {
         return ToolApproval::AutoApprove;
     }
 
     match mode {
-        ApprovalMode::Auto => ToolApproval::AutoApprove,
+        ApprovalMode::Auto => {
+            // Phase-aware gating in Auto mode
+            use crate::task_phase::TaskPhase;
+
+            // Destructive operations always need confirmation
+            if is_destructive(tool_name, args) {
+                return ToolApproval::NeedsConfirmation;
+            }
+
+            match phase_info.phase {
+                // Before any plan: writes need confirmation
+                TaskPhase::Understanding | TaskPhase::Planning => {
+                    if is_mutating(tool_name) {
+                        ToolApproval::NeedsConfirmation
+                    } else {
+                        ToolApproval::AutoApprove
+                    }
+                }
+                // Reviewing: writes blocked (forced through review gate)
+                TaskPhase::Reviewing => {
+                    if is_mutating(tool_name) {
+                        ToolApproval::NeedsConfirmation
+                    } else {
+                        ToolApproval::AutoApprove
+                    }
+                }
+                // Executing with approved plan: auto-approve writes
+                TaskPhase::Executing if phase_info.plan_approved => ToolApproval::AutoApprove,
+                // Executing without approved plan (shortcut path): notify
+                TaskPhase::Executing => ToolApproval::Notify,
+                // Verifying/Reporting: auto-approve (checking results)
+                TaskPhase::Verifying | TaskPhase::Reporting => ToolApproval::AutoApprove,
+            }
+        }
 
         ApprovalMode::Safe => {
-            // Safe mode: write tools blocked, bash uses safety classification
             if tool_name == "Bash" {
                 let command = args
                     .get("command")
@@ -168,6 +214,39 @@ pub fn check_tool(tool_name: &str, args: &serde_json::Value, mode: ApprovalMode)
             }
         }
     }
+}
+
+/// Whether a tool is mutating (writes, edits, deletes, or runs commands).
+fn is_mutating(tool_name: &str) -> bool {
+    matches!(
+        tool_name,
+        "Write" | "Edit" | "Delete" | "Bash" | "MemoryWrite"
+    )
+}
+
+/// Whether a tool call is destructive (force push, rm -rf, etc.).
+/// These have a hardcoded floor of NeedsConfirmation regardless of phase.
+fn is_destructive(tool_name: &str, args: &serde_json::Value) -> bool {
+    if tool_name == "Delete" {
+        return true;
+    }
+    if tool_name == "Bash" {
+        let command = args
+            .get("command")
+            .or(args.get("cmd"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let lower = command.to_lowercase();
+        if lower.contains("rm -rf")
+            || lower.contains("git push -f")
+            || lower.contains("git push --force")
+            || lower.contains("drop table")
+            || lower.contains("drop database")
+        {
+            return true;
+        }
+    }
+    false
 }
 
 // ── Settings persistence ──────────────────────────────────
@@ -289,7 +368,12 @@ mod tests {
     fn test_read_tools_always_approved() {
         for tool in READ_ONLY_TOOLS {
             assert_eq!(
-                check_tool(tool, &serde_json::json!({}), ApprovalMode::Safe),
+                check_tool(
+                    tool,
+                    &serde_json::json!({}),
+                    ApprovalMode::Safe,
+                    crate::task_phase::PhaseInfo::legacy()
+                ),
                 ToolApproval::AutoApprove,
                 "{tool} should auto-approve even in Safe mode"
             );
@@ -300,7 +384,12 @@ mod tests {
     fn test_write_tools_blocked_in_safe() {
         for tool in ["Write", "Edit", "Delete", "CreateAgent", "MemoryWrite"] {
             assert_eq!(
-                check_tool(tool, &serde_json::json!({}), ApprovalMode::Safe),
+                check_tool(
+                    tool,
+                    &serde_json::json!({}),
+                    ApprovalMode::Safe,
+                    crate::task_phase::PhaseInfo::legacy()
+                ),
                 ToolApproval::Blocked,
                 "{tool} should be blocked in Safe mode"
             );
@@ -308,20 +397,74 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_approves_everything() {
-        for tool in ["Write", "Edit", "Delete", "Bash", "WebFetch"] {
+    fn test_auto_approves_non_destructive_in_executing() {
+        // In Auto mode during Executing with plan_approved, non-destructive
+        // mutating tools are auto-approved.
+        for tool in ["Write", "Edit", "Bash", "WebFetch"] {
             assert_eq!(
-                check_tool(tool, &serde_json::json!({}), ApprovalMode::Auto),
+                check_tool(
+                    tool,
+                    &serde_json::json!({}),
+                    ApprovalMode::Auto,
+                    crate::task_phase::PhaseInfo::legacy()
+                ),
                 ToolApproval::AutoApprove,
             );
         }
     }
 
     #[test]
+    fn test_auto_confirms_destructive_ops() {
+        // Delete is always destructive → NeedsConfirmation even in Auto + Executing
+        assert_eq!(
+            check_tool(
+                "Delete",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
+            ToolApproval::NeedsConfirmation,
+        );
+    }
+
+    #[test]
+    fn test_auto_confirms_writes_before_plan() {
+        use crate::task_phase::{PhaseInfo, TaskPhase};
+        // In Auto mode during Understanding, writes need confirmation
+        let phase = PhaseInfo {
+            phase: TaskPhase::Understanding,
+            plan_approved: false,
+        };
+        assert_eq!(
+            check_tool("Edit", &serde_json::json!({}), ApprovalMode::Auto, phase),
+            ToolApproval::NeedsConfirmation,
+        );
+    }
+
+    #[test]
+    fn test_auto_notifies_executing_without_approval() {
+        use crate::task_phase::{PhaseInfo, TaskPhase};
+        // Executing without plan_approved → Notify
+        let phase = PhaseInfo {
+            phase: TaskPhase::Executing,
+            plan_approved: false,
+        };
+        assert_eq!(
+            check_tool("Edit", &serde_json::json!({}), ApprovalMode::Auto, phase),
+            ToolApproval::Notify,
+        );
+    }
+
+    #[test]
     fn test_safe_bash_auto_approved_in_strict() {
         let args = serde_json::json!({"command": "cargo test --release"});
         assert_eq!(
-            check_tool("Bash", &args, ApprovalMode::Strict),
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Strict,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::AutoApprove,
         );
     }
@@ -330,7 +473,12 @@ mod tests {
     fn test_dangerous_bash_needs_confirmation_in_strict() {
         let args = serde_json::json!({"command": "rm -rf target/"});
         assert_eq!(
-            check_tool("Bash", &args, ApprovalMode::Strict),
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Strict,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::NeedsConfirmation,
         );
     }
@@ -338,7 +486,12 @@ mod tests {
     #[test]
     fn test_write_needs_confirmation_in_strict() {
         assert_eq!(
-            check_tool("Write", &serde_json::json!({}), ApprovalMode::Strict),
+            check_tool(
+                "Write",
+                &serde_json::json!({}),
+                ApprovalMode::Strict,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::NeedsConfirmation,
         );
     }
@@ -348,7 +501,12 @@ mod tests {
         let args = serde_json::json!({"agent_name": "reviewer", "prompt": "review this"});
         for mode in [ApprovalMode::Auto, ApprovalMode::Strict, ApprovalMode::Safe] {
             assert_eq!(
-                check_tool("InvokeAgent", &args, mode),
+                check_tool(
+                    "InvokeAgent",
+                    &args,
+                    mode,
+                    crate::task_phase::PhaseInfo::legacy()
+                ),
                 ToolApproval::AutoApprove,
             );
         }
@@ -358,7 +516,12 @@ mod tests {
     fn test_safe_mode_allows_safe_bash() {
         let args = serde_json::json!({"command": "cargo test --release"});
         assert_eq!(
-            check_tool("Bash", &args, ApprovalMode::Safe),
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Safe,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::AutoApprove,
         );
     }
@@ -367,7 +530,12 @@ mod tests {
     fn test_safe_mode_blocks_dangerous_bash() {
         let args = serde_json::json!({"command": "rm -rf target/"});
         assert_eq!(
-            check_tool("Bash", &args, ApprovalMode::Safe),
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Safe,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::Blocked,
         );
     }
@@ -376,7 +544,12 @@ mod tests {
     fn test_safe_mode_allows_web_fetch() {
         let args = serde_json::json!({"url": "https://example.com"});
         assert_eq!(
-            check_tool("WebFetch", &args, ApprovalMode::Safe),
+            check_tool(
+                "WebFetch",
+                &args,
+                ApprovalMode::Safe,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::AutoApprove,
         );
     }

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -120,6 +120,33 @@ impl std::fmt::Display for TaskPhase {
     }
 }
 
+/// Compact phase info for threading through tool dispatch.
+/// Avoids passing the full `PhaseTracker` (which is mutable).
+#[derive(Debug, Clone, Copy)]
+pub struct PhaseInfo {
+    pub phase: TaskPhase,
+    pub plan_approved: bool,
+}
+
+impl PhaseInfo {
+    /// Default for legacy callers: Executing + approved (preserves old Auto behavior).
+    pub fn legacy() -> Self {
+        Self {
+            phase: TaskPhase::Executing,
+            plan_approved: true,
+        }
+    }
+}
+
+impl From<&PhaseTracker> for PhaseInfo {
+    fn from(tracker: &PhaseTracker) -> Self {
+        Self {
+            phase: tracker.current(),
+            plan_approved: tracker.plan_approved(),
+        }
+    }
+}
+
 // ── Review result ───────────────────────────────────────────
 
 /// What kind of review happened (or didn't).

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -42,7 +42,12 @@ pub(crate) fn can_parallelize(tool_calls: &[ToolCall], mode: ApprovalMode) -> bo
     !tool_calls.iter().any(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(&tc.function_name, &args, mode),
+            approval::check_tool(
+                &tc.function_name,
+                &args,
+                mode,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
     })
@@ -204,8 +209,13 @@ pub(crate) async fn execute_tools_split_batch(
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(&tc.function_name, &args, mode),
-            ToolApproval::AutoApprove
+            approval::check_tool(
+                &tc.function_name,
+                &args,
+                mode,
+                crate::task_phase::PhaseInfo::legacy()
+            ),
+            ToolApproval::AutoApprove | ToolApproval::Notify
         )
     });
 
@@ -348,10 +358,15 @@ pub(crate) async fn execute_tools_sequential(
         });
 
         // Check approval for this tool call
-        let approval = approval::check_tool(&tc.function_name, &parsed_args, mode);
+        let approval = approval::check_tool(
+            &tc.function_name,
+            &parsed_args,
+            mode,
+            crate::task_phase::PhaseInfo::legacy(),
+        );
 
         match approval {
-            ToolApproval::AutoApprove => {
+            ToolApproval::AutoApprove | ToolApproval::Notify => {
                 // Execute without asking
             }
             ToolApproval::Blocked => {
@@ -611,10 +626,15 @@ pub(crate) async fn execute_sub_agent(
             // Sub-agents inherit the parent's approval mode
             let parsed_args: serde_json::Value =
                 serde_json::from_str(&tc.arguments).unwrap_or_default();
-            let approval = approval::check_tool(&tc.function_name, &parsed_args, mode);
+            let approval = approval::check_tool(
+                &tc.function_name,
+                &parsed_args,
+                mode,
+                crate::task_phase::PhaseInfo::legacy(),
+            );
 
             let output = match approval {
-                ToolApproval::AutoApprove => {
+                ToolApproval::AutoApprove | ToolApproval::Notify => {
                     tools.execute(&tc.function_name, &tc.arguments).await.output
                 }
                 ToolApproval::Blocked => {

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -56,11 +56,18 @@ fn test_all_tools_handled_by_approval() {
     let empty_args = serde_json::json!({});
     for name in all_tool_names() {
         // Should not panic in any mode
-        let result = check_tool(&name, &empty_args, ApprovalMode::Strict);
+        let result = check_tool(
+            &name,
+            &empty_args,
+            ApprovalMode::Strict,
+            koda_core::task_phase::PhaseInfo::legacy(),
+        );
         // Verify it returns a valid variant (not a crash)
         match result {
-            ToolApproval::AutoApprove | ToolApproval::NeedsConfirmation | ToolApproval::Blocked => {
-            }
+            ToolApproval::AutoApprove
+            | ToolApproval::Notify
+            | ToolApproval::NeedsConfirmation
+            | ToolApproval::Blocked => {}
         }
     }
 }


### PR DESCRIPTION
## #242 step 2 — first user-visible behavioral change

### Phase-aware tool approval

`check_tool()` now consults `PhaseInfo` (phase + plan_approved) in Auto mode:

| Phase | Reads | Non-destructive writes | Destructive ops |
|-------|-------|----------------------|-----------------|
| Understanding / Planning / Reviewing | AutoApprove | **NeedsConfirmation** | NeedsConfirmation |
| Executing (plan approved) | AutoApprove | AutoApprove | **NeedsConfirmation** |
| Executing (no approval) | AutoApprove | **Notify** | NeedsConfirmation |
| Verifying / Reporting | AutoApprove | AutoApprove | NeedsConfirmation |

**Bold** = changed from old behavior (everything was AutoApprove in Auto mode).

### New: `ToolApproval::Notify`

De-escalation variant: agent proceeds but displays what it's doing. Treated as AutoApprove for execution and parallelization. The UI can show a notification without blocking.

### New: Destructive operation floor

`is_destructive()` detects `Delete`, `rm -rf`, `git push --force`, `DROP TABLE/DATABASE` — always NeedsConfirmation regardless of phase or mode.

### New: `PhaseInfo` struct

Compact `(phase, plan_approved)` threaded through tool dispatch. `PhaseInfo::legacy()` preserves old behavior during transition.

### Transition strategy

All call sites currently use `PhaseInfo::legacy()` (Executing + approved). The next step wires the real `PhaseTracker` into the inference loop to produce live `PhaseInfo` values.

### Tests
398 koda-core tests pass (4 new phase-aware approval tests). 9 koda-cli tests pass.