### PR TITLE
fix: bump koda-ast and koda-email to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
Missed in the release docs PR. Release workflow verify-version failed because these two crates were still at 0.1.3. After merge, delete and re-push the v0.1.4 tag.