### PR TITLE
feat: phase demotion/escalation + error classification (#320 Phase 3)

### DIFF
--- a/koda-core/src/escalation.rs
+++ b/koda-core/src/escalation.rs
@@ -1,0 +1,172 @@
+//! Escalation detection for phase demotion.
+//!
+//! When a tool fails during execution, this module classifies whether
+//! the error represents a scope change (requiring phase demotion to
+//! Understanding) or a retryable/ignorable error.
+//!
+//! Conservative by design: requires ≥2 scope-change signals to escalate.
+//! Single keyword matches are too noisy.
+
+use regex::RegexSet;
+use std::sync::LazyLock;
+
+/// Patterns indicating the task scope has changed.
+/// These suggest the agent needs to re-observe before re-planning.
+static SCOPE_CHANGE_PATTERNS: LazyLock<RegexSet> = LazyLock::new(|| {
+    RegexSet::new([
+        r"(?i)CONFLICT",
+        r"(?i)merge conflict",
+        r"(?i)unresolved dependency",
+        r"(?i)schema mismatch",
+        r"(?i)breaking change",
+        r"(?i)incompatible version",
+        r"(?i)cannot find module",
+        r"(?i)undefined reference",
+        r"(?i)circular dependency",
+        r"(?i)missing required",
+        r"(?i)no such table",
+        r"(?i)migration failed",
+    ])
+    .expect("valid regex patterns")
+});
+
+/// Patterns indicating retryable errors (no scope change).
+/// The agent should retry or adjust the command, not re-observe.
+static RETRYABLE_PATTERNS: LazyLock<RegexSet> = LazyLock::new(|| {
+    RegexSet::new([
+        r"(?i)permission denied",
+        r"(?i)file not found",
+        r"(?i)no such file",
+        r"(?i)syntax error",
+        r"(?i)command not found",
+        r"(?i)timed? ?out",
+        r"(?i)connection refused",
+        r"(?i)already exists",
+        r"(?i)not a directory",
+        r"(?i)resource busy",
+    ])
+    .expect("valid regex patterns")
+});
+
+/// Result of analyzing a tool error for escalation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EscalationSignal {
+    /// Scope changed — demote to Understanding.
+    Escalate {
+        /// Number of scope-change patterns matched.
+        match_count: usize,
+        /// Description for the reflection prompt.
+        reason: String,
+    },
+    /// Retryable error — stay in current phase.
+    Retryable,
+    /// Unknown error — stay in current phase, inject reflection.
+    Unknown,
+}
+
+/// Analyze tool output/error for escalation signals.
+///
+/// Only escalates if ≥2 scope-change patterns match (confidence gate).
+/// Returns `Retryable` if any retryable pattern matches (takes precedence
+/// over single scope-change matches).
+pub fn classify_error(tool_name: &str, output: &str) -> EscalationSignal {
+    let scope_matches: Vec<usize> = SCOPE_CHANGE_PATTERNS.matches(output).into_iter().collect();
+    let retryable_matches = RETRYABLE_PATTERNS.matches(output);
+
+    // Retryable patterns take precedence over single scope-change matches
+    if retryable_matches.matched_any() && scope_matches.len() < 2 {
+        return EscalationSignal::Retryable;
+    }
+
+    // Confidence gate: require ≥2 scope-change signals
+    if scope_matches.len() >= 2 {
+        // Build a human-readable reason from the first few matches
+        let reason = format!(
+            "{tool_name} failed with {} scope-change signals",
+            scope_matches.len()
+        );
+        return EscalationSignal::Escalate {
+            match_count: scope_matches.len(),
+            reason,
+        };
+    }
+
+    if scope_matches.len() == 1 {
+        // Single match — not confident enough to escalate, but notable
+        return EscalationSignal::Unknown;
+    }
+
+    EscalationSignal::Unknown
+}
+
+/// Build the reflection prompt injected when escalating.
+pub fn escalation_prompt(tool_name: &str, reason: &str) -> String {
+    format!(
+        "\u{26a0}\u{fe0f} Tool `{tool_name}` failed \u{2014} {reason}.\n\
+         This changes task scope. Falling back to Observe phase.\n\
+         [Phase: Observe \u{2014} Read and understand what changed before re-planning.]"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_conflict_escalates() {
+        let output = "CONFLICT (content): Merge conflict in src/main.rs\n\
+                      Auto-merging failed; fix conflicts and then commit.";
+        match classify_error("Bash", output) {
+            EscalationSignal::Escalate { match_count, .. } => {
+                assert!(match_count >= 2, "expected ≥2 matches, got {match_count}");
+            }
+            other => panic!("expected Escalate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_permission_denied_is_retryable() {
+        let output = "error: permission denied: /etc/shadow";
+        assert_eq!(classify_error("Bash", output), EscalationSignal::Retryable);
+    }
+
+    #[test]
+    fn test_single_scope_signal_is_unknown() {
+        // Only one scope-change pattern — not confident enough
+        let output = "error: incompatible version of rustc";
+        assert_eq!(classify_error("Bash", output), EscalationSignal::Unknown);
+    }
+
+    #[test]
+    fn test_retryable_overrides_single_scope() {
+        // Has both a retryable pattern and one scope-change pattern
+        let output = "file not found: missing required config.toml";
+        assert_eq!(classify_error("Bash", output), EscalationSignal::Retryable);
+    }
+
+    #[test]
+    fn test_multiple_scope_signals_escalate() {
+        let output = "error: incompatible version of openssl\n\
+                      unresolved dependency: libssl-dev";
+        match classify_error("Bash", output) {
+            EscalationSignal::Escalate { match_count, .. } => {
+                assert!(match_count >= 2);
+            }
+            other => panic!("expected Escalate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_clean_output_is_unknown() {
+        let output = "Everything compiled successfully.";
+        assert_eq!(classify_error("Bash", output), EscalationSignal::Unknown);
+    }
+
+    #[test]
+    fn test_escalation_prompt_format() {
+        let prompt = escalation_prompt("Bash", "merge conflict detected");
+        assert!(prompt.contains("Bash"));
+        assert!(prompt.contains("merge conflict"));
+        assert!(prompt.contains("Observe"));
+    }
+}

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -543,6 +543,51 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                     )
                     .await;
             }
+
+            // Escalation check: if we're in Executing and tool output
+            // suggests scope changed, demote to Understanding.
+            if matches!(
+                phase_tracker.current(),
+                crate::task_phase::TaskPhase::Executing | crate::task_phase::TaskPhase::Verifying
+            ) {
+                // Check recent tool results for escalation signals
+                let recent = db.load_context(session_id, 2000).await.unwrap_or_default();
+                let last_tool_output = recent
+                    .iter()
+                    .rev()
+                    .find(|m| m.role == crate::persistence::Role::Tool)
+                    .and_then(|m| m.content.as_deref())
+                    .unwrap_or("");
+
+                if let crate::escalation::EscalationSignal::Escalate { reason, .. } =
+                    crate::escalation::classify_error("tool", last_tool_output)
+                    && let Some(transition) = phase_tracker.demote_to_understanding("escalation")
+                {
+                    intervention_observer.record_auto(transition.to);
+                    let _ = db
+                        .insert_phase_transition(
+                            session_id,
+                            iteration,
+                            &transition.from.to_string(),
+                            &transition.to.to_string(),
+                            Some("error_escalation"),
+                        )
+                        .await;
+
+                    // Inject reflection prompt
+                    let prompt = crate::escalation::escalation_prompt("tool", &reason);
+                    let _ = db
+                        .insert_message(
+                            session_id,
+                            &crate::persistence::Role::Phase,
+                            Some(&prompt),
+                            None,
+                            None,
+                            None,
+                        )
+                        .await;
+                }
+            }
         }
 
         // If no tool calls, we already streamed the response — done

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod context;
 pub mod db;
 pub mod delegation;
 pub mod engine;
+pub mod escalation;
 pub mod git;
 pub mod inference;
 pub mod inference_helpers;

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -335,6 +335,47 @@ impl PhaseTracker {
         self.expect_full_progression
     }
 
+    /// Force a phase demotion (escalation).
+    ///
+    /// Used when the agent discovers unexpected complexity mid-execution.
+    /// Only demotes from Executing or Verifying back to Understanding.
+    /// Returns the transition record, or None if demotion isn't applicable.
+    pub fn demote_to_understanding(&mut self, trigger: &'static str) -> Option<PhaseTransition> {
+        if !matches!(self.current, TaskPhase::Executing | TaskPhase::Verifying) {
+            return None;
+        }
+
+        let old = self.current;
+        self.current = TaskPhase::Understanding;
+        self.plan_approved = false; // plan is invalidated by scope change
+
+        Some(PhaseTransition {
+            from: old,
+            to: TaskPhase::Understanding,
+            trigger,
+        })
+    }
+
+    /// Collapse to a simpler phase (complexity decreased).
+    ///
+    /// Used when the agent discovers existing solutions during Review.
+    /// Only collapses from Reviewing to Executing.
+    pub fn collapse_to_executing(&mut self) -> Option<PhaseTransition> {
+        if self.current != TaskPhase::Reviewing {
+            return None;
+        }
+
+        let old = self.current;
+        self.current = TaskPhase::Executing;
+        self.plan_approved = true;
+
+        Some(PhaseTransition {
+            from: old,
+            to: TaskPhase::Executing,
+            trigger: "simplification",
+        })
+    }
+
     /// Advance the phase based on a structural turn signal.
     ///
     /// Returns the new phase (which may be unchanged).


### PR DESCRIPTION
## #320 Phase 3 — Phase demotion/escalation

When tool execution reveals unexpected complexity, the agent demotes back to Understanding instead of blindly retrying.

### Escalation decision tree
```
Tool failure?
├─ stderr matches ≥2 SCOPE_CHANGE_PATTERNS → Escalate to Understanding
│   (CONFLICT, unresolved dependency, schema mismatch, etc.)
├─ stderr matches RETRYABLE_PATTERNS → Stay in current phase
│   (permission denied, file not found, syntax error, etc.)
└─ Unknown → Stay, inject reflection prompt
```

**Confidence gate**: requires ≥2 scope-change signals. Single keyword match is too noisy.

### New methods on PhaseTracker
- `demote_to_understanding()` — force demotion from Executing/Verifying
- `collapse_to_executing()` — skip review when complexity decreases

### Wiring
After each tool execution turn, the inference loop checks the latest tool output. If escalation is detected: demote phase → log to flow log → inject reflection prompt.

### Tests
7 new escalation tests. 489 total lib tests. clippy clean.

Part of #320