### PR TITLE
fix: pre-release fixes from 4-reviewer audit

### DIFF
--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -84,3 +84,7 @@ required-features = ["test-support"]
 [[test]]
 name = "cancel_test"
 required-features = ["test-support"]
+
+[[test]]
+name = "inference_recovery_test"
+required-features = ["test-support"]

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -250,7 +250,10 @@ fn is_mutating(tool_name: &str) -> bool {
 /// Hardcoded floor: always NeedsConfirmation regardless of mode or phase.
 fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> bool {
     let path_arg = match tool_name {
-        "Write" | "Edit" | "Delete" => args.get("file_path").and_then(|v| v.as_str()),
+        "Write" | "Edit" | "Delete" => args
+            .get("path")
+            .or(args.get("file_path"))
+            .and_then(|v| v.as_str()),
         _ => None,
     };
     match path_arg {
@@ -625,7 +628,7 @@ mod tests {
     #[test]
     fn test_write_outside_project_needs_confirmation() {
         let root = Path::new("/home/user/project");
-        let args = serde_json::json!({"file_path": "/etc/hosts"});
+        let args = serde_json::json!({"path": "/etc/hosts"});
         assert_eq!(
             check_tool(
                 "Write",
@@ -641,7 +644,7 @@ mod tests {
     #[test]
     fn test_write_inside_project_auto_approved() {
         let root = Path::new("/home/user/project");
-        let args = serde_json::json!({"file_path": "src/main.rs"});
+        let args = serde_json::json!({"path": "src/main.rs"});
         assert_eq!(
             check_tool(
                 "Write",
@@ -657,7 +660,7 @@ mod tests {
     #[test]
     fn test_edit_with_dotdot_escape_needs_confirmation() {
         let root = Path::new("/home/user/project");
-        let args = serde_json::json!({"file_path": "../../../etc/passwd"});
+        let args = serde_json::json!({"path": "../../../etc/passwd"});
         assert_eq!(
             check_tool(
                 "Edit",
@@ -704,7 +707,7 @@ mod tests {
 
     #[test]
     fn test_no_project_root_skips_path_check() {
-        let args = serde_json::json!({"file_path": "/etc/hosts"});
+        let args = serde_json::json!({"path": "/etc/hosts"});
         assert_eq!(
             check_tool(
                 "Write",

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -155,11 +155,21 @@ const SAFE_PREFIXES: &[&str] = &[
     "gh release ",
     "gh run ",
     "gh workflow ",
-    // ── Cloud CLIs (read-only) ──
-    "gcloud ",
-    "bq ",
-    "aws ",
-    "az ",
+    // ── Cloud CLIs (read-only subcommands only) ──
+    "gcloud projects list",
+    "gcloud compute instances list",
+    "gcloud config ",
+    "gcloud auth ",
+    "gcloud info",
+    "bq ls",
+    "bq show",
+    "bq query ",
+    "bq head ",
+    "aws sts ",
+    "aws s3 ls",
+    "aws s3api list",
+    "az account ",
+    "az group list",
     // ── Misc dev tools ──
     "brew ",
     "open ",
@@ -205,6 +215,11 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     "git push --force",
     "git reset --hard",
     "git clean -fd",
+    // Safe-command escalation: safe prefixes that become dangerous with certain args
+    "sed -i",
+    "sed -i ",
+    "sed -i'",
+    "sed --in-place",
     // System control
     "reboot",
     "shutdown",
@@ -608,6 +623,20 @@ mod tests {
         assert!(is_command_safe("bq query 'SELECT 1'"));
         assert!(is_command_safe("aws s3 ls"));
         assert!(is_command_safe("az account list"));
+    }
+
+    #[test]
+    fn test_cloud_cli_destructive_not_safe() {
+        assert!(!is_command_safe("gcloud compute instances delete my-vm"));
+        assert!(!is_command_safe("aws s3 rm s3://bucket/key"));
+        assert!(!is_command_safe("bq rm dataset.table"));
+    }
+
+    #[test]
+    fn test_sed_in_place_not_safe() {
+        assert!(!is_command_safe("sed -i 's/foo/bar/g' file.txt"));
+        assert!(!is_command_safe("sed --in-place 's/foo/bar/' file.txt"));
+        assert!(is_command_safe("sed 's/foo/bar/g' file.txt")); // read-only sed is fine
     }
 
     #[test]

--- a/koda-core/src/intervention_observer.rs
+++ b/koda-core/src/intervention_observer.rs
@@ -129,14 +129,24 @@ impl InterventionObserver {
         }
     }
 
-    /// Save to disk.
+    /// Save to disk. Logs a warning if persistence fails.
     pub fn save(&self) {
         let path = Self::storage_path();
         if let Some(parent) = path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        if let Ok(json) = serde_json::to_string_pretty(self) {
-            let _ = std::fs::write(&path, json);
+        match serde_json::to_string_pretty(self) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&path, json) {
+                    tracing::warn!(
+                        "Failed to save intervention priors to {}: {e}",
+                        path.display()
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to serialize intervention priors: {e}");
+            }
         }
     }
 


### PR DESCRIPTION
## Pre-release fixes from cross-reviewer audit

Four sub-agents reviewed the codebase for v0.1.4 release readiness: code-reviewer, rust-programmer, security-auditor, and qa-expert.

### Fixes (consensus findings — 3+ reviewers flagged)

| # | Fix | Reviewers |
|---|-----|-----------|
| 1 | `is_outside_project`: check `"path"` key (tool schema), not `"file_path"` — **guard was silently non-functional** | Code, Security, QA |
| 2 | `sed -i` / `sed --in-place` added to DANGEROUS_PATTERNS — safe prefix + in-place flag = file mutation | Code, Rust, Security, QA |
| 3 | Cloud CLIs narrowed to read-only subcommands — was auto-approving `aws s3 rm`, `gcloud delete`, etc. | Security |
| 4 | `inference_recovery_test.rs` added to `required-features` in Cargo.toml — was breaking bare `cargo test` | QA |
| 5 | `InterventionObserver::save()` logs errors via `tracing::warn` instead of silent `let _ =` | Rust, QA |

### Deferred findings (tracked for v0.1.5)

| Finding | Severity | Reason to defer |
|---------|----------|----------------|
| Symlink escape in path scoping | Medium | Needs `canonicalize()` which requires paths to exist — design decision needed |
| `InferenceContext` struct (14-param function) | P2 | Tech debt, not a bug |
| Consolidate `is_mutating` definitions | P2 | Three copies across files |
| Move Settings out of approval.rs | P2 | Historical accident, cosmetic |
| `Message.role` String → Role enum | P1 | Bigger refactor, API change |

### Tests
432 lib + 3 integration tests pass. 2 new tests (cloud CLI destructive, sed -i). clippy clean.