### PR TITLE
feat: SelfReview Phase 2 — SubmitPlan/SubmitReview tools + inference loop wiring (#335)

### DIFF
--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -185,6 +185,29 @@ impl Database {
         .execute(pool)
         .await?;
 
+        // Review records — child table of phase_transitions.
+        // Only SelfReview and PeerReview create rows (not FastPath).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS review_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                phase_transition_id INTEGER NOT NULL REFERENCES phase_transitions(id),
+                review_depth TEXT NOT NULL CHECK(review_depth IN ('self_review', 'peer_review')),
+                reviewer_model TEXT NOT NULL,
+                planner_model TEXT NOT NULL,
+                plan_summary TEXT NOT NULL,
+                reviewer_verdict TEXT NOT NULL CHECK(reviewer_verdict IN ('approved', 'rejected', 'revised')),
+                reviewer_reasoning TEXT,
+                human_decision TEXT CHECK(human_decision IN ('accepted_plan', 'accepted_review', 'manual_edit', 'aborted')),
+                gate_reason TEXT NOT NULL CHECK(gate_reason IN (
+                    'destructive_floor', 'complexity_threshold', 'observer_auto',
+                    'peer_review_disagreement', 're_plan_exhausted'
+                )),
+                created_at TEXT DEFAULT (datetime('now'))
+            );",
+        )
+        .execute(pool)
+        .await?;
+
         Ok(())
     }
 }
@@ -717,8 +740,8 @@ impl Persistence for Database {
         from_phase: &str,
         to_phase: &str,
         trigger: Option<&str>,
-    ) -> Result<()> {
-        sqlx::query(
+    ) -> Result<i64> {
+        let result = sqlx::query(
             "INSERT INTO phase_transitions \
              (session_id, iteration, from_phase, to_phase, trigger) \
              VALUES (?, ?, ?, ?, ?)",
@@ -728,6 +751,40 @@ impl Persistence for Database {
         .bind(from_phase)
         .bind(to_phase)
         .bind(trigger)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.last_insert_rowid())
+    }
+
+    /// Insert a review record (child of a phase transition).
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_review_record(
+        &self,
+        phase_transition_id: i64,
+        review_depth: &str,
+        reviewer_model: &str,
+        planner_model: &str,
+        plan_summary: &str,
+        reviewer_verdict: &str,
+        reviewer_reasoning: Option<&str>,
+        human_decision: Option<&str>,
+        gate_reason: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO review_records \
+             (phase_transition_id, review_depth, reviewer_model, planner_model, \
+              plan_summary, reviewer_verdict, reviewer_reasoning, human_decision, gate_reason) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(phase_transition_id)
+        .bind(review_depth)
+        .bind(reviewer_model)
+        .bind(planner_model)
+        .bind(plan_summary)
+        .bind(reviewer_verdict)
+        .bind(reviewer_reasoning)
+        .bind(human_decision)
+        .bind(gate_reason)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -44,6 +44,8 @@ pub struct InferenceContext<'a> {
     pub cancel: CancellationToken,
     pub cmd_rx: &'a mut mpsc::Receiver<EngineCommand>,
     pub skip_probe: bool,
+    /// The user's original prompt for this turn (used by plan review).
+    pub original_prompt: String,
 }
 
 /// Run inference, executing tool calls until the LLM produces a text response.
@@ -64,6 +66,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         cancel,
         cmd_rx,
         skip_probe,
+        original_prompt,
     } = ctx;
 
     // Capability probe: verify the model can produce structured output.
@@ -126,6 +129,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         crate::task_signature::TaskSignature::from_prompt(prompt)
     };
     let mut phase_tracker = PhaseTracker::new(&intent);
+    let mut re_plan_count: u32 = 0;
 
     loop {
         if iteration >= hard_cap {
@@ -608,6 +612,180 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                         )
                         .await;
                 }
+            }
+        }
+
+        // ── SubmitPlan interception: typed plan review handoff ─────────
+        // If the model called SubmitPlan, intercept it before normal tool execution.
+        // Parse the plan, run review (if not FastPath), handle verdict.
+        if let Some(submit_idx) = tool_calls
+            .iter()
+            .position(|tc| tc.function_name == "SubmitPlan")
+        {
+            let submit_tc = &tool_calls[submit_idx];
+            let args: serde_json::Value =
+                serde_json::from_str(&submit_tc.arguments).unwrap_or_default();
+
+            match crate::review::PlanArtifact::from_tool_args(&args) {
+                Ok(plan) => {
+                    let depth = phase_tracker.select_review_depth(&intervention_observer);
+
+                    // Upgrade depth based on plan content
+                    let depth = if plan.has_destructive_step()
+                        && depth == crate::task_phase::ReviewDepth::FastPath
+                    {
+                        crate::task_phase::ReviewDepth::SelfReview
+                    } else {
+                        depth
+                    };
+
+                    sink.emit(EngineEvent::Info {
+                        message: format!(
+                            "Plan submitted: {} ({} steps) — review: {depth}",
+                            plan.goal,
+                            plan.steps.len()
+                        ),
+                    });
+
+                    if depth != crate::task_phase::ReviewDepth::FastPath {
+                        // Determine gate reason
+                        let gate_reason = if plan.has_destructive_step() {
+                            crate::review::GateReason::DestructiveFloor
+                        } else {
+                            crate::review::GateReason::ComplexityThreshold
+                        };
+
+                        // Run review (fresh context, reviewer-only tools)
+                        let review_result =
+                            crate::review::run_review(&plan, &original_prompt, provider, depth)
+                                .await;
+
+                        match review_result {
+                            Ok(result) => {
+                                // Persist review record
+                                let transition_id = db
+                                    .insert_phase_transition(
+                                        session_id,
+                                        iteration,
+                                        "Planning",
+                                        "Reviewing",
+                                        Some("submit_plan"),
+                                    )
+                                    .await
+                                    .unwrap_or(0);
+
+                                let plan_json = serde_json::to_string(&plan).unwrap_or_default();
+                                let _ = db
+                                    .insert_review_record(
+                                        transition_id,
+                                        &depth.to_string(),
+                                        &config.model,
+                                        &config.model,
+                                        &plan_json,
+                                        &result.verdict.to_string(),
+                                        Some(&result.reasoning),
+                                        None, // human_decision (Phase 3)
+                                        &gate_reason.to_string(),
+                                    )
+                                    .await;
+
+                                match result.verdict {
+                                    crate::review::ReviewVerdict::Approved => {
+                                        sink.emit(EngineEvent::Info {
+                                            message: format!(
+                                                "✅ Review passed: {}",
+                                                result.reasoning
+                                            ),
+                                        });
+                                        // Mark plan as approved, continue to execution
+                                        phase_tracker.approve_plan();
+                                    }
+                                    crate::review::ReviewVerdict::Rejected
+                                    | crate::review::ReviewVerdict::Revised => {
+                                        re_plan_count += 1;
+                                        if re_plan_count > 2 {
+                                            sink.emit(EngineEvent::Warn {
+                                                message: "Re-plan budget exhausted (2 attempts). \
+                                                    Proceeding with current plan."
+                                                    .into(),
+                                            });
+                                            phase_tracker.approve_plan();
+                                        } else {
+                                            // Append rejection feedback and re-enter Planning
+                                            let feedback = format!(
+                                                "Plan review ({depth}): {}\nReason: {}\n{}",
+                                                result.verdict,
+                                                result.reasoning,
+                                                result
+                                                    .suggested_changes
+                                                    .as_ref()
+                                                    .map(|c| format!(
+                                                        "Suggested changes:\n{}",
+                                                        c.iter()
+                                                            .map(|s| format!("- {s}"))
+                                                            .collect::<Vec<_>>()
+                                                            .join("\n")
+                                                    ))
+                                                    .unwrap_or_default()
+                                            );
+                                            sink.emit(EngineEvent::Info {
+                                                message: format!(
+                                                    "❌ Review rejected (attempt {re_plan_count}/2): {}",
+                                                    result.reasoning
+                                                ),
+                                            });
+
+                                            // Insert feedback as assistant message
+                                            // so the planner sees it on next iteration
+                                            let _ = db
+                                                .insert_message(
+                                                    session_id,
+                                                    &Role::Phase,
+                                                    Some(&feedback),
+                                                    None,
+                                                    None,
+                                                    None,
+                                                )
+                                                .await;
+
+                                            // Demote back to Planning
+                                            let _ = phase_tracker
+                                                .demote_to_understanding("review_rejected");
+
+                                            // Skip normal tool execution, re-enter loop
+                                            continue;
+                                        }
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                // Review call failed — log and proceed (don't block execution)
+                                sink.emit(EngineEvent::Warn {
+                                    message: format!(
+                                        "Review call failed: {e}. Proceeding without review."
+                                    ),
+                                });
+                                phase_tracker.approve_plan();
+                            }
+                        }
+                    } else {
+                        // FastPath: no review, just approve
+                        phase_tracker.approve_plan();
+                    }
+                }
+                Err(e) => {
+                    sink.emit(EngineEvent::Warn {
+                        message: format!("Invalid SubmitPlan: {e}. Ignoring."),
+                    });
+                }
+            }
+
+            // Remove SubmitPlan from tool_calls so it doesn't get dispatched normally
+            tool_calls.remove(submit_idx);
+
+            // If no other tool calls remain, continue to next iteration
+            if tool_calls.is_empty() {
+                continue;
             }
         }
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod preview;
 pub mod progress;
 pub mod prompt;
 pub mod providers;
+pub mod review;
 pub mod runtime_env;
 pub mod session;
 pub mod settings;

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -161,6 +161,20 @@ pub trait Persistence: Send + Sync {
         from_phase: &str,
         to_phase: &str,
         trigger: Option<&str>,
+    ) -> Result<i64>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_review_record(
+        &self,
+        phase_transition_id: i64,
+        review_depth: &str,
+        reviewer_model: &str,
+        planner_model: &str,
+        plan_summary: &str,
+        reviewer_verdict: &str,
+        reviewer_reasoning: Option<&str>,
+        human_decision: Option<&str>,
+        gate_reason: &str,
     ) -> Result<()>;
 
     async fn phase_flow_summary(&self, session_id: &str) -> Result<String>;

--- a/koda-core/src/review.rs
+++ b/koda-core/src/review.rs
@@ -1,0 +1,624 @@
+//! Plan review system: typed handoffs between Planning and Reviewing phases.
+//!
+//! Two tools form the phase transition contracts:
+//! - `SubmitPlan`: planner's exit — crystallizes reasoning into a structured artifact
+//! - `SubmitReview`: reviewer's exit — typed verdict on the plan
+//!
+//! See #335 for the full design.
+
+use crate::providers::{LlmProvider, ToolDefinition};
+use crate::task_phase::ReviewDepth;
+use crate::tools::ToolEffect;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+// ── Plan artifact (from submit_plan tool) ───────────────────
+
+/// A single step in a plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanStep {
+    pub description: String,
+    pub tool: String,
+    pub files: Vec<String>,
+    pub effect: ToolEffect,
+}
+
+/// The planner's crystallized output — typed from birth via `submit_plan` tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanArtifact {
+    pub goal: String,
+    pub steps: Vec<PlanStep>,
+}
+
+impl PlanArtifact {
+    /// Parse from the submit_plan tool call arguments.
+    pub fn from_tool_args(args: &serde_json::Value) -> Result<Self, String> {
+        let goal = args["goal"]
+            .as_str()
+            .ok_or("missing 'goal' field")?
+            .to_string();
+
+        let steps_val = args["steps"]
+            .as_array()
+            .ok_or("missing or invalid 'steps' array")?;
+
+        if steps_val.is_empty() {
+            return Err("plan must have at least one step".to_string());
+        }
+
+        let mut steps = Vec::with_capacity(steps_val.len());
+        for (i, s) in steps_val.iter().enumerate() {
+            steps.push(PlanStep {
+                description: s["description"]
+                    .as_str()
+                    .ok_or(format!("step {i}: missing 'description'"))?
+                    .to_string(),
+                tool: s["tool"]
+                    .as_str()
+                    .ok_or(format!("step {i}: missing 'tool'"))?
+                    .to_string(),
+                files: s["files"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                effect: serde_json::from_value(s["effect"].clone())
+                    .unwrap_or(ToolEffect::LocalMutation),
+            });
+        }
+
+        Ok(Self { goal, steps })
+    }
+
+    /// Render as markdown for the reviewer's context window.
+    pub fn to_review_markdown(&self, task: &str) -> String {
+        let mut md = format!("## Task\n{}\n\n## Goal\n{}\n\n## Plan\n", task, self.goal);
+        for (i, step) in self.steps.iter().enumerate() {
+            let files = if step.files.is_empty() {
+                String::new()
+            } else {
+                format!(", files: [{}]", step.files.join(", "))
+            };
+            md.push_str(&format!(
+                "{}. {} — tool: {}{}, effect: {:?}\n",
+                i + 1,
+                step.description,
+                step.tool,
+                files,
+                step.effect,
+            ));
+        }
+        md
+    }
+
+    /// Check if any step has a destructive effect.
+    pub fn has_destructive_step(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|s| s.effect == ToolEffect::Destructive)
+    }
+
+    /// Check if any step has a remote action effect.
+    pub fn has_remote_step(&self) -> bool {
+        self.steps
+            .iter()
+            .any(|s| s.effect == ToolEffect::RemoteAction)
+    }
+
+    /// Affected file paths (deduplicated), capped at `limit`.
+    pub fn affected_files(&self, limit: usize) -> (Vec<String>, usize) {
+        let mut seen = std::collections::HashSet::new();
+        let mut files = Vec::new();
+        for step in &self.steps {
+            for f in &step.files {
+                if seen.insert(f.clone()) {
+                    files.push(f.clone());
+                }
+            }
+        }
+        let total = files.len();
+        files.truncate(limit);
+        (files, total)
+    }
+}
+
+// ── Review verdict (from submit_review tool) ────────────────
+
+/// Reviewer's typed verdict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewVerdict {
+    Approved,
+    Rejected,
+    Revised,
+}
+
+impl std::fmt::Display for ReviewVerdict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Approved => write!(f, "approved"),
+            Self::Rejected => write!(f, "rejected"),
+            Self::Revised => write!(f, "revised"),
+        }
+    }
+}
+
+/// Human's arbitration decision (for PeerReview disagreements).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HumanDecision {
+    AcceptedPlan,
+    AcceptedReview,
+    ManualEdit,
+    Aborted,
+}
+
+impl std::fmt::Display for HumanDecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AcceptedPlan => write!(f, "accepted_plan"),
+            Self::AcceptedReview => write!(f, "accepted_review"),
+            Self::ManualEdit => write!(f, "manual_edit"),
+            Self::Aborted => write!(f, "aborted"),
+        }
+    }
+}
+
+/// Why the review gate was engaged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GateReason {
+    /// `ToolEffect::Destructive` detected in plan.
+    DestructiveFloor,
+    /// Plan has >3 steps or full progression expected.
+    ComplexityThreshold,
+    /// `InterventionObserver` recommended auto.
+    ObserverAuto,
+    /// PeerReview rejected, escalated to human.
+    PeerReviewDisagreement,
+    /// SelfReview re-plan budget (2) exceeded.
+    RePlanExhausted,
+}
+
+impl std::fmt::Display for GateReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DestructiveFloor => write!(f, "destructive_floor"),
+            Self::ComplexityThreshold => write!(f, "complexity_threshold"),
+            Self::ObserverAuto => write!(f, "observer_auto"),
+            Self::PeerReviewDisagreement => write!(f, "peer_review_disagreement"),
+            Self::RePlanExhausted => write!(f, "re_plan_exhausted"),
+        }
+    }
+}
+
+/// Result of the submit_review tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubmitReviewResult {
+    pub verdict: ReviewVerdict,
+    pub reasoning: String,
+    pub suggested_changes: Option<Vec<String>>,
+}
+
+impl SubmitReviewResult {
+    /// Parse from the submit_review tool call arguments.
+    pub fn from_tool_args(args: &serde_json::Value) -> Result<Self, String> {
+        let verdict_str = args["verdict"].as_str().ok_or("missing 'verdict' field")?;
+        let verdict: ReviewVerdict = serde_json::from_value(json!(verdict_str)).map_err(|_| {
+            format!("invalid verdict: '{verdict_str}'. Expected: approved, rejected, revised")
+        })?;
+
+        let reasoning = args["reasoning"].as_str().unwrap_or("").to_string();
+
+        let suggested_changes = args["suggested_changes"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
+
+        Ok(Self {
+            verdict,
+            reasoning,
+            suggested_changes,
+        })
+    }
+}
+
+// ── Review record (for DB persistence) ──────────────────────
+
+/// A review event persisted to the `review_records` table.
+/// Only created for SelfReview and PeerReview (not FastPath).
+pub struct ReviewRecord {
+    pub review_depth: ReviewDepth,
+    pub reviewer_model: String,
+    pub planner_model: String,
+    pub plan_summary: String,
+    pub reviewer_verdict: ReviewVerdict,
+    pub reviewer_reasoning: Option<String>,
+    pub human_decision: Option<HumanDecision>,
+    pub gate_reason: GateReason,
+}
+
+impl ReviewRecord {
+    /// Outcome is derived, not stored.
+    /// When human was asked: outcome = human_decision.
+    /// When human was not asked and reviewer approved: outcome = AcceptedPlan.
+    pub fn outcome(&self) -> HumanDecision {
+        self.human_decision.unwrap_or(HumanDecision::AcceptedPlan)
+    }
+}
+
+// ── Tool definitions ────────────────────────────────────────
+
+/// Tool definition for `SubmitPlan`.
+pub fn submit_plan_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "SubmitPlan".to_string(),
+        description: "Submit a structured plan for review. Call this when you have finished \
+            planning and want to proceed to execution. The plan will be reviewed before \
+            any changes are made."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": "Your one-line interpretation of what the task requires"
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {
+                                "type": "string",
+                                "description": "What this step does"
+                            },
+                            "tool": {
+                                "type": "string",
+                                "description": "Which tool will be used (Read, Edit, Bash, etc.)"
+                            },
+                            "files": {
+                                "type": "array",
+                                "items": { "type": "string" },
+                                "description": "Files affected by this step"
+                            },
+                            "effect": {
+                                "type": "string",
+                                "enum": ["ReadOnly", "RemoteAction", "LocalMutation", "Destructive"],
+                                "description": "Effect classification of this step"
+                            }
+                        },
+                        "required": ["description", "tool"]
+                    },
+                    "description": "Ordered list of steps to execute"
+                }
+            },
+            "required": ["goal", "steps"]
+        }),
+    }
+}
+
+/// Tool definition for `SubmitReview`.
+pub fn submit_review_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "SubmitReview".to_string(),
+        description: "Submit your review verdict on the plan. You MUST call this tool \
+            to complete your review."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "verdict": {
+                    "type": "string",
+                    "enum": ["approved", "rejected", "revised"],
+                    "description": "Your verdict: approved (plan is sound), \
+                        rejected (plan has issues, needs re-planning), or \
+                        revised (plan is mostly good but needs specific changes)"
+                },
+                "reasoning": {
+                    "type": "string",
+                    "description": "Why you reached this verdict"
+                },
+                "suggested_changes": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Specific changes to make (for rejected/revised verdicts)"
+                }
+            },
+            "required": ["verdict", "reasoning"]
+        }),
+    }
+}
+
+// ── run_review: standalone review function ──────────────────
+
+/// Build the reviewer's system prompt.
+fn reviewer_system_prompt(depth: ReviewDepth) -> &'static str {
+    match depth {
+        ReviewDepth::SelfReview => {
+            "You are an independent code reviewer. You did NOT produce the plan below. \
+             Evaluate it critically using these dimensions:\n\
+             1. Feasibility: Can each step be done with available tools?\n\
+             2. Completeness: Does the plan cover the full request?\n\
+             3. Risk: What could go wrong? Is there a rollback?\n\
+             4. Resources: Which files are affected? Is scope reasonable?\n\n\
+             You MUST call the SubmitReview tool with your verdict."
+        }
+        ReviewDepth::PeerReview => {
+            "You are an independent reviewer. A DIFFERENT agent produced the plan below. \
+             Your job is adversarial — find what the planner missed:\n\
+             1. Feasibility: Can each step be done with available tools?\n\
+             2. Completeness: Does the plan cover the full request?\n\
+             3. Risk: What could go wrong? Is there a rollback?\n\
+             4. Resources: Which files are affected? Is scope reasonable?\n\
+             5. Alternatives: Is there a simpler approach the planner missed?\n\n\
+             You MUST call the SubmitReview tool with your verdict."
+        }
+        ReviewDepth::FastPath => {
+            unreachable!("FastPath should never call run_review")
+        }
+    }
+}
+
+/// Run a review of the plan artifact.
+///
+/// For SelfReview: same provider as the planner, fresh context.
+/// For PeerReview: different provider, fresh context.
+/// For FastPath: this function is never called.
+///
+/// Returns the reviewer's typed verdict.
+pub async fn run_review(
+    plan: &PlanArtifact,
+    task: &str,
+    provider: &dyn LlmProvider,
+    depth: ReviewDepth,
+) -> anyhow::Result<SubmitReviewResult> {
+    use crate::providers::ChatMessage;
+
+    let system = reviewer_system_prompt(depth).to_string();
+
+    // Build the plan markdown for the reviewer
+    let plan_md = plan.to_review_markdown(task);
+
+    // Affected files summary
+    let (files, total) = plan.affected_files(20);
+    let files_section = if files.is_empty() {
+        String::new()
+    } else {
+        let mut s = "\n## Affected Files\n".to_string();
+        for f in &files {
+            s.push_str(&format!("- {f}\n"));
+        }
+        if total > files.len() {
+            s.push_str(&format!("...and {} other files\n", total - files.len()));
+        }
+        s
+    };
+
+    let user_content = format!("{plan_md}{files_section}");
+
+    let messages = vec![
+        ChatMessage::text("system", &system),
+        ChatMessage::text("user", &user_content),
+    ];
+
+    // Only tool available to the reviewer
+    let tools = vec![submit_review_definition()];
+
+    let settings = crate::config::ModelSettings {
+        model: String::new(),   // provider will use its configured model
+        max_tokens: Some(2048), // reviewer doesn't need much output
+        temperature: Some(0.0), // deterministic review
+        thinking_budget: None,
+        reasoning_effort: None,
+        max_context_tokens: 32_000,
+    };
+    let response = provider.chat(&messages, &tools, &settings).await?;
+
+    // Extract the SubmitReview tool call from the response
+    for tc in &response.tool_calls {
+        if tc.function_name == "SubmitReview" {
+            let args: serde_json::Value = serde_json::from_str(&tc.arguments)
+                .map_err(|e| anyhow::anyhow!("Failed to parse SubmitReview args: {e}"))?;
+            return SubmitReviewResult::from_tool_args(&args)
+                .map_err(|e| anyhow::anyhow!("Invalid SubmitReview: {e}"));
+        }
+    }
+
+    // If reviewer didn't call the tool, treat as rejection (safe default)
+    Ok(SubmitReviewResult {
+        verdict: ReviewVerdict::Rejected,
+        reasoning: "Reviewer did not submit a structured verdict. \
+            Treating as rejection for safety."
+            .to_string(),
+        suggested_changes: None,
+    })
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plan_artifact_from_valid_args() {
+        let args = json!({
+            "goal": "Fix the bug in auth",
+            "steps": [
+                {
+                    "description": "Read the auth module",
+                    "tool": "Read",
+                    "files": ["src/auth.rs"],
+                    "effect": "ReadOnly"
+                },
+                {
+                    "description": "Edit the validation logic",
+                    "tool": "Edit",
+                    "files": ["src/auth.rs"],
+                    "effect": "LocalMutation"
+                }
+            ]
+        });
+        let plan = PlanArtifact::from_tool_args(&args).unwrap();
+        assert_eq!(plan.goal, "Fix the bug in auth");
+        assert_eq!(plan.steps.len(), 2);
+        assert_eq!(plan.steps[0].tool, "Read");
+        assert_eq!(plan.steps[1].effect, ToolEffect::LocalMutation);
+    }
+
+    #[test]
+    fn test_plan_artifact_missing_goal() {
+        let args = json!({ "steps": [{ "description": "x", "tool": "Read" }] });
+        assert!(PlanArtifact::from_tool_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_plan_artifact_empty_steps() {
+        let args = json!({ "goal": "test", "steps": [] });
+        let err = PlanArtifact::from_tool_args(&args).unwrap_err();
+        assert!(err.contains("at least one step"));
+    }
+
+    #[test]
+    fn test_plan_artifact_missing_step_fields() {
+        let args = json!({ "goal": "test", "steps": [{ "description": "x" }] });
+        let err = PlanArtifact::from_tool_args(&args).unwrap_err();
+        assert!(err.contains("missing 'tool'"));
+    }
+
+    #[test]
+    fn test_plan_has_destructive_step() {
+        let plan = PlanArtifact {
+            goal: "delete stuff".into(),
+            steps: vec![
+                PlanStep {
+                    description: "read".into(),
+                    tool: "Read".into(),
+                    files: vec![],
+                    effect: ToolEffect::ReadOnly,
+                },
+                PlanStep {
+                    description: "delete".into(),
+                    tool: "Bash".into(),
+                    files: vec!["data/".into()],
+                    effect: ToolEffect::Destructive,
+                },
+            ],
+        };
+        assert!(plan.has_destructive_step());
+        assert!(!plan.has_remote_step());
+    }
+
+    #[test]
+    fn test_affected_files_dedup_and_cap() {
+        let plan = PlanArtifact {
+            goal: "test".into(),
+            steps: vec![
+                PlanStep {
+                    description: "a".into(),
+                    tool: "Edit".into(),
+                    files: vec!["a.rs".into(), "b.rs".into()],
+                    effect: ToolEffect::LocalMutation,
+                },
+                PlanStep {
+                    description: "b".into(),
+                    tool: "Edit".into(),
+                    files: vec!["b.rs".into(), "c.rs".into()],
+                    effect: ToolEffect::LocalMutation,
+                },
+            ],
+        };
+        let (files, total) = plan.affected_files(2);
+        assert_eq!(files.len(), 2);
+        assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn test_to_review_markdown() {
+        let plan = PlanArtifact {
+            goal: "Fix auth".into(),
+            steps: vec![PlanStep {
+                description: "Edit auth module".into(),
+                tool: "Edit".into(),
+                files: vec!["src/auth.rs".into()],
+                effect: ToolEffect::LocalMutation,
+            }],
+        };
+        let md = plan.to_review_markdown("fix the auth bug");
+        assert!(md.contains("## Task"));
+        assert!(md.contains("fix the auth bug"));
+        assert!(md.contains("## Goal"));
+        assert!(md.contains("Fix auth"));
+        assert!(md.contains("## Plan"));
+        assert!(md.contains("Edit auth module"));
+    }
+
+    #[test]
+    fn test_submit_review_parse_approved() {
+        let args = json!({
+            "verdict": "approved",
+            "reasoning": "Plan looks good"
+        });
+        let result = SubmitReviewResult::from_tool_args(&args).unwrap();
+        assert_eq!(result.verdict, ReviewVerdict::Approved);
+        assert_eq!(result.reasoning, "Plan looks good");
+        assert!(result.suggested_changes.is_none());
+    }
+
+    #[test]
+    fn test_submit_review_parse_rejected_with_changes() {
+        let args = json!({
+            "verdict": "rejected",
+            "reasoning": "Missing error handling",
+            "suggested_changes": ["Add error handling to step 2"]
+        });
+        let result = SubmitReviewResult::from_tool_args(&args).unwrap();
+        assert_eq!(result.verdict, ReviewVerdict::Rejected);
+        assert_eq!(result.suggested_changes.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_submit_review_invalid_verdict() {
+        let args = json!({
+            "verdict": "maybe",
+            "reasoning": "unsure"
+        });
+        let err = SubmitReviewResult::from_tool_args(&args).unwrap_err();
+        assert!(err.contains("invalid verdict"));
+    }
+
+    #[test]
+    fn test_review_record_outcome_derived() {
+        let rec = ReviewRecord {
+            review_depth: ReviewDepth::SelfReview,
+            reviewer_model: "test".into(),
+            planner_model: "test".into(),
+            plan_summary: "test".into(),
+            reviewer_verdict: ReviewVerdict::Approved,
+            reviewer_reasoning: None,
+            human_decision: None,
+            gate_reason: GateReason::ComplexityThreshold,
+        };
+        assert_eq!(rec.outcome(), HumanDecision::AcceptedPlan);
+
+        let rec2 = ReviewRecord {
+            human_decision: Some(HumanDecision::AcceptedReview),
+            ..rec
+        };
+        assert_eq!(rec2.outcome(), HumanDecision::AcceptedReview);
+    }
+
+    #[test]
+    fn test_gate_reason_display() {
+        assert_eq!(
+            GateReason::DestructiveFloor.to_string(),
+            "destructive_floor"
+        );
+        assert_eq!(GateReason::RePlanExhausted.to_string(), "re_plan_exhausted");
+    }
+}

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -103,6 +103,21 @@ impl KodaSession {
             cancel: self.cancel.clone(),
             cmd_rx,
             skip_probe: self.skip_probe,
+            original_prompt: {
+                // Extract the most recent user message as the original prompt
+                let ctx_size = config.model_settings.max_context_tokens;
+                let history = self
+                    .db
+                    .load_context(&self.id, ctx_size)
+                    .await
+                    .unwrap_or_default();
+                history
+                    .iter()
+                    .rev()
+                    .find(|m| m.role == crate::db::Role::User)
+                    .and_then(|m| m.content.clone())
+                    .unwrap_or_default()
+            },
         })
         .await;
 

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -345,6 +345,11 @@ impl PhaseTracker {
         self.plan_approved
     }
 
+    /// Mark the plan as approved (review passed or FastPath).
+    pub fn approve_plan(&mut self) {
+        self.plan_approved = true;
+    }
+
     pub fn review_result(&self) -> Option<ReviewResult> {
         self.review_result
     }

--- a/koda-core/src/task_phase.rs
+++ b/koda-core/src/task_phase.rs
@@ -79,7 +79,11 @@ impl TaskPhase {
             Self::Understanding => {
                 "[Phase: Understanding — read relevant files before making changes]"
             }
-            Self::Planning => "[Phase: Planning — list the steps you will take before executing]",
+            Self::Planning => {
+                "[Phase: Planning — list the steps you will take. \
+                 When your plan is complete, call SubmitPlan with your goal and steps. \
+                 Do not begin execution until the plan has been reviewed.]"
+            }
             Self::Reviewing => "[Phase: Reviewing — list what could go wrong. Stop if unclear.]",
             Self::Executing => "[Phase: Executing — make changes one file at a time]",
             Self::Verifying => "[Phase: Verifying — run tests and check for errors]",

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -32,6 +32,8 @@ pub fn normalize_tool_name(name: &str) -> String {
         "emailread" | "email_read" => "EmailRead".to_string(),
         "emailsend" | "email_send" => "EmailSend".to_string(),
         "emailsearch" | "email_search" => "EmailSearch".to_string(),
+        "submitplan" | "submit_plan" => "SubmitPlan".to_string(),
+        "submitreview" | "submit_review" => "SubmitReview".to_string(),
         _ => name.to_string(), // pass through unknown names (e.g., MCP tools)
     }
 }
@@ -189,6 +191,11 @@ impl ToolRegistry {
         // RecallContext — on-demand history retrieval
         let recall_def = recall::definition();
         definitions.insert(recall_def.name.clone(), recall_def);
+        // Review tools — phase transition contracts
+        let submit_plan_def = crate::review::submit_plan_definition();
+        definitions.insert(submit_plan_def.name.clone(), submit_plan_def);
+        // Note: SubmitReview is NOT registered here — it's only available
+        // in the reviewer's fresh context window, not the main tool set.
         // Auto-provisionable MCP tools (registered so the LLM knows they exist)
         for def in crate::mcp::capability_registry::tool_definitions() {
             definitions.insert(def.name.clone(), def);
@@ -349,6 +356,26 @@ impl ToolRegistry {
             // Memory
             "MemoryRead" => memory::memory_read(&self.project_root).await,
             "MemoryWrite" => memory::memory_write(&self.project_root, &args).await,
+
+            // Review tools (phase transition contracts)
+            "SubmitPlan" => {
+                // Validate the plan artifact structure.
+                // The actual phase transition is handled by the inference loop
+                // when it sees this tool result.
+                match crate::review::PlanArtifact::from_tool_args(&args) {
+                    Ok(plan) => {
+                        let summary =
+                            format!("Plan submitted: {} ({} steps)", plan.goal, plan.steps.len());
+                        Ok(summary)
+                    }
+                    Err(e) => Err(anyhow::anyhow!("Invalid plan: {e}")),
+                }
+            }
+            "SubmitReview" => {
+                // Should only be called in the reviewer's context, not the main loop.
+                // If called here, it's a model error — return gracefully.
+                Ok("SubmitReview is only valid during plan review.".to_string())
+            }
 
             // Agent tools
             "ListAgents" => {

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -101,6 +101,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         cancel,
         cmd_rx: &mut cmd_rx,
         skip_probe: true,
+        original_prompt: String::new(),
     })
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -91,6 +91,7 @@ impl Env {
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,
             skip_probe: true,
+            original_prompt: String::new(),
         })
         .await;
 
@@ -263,6 +264,7 @@ async fn test_provider_error_emits_error_event() {
         cancel: CancellationToken::new(),
         cmd_rx: &mut cmd_rx,
         skip_probe: true,
+        original_prompt: String::new(),
     })
     .await;
 
@@ -377,6 +379,7 @@ async fn test_cancel_during_streaming() {
         cancel,
         cmd_rx: &mut cmd_rx,
         skip_probe: true,
+        original_prompt: String::new(),
     })
     .await;
 

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -81,6 +81,7 @@ impl Env {
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,
             skip_probe: true,
+            original_prompt: String::new(),
         })
         .await;
 


### PR DESCRIPTION
## #335 Phase 2: SelfReview context isolation

### What this PR does
Complete Phase 2 of the review depth isolation design. The inference loop now supports typed plan review handoffs.

### New module: `review.rs` (624 lines)
**Types:**
- `PlanArtifact` + `PlanStep` — typed plan from birth via `submit_plan` tool
- `ReviewVerdict` (Approved/Rejected/Revised), `HumanDecision`, `GateReason` — closed-set enums
- `SubmitReviewResult` — parsed reviewer response
- `ReviewRecord` — DB persistence (outcome derived from verdict + decision, not stored)

**Tools:**
- `SubmitPlan` — planner's exit contract. Crystallizes reasoning into structured artifact.
- `SubmitReview` — reviewer's ONLY tool. Judge by construction, not instruction.

**`run_review()`** — standalone async function:
- Takes `PlanArtifact` + task + provider + `ReviewDepth`
- Builds fresh context: system prompt + plan markdown + affected files
- Reviewer gets `[SubmitReview]` as only tool — can't execute, only judge
- FastPath never calls this function (zero cost)

### Inference loop wiring
- Intercepts `SubmitPlan` tool call before normal dispatch
- Selects `ReviewDepth` (upgrades if destructive steps detected)
- Calls `run_review()` for non-FastPath
- On approval: `approve_plan()`, continue to Executing
- On rejection: append feedback, re-enter Planning (封驳 path)
- Re-plan budget: 2 attempts, then proceed with warning
- Review failure: warn and proceed (non-blocking)

### DB: `review_records` table
Child table of `phase_transitions` with CHECK constraints on all closed-set columns. FastPath does NOT create rows.

### Breaking changes
- `InferenceContext` gains `original_prompt: String`
- `insert_phase_transition` returns `Result<i64>` (row ID for FK)
- `Persistence` trait gains `insert_review_record`
- Old DBs need to be deleted (no migration)

508 lib tests (12 new). clippy clean.

Part of #335