### PR TITLE
fix: Group A audit bugs — cancel, intent, oscillation, symlinks

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -259,12 +259,19 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
     match path_arg {
         Some(p) => {
             let requested = Path::new(p);
-            let resolved = if requested.is_absolute() {
-                requested.to_path_buf().clean()
+            let abs_path = if requested.is_absolute() {
+                requested.to_path_buf()
             } else {
-                project_root.join(requested).clean()
+                project_root.join(requested)
             };
-            !resolved.starts_with(project_root)
+            // Try canonicalize (follows symlinks, resolves ..).
+            // Falls back to lexical clean for new files that don't exist yet.
+            let resolved = abs_path.canonicalize().unwrap_or_else(|_| abs_path.clean());
+            // Also canonicalize project_root for consistent comparison
+            let canon_root = project_root
+                .canonicalize()
+                .unwrap_or_else(|_| project_root.to_path_buf());
+            !resolved.starts_with(&canon_root)
         }
         None => false,
     }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -72,12 +72,19 @@ pub async fn inference_loop(
     let mut recent_tool_names: Vec<String> = Vec::new();
 
     // Phase tracker: structural detection of task progression.
-    // Created fresh per-turn (per inference_loop invocation) — phase state
-    // is transient within a turn, not persisted across turns.
-    // Session-level phase history will be tracked via Role::Phase flow log
-    // (step 3, v0.1.5) for the InterventionObserver's learning.
-    // Defaults to Modify intent (adapts structurally regardless).
-    let mut phase_tracker = PhaseTracker::new(&crate::intent::TaskIntent::Modify);
+    // Classify intent from the last user message for phase expectations.
+    let intent = {
+        let history = db.load_context(session_id, available).await?;
+        history
+            .iter()
+            .rev()
+            .find(|m| m.role == "user")
+            .and_then(|m| m.content.as_deref())
+            .map(crate::intent::classify_intent)
+            .map(|s| s.intent)
+            .unwrap_or(crate::intent::TaskIntent::Modify)
+    };
+    let mut phase_tracker = PhaseTracker::new(&intent);
 
     loop {
         if iteration >= hard_cap {

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -221,6 +221,9 @@ pub struct PhaseTracker {
     /// Whether to expect full six-phase progression.
     /// Set from TaskIntent at construction.
     expect_full_progression: bool,
+    /// Transition count per phase pair — for oscillation detection (#287).
+    /// Key: (from_ordinal, to_ordinal), Value: count.
+    transition_counts: std::collections::HashMap<(u8, u8), u8>,
 }
 
 /// Record of a phase transition, for logging as `Role::Phase` messages.
@@ -266,6 +269,7 @@ impl PhaseTracker {
                 intent,
                 TaskIntent::Complex | TaskIntent::Review | TaskIntent::TestGen
             ),
+            transition_counts: std::collections::HashMap::new(),
         }
     }
 
@@ -381,6 +385,16 @@ impl PhaseTracker {
 
         // Return transition record if phase actually changed
         if old_phase != new_phase {
+            // Oscillation detection (#287): cap transitions per phase pair
+            let pair = (old_phase.ordinal(), new_phase.ordinal());
+            let count = self.transition_counts.entry(pair).or_insert(0);
+            *count = count.saturating_add(1);
+            if *count > Self::MAX_PAIR_TRANSITIONS {
+                // Oscillation detected — stop transitioning, stay in current phase
+                self.current = old_phase;
+                return None;
+            }
+
             let trigger = match (old_phase, new_phase) {
                 (TaskPhase::Understanding, TaskPhase::Planning) => "text_only_after_reads",
                 (TaskPhase::Understanding, TaskPhase::Executing) => "simple_task_shortcut",
@@ -402,6 +416,11 @@ impl PhaseTracker {
             None
         }
     }
+
+    /// Max transitions allowed per phase pair before oscillation is capped.
+    /// 5 round-trips (e.g., Executing ↔ Verifying) is generous; beyond that
+    /// the agent is stuck and the loop guard will eventually terminate.
+    const MAX_PAIR_TRANSITIONS: u8 = 5;
 
     /// Force an escalation (Executing → Understanding) on tool failure
     /// indicating scope change.
@@ -842,5 +861,41 @@ mod tests {
         assert_eq!(tr.trigger, "封驳");
         assert_eq!(tr.from, TaskPhase::Reviewing);
         assert_eq!(tr.to, TaskPhase::Planning);
+    }
+
+    #[test]
+    fn test_oscillation_capped() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        // Get to Executing
+        t.advance(&signal(true, ToolType::HasWrites, false)); // Understanding → Executing
+        assert_eq!(t.current(), TaskPhase::Executing);
+
+        // Oscillate Executing ↔ Verifying
+        for i in 0..20 {
+            t.advance(&signal(false, ToolType::ReadOnly, true)); // → Verifying
+            t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
+            // After MAX_PAIR_TRANSITIONS (5), oscillation should be capped
+            if i >= 5 {
+                // Phase should stop transitioning
+                let stuck = t.current();
+                assert!(
+                    stuck == TaskPhase::Executing || stuck == TaskPhase::Verifying,
+                    "phase should be stuck in Executing or Verifying, got {stuck:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_oscillation_does_not_affect_different_pairs() {
+        let mut t = PhaseTracker::new(&TaskIntent::Modify);
+        // Understanding → Planning (text) — this pair shouldn't be affected
+        // by Executing ↔ Verifying oscillation
+        t.advance(&signal(false, ToolType::ReadOnly, false)); // → Planning
+        assert_eq!(t.current(), TaskPhase::Planning);
+        t.advance(&signal(false, ToolType::ReadOnly, false)); // → Reviewing
+        assert_eq!(t.current(), TaskPhase::Reviewing);
+        t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
+        assert_eq!(t.current(), TaskPhase::Executing);
     }
 }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -511,7 +511,7 @@ pub(crate) async fn execute_sub_agent(
     mode: ApprovalMode,
     _settings: &mut Settings,
     sink: &dyn crate::engine::EngineSink,
-    _cancel: CancellationToken,
+    cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     parent_cache: Option<crate::tools::FileReadCache>,
     sub_agent_cache: &SubAgentCache,
@@ -585,6 +585,10 @@ pub(crate) async fn execute_sub_agent(
     let available = sub_config.max_context_tokens.saturating_sub(system_tokens);
 
     for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
+        // Respect parent cancellation (#286)
+        if cancel.is_cancelled() {
+            return Ok("[cancelled by parent]".to_string());
+        }
         let history = db.load_context(&sub_session, available).await?;
         let mut messages = vec![ChatMessage::text("system", &system_prompt)];
         for msg in &history {
@@ -672,11 +676,10 @@ pub(crate) async fn execute_sub_agent(
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
                     let diff_preview =
                         preview::compute(&tc.function_name, &parsed_args, project_root).await;
-                    let sub_cancel = CancellationToken::new();
                     match request_approval(
                         sink,
                         cmd_rx,
-                        &sub_cancel,
+                        &cancel,
                         &tc.function_name,
                         &detail,
                         diff_preview,


### PR DESCRIPTION
## Four bugs from v0.1.4 4-reviewer audit

| # | Bug | Fix | Reviewer |
|---|-----|-----|----------|
| #286 | Sub-agents ignore parent cancel token | Wire `cancel` through; check `is_cancelled()` each iteration | Code |
| #285 | classify_intent dead code — hardcoded `TaskIntent::Modify` | Load last user message, classify, pass to PhaseTracker | Code |
| #287 | No oscillation bound on Executing ↔ Verifying | Cap at 5 transitions per phase pair | QA |
| #280 | Symlink escape in path scoping | `canonicalize()` with fallback to `PathClean` for new files | Security, QA |

### Details

**#286**: `execute_sub_agent` had `_cancel: CancellationToken` (never used). Sub-agents created orphan `CancellationToken::new()` for approvals. Now the parent's token is checked at each loop iteration and passed to approval requests.

**#285**: `inference_loop` always created `PhaseTracker::new(&TaskIntent::Modify)`. Now loads the last user message from DB and classifies intent via the rule-based classifier (zero LLM cost). Question/Explore intents skip full progression; Complex/Review/TestGen expect six phases.

**#287**: Added `transition_counts: HashMap<(u8, u8), u8>` to PhaseTracker. After 5 transitions on the same phase pair, further transitions are suppressed. Prevents a pathological LLM from burning all 200 iterations oscillating.

**#280**: `is_outside_project()` now tries `std::fs::canonicalize()` (follows symlinks) before falling back to lexical `PathClean`. Both the path and `project_root` are canonicalized for consistent comparison.

### Tests
434 lib + 3 integration tests (2 new oscillation tests). clippy clean.

Closes #286, #285, #287, #280