### PR TITLE
feat: remove PhaseInfo::legacy() + action budget (#304, #293 Phase B)

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -111,6 +111,9 @@ pub enum ToolApproval {
     NeedsConfirmation,
     /// Safe mode: show what would happen, don't execute.
     Blocked,
+    /// Simple-task action budget exhausted. The inference loop should
+    /// inject a system message requiring the LLM to produce a plan.
+    PlanRequired,
 }
 
 /// Read-only tools that auto-approve in all modes (including Safe).
@@ -149,7 +152,7 @@ pub fn check_tool(
     tool_name: &str,
     args: &serde_json::Value,
     mode: ApprovalMode,
-    phase_info: crate::task_phase::PhaseInfo,
+    mut phase_info: crate::task_phase::PhaseInfo,
     project_root: Option<&Path>,
 ) -> ToolApproval {
     // Classify the tool's effect
@@ -177,6 +180,14 @@ pub fn check_tool(
                 return ToolApproval::NeedsConfirmation;
             }
         }
+    }
+
+    // Action budget check: if budget-limited and this is a mutation,
+    // consume one action. If exhausted, require a plan.
+    if matches!(effect, ToolEffect::LocalMutation | ToolEffect::Destructive)
+        && phase_info.consume_action()
+    {
+        return ToolApproval::PlanRequired;
     }
 
     // Apply the ToolEffect × ApprovalMode matrix
@@ -333,7 +344,7 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
-                    crate::task_phase::PhaseInfo::legacy(),
+                    crate::task_phase::PhaseInfo::delegated(),
                     None
                 ),
                 ToolApproval::AutoApprove,
@@ -350,7 +361,7 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
-                    crate::task_phase::PhaseInfo::legacy(),
+                    crate::task_phase::PhaseInfo::delegated(),
                     None
                 ),
                 ToolApproval::Blocked,
@@ -369,7 +380,7 @@ mod tests {
                     tool,
                     &serde_json::json!({}),
                     ApprovalMode::Auto,
-                    crate::task_phase::PhaseInfo::legacy(),
+                    crate::task_phase::PhaseInfo::delegated(),
                     None
                 ),
                 ToolApproval::AutoApprove,
@@ -385,7 +396,7 @@ mod tests {
                 "Delete",
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::NeedsConfirmation,
@@ -399,6 +410,7 @@ mod tests {
         let phase = PhaseInfo {
             phase: TaskPhase::Understanding,
             plan_approved: false,
+            action_budget: None,
         };
         assert_eq!(
             check_tool(
@@ -419,6 +431,7 @@ mod tests {
         let phase = PhaseInfo {
             phase: TaskPhase::Executing,
             plan_approved: false,
+            action_budget: None,
         };
         assert_eq!(
             check_tool(
@@ -441,7 +454,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::AutoApprove,
@@ -457,7 +470,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::NeedsConfirmation,
@@ -473,7 +486,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::NeedsConfirmation,
@@ -487,7 +500,7 @@ mod tests {
                 "Write",
                 &serde_json::json!({}),
                 ApprovalMode::Strict,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::NeedsConfirmation,
@@ -503,7 +516,7 @@ mod tests {
                     "InvokeAgent",
                     &args,
                     mode,
-                    crate::task_phase::PhaseInfo::legacy(),
+                    crate::task_phase::PhaseInfo::delegated(),
                     None
                 ),
                 ToolApproval::AutoApprove,
@@ -520,7 +533,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::AutoApprove,
@@ -536,7 +549,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::AutoApprove,
@@ -552,7 +565,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::Blocked,
@@ -568,7 +581,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::Blocked,
@@ -583,7 +596,7 @@ mod tests {
                 "WebFetch",
                 &args,
                 ApprovalMode::Safe,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None
             ),
             ToolApproval::AutoApprove,
@@ -601,7 +614,7 @@ mod tests {
                 "Write",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
             ),
             ToolApproval::NeedsConfirmation,
@@ -617,7 +630,7 @@ mod tests {
                 "Write",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
             ),
             ToolApproval::AutoApprove,
@@ -633,7 +646,7 @@ mod tests {
                 "Edit",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
             ),
             ToolApproval::NeedsConfirmation,
@@ -649,7 +662,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
             ),
             ToolApproval::NeedsConfirmation,
@@ -665,7 +678,7 @@ mod tests {
                 "Bash",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
             ),
             ToolApproval::AutoApprove,
@@ -680,10 +693,90 @@ mod tests {
                 "Write",
                 &args,
                 ApprovalMode::Auto,
-                crate::task_phase::PhaseInfo::legacy(),
+                crate::task_phase::PhaseInfo::delegated(),
                 None,
             ),
             ToolApproval::AutoApprove,
         );
+    }
+
+    // ── Action budget tests ──────────────────────────────────
+
+    #[test]
+    fn test_simple_task_budget_exhausted() {
+        use crate::task_phase::PhaseInfo;
+        // simple_task(2) allows 2 mutations, 3rd triggers PlanRequired
+        let phase = PhaseInfo::simple_task(2);
+        // First mutation: auto-approve (budget 2 → 1)
+        assert_eq!(
+            check_tool(
+                "Write",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase.clone(),
+                None
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    #[test]
+    fn test_simple_task_budget_triggers_plan_required() {
+        use crate::task_phase::PhaseInfo;
+        // Budget of 0 → immediately triggers PlanRequired
+        let phase = PhaseInfo::simple_task(0);
+        assert_eq!(
+            check_tool(
+                "Write",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase,
+                None
+            ),
+            ToolApproval::PlanRequired,
+        );
+    }
+
+    #[test]
+    fn test_simple_task_budget_readonly_doesnt_count() {
+        use crate::task_phase::PhaseInfo;
+        // ReadOnly tools don't consume budget
+        let phase = PhaseInfo::simple_task(0);
+        assert_eq!(
+            check_tool(
+                "Read",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase,
+                None
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    #[test]
+    fn test_delegated_has_no_budget() {
+        use crate::task_phase::PhaseInfo;
+        // delegated() has no budget → unlimited mutations
+        let phase = PhaseInfo::delegated();
+        assert_eq!(
+            check_tool(
+                "Write",
+                &serde_json::json!({}),
+                ApprovalMode::Auto,
+                phase,
+                None
+            ),
+            ToolApproval::AutoApprove,
+        );
+    }
+
+    #[test]
+    fn test_new_session_starts_at_understanding() {
+        use crate::task_phase::{PhaseInfo, TaskPhase};
+        let phase = PhaseInfo::new_session();
+        assert_eq!(phase.phase, TaskPhase::Understanding);
+        assert!(!phase.plan_approved);
+        assert!(phase.action_budget.is_none());
     }
 }

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -713,7 +713,7 @@ mod tests {
                 "Write",
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
-                phase.clone(),
+                phase,
                 None
             ),
             ToolApproval::AutoApprove,

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -126,14 +126,55 @@ impl std::fmt::Display for TaskPhase {
 pub struct PhaseInfo {
     pub phase: TaskPhase,
     pub plan_approved: bool,
+    /// If `Some(n)`, at most `n` LocalMutation/Destructive actions allowed
+    /// before the system forces a plan. Used by the simple-task shortcut.
+    pub action_budget: Option<usize>,
 }
 
 impl PhaseInfo {
-    /// Default for legacy callers: Executing + approved (preserves old Auto behavior).
-    pub fn legacy() -> Self {
+    /// Normal entry point: starts at Understanding, no plan approved.
+    pub fn new_session() -> Self {
+        Self {
+            phase: TaskPhase::Understanding,
+            plan_approved: false,
+            action_budget: None,
+        }
+    }
+
+    /// Simple-task shortcut: Executing + approved, but budget-limited.
+    ///
+    /// After `max_actions` mutating tool calls, the system injects a
+    /// plan-requirement message. Default budget: 3.
+    pub fn simple_task(max_actions: usize) -> Self {
         Self {
             phase: TaskPhase::Executing,
             plan_approved: true,
+            action_budget: Some(max_actions),
+        }
+    }
+
+    /// Delegated sub-agent: Executing + approved (parent already approved).
+    pub fn delegated() -> Self {
+        Self {
+            phase: TaskPhase::Executing,
+            plan_approved: true,
+            action_budget: None,
+        }
+    }
+
+    /// Consume one action from the budget. Returns `true` if budget
+    /// is exhausted (caller should inject a plan-requirement message).
+    ///
+    /// Returns `false` if there's no budget (unlimited) or budget > 0.
+    pub fn consume_action(&mut self) -> bool {
+        if let Some(ref mut budget) = self.action_budget {
+            if *budget == 0 {
+                return true; // already exhausted
+            }
+            *budget -= 1;
+            *budget == 0
+        } else {
+            false
         }
     }
 }
@@ -143,6 +184,7 @@ impl From<&PhaseTracker> for PhaseInfo {
         Self {
             phase: tracker.current(),
             plan_approved: tracker.plan_approved(),
+            action_budget: None,
         }
     }
 }
@@ -897,5 +939,52 @@ mod tests {
         assert_eq!(t.current(), TaskPhase::Reviewing);
         t.advance(&signal(true, ToolType::HasWrites, false)); // → Executing
         assert_eq!(t.current(), TaskPhase::Executing);
+    }
+
+    #[test]
+    fn test_consume_action_with_budget() {
+        let mut info = PhaseInfo::simple_task(3);
+        assert!(!info.consume_action()); // 3 → 2
+        assert!(!info.consume_action()); // 2 → 1
+        assert!(info.consume_action()); // 1 → 0 (exhausted)
+        assert!(info.consume_action()); // still exhausted
+    }
+
+    #[test]
+    fn test_consume_action_no_budget() {
+        let mut info = PhaseInfo::delegated();
+        assert!(!info.consume_action()); // unlimited
+        assert!(!info.consume_action());
+        assert!(!info.consume_action());
+    }
+
+    #[test]
+    fn test_consume_action_zero_budget() {
+        let mut info = PhaseInfo::simple_task(0);
+        assert!(info.consume_action()); // immediately exhausted
+    }
+
+    #[test]
+    fn test_new_session_constructor() {
+        let info = PhaseInfo::new_session();
+        assert_eq!(info.phase, TaskPhase::Understanding);
+        assert!(!info.plan_approved);
+        assert!(info.action_budget.is_none());
+    }
+
+    #[test]
+    fn test_simple_task_constructor() {
+        let info = PhaseInfo::simple_task(5);
+        assert_eq!(info.phase, TaskPhase::Executing);
+        assert!(info.plan_approved);
+        assert_eq!(info.action_budget, Some(5));
+    }
+
+    #[test]
+    fn test_delegated_constructor() {
+        let info = PhaseInfo::delegated();
+        assert_eq!(info.phase, TaskPhase::Executing);
+        assert!(info.plan_approved);
+        assert!(info.action_budget.is_none());
     }
 }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -381,6 +381,23 @@ pub(crate) async fn execute_tools_sequential(
             ToolApproval::AutoApprove | ToolApproval::Notify => {
                 // Execute without asking
             }
+            ToolApproval::PlanRequired => {
+                // Simple-task action budget exhausted — tell the LLM to plan
+                db.insert_message(
+                    session_id,
+                    &Role::Tool,
+                    Some(
+                        "[system] You have exceeded the simple-task action limit. \
+                          Please produce a plan for the remaining work before \
+                          continuing with more tool calls.",
+                    ),
+                    None,
+                    Some(&tc.id),
+                    None,
+                )
+                .await?;
+                continue;
+            }
             ToolApproval::Blocked => {
                 // Plan mode: emit ActionBlocked event, let the client render it
                 let detail = tools::describe_action(&tc.function_name, &parsed_args);
@@ -656,6 +673,9 @@ pub(crate) async fn execute_sub_agent(
                 ToolApproval::AutoApprove | ToolApproval::Notify => {
                     tools.execute(&tc.function_name, &tc.arguments).await.output
                 }
+                ToolApproval::PlanRequired => {
+                    "[system] Simple-task action budget exhausted. Produce a plan.".to_string()
+                }
                 ToolApproval::Blocked => {
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
                     let diff_preview =
@@ -768,7 +788,7 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }
@@ -779,7 +799,7 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }
@@ -799,7 +819,7 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }
@@ -810,7 +830,7 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }
@@ -834,7 +854,7 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             ApprovalMode::Strict,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }
@@ -845,7 +865,7 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             ApprovalMode::Auto,
-            crate::task_phase::PhaseInfo::legacy(),
+            crate::task_phase::PhaseInfo::delegated(),
             Path::new("/test/project")
         ));
     }

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -60,7 +60,7 @@ fn test_all_tools_handled_by_approval() {
             &name,
             &empty_args,
             ApprovalMode::Strict,
-            koda_core::task_phase::PhaseInfo::legacy(),
+            koda_core::task_phase::PhaseInfo::delegated(),
             None,
         );
         // Verify it returns a valid variant (not a crash)
@@ -68,7 +68,8 @@ fn test_all_tools_handled_by_approval() {
             ToolApproval::AutoApprove
             | ToolApproval::Notify
             | ToolApproval::NeedsConfirmation
-            | ToolApproval::Blocked => {}
+            | ToolApproval::Blocked
+            | ToolApproval::PlanRequired => {}
         }
     }
 }


### PR DESCRIPTION
## Phase B of #293 — PhaseInfo cleanup + action budget

### Remove PhaseInfo::legacy()
Replaced all 27 call sites with explicit constructors:

| Constructor | Phase | plan_approved | action_budget | Use case |
|-------------|-------|---------------|---------------|----------|
| `new_session()` | Understanding | false | None | Normal task start |
| `simple_task(n)` | Executing | true | Some(n) | LLM skipped planning |
| `delegated()` | Executing | true | None | Sub-agent (parent approved) |

### Action budget
PhaseInfo gains `action_budget: Option<usize>`:
- Each LocalMutation/Destructive tool call decrements the budget
- ReadOnly/RemoteAction calls don't count
- When budget hits 0: `check_tool()` returns new `ToolApproval::PlanRequired`
- Inference loop injects system message: "produce a plan before continuing"

### New ToolApproval variant
`PlanRequired` — handled in both dispatch paths (single tool + parallel batch). Blocks the tool call and injects a plan-forcing message.

### Tests
452 lib + 3 integration = 455 total. 11 new tests for constructors, consume_action, and PlanRequired triggering. clippy clean.

Closes #304