### PR TITLE
feat: phase transition flow log in SQLite (#320 Phase 2)

### DIFF
--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -262,6 +262,33 @@ impl Database {
             }
         }
 
+        // Phase transition flow log (#320 Phase 2).
+        // Survives compaction — separate from conversation history.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS phase_transitions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                iteration INTEGER NOT NULL,
+                from_phase TEXT NOT NULL,
+                to_phase TEXT NOT NULL,
+                trigger TEXT,
+                autonomy TEXT,
+                review_depth TEXT,
+                human_response TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                FOREIGN KEY(session_id) REFERENCES sessions(id)
+            );",
+        )
+        .execute(pool)
+        .await?;
+
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS idx_phase_transitions_session \
+             ON phase_transitions(session_id);",
+        )
+        .execute(pool)
+        .await?;
+
         Ok(())
     }
 
@@ -875,6 +902,58 @@ impl Database {
     pub async fn set_todo(&self, session_id: &str, content: &str) -> Result<()> {
         self.set_metadata(session_id, "todo", content).await
     }
+
+    // ── Phase transition flow log ────────────────────────────
+
+    /// Record a phase transition in the flow log.
+    pub async fn insert_phase_transition(
+        &self,
+        session_id: &str,
+        iteration: u32,
+        from_phase: &str,
+        to_phase: &str,
+        trigger: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO phase_transitions \
+             (session_id, iteration, from_phase, to_phase, trigger) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(session_id)
+        .bind(iteration as i64)
+        .bind(from_phase)
+        .bind(to_phase)
+        .bind(trigger)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Load a compact phase flow summary for a session.
+    ///
+    /// Returns a string like: `Observe(3) → Plan(1) → Review(1) → Act(7)`
+    pub async fn phase_flow_summary(&self, session_id: &str) -> Result<String> {
+        let rows: Vec<PhaseTransitionRow> = sqlx::query_as(
+            "SELECT to_phase, COUNT(*) as count \
+             FROM phase_transitions \
+             WHERE session_id = ? \
+             GROUP BY to_phase \
+             ORDER BY MIN(id)",
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(String::new());
+        }
+
+        let parts: Vec<String> = rows
+            .iter()
+            .map(|r| format!("{}({})", r.to_phase, r.count))
+            .collect();
+        Ok(parts.join(" \u{2192} "))
+    }
 }
 
 /// Internal row type for sqlx deserialization.
@@ -891,6 +970,13 @@ struct MessageRow {
     cache_read_tokens: Option<i64>,
     cache_creation_tokens: Option<i64>,
     thinking_tokens: Option<i64>,
+}
+
+/// Internal row type for phase transition queries.
+#[derive(sqlx::FromRow)]
+struct PhaseTransitionRow {
+    to_phase: String,
+    count: i64,
 }
 
 /// Session metadata for listing.
@@ -1498,5 +1584,45 @@ mod tests {
 
         let msg = db.last_assistant_message(&session).await.unwrap();
         assert_eq!(msg, "Done!");
+    }
+
+    #[tokio::test]
+    async fn test_phase_transitions_insert_and_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db").as_path(), dir.path())
+            .await
+            .unwrap();
+        let session = db.create_session("test", dir.path()).await.unwrap();
+
+        db.insert_phase_transition(&session, 1, "Understanding", "Planning", Some("text_only"))
+            .await
+            .unwrap();
+        db.insert_phase_transition(&session, 2, "Planning", "Reviewing", Some("text_only"))
+            .await
+            .unwrap();
+        db.insert_phase_transition(&session, 3, "Reviewing", "Executing", Some("tool:Edit"))
+            .await
+            .unwrap();
+        db.insert_phase_transition(&session, 5, "Executing", "Executing", Some("tool:Bash"))
+            .await
+            .unwrap();
+
+        let summary = db.phase_flow_summary(&session).await.unwrap();
+        assert!(summary.contains("Planning"));
+        assert!(summary.contains("Reviewing"));
+        assert!(summary.contains("Executing"));
+        assert!(summary.contains("\u{2192}")); // arrow
+    }
+
+    #[tokio::test]
+    async fn test_phase_flow_summary_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(dir.path().join("test.db").as_path(), dir.path())
+            .await
+            .unwrap();
+        let session = db.create_session("test", dir.path()).await.unwrap();
+
+        let summary = db.phase_flow_summary(&session).await.unwrap();
+        assert!(summary.is_empty());
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -146,8 +146,14 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let progress = crate::progress::get_progress_summary(db, session_id)
             .await
             .unwrap_or_default();
+        let flow_summary = db.phase_flow_summary(session_id).await.unwrap_or_default();
+        let flow_line = if flow_summary.is_empty() {
+            String::new()
+        } else {
+            format!("\n[Flow: {flow_summary}]")
+        };
         let phase_prompt = format!(
-            "{base_system_prompt}\n\n{}{progress}",
+            "{base_system_prompt}\n\n{}{progress}{flow_line}",
             phase.prompt_hint(config.model_tier)
         );
         let system_message = ChatMessage::text("system", &phase_prompt);
@@ -509,6 +515,17 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 // TODO(#320 Phase 6): record_override when plan approval (#217)
                 // gates are wired — requires approval results to flow back.
                 intervention_observer.record_auto(transition.to);
+
+                // Persist to flow log (survives compaction)
+                let _ = db
+                    .insert_phase_transition(
+                        session_id,
+                        iteration,
+                        &transition.from.to_string(),
+                        &transition.to.to_string(),
+                        Some(transition.trigger),
+                    )
+                    .await;
 
                 // Log phase transition as a Role::Phase message
                 let _ = db


### PR DESCRIPTION
## #320 Phase 2 — Flow log

### New: `phase_transitions` table
Durable record of every phase transition, separate from conversation history (survives compaction).

```sql
CREATE TABLE phase_transitions (
    session_id TEXT, iteration INTEGER,
    from_phase TEXT, to_phase TEXT,
    trigger TEXT,        -- 'tool:Edit', 'text_only'
    autonomy TEXT,       -- NULL until Phase 6
    review_depth TEXT,   -- NULL until Phase 4
    human_response TEXT, -- NULL until Phase 6
    created_at TEXT
);
```

### New DB methods
- `insert_phase_transition()` — record each transition
- `phase_flow_summary()` — compact summary: `Planning(1) → Reviewing(1) → Executing(3)`

### System prompt injection
Flow summary appended to system prompt each iteration:
```
[Flow: Planning(1) → Reviewing(1) → Executing(3)]
```
Gives the LLM awareness of its own process progression.

### Tests
2 new DB tests. 474 total lib tests pass. clippy clean.

**Depends on:** #321 (Phase 1)
Part of #320