### PR TITLE
fix: skip Role::Phase messages in all providers (#312)

### DIFF
--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -668,6 +668,11 @@ impl AnthropicProvider {
                 continue;
             }
 
+            // Skip internal metadata roles (phase transitions, etc.)
+            if msg.role == "phase" {
+                continue;
+            }
+
             if msg.role == "tool" {
                 // Tool results need to be wrapped in a content block
                 let tool_use_id = msg.tool_call_id.clone().unwrap_or_default();

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -525,6 +525,12 @@ impl GeminiProvider {
                 continue;
             }
 
+            // Skip internal metadata roles (phase transitions, etc.)
+            // Gemini only accepts "user" and "model" as content roles.
+            if msg.role == "phase" {
+                continue;
+            }
+
             let role = match msg.role.as_str() {
                 "assistant" => "model",
                 "tool" => "function",

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -174,6 +174,7 @@ impl OpenAiCompatProvider {
     ) -> ChatRequest {
         let api_messages: Vec<ApiMessage> = messages
             .iter()
+            .filter(|m| m.role != "phase") // skip internal metadata roles
             .map(|m| {
                 // Build content: if images are attached, use multi-part array format
                 let content = if let Some(images) = &m.images {


### PR DESCRIPTION
Phase-transition messages (`role="phase"`) leaked into provider API calls, causing Gemini 400 Bad Request.

Fixed in all three providers:
- **gemini.rs**: `continue` on `"phase"` role (like `"system"`)
- **anthropic.rs**: `continue` on `"phase"` role
- **openai_compat.rs**: `.filter()` out `"phase"` before `.map()`

Closes #312