### PR TITLE
docs: crate READMEs, email parity, rustdoc TODO (#295)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ echo "explain this" | koda        # Piped input
 ### 🌳 AST Code Analysis
 
 Koda natively understands the structure of your codebase using embedded `tree-sitter` parsers.
+- **Auto-provisioned:** just ask koda to analyze code structure — no setup needed.
 - **Built-in languages:** Rust, Python, JavaScript, TypeScript — instant function/class extraction and call graphs.
 - **Extending with MCP:** Need Go, C++, or Java? Connect a community Tree-sitter MCP server via `.mcp.json`.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Koda natively understands the structure of your codebase using embedded `tree-si
 - **Built-in languages:** Rust, Python, JavaScript, TypeScript — instant function/class extraction and call graphs.
 - **Extending with MCP:** Need Go, C++, or Java? Connect a community Tree-sitter MCP server via `.mcp.json`.
 
+### 📧 Email Integration
+
+Koda connects to your email via IMAP/SMTP through the koda-email MCP server.
+- **Auto-provisioned:** just ask "check my email" — koda sets it up.
+- **Any provider:** Gmail, Outlook, FastMail, self-hosted.
+- **Read, search, send:** full email workflow from the CLI.
+
 ## REPL Commands
 
 | Command | Description |

--- a/koda-ast/README.md
+++ b/koda-ast/README.md
@@ -1,0 +1,44 @@
+# koda-ast
+
+MCP server for tree-sitter AST analysis, part of the [Koda](https://github.com/lijunzh/koda) AI coding agent.
+
+Extracts function signatures, class definitions, and call graphs from source
+code using embedded tree-sitter parsers. Communicates via the
+[Model Context Protocol](https://modelcontextprotocol.io) over stdio.
+
+## Built-in languages
+
+Rust, Python, JavaScript, TypeScript.
+
+## Auto-provisioning
+
+Koda auto-installs and connects this server when AST analysis is needed.
+No manual setup required — just ask koda to analyze code structure.
+
+## Manual setup
+
+```bash
+cargo install koda-ast
+```
+
+Add to `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "ast": {
+      "command": "koda-ast",
+      "args": []
+    }
+  }
+}
+```
+
+## MCP tools exposed
+
+| Tool | Description |
+|------|-------------|
+| `AstAnalysis` | Extract functions, classes, and call graphs from source files |
+
+## License
+
+MIT

--- a/koda-ast/README.md
+++ b/koda-ast/README.md
@@ -8,7 +8,8 @@ code using embedded tree-sitter parsers. Communicates via the
 
 ## Built-in languages
 
-Rust, Python, JavaScript, TypeScript.
+Rust, Python, JavaScript, TypeScript. Additional languages require adding
+tree-sitter grammars to this crate — see [#298](https://github.com/lijunzh/koda/issues/298).
 
 ## Auto-provisioning
 
@@ -33,11 +34,8 @@ Add to `.mcp.json`:
 }
 ```
 
-## MCP tools exposed
-
-| Tool | Description |
-|------|-------------|
-| `AstAnalysis` | Extract functions, classes, and call graphs from source files |
+Exposes one MCP tool: **AstAnalysis** — extracts functions, classes, and
+call graphs from source files.
 
 ## License
 

--- a/koda-cli/README.md
+++ b/koda-cli/README.md
@@ -31,7 +31,7 @@ Cycle with `Shift+Tab`:
 | **Strict** | Every non-read action requires confirmation |
 | **Safe** | Read-only: safe bash allowed, mutations blocked |
 
-See the [root README](../README.md) for full documentation.
+See the [README](https://github.com/lijunzh/koda) for full documentation.
 
 ## License
 

--- a/koda-cli/README.md
+++ b/koda-cli/README.md
@@ -1,0 +1,38 @@
+# koda-cli
+
+CLI frontend for the [Koda](https://github.com/lijunzh/koda) AI coding agent.
+
+Built with [ratatui](https://ratatui.rs/) for an inline TUI experience —
+streaming markdown, tab completion, diff previews, and approval widgets
+without ever leaving the terminal.
+
+## Install
+
+```bash
+cargo install koda-cli
+```
+
+## Quick start
+
+```bash
+koda                              # Interactive REPL
+koda --provider anthropic         # Use a cloud provider
+koda -p "fix the bug in auth.rs"  # Headless one-shot
+koda server --stdio               # ACP server for editor integration
+```
+
+## Approval modes
+
+Cycle with `Shift+Tab`:
+
+| Mode | Behavior |
+|------|----------|
+| **Auto** | Phase-gated: writes confirmed before plan, auto-approved after |
+| **Strict** | Every non-read action requires confirmation |
+| **Safe** | Read-only: safe bash allowed, mutations blocked |
+
+See the [root README](../README.md) for full documentation.
+
+## License
+
+MIT

--- a/koda-cli/README.md
+++ b/koda-cli/README.md
@@ -12,6 +12,8 @@ without ever leaving the terminal.
 cargo install koda-cli
 ```
 
+On first run, an onboarding wizard guides you through provider and API key setup.
+
 ## Quick start
 
 ```bash

--- a/koda-core/README.md
+++ b/koda-core/README.md
@@ -1,0 +1,30 @@
+# koda-core
+
+Engine library for the [Koda](https://github.com/lijunzh/koda) AI coding agent.
+
+Pure logic with zero terminal dependencies — communicates exclusively through
+`EngineEvent` (output) and `EngineCommand` (input) enums over async channels.
+
+## What's inside
+
+- **LLM providers** — 14 providers (Anthropic, OpenAI, Gemini, Groq, Ollama, LM Studio, etc.)
+- **Tool system** — 20+ built-in tools (file ops, shell, search, memory, agents)
+- **Phase-gated approval** — six-phase state machine gates tool permissions
+- **Inference loop** — streaming tool-use loop with parallel execution
+- **SQLite persistence** — sessions, messages, compaction, phase flow log
+- **MCP client** — connects to external MCP servers for extensibility
+
+## Usage
+
+```rust
+use koda_core::{agent::KodaAgent, db::Database, inference::inference_loop};
+
+// koda-core is a library — see koda-cli for the full CLI application.
+// The engine communicates through EngineEvent/EngineCommand channels.
+```
+
+See [DESIGN.md](../DESIGN.md) for architectural decisions.
+
+## License
+
+MIT

--- a/koda-core/README.md
+++ b/koda-core/README.md
@@ -14,16 +14,30 @@ Pure logic with zero terminal dependencies — communicates exclusively through
 - **SQLite persistence** — sessions, messages, compaction, phase flow log
 - **MCP client** — connects to external MCP servers for extensibility
 
+**Rust edition:** 2024
+
 ## Usage
 
-```rust
-use koda_core::{agent::KodaAgent, db::Database, inference::inference_loop};
+koda-core is a channel-driven engine. Create async channels, spawn the
+inference loop, and drive the engine through `EngineCommand`/`EngineEvent` pairs:
 
-// koda-core is a library — see koda-cli for the full CLI application.
-// The engine communicates through EngineEvent/EngineCommand channels.
+```rust
+use koda_core::engine::{EngineCommand, EngineEvent};
+use tokio::sync::mpsc;
+
+// The engine communicates exclusively through async channels.
+// EngineEvents flow out (streaming text, tool calls, approvals).
+// EngineCommands flow in (approval responses, cancellation).
+let (cmd_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(64);
+let (evt_tx, mut evt_rx) = mpsc::channel::<EngineEvent>(64);
+
+// Spawn the inference loop, then select over evt_rx for streaming
+// output and cmd_tx to send approval decisions back.
+// See koda-cli for a complete implementation.
 ```
 
-See [DESIGN.md](../DESIGN.md) for architectural decisions.
+See [DESIGN.md](https://github.com/lijunzh/koda/blob/main/DESIGN.md) for
+architectural decisions.
 
 ## License
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -1,6 +1,9 @@
 //! Koda Core — the engine library for the Koda AI coding agent.
 //!
 //! This crate contains the pure engine logic with zero terminal dependencies.
+
+// TODO(#295): enable once public API docs are written (~235 items)
+// #![warn(missing_docs)]
 //! It communicates exclusively through [`engine::EngineEvent`] (output) and
 //! [`engine::EngineCommand`] (input) enums.
 //!

--- a/koda-email/README.md
+++ b/koda-email/README.md
@@ -19,7 +19,7 @@ On first use, you'll be prompted for IMAP/SMTP credentials.
 cargo install koda-email
 ```
 
-Add to `.mcp.json`:
+Add to `.mcp.json` (use env var references — don't hardcode credentials):
 ```json
 {
   "mcpServers": {
@@ -28,16 +28,21 @@ Add to `.mcp.json`:
       "args": [],
       "env": {
         "IMAP_HOST": "imap.gmail.com",
-        "IMAP_USER": "you@gmail.com",
-        "IMAP_PASS": "app-password",
+        "IMAP_USER": "$EMAIL_USER",
+        "IMAP_PASS": "$EMAIL_PASS",
         "SMTP_HOST": "smtp.gmail.com",
-        "SMTP_USER": "you@gmail.com",
-        "SMTP_PASS": "app-password"
+        "SMTP_USER": "$EMAIL_USER",
+        "SMTP_PASS": "$EMAIL_PASS"
       }
     }
   }
 }
 ```
+
+> **⚠️ Security:** Never hardcode email credentials in `.mcp.json` — if that
+> file is committed to a repo, your inbox is exposed. Set `EMAIL_USER` and
+> `EMAIL_PASS` as environment variables or use koda's built-in keystore
+> (`/provider` wizard stores credentials encrypted at `~/.config/koda/keys`).
 
 ## MCP tools exposed
 

--- a/koda-email/README.md
+++ b/koda-email/README.md
@@ -1,0 +1,52 @@
+# koda-email
+
+MCP server for email integration, part of the [Koda](https://github.com/lijunzh/koda) AI coding agent.
+
+Read, search, and send email via IMAP/SMTP. Works with any email provider
+(Gmail, Outlook, FastMail, self-hosted). Communicates via the
+[Model Context Protocol](https://modelcontextprotocol.io) over stdio.
+
+## Auto-provisioning
+
+Koda auto-installs and connects this server when email access is needed.
+Just ask — "check my email" — and koda handles the rest.
+
+On first use, you'll be prompted for IMAP/SMTP credentials.
+
+## Manual setup
+
+```bash
+cargo install koda-email
+```
+
+Add to `.mcp.json`:
+```json
+{
+  "mcpServers": {
+    "email": {
+      "command": "koda-email",
+      "args": [],
+      "env": {
+        "IMAP_HOST": "imap.gmail.com",
+        "IMAP_USER": "you@gmail.com",
+        "IMAP_PASS": "app-password",
+        "SMTP_HOST": "smtp.gmail.com",
+        "SMTP_USER": "you@gmail.com",
+        "SMTP_PASS": "app-password"
+      }
+    }
+  }
+}
+```
+
+## MCP tools exposed
+
+| Tool | Description |
+|------|-------------|
+| `EmailRead` | Read emails from inbox or specified folder |
+| `EmailSearch` | Search emails by subject, sender, date, or body |
+| `EmailSend` | Compose and send emails |
+
+## License
+
+MIT


### PR DESCRIPTION
## #295 — v0.1.5 doc scope (tiers 1-2)

### 4 crate READMEs (new files)
Required for crates.io. Short and stable — what it is, how to configure, what it exposes.

| Crate | Content |
|-------|---------|
| `koda-core/README.md` | Engine library, what's inside, usage hint |
| `koda-cli/README.md` | Install, quick start, approval modes table |
| `koda-ast/README.md` | Languages, auto-provisioning, MCP tools table |
| `koda-email/README.md` | Provider setup, IMAP/SMTP config example, MCP tools table |

### Root README: symmetric coverage
Both 🌳 AST and 📧 Email sections now follow the same structure: auto-provisioned bullet + capability bullets + same heading level.

### rustdoc TODO
Added commented-out `#![warn(missing_docs)]` to koda-core with a count (~235 items). Not enforcing yet — the marker tracks the goal without creating noise.

### CLAUDE.md doc rules
Already merged in #296 — documentation workflow rules are in place.

Partially addresses #295 (tiers 1-2 of 5). Remaining:
- Tier 3 (docs/user-guide.md) → v0.2.0
- Tier 4 (DESIGN.md refactor) → someday
- Tier 5 (CLAUDE.md) → ✅ done in #296