### PR TITLE
feat: wire PhaseTracker into inference loop — phase gating is live (#242)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -13,6 +13,7 @@ use crate::inference_helpers::{
 };
 use crate::loop_guard::LoopDetector;
 use crate::providers::{ChatMessage, ImageData, LlmProvider, StreamChunk, ToolCall};
+use crate::task_phase::{PhaseInfo, PhaseTracker, ToolType, TurnSignal};
 use crate::tool_dispatch::{
     can_parallelize, execute_tools_parallel, execute_tools_sequential, execute_tools_split_batch,
 };
@@ -70,6 +71,14 @@ pub async fn inference_loop(
     let base_system_prompt = system_prompt.to_string();
     let mut recent_tool_names: Vec<String> = Vec::new();
 
+    // Phase tracker: structural detection of task progression.
+    // Created fresh per-turn (per inference_loop invocation) — phase state
+    // is transient within a turn, not persisted across turns.
+    // Session-level phase history will be tracked via Role::Phase flow log
+    // (step 3, v0.1.5) for the InterventionObserver's learning.
+    // Defaults to Modify intent (adapts structurally regardless).
+    let mut phase_tracker = PhaseTracker::new(&crate::intent::TaskIntent::Modify);
+
     loop {
         if iteration >= hard_cap {
             let recent = loop_detector.recent_names();
@@ -103,7 +112,7 @@ pub async fn inference_loop(
         }
 
         // Inject task phase hint + progress summary into system prompt
-        let phase = crate::task_phase::PhaseTracker::detect_legacy(&recent_tool_names);
+        let phase = phase_tracker.current();
         let progress = crate::progress::get_progress_summary(db, session_id)
             .await
             .unwrap_or_default();
@@ -453,6 +462,21 @@ pub async fn inference_loop(
         )
         .await?;
 
+        // Advance phase tracker based on structural turn signal
+        {
+            let tool_names: Vec<&str> = tool_calls
+                .iter()
+                .map(|tc| tc.function_name.as_str())
+                .collect();
+            let after_bash = recent_tool_names.iter().rev().take(3).any(|n| n == "Bash");
+            let signal = TurnSignal {
+                has_tool_calls: !tool_calls.is_empty(),
+                tool_type: ToolType::classify(&tool_names),
+                after_bash,
+            };
+            phase_tracker.advance(&signal);
+        }
+
         // If no tool calls, we already streamed the response — done
         if tool_calls.is_empty() {
             if made_tool_calls && full_text.trim().is_empty() {
@@ -508,9 +532,10 @@ pub async fn inference_loop(
 
         // Execute tool calls — parallelize when possible
         // (Lite tier models must use sequential to avoid confusion)
+        let pi = PhaseInfo::from(&phase_tracker);
         if tool_calls.len() > 1
             && config.model_tier.allows_parallel_tools()
-            && can_parallelize(&tool_calls, mode)
+            && can_parallelize(&tool_calls, mode, pi)
         {
             execute_tools_parallel(
                 &tool_calls,
@@ -523,6 +548,7 @@ pub async fn inference_loop(
                 sink,
                 cancel.clone(),
                 &sub_agent_cache,
+                pi,
             )
             .await?;
         } else if tool_calls.len() > 1 && config.model_tier.allows_parallel_tools() {
@@ -541,6 +567,7 @@ pub async fn inference_loop(
                 cancel.clone(),
                 cmd_rx,
                 &sub_agent_cache,
+                pi,
             )
             .await?;
         } else {
@@ -557,6 +584,7 @@ pub async fn inference_loop(
                 cancel.clone(),
                 cmd_rx,
                 &sub_agent_cache,
+                pi,
             )
             .await?;
         }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -38,16 +38,15 @@ fn truncate_for_history(output: &str, max_chars: usize) -> String {
     )
 }
 
-pub(crate) fn can_parallelize(tool_calls: &[ToolCall], mode: ApprovalMode) -> bool {
+pub(crate) fn can_parallelize(
+    tool_calls: &[ToolCall],
+    mode: ApprovalMode,
+    phase_info: crate::task_phase::PhaseInfo,
+) -> bool {
     !tool_calls.iter().any(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(
-                &tc.function_name,
-                &args,
-                mode,
-                crate::task_phase::PhaseInfo::legacy()
-            ),
+            approval::check_tool(&tc.function_name, &args, mode, phase_info),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
     })
@@ -66,6 +65,7 @@ pub(crate) async fn execute_one_tool(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
+    phase_info: crate::task_phase::PhaseInfo,
 ) -> (String, String) {
     let result = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
@@ -83,6 +83,7 @@ pub(crate) async fn execute_one_tool(
             &mut mpsc::channel(1).1,
             Some(tools.file_read_cache()),
             sub_agent_cache,
+            phase_info,
         )
         .await
         {
@@ -118,6 +119,7 @@ pub(crate) async fn execute_tools_parallel(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
+    phase_info: crate::task_phase::PhaseInfo,
 ) -> Result<()> {
     // Print all tool call banners upfront
     for tc in tool_calls {
@@ -149,6 +151,7 @@ pub(crate) async fn execute_tools_parallel(
                 sink,
                 cancel.clone(),
                 sub_agent_cache,
+                phase_info,
             )
         })
         .collect();
@@ -204,17 +207,13 @@ pub(crate) async fn execute_tools_split_batch(
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
+    phase_info: crate::task_phase::PhaseInfo,
 ) -> Result<()> {
     // Partition into parallelizable vs sequential
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(
-                &tc.function_name,
-                &args,
-                mode,
-                crate::task_phase::PhaseInfo::legacy()
-            ),
+            approval::check_tool(&tc.function_name, &args, mode, phase_info),
             ToolApproval::AutoApprove | ToolApproval::Notify
         )
     });
@@ -247,6 +246,7 @@ pub(crate) async fn execute_tools_split_batch(
                     sink,
                     cancel.clone(),
                     sub_agent_cache,
+                    phase_info,
                 )
             })
             .collect();
@@ -294,6 +294,7 @@ pub(crate) async fn execute_tools_split_batch(
                 cancel.clone(),
                 cmd_rx,
                 sub_agent_cache,
+                phase_info,
             )
             .await?;
         }
@@ -315,6 +316,7 @@ pub(crate) async fn execute_tools_split_batch(
             cancel.clone(),
             cmd_rx,
             sub_agent_cache,
+            phase_info,
         )
         .await?;
     }
@@ -337,6 +339,7 @@ pub(crate) async fn execute_tools_sequential(
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
+    phase_info: crate::task_phase::PhaseInfo,
 ) -> Result<()> {
     for tc in tool_calls {
         // Check for interrupt before each tool
@@ -358,12 +361,7 @@ pub(crate) async fn execute_tools_sequential(
         });
 
         // Check approval for this tool call
-        let approval = approval::check_tool(
-            &tc.function_name,
-            &parsed_args,
-            mode,
-            crate::task_phase::PhaseInfo::legacy(),
-        );
+        let approval = approval::check_tool(&tc.function_name, &parsed_args, mode, phase_info);
 
         match approval {
             ToolApproval::AutoApprove | ToolApproval::Notify => {
@@ -450,6 +448,7 @@ pub(crate) async fn execute_tools_sequential(
             sink,
             cancel.clone(),
             sub_agent_cache,
+            phase_info,
         )
         .await;
         sink.emit(EngineEvent::ToolCallResult {
@@ -497,6 +496,7 @@ pub(crate) async fn execute_sub_agent(
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     parent_cache: Option<crate::tools::FileReadCache>,
     sub_agent_cache: &SubAgentCache,
+    phase_info: crate::task_phase::PhaseInfo,
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"]
@@ -626,12 +626,7 @@ pub(crate) async fn execute_sub_agent(
             // Sub-agents inherit the parent's approval mode
             let parsed_args: serde_json::Value =
                 serde_json::from_str(&tc.arguments).unwrap_or_default();
-            let approval = approval::check_tool(
-                &tc.function_name,
-                &parsed_args,
-                mode,
-                crate::task_phase::PhaseInfo::legacy(),
-            );
+            let approval = approval::check_tool(&tc.function_name, &parsed_args, mode, phase_info);
 
             let output = match approval {
                 ToolApproval::AutoApprove | ToolApproval::Notify => {
@@ -747,13 +742,21 @@ mod tests {
     #[test]
     fn test_can_parallelize_read_only() {
         let calls = vec![make_tool_call("Read"), make_tool_call("Grep")];
-        assert!(can_parallelize(&calls, ApprovalMode::Strict));
+        assert!(can_parallelize(
+            &calls,
+            ApprovalMode::Strict,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 
     #[test]
     fn test_cannot_parallelize_writes() {
         let calls = vec![make_tool_call("Read"), make_tool_call("Write")];
-        assert!(!can_parallelize(&calls, ApprovalMode::Strict));
+        assert!(!can_parallelize(
+            &calls,
+            ApprovalMode::Strict,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 
     #[test]
@@ -768,13 +771,21 @@ mod tests {
                 thought_signature: None,
             },
         ];
-        assert!(!can_parallelize(&calls, ApprovalMode::Strict));
+        assert!(!can_parallelize(
+            &calls,
+            ApprovalMode::Strict,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 
     #[test]
     fn test_can_parallelize_agents() {
         let calls = vec![make_tool_call("InvokeAgent"), make_tool_call("InvokeAgent")];
-        assert!(can_parallelize(&calls, ApprovalMode::Strict));
+        assert!(can_parallelize(
+            &calls,
+            ApprovalMode::Strict,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 
     #[test]
@@ -792,12 +803,20 @@ mod tests {
     #[test]
     fn test_mixed_batch_not_fully_parallelizable() {
         let calls = vec![make_tool_call("InvokeAgent"), make_tool_call("Write")];
-        assert!(!can_parallelize(&calls, ApprovalMode::Strict));
+        assert!(!can_parallelize(
+            &calls,
+            ApprovalMode::Strict,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 
     #[test]
     fn test_mixed_batch_fully_parallelizable_in_auto() {
         let calls = vec![make_tool_call("InvokeAgent"), make_tool_call("Write")];
-        assert!(can_parallelize(&calls, ApprovalMode::Auto));
+        assert!(can_parallelize(
+            &calls,
+            ApprovalMode::Auto,
+            crate::task_phase::PhaseInfo::legacy()
+        ));
     }
 }


### PR DESCRIPTION
## #242 — PhaseTracker is now live in the inference loop

This PR activates the phase-aware tool approval system. `PhaseInfo::legacy()` is replaced with live `PhaseTracker` state.

### What changed

**`inference.rs`**:
- `PhaseTracker` created at loop start
- `TurnSignal` built after each LLM response (has_tool_calls + tool_type + after_bash)
- `tracker.advance()` called each iteration
- `PhaseInfo::from(&tracker)` threaded to all tool dispatch calls
- `prompt_hint()` uses `tracker.current()` instead of `detect_legacy()`

**`tool_dispatch.rs`**: all 6 dispatch functions now accept `PhaseInfo`:
`can_parallelize`, `execute_tools_parallel`, `execute_tools_split_batch`, `execute_tools_sequential`, `execute_one_tool`, `execute_sub_agent`

### Behavioral impact (Auto mode only)

| Phase | Writes | Before | After |
|-------|--------|--------|-------|
| Understanding | Edit/Write/Bash | AutoApprove | **NeedsConfirmation** |
| Planning | Edit/Write/Bash | AutoApprove | **NeedsConfirmation** |
| Reviewing | Edit/Write/Bash | AutoApprove | **NeedsConfirmation** |
| Executing (approved) | Edit/Write/Bash | AutoApprove | AutoApprove |
| Executing (no plan) | Edit/Write/Bash | AutoApprove | **Notify** |
| Delete / rm -rf / force push | any | AutoApprove | **NeedsConfirmation** |

Safe and Strict modes are unchanged.

### Tests
398 koda-core lib tests pass. Clippy clean. fmt clean.