### PR TITLE
fix: Read unchanged hint + Edit diff coloring (#348, #350)

### DIFF
--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -341,6 +341,7 @@ fn render_tool_output(
 
     // Syntax highlighting for Read tool output
     let use_highlight = name == "Read" && file_ext.is_some();
+    let is_diff_tool = matches!(name, "Edit" | "Write" | "Delete");
     let mut highlighter = if use_highlight {
         Some(crate::highlight::CodeHighlighter::new(file_ext.unwrap()))
     } else {
@@ -357,6 +358,30 @@ fn render_tool_output(
                 let mut spans = vec![Span::styled("  \u{2502} ", DIM)];
                 spans.extend(h.highlight_spans(line));
                 tui_output::emit_line(terminal, Line::from(spans));
+            } else if is_diff_tool && line.starts_with('+') {
+                tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![
+                        Span::styled("  \u{2502} ", DIM),
+                        Span::styled(line.to_string(), Style::default().fg(Color::Green)),
+                    ]),
+                );
+            } else if is_diff_tool && line.starts_with('-') {
+                tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![
+                        Span::styled("  \u{2502} ", DIM),
+                        Span::styled(line.to_string(), Style::default().fg(Color::Red)),
+                    ]),
+                );
+            } else if is_diff_tool && line.starts_with('@') {
+                tui_output::emit_line(
+                    terminal,
+                    Line::from(vec![
+                        Span::styled("  \u{2502} ", DIM),
+                        Span::styled(line.to_string(), Style::default().fg(Color::Cyan)),
+                    ]),
+                );
             } else {
                 tui_output::emit_line(
                     terminal,

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -169,7 +169,9 @@ pub async fn read_file(
             && cached_mtime == mtime
         {
             return Ok(format!(
-                "[File '{}' is unchanged since last read. Full content is already in your conversation history.]",
+                "[File '{}' is unchanged since last read. Full content is already in \
+                 your conversation history. To read a specific section, use the \
+                 start_line and num_lines parameters instead of re-reading the whole file.]",
                 path_str
             ));
         }


### PR DESCRIPTION
## Fixes #348, #350

### #348: Read tool's 'unchanged' message doesn't mention line-range params

**Before:**
```
[File 'task_phase.rs' is unchanged since last read. Full content is already in your conversation history.]
```
Model uses `cat -n | sed` via Bash to work around it.

**After:**
```
[File 'task_phase.rs' is unchanged since last read. ...To read a specific section, use the start_line and num_lines parameters instead of re-reading the whole file.]
```
Model uses `Read(file, start_line=370, num_lines=40)` instead.

### #350: Edit diffs have no color

**Before:** All diff lines are plain white — hard to scan.

**After:**
- `+` lines → green
- `-` lines → red
- `@` hunk headers → cyan

Applied to Edit, Write, and Delete tool outputs.

511 lib tests. clippy clean.