### PR TITLE
feat: MCP readOnly classification + config override (#305, #293 Phase C)

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -154,9 +154,10 @@ pub fn check_tool(
     mode: ApprovalMode,
     mut phase_info: crate::task_phase::PhaseInfo,
     project_root: Option<&Path>,
+    mcp_effect: Option<ToolEffect>,
 ) -> ToolApproval {
-    // Classify the tool's effect
-    let effect = resolve_effect(tool_name, args);
+    // Classify the tool's effect (MCP override takes precedence)
+    let effect = mcp_effect.unwrap_or_else(|| resolve_effect(tool_name, args));
 
     // Read-only tools always auto-approve in every mode
     if effect == ToolEffect::ReadOnly {
@@ -345,7 +346,8 @@ mod tests {
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
                     crate::task_phase::PhaseInfo::delegated(),
-                    None
+                    None,
+                    None,
                 ),
                 ToolApproval::AutoApprove,
                 "{tool} should auto-approve even in Safe mode"
@@ -362,7 +364,8 @@ mod tests {
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
                     crate::task_phase::PhaseInfo::delegated(),
-                    None
+                    None,
+                    None,
                 ),
                 ToolApproval::Blocked,
                 "{tool} should be blocked in Safe mode"
@@ -381,7 +384,8 @@ mod tests {
                     &serde_json::json!({}),
                     ApprovalMode::Auto,
                     crate::task_phase::PhaseInfo::delegated(),
-                    None
+                    None,
+                    None,
                 ),
                 ToolApproval::AutoApprove,
             );
@@ -397,7 +401,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -418,7 +423,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -439,7 +445,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::Notify,
         );
@@ -455,7 +462,8 @@ mod tests {
                 &args,
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -471,7 +479,8 @@ mod tests {
                 &args,
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -487,7 +496,8 @@ mod tests {
                 &args,
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -501,7 +511,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -517,7 +528,8 @@ mod tests {
                     &args,
                     mode,
                     crate::task_phase::PhaseInfo::delegated(),
-                    None
+                    None,
+                    None,
                 ),
                 ToolApproval::AutoApprove,
             );
@@ -534,7 +546,8 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -550,7 +563,8 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -566,7 +580,8 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::Blocked,
         );
@@ -582,7 +597,8 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::Blocked,
         );
@@ -597,7 +613,8 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -616,6 +633,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -632,6 +650,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -648,6 +667,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -664,6 +684,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -680,6 +701,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -694,6 +716,7 @@ mod tests {
                 &args,
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
             ),
             ToolApproval::AutoApprove,
@@ -714,7 +737,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -731,7 +755,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::PlanRequired,
         );
@@ -748,7 +773,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -765,7 +791,8 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
-                None
+                None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -19,6 +19,7 @@ use tokio::process::Command;
 
 use crate::mcp::config::McpServerConfig;
 use crate::providers::ToolDefinition;
+use crate::tools::ToolEffect;
 
 /// Default timeout for tool calls (seconds).
 const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 30;
@@ -51,6 +52,8 @@ pub struct McpClient {
     service: RunningService<RoleClient, KodaClientHandler>,
     /// Cached tool definitions (converted to Koda format).
     tools: Vec<ToolDefinition>,
+    /// Effect classification per namespaced tool name (from MCP annotations).
+    tool_effects: std::collections::HashMap<String, ToolEffect>,
     /// Timeout for tool calls.
     _timeout: Duration,
 }
@@ -99,6 +102,17 @@ impl McpClient {
             .map(|t| mcp_tool_to_definition(&name, t))
             .collect();
 
+        // Extract ToolEffect classification from MCP annotations
+        let tool_effects = tools_result
+            .tools
+            .iter()
+            .map(|t| {
+                let namespaced = format!("{name}.{}", t.name);
+                let effect = classify_mcp_annotations(t);
+                (namespaced, effect)
+            })
+            .collect();
+
         tracing::info!(
             "MCP server '{}' connected — {} tools available",
             name,
@@ -110,6 +124,7 @@ impl McpClient {
             config,
             service,
             tools,
+            tool_effects,
             _timeout: timeout,
         })
     }
@@ -117,6 +132,11 @@ impl McpClient {
     /// Get the namespaced tool definitions for this server.
     pub fn tool_definitions(&self) -> &[ToolDefinition] {
         &self.tools
+    }
+
+    /// Get the ToolEffect for a namespaced tool name.
+    pub fn tool_effect(&self, namespaced_name: &str) -> Option<ToolEffect> {
+        self.tool_effects.get(namespaced_name).copied()
     }
 
     /// Call a tool on this MCP server.
@@ -165,6 +185,28 @@ fn mcp_tool_to_definition(server_name: &str, tool: &McpTool) -> ToolDefinition {
     }
 }
 
+/// Classify an MCP tool's effect from its annotations.
+///
+/// MCP spec annotations (all optional hints):
+/// - `readOnlyHint: true`  → ReadOnly
+/// - `destructiveHint: true` → Destructive
+/// - Neither → LocalMutation (conservative default)
+fn classify_mcp_annotations(tool: &McpTool) -> ToolEffect {
+    match &tool.annotations {
+        Some(ann) => {
+            if ann.read_only_hint == Some(true) {
+                ToolEffect::ReadOnly
+            } else if ann.destructive_hint == Some(true) {
+                ToolEffect::Destructive
+            } else {
+                // No hints or readOnly=false → assume local mutation
+                ToolEffect::LocalMutation
+            }
+        }
+        None => ToolEffect::LocalMutation,
+    }
+}
+
 /// Format a CallToolResult into a human-readable string.
 fn format_call_result(result: &rmcp::model::CallToolResult) -> String {
     let mut output = String::new();
@@ -180,4 +222,62 @@ fn format_call_result(result: &rmcp::model::CallToolResult) -> String {
         output = "MCP tool returned an error with no details.".to_string();
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::ToolAnnotations;
+    use std::sync::Arc;
+
+    fn empty_schema() -> Arc<serde_json::Map<String, serde_json::Value>> {
+        let mut map = serde_json::Map::new();
+        map.insert("type".to_string(), serde_json::json!("object"));
+        Arc::new(map)
+    }
+
+    fn make_tool(name: &str, annotations: Option<ToolAnnotations>) -> McpTool {
+        let mut tool = McpTool::new(name.to_string(), "", empty_schema());
+        tool.annotations = annotations;
+        tool
+    }
+
+    #[test]
+    fn test_classify_read_only_hint() {
+        let tool = make_tool(
+            "list_items",
+            Some(ToolAnnotations::default().read_only(true)),
+        );
+        assert_eq!(classify_mcp_annotations(&tool), ToolEffect::ReadOnly);
+    }
+
+    #[test]
+    fn test_classify_destructive_hint() {
+        let tool = make_tool(
+            "drop_table",
+            Some(ToolAnnotations::default().destructive(true)),
+        );
+        assert_eq!(classify_mcp_annotations(&tool), ToolEffect::Destructive);
+    }
+
+    #[test]
+    fn test_classify_no_annotations() {
+        let tool = make_tool("unknown", None);
+        assert_eq!(classify_mcp_annotations(&tool), ToolEffect::LocalMutation);
+    }
+
+    #[test]
+    fn test_classify_read_only_false() {
+        let tool = make_tool(
+            "write_file",
+            Some(ToolAnnotations::default().read_only(false)),
+        );
+        assert_eq!(classify_mcp_annotations(&tool), ToolEffect::LocalMutation);
+    }
+
+    #[test]
+    fn test_classify_destructive_trumps_when_not_readonly() {
+        let tool = make_tool("nuke", Some(ToolAnnotations::default().destructive(true)));
+        assert_eq!(classify_mcp_annotations(&tool), ToolEffect::Destructive);
+    }
 }

--- a/koda-core/src/mcp/config.rs
+++ b/koda-core/src/mcp/config.rs
@@ -21,12 +21,19 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::tools::ToolEffect;
+
 /// Top-level `.mcp.json` file structure.
 #[derive(Debug, Deserialize, Default)]
 pub struct McpConfigFile {
     /// Server configurations keyed by name.
     #[serde(rename = "mcpServers", default)]
     pub mcp_servers: HashMap<String, McpServerConfig>,
+
+    /// Tool effect overrides keyed by namespaced tool name.
+    /// Example: `{ "github.create_issue": "RemoteAction" }`
+    #[serde(rename = "toolOverrides", default)]
+    pub tool_overrides: HashMap<String, ToolEffect>,
 }
 
 /// Configuration for a single MCP server.
@@ -49,27 +56,39 @@ pub struct McpServerConfig {
     pub timeout: Option<u64>,
 }
 
+/// Loaded MCP configuration: server configs + tool effect overrides.
+pub struct McpConfigs {
+    pub servers: HashMap<String, McpServerConfig>,
+    pub tool_overrides: HashMap<String, ToolEffect>,
+}
+
 /// Load MCP server configs from project-level and user-level config files.
 /// Project-level configs override user-level configs for the same server name.
-pub fn load_mcp_configs(project_root: &Path) -> HashMap<String, McpServerConfig> {
-    let mut configs = HashMap::new();
+pub fn load_mcp_configs(project_root: &Path) -> McpConfigs {
+    let mut servers = HashMap::new();
+    let mut tool_overrides = HashMap::new();
 
     // 1. User-level: ~/.config/koda/mcp.json
     if let Some(user_config) = load_user_config() {
-        configs.extend(user_config.mcp_servers);
+        servers.extend(user_config.mcp_servers);
+        tool_overrides.extend(user_config.tool_overrides);
     }
 
     // 2. Project-level: .mcp.json in project root (overrides user-level)
     if let Some(project_config) = load_project_config(project_root) {
-        configs.extend(project_config.mcp_servers);
+        servers.extend(project_config.mcp_servers);
+        tool_overrides.extend(project_config.tool_overrides);
     }
 
     // Expand environment variables in all configs
-    for config in configs.values_mut() {
+    for config in servers.values_mut() {
         expand_env_vars(config);
     }
 
-    configs
+    McpConfigs {
+        servers,
+        tool_overrides,
+    }
 }
 
 /// Load project-level `.mcp.json`.
@@ -202,8 +221,11 @@ pub fn remove_server_from_project(project_root: &Path, name: &str) -> Result<boo
 impl serde::Serialize for McpConfigFile {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
-        let mut map = serializer.serialize_map(Some(1))?;
+        let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("mcpServers", &self.mcp_servers)?;
+        if !self.tool_overrides.is_empty() {
+            map.serialize_entry("toolOverrides", &self.tool_overrides)?;
+        }
         map.end()
     }
 }
@@ -296,5 +318,39 @@ mod tests {
         let parsed: McpConfigFile = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.mcp_servers.len(), 1);
         assert_eq!(parsed.mcp_servers["test"].command, "echo");
+    }
+
+    #[test]
+    fn test_parse_tool_overrides() {
+        let json = r#"{
+            "mcpServers": {},
+            "toolOverrides": {
+                "github.create_issue": "RemoteAction",
+                "filesystem.write": "LocalMutation",
+                "dangerous.drop_db": "Destructive"
+            }
+        }"#;
+
+        let config: McpConfigFile = serde_json::from_str(json).unwrap();
+        assert_eq!(config.tool_overrides.len(), 3);
+        assert_eq!(
+            config.tool_overrides["github.create_issue"],
+            crate::tools::ToolEffect::RemoteAction
+        );
+        assert_eq!(
+            config.tool_overrides["filesystem.write"],
+            crate::tools::ToolEffect::LocalMutation
+        );
+        assert_eq!(
+            config.tool_overrides["dangerous.drop_db"],
+            crate::tools::ToolEffect::Destructive
+        );
+    }
+
+    #[test]
+    fn test_parse_config_without_overrides() {
+        let json = r#"{ "mcpServers": {} }"#;
+        let config: McpConfigFile = serde_json::from_str(json).unwrap();
+        assert!(config.tool_overrides.is_empty());
     }
 }

--- a/koda-core/src/mcp/registry.rs
+++ b/koda-core/src/mcp/registry.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use crate::mcp::client::McpClient;
 use crate::mcp::config::{self, McpServerConfig};
 use crate::providers::ToolDefinition;
+use crate::tools::ToolEffect;
 
 /// Separator between server name and tool name.
 pub const TOOL_NAME_SEP: char = '.';
@@ -18,6 +19,9 @@ pub const TOOL_NAME_SEP: char = '.';
 pub struct McpRegistry {
     /// Connected servers keyed by name.
     servers: HashMap<String, McpClient>,
+    /// Config-level tool effect overrides (from `.mcp.json` `toolOverrides`).
+    /// These take precedence over schema-declared annotations.
+    tool_overrides: HashMap<String, ToolEffect>,
 }
 
 impl McpRegistry {
@@ -25,6 +29,7 @@ impl McpRegistry {
     pub fn new() -> Self {
         Self {
             servers: HashMap::new(),
+            tool_overrides: HashMap::new(),
         }
     }
 
@@ -36,14 +41,16 @@ impl McpRegistry {
         &mut self,
         project_root: &Path,
     ) -> Vec<(String, Result<usize, String>)> {
-        let configs = config::load_mcp_configs(project_root);
-        if configs.is_empty() {
+        let mcp_configs = config::load_mcp_configs(project_root);
+        self.tool_overrides = mcp_configs.tool_overrides;
+
+        if mcp_configs.servers.is_empty() {
             return Vec::new();
         }
 
         let mut statuses = Vec::new();
 
-        for (name, server_config) in configs {
+        for (name, server_config) in mcp_configs.servers {
             match McpClient::connect(name.clone(), server_config).await {
                 Ok(client) => {
                     let tool_count = client.tool_definitions().len();
@@ -76,8 +83,9 @@ impl McpRegistry {
 
     /// Restart a server (remove + reconnect from config).
     pub async fn restart_server(&mut self, name: &str, project_root: &Path) -> Result<()> {
-        let configs = config::load_mcp_configs(project_root);
-        let config = configs
+        let mcp_configs = config::load_mcp_configs(project_root);
+        let config = mcp_configs
+            .servers
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("No config found for MCP server '{name}'"))?;
         self.remove_server(name);
@@ -123,6 +131,22 @@ impl McpRegistry {
             && name
                 .split_once(TOOL_NAME_SEP)
                 .is_some_and(|(server, _)| self.servers.contains_key(server))
+    }
+
+    /// Get the ToolEffect classification for an MCP tool.
+    ///
+    /// Returns `None` if the tool isn't found. Config overrides
+    /// (from `.mcp.json` `toolOverrides`) take precedence over
+    /// schema-declared annotations.
+    pub fn tool_effect(&self, namespaced_name: &str) -> Option<ToolEffect> {
+        // Check config overrides first
+        if let Some(effect) = self.tool_overrides.get(namespaced_name) {
+            return Some(*effect);
+        }
+        // Fall back to schema-declared annotations
+        let (server_name, _) = namespaced_name.split_once(TOOL_NAME_SEP)?;
+        let client = self.servers.get(server_name)?;
+        client.tool_effect(namespaced_name)
     }
 
     /// Get info about all connected servers (for /mcp status display).

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -52,7 +52,8 @@ pub(crate) fn can_parallelize(
                 &args,
                 mode,
                 phase_info,
-                Some(project_root)
+                Some(project_root),
+                None,
             ),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
@@ -220,7 +221,8 @@ pub(crate) async fn execute_tools_split_batch(
                 &args,
                 mode,
                 phase_info,
-                Some(project_root)
+                Some(project_root),
+                None,
             ),
             ToolApproval::AutoApprove | ToolApproval::Notify
         )
@@ -375,6 +377,7 @@ pub(crate) async fn execute_tools_sequential(
             mode,
             phase_info,
             Some(project_root),
+            None,
         );
 
         match approval {
@@ -667,6 +670,7 @@ pub(crate) async fn execute_sub_agent(
                 mode,
                 phase_info,
                 Some(project_root),
+                None,
             );
 
             let output = match approval {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -40,7 +40,8 @@ pub fn normalize_tool_name(name: &str) -> String {
 ///
 /// Two-axis model: what does the tool touch (local vs. remote)
 /// and how severe are its effects (read vs. mutate vs. destroy)?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum ToolEffect {
     /// No side-effects: file reads, grep, git status.
     ReadOnly,

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -62,6 +62,7 @@ fn test_all_tools_handled_by_approval() {
             ApprovalMode::Strict,
             koda_core::task_phase::PhaseInfo::delegated(),
             None,
+            None,
         );
         // Verify it returns a valid variant (not a crash)
         match result {


### PR DESCRIPTION
## Phase C of #293 — MCP tool classification

### MCP annotation parsing
Reads `readOnlyHint` and `destructiveHint` from MCP tool annotations at connection time:

| Annotation | ToolEffect | Safe mode | Strict mode |
|-----------|------------|-----------|-------------|
| `readOnlyHint: true` | ReadOnly | ✅ auto | ✅ auto |
| `destructiveHint: true` | Destructive | ❌ blocked | ⚠️ confirm |
| Neither/unknown | LocalMutation | ❌ blocked | ⚠️ confirm |

### Config override (`.mcp.json`)
```json
{
  "mcpServers": { ... },
  "toolOverrides": {
    "github.create_issue": "RemoteAction",
    "filesystem.write": "LocalMutation"
  }
}
```
Config overrides take precedence over schema-declared annotations.

### API change
`check_tool()` gains a 6th parameter: `mcp_effect: Option<ToolEffect>`. Callers pass `None` for built-in tools. Full MCP registry lookup in dispatch will be wired in Phase D/E.

### Tests
459 lib + 3 integration = 462 total. 7 new MCP classification + config tests. clippy clean (`--all-targets`).

Closes #305