### PR TITLE
feat: sub-agent delegation scope + FsGrant (#306, #293 Phase D)

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -155,13 +155,30 @@ pub fn check_tool(
     mut phase_info: crate::task_phase::PhaseInfo,
     project_root: Option<&Path>,
     mcp_effect: Option<ToolEffect>,
+    delegation: Option<&crate::delegation::DelegationScope>,
 ) -> ToolApproval {
+    // Delegation scope: tool allowlist check
+    if let Some(scope) = delegation
+        && !scope.is_tool_allowed(tool_name)
+    {
+        return ToolApproval::Blocked;
+    }
+
     // Classify the tool's effect (MCP override takes precedence)
     let effect = mcp_effect.unwrap_or_else(|| resolve_effect(tool_name, args));
 
     // Read-only tools always auto-approve in every mode
     if effect == ToolEffect::ReadOnly {
         return ToolApproval::AutoApprove;
+    }
+
+    // Delegation scope: filesystem write check
+    if let (Some(scope), Some(root)) = (delegation, project_root)
+        && matches!(effect, ToolEffect::LocalMutation | ToolEffect::Destructive)
+        && let Some(p) = extract_write_path(tool_name, args)
+        && !scope.can_write(Path::new(p), root)
+    {
+        return ToolApproval::Blocked;
     }
 
     // Hardcoded floor: writes outside project root always need confirmation (#218)
@@ -250,6 +267,17 @@ fn auto_phase_gate(phase_info: crate::task_phase::PhaseInfo) -> ToolApproval {
         TaskPhase::Executing => ToolApproval::Notify,
         // Verifying/Reporting: auto-approve (checking results)
         TaskPhase::Verifying | TaskPhase::Reporting => ToolApproval::AutoApprove,
+    }
+}
+
+/// Extract the file path that a write tool targets.
+fn extract_write_path<'a>(tool_name: &str, args: &'a serde_json::Value) -> Option<&'a str> {
+    match tool_name {
+        "Write" | "Edit" | "Delete" => args
+            .get("path")
+            .or(args.get("file_path"))
+            .and_then(|v| v.as_str()),
+        _ => None,
     }
 }
 
@@ -348,6 +376,7 @@ mod tests {
                     crate::task_phase::PhaseInfo::delegated(),
                     None,
                     None,
+                    None,
                 ),
                 ToolApproval::AutoApprove,
                 "{tool} should auto-approve even in Safe mode"
@@ -364,6 +393,7 @@ mod tests {
                     &serde_json::json!({}),
                     ApprovalMode::Safe,
                     crate::task_phase::PhaseInfo::delegated(),
+                    None,
                     None,
                     None,
                 ),
@@ -386,6 +416,7 @@ mod tests {
                     crate::task_phase::PhaseInfo::delegated(),
                     None,
                     None,
+                    None,
                 ),
                 ToolApproval::AutoApprove,
             );
@@ -401,6 +432,7 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -425,6 +457,7 @@ mod tests {
                 phase,
                 None,
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -447,6 +480,7 @@ mod tests {
                 phase,
                 None,
                 None,
+                None,
             ),
             ToolApproval::Notify,
         );
@@ -462,6 +496,7 @@ mod tests {
                 &args,
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -481,6 +516,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 None,
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -498,6 +534,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 None,
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -511,6 +548,7 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Strict,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -528,6 +566,7 @@ mod tests {
                     &args,
                     mode,
                     crate::task_phase::PhaseInfo::delegated(),
+                    None,
                     None,
                     None,
                 ),
@@ -548,6 +587,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 None,
                 None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -563,6 +603,7 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -582,6 +623,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 None,
                 None,
+                None,
             ),
             ToolApproval::Blocked,
         );
@@ -599,6 +641,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 None,
                 None,
+                None,
             ),
             ToolApproval::Blocked,
         );
@@ -613,6 +656,7 @@ mod tests {
                 &args,
                 ApprovalMode::Safe,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -634,6 +678,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -650,6 +695,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
                 None,
             ),
             ToolApproval::AutoApprove,
@@ -668,6 +714,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation,
         );
@@ -684,6 +731,7 @@ mod tests {
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
+                None,
                 None,
             ),
             ToolApproval::NeedsConfirmation,
@@ -702,6 +750,7 @@ mod tests {
                 crate::task_phase::PhaseInfo::delegated(),
                 Some(root),
                 None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -716,6 +765,7 @@ mod tests {
                 &args,
                 ApprovalMode::Auto,
                 crate::task_phase::PhaseInfo::delegated(),
+                None,
                 None,
                 None,
             ),
@@ -739,6 +789,7 @@ mod tests {
                 phase,
                 None,
                 None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -755,6 +806,7 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
+                None,
                 None,
                 None,
             ),
@@ -775,6 +827,7 @@ mod tests {
                 phase,
                 None,
                 None,
+                None,
             ),
             ToolApproval::AutoApprove,
         );
@@ -791,6 +844,7 @@ mod tests {
                 &serde_json::json!({}),
                 ApprovalMode::Auto,
                 phase,
+                None,
                 None,
                 None,
             ),

--- a/koda-core/src/delegation.rs
+++ b/koda-core/src/delegation.rs
@@ -1,0 +1,213 @@
+//! Sub-agent delegation scope.
+//!
+//! When a parent agent spawns a sub-agent, it can constrain what the
+//! sub-agent is allowed to do via a `DelegationScope`. This limits
+//! blast radius from prompt injection attacks.
+
+use crate::approval::ApprovalMode;
+use path_clean::PathClean;
+use std::path::{Path, PathBuf};
+
+/// Filesystem access grant for a delegated sub-agent.
+#[derive(Debug, Clone)]
+pub enum FsGrant {
+    /// Read anything within project_root, write nothing.
+    ReadOnly,
+    /// Read + write within specific paths only.
+    Scoped {
+        read_paths: Vec<PathBuf>,
+        write_paths: Vec<PathBuf>,
+    },
+    /// Full project_root access (default for auto mode).
+    FullProject,
+}
+
+/// Constraints on what a sub-agent can do.
+///
+/// Rules:
+/// - Mode can never escalate (safe parent → safe sub-agent only)
+/// - Scope can only narrow (FullProject → Scoped, never reverse)
+/// - Auto mode default: FullProject (no friction unless explicitly constrained)
+#[derive(Debug, Clone)]
+pub struct DelegationScope {
+    /// Approval mode — can never exceed parent's mode.
+    pub mode: ApprovalMode,
+    /// Filesystem grant.
+    pub fs_grant: FsGrant,
+    /// Tool allowlist. None = inherit parent's full set.
+    pub allowed_tools: Option<Vec<String>>,
+    /// Whether the sub-agent can spawn further sub-agents.
+    pub can_delegate: bool,
+}
+
+impl DelegationScope {
+    /// Default scope for auto mode: full project access, can delegate.
+    pub fn auto_default(parent_mode: ApprovalMode) -> Self {
+        Self {
+            mode: parent_mode,
+            fs_grant: FsGrant::FullProject,
+            allowed_tools: None,
+            can_delegate: true,
+        }
+    }
+
+    /// Restricted scope: read-only filesystem, no delegation.
+    pub fn read_only(parent_mode: ApprovalMode) -> Self {
+        Self {
+            mode: clamp_mode(parent_mode, ApprovalMode::Safe),
+            fs_grant: FsGrant::ReadOnly,
+            allowed_tools: None,
+            can_delegate: false,
+        }
+    }
+
+    /// Check if a file write is allowed by this scope.
+    pub fn can_write(&self, path: &Path, project_root: &Path) -> bool {
+        match &self.fs_grant {
+            FsGrant::ReadOnly => false,
+            FsGrant::FullProject => {
+                // Must be within project_root
+                let resolved = resolve(path, project_root);
+                resolved.starts_with(project_root)
+            }
+            FsGrant::Scoped { write_paths, .. } => {
+                let resolved = resolve(path, project_root);
+                write_paths
+                    .iter()
+                    .any(|wp| resolved.starts_with(project_root.join(wp).clean()))
+            }
+        }
+    }
+
+    /// Check if a file read is allowed by this scope.
+    pub fn can_read(&self, path: &Path, project_root: &Path) -> bool {
+        match &self.fs_grant {
+            FsGrant::ReadOnly | FsGrant::FullProject => {
+                let resolved = resolve(path, project_root);
+                resolved.starts_with(project_root)
+            }
+            FsGrant::Scoped { read_paths, .. } => {
+                let resolved = resolve(path, project_root);
+                read_paths
+                    .iter()
+                    .any(|rp| resolved.starts_with(project_root.join(rp).clean()))
+            }
+        }
+    }
+
+    /// Check if a tool is allowed by this scope.
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        match &self.allowed_tools {
+            None => true,
+            Some(allowed) => allowed.iter().any(|t| t == tool_name),
+        }
+    }
+}
+
+/// Clamp a child mode to never exceed the parent's mode.
+/// Mode ordering: Safe < Strict < Auto.
+fn clamp_mode(parent: ApprovalMode, child: ApprovalMode) -> ApprovalMode {
+    if (child as u8) > (parent as u8) {
+        parent
+    } else {
+        child
+    }
+}
+
+/// Resolve a path relative to project_root.
+fn resolve(path: &Path, project_root: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf().clean()
+    } else {
+        project_root.join(path).clean()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root() -> PathBuf {
+        PathBuf::from("/home/user/project")
+    }
+
+    #[test]
+    fn test_full_project_allows_writes_inside() {
+        let scope = DelegationScope::auto_default(ApprovalMode::Auto);
+        assert!(scope.can_write(Path::new("src/main.rs"), &root()));
+    }
+
+    #[test]
+    fn test_full_project_blocks_writes_outside() {
+        let scope = DelegationScope::auto_default(ApprovalMode::Auto);
+        assert!(!scope.can_write(Path::new("/etc/passwd"), &root()));
+    }
+
+    #[test]
+    fn test_read_only_blocks_all_writes() {
+        let scope = DelegationScope::read_only(ApprovalMode::Auto);
+        assert!(!scope.can_write(Path::new("src/main.rs"), &root()));
+        assert!(scope.can_read(Path::new("src/main.rs"), &root()));
+    }
+
+    #[test]
+    fn test_scoped_write_paths() {
+        let scope = DelegationScope {
+            mode: ApprovalMode::Auto,
+            fs_grant: FsGrant::Scoped {
+                read_paths: vec![PathBuf::from(".")],
+                write_paths: vec![PathBuf::from("src/")],
+            },
+            allowed_tools: None,
+            can_delegate: false,
+        };
+        assert!(scope.can_write(Path::new("src/main.rs"), &root()));
+        assert!(!scope.can_write(Path::new("tests/test.rs"), &root()));
+        assert!(scope.can_read(Path::new("tests/test.rs"), &root()));
+    }
+
+    #[test]
+    fn test_mode_clamping() {
+        // Safe parent can't spawn Auto child
+        assert_eq!(
+            clamp_mode(ApprovalMode::Safe, ApprovalMode::Auto),
+            ApprovalMode::Safe
+        );
+        // Auto parent can spawn any child
+        assert_eq!(
+            clamp_mode(ApprovalMode::Auto, ApprovalMode::Safe),
+            ApprovalMode::Safe
+        );
+        // Same mode passes through
+        assert_eq!(
+            clamp_mode(ApprovalMode::Strict, ApprovalMode::Strict),
+            ApprovalMode::Strict
+        );
+    }
+
+    #[test]
+    fn test_tool_allowlist() {
+        let scope = DelegationScope {
+            mode: ApprovalMode::Auto,
+            fs_grant: FsGrant::FullProject,
+            allowed_tools: Some(vec!["Read".to_string(), "Grep".to_string()]),
+            can_delegate: false,
+        };
+        assert!(scope.is_tool_allowed("Read"));
+        assert!(scope.is_tool_allowed("Grep"));
+        assert!(!scope.is_tool_allowed("Write"));
+    }
+
+    #[test]
+    fn test_tool_allowlist_none_allows_all() {
+        let scope = DelegationScope::auto_default(ApprovalMode::Auto);
+        assert!(scope.is_tool_allowed("Write"));
+        assert!(scope.is_tool_allowed("Delete"));
+    }
+
+    #[test]
+    fn test_read_only_clamps_to_safe() {
+        let scope = DelegationScope::read_only(ApprovalMode::Auto);
+        assert_eq!(scope.mode, ApprovalMode::Safe);
+    }
+}

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod compact;
 pub mod config;
 pub mod context;
 pub mod db;
+pub mod delegation;
 pub mod engine;
 pub mod inference;
 pub mod inference_helpers;

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -54,6 +54,7 @@ pub(crate) fn can_parallelize(
                 phase_info,
                 Some(project_root),
                 None,
+                None,
             ),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
@@ -223,6 +224,7 @@ pub(crate) async fn execute_tools_split_batch(
                 phase_info,
                 Some(project_root),
                 None,
+                None,
             ),
             ToolApproval::AutoApprove | ToolApproval::Notify
         )
@@ -377,6 +379,7 @@ pub(crate) async fn execute_tools_sequential(
             mode,
             phase_info,
             Some(project_root),
+            None,
             None,
         );
 
@@ -670,6 +673,7 @@ pub(crate) async fn execute_sub_agent(
                 mode,
                 phase_info,
                 Some(project_root),
+                None,
                 None,
             );
 

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -63,6 +63,7 @@ fn test_all_tools_handled_by_approval() {
             koda_core::task_phase::PhaseInfo::delegated(),
             None,
             None,
+            None,
         );
         // Verify it returns a valid variant (not a crash)
         match result {


### PR DESCRIPTION
## Phase D of #293 — Sub-agent delegation scope

### DelegationScope
Constrains what a sub-agent can do, limiting blast radius from prompt injection:

```rust
struct DelegationScope {
    mode: ApprovalMode,                    // can never exceed parent
    fs_grant: FsGrant,                     // ReadOnly | Scoped | FullProject
    allowed_tools: Option<Vec<String>>,    // None = all tools
    can_delegate: bool,                    // can spawn further sub-agents?
}
```

### Enforcement rules
- **Mode clamping**: Safe parent → Safe child only. Auto parent → any child.
- **Scope narrowing**: FullProject → Scoped allowed, reverse blocked.
- **Tool allowlist**: Hard gate in `check_tool()` — blocked before mode matrix.
- **Filesystem write check**: Hard gate — validates target path against `FsGrant`.

### Current wiring
All callers pass `None` (no scope constraint). Sub-agent dispatch will pass `DelegationScope` when the LLM specifies scope at delegation time — deferred to Phase E or a follow-up.

### Tests
467 lib + 3 integration = 470 total. 8 new delegation tests. clippy clean (`--all-targets`).

Closes #306