### PR TITLE
feat: wire InterventionObserver into inference loop + /priors command (#320 Phase 1)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -18,6 +18,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/mcp", "MCP servers: status / add / remove"),
     ("/memory", "View/save project & global memory"),
     ("/model", "Pick a model interactively"),
+    ("/priors", "Show learned intervention priors"),
     ("/provider", "Switch LLM provider"),
     ("/sessions", "List/resume/delete sessions"),
     ("/undo", "Undo last turn's file changes"),

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -39,6 +39,8 @@ pub enum ReplAction {
     MemoryCommand(Option<String>),
     /// Undo last turn's file mutations
     Undo,
+    /// Show learned intervention priors
+    ShowPriors,
     #[allow(dead_code)]
     Handled,
     NotACommand,
@@ -127,6 +129,8 @@ pub async fn handle_command(
         "/memory" => ReplAction::MemoryCommand(arg.map(|s| s.to_string())),
 
         "/undo" => ReplAction::Undo,
+
+        "/priors" => ReplAction::ShowPriors,
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -95,6 +95,10 @@ pub async fn handle_slash_command(
             }
             SlashAction::Continue
         }
+        ReplAction::ShowPriors => {
+            handle_priors();
+            SlashAction::Continue
+        }
         ReplAction::ListSessions => {
             // Handled inline by tui_app.rs MenuContent::Session dropdown
             SlashAction::Continue
@@ -301,7 +305,35 @@ async fn handle_resume_session(
 }
 
 #[allow(unused_variables)]
-fn handle_expand(terminal: &mut Term, renderer: &TuiRenderer, n: usize) {
+fn handle_priors() {
+    let observer = koda_core::intervention_observer::InterventionObserver::load();
+    let summary = observer.summary();
+
+    tui_output::write_blank();
+    tui_output::write_line(&Line::from(vec![Span::styled(
+        "  Intervention Priors",
+        BOLD,
+    )]));
+    tui_output::write_line(&Line::styled(
+        "  ─────────────────────────────────────────────────────",
+        DIM,
+    ));
+
+    let has_data = summary.iter().any(|p| p.auto_count + p.override_count > 0);
+    if !has_data {
+        tui_output::write_line(&Line::styled(
+            "  No data yet. Priors are learned as you use koda.",
+            DIM,
+        ));
+    } else {
+        for prior in &summary {
+            tui_output::write_line(&Line::styled(format!("  {prior}"), DIM));
+        }
+    }
+    tui_output::write_blank();
+}
+
+fn handle_expand(_terminal: &mut Term, renderer: &TuiRenderer, n: usize) {
     match renderer.tool_history.get(n) {
         Some(record) => {
             tui_output::write_blank();

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -79,6 +79,10 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Tier is explicitly set if it came from agent config (not auto-detected)
         false,
     );
+    // Intervention observer: learns human override patterns at phase gates.
+    // Auto-saves on drop (ObserverGuard), so all exit paths are covered.
+    let mut intervention_observer =
+        crate::intervention_observer::InterventionObserver::load_auto_save();
     let mut total_prompt_tokens: i64 = 0;
     let mut total_completion_tokens: i64 = 0;
     let mut total_cache_read_tokens: i64 = 0;
@@ -501,6 +505,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 after_bash,
             };
             if let Some(transition) = phase_tracker.advance(&signal) {
+                // Record auto transition (no human intervention at this gate)
+                // TODO(#320 Phase 6): record_override when plan approval (#217)
+                // gates are wired — requires approval results to flow back.
+                intervention_observer.record_auto(transition.to);
+
                 // Log phase transition as a Role::Phase message
                 let _ = db
                     .insert_message(

--- a/koda-core/src/intervention_observer.rs
+++ b/koda-core/src/intervention_observer.rs
@@ -150,6 +150,13 @@ impl InterventionObserver {
         }
     }
 
+    /// Load from disk with auto-save on drop.
+    pub fn load_auto_save() -> ObserverGuard {
+        ObserverGuard {
+            observer: Self::load(),
+        }
+    }
+
     fn storage_path() -> PathBuf {
         let config_dir = std::env::var("XDG_CONFIG_HOME")
             .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.config")))
@@ -164,6 +171,34 @@ impl InterventionObserver {
 impl Default for InterventionObserver {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// RAII wrapper that saves the observer on drop.
+///
+/// Use `InterventionObserver::load_auto_save()` to get one.
+/// The observer is saved when this guard goes out of scope,
+/// guaranteeing persistence even on early returns.
+pub struct ObserverGuard {
+    pub observer: InterventionObserver,
+}
+
+impl std::ops::Deref for ObserverGuard {
+    type Target = InterventionObserver;
+    fn deref(&self) -> &Self::Target {
+        &self.observer
+    }
+}
+
+impl std::ops::DerefMut for ObserverGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.observer
+    }
+}
+
+impl Drop for ObserverGuard {
+    fn drop(&mut self) {
+        self.observer.save();
     }
 }
 


### PR DESCRIPTION
## #320 Phase 1 — Wire InterventionObserver

The `InterventionObserver` was built and tested (10 tests, persistence, summary display) but never wired into the inference loop. This PR activates it.

### What it does now
- **Records `auto` transitions** at every phase gate (Understanding → Planning → Reviewing → etc.)
- **Auto-saves on drop** via `ObserverGuard` (RAII) — no early-return bugs
- **`/priors` slash command** shows learned per-phase autonomy scores

### What it doesn't do yet
- `record_override` — needs plan-approval gates (#217) to be meaningful
- Influence autonomy decisions — that's Phase 6

### Why ship now
Starts data collection immediately. Every session builds the prior. By the time Phase 6 ships, there'll be real data to learn from.

472 lib tests pass. clippy clean.

Part of #320