### PR TITLE
fix: re-plan loop exits when model responds with text instead of submit_plan (#342)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -922,7 +922,25 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
 
         // If no tool calls, we already streamed the response — done
+        // UNLESS we're waiting for a re-plan (rejected plan, re_plan_count > 0)
         if tool_calls.is_empty() {
+            // Re-plan guard: if a plan was rejected and the model responded
+            // with text instead of calling submit_plan, nudge it to try again.
+            if re_plan_count > 0 && !phase_tracker.plan_approved() && re_plan_count <= 2 {
+                sink.emit(EngineEvent::Info {
+                    message: format!(
+                        "⚠️ Model responded with text instead of submit_plan \
+                         (re-plan attempt {re_plan_count}/2). Nudging..."
+                    ),
+                });
+                let nudge = "You must revise and resubmit your plan by calling \
+                    the `submit_plan` tool. Do NOT respond with text — call the tool.";
+                let _ = db
+                    .insert_message(session_id, &Role::Phase, Some(nudge), None, None, None)
+                    .await;
+                continue;
+            }
+
             if made_tool_calls && full_text.trim().is_empty() {
                 sink.emit(EngineEvent::Warn {
                     message: "Model produced an empty response after tool use — it may have given up mid-task. Try rephrasing or switching to a more capable model.".into(),


### PR DESCRIPTION
## Fixes #342 (reopened)

### Root cause

After plan rejection, the inference loop injects feedback and continues. On the next iteration, small models (gemini-3.1-flash-lite) respond with **prose** instead of calling `submit_plan`:

```
❌ Review rejected (attempt 1/2)...
📝 Understanding → Planning (text_only_after_reads) — model: gemini-3.1-flash-lite-preview
🔍>   Type a message...     ← inference ended, user dropped to prompt
```

The loop sees `tool_calls.is_empty()` → treats it as the final response → **ends the turn**. No re-plan attempt ever happens.

### Fix

Before the "no tool calls = done" exit path, check if we're waiting for a re-plan:
- `re_plan_count > 0` (at least one rejection happened)
- `!plan_approved` (plan hasn't been approved yet)
- `re_plan_count <= 2` (budget not exhausted)

If all true: inject a nudge message ("call submit_plan, not text") and `continue` the loop instead of exiting.

### Safety bounds
- Nudge fires at most once per rejection (bounded by `re_plan_count <= 2`)
- Hard cap on iterations prevents infinite loops
- If budget exhausts (2 rejections), the turn ends normally

### Expected flow after fix
```
Plan submitted → review rejects → feedback injected
→ model responds with text (not submit_plan)
→ ⚠️ nudge: 'call submit_plan' → continue loop
→ model calls submit_plan → review runs
→ approved → execute  OR  rejected (attempt 2/2) → budget exhausted → proceed
```

502 lib tests. clippy clean.