### PR TITLE
fix: fast_path plan approval injects feedback + dedup submissions (#342)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -673,272 +673,301 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             .iter()
             .position(|tc| tc.function_name == "SubmitPlan")
         {
-            let submit_tc = &tool_calls[submit_idx];
-            let args: serde_json::Value =
-                serde_json::from_str(&submit_tc.arguments).unwrap_or_default();
+            // If a plan is already approved, ignore duplicate submissions
+            if phase_tracker.plan_approved() {
+                sink.emit(EngineEvent::Info {
+                    message: "Plan already approved — ignoring duplicate SubmitPlan. \
+                        Proceed with execution."
+                        .into(),
+                });
+                tool_calls.remove(submit_idx);
+                if tool_calls.is_empty() {
+                    continue;
+                }
+            } else {
+                let submit_tc = &tool_calls[submit_idx];
+                let args: serde_json::Value =
+                    serde_json::from_str(&submit_tc.arguments).unwrap_or_default();
 
-            match crate::review::PlanArtifact::from_tool_args(&args) {
-                Ok(plan) => {
-                    let base_depth = phase_tracker.select_review_depth(&intervention_observer);
-
-                    // Upgrade depth based on plan content (one-way ratchet):
-                    // ToolEffect::Destructive → always PeerReview
-                    // ToolEffect::RemoteAction → at least SelfReview
-                    let depth = if plan.has_destructive_step() {
-                        crate::task_phase::ReviewDepth::PeerReview
-                    } else if plan.has_remote_step()
-                        && base_depth == crate::task_phase::ReviewDepth::FastPath
-                    {
-                        crate::task_phase::ReviewDepth::SelfReview
-                    } else {
-                        base_depth
-                    };
-
-                    // Show the full plan so the user can judge quality
-                    let plan_detail = format_plan_detail(&plan, &config.model, depth);
-                    sink.emit(EngineEvent::Info {
-                        message: plan_detail,
-                    });
-
-                    if depth != crate::task_phase::ReviewDepth::FastPath {
-                        // Determine gate reason
-                        let gate_reason = if plan.has_destructive_step() {
-                            crate::review::GateReason::DestructiveFloor
-                        } else if plan.has_remote_step() {
-                            crate::review::GateReason::RemoteActionFloor
-                        } else {
-                            crate::review::GateReason::ComplexityThreshold
+                match crate::review::PlanArtifact::from_tool_args(&args) {
+                    Ok(plan) => {
+                        let base_depth = phase_tracker.select_review_depth(&intervention_observer);
+                        let submit_action = crate::review::decide_plan_submit(
+                            false, // outer guard already checked plan_approved
+                            &plan, base_depth,
+                        );
+                        let (depth, gate_reason) = match submit_action {
+                            crate::review::PlanSubmitAction::Review { depth, gate_reason } => {
+                                (depth, gate_reason)
+                            }
+                            // DuplicateIgnored can't happen here (outer guard)
+                            // ParseError can't happen here (plan already parsed)
+                            _ => unreachable!(),
                         };
 
-                        // Show who is reviewing
-                        let reviewer_label = if depth == crate::task_phase::ReviewDepth::PeerReview
-                        {
-                            cached_reviewer
-                                .as_ref()
-                                .map(|(_, m)| m.as_str())
-                                .unwrap_or("cross-provider")
-                                .to_string()
-                        } else {
-                            config.model.clone()
-                        };
+                        // Show the full plan so the user can judge quality
+                        let plan_detail = format_plan_detail(&plan, &config.model, depth);
                         sink.emit(EngineEvent::Info {
-                            message: format!("🔍 Reviewing ({depth} by {reviewer_label})..."),
+                            message: plan_detail,
                         });
 
-                        // Run review (fresh context, reviewer-only tools)
-                        let review_result = if depth == crate::task_phase::ReviewDepth::PeerReview {
-                            // PeerReview: different model, fallthrough on model-not-found
-                            match crate::review::run_peer_review(
-                                &plan,
-                                &original_prompt,
-                                &config.provider_type,
-                                &mut cached_reviewer,
-                            )
-                            .await
-                            {
-                                Some(result) => result,
-                                None => {
-                                    // No cross-provider available — downgrade to SelfReview
-                                    sink.emit(EngineEvent::Info {
-                                        message: "No cross-provider key available. \
+                        if depth != crate::task_phase::ReviewDepth::FastPath {
+                            // gate_reason already computed by decide_plan_submit
+
+                            // Show who is reviewing
+                            let reviewer_label =
+                                if depth == crate::task_phase::ReviewDepth::PeerReview {
+                                    cached_reviewer
+                                        .as_ref()
+                                        .map(|(_, m)| m.as_str())
+                                        .unwrap_or("cross-provider")
+                                        .to_string()
+                                } else {
+                                    config.model.clone()
+                                };
+                            sink.emit(EngineEvent::Info {
+                                message: format!("🔍 Reviewing ({depth} by {reviewer_label})..."),
+                            });
+
+                            // Run review (fresh context, reviewer-only tools)
+                            let review_result =
+                                if depth == crate::task_phase::ReviewDepth::PeerReview {
+                                    // PeerReview: different model, fallthrough on model-not-found
+                                    match crate::review::run_peer_review(
+                                        &plan,
+                                        &original_prompt,
+                                        &config.provider_type,
+                                        &mut cached_reviewer,
+                                    )
+                                    .await
+                                    {
+                                        Some(result) => result,
+                                        None => {
+                                            // No cross-provider available — downgrade to SelfReview
+                                            sink.emit(EngineEvent::Info {
+                                                message: "No cross-provider key available. \
                                             Downgrading PeerReview → SelfReview."
-                                            .into(),
-                                    });
+                                                    .into(),
+                                            });
+                                            crate::review::run_review(
+                                                &plan,
+                                                &original_prompt,
+                                                provider,
+                                                crate::task_phase::ReviewDepth::SelfReview,
+                                                &config.model,
+                                            )
+                                            .await
+                                        }
+                                    }
+                                } else {
+                                    // SelfReview: same provider, fresh context
                                     crate::review::run_review(
                                         &plan,
                                         &original_prompt,
                                         provider,
-                                        crate::task_phase::ReviewDepth::SelfReview,
+                                        depth,
                                         &config.model,
                                     )
                                     .await
-                                }
-                            }
-                        } else {
-                            // SelfReview: same provider, fresh context
-                            crate::review::run_review(
-                                &plan,
-                                &original_prompt,
-                                provider,
-                                depth,
-                                &config.model,
-                            )
-                            .await
-                        };
+                                };
 
-                        match review_result {
-                            Ok(result) => {
-                                // Persist review record
-                                let transition_id = db
-                                    .insert_phase_transition(
-                                        session_id,
-                                        iteration,
-                                        "Planning",
-                                        "Reviewing",
-                                        Some("submit_plan"),
-                                    )
-                                    .await
-                                    .unwrap_or(0);
+                            match review_result {
+                                Ok(result) => {
+                                    // Persist review record
+                                    let transition_id = db
+                                        .insert_phase_transition(
+                                            session_id,
+                                            iteration,
+                                            "Planning",
+                                            "Reviewing",
+                                            Some("submit_plan"),
+                                        )
+                                        .await
+                                        .unwrap_or(0);
 
-                                let reviewer_model_name = cached_reviewer
-                                    .as_ref()
-                                    .map(|(_, m)| m.as_str())
-                                    .unwrap_or(&config.model);
-                                let plan_json = serde_json::to_string(&plan).unwrap_or_default();
-                                let _ = db
-                                    .insert_review_record(
-                                        transition_id,
-                                        &depth.to_string(),
-                                        reviewer_model_name,
-                                        &config.model,
-                                        &plan_json,
-                                        &result.verdict.to_string(),
-                                        Some(&result.reasoning),
-                                        None, // human_decision (future: user arbitration)
-                                        &gate_reason.to_string(),
-                                    )
-                                    .await;
+                                    let reviewer_model_name = cached_reviewer
+                                        .as_ref()
+                                        .map(|(_, m)| m.as_str())
+                                        .unwrap_or(&config.model);
+                                    let plan_json =
+                                        serde_json::to_string(&plan).unwrap_or_default();
+                                    let _ = db
+                                        .insert_review_record(
+                                            transition_id,
+                                            &depth.to_string(),
+                                            reviewer_model_name,
+                                            &config.model,
+                                            &plan_json,
+                                            &result.verdict.to_string(),
+                                            Some(&result.reasoning),
+                                            None, // human_decision (future: user arbitration)
+                                            &gate_reason.to_string(),
+                                        )
+                                        .await;
 
-                                match result.verdict {
-                                    crate::review::ReviewVerdict::Approved => {
-                                        sink.emit(EngineEvent::Info {
-                                            message: format!(
-                                                "✅ Review passed ({reviewer_label}): {}",
-                                                result.reasoning
-                                            ),
-                                        });
-                                        // Mark plan as approved, continue to execution
-                                        phase_tracker.approve_plan();
-                                    }
-                                    crate::review::ReviewVerdict::Rejected
-                                    | crate::review::ReviewVerdict::Revised => {
-                                        re_plan_count += 1;
-                                        if re_plan_count > 2 {
-                                            sink.emit(EngineEvent::Warn {
-                                                message: "Re-plan budget exhausted (2 attempts). \
-                                                    Proceeding with current plan."
-                                                    .into(),
+                                    match result.verdict {
+                                        crate::review::ReviewVerdict::Approved => {
+                                            sink.emit(EngineEvent::Info {
+                                                message: format!(
+                                                    "✅ Review passed ({reviewer_label}): {}",
+                                                    result.reasoning
+                                                ),
                                             });
+                                            // Mark plan as approved, continue to execution
                                             phase_tracker.approve_plan();
-                                        } else {
-                                            // Build structured rejection feedback
-                                            let suggested = result
-                                                .suggested_changes
-                                                .as_ref()
-                                                .map(|c| {
-                                                    c.iter()
-                                                        .map(|s| format!("  - {s}"))
-                                                        .collect::<Vec<_>>()
-                                                        .join("\n")
-                                                })
-                                                .unwrap_or_default();
+                                        }
+                                        crate::review::ReviewVerdict::Rejected
+                                        | crate::review::ReviewVerdict::Revised => {
+                                            re_plan_count += 1;
+                                            if re_plan_count > 2 {
+                                                sink.emit(EngineEvent::Warn {
+                                                    message:
+                                                        "Re-plan budget exhausted (2 attempts). \
+                                                    Proceeding with current plan."
+                                                            .into(),
+                                                });
+                                                phase_tracker.approve_plan();
+                                            } else {
+                                                // Build structured rejection feedback
+                                                let suggested = result
+                                                    .suggested_changes
+                                                    .as_ref()
+                                                    .map(|c| {
+                                                        c.iter()
+                                                            .map(|s| format!("  - {s}"))
+                                                            .collect::<Vec<_>>()
+                                                            .join("\n")
+                                                    })
+                                                    .unwrap_or_default();
 
-                                            // Show full rejection detail to user
-                                            let user_msg = format!(
-                                                "\u{274c} Review rejected (attempt {re_plan_count}/2)\n\
+                                                // Show full rejection detail to user
+                                                let user_msg = format!(
+                                                    "\u{274c} Review rejected (attempt {re_plan_count}/2)\n\
                                                  Reviewer: {reviewer_label}\n\
                                                  Verdict: {}\n\
                                                  Reasoning: {}\n\
                                                  {}",
-                                                result.verdict,
-                                                result.reasoning,
-                                                if suggested.is_empty() {
-                                                    String::new()
-                                                } else {
-                                                    format!("Suggested changes:\n{suggested}")
-                                                }
-                                            );
-                                            sink.emit(EngineEvent::Info { message: user_msg });
+                                                    result.verdict,
+                                                    result.reasoning,
+                                                    if suggested.is_empty() {
+                                                        String::new()
+                                                    } else {
+                                                        format!("Suggested changes:\n{suggested}")
+                                                    }
+                                                );
+                                                sink.emit(EngineEvent::Info { message: user_msg });
 
-                                            // Feedback for the planner — explicit re-plan instruction
-                                            let feedback = format!(
-                                                "Your plan was REJECTED by the reviewer ({depth}).\n\
+                                                // Feedback for the planner — explicit re-plan instruction
+                                                let feedback = format!(
+                                                    "Your plan was REJECTED by the reviewer ({depth}).\n\
                                                  Reason: {}\n\
                                                  {}\n\n\
                                                  You MUST revise your plan and call `submit_plan` again \
                                                with an improved plan. Do NOT respond with text — \
                                                  call the submit_plan tool.",
-                                                result.reasoning,
-                                                if suggested.is_empty() {
-                                                    String::new()
-                                                } else {
-                                                    format!("Suggested changes:\n{suggested}")
-                                                }
-                                            );
+                                                    result.reasoning,
+                                                    if suggested.is_empty() {
+                                                        String::new()
+                                                    } else {
+                                                        format!("Suggested changes:\n{suggested}")
+                                                    }
+                                                );
 
-                                            // Insert feedback so the planner sees it
-                                            let _ = db
-                                                .insert_message(
-                                                    session_id,
-                                                    &Role::Phase,
-                                                    Some(&feedback),
-                                                    None,
-                                                    None,
-                                                    None,
-                                                )
-                                                .await;
+                                                // Insert feedback so the planner sees it
+                                                let _ = db
+                                                    .insert_message(
+                                                        session_id,
+                                                        &Role::Phase,
+                                                        Some(&feedback),
+                                                        None,
+                                                        None,
+                                                        None,
+                                                    )
+                                                    .await;
 
-                                            // Stay in Planning phase (don't demote
-                                            // to Understanding — the planner already
-                                            // understands the task, it just needs to
-                                            // revise the plan)
-                                            phase_tracker.invalidate_plan();
+                                                // Stay in Planning phase (don't demote
+                                                // to Understanding — the planner already
+                                                // understands the task, it just needs to
+                                                // revise the plan)
+                                                phase_tracker.invalidate_plan();
 
-                                            // Skip normal tool execution, re-enter loop
-                                            continue;
+                                                // Skip normal tool execution, re-enter loop
+                                                continue;
+                                            }
                                         }
                                     }
                                 }
+                                Err(e) => {
+                                    // Review call failed — log and proceed (don't block execution)
+                                    sink.emit(EngineEvent::Warn {
+                                        message: format!(
+                                            "Review call failed: {e}. Proceeding without review."
+                                        ),
+                                    });
+                                    phase_tracker.approve_plan();
+                                }
                             }
-                            Err(e) => {
-                                // Review call failed — log and proceed (don't block execution)
-                                sink.emit(EngineEvent::Warn {
-                                    message: format!(
-                                        "Review call failed: {e}. Proceeding without review."
-                                    ),
-                                });
-                                phase_tracker.approve_plan();
-                            }
+                        } else {
+                            // FastPath: no review, just approve
+                            phase_tracker.approve_plan();
+
+                            // Inject feedback so the model knows its plan was approved
+                            // and should proceed to execution.
+                            let approval_msg = format!(
+                                "Plan approved (fast_path). Proceed to execute the plan. \
+                             Goal: {}",
+                                plan.goal
+                            );
+                            let _ = db
+                                .insert_message(
+                                    session_id,
+                                    &Role::Phase,
+                                    Some(&approval_msg),
+                                    None,
+                                    None,
+                                    None,
+                                )
+                                .await;
                         }
-                    } else {
-                        // FastPath: no review, just approve
-                        phase_tracker.approve_plan();
+                    }
+                    Err(e) => {
+                        sink.emit(EngineEvent::Warn {
+                            message: format!("Invalid SubmitPlan: {e}. Ignoring."),
+                        });
                     }
                 }
-                Err(e) => {
-                    sink.emit(EngineEvent::Warn {
-                        message: format!("Invalid SubmitPlan: {e}. Ignoring."),
-                    });
+
+                // Remove SubmitPlan from tool_calls so it doesn't get dispatched normally
+                tool_calls.remove(submit_idx);
+
+                // If no other tool calls remain, continue to next iteration
+                if tool_calls.is_empty() {
+                    continue;
                 }
-            }
-
-            // Remove SubmitPlan from tool_calls so it doesn't get dispatched normally
-            tool_calls.remove(submit_idx);
-
-            // If no other tool calls remain, continue to next iteration
-            if tool_calls.is_empty() {
-                continue;
-            }
+            } // close else (plan not already approved)
         }
 
         // If no tool calls, we already streamed the response — done
         // UNLESS we're waiting for a re-plan (rejected plan, re_plan_count > 0)
         if tool_calls.is_empty() {
-            // Re-plan guard: if a plan was rejected and the model responded
-            // with text instead of calling submit_plan, nudge it to try again.
-            if re_plan_count > 0 && !phase_tracker.plan_approved() && re_plan_count <= 2 {
-                sink.emit(EngineEvent::Info {
-                    message: format!(
-                        "⚠️ Model responded with text instead of submit_plan \
-                         (re-plan attempt {re_plan_count}/2). Nudging..."
-                    ),
-                });
-                let nudge = "You must revise and resubmit your plan by calling \
-                    the `submit_plan` tool. Do NOT respond with text — call the tool.";
-                let _ = db
-                    .insert_message(session_id, &Role::Phase, Some(nudge), None, None, None)
-                    .await;
-                continue;
+            // Use extracted decision logic (testable in review.rs)
+            match crate::review::decide_text_response(re_plan_count, phase_tracker.plan_approved())
+            {
+                crate::review::TextResponseAction::NudgeReplan { attempt } => {
+                    sink.emit(EngineEvent::Info {
+                        message: format!(
+                            "⚠️ Model responded with text instead of submit_plan \
+                             (re-plan attempt {attempt}/2). Nudging..."
+                        ),
+                    });
+                    let nudge = "You must revise and resubmit your plan by calling \
+                        the `submit_plan` tool. Do NOT respond with text — call the tool.";
+                    let _ = db
+                        .insert_message(session_id, &Role::Phase, Some(nudge), None, None, None)
+                        .await;
+                    continue;
+                }
+                crate::review::TextResponseAction::EndTurn => {}
             }
 
             if made_tool_calls && full_text.trim().is_empty() {

--- a/koda-core/src/review.rs
+++ b/koda-core/src/review.rs
@@ -673,6 +673,75 @@ pub async fn run_peer_review(
     None
 }
 
+// ── Plan submission decision logic (testable) ───────────────
+
+/// What should happen when the model calls SubmitPlan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanSubmitAction {
+    /// Plan already approved — ignore duplicate submission.
+    DuplicateIgnored,
+    /// Plan parsed, review at the given depth.
+    Review {
+        depth: crate::task_phase::ReviewDepth,
+        gate_reason: GateReason,
+    },
+    /// Plan parsing failed.
+    ParseError(String),
+}
+
+/// What should happen when the model responds with text (no tool calls)
+/// and a re-plan is pending.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TextResponseAction {
+    /// Normal end of turn.
+    EndTurn,
+    /// Re-plan pending: nudge the model to call submit_plan.
+    NudgeReplan { attempt: u32 },
+}
+
+/// Decide what to do when SubmitPlan is called.
+pub fn decide_plan_submit(
+    plan_already_approved: bool,
+    plan: &PlanArtifact,
+    base_depth: crate::task_phase::ReviewDepth,
+) -> PlanSubmitAction {
+    if plan_already_approved {
+        return PlanSubmitAction::DuplicateIgnored;
+    }
+
+    use crate::task_phase::ReviewDepth;
+
+    // One-way ratchet: upgrade depth based on plan content
+    let depth = if plan.has_destructive_step() {
+        ReviewDepth::PeerReview
+    } else if plan.has_remote_step() && base_depth == ReviewDepth::FastPath {
+        ReviewDepth::SelfReview
+    } else {
+        base_depth
+    };
+
+    let gate_reason = if plan.has_destructive_step() {
+        GateReason::DestructiveFloor
+    } else if plan.has_remote_step() {
+        GateReason::RemoteActionFloor
+    } else {
+        GateReason::ComplexityThreshold
+    };
+
+    PlanSubmitAction::Review { depth, gate_reason }
+}
+
+/// Decide what to do when the model produces text with no tool calls.
+pub fn decide_text_response(re_plan_count: u32, plan_approved: bool) -> TextResponseAction {
+    if re_plan_count > 0 && !plan_approved && re_plan_count <= 2 {
+        TextResponseAction::NudgeReplan {
+            attempt: re_plan_count,
+        }
+    } else {
+        TextResponseAction::EndTurn
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -854,5 +923,122 @@ mod tests {
             "destructive_floor"
         );
         assert_eq!(GateReason::RePlanExhausted.to_string(), "re_plan_exhausted");
+    }
+
+    // ── Plan submission decision tests (#342 regression) ───────
+
+    fn make_plan(steps: &[(&str, crate::tools::ToolEffect)]) -> PlanArtifact {
+        PlanArtifact {
+            goal: "test goal".into(),
+            steps: steps
+                .iter()
+                .map(|(desc, effect)| PlanStep {
+                    description: desc.to_string(),
+                    tool: "Bash".into(),
+                    files: vec![],
+                    effect: *effect,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_duplicate_submit_ignored() {
+        let plan = make_plan(&[("step 1", crate::tools::ToolEffect::ReadOnly)]);
+        let action = decide_plan_submit(
+            true, // already approved
+            &plan,
+            crate::task_phase::ReviewDepth::FastPath,
+        );
+        assert_eq!(action, PlanSubmitAction::DuplicateIgnored);
+    }
+
+    #[test]
+    fn test_fastpath_plan_returns_review() {
+        let plan = make_plan(&[("read files", crate::tools::ToolEffect::ReadOnly)]);
+        let action = decide_plan_submit(false, &plan, crate::task_phase::ReviewDepth::FastPath);
+        assert_eq!(
+            action,
+            PlanSubmitAction::Review {
+                depth: crate::task_phase::ReviewDepth::FastPath,
+                gate_reason: GateReason::ComplexityThreshold,
+            }
+        );
+    }
+
+    #[test]
+    fn test_destructive_step_escalates_to_peer_review() {
+        let plan = make_plan(&[
+            ("delete files", crate::tools::ToolEffect::Destructive),
+            ("read config", crate::tools::ToolEffect::ReadOnly),
+        ]);
+        let action = decide_plan_submit(false, &plan, crate::task_phase::ReviewDepth::FastPath);
+        assert_eq!(
+            action,
+            PlanSubmitAction::Review {
+                depth: crate::task_phase::ReviewDepth::PeerReview,
+                gate_reason: GateReason::DestructiveFloor,
+            }
+        );
+    }
+
+    #[test]
+    fn test_remote_step_escalates_fastpath_to_self_review() {
+        let plan = make_plan(&[("api call", crate::tools::ToolEffect::RemoteAction)]);
+        let action = decide_plan_submit(false, &plan, crate::task_phase::ReviewDepth::FastPath);
+        assert_eq!(
+            action,
+            PlanSubmitAction::Review {
+                depth: crate::task_phase::ReviewDepth::SelfReview,
+                gate_reason: GateReason::RemoteActionFloor,
+            }
+        );
+    }
+
+    #[test]
+    fn test_remote_step_s_not_downgrade_self_review() {
+        let plan = make_plan(&[("api call", crate::tools::ToolEffect::RemoteAction)]);
+        let action = decide_plan_submit(false, &plan, crate::task_phase::ReviewDepth::SelfReview);
+        // SelfReview stays SelfReview (one-way ratchet, no downgrade)
+        assert_eq!(
+            action,
+            PlanSubmitAction::Review {
+                depth: crate::task_phase::ReviewDepth::SelfReview,
+                gate_reason: GateReason::RemoteActionFloor,
+            }
+        );
+    }
+
+    // ── Text response decision tests (#342 regression) ────────
+
+    #[test]
+    fn test_text_response_no_replan_ends_turn() {
+        assert_eq!(decide_text_response(0, false), TextResponseAction::EndTurn);
+    }
+
+    #[test]
+    fn test_text_response_plan_approved_ends_turn() {
+        assert_eq!(
+            decide_text_response(1, true), // rejected once but then approved
+            TextResponseAction::EndTurn
+        );
+    }
+
+    #[test]
+    fn test_text_response_replan_pending_nudges() {
+        assert_eq!(
+            decide_text_response(1, false),
+            TextResponseAction::NudgeReplan { attempt: 1 }
+        );
+        assert_eq!(
+            decide_text_response(2, false),
+            TextResponseAction::NudgeReplan { attempt: 2 }
+        );
+    }
+
+    #[test]
+    fn test_text_response_replan_budget_exhausted_ends_turn() {
+        // re_plan_count > 2 means budget exhausted
+        assert_eq!(decide_text_response(3, false), TextResponseAction::EndTurn);
     }
 }


### PR DESCRIPTION
## Fixes #342 (third attempt — correct root cause this time)

### The actual bug

After `fast_path` approval, the model received **zero feedback**. The reviewed path (`self_review`/`peer_review`) injects `✅ Review passed: ...` into the conversation, but fast_path just called `approve_plan()` silently.

The model had no idea its `submit_plan` call was processed. So it:
1. Submitted the same plan again (approved silently again)
2. Submitted it a third time, or gave up with empty response
3. User saw: `⚠ Model produced an empty response after tool use`

### Fix 1: fast_path feedback
After fast_path approval, inject:
```
Plan approved (fast_path). Proceed to execute the plan. Goal: <goal>
```

### Fix 2: duplicate plan dedup
If `plan_approved` is already true when a new `SubmitPlan` arrives, skip it:
```
Plan already approved — ignoring duplicate SubmitPlan. Proceed with execution.
```

### Why the previous fixes didn't catch this
- **#343** added visibility (plan detail, model names) — correct but UX-only
- **#345** added re-plan nudge when model responds with text after rejection — correct but only fires when `re_plan_count > 0`, which requires a rejection. Fast_path plans are never rejected, so `re_plan_count` stays 0.

The actual bug was upstream: the model never got told its plan was approved.

### Also created
[#346](https://github.com/lijunzh/koda/issues/346) — UX: better feedback when tools are blocked by safe mode (separate issue)

502 lib tests. clippy clean.