### PR TITLE
feat: Role::Phase flow log — phase transitions stored as messages (#242 step 3)

### DIFF
--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -15,6 +15,11 @@ pub enum Role {
     User,
     Assistant,
     Tool,
+    /// Phase transition log entry. Stored in the same messages table
+    /// with structured JSON metadata in the content field.
+    /// The LLM sees these as self-awareness of its own process.
+    /// The InterventionObserver parses the metadata for learning.
+    Phase,
 }
 
 impl Role {
@@ -24,6 +29,7 @@ impl Role {
             Self::User => "user",
             Self::Assistant => "assistant",
             Self::Tool => "tool",
+            Self::Phase => "phase",
         }
     }
 }
@@ -349,7 +355,15 @@ impl Database {
             // - Old assistant text: moderate truncation (1000 chars)
             // - User messages: keep full (they're the source of intent)
             if idx >= recency_threshold {
-                if msg.role == "tool"
+                if msg.role == "phase" {
+                    // Phase messages: keep only the human-readable summary when old.
+                    // Strip the JSON metadata to save tokens.
+                    if let Some(ref content) = msg.content
+                        && let Some(nl) = content.find('\n')
+                    {
+                        msg.content = Some(content[..nl].to_string());
+                    }
+                } else if msg.role == "tool"
                     && let Some(ref content) = msg.content
                     && content.len() > 200
                 {

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -474,7 +474,19 @@ pub async fn inference_loop(
                 tool_type: ToolType::classify(&tool_names),
                 after_bash,
             };
-            phase_tracker.advance(&signal);
+            if let Some(transition) = phase_tracker.advance(&signal) {
+                // Log phase transition as a Role::Phase message
+                let _ = db
+                    .insert_message(
+                        session_id,
+                        &crate::db::Role::Phase,
+                        Some(&transition.as_message_content()),
+                        None,
+                        None,
+                        None,
+                    )
+                    .await;
+            }
         }
 
         // If no tool calls, we already streamed the response — done

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -223,6 +223,37 @@ pub struct PhaseTracker {
     expect_full_progression: bool,
 }
 
+/// Record of a phase transition, for logging as `Role::Phase` messages.
+#[derive(Debug, Clone)]
+pub struct PhaseTransition {
+    pub from: TaskPhase,
+    pub to: TaskPhase,
+    pub trigger: &'static str,
+}
+
+impl PhaseTransition {
+    /// Human-readable summary (stored as message content, visible to LLM).
+    pub fn summary(&self) -> String {
+        format!("Phase: {} → {} ({})", self.from, self.to, self.trigger)
+    }
+
+    /// Structured JSON metadata (stored alongside summary, parsed by InterventionObserver).
+    pub fn metadata_json(&self) -> String {
+        serde_json::json!({
+            "from": self.from.to_string(),
+            "to": self.to.to_string(),
+            "trigger": self.trigger,
+        })
+        .to_string()
+    }
+
+    /// Combined content for storage: human-readable summary + JSON metadata.
+    /// The LLM sees the summary; the InterventionObserver parses the JSON.
+    pub fn as_message_content(&self) -> String {
+        format!("{}\n{}", self.summary(), self.metadata_json())
+    }
+}
+
 impl PhaseTracker {
     /// Create a new tracker with intent-based initial expectations.
     pub fn new(intent: &TaskIntent) -> Self {
@@ -262,7 +293,8 @@ impl PhaseTracker {
     ///
     /// Returns the new phase (which may be unchanged).
     /// See #242 decision tree for the full specification.
-    pub fn advance(&mut self, signal: &TurnSignal) -> TaskPhase {
+    pub fn advance(&mut self, signal: &TurnSignal) -> Option<PhaseTransition> {
+        let old_phase = self.current;
         let new_phase = match (self.current, signal.has_tool_calls, signal.tool_type) {
             // Understanding: exploring the codebase
             (TaskPhase::Understanding, true, ToolType::HasWrites) => {
@@ -347,7 +379,28 @@ impl PhaseTracker {
             self.high_water = new_phase;
         }
 
-        new_phase
+        // Return transition record if phase actually changed
+        if old_phase != new_phase {
+            let trigger = match (old_phase, new_phase) {
+                (TaskPhase::Understanding, TaskPhase::Planning) => "text_only_after_reads",
+                (TaskPhase::Understanding, TaskPhase::Executing) => "simple_task_shortcut",
+                (TaskPhase::Planning, TaskPhase::Reviewing) => "plan_complete",
+                (TaskPhase::Reviewing, TaskPhase::Executing) => "review_passed",
+                (TaskPhase::Reviewing, TaskPhase::Planning) => "封驳",
+                (TaskPhase::Executing, TaskPhase::Verifying) => "tests_after_bash",
+                (TaskPhase::Executing, TaskPhase::Understanding) => "escalation",
+                (TaskPhase::Verifying, TaskPhase::Reporting) => "summarizing",
+                (TaskPhase::Verifying, TaskPhase::Executing) => "fixing_test_failures",
+                _ => "transition",
+            };
+            Some(PhaseTransition {
+                from: old_phase,
+                to: new_phase,
+                trigger,
+            })
+        } else {
+            None
+        }
     }
 
     /// Force an escalation (Executing → Understanding) on tool failure
@@ -496,14 +549,16 @@ mod tests {
     fn test_understanding_to_planning_on_text() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         let s = signal(false, ToolType::ReadOnly, false);
-        assert_eq!(t.advance(&s), TaskPhase::Planning);
+        t.advance(&s);
+        assert_eq!(t.current(), TaskPhase::Planning);
     }
 
     #[test]
     fn test_understanding_to_executing_shortcut() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         let s = signal(true, ToolType::HasWrites, false);
-        assert_eq!(t.advance(&s), TaskPhase::Executing);
+        t.advance(&s);
+        assert_eq!(t.current(), TaskPhase::Executing);
         assert!(t.plan_approved()); // shortcut grants approval
         assert!(t.review_result().is_none()); // Reviewing never entered
     }
@@ -512,17 +567,16 @@ mod tests {
     fn test_understanding_stays_on_reads() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         let s = signal(true, ToolType::ReadOnly, false);
-        assert_eq!(t.advance(&s), TaskPhase::Understanding);
+        t.advance(&s);
+        assert_eq!(t.current(), TaskPhase::Understanding);
     }
 
     #[test]
     fn test_planning_to_reviewing_on_text() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
-        assert_eq!(
-            t.advance(&signal(false, ToolType::ReadOnly, false)),
-            TaskPhase::Reviewing
-        );
+        t.advance(&signal(false, ToolType::ReadOnly, false));
+        assert_eq!(t.current(), TaskPhase::Reviewing);
     }
 
     #[test]
@@ -530,10 +584,8 @@ mod tests {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
         // LLM tries to write during Planning → forced to Reviewing
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Reviewing
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Reviewing);
         assert!(!t.plan_approved()); // not yet approved
     }
 
@@ -542,10 +594,8 @@ mod tests {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reviewing
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Executing
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Executing);
         assert!(t.plan_approved());
         assert_eq!(t.review_result(), Some(ReviewResult::RulePassed));
     }
@@ -556,10 +606,8 @@ mod tests {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reviewing
-        assert_eq!(
-            t.advance(&signal(true, ToolType::ReadOnly, false)),
-            TaskPhase::Planning
-        );
+        t.advance(&signal(true, ToolType::ReadOnly, false));
+        assert_eq!(t.current(), TaskPhase::Planning);
         assert!(!t.plan_approved());
     }
 
@@ -567,20 +615,16 @@ mod tests {
     fn test_executing_stays_on_tools() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(true, ToolType::HasWrites, false)); // shortcut → Executing
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Executing
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Executing);
     }
 
     #[test]
     fn test_executing_to_verifying_after_bash() {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
-        assert_eq!(
-            t.advance(&signal(false, ToolType::ReadOnly, true)),
-            TaskPhase::Verifying
-        );
+        t.advance(&signal(false, ToolType::ReadOnly, true));
+        assert_eq!(t.current(), TaskPhase::Verifying);
     }
 
     #[test]
@@ -588,10 +632,8 @@ mod tests {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         // Mid-execution explanation (no bash) → stays Executing
-        assert_eq!(
-            t.advance(&signal(false, ToolType::ReadOnly, false)),
-            TaskPhase::Executing
-        );
+        t.advance(&signal(false, ToolType::ReadOnly, false));
+        assert_eq!(t.current(), TaskPhase::Executing);
     }
 
     #[test]
@@ -599,10 +641,8 @@ mod tests {
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         t.advance(&signal(false, ToolType::ReadOnly, true)); // → Verifying
-        assert_eq!(
-            t.advance(&signal(false, ToolType::ReadOnly, false)),
-            TaskPhase::Reporting
-        );
+        t.advance(&signal(false, ToolType::ReadOnly, false));
+        assert_eq!(t.current(), TaskPhase::Reporting);
     }
 
     #[test]
@@ -611,10 +651,8 @@ mod tests {
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         t.advance(&signal(false, ToolType::ReadOnly, true)); // → Verifying
         // Fixing test failures → back to Executing
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Executing
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Executing);
     }
 
     #[test]
@@ -623,10 +661,8 @@ mod tests {
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         t.advance(&signal(false, ToolType::ReadOnly, true)); // → Verifying
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reporting
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Reporting
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Reporting);
     }
 
     // ── High-water mark ──────────────────────────────────────
@@ -700,10 +736,8 @@ mod tests {
     fn test_scenario_simple_task() {
         // "fix the typo" → Understanding → Executing shortcut
         let mut t = PhaseTracker::new(&TaskIntent::Modify);
-        assert_eq!(
-            t.advance(&signal(true, ToolType::HasWrites, false)),
-            TaskPhase::Executing
-        );
+        t.advance(&signal(true, ToolType::HasWrites, false));
+        assert_eq!(t.current(), TaskPhase::Executing);
         assert!(t.plan_approved());
         assert!(t.review_result().is_none()); // never reviewed
     }
@@ -759,5 +793,54 @@ mod tests {
         t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reviewing
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         assert!(t.plan_approved());
+    }
+
+    // ── PhaseTransition tests ─────────────────────────────────
+
+    #[test]
+    fn test_advance_returns_transition_on_change() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        let transition = t.advance(&signal(false, ToolType::ReadOnly, false));
+        assert!(transition.is_some());
+        let tr = transition.unwrap();
+        assert_eq!(tr.from, TaskPhase::Understanding);
+        assert_eq!(tr.to, TaskPhase::Planning);
+        assert_eq!(tr.trigger, "text_only_after_reads");
+    }
+
+    #[test]
+    fn test_advance_returns_none_on_no_change() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        // Read tools during Understanding → stays Understanding
+        let transition = t.advance(&signal(true, ToolType::ReadOnly, false));
+        assert!(transition.is_none());
+    }
+
+    #[test]
+    fn test_transition_message_content() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        let tr = t
+            .advance(&signal(false, ToolType::ReadOnly, false))
+            .unwrap();
+        let content = tr.as_message_content();
+        assert!(content.contains("Phase: Understanding → Planning"));
+        assert!(content.contains("text_only_after_reads"));
+        // Second line should be JSON
+        let lines: Vec<&str> = content.lines().collect();
+        assert!(lines.len() >= 2);
+        let meta: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(meta["from"], "Understanding");
+        assert_eq!(meta["to"], "Planning");
+    }
+
+    #[test]
+    fn test_fengbo_transition_trigger() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
+        t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reviewing
+        let tr = t.advance(&signal(true, ToolType::ReadOnly, false)).unwrap(); // 封驳
+        assert_eq!(tr.trigger, "封驳");
+        assert_eq!(tr.from, TaskPhase::Reviewing);
+        assert_eq!(tr.to, TaskPhase::Planning);
     }
 }


### PR DESCRIPTION
## #242 step 3 — phase transition flow log

### What's new

**`Role::Phase`** — new message role variant stored as `"phase"` in the DB. Dual-consumer content format:

```
Phase: Understanding → Planning (text_only_after_reads)
{"from":"Understanding","to":"Planning","trigger":"text_only_after_reads"}
```

- Line 1: human-readable summary (LLM sees this for process self-awareness)
- Line 2: structured JSON (InterventionObserver will parse this in step 4)

**`PhaseTransition`** — returned by `advance()` when phase actually changes:
- `from`, `to`: the phases
- `trigger`: descriptive label (`text_only_after_reads`, `simple_task_shortcut`, `plan_complete`, `review_passed`, `封驳`, `tests_after_bash`, `escalation`, etc.)

**`advance()`** signature changed: returns `Option<PhaseTransition>` instead of `TaskPhase`. `None` = phase didn't change, `Some` = transition occurred.

**`load_context`**: phase messages included in LLM context. Old phase messages get JSON metadata stripped (keep only summary line) for token efficiency.

**`inference.rs`**: logs transitions to DB via `insert_message(Role::Phase, ...)` after each `advance()`.

### Zero new infrastructure
Uses the existing `messages` table. No schema migration needed — `role` is a string column.

### Tests
32 task_phase tests (4 new for transition records). 405 total tests pass. fmt + clippy clean.

### Next
Step 4: `InterventionObserver` — reads the Phase flow log to learn human override patterns.