### PR TITLE
fix: detect max_tokens truncation vs model giving up (#342)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -997,7 +997,20 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 crate::review::TextResponseAction::EndTurn => {}
             }
 
-            if made_tool_calls && full_text.trim().is_empty() {
+            // Detect why the model stopped
+            if usage.stop_reason == "max_tokens" {
+                // Model was truncated — it didn't finish, it ran out of output tokens
+                sink.emit(EngineEvent::Warn {
+                    message: format!(
+                        "Model {} hit max_tokens limit — response was truncated. \
+                         The context may be too large. Try /compact or start a new session.",
+                        config.model,
+                    ),
+                });
+                // Don't end the turn — continue so the model can try again
+                // with the truncated response in context
+                continue;
+            } else if made_tool_calls && full_text.trim().is_empty() {
                 sink.emit(EngineEvent::Warn {
                     message: format!(
                         "Model {} produced an empty response after tool use — \

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -271,6 +271,9 @@ struct StreamDelta {
     thinking: Option<String>,
     #[serde(default)]
     partial_json: Option<String>,
+    /// Present on message_delta events: "end_turn", "max_tokens", "stop_sequence"
+    #[serde(default)]
+    stop_reason: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -613,9 +616,14 @@ impl LlmProvider for AnthropicProvider {
                             }
                         }
                         "message_delta" => {
-                            // Final usage info
+                            // Final usage info + stop reason
                             if let Some(u) = event.usage {
                                 final_usage.completion_tokens = u.output_tokens;
+                            }
+                            if let Some(delta) = &event.delta
+                                && let Some(reason) = &delta.stop_reason
+                            {
+                                final_usage.stop_reason = reason.clone();
                             }
                         }
                         "message_start" => {

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -186,6 +186,9 @@ struct GenerateResponse {
 #[derive(Deserialize)]
 struct Candidate {
     content: Option<CandidateContent>,
+    /// "STOP", "MAX_TOKENS", "SAFETY", "RECITATION", etc.
+    #[serde(default, rename = "finishReason")]
+    finish_reason: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -458,9 +461,14 @@ impl LlmProvider for GeminiProvider {
                         usage.log_cache_stats();
                     }
 
-                    // Extract content parts
+                    // Extract content parts + finish reason
                     if let Some(candidates) = &event.candidates {
                         for candidate in candidates {
+                            // Capture finish reason (last one wins)
+                            if let Some(reason) = &candidate.finish_reason {
+                                // Gemini uses "MAX_TOKENS", normalize to lowercase
+                                final_usage.stop_reason = reason.to_lowercase();
+                            }
                             if let Some(content) = &candidate.content
                                 && let Some(parts) = &content.parts
                             {
@@ -866,6 +874,7 @@ mod tests {
         let p = make_provider();
         let resp = GenerateResponse {
             candidates: Some(vec![Candidate {
+                finish_reason: None,
                 content: Some(CandidateContent {
                     parts: Some(vec![ResponsePart {
                         text: Some("Hello!".into()),
@@ -894,6 +903,7 @@ mod tests {
         let p = make_provider();
         let resp = GenerateResponse {
             candidates: Some(vec![Candidate {
+                finish_reason: None,
                 content: Some(CandidateContent {
                     parts: Some(vec![ResponsePart {
                         text: None,
@@ -919,6 +929,7 @@ mod tests {
         let p = make_provider();
         let resp = GenerateResponse {
             candidates: Some(vec![Candidate {
+                finish_reason: None,
                 content: Some(CandidateContent {
                     parts: Some(vec![
                         ResponsePart {

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -37,6 +37,9 @@ pub struct TokenUsage {
     pub cache_creation_tokens: i64,
     /// Tokens used for reasoning/thinking (e.g. OpenAI reasoning_tokens, Anthropic thinking).
     pub thinking_tokens: i64,
+    /// Why the model stopped: "end_turn", "max_tokens", "stop_sequence", etc.
+    /// Empty string means unknown (provider didn't report it).
+    pub stop_reason: String,
 }
 
 /// The LLM's response: either text, tool calls, or both.

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -135,7 +135,6 @@ struct StreamChatResponse {
 #[derive(Deserialize)]
 struct StreamChoice {
     delta: StreamDelta,
-    #[allow(dead_code)]
     finish_reason: Option<String>,
 }
 
@@ -403,6 +402,16 @@ impl LlmProvider for OpenAiCompatProvider {
                     }
 
                     for choice in &chunk.choices {
+                        // Capture finish_reason ("stop", "length", "tool_calls", etc.)
+                        if let Some(reason) = &choice.finish_reason {
+                            // OpenAI uses "length" for max_tokens, normalize
+                            final_usage.stop_reason = if reason == "length" {
+                                "max_tokens".to_string()
+                            } else {
+                                reason.clone()
+                            };
+                        }
+
                         // Reasoning content (o1/o3/o4-mini)
                         if let Some(reasoning) = &choice.delta.reasoning_content
                             && !reasoning.is_empty()


### PR DESCRIPTION
## Part of #342

### The real problem

Even **Claude Opus** produces 'empty response after tool use' when the context gets large (reading multiple big files like review.rs + task_phase.rs + intervention_observer.rs). The model isn't giving up — it's being **truncated** by max_tokens. But we couldn't tell the difference.

### Fix

1. **`TokenUsage.stop_reason`** — new field: `"end_turn"`, `"max_tokens"`, `"stop_sequence"`, or empty (unknown)
2. **Anthropic streaming** — captures `stop_reason` from `message_delta` event
3. **Inference loop** — distinguishes the two cases:
   - `max_tokens` → warn about context size, suggest `/compact`, **continue the loop** (auto-retry)
   - Empty response + `end_turn` → warn about model capability, suggest `/model` (end turn)

### Before
```
⚠ Model claude-opus-4-6 produced an empty response after tool use — it may have exceeded its capability for this task.
```

### After (if truncated)
```
⚠ Model claude-opus-4-6 hit max_tokens limit — response was truncated. The context may be too large. Try /compact or start a new session.
```
And the loop **continues** instead of ending.

511 lib tests. clippy clean.