### PR TITLE
ci: eliminate redundant CI runs on main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    tags: ["v*"]        # Release needs CI on the tagged commit
   pull_request:
-    branches: [main]
-  workflow_call:
+    branches: [main]    # PR status checks
+  workflow_call:        # Called by other workflows
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
**Before:** CI ran on `pull_request` AND `push to main` — same code tested twice (~5 min wasted per merge).

**After:**
- `pull_request` → PR status checks (unchanged)
- `push tags: ["v*"]` → release workflow dependency (new)
- `push branches: [main]` → **removed** (was redundant)

Also adds `concurrency` group to cancel stale PR runs when new commits push to the same branch.

The release workflow's `gh run watch` finds the tag-triggered CI run, so no gap.