### PR TITLE
feat: folder-scoped permissions — path-aware approval + bash lint (#218)

### DIFF
--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -180,6 +180,19 @@ async fn main() -> Result<()> {
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);
 
+    // Footgun detection: warn if project_root is the home directory
+    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+        let home_path = std::fs::canonicalize(home).unwrap_or_default();
+        if project_root == home_path {
+            eprintln!(
+                "\n\x1b[33m⚠️  Project root is your home directory ({}).\n   \
+                koda can modify any file in this tree.\n   \
+                Consider running from a project subdirectory.\x1b[0m\n",
+                project_root.display()
+            );
+        }
+    }
+
     // Load and inject stored API keys (env vars take precedence)
     match koda_core::keystore::KeyStore::load() {
         Ok(store) => store.inject_into_env(),

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -9,6 +9,7 @@
 //! against a built-in safe list.
 
 use crate::bash_safety::is_command_safe;
+use path_clean::PathClean;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -133,15 +134,36 @@ const READ_ONLY_TOOLS: &[&str] = &[
 /// - Writes during `Executing` after `plan_approved` → auto-approved
 /// - Writes during `Understanding` (before any plan) → require confirmation in Auto mode
 /// - Destructive operations → hardcoded floor of NeedsConfirmation
+/// - Writes outside project root → hardcoded floor of NeedsConfirmation (#218)
 pub fn check_tool(
     tool_name: &str,
     args: &serde_json::Value,
     mode: ApprovalMode,
     phase_info: crate::task_phase::PhaseInfo,
+    project_root: Option<&Path>,
 ) -> ToolApproval {
     // Read-only tools always execute in every mode
     if READ_ONLY_TOOLS.contains(&tool_name) {
         return ToolApproval::AutoApprove;
+    }
+
+    // Hardcoded floor: writes outside project root always need confirmation (#218)
+    if let Some(root) = project_root {
+        if is_outside_project(tool_name, args, root) {
+            return ToolApproval::NeedsConfirmation;
+        }
+        // Bash path lint: check for cd/path escapes
+        if tool_name == "Bash" {
+            let command = args
+                .get("command")
+                .or(args.get("cmd"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let lint = crate::bash_safety::lint_bash_paths(command, root);
+            if lint.has_warnings() {
+                return ToolApproval::NeedsConfirmation;
+            }
+        }
     }
 
     match mode {
@@ -222,6 +244,27 @@ fn is_mutating(tool_name: &str) -> bool {
         tool_name,
         "Write" | "Edit" | "Delete" | "Bash" | "MemoryWrite"
     )
+}
+
+/// Whether a file tool targets a path outside the project root (#218).
+/// Hardcoded floor: always NeedsConfirmation regardless of mode or phase.
+fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> bool {
+    let path_arg = match tool_name {
+        "Write" | "Edit" | "Delete" => args.get("file_path").and_then(|v| v.as_str()),
+        _ => None,
+    };
+    match path_arg {
+        Some(p) => {
+            let requested = Path::new(p);
+            let resolved = if requested.is_absolute() {
+                requested.to_path_buf().clean()
+            } else {
+                project_root.join(requested).clean()
+            };
+            !resolved.starts_with(project_root)
+        }
+        None => false,
+    }
 }
 
 /// Whether a tool call is destructive (force push, rm -rf, etc.).
@@ -372,7 +415,8 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
-                    crate::task_phase::PhaseInfo::legacy()
+                    crate::task_phase::PhaseInfo::legacy(),
+                    None
                 ),
                 ToolApproval::AutoApprove,
                 "{tool} should auto-approve even in Safe mode"
@@ -388,7 +432,8 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
-                    crate::task_phase::PhaseInfo::legacy()
+                    crate::task_phase::PhaseInfo::legacy(),
+                    None
                 ),
                 ToolApproval::Blocked,
                 "{tool} should be blocked in Safe mode"
@@ -406,7 +451,8 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Auto,
-                    crate::task_phase::PhaseInfo::legacy()
+                    crate::task_phase::PhaseInfo::legacy(),
+                    None
                 ),
                 ToolApproval::AutoApprove,
             );
@@ -421,7 +467,8 @@ mod tests {
                 "Delete",
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -436,7 +483,13 @@ mod tests {
             plan_approved: false,
         };
         assert_eq!(
-            check_tool("Edit", &serde_json::json!({}), ApprovalMode::Auto, phase),
+            check_tool(
+                "Edit",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase,
+                None
+            ),
             ToolApproval::NeedsConfirmation,
         );
     }
@@ -450,7 +503,13 @@ mod tests {
             plan_approved: false,
         };
         assert_eq!(
-            check_tool("Edit", &serde_json::json!({}), ApprovalMode::Auto, phase),
+            check_tool(
+                "Edit",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase,
+                None
+            ),
             ToolApproval::Notify,
         );
     }
@@ -463,7 +522,8 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::AutoApprove,
         );
@@ -477,7 +537,8 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -490,7 +551,8 @@ mod tests {
                 "Write",
                 &serde_json::json!({}),
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -505,7 +567,8 @@ mod tests {
                     "InvokeAgent",
                     &args,
                     mode,
-                    crate::task_phase::PhaseInfo::legacy()
+                    crate::task_phase::PhaseInfo::legacy(),
+                    None
                 ),
                 ToolApproval::AutoApprove,
             );
@@ -520,7 +583,8 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::AutoApprove,
         );
@@ -534,7 +598,8 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
             ),
             ToolApproval::Blocked,
         );
@@ -548,7 +613,105 @@ mod tests {
                 "WebFetch",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy()
+                crate::task_phase::PhaseInfo::legacy(),
+                None
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    // ── Path scoping tests (#218) ──────────────────────────
+
+    #[test]
+    fn test_write_outside_project_needs_confirmation() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"file_path": "/etc/hosts"});
+        assert_eq!(
+            check_tool(
+                "Write",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                Some(root),
+            ),
+            ToolApproval::NeedsConfirmation,
+        );
+    }
+
+    #[test]
+    fn test_write_inside_project_auto_approved() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"file_path": "src/main.rs"});
+        assert_eq!(
+            check_tool(
+                "Write",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                Some(root),
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    #[test]
+    fn test_edit_with_dotdot_escape_needs_confirmation() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"file_path": "../../../etc/passwd"});
+        assert_eq!(
+            check_tool(
+                "Edit",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                Some(root),
+            ),
+            ToolApproval::NeedsConfirmation,
+        );
+    }
+
+    #[test]
+    fn test_bash_cd_outside_needs_confirmation() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"command": "cd /tmp && ls"});
+        assert_eq!(
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                Some(root),
+            ),
+            ToolApproval::NeedsConfirmation,
+        );
+    }
+
+    #[test]
+    fn test_bash_cd_inside_auto_approved() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"command": "cd src && ls"});
+        assert_eq!(
+            check_tool(
+                "Bash",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                Some(root),
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    #[test]
+    fn test_no_project_root_skips_path_check() {
+        let args = serde_json::json!({"file_path": "/etc/hosts"});
+        assert_eq!(
+            check_tool(
+                "Write",
+                &args,
+                ApprovalMode::Auto,
+                crate::task_phase::PhaseInfo::legacy(),
+                None,
             ),
             ToolApproval::AutoApprove,
         );

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -380,6 +380,132 @@ fn find_unquoted_space(s: &str) -> Option<usize> {
     None
 }
 
+// ── Bash Path Lint (#218) ─────────────────────────────────
+
+use path_clean::PathClean;
+use std::path::Path;
+
+/// Result of linting a bash command for path escapes.
+#[derive(Debug, Clone, Default)]
+pub struct BashPathLint {
+    /// Paths in the command that escape project_root.
+    pub outside_paths: Vec<String>,
+    /// Whether the command contains `cd ~` or bare `cd` (→ $HOME).
+    pub home_escape: bool,
+}
+
+impl BashPathLint {
+    /// Whether the lint found any warnings.
+    pub fn has_warnings(&self) -> bool {
+        !self.outside_paths.is_empty() || self.home_escape
+    }
+}
+
+/// Lint a bash command for paths that escape project_root.
+///
+/// Heuristic analysis — catches common accidental escapes, not adversarial inputs.
+/// Dynamic targets (`cd $VAR`, `cd $(cmd)`) are intentionally ignored.
+pub fn lint_bash_paths(command: &str, project_root: &Path) -> BashPathLint {
+    let mut lint = BashPathLint::default();
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return lint;
+    }
+
+    let segments = split_command_segments(trimmed);
+
+    for segment in &segments {
+        let seg = segment.trim();
+
+        // Check for cd targets
+        if let Some(target) = extract_cd_target(seg) {
+            match target {
+                CdTarget::Home => lint.home_escape = true,
+                CdTarget::Dynamic => {} // can't resolve, skip
+                CdTarget::Path(p) => {
+                    let path = Path::new(&p);
+                    let resolved = if path.is_absolute() {
+                        path.to_path_buf().clean()
+                    } else {
+                        project_root.join(&p).clean()
+                    };
+                    if !resolved.starts_with(project_root) {
+                        lint.outside_paths.push(p);
+                    }
+                }
+            }
+        }
+
+        // Check for absolute path arguments (not cd)
+        for token in seg.split_whitespace().skip(1) {
+            // Skip flags
+            if token.starts_with('-') {
+                continue;
+            }
+            // Absolute paths outside project root
+            if token.starts_with('/') {
+                let resolved = Path::new(token).to_path_buf().clean();
+                if !resolved.starts_with(project_root) {
+                    lint.outside_paths.push(token.to_string());
+                }
+            }
+            // Relative paths with ../ that escape
+            if token.contains("..") {
+                let resolved = project_root.join(token).clean();
+                if !resolved.starts_with(project_root) {
+                    lint.outside_paths.push(token.to_string());
+                }
+            }
+        }
+    }
+
+    // Deduplicate
+    lint.outside_paths.sort();
+    lint.outside_paths.dedup();
+    lint
+}
+
+#[derive(Debug)]
+enum CdTarget {
+    Home,         // cd ~ or bare cd
+    Dynamic,      // cd $VAR or cd $(cmd)
+    Path(String), // cd <literal>
+}
+
+/// Extract the target of a `cd` command from a segment.
+fn extract_cd_target(segment: &str) -> Option<CdTarget> {
+    let seg = segment.trim();
+
+    // Strip leading env vars (FOO=bar cd /somewhere)
+    let seg = strip_env_vars(seg);
+    let seg = seg.trim();
+
+    // Must start with "cd" followed by space/tab or end of string
+    if seg == "cd" {
+        return Some(CdTarget::Home);
+    }
+    if !seg.starts_with("cd ") && !seg.starts_with("cd\t") {
+        return None;
+    }
+
+    let target = seg[2..].trim();
+
+    if target.is_empty() || target == "~" {
+        return Some(CdTarget::Home);
+    }
+    if target.starts_with('$') || target.starts_with('`') || target.contains("$(") {
+        return Some(CdTarget::Dynamic);
+    }
+
+    Some(CdTarget::Path(
+        target
+            .split_whitespace()
+            .next()
+            .unwrap_or(target)
+            .to_string(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -526,5 +652,87 @@ mod tests {
         let segs = split_command_segments("echo 'a | b' | grep x");
         assert_eq!(segs.len(), 2);
         assert!(segs[0].contains("'a | b'"));
+    }
+
+    // ── Bash Path Lint tests (#218) ────────────────────
+
+    fn project() -> std::path::PathBuf {
+        std::path::PathBuf::from("/home/user/project")
+    }
+
+    #[test]
+    fn test_lint_safe_command() {
+        let lint = lint_bash_paths("cargo test", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_cd_inside_project() {
+        let lint = lint_bash_paths("cd src && ls", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_cd_outside_project() {
+        let lint = lint_bash_paths("cd /tmp && ls", &project());
+        assert!(lint.has_warnings());
+        assert!(lint.outside_paths.contains(&"/tmp".to_string()));
+    }
+
+    #[test]
+    fn test_lint_cd_home() {
+        let lint = lint_bash_paths("cd ~", &project());
+        assert!(lint.home_escape);
+    }
+
+    #[test]
+    fn test_lint_bare_cd() {
+        let lint = lint_bash_paths("cd", &project());
+        assert!(lint.home_escape);
+    }
+
+    #[test]
+    fn test_lint_cd_dynamic_ignored() {
+        let lint = lint_bash_paths("cd $SOME_DIR", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_absolute_path_arg() {
+        let lint = lint_bash_paths("cp file.txt /etc/hosts", &project());
+        assert!(lint.has_warnings());
+        assert!(lint.outside_paths.contains(&"/etc/hosts".to_string()));
+    }
+
+    #[test]
+    fn test_lint_relative_escape() {
+        let lint = lint_bash_paths("cat ../../../etc/passwd", &project());
+        assert!(lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_relative_inside() {
+        let lint = lint_bash_paths("cat ../project/src/main.rs", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_path_inside_project_absolute() {
+        let lint = lint_bash_paths("ls /home/user/project/src", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_empty_command() {
+        let lint = lint_bash_paths("", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_deduplicates() {
+        let lint = lint_bash_paths("cp /tmp/a /tmp/b", &project());
+        assert!(lint.has_warnings());
+        // /tmp/a and /tmp/b are separate paths
+        assert_eq!(lint.outside_paths.len(), 2);
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -547,7 +547,7 @@ pub async fn inference_loop(
         let pi = PhaseInfo::from(&phase_tracker);
         if tool_calls.len() > 1
             && config.model_tier.allows_parallel_tools()
-            && can_parallelize(&tool_calls, mode, pi)
+            && can_parallelize(&tool_calls, mode, pi, project_root)
         {
             execute_tools_parallel(
                 &tool_calls,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -42,11 +42,18 @@ pub(crate) fn can_parallelize(
     tool_calls: &[ToolCall],
     mode: ApprovalMode,
     phase_info: crate::task_phase::PhaseInfo,
+    project_root: &Path,
 ) -> bool {
     !tool_calls.iter().any(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(&tc.function_name, &args, mode, phase_info),
+            approval::check_tool(
+                &tc.function_name,
+                &args,
+                mode,
+                phase_info,
+                Some(project_root)
+            ),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
     })
@@ -213,7 +220,13 @@ pub(crate) async fn execute_tools_split_batch(
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            approval::check_tool(&tc.function_name, &args, mode, phase_info),
+            approval::check_tool(
+                &tc.function_name,
+                &args,
+                mode,
+                phase_info,
+                Some(project_root)
+            ),
             ToolApproval::AutoApprove | ToolApproval::Notify
         )
     });
@@ -361,7 +374,13 @@ pub(crate) async fn execute_tools_sequential(
         });
 
         // Check approval for this tool call
-        let approval = approval::check_tool(&tc.function_name, &parsed_args, mode, phase_info);
+        let approval = approval::check_tool(
+            &tc.function_name,
+            &parsed_args,
+            mode,
+            phase_info,
+            Some(project_root),
+        );
 
         match approval {
             ToolApproval::AutoApprove | ToolApproval::Notify => {
@@ -626,7 +645,13 @@ pub(crate) async fn execute_sub_agent(
             // Sub-agents inherit the parent's approval mode
             let parsed_args: serde_json::Value =
                 serde_json::from_str(&tc.arguments).unwrap_or_default();
-            let approval = approval::check_tool(&tc.function_name, &parsed_args, mode, phase_info);
+            let approval = approval::check_tool(
+                &tc.function_name,
+                &parsed_args,
+                mode,
+                phase_info,
+                Some(project_root),
+            );
 
             let output = match approval {
                 ToolApproval::AutoApprove | ToolApproval::Notify => {
@@ -745,7 +770,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 
@@ -755,7 +781,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 
@@ -774,7 +801,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 
@@ -784,7 +812,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 
@@ -806,7 +835,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 
@@ -816,7 +846,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Auto,
-            crate::task_phase::PhaseInfo::legacy()
+            crate::task_phase::PhaseInfo::legacy(),
+            Path::new("/test/project")
         ));
     }
 }

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -61,6 +61,7 @@ fn test_all_tools_handled_by_approval() {
             &empty_args,
             ApprovalMode::Strict,
             koda_core::task_phase::PhaseInfo::legacy(),
+            None,
         );
         // Verify it returns a valid variant (not a crash)
         match result {


### PR DESCRIPTION
## #218 — folder-scoped permissions

Three safety layers, all built on the existing `project_root` infrastructure:

### 1. Startup footgun warning
If `project_root == $HOME`, warn:
```
⚠️  Project root is your home directory (/Users/lijun).
   koda can modify any file in this tree.
   Consider running from a project subdirectory.
```

### 2. Path-aware `check_tool()`
`is_outside_project()` checks Write/Edit/Delete `file_path` args against `project_root`. Hardcoded floor of `NeedsConfirmation` — the `InterventionObserver` can never learn to skip this.

Defense-in-depth: `safe_resolve_path()` already blocks at execution, but `check_tool()` catches it at the approval layer with a clear warning.

### 3. Bash path lint (`lint_bash_paths()`)
Pre-execution heuristic analysis of bash commands:

| Pattern | Action |
|---------|--------|
| `cd /outside` | Flag → NeedsConfirmation |
| `cd ~` / bare `cd` | Flag (→ $HOME) |
| `cd $VAR` / `cd $(cmd)` | Skip (dynamic, can't resolve) |
| Absolute path args (`cp file /etc/hosts`) | Flag if outside project_root |
| Relative escapes (`../../../etc/passwd`) | Flag if canonicalized path escapes |

### API change
`check_tool()` and `can_parallelize()` now take `project_root: Option<&Path>`. Passing `None` skips path checks (backward compatible).

### Tests
6 new approval tests + 12 new bash lint tests. 430 lib + 3 integration tests pass. clippy clean.

### What's NOT in this PR (deferred per #218 brainstorm)
- `allow_paths` config (YAGNI)
- Sub-agent scope enforcement (bigger protocol change)
- Bash sandboxing (seccomp/landlock — v1.0)
- Read scoping (reads are safe)

Closes #218