### PR TITLE
fix: /provider re-prompts for saved API keys (#356) + parallel tool display (#353)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,34 +27,25 @@ Koda adapts behavior based on observed model quality:
   - Fallback: `model_context.rs` lookup table
 - **DiscoverTools** (`tools/discover.rs`): on-demand tool schema injection by category
 - **RecallContext** (`tools/recall.rs`): search/recall older conversation turns
-- **Intent classifier** (`intent.rs`): rule-based task routing to agents/skills
 - **Rate limit retry**: exponential backoff (2/4/8/16/32s) for 429 errors
 - **Built-in agents**: default, testgen, releaser, scout, planner, verifier
 
-### v0.1.4 Architecture (Phase-Gated Safety)
+### v0.1.4 Architecture (Simplified Safety)
 
-Koda tracks agent process via a six-phase state machine:
+Approval is per-tool, not per-phase. Three modes (Auto/Strict/Safe) control
+how mutations are gated:
 
-- **PhaseTracker** (`task_phase.rs`): Understanding → Planning → Reviewing → Executing → Verifying → Reporting
-  - Structural detection: `(current_phase, has_tool_calls, tool_type)` decision tree
-  - `PhaseTransition` records: from, to, trigger label
-  - Escalation: Executing → Understanding on tool failure
-  - 封驳 (rejection): Reviewing → Planning on review failure
-- **Phase-aware approval** (`approval.rs`): `check_tool()` consults `PhaseInfo`
-  - Understanding/Planning: writes need confirmation in Auto mode
-  - Executing + plan_approved: writes auto-approved
-  - Destructive ops + outside-project writes: hardcoded NeedsConfirmation floor
-- **Role::Phase** (`db.rs`): phase transitions logged as messages
-  - Line 1: human-readable summary (LLM sees for self-awareness)
-  - Line 2: JSON metadata (InterventionObserver parses)
-- **InterventionObserver** (`intervention_observer.rs`): per-phase autonomy learning
-  - Records auto/override data points at phase gates
-  - Persists to `~/.config/koda/intervention_priors.json`
-  - Not yet wired into inference loop (data structure + persistence only)
+- **ToolEffect** (`approval.rs`): ReadOnly / LocalMutation / Destructive / RemoteAction
+  - Auto: local mutations auto-approved, destructive/remote need confirmation
+  - Strict: everything needs confirmation
+  - Safe: all mutations blocked
+- **Hardcoded floors**: destructive ops and outside-project writes always need
+  confirmation regardless of mode
 - **Folder scoping** (`approval.rs`, `bash_safety.rs`):
   - `is_outside_project()`: checks file tool paths against project_root
   - `lint_bash_paths()`: heuristic bash command analysis for cd/path escapes
   - Startup warning when project_root == $HOME
+- **Model probe** (`model_probe.rs`): one-time structured output test at session start
 
 ## Documentation Rules
 
@@ -112,8 +103,6 @@ koda/
 │   │   ├── model_context.rs# Model → context window size lookup table (fallback)
 │   │   ├── model_tier.rs   # ModelTier enum (Strong/Standard/Lite) prompt strategies
 │   │   ├── tier_observer.rs# Runtime tier promotion/demotion based on tool-use quality
-│   │   ├── intent.rs       # Rule-based intent classifier (task → agent/skill)
-│   │   ├── task_phase.rs   # Task phase state machine (Understanding→Verifying)
 │   │   ├── preview.rs      # Pre-confirmation diff previews for Edit/Write
 │   │   ├── runtime_env.rs  # Thread-safe runtime env for API keys
 │   │   ├── version.rs      # Background version checker (queries crates.io)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,22 +19,23 @@ autonomy accordingly. Configuration is a confession that the system can't figure
 it out — a personal AI tool should learn how you work by working with you.
 
 This principle drives several architectural choices:
-- `InterventionObserver` ([#242](https://github.com/lijunzh/koda/issues/242))
-  learns human oversight preferences from phase-gate override patterns.
+- Approval modes (auto/strict/safe) are the only user-facing setting
 - No `DepthMode` enum or `--autonomy` flag — autonomy is a continuous variable
-  that emerges from data, not a discrete setting the user picks.
+  that should emerge from data, not a discrete setting the user picks
+- The v0.1.4 `InterventionObserver` was an attempt at this but was removed
+  in #355 due to insufficient data — the cold-start problem was never solved
 
-**Control the information environment, not the model's behavior.** Koda's value
-in the OPAR loop isn't telling the model *what* to think. It's controlling what
-the model can **see**. This is what separates an orchestrator from a prompt
-wrapper. Phase boundaries are valuable because they are **context boundaries**,
-not instruction boundaries. A reviewer that can't see the planner's reasoning
-chain is a meaningfully different reviewer, even if it's the same weights.
+**Don’t reimplement what the model does.** The LLM’s extended thinking IS the
+planning. The tool results ARE the verification. Koda’s inference loop is
+simple: prompt → stream (thinking + tool calls) → execute tools → repeat.
+The v0.1.4 phase system attempted to formalize this loop in application code
+and was removed in [#355](https://github.com/lijunzh/koda/pull/355) after
+proving that it reimplemented what the model already does, but worse.
+See [#216 post-mortem](https://github.com/lijunzh/koda/issues/216#issuecomment-4035670832).
 
-This principle drives the `ReviewDepth` tiers ([#335](https://github.com/lijunzh/koda/issues/335)):
-- `FastPath`: no boundary — model's own deep thinking IS the review.
-- `SelfReview`: context wall — same model, fresh context window.
-- `PeerReview`: model wall — different model, fresh context window.
+**Gate at the action, not the plan.** Review individual destructive operations
+(`ToolEffect::Destructive` → `NeedsConfirmation`), not entire plans. Per-tool
+approval is cheaper, more precise, and doesn’t fight the model’s natural flow.
 
 ## Execution Modes
 
@@ -314,52 +315,28 @@ is help. Keyboard shortcuts moved to the startup banner header.
 
 **Implementation**: [#229](https://github.com/lijunzh/koda/pull/229)
 
-### 16. Adaptive Phase-Gated Agent Loop (v0.1.4)
+### 16. ~~Adaptive Phase-Gated Agent Loop~~ (v0.1.4 — RETIRED in #355)
 
-**Decision**: Koda tracks a six-phase state machine per conversation turn:
-Understanding → Planning → Reviewing → Executing → Verifying → Reporting.
-Phase transitions are detected structurally from tool-use signals, not by
-parsing LLM text output.
+**Decision**: RETIRED. The six-phase state machine (Understanding → Planning →
+Reviewing → Executing → Verifying → Reporting) was fully implemented and then
+stripped in [#355](https://github.com/lijunzh/koda/pull/355) (-4,308 lines).
 
-**Design reference**: [#216](https://github.com/lijunzh/koda/issues/216)
-(original OPAR design), [#242](https://github.com/lijunzh/koda/issues/242)
-(implementation plan with Tang Dynasty bureaucracy mapping).
+**Why it was removed**: Formal plan submission cost ~500 tokens/turn in schema
+overhead. SelfReview re-sent the entire context for the same model to review
+its own output. Strong models plan naturally; weak models couldn’t follow the
+protocol. The state machine became the primary source of bugs (7 PRs to fix
+one bug, #342). See [#216 post-mortem](https://github.com/lijunzh/koda/issues/216#issuecomment-4035670832).
 
-**Key components**:
-- `PhaseTracker` (`task_phase.rs`): state machine with `advance(signal)` that
-  returns `Option<PhaseTransition>` on phase change. Decision tree uses
-  `(current_phase, has_tool_calls, tool_type)` — no LLM output parsing.
-- `PhaseInfo`: snapshot of tracker state passed to `check_tool()` for
-  phase-aware approval decisions.
-- `Role::Phase` messages: phase transitions logged to the DB as structured
-  messages. Human-readable summary + JSON metadata. The LLM sees these for
-  process self-awareness; the InterventionObserver parses the metadata.
-- `InterventionObserver`: per-phase override frequency tracker. Learns from
-  auto/override data points at phase gates. Not yet wired into the inference
-  loop — data structure and persistence only in v0.1.4.
+**What survived**: Per-tool safety gates (`ToolEffect` → `check_tool()`),
+folder-scoped permissions (§17), and the principle that the LLM’s extended
+thinking IS the planning.
 
-**Phase-aware approval** (`check_tool()`):
-- Understanding/Planning: writes require confirmation even in Auto mode
-  (the agent hasn't formed a plan yet)
-- Reviewing: writes blocked (forced through the review gate)
-- Executing with `plan_approved`: writes auto-approved
-- Destructive operations: hardcoded floor regardless of phase
-
-**Escalation and rejection**:
-- Executing → Understanding ("escalation"): tool failure suggests scope
-  changed (e.g., merge conflict). Explicit, logged transition.
-- Reviewing → Planning ("封驳"): LLM self-reflection or human review finds
-  the plan unsound.
-
-**Philosophy**: The process adapts to the task, not the other way around.
-Simple tasks shortcut (Understanding → Executing). Complex tasks get full
-six-phase progression. The human's level of involvement is learned, not
-configured. See Design Principles above.
+**Archive**: Tag `v0.1.4-phase-system` preserves the full implementation.
 
 ### 17. Folder-Scoped Permissions (v0.1.4)
 
 **Decision**: Writes outside `project_root` always require explicit
-confirmation, regardless of approval mode or phase. Bash commands are
+confirmation, regardless of approval mode. Bash commands are
 linted for path escapes before execution.
 
 **Design reference**: [#218](https://github.com/lijunzh/koda/issues/218)
@@ -384,56 +361,14 @@ The concern is accidental blast radius, not targeted attacks. The lint catches
 common accidental escapes; OS-level sandboxing (seccomp/landlock) is a v1.0
 concern.
 
-### 18. Review Depth as Isolation Boundaries (v0.1.4)
+### 18. ~~Review Depth as Isolation Boundaries~~ (v0.1.4 — RETIRED in #355)
 
-**Decision**: `ReviewDepth` tiers are defined by **isolation boundaries**, not
-review intensity. Each tier adds exactly one isolation dimension.
+**Decision**: RETIRED along with the phase system in [#355](https://github.com/lijunzh/koda/pull/355).
+The concept of asymmetric model collaboration (weak model asks questions,
+strong model answers) remains valuable and may return as a standalone
+`/review` command ([#256](https://github.com/lijua/issues/256)).
 
-**Design reference**: [#335](https://github.com/lijunzh/koda/issues/335)
-(full design doc), [#216](https://github.com/lijunzh/koda/issues/216)
-(original OPAR design).
-
-| Tier | Model | Context | Analogy |
-|------|-------|---------|--------|
-| `FastPath` | Same | Same | Thinking harder about your own essay |
-| `SelfReview` | Same | **Fresh** | Reading your essay after sleeping on it |
-| `PeerReview` | **Different** | Fresh | Handing it to a colleague |
-
-**The core insight**: Koda's value in the OPAR loop isn't telling the model
-*what* to think. It's controlling what the model can **see**. The review phase
-boundary is valuable because it's a **context boundary**, not an instruction
-boundary. A reviewer that can't see the planner's reasoning chain is a
-meaningfully different reviewer, even if it's the same weights.
-
-**FastPath**: The model's extended thinking (Opus, o3) IS the review. One
-inference call. Koda does nothing extra. This is where "deep think" happens —
-the model plans, critiques, revises, and emits internally.
-
-**SelfReview**: Koda serializes the plan, strips the conversation history,
-and makes a second inference call with only: reviewer system prompt + original
-task + plan artifact + file summaries. The reviewer sees the plan as an
-external artifact and cannot trace back through the reasoning that produced it.
-Breaks self-confirmation bias at near-zero cost.
-
-**PeerReview**: Same fresh context as SelfReview, routed to a different
-model/provider. Different training data = different blind spots. The prompt
-frames the reviewer as adversarial and adds a 5th review dimension:
-**Alternatives** — "Is there a simpler approach the planner missed?"
-
-**Trigger selection** (`select_review_depth()`):
-- `InterventionObserver` recommends auto → FastPath
-- Simple task (shortcutted Understanding → Executing) → FastPath
-- Complex intent with full progression → PeerReview
-- Default → SelfReview
-
-**One-way ratchet**: The agent can escalate review depth (FastPath →
-SelfReview → PeerReview) but never de-escalate without user consent.
-Destructive operations promote to PeerReview regardless of learned behavior.
-Safety floors are not overridable by `InterventionObserver`.
-
-**Implementation status**: Semantic contract and prompt framing shipped in
-v0.1.4 ([#334](https://github.com/lijunzh/koda/pull/334)). Inference-level
-plumbing (fresh context window, secondary provider routing) is future work.
+**Archive**: Tag `v0.1.4-phase-system` preserves the full implementation.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ echo "explain this" | koda        # Piped input
 - **Lazy tool loading** — Strong models get 9 core tools; discover more on demand via `DiscoverTools`
 - **Smart context** — queries context window from provider API at startup (falls back to lookup table), rate limit retry with backoff, auto-compact
 - **Approval modes** — auto (default) / strict (confirm writes) / safe (read-only) via `Shift+Tab`
-- **Phase-aware gating** — six-phase state machine (Understanding → Executing → Verifying) gates write approval based on where the agent is in its process
+- **Per-tool safety gates** — destructive ops and outside-project writes always need confirmation; local mutations auto-approved in auto mode
 - **Folder-scoped permissions** — writes outside `project_root` always require confirmation; bash commands with path escapes are flagged
-- **Learned autonomy** — `InterventionObserver` tracks human override patterns at phase gates and adapts autonomy over time
 - **Diff preview** — see exactly what changes before approving Edit, Write, Delete
 - **Loop detection** — catches repeated tool calls with configurable iteration caps
 - **Parallel execution** — concurrent tool calls and sub-agent orchestration

--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -1191,22 +1191,63 @@ impl TuiContext {
                                                 let provider_name = item.name.to_string();
 
                                                 if ptype.requires_api_key() {
-                                                    // Start wizard: need API key
                                                     let env_name = ptype.env_key_name().to_string();
-                                                    self.menu = MenuContent::WizardTrail(vec![
-                                                        ("Provider".into(), provider_name),
-                                                    ]);
-                                                    self.prompt_mode = PromptMode::WizardInput {
-                                                        label: format!("API key for {}", ptype),
-                                                        masked: true,
-                                                    };
-                                                    self.provider_wizard = Some(ProviderWizard::NeedApiKey {
-                                                        provider_type: ptype,
-                                                        base_url,
-                                                        env_name,
-                                                    });
-                                                    self.textarea.select_all();
-                                                    self.textarea.cut();
+                                                    // Check if key already exists — skip wizard
+                                                    if koda_core::runtime_env::is_set(&env_name) {
+                                                        self.config.provider_type = ptype.clone();
+                                                        self.config.base_url = base_url;
+                                                        self.config.model = ptype.default_model().to_string();
+                                                        self.config.model_settings.model =
+                                                            self.config.model.clone();
+                                                        self.config.recalculate_model_derived();
+                                                        *self.provider.write().await =
+                                                            koda_core::providers::create_provider(&self.config);
+                                                        crate::tui_wizards::save_provider(&self.config);
+                                                        let prov = self.provider.read().await;
+                                                        if let Ok(models) = prov.list_models().await {
+                                                            if let Some(first) = models.first() {
+                                                                self.config.model = first.id.clone();
+                                                                self.config.model_settings.model =
+                                                                    self.config.model.clone();
+                                                                self.config.recalculate_model_derived();
+                                                            }
+                                                            self.config
+                                                                .query_and_apply_capabilities(prov.as_ref())
+                                                                .await;
+                                                            self.completer.set_model_names(
+                                                                models.iter().map(|m| m.id.clone()).collect(),
+                                                            );
+                                                        }
+                                                        self.renderer.model = self.config.model.clone();
+                                                        self.menu = MenuContent::None;
+                                                        self.prompt_mode = PromptMode::Chat;
+                                                        emit_above(
+                                                            &mut self.terminal,
+                                                            Line::styled(
+                                                                format!(
+                                                                    "  \u{2714} Provider: {} ({})",
+                                                                    self.config.provider_type, self.config.model
+                                                                ),
+                                                                Style::default().fg(Color::Green),
+                                                            ),
+                                                        );
+                                                    } else {
+                                                        // No key — start wizard
+                                                        self.menu = MenuContent::WizardTrail(vec![
+                                                            ("Provider".into(), provider_name),
+                                                        ]);
+                                                        self.prompt_mode = PromptMode::WizardInput {
+                                                            label: format!("API key for {}", ptype),
+                                                            masked: true,
+                                                        };
+                                                        self.provider_wizard = Some(ProviderWizard::NeedApiKey {
+                                                            provider_type: ptype,
+                                                            base_url,
+                                                            env_name,
+                                                        });
+                                                        self.textarea.select_all();
+                                                        self.textarea.cut();
+                                                    }
                                                 } else {
                                                     // Local self.provider: need URL
                                                     self.menu = MenuContent::WizardTrail(vec![

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -339,6 +339,11 @@ fn render_tool_output(
         return;
     }
 
+    // Collapse consecutive blank lines (3+ → 1) to reduce visual noise,
+    // especially from WebFetch HTML-to-text conversion.
+    let collapsed = collapse_blank_lines(output);
+    let output = &collapsed;
+
     // Syntax highlighting for Read tool output
     let use_highlight = name == "Read" && file_ext.is_some();
     let is_diff_tool = matches!(name, "Edit" | "Write" | "Delete");
@@ -430,6 +435,31 @@ fn render_tool_output(
     }
 }
 
+/// Collapse runs of consecutive blank lines down to at most 1.
+///
+/// WebFetch HTML-to-text conversion often produces dozens of empty lines
+/// from page footers, nav elements, etc. This keeps output scannable
+/// without losing meaningful whitespace (single blank lines are preserved).
+fn collapse_blank_lines(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut consecutive_blanks = 0u32;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            consecutive_blanks += 1;
+            if consecutive_blanks <= 1 {
+                result.push('\n');
+            }
+        } else {
+            consecutive_blanks = 0;
+            if !result.is_empty() {
+                result.push('\n');
+            }
+            result.push_str(line);
+        }
+    }
+    result
+}
+
 /// Render a single list entry with directory/file coloring.
 ///
 /// List output format: `d path/to/dir` (directory) or `  path/to/file` (file).
@@ -503,5 +533,30 @@ fn render_grep_line(terminal: &mut Term, line: &str) {
                 Span::raw(line.to_string()),
             ]),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collapse_preserves_single_blank() {
+        assert_eq!(collapse_blank_lines("a\n\nb"), "a\n\nb");
+    }
+
+    #[test]
+    fn test_collapse_many_blanks() {
+        assert_eq!(collapse_blank_lines("a\n\n\n\n\nb"), "a\n\nb");
+    }
+
+    #[test]
+    fn test_collapse_no_blanks() {
+        assert_eq!(collapse_blank_lines("a\nb\nc"), "a\nb\nc");
+    }
+
+    #[test]
+    fn test_collapse_all_blank() {
+        assert_eq!(collapse_blank_lines("\n\n\n\n"), "\n");
     }
 }

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -266,10 +266,18 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
             } else {
                 project_root.join(requested)
             };
-            // Try canonicalize (follows symlinks, resolves ..).
-            // Falls back to lexical clean for new files that don't exist yet.
-            let resolved = abs_path.canonicalize().unwrap_or_else(|_| abs_path.clean());
-            // Also canonicalize project_root for consistent comparison
+            // Canonicalize for symlink resolution (macOS /var → /private/var).
+            // For new files, canonicalize the parent dir and append the filename.
+            let resolved = abs_path.canonicalize().unwrap_or_else(|_| {
+                if let Some(parent) = abs_path.parent() {
+                    if let Ok(canon_parent) = parent.canonicalize() {
+                        if let Some(name) = abs_path.file_name() {
+                            return canon_parent.join(name);
+                        }
+                    }
+                }
+                abs_path.clean()
+            });
             let canon_root = project_root
                 .canonicalize()
                 .unwrap_or_else(|_| project_root.to_path_buf());

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -237,7 +237,6 @@ fn resolve_effect(tool_name: &str, args: &serde_json::Value) -> ToolEffect {
     base
 }
 
-/// Phase-aware gating for Auto mode.
 /// Extract the file path that a write tool targets.
 fn extract_write_path<'a>(tool_name: &str, args: &'a serde_json::Value) -> Option<&'a str> {
     match tool_name {
@@ -250,7 +249,7 @@ fn extract_write_path<'a>(tool_name: &str, args: &'a serde_json::Value) -> Optio
 }
 
 /// Whether a file tool targets a path outside the project root (#218).
-/// Hardcoded floor: always NeedsConfirmation regardless of mode or phase.
+/// Hardcoded floor: always NeedsConfirmation regardless of mode.
 fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> bool {
     let path_arg = match tool_name {
         "Write" | "Edit" | "Delete" => args
@@ -371,8 +370,7 @@ mod tests {
 
     #[test]
     fn test_auto_approves_non_destructive_in_executing() {
-        // In Auto mode during Executing with plan_approved, non-destructive
-        // mutating tools are auto-approved.
+        // In Auto mode, non-destructive mutating tools are auto-approved.
         for tool in ["Write", "Edit", "Bash", "WebFetch"] {
             assert_eq!(
                 check_tool(

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -269,12 +269,11 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
             // Canonicalize for symlink resolution (macOS /var → /private/var).
             // For new files, canonicalize the parent dir and append the filename.
             let resolved = abs_path.canonicalize().unwrap_or_else(|_| {
-                if let Some(parent) = abs_path.parent() {
-                    if let Ok(canon_parent) = parent.canonicalize() {
-                        if let Some(name) = abs_path.file_name() {
-                            return canon_parent.join(name);
-                        }
-                    }
+                if let Some(parent) = abs_path.parent()
+                    && let Ok(canon_parent) = parent.canonicalize()
+                    && let Some(name) = abs_path.file_name()
+                {
+                    return canon_parent.join(name);
                 }
                 abs_path.clean()
             });

--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -306,15 +306,7 @@ impl Persistence for Database {
             // - Old assistant text: moderate truncation (1000 chars)
             // - User messages: keep full (they're the source of intent)
             if idx >= recency_threshold {
-                if msg.role == Role::Phase {
-                    // Phase messages: keep only the human-readable summary when old.
-                    // Strip the JSON metadata to save tokens.
-                    if let Some(ref content) = msg.content
-                        && let Some(nl) = content.find('\n')
-                    {
-                        msg.content = Some(content[..nl].to_string());
-                    }
-                } else if msg.role == Role::Tool
+                if msg.role == Role::Tool
                     && let Some(ref content) = msg.content
                     && content.len() > 200
                 {

--- a/koda-core/src/model_probe.rs
+++ b/koda-core/src/model_probe.rs
@@ -12,10 +12,10 @@ use std::path::PathBuf;
 
 /// The probe prompt — tests structured JSON output + instruction following.
 const PROBE_PROMPT: &str = r#"You are being tested. Respond with ONLY this JSON, no other text:
-{"phase": "Understanding", "tool": "Read", "reasoning": "need to explore first"}"#;
+{"action": "read_file", "target": "src/main.rs", "reasoning": "need to explore first"}"#;
 
 /// Expected keys in the probe response.
-const EXPECTED_KEYS: &[&str] = &["phase", "tool", "reasoning"];
+const EXPECTED_KEYS: &[&str] = &["action", "target", "reasoning"];
 
 /// Run the capability probe for a model.
 ///
@@ -122,32 +122,33 @@ mod tests {
 
     #[test]
     fn test_valid_response() {
-        let response = r#"{"phase": "Understanding", "tool": "Read", "reasoning": "exploring"}"#;
+        let response =
+            r#"{"action": "read_file", "target": "src/main.rs", "reasoning": "exploring"}"#;
         assert!(validate_probe_response(response).is_ok());
     }
 
     #[test]
     fn test_valid_response_with_code_fence() {
-        let response = "```json\n{\"phase\": \"Understanding\", \"tool\": \"Read\", \"reasoning\": \"exploring\"}\n```";
+        let response = "```json\n{\"action\": \"read_file\", \"target\": \"src/main.rs\", \"reasoning\": \"exploring\"}\n```";
         assert!(validate_probe_response(response).is_ok());
     }
 
     #[test]
     fn test_invalid_not_json() {
-        let response = "Sure! Here is the JSON: {phase: Understanding}";
+        let response = "Sure! Here is the JSON: {action: read_file}";
         assert!(validate_probe_response(response).is_err());
     }
 
     #[test]
     fn test_invalid_missing_key() {
-        let response = r#"{"phase": "Understanding", "tool": "Read"}"#;
+        let response = r#"{"action": "read_file", "target": "src/main.rs"}"#;
         let err = validate_probe_response(response).unwrap_err();
         assert!(err.contains("reasoning"));
     }
 
     #[test]
     fn test_invalid_not_object() {
-        let response = r#"["phase", "Understanding"]"#;
+        let response = r#"["action", "read_file"]"#;
         assert!(validate_probe_response(response).is_err());
     }
 

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -16,8 +16,6 @@ pub enum Role {
     User,
     Assistant,
     Tool,
-    /// Phase transition log entry.
-    Phase,
 }
 
 impl Role {
@@ -27,7 +25,6 @@ impl Role {
             Self::User => "user",
             Self::Assistant => "assistant",
             Self::Tool => "tool",
-            Self::Phase => "phase",
         }
     }
 }
@@ -46,7 +43,6 @@ impl std::str::FromStr for Role {
             "user" => Ok(Self::User),
             "assistant" => Ok(Self::Assistant),
             "tool" => Ok(Self::Tool),
-            "phase" => Ok(Self::Phase),
             other => Err(format!("unknown role: {other}")),
         }
     }

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -676,11 +676,6 @@ impl AnthropicProvider {
                 continue;
             }
 
-            // Skip internal metadata roles (phase transitions, etc.)
-            if msg.role == "phase" {
-                continue;
-            }
-
             if msg.role == "tool" {
                 // Tool results need to be wrapped in a content block
                 let tool_use_id = msg.tool_call_id.clone().unwrap_or_default();

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -533,12 +533,6 @@ impl GeminiProvider {
                 continue;
             }
 
-            // Skip internal metadata roles (phase transitions, etc.)
-            // Gemini only accepts "user" and "model" as content roles.
-            if msg.role == "phase" {
-                continue;
-            }
-
             let role = match msg.role.as_str() {
                 "assistant" => "model",
                 "tool" => "function",

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -173,7 +173,6 @@ impl OpenAiCompatProvider {
     ) -> ChatRequest {
         let api_messages: Vec<ApiMessage> = messages
             .iter()
-            .filter(|m| m.role != "phase") // skip internal metadata roles
             .map(|m| {
                 // Build content: if images are attached, use multi-part array format
                 let content = if let Some(images) = &m.images {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -91,7 +91,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
 /// Returns true if the tool performs a mutating operation.
 ///
 /// Convenience wrapper over [`classify_tool`] for call sites that only
-/// need a bool (e.g., loop guard, phase tracker).
+/// need a bool (e.g., loop guard).
 pub fn is_mutating_tool(name: &str) -> bool {
     !matches!(classify_tool(name), ToolEffect::ReadOnly)
 }


### PR DESCRIPTION
### Bug #356: /provider re-prompts for API key
The dropdown path for `/provider` always started the API key wizard, even when the key was already saved in keystore. The inline `/provider <name>` path correctly checked `is_set()` — the dropdown handler didn't.

**Fix**: Add the same `is_set()` check to the dropdown Enter handler. If key exists, switch provider immediately.

### Bug #353: Parallel tool display noise
WebFetch HTML-to-text conversion produces dozens of empty lines (page footers, nav elements). Each renders as `│ ` — creating a wall of empty bordered lines.

**Fix**: `collapse_blank_lines()` squashes runs of consecutive blank lines to at most 1 before rendering.

### Bonus: macOS symlink false positive
`is_outside_project()` flagged new-file writes in temp dirs because `/var` → `/private/var` symlink caused path mismatch. Fixed by canonicalizing the parent directory for files that don't exist yet.

This also fixes the pre-existing `test_write_tool_creates_file_in_sandbox` E2E test failure.

Closes #353, closes #356