### PR TITLE
feat: truncate long tool output in TUI and headless sinks (#318)

### DIFF
--- a/koda-cli/src/headless_sink.rs
+++ b/koda-cli/src/headless_sink.rs
@@ -54,8 +54,32 @@ impl EngineSink for HeadlessSink {
                 eprintln!("\x1b[36m  \u{26a1} {name}\x1b[0m");
             }
             EngineEvent::ToolCallResult { name, output, .. } => {
-                let summary = truncate(&output, 200);
-                eprintln!("\x1b[32m  \u{2713} {name}\x1b[0m: {summary}");
+                use koda_core::truncate::{Truncated, truncate_for_display};
+                eprintln!("\x1b[32m  \u{2713} {name}\x1b[0m");
+                match truncate_for_display(&output) {
+                    Truncated::Full(_) => {
+                        for line in output.lines() {
+                            eprintln!("  \u{2502} {line}");
+                        }
+                    }
+                    Truncated::Split {
+                        head,
+                        tail,
+                        hidden,
+                        total,
+                    } => {
+                        for line in &head {
+                            eprintln!("  \u{2502} {line}");
+                        }
+                        eprintln!(
+                            "\x1b[2m{}\x1b[0m",
+                            koda_core::truncate::separator(hidden, total)
+                        );
+                        for line in &tail {
+                            eprintln!("  \u{2502} {line}");
+                        }
+                    }
+                }
             }
 
             // ── Sub-agents ──────────────────────────────────────
@@ -106,37 +130,5 @@ impl EngineSink for HeadlessSink {
                 );
             }
         }
-    }
-}
-
-fn truncate(s: &str, max: usize) -> &str {
-    if s.len() <= max {
-        s
-    } else {
-        // Find a safe char boundary
-        let mut end = max;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        &s[..end]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_truncate_ascii() {
-        assert_eq!(truncate("hello world", 5), "hello");
-        assert_eq!(truncate("hi", 10), "hi");
-    }
-
-    #[test]
-    fn test_truncate_unicode() {
-        // '🐶' is 4 bytes — truncating at 2 should give empty
-        let s = "🐶hello";
-        let t = truncate(s, 2);
-        assert!(t.len() <= 2);
     }
 }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -333,14 +333,11 @@ fn render_tool_output(
     verbose: bool,
     file_ext: Option<&str>,
 ) {
+    use koda_core::truncate::{Truncated, truncate_for_display};
+
     if output.is_empty() {
         return;
     }
-
-    let lines: Vec<&str> = output.lines().collect();
-    let total = lines.len();
-    let max_lines = if verbose { total } else { 4 };
-    let show = total.min(max_lines);
 
     // Syntax highlighting for Read tool output
     let use_highlight = name == "Read" && file_ext.is_some();
@@ -350,33 +347,61 @@ fn render_tool_output(
         None
     };
 
-    for line in &lines[..show] {
-        if name == "Grep" {
-            render_grep_line(terminal, line);
-        } else if name == "List" {
-            render_list_line(terminal, line);
-        } else if let Some(ref mut hl) = highlighter {
-            let mut spans = vec![Span::styled("  \u{2502} ", DIM)];
-            spans.extend(hl.highlight_spans(line));
-            tui_output::emit_line(terminal, Line::from(spans));
-        } else {
+    let render_line =
+        |terminal: &mut Term, line: &str, hl: &mut Option<crate::highlight::CodeHighlighter>| {
+            if name == "Grep" {
+                render_grep_line(terminal, line);
+            } else if name == "List" {
+                render_list_line(terminal, line);
+            } else if let Some(h) = hl.as_mut() {
+                let mut spans = vec![Span::styled("  \u{2502} ", DIM)];
+                spans.extend(h.highlight_spans(line));
+                tui_output::emit_line(terminal, Line::from(spans));
+            } else {
+                tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![
+                        Span::styled("  \u{2502} ", DIM),
+                        Span::raw(line.to_string()),
+                    ]),
+                );
+            }
+        };
+
+    if verbose {
+        // Show everything in verbose mode
+        for line in output.lines() {
+            render_line(terminal, line, &mut highlighter);
+        }
+        return;
+    }
+
+    match truncate_for_display(output) {
+        Truncated::Full(_) => {
+            for line in output.lines() {
+                render_line(terminal, line, &mut highlighter);
+            }
+        }
+        Truncated::Split {
+            head,
+            tail,
+            hidden,
+            total,
+        } => {
+            for line in &head {
+                render_line(terminal, line, &mut highlighter);
+            }
             tui_output::emit_line(
                 terminal,
-                Line::from(vec![
-                    Span::styled("  \u{2502} ", DIM),
-                    Span::raw(line.to_string()),
-                ]),
+                Line::from(vec![Span::styled(
+                    koda_core::truncate::separator(hidden, total),
+                    DIM,
+                )]),
             );
+            for line in &tail {
+                render_line(terminal, line, &mut highlighter);
+            }
         }
-    }
-    if total > show {
-        tui_output::emit_line(
-            terminal,
-            Line::from(vec![Span::styled(
-                format!("  \u{2502} ... ({} more lines)", total - show),
-                DIM,
-            )]),
-        );
     }
 }
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -43,5 +43,6 @@ pub mod task_phase;
 pub mod tier_observer;
 pub mod tool_dispatch;
 pub mod tools;
+pub mod truncate;
 pub mod undo;
 pub mod version;

--- a/koda-core/src/truncate.rs
+++ b/koda-core/src/truncate.rs
@@ -1,0 +1,130 @@
+//! Output truncation for display.
+//!
+//! When tool output exceeds a threshold, we show the first N lines (head)
+//! and the last N lines (tail) with a separator indicating how many lines
+//! were hidden. This keeps the UI scannable while preserving the most
+//! important parts (beginning for context, end for results).
+
+/// Default threshold: truncate if output exceeds this many lines.
+pub const TRUNCATE_THRESHOLD: usize = 50;
+/// Number of head lines to keep.
+const HEAD_LINES: usize = 20;
+/// Number of tail lines to keep.
+const TAIL_LINES: usize = 20;
+
+/// Result of truncation.
+#[derive(Debug, PartialEq)]
+pub enum Truncated<'a> {
+    /// Output was short enough — no truncation needed.
+    Full(&'a str),
+    /// Output was truncated into head + tail.
+    Split {
+        head: Vec<&'a str>,
+        tail: Vec<&'a str>,
+        hidden: usize,
+        total: usize,
+    },
+}
+
+/// Truncate long output for display, keeping head and tail lines.
+///
+/// Returns `Truncated::Full` if output is within the threshold,
+/// or `Truncated::Split` with head/tail lines and hidden count.
+pub fn truncate_for_display(output: &str) -> Truncated<'_> {
+    let lines: Vec<&str> = output.lines().collect();
+    let total = lines.len();
+
+    if total <= TRUNCATE_THRESHOLD {
+        return Truncated::Full(output);
+    }
+
+    let head = lines[..HEAD_LINES].to_vec();
+    let tail = lines[total - TAIL_LINES..].to_vec();
+    let hidden = total - HEAD_LINES - TAIL_LINES;
+
+    Truncated::Split {
+        head,
+        tail,
+        hidden,
+        total,
+    }
+}
+
+/// Format a separator line for the truncation gap.
+pub fn separator(hidden: usize, total: usize) -> String {
+    format!(
+        "  \u{2502} \u{2500}\u{2500}\u{2500} {hidden} lines hidden ({total} total, use /expand to see all) \u{2500}\u{2500}\u{2500}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_short_output_not_truncated() {
+        let output = "line1\nline2\nline3";
+        assert_eq!(truncate_for_display(output), Truncated::Full(output));
+    }
+
+    #[test]
+    fn test_exactly_at_threshold() {
+        let lines: Vec<String> = (0..TRUNCATE_THRESHOLD)
+            .map(|i| format!("line {i}"))
+            .collect();
+        let output = lines.join("\n");
+        assert_eq!(truncate_for_display(&output), Truncated::Full(&output));
+    }
+
+    #[test]
+    fn test_over_threshold_splits() {
+        let lines: Vec<String> = (0..100).map(|i| format!("line {i}")).collect();
+        let output = lines.join("\n");
+        match truncate_for_display(&output) {
+            Truncated::Split {
+                head,
+                tail,
+                hidden,
+                total,
+            } => {
+                assert_eq!(head.len(), HEAD_LINES);
+                assert_eq!(tail.len(), TAIL_LINES);
+                assert_eq!(hidden, 100 - HEAD_LINES - TAIL_LINES);
+                assert_eq!(total, 100);
+                assert_eq!(head[0], "line 0");
+                assert_eq!(head[HEAD_LINES - 1], &format!("line {}", HEAD_LINES - 1));
+                assert_eq!(tail[0], &format!("line {}", 100 - TAIL_LINES));
+                assert_eq!(tail[TAIL_LINES - 1], "line 99");
+            }
+            Truncated::Full(_) => panic!("Expected Split"),
+        }
+    }
+
+    #[test]
+    fn test_just_over_threshold() {
+        let lines: Vec<String> = (0..51).map(|i| format!("line {i}")).collect();
+        let output = lines.join("\n");
+        match truncate_for_display(&output) {
+            Truncated::Split {
+                head,
+                tail,
+                hidden,
+                total,
+            } => {
+                assert_eq!(head.len(), HEAD_LINES);
+                assert_eq!(tail.len(), TAIL_LINES);
+                assert_eq!(hidden, 11); // 51 - 20 - 20
+                assert_eq!(total, 51);
+            }
+            Truncated::Full(_) => panic!("Expected Split"),
+        }
+    }
+
+    #[test]
+    fn test_separator_format() {
+        let sep = separator(60, 100);
+        assert!(sep.contains("60 lines hidden"));
+        assert!(sep.contains("100 total"));
+        assert!(sep.contains("/expand"));
+    }
+}


### PR DESCRIPTION
When tool output exceeds 50 lines, display **head(20) + separator + tail(20)** instead of flooding the terminal.

### Before
- TUI: hardcoded 4-line limit with `... (N more lines)` — too aggressive, loses tail
- Headless: 200-char single-line truncation — useless for long output

### After
- Both sinks: head(20) + `── 60 lines hidden (100 total, use /expand to see all) ──` + tail(20)
- Verbose mode (`/verbose`) still shows everything
- `/expand N` still works for full output

### New module: `koda-core::truncate`
- `truncate_for_display()` → `Truncated::Full` | `Truncated::Split { head, tail, hidden, total }`
- 5 unit tests

Closes #318