### PR TITLE
feat: Phase 4 — trigger refinement via ToolEffect (#335)

### DIFF
--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -199,8 +199,8 @@ impl Database {
                 reviewer_reasoning TEXT,
                 human_decision TEXT CHECK(human_decision IN ('accepted_plan', 'accepted_review', 'manual_edit', 'aborted')),
                 gate_reason TEXT NOT NULL CHECK(gate_reason IN (
-                    'destructive_floor', 'complexity_threshold', 'observer_auto',
-                    'peer_review_disagreement', 're_plan_exhausted'
+                    'destructive_floor', 'remote_action_floor', 'complexity_threshold',
+                    'observer_auto', 'peer_review_disagreement', 're_plan_exhausted'
                 )),
                 created_at TEXT DEFAULT (datetime('now'))
             );",

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -629,15 +629,19 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
             match crate::review::PlanArtifact::from_tool_args(&args) {
                 Ok(plan) => {
-                    let depth = phase_tracker.select_review_depth(&intervention_observer);
+                    let base_depth = phase_tracker.select_review_depth(&intervention_observer);
 
-                    // Upgrade depth based on plan content
-                    let depth = if plan.has_destructive_step()
-                        && depth == crate::task_phase::ReviewDepth::FastPath
+                    // Upgrade depth based on plan content (one-way ratchet):
+                    // ToolEffect::Destructive → always PeerReview
+                    // ToolEffect::RemoteAction → at least SelfReview
+                    let depth = if plan.has_destructive_step() {
+                        crate::task_phase::ReviewDepth::PeerReview
+                    } else if plan.has_remote_step()
+                        && base_depth == crate::task_phase::ReviewDepth::FastPath
                     {
                         crate::task_phase::ReviewDepth::SelfReview
                     } else {
-                        depth
+                        base_depth
                     };
 
                     sink.emit(EngineEvent::Info {
@@ -652,6 +656,8 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                         // Determine gate reason
                         let gate_reason = if plan.has_destructive_step() {
                             crate::review::GateReason::DestructiveFloor
+                        } else if plan.has_remote_step() {
+                            crate::review::GateReason::RemoteActionFloor
                         } else {
                             crate::review::GateReason::ComplexityThreshold
                         };

--- a/koda-core/src/review.rs
+++ b/koda-core/src/review.rs
@@ -171,8 +171,10 @@ impl std::fmt::Display for HumanDecision {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GateReason {
-    /// `ToolEffect::Destructive` detected in plan.
+    /// `ToolEffect::Destructive` detected in plan → PeerReview.
     DestructiveFloor,
+    /// `ToolEffect::RemoteAction` detected in plan → at least SelfReview.
+    RemoteActionFloor,
     /// Plan has >3 steps or full progression expected.
     ComplexityThreshold,
     /// `InterventionObserver` recommended auto.
@@ -187,6 +189,7 @@ impl std::fmt::Display for GateReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DestructiveFloor => write!(f, "destructive_floor"),
+            Self::RemoteActionFloor => write!(f, "remote_action_floor"),
             Self::ComplexityThreshold => write!(f, "complexity_threshold"),
             Self::ObserverAuto => write!(f, "observer_auto"),
             Self::PeerReviewDisagreement => write!(f, "peer_review_disagreement"),


### PR DESCRIPTION
## #335 Phase 4: Review depth escalation from plan content

### The one-way ratchet
Review depth is upgraded based on what's in the plan, never downgraded:

| Plan content | Minimum depth | Gate reason |
|-------------|---------------|-------------|
| `ToolEffect::Destructive` | **PeerReview** | `destructive_floor` |
| `ToolEffect::RemoteAction` | **SelfReview** | `remote_action_floor` |
| Neither | Base depth from `select_review_depth()` | `complexity_threshold` |

### Why separate gate reasons matter
`InterventionObserver` needs to distinguish *why* the user was asked. "Asked because of a destructive op" and "asked because the plan has remote actions" are different learning signals. Without `gate_reason`, `/priors` shows the user was asked but not why.

### No parallel detection
`ToolEffect` from #303 IS the detection system. `has_destructive_step()` and `has_remote_step()` on `PlanArtifact` check the `effect` field on each `PlanStep` — which was set by the planner in the `submit_plan` tool call.

508 lib tests. clippy clean.

Part of #335