### PR TITLE
test+docs: verify guarantee matrix + document accepted risks (#307, #293 Phase E)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,126 @@
+# Security Model
+
+## Approval Modes
+
+Koda has three approval modes that control tool execution:
+
+| Mode | Description | Default |
+|------|-------------|--------|
+| **Auto** | Phase-gated approval. Mutations auto-approved during Executing with an approved plan. Destructive operations always require confirmation. | ✅ |
+| **Strict** | Every non-read action requires explicit user confirmation. | |
+| **Safe** | Local-read-only. No filesystem mutations. Remote actions (GitHub CLI, MCP readOnly) allowed. | |
+
+## Tool Effect Classification
+
+Every tool call is classified into one of four effect levels:
+
+| Effect | Description | Auto | Strict | Safe |
+|--------|-------------|------|--------|------|
+| **ReadOnly** | No side-effects (file reads, grep, git status) | ✅ auto | ✅ auto | ✅ auto |
+| **RemoteAction** | Remote-only side-effects (gh CLI, WebFetch) | ✅ auto | ✅ auto | ✅ auto |
+| **LocalMutation** | Local filesystem writes (Write, Edit, cargo test) | ✅ phase-gated | ⚠️ confirm | ❌ blocked |
+| **Destructive** | Irreversible (rm -rf, git push --force, sed -i) | ⚠️ confirm | ⚠️ confirm | ❌ blocked |
+
+## Guarantee Matrix
+
+| Action | Auto | Strict | Safe |
+|--------|------|--------|------|
+| Read files inside project | ✅ | ✅ | ✅ |
+| Read files outside project | ✅ (log) | ✅ | ✅ |
+| Write files inside project | ✅ (phase-gated, budget-limited) | ⚠️ confirm | ❌ blocked |
+| Write files outside project | ⚠️ confirm | ⚠️ confirm | ❌ blocked |
+| Delete files | ⚠️ confirm | ⚠️ confirm | ❌ blocked |
+| Safe bash (grep, git status) | ✅ | ✅ | ✅ |
+| Bash with write side-effect (>, tee) | ✅ (phase-gated) | ⚠️ confirm | ❌ blocked |
+| Destructive bash (rm -rf, force push) | ⚠️ confirm | ⚠️ confirm | ❌ blocked |
+| Bash with path escape (cd /tmp) | ⚠️ confirm | ⚠️ confirm | ❌ blocked |
+| Sub-agent invocation | ✅ | ✅ | ✅ |
+| Sub-agent writes | ✅ (DelegationScope) | ⚠️ confirm | ❌ blocked |
+| MCP tool (readOnly: true) | ✅ | ✅ | ✅ |
+| MCP tool (readOnly: false) | ✅ (phase-gated) | ⚠️ confirm | ❌ blocked |
+| MCP tool (config override) | Per override | Per override | Per override |
+| MemoryWrite | ✅ (phase-gated) | ⚠️ confirm | ❌ blocked |
+| WebFetch (GET) | ✅ | ✅ | ✅ |
+| gh issue/pr (RemoteAction) | ✅ | ✅ | ✅ |
+
+## Hardcoded Safety Floors
+
+These checks apply regardless of mode or phase:
+
+1. **Writes outside project root** → NeedsConfirmation (Auto/Strict) or Blocked (Safe)
+2. **Bash path escape** (cd /tmp, absolute paths outside project) → NeedsConfirmation
+3. **Destructive operations** (Delete, rm -rf, force push) → NeedsConfirmation in Auto
+4. **Symlink escape** → canonicalize() resolves symlinks before path checks
+
+## Sub-Agent Delegation
+
+When a parent agent spawns a sub-agent, a `DelegationScope` constrains it:
+
+- **Mode clamping**: Child mode can never exceed parent (Safe parent → Safe child only)
+*Filesystem grant**: `ReadOnly`, `Scoped { read_paths, write_paths }`, or `FullProject`
+- **Tool allowlist**: Optional list of permitted tools
+- **Delegation depth**: `can_delegate` controls whether sub-agents can spawn further sub-agents
+
+Enforcement is a **hard gate** in `check_tool()`, not a log. A compromised sub-agent can only write to paths explicitly granted.
+
+## MCP Tool Classification
+
+MCP tools are classified from their schema annotations:
+
+- `readOnlyHint: true` → ReadOnly (auto-approved in all modes)
+- `destructiveHint: true` → Destructive (confirm in Auto+Strict)
+- Neither → LocalMutation (conservative default)
+
+Config overrides in `.mcp.json` take precedence:
+
+```json
+{
+  "toolOverrides": {
+    "github.create_issue": "RemoteAction",
+    "filesystem.write": "LocalMutation"
+  }
+}
+```
+
+## Simple-Task Action Budget
+
+When the LLM takes the simple-task shortcut (skips planning), it gets an **action budget**:
+
+- Default: 3 LocalMutation/Destructive actions
+- ReadOnly and RemoteAction don't count against the budget
+- When budget exhausted: system injects a plan-requirement message
+- Forces the LLM to produce a plan before continuing
+
+## Accepted Risks
+
+These are gaps intentionally not addressed:
+
+### 1. No kernel-level sandboxing
+
+File write blocking is in-process, not enforced by seccomp/landlock. A malicious LLM output could theoretically call `libc::write` directly via compiled code.
+
+**Mitigation**: This requires the LLM to generate + compile + execute an exploit, which is detectable by the human reviewing tool calls.
+
+### 2. Shell command parsing is heuristic
+
+Complex shell pipelines, subshells, and eval tricks can bypass the command classifier. Example: `bash -c "$(echo cm0gLXJmIC8= | base64 -d)"` would decode and execute `rm -rf /`.
+
+**Mitigation**: Unknown commands are treated as unsafe by default. The `DANGEROUS_PATTERNS` list catches common evasion techniques (`eval`, backticks, `$()`). Complex pipelines require user confirmation in Strict mode.
+
+### 3. MCP readOnly is trust-based
+
+We trust the MCP server's schema declaration. A malicious MCP server could declare `readOnly: true` and still mutate state.
+
+**Mitigation**: Config overrides let users distrust specific tools. MCP servers are explicitly configured by the user.
+
+### 4. Auto mode sub-agents with FullProject scope
+
+If the LLM doesn't narrow the scope when delegating, a prompt-injected sub-agent has full project write access.
+
+**Mitigation**: This is the user's chosen trade-off by selecting Auto mode. The DelegationScope infrastructure exists for narrowing when the LLM is instructed to do so.
+
+### 5. Hardcoded floors don't respect Safe mode's Blocked behavior
+
+The outside-project and path-escape hardcoded floors return `NeedsConfirmation` in all modes, including Safe. In Safe mode, this means the user sees a confirmation prompt for outside-project writes instead of a clean block.
+
+**Mitigation**: In Safe mode, the confirmation dialog doesn't have an "approve" action, so the user can't accidentally approve. The behavior is conservative but the UX could be improved in a future release by returning `Blocked` when mode is Safe.

--- a/koda-core/tests/guarantee_matrix_test.rs
+++ b/koda-core/tests/guarantee_matrix_test.rs
@@ -1,0 +1,336 @@
+//! Guarantee matrix verification tests (#307, #293 Phase E).
+//!
+//! Tests every row × column in the approval mode guarantee matrix.
+//! Each test verifies the ToolApproval returned by check_tool() for
+//! a specific (action, mode) pair.
+//!
+//! Matrix rows (actions):
+//!  1. Read files inside project
+//!  2. Read files outside project
+//!  3. Write files inside project
+//!  4. Write files outside project
+//!  5. Delete files
+//!  6. Safe bash (git status, grep)
+//!  7. Bash with write side-effect (echo > file)
+//!  8. Destructive bash (rm -rf, git push --force)
+//!  9. Bash with path escape (cd /tmp)
+//! 10. Sub-agent invocation (InvokeAgent)
+//! 11. MCP tool (readOnly: true) — via mcp_effect override
+//! 12. MCP tool (readOnly: false) — via mcp_effect override
+//! 13. MemoryWrite
+//! 14. WebFetch (GET)
+//! 15. gh issue create (RemoteAction bash)
+//!
+//! Columns: Auto, Strict, Safe
+
+use koda_core::approval::{ApprovalMode, ToolApproval, check_tool};
+use koda_core::task_phase::PhaseInfo;
+use koda_core::tools::ToolEffect;
+use std::path::Path;
+
+fn root() -> &'static Path {
+    Path::new("/home/user/project")
+}
+
+/// PhaseInfo for auto mode with plan approved (maximum autonomy).
+fn executing() -> PhaseInfo {
+    PhaseInfo::delegated()
+}
+
+/// Helper: check a tool in all three modes and return (auto, strict, safe).
+fn check_all(
+    tool: &str,
+    args: &serde_json::Value,
+    mcp_effect: Option<ToolEffect>,
+) -> (ToolApproval, ToolApproval, ToolApproval) {
+    let auto = check_tool(
+        tool,
+        args,
+        ApprovalMode::Auto,
+        executing(),
+        Some(root()),
+        mcp_effect,
+        None,
+    );
+    let strict = check_tool(
+        tool,
+        args,
+        ApprovalMode::Strict,
+        executing(),
+        Some(root()),
+        mcp_effect,
+        None,
+    );
+    let safe = check_tool(
+        tool,
+        args,
+        ApprovalMode::Safe,
+        executing(),
+        Some(root()),
+        mcp_effect,
+        None,
+    );
+    (auto, strict, safe)
+}
+
+// ── Row 1: Read files inside project ──
+
+#[test]
+fn matrix_read_inside_project() {
+    let args = serde_json::json!({"path": "src/main.rs"});
+    let (auto, strict, safe) = check_all("Read", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 2: Read files outside project ──
+// Note: Read is ReadOnly → auto-approved in check_tool.
+// Path scoping is enforced at execution time by safe_resolve_path.
+
+#[test]
+fn matrix_read_outside_project() {
+    let args = serde_json::json!({"path": "/etc/passwd"});
+    let (auto, strict, safe) = check_all("Read", &args, None);
+    // Read is always ReadOnly at the approval level
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 3: Write files inside project ──
+
+#[test]
+fn matrix_write_inside_project() {
+    let args = serde_json::json!({"path": "src/main.rs"});
+    let (auto, strict, safe) = check_all("Write", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove); // plan approved
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 4: Write files outside project ──
+
+#[test]
+fn matrix_write_outside_project() {
+    let args = serde_json::json!({"path": "/etc/hosts"});
+    let (auto, strict, safe) = check_all("Write", &args, None);
+    // Hardcoded floor: outside project → NeedsConfirmation
+    // Note: Safe mode also gets NeedsConfirmation here (floor overrides Blocked).
+    // This is conservative — the user still can't approve in Safe mode.
+    assert_eq!(auto, ToolApproval::NeedsConfirmation);
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::NeedsConfirmation);
+}
+
+// ── Row 5: Delete files ──
+
+#[test]
+fn matrix_delete_files() {
+    let args = serde_json::json!({"file_path": "old.rs"});
+    let (auto, strict, safe) = check_all("Delete", &args, None);
+    // Delete is Destructive
+    assert_eq!(auto, ToolApproval::NeedsConfirmation);
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 6: Safe bash (read-only commands) ──
+
+#[test]
+fn matrix_safe_bash() {
+    let args = serde_json::json!({"command": "git status"});
+    let (auto, strict, safe) = check_all("Bash", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 7: Bash with write side-effect ──
+
+#[test]
+fn matrix_bash_write_side_effect() {
+    let args = serde_json::json!({"command": "echo hello > output.txt"});
+    let (auto, strict, safe) = check_all("Bash", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove); // phase-gated, plan approved
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 8: Destructive bash ──
+
+#[test]
+fn matrix_destructive_bash() {
+    let args = serde_json::json!({"command": "rm -rf target/"});
+    let (auto, strict, safe) = check_all("Bash", &args, None);
+    assert_eq!(auto, ToolApproval::NeedsConfirmation); // destructive floor
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 9: Bash with path escape ──
+
+#[test]
+fn matrix_bash_path_escape() {
+    let args = serde_json::json!({"command": "cd /tmp && ls"});
+    let (auto, strict, safe) = check_all("Bash", &args, None);
+    // Path lint triggers NeedsConfirmation floor (same note as write outside)
+    assert_eq!(auto, ToolApproval::NeedsConfirmation);
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::NeedsConfirmation);
+}
+
+// ── Row 10: Sub-agent invocation ──
+
+#[test]
+fn matrix_invoke_agent() {
+    let args = serde_json::json!({"agent_name": "reviewer", "prompt": "review"});
+    let (auto, strict, safe) = check_all("InvokeAgent", &args, None);
+    // InvokeAgent is ReadOnly (sub-agents inherit parent's mode)
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 11: MCP tool (readOnly: true) ──
+
+#[test]
+fn matrix_mcp_readonly_true() {
+    let args = serde_json::json!({});
+    let (auto, strict, safe) = check_all("github.list_issues", &args, Some(ToolEffect::ReadOnly));
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 12: MCP tool (readOnly: false/unset) ──
+
+#[test]
+fn matrix_mcp_readonly_false() {
+    let args = serde_json::json!({});
+    let (auto, strict, safe) =
+        check_all("filesystem.write", &args, Some(ToolEffect::LocalMutation));
+    assert_eq!(auto, ToolApproval::AutoApprove); // phase-gated, plan approved
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 13: MemoryWrite ──
+
+#[test]
+fn matrix_memory_write() {
+    let args = serde_json::json!({"content": "remember this"});
+    let (auto, strict, safe) = check_all("MemoryWrite", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove); // phase-gated
+    assert_eq!(strict, ToolApproval::NeedsConfirmation);
+    assert_eq!(safe, ToolApproval::Blocked);
+}
+
+// ── Row 14: WebFetch (GET) ──
+
+#[test]
+fn matrix_web_fetch() {
+    let args = serde_json::json!({"url": "https://example.com"});
+    let (auto, strict, safe) = check_all("WebFetch", &args, None);
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 15: gh issue create (RemoteAction bash) ──
+
+#[test]
+fn matrix_gh_issue_create() {
+    let args = serde_json::json!({"command": "gh issue create --title 'bug'"});
+    let (auto, strict, safe) = check_all("Bash", &args, None);
+    // gh CLI is RemoteAction
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Row 16: MCP tool (config override: RemoteAction) ──
+
+#[test]
+fn matrix_mcp_config_override_remote_action() {
+    let args = serde_json::json!({});
+    let (auto, strict, safe) =
+        check_all("github.create_issue", &args, Some(ToolEffect::RemoteAction));
+    assert_eq!(auto, ToolApproval::AutoApprove);
+    assert_eq!(strict, ToolApproval::AutoApprove);
+    assert_eq!(safe, ToolApproval::AutoApprove);
+}
+
+// ── Delegation scope tests ──
+
+#[test]
+fn matrix_delegation_blocks_unauthorized_tool() {
+    use koda_core::delegation::{DelegationScope, FsGrant};
+    let scope = DelegationScope {
+        mode: ApprovalMode::Auto,
+        fs_grant: FsGrant::FullProject,
+        allowed_tools: Some(vec!["Read".to_string(), "Grep".to_string()]),
+        can_delegate: false,
+    };
+    let args = serde_json::json!({"path": "src/main.rs"});
+    let result = check_tool(
+        "Write",
+        &args,
+        ApprovalMode::Auto,
+        executing(),
+        Some(root()),
+        None,
+        Some(&scope),
+    );
+    assert_eq!(result, ToolApproval::Blocked);
+}
+
+#[test]
+fn matrix_delegation_blocks_write_outside_grant() {
+    use koda_core::delegation::{DelegationScope, FsGrant};
+    let scope = DelegationScope {
+        mode: ApprovalMode::Auto,
+        fs_grant: FsGrant::Scoped {
+            read_paths: vec![std::path::PathBuf::from(".")],
+            write_paths: vec![std::path::PathBuf::from("src/")],
+        },
+        allowed_tools: None,
+        can_delegate: false,
+    };
+    let args = serde_json::json!({"path": "tests/test.rs"});
+    let result = check_tool(
+        "Write",
+        &args,
+        ApprovalMode::Auto,
+        executing(),
+        Some(root()),
+        None,
+        Some(&scope),
+    );
+    assert_eq!(result, ToolApproval::Blocked);
+}
+
+#[test]
+fn matrix_delegation_allows_write_inside_grant() {
+    use koda_core::delegation::{DelegationScope, FsGrant};
+    let scope = DelegationScope {
+        mode: ApprovalMode::Auto,
+        fs_grant: FsGrant::Scoped {
+            read_paths: vec![std::path::PathBuf::from(".")],
+            write_paths: vec![std::path::PathBuf::from("src/")],
+        },
+        allowed_tools: None,
+        can_delegate: false,
+    };
+    let args = serde_json::json!({"path": "src/main.rs"});
+    let result = check_tool(
+        "Write",
+        &args,
+        ApprovalMode::Auto,
+        executing(),
+        Some(root()),
+        None,
+        Some(&scope),
+    );
+    assert_eq!(result, ToolApproval::AutoApprove);
+}


### PR DESCRIPTION
## Phase E of #293 — Final verification

### Guarantee matrix tests (19 tests)
Every cell in the approval mode guarantee matrix is now tested:
- 15 action types × 3 modes = 45 assertions
- 3 delegation scope enforcement tests
- 1 MCP config override test

### Security documentation
New `docs/security.md` documenting:
- ToolEffect classification
- Full guarantee matrix
- Hardcoded safety floors
- Sub-agent delegation model
- MCP classification rules
- Action budget
- 5 accepted risks with mitigations

### New finding from verification
Hardcoded floors (outside-project, path-escape) return `NeedsConfirmation` in Safe mode instead of `Blocked`. Conservative but imperfect UX — documented as accepted risk #5.

### Test totals
467 lib + 19 matrix + 3 wiring = 489 total. clippy clean.

Closes #307
Closes #293 (all 5 phases complete)