### PR TITLE
test: SSE parser tests, fix dispatch tests, session lifecycle + shell timeout (#384 #385 #386)

### DIFF
--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod acp_adapter;
+pub mod repl;

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -17,11 +17,10 @@ mod repl_commands {
             .build()
             .unwrap();
         let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
-        let provider: Arc<RwLock<Box<dyn koda_core::providers::LlmProvider>>> = Arc::new(
-            RwLock::new(Box::new(MockProvider::new(vec![MockResponse::Text(
-                String::new(),
-            )]))),
-        );
+        let provider: Arc<RwLock<Box<dyn koda_core::providers::LlmProvider>>> =
+            Arc::new(RwLock::new(Box::new(MockProvider::new(vec![
+                MockResponse::Text(String::new()),
+            ]))));
         rt.block_on(handle_command(input, &config, &provider))
     }
 
@@ -143,10 +142,7 @@ mod repl_commands {
     #[test]
     fn verbose_bare_returns_toggle() {
         // No argument → None (toggle)
-        assert!(matches!(
-            dispatch("/verbose"),
-            ReplAction::Verbose(None)
-        ));
+        assert!(matches!(dispatch("/verbose"), ReplAction::Verbose(None)));
     }
 
     #[test]
@@ -197,10 +193,7 @@ mod repl_commands {
 
     #[test]
     fn mcp_with_arg_returns_mcp_command() {
-        assert!(matches!(
-            dispatch("/mcp status"),
-            ReplAction::McpCommand(_)
-        ));
+        assert!(matches!(dispatch("/mcp status"), ReplAction::McpCommand(_)));
         if let ReplAction::McpCommand(arg) = dispatch("/mcp status") {
             assert_eq!(arg, "status");
         }

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -4,82 +4,235 @@
 //! and catch regressions when commands are added/removed.
 
 mod repl_commands {
-    /// Reproduce the REPL command dispatch logic for testing.
-    /// Maps a slash command to the action name it should produce.
-    fn dispatch(input: &str) -> &'static str {
-        let parts: Vec<&str> = input.splitn(2, ' ').collect();
-        let cmd = parts[0];
-        let arg = parts.get(1).copied().unwrap_or("");
+    use koda_cli::repl::{ReplAction, handle_command};
+    use koda_core::config::{KodaConfig, ProviderType};
+    use koda_core::providers::mock::{MockProvider, MockResponse};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
 
-        match cmd {
-            "/exit" => "Quit",
-            "/model" if !arg.is_empty() => "SwitchModel",
-            "/model" => "PickModel",
-            "/provider" if !arg.is_empty() => "SetupProvider",
-            "/provider" => "PickProvider",
-            "/help" => "ShowHelp",
-            "/cost" => "ShowCost",
-            "/diff" if !arg.is_empty() => "InjectPrompt_or_Handled",
-            "/diff" => "Handled",
-            "/sessions" if arg.starts_with("delete ") => "DeleteSession",
-            "/sessions" if arg.starts_with("resume ") => "ResumeSession",
-            "/sessions"
-                if !arg.is_empty() && arg.chars().all(|c| c.is_ascii_hexdigit() || c == '-') =>
-            {
-                "ResumeSession"
-            }
-            "/sessions" => "ListSessions",
-            "/expand" => "Expand",
-            "/verbose" => "Verbose",
-            "/memory" => "Handled",
+    /// Synchronous helper: runs `handle_command` in a single-threaded tokio runtime
+    /// with dummy config/provider values (both are unused by the dispatcher).
+    fn dispatch(input: &str) -> ReplAction {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
+        let provider: Arc<RwLock<Box<dyn koda_core::providers::LlmProvider>>> = Arc::new(
+            RwLock::new(Box::new(MockProvider::new(vec![MockResponse::Text(
+                String::new(),
+            )]))),
+        );
+        rt.block_on(handle_command(input, &config, &provider))
+    }
 
-            "/compact" => "Compact",
-            "/mcp" => "McpCommand",
-            "/agent" => "Handled",
-            _ => "NotACommand",
+    #[test]
+    fn exit_command_returns_quit() {
+        assert!(matches!(dispatch("/exit"), ReplAction::Quit));
+    }
+
+    #[test]
+    fn model_bare_returns_pick_model() {
+        assert!(matches!(dispatch("/model"), ReplAction::PickModel));
+    }
+
+    #[test]
+    fn model_with_name_returns_switch_model() {
+        assert!(matches!(
+            dispatch("/model gpt-4o"),
+            ReplAction::SwitchModel(_)
+        ));
+        // Verify the model name is carried through
+        if let ReplAction::SwitchModel(name) = dispatch("/model gpt-4o") {
+            assert_eq!(name, "gpt-4o");
         }
     }
 
     #[test]
-    fn test_key_command_is_removed() {
-        assert_eq!(dispatch("/key"), "NotACommand");
-        assert_eq!(dispatch("/key my-secret-key"), "NotACommand");
+    fn provider_bare_returns_pick_provider() {
+        assert!(matches!(dispatch("/provider"), ReplAction::PickProvider));
     }
 
     #[test]
-    fn test_all_expected_commands_dispatch() {
-        assert_eq!(dispatch("/exit"), "Quit");
-        assert_eq!(dispatch("/model"), "PickModel");
-        assert_eq!(dispatch("/model gpt-4o"), "SwitchModel");
-        assert_eq!(dispatch("/provider"), "PickProvider");
-        assert_eq!(dispatch("/provider openai"), "SetupProvider");
-        assert_eq!(dispatch("/help"), "ShowHelp");
-        assert_eq!(dispatch("/cost"), "ShowCost");
-        assert_eq!(dispatch("/diff"), "Handled");
-        assert_eq!(dispatch("/diff review"), "InjectPrompt_or_Handled");
-        assert_eq!(dispatch("/diff commit"), "InjectPrompt_or_Handled");
-        assert_eq!(dispatch("/sessions"), "ListSessions");
-        assert_eq!(dispatch("/sessions delete abc123"), "DeleteSession");
-        assert_eq!(dispatch("/sessions resume abc123"), "ResumeSession");
-        assert_eq!(dispatch("/sessions abc12345"), "ResumeSession");
-        assert_eq!(dispatch("/expand"), "Expand");
-        assert_eq!(dispatch("/verbose"), "Verbose");
-        assert_eq!(dispatch("/memory"), "Handled");
-        assert_eq!(dispatch("/memory add test"), "Handled");
-        assert_eq!(dispatch("/memory global test"), "Handled");
-
-        assert_eq!(dispatch("/compact"), "Compact");
-        assert_eq!(dispatch("/mcp"), "McpCommand");
-        assert_eq!(dispatch("/mcp status"), "McpCommand");
-        assert_eq!(dispatch("/agent"), "Handled");
+    fn provider_with_name_returns_setup_provider() {
+        assert!(matches!(
+            dispatch("/provider openai"),
+            ReplAction::SetupProvider(_, _)
+        ));
     }
 
     #[test]
-    fn test_unknown_commands_fall_through() {
-        assert_eq!(dispatch("/foo"), "NotACommand");
-        assert_eq!(dispatch("/set"), "NotACommand");
-        assert_eq!(dispatch("/config"), "NotACommand");
-        assert_eq!(dispatch("/transcript"), "NotACommand"); // removed feature
+    fn help_returns_show_help() {
+        assert!(matches!(dispatch("/help"), ReplAction::ShowHelp));
+    }
+
+    #[test]
+    fn cost_returns_show_cost() {
+        assert!(matches!(dispatch("/cost"), ReplAction::ShowCost));
+    }
+
+    #[test]
+    fn diff_bare_returns_show_diff() {
+        assert!(matches!(dispatch("/diff"), ReplAction::ShowDiff));
+    }
+
+    #[test]
+    fn diff_review_returns_inject_prompt() {
+        assert!(matches!(
+            dispatch("/diff review"),
+            ReplAction::InjectPrompt(_)
+        ));
+    }
+
+    #[test]
+    fn diff_commit_returns_inject_prompt() {
+        assert!(matches!(
+            dispatch("/diff commit"),
+            ReplAction::InjectPrompt(_)
+        ));
+    }
+
+    #[test]
+    fn sessions_bare_returns_list_sessions() {
+        assert!(matches!(dispatch("/sessions"), ReplAction::ListSessions));
+    }
+
+    #[test]
+    fn sessions_delete_returns_delete_session() {
+        assert!(matches!(
+            dispatch("/sessions delete abc123"),
+            ReplAction::DeleteSession(_)
+        ));
+        if let ReplAction::DeleteSession(id) = dispatch("/sessions delete abc123") {
+            assert_eq!(id, "abc123");
+        }
+    }
+
+    #[test]
+    fn sessions_resume_returns_resume_session() {
+        assert!(matches!(
+            dispatch("/sessions resume abc123"),
+            ReplAction::ResumeSession(_)
+        ));
+        if let ReplAction::ResumeSession(id) = dispatch("/sessions resume abc123") {
+            assert_eq!(id, "abc123");
+        }
+    }
+
+    #[test]
+    fn sessions_bare_id_returns_resume_session() {
+        // Bare hex ID shorthand: /sessions <hex-id>
+        assert!(matches!(
+            dispatch("/sessions abc12345"),
+            ReplAction::ResumeSession(_)
+        ));
+    }
+
+    #[test]
+    fn expand_returns_expand() {
+        assert!(matches!(dispatch("/expand"), ReplAction::Expand(_)));
+        // Default n=1 when no argument given
+        if let ReplAction::Expand(n) = dispatch("/expand") {
+            assert_eq!(n, 1);
+        }
+        // Explicit n
+        if let ReplAction::Expand(n) = dispatch("/expand 3") {
+            assert_eq!(n, 3);
+        }
+    }
+
+    #[test]
+    fn verbose_bare_returns_toggle() {
+        // No argument → None (toggle)
+        assert!(matches!(
+            dispatch("/verbose"),
+            ReplAction::Verbose(None)
+        ));
+    }
+
+    #[test]
+    fn verbose_on_returns_true() {
+        assert!(matches!(
+            dispatch("/verbose on"),
+            ReplAction::Verbose(Some(true))
+        ));
+    }
+
+    #[test]
+    fn verbose_off_returns_false() {
+        assert!(matches!(
+            dispatch("/verbose off"),
+            ReplAction::Verbose(Some(false))
+        ));
+    }
+
+    #[test]
+    fn memory_bare_returns_memory_command() {
+        assert!(matches!(
+            dispatch("/memory"),
+            ReplAction::MemoryCommand(None)
+        ));
+    }
+
+    #[test]
+    fn memory_with_arg_returns_memory_command_some() {
+        assert!(matches!(
+            dispatch("/memory add test"),
+            ReplAction::MemoryCommand(Some(_))
+        ));
+        assert!(matches!(
+            dispatch("/memory global test"),
+            ReplAction::MemoryCommand(Some(_))
+        ));
+    }
+
+    #[test]
+    fn compact_returns_compact() {
+        assert!(matches!(dispatch("/compact"), ReplAction::Compact));
+    }
+
+    #[test]
+    fn mcp_bare_returns_mcp_command() {
+        assert!(matches!(dispatch("/mcp"), ReplAction::McpCommand(_)));
+    }
+
+    #[test]
+    fn mcp_with_arg_returns_mcp_command() {
+        assert!(matches!(
+            dispatch("/mcp status"),
+            ReplAction::McpCommand(_)
+        ));
+        if let ReplAction::McpCommand(arg) = dispatch("/mcp status") {
+            assert_eq!(arg, "status");
+        }
+    }
+
+    #[test]
+    fn agent_returns_list_agents() {
+        assert!(matches!(dispatch("/agent"), ReplAction::ListAgents));
+    }
+
+    #[test]
+    fn undo_returns_undo() {
+        assert!(matches!(dispatch("/undo"), ReplAction::Undo));
+    }
+
+    #[test]
+    fn key_command_is_not_a_command() {
+        // /key was removed; must fall through
+        assert!(matches!(dispatch("/key"), ReplAction::NotACommand));
+        assert!(matches!(
+            dispatch("/key my-secret-key"),
+            ReplAction::NotACommand
+        ));
+    }
+
+    #[test]
+    fn unknown_commands_fall_through() {
+        assert!(matches!(dispatch("/foobar"), ReplAction::NotACommand));
+        assert!(matches!(dispatch("/foo"), ReplAction::NotACommand));
+        assert!(matches!(dispatch("/set"), ReplAction::NotACommand));
+        assert!(matches!(dispatch("/config"), ReplAction::NotACommand));
+        assert!(matches!(dispatch("/transcript"), ReplAction::NotACommand));
     }
 }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -88,3 +88,7 @@ required-features = ["test-support"]
 [[test]]
 name = "inference_recovery_test"
 required-features = ["test-support"]
+
+[[test]]
+name = "session_test"
+required-features = ["test-support"]

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -1094,7 +1094,8 @@ mod tests {
 
     #[test]
     fn stream_event_deserializes_message_start_with_usage() {
-        let json = r#"{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let json =
+            r#"{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#;
         let event: StreamEvent = serde_json::from_str(json).unwrap();
         assert_eq!(event.event_type, "message_start");
         let message = event.message.unwrap();

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -78,6 +78,15 @@ pub struct AnthropicProvider {
     api_key: String,
 }
 
+impl std::fmt::Debug for AnthropicProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicProvider")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
 impl AnthropicProvider {
     /// Build the system prompt as a cacheable content block array.
     /// The cache_control on the last block tells Anthropic to cache
@@ -1068,5 +1077,64 @@ mod tests {
         let header = beta_header(true);
         assert!(header.contains(ANTHROPIC_BETA_FEATURES));
         assert!(header.contains(EXTENDED_CONTEXT_BETA));
+    }
+
+    // ── SSE StreamEvent deserialization tests ──────────────────
+
+    #[test]
+    fn stream_event_deserializes_content_block_delta() {
+        let json = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}"#;
+        let event: StreamEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "content_block_delta");
+        assert_eq!(event.index, Some(0));
+        let delta = event.delta.unwrap();
+        assert_eq!(delta.delta_type.as_deref(), Some("text_delta"));
+        assert_eq!(delta.text.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn stream_event_deserializes_message_start_with_usage() {
+        let json = r#"{"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let event: StreamEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "message_start");
+        let message = event.message.unwrap();
+        let usage = message.usage.unwrap();
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 0);
+    }
+
+    #[test]
+    fn stream_event_deserializes_message_delta_with_stop_reason() {
+        let json = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":25}}"#;
+        let event: StreamEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.event_type, "message_delta");
+        let delta = event.delta.unwrap();
+        assert_eq!(delta.stop_reason.as_deref(), Some("end_turn"));
+        let usage = event.usage.unwrap();
+        assert_eq!(usage.output_tokens, 25);
+    }
+
+    #[test]
+    fn stream_event_unknown_type_deserializes_gracefully() {
+        let json = r#"{"type":"ping"}"#;
+        let result = serde_json::from_str::<StreamEvent>(json);
+        // Should not error — unknown event types are valid in the SSE protocol
+        assert!(result.is_ok());
+        let event = result.unwrap();
+        assert_eq!(event.event_type, "ping");
+        assert!(event.delta.is_none());
+        assert!(event.message.is_none());
+    }
+
+    #[test]
+    fn stream_event_missing_delta_field() {
+        // A content_block_delta event with no "delta" key — should parse
+        // but delta will be None (all fields have #[serde(default)])
+        let json = r#"{"type":"content_block_delta","index":0}"#;
+        let result = serde_json::from_str::<StreamEvent>(json);
+        assert!(result.is_ok());
+        let event = result.unwrap();
+        assert_eq!(event.event_type, "content_block_delta");
+        assert!(event.delta.is_none());
     }
 }

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -25,6 +25,15 @@ pub struct GeminiProvider {
     cached_content: std::sync::Mutex<Option<CachedContentState>>,
 }
 
+impl std::fmt::Debug for GeminiProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GeminiProvider")
+            .field("base_url", &self.base_url)
+            .field("api_key", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
 /// State for Gemini explicit context caching.
 #[derive(Debug, Clone)]
 struct CachedContentState {
@@ -989,5 +998,85 @@ mod tests {
         };
         let body = p.build_request_body(&[], None, &[], Some(&settings));
         assert!(body["generationConfig"]["thinkingConfig"].is_null());
+    }
+
+    // ── GenerateResponse / Candidate / ResponsePart deserialization tests ──
+
+    #[test]
+    fn generate_response_deserializes_text_part() {
+        let json = r#"{
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "Hello, world!"}]
+                }
+            }]
+        }"#;
+        let resp: GenerateResponse = serde_json::from_str(json).unwrap();
+        let candidates = resp.candidates.unwrap();
+        assert_eq!(candidates.len(), 1);
+        let parts = candidates[0].content.as_ref().unwrap().parts.as_ref().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].text.as_deref(), Some("Hello, world!"));
+        assert!(parts[0].thought.is_none());
+    }
+
+    #[test]
+    fn generate_response_deserializes_thinking_part() {
+        let json = r#"{
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "Let me reason...", "thought": true}]
+                }
+            }]
+        }"#;
+        let resp: GenerateResponse = serde_json::from_str(json).unwrap();
+        let candidates = resp.candidates.unwrap();
+        let parts = candidates[0].content.as_ref().unwrap().parts.as_ref().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].text.as_deref(), Some("Let me reason..."));
+        assert_eq!(parts[0].thought, Some(true));
+    }
+
+    #[test]
+    fn generate_response_deserializes_finish_reason() {
+        let json = r#"{
+            "candidates": [{
+                "finishReason": "STOP",
+                "content": {"parts": [{"text": "done"}]}
+            }]
+        }"#;
+        let resp: GenerateResponse = serde_json::from_str(json).unwrap();
+        let candidates = resp.candidates.unwrap();
+        assert_eq!(candidates[0].finish_reason.as_deref(), Some("STOP"));
+    }
+
+    #[test]
+    fn generate_response_with_usage_metadata() {
+        let json = r#"{
+            "candidates": [],
+            "usageMetadata": {
+                "promptTokenCount": 42,
+                "candidatesTokenCount": 17,
+                "cachedContentTokenCount": 5,
+                "thoughtsTokenCount": 8
+            }
+        }"#;
+        let resp: GenerateResponse = serde_json::from_str(json).unwrap();
+        let usage = resp.usage_metadata.unwrap();
+        assert_eq!(usage.prompt_token_count, 42);
+        assert_eq!(usage.candidates_token_count, 17);
+        assert_eq!(usage.cached_content_token_count, 5);
+        assert_eq!(usage.thoughts_token_count, 8);
+    }
+
+    #[test]
+    fn response_part_empty_text_is_valid() {
+        let json = r#"{"text": ""}"#;
+        let result = serde_json::from_str::<ResponsePart>(json);
+        assert!(result.is_ok());
+        let part = result.unwrap();
+        assert_eq!(part.text.as_deref(), Some(""));
+        assert!(part.function_call.is_none());
+        assert!(part.thought.is_none());
     }
 }

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -1014,7 +1014,13 @@ mod tests {
         let resp: GenerateResponse = serde_json::from_str(json).unwrap();
         let candidates = resp.candidates.unwrap();
         assert_eq!(candidates.len(), 1);
-        let parts = candidates[0].content.as_ref().unwrap().parts.as_ref().unwrap();
+        let parts = candidates[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .parts
+            .as_ref()
+            .unwrap();
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].text.as_deref(), Some("Hello, world!"));
         assert!(parts[0].thought.is_none());
@@ -1031,7 +1037,13 @@ mod tests {
         }"#;
         let resp: GenerateResponse = serde_json::from_str(json).unwrap();
         let candidates = resp.candidates.unwrap();
-        let parts = candidates[0].content.as_ref().unwrap().parts.as_ref().unwrap();
+        let parts = candidates[0]
+            .content
+            .as_ref()
+            .unwrap()
+            .parts
+            .as_ref()
+            .unwrap();
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0].text.as_deref(), Some("Let me reason..."));
         assert_eq!(parts[0].thought, Some(true));

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -19,6 +19,15 @@ pub struct OpenAiCompatProvider {
     api_key: Option<String>,
 }
 
+impl std::fmt::Debug for OpenAiCompatProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiCompatProvider")
+            .field("base_url", &self.base_url)
+            .field("api_key", &self.api_key.as_deref().map(|_| "[REDACTED]"))
+            .finish_non_exhaustive()
+    }
+}
+
 impl OpenAiCompatProvider {
     pub fn new(base_url: &str, api_key: Option<String>) -> Self {
         Self {
@@ -683,5 +692,68 @@ mod tests {
         let tcs = request.messages[0].tool_calls.as_ref().unwrap();
         assert_eq!(tcs.len(), 1);
         assert_eq!(tcs[0].function.name, "Read");
+    }
+
+    // ── SSE StreamChatResponse / StreamChoice / StreamDelta / StreamToolCall deserialization tests ──
+
+    #[test]
+    fn stream_response_deserializes_text_delta() {
+        let json = r#"{"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}"#;
+        let resp: StreamChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.choices.len(), 1);
+        let choice = &resp.choices[0];
+        assert_eq!(choice.delta.content.as_deref(), Some("hello"));
+        assert!(choice.finish_reason.is_none());
+    }
+
+    #[test]
+    fn stream_response_deserializes_finish_reason() {
+        let json = r#"{"choices":[{"delta":{},"finish_reason":"stop"}]}"#;
+        let resp: StreamChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.choices.len(), 1);
+        assert_eq!(resp.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+
+    #[test]
+    fn stream_response_deserializes_tool_call_delta() {
+        let json = r#"{
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_abc",
+                        "function": {"name": "Bash", "arguments": "{\"cmd\""}
+                    }]
+                },
+                "finish_reason": null
+            }]
+        }"#;
+        let resp: StreamChatResponse = serde_json::from_str(json).unwrap();
+        let choice = &resp.choices[0];
+        let tool_calls = choice.delta.tool_calls.as_ref().unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        let tc = &tool_calls[0];
+        assert_eq!(tc.index, Some(0));
+        assert_eq!(tc.id.as_deref(), Some("call_abc"));
+        let func = tc.function.as_ref().unwrap();
+        assert_eq!(func.name.as_deref(), Some("Bash"));
+        assert_eq!(func.arguments.as_deref(), Some("{\"cmd\""));
+    }
+
+    #[test]
+    fn stream_response_handles_null_content() {
+        let json = r#"{"choices":[{"delta":{"content":null},"finish_reason":null}]}"#;
+        let resp: StreamChatResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.choices.len(), 1);
+        assert!(resp.choices[0].delta.content.is_none());
+    }
+
+    #[test]
+    fn stream_response_handles_empty_choices() {
+        let json = r#"{"choices":[]}"#;
+        let result = serde_json::from_str::<StreamChatResponse>(json);
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert!(resp.choices.is_empty());
     }
 }

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -104,6 +104,42 @@ fn cap_output(output: &str, max_lines: usize) -> String {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn shell_timeout_returns_timeout_message() {
+        // Run a command that sleeps longer than the timeout (1 second) to keep the test fast.
+        let tmp = tempfile::tempdir().unwrap();
+        let args = serde_json::json!({"command": "sleep 5", "timeout": 1});
+        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        assert!(
+            result.contains("timed out"),
+            "Expected timeout message, got: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_respects_custom_timeout_parameter() {
+        // A fast command should succeed even with a short timeout.
+        let tmp = tempfile::tempdir().unwrap();
+        let args = serde_json::json!({"command": "echo hello", "timeout": 5});
+        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        assert!(
+            result.contains("hello"),
+            "Fast command should succeed within timeout: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_default_timeout_is_applied_when_not_specified() {
+        // Verify a normal command works when no timeout parameter is given.
+        let tmp = tempfile::tempdir().unwrap();
+        let args = serde_json::json!({"command": "echo world"});
+        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        assert!(
+            result.contains("world"),
+            "Command without explicit timeout should work: {result}"
+        );
+    }
+
     #[test]
     fn test_cap_output_short() {
         let input = "line1\nline2\nline3";

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -1,0 +1,322 @@
+//! Session lifecycle tests: TurnStart/TurnEnd events, cancellation, and DB persistence.
+//!
+//! Uses MockProvider + TestSink (requires the `test-support` feature).
+//! Run with: `cargo test -p koda-core --features koda-core/test-support`
+
+use anyhow::Result;
+use async_trait::async_trait;
+use koda_core::{
+    approval::ApprovalMode,
+    config::{KodaConfig, ProviderType},
+    db::{Database, Persistence, Role},
+    engine::{EngineCommand, EngineEvent, event::TurnEndReason, sink::TestSink},
+    providers::{
+        ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
+        mock::{MockProvider, MockResponse},
+    },
+    session::KodaSession,
+    settings::Settings,
+    tools::ToolRegistry,
+};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+// ── Shared test harness ──────────────────────────────────────────────────────
+
+struct Env {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+    db: Database,
+    session_id: String,
+    config: KodaConfig,
+}
+
+impl Env {
+    async fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let db = Database::init(&root).await.unwrap();
+        let session_id = db.create_session("test-agent", &root).await.unwrap();
+        let config = KodaConfig::default_for_testing(ProviderType::Mock);
+        Self {
+            _tmp: tmp,
+            root,
+            db,
+            session_id,
+            config,
+        }
+    }
+
+    async fn insert_user_message(&self, text: &str) {
+        self.db
+            .insert_message(&self.session_id, &Role::User, Some(text), None, None, None)
+            .await
+            .unwrap();
+    }
+
+    /// Build a KodaSession, injecting an arbitrary provider.
+    ///
+    /// Bypasses `KodaSession::new()` (which calls `create_provider` internally)
+    /// so tests can supply a pre-configured MockProvider.  A fresh ToolRegistry
+    /// is created each call because ToolRegistry does not implement Clone.
+    fn make_session(&self, provider: Box<dyn LlmProvider>) -> (KodaSession, CancellationToken) {
+        let cancel = CancellationToken::new();
+        let tools = ToolRegistry::new(self.root.clone(), self.config.max_context_tokens);
+
+        let agent = Arc::new(koda_core::agent::KodaAgent {
+            project_root: self.root.clone(),
+            tools,
+            tool_defs: ToolRegistry::new(self.root.clone(), self.config.max_context_tokens)
+                .get_definitions(&[]),
+            system_prompt: "You are a test assistant.".to_string(),
+            mcp_registry: Arc::new(tokio::sync::RwLock::new(
+                koda_core::mcp::McpRegistry::new(),
+            )),
+            mcp_statuses: vec![],
+        });
+
+        // Wire the DB+session into the ToolRegistry so RecallContext works.
+        agent
+            .tools
+            .set_session(Arc::new(self.db.clone()), self.session_id.clone());
+
+        let session = KodaSession {
+            id: self.session_id.clone(),
+            agent,
+            db: self.db.clone(),
+            provider,
+            mode: ApprovalMode::Auto,
+            settings: Settings::load(),
+            cancel: cancel.clone(),
+            skip_probe: true,
+        };
+        (session, cancel)
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// `run_turn()` must emit `TurnStart` as the first event and
+/// `TurnEnd { reason: Complete }` as the last event after a successful turn.
+#[tokio::test]
+async fn session_run_turn_emits_turn_start_and_end() {
+    let env = Env::new().await;
+    env.insert_user_message("say hello").await;
+
+    let provider = Box::new(MockProvider::new(vec![MockResponse::Text(
+        "Hello!".to_string(),
+    )]));
+    let (mut session, _cancel) = env.make_session(provider);
+
+    let sink = TestSink::new();
+    let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+
+    let result = session
+        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .await;
+    assert!(result.is_ok(), "run_turn should succeed: {:?}", result.err());
+
+    let events = sink.events();
+
+    // TurnStart must be the first event emitted.
+    let first = events.first().expect("expected at least one event");
+    assert!(
+        matches!(first, EngineEvent::TurnStart { .. }),
+        "first event must be TurnStart, got: {first:?}"
+    );
+
+    // TurnEnd must be the last event emitted.
+    let last = events.last().expect("expected at least one event");
+    assert!(
+        matches!(last, EngineEvent::TurnEnd { .. }),
+        "last event must be TurnEnd, got: {last:?}"
+    );
+
+    // Reason must be Complete on a successful turn.
+    if let EngineEvent::TurnEnd { reason, .. } = last {
+        assert_eq!(
+            *reason,
+            TurnEndReason::Complete,
+            "TurnEnd reason should be Complete after successful turn"
+        );
+    }
+
+    // The turn_id in TurnStart and TurnEnd must match.
+    let start_id = if let EngineEvent::TurnStart { turn_id } = first {
+        turn_id.clone()
+    } else {
+        unreachable!()
+    };
+    let end_id = if let EngineEvent::TurnEnd { turn_id, .. } = last {
+        turn_id.clone()
+    } else {
+        unreachable!()
+    };
+    assert_eq!(
+        start_id, end_id,
+        "TurnStart and TurnEnd must share the same turn_id"
+    );
+}
+
+/// Cancelling the token during inference causes `TurnEnd` to carry reason `Cancelled`.
+#[tokio::test]
+async fn session_cancellation_produces_turn_end_cancelled() {
+    let env = Env::new().await;
+    env.insert_user_message("hello").await;
+
+    // A provider that hangs forever so that cancellation can be observed.
+    struct HangingProvider;
+
+    #[async_trait]
+    impl LlmProvider for HangingProvider {
+        async fn chat(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &koda_core::config::ModelSettings,
+        ) -> Result<LlmResponse> {
+            unreachable!()
+        }
+        async fn chat_stream(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &koda_core::config::ModelSettings,
+        ) -> Result<mpsc::Receiver<StreamChunk>> {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            unreachable!()
+        }
+        async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+            Ok(vec![])
+        }
+        fn provider_name(&self) -> &str {
+            "hanging"
+        }
+    }
+
+    let (mut session, cancel) = env.make_session(Box::new(HangingProvider));
+
+    // Cancel after 100 ms so the test completes quickly.
+    let cancel_clone = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancel_clone.cancel();
+    });
+
+    let sink = TestSink::new();
+    let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+
+    let start = std::time::Instant::now();
+    let result = session
+        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .await;
+
+    let elapsed = start.elapsed();
+    assert!(
+        result.is_ok(),
+        "cancellation should be graceful, not an error"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "cancellation should unblock quickly, took {elapsed:?}"
+    );
+
+    let events = sink.events();
+
+    // A TurnEnd event must be present with reason Cancelled.
+    let turn_end_reason = events.iter().find_map(|e| {
+        if let EngineEvent::TurnEnd { reason, .. } = e {
+            Some(reason.clone())
+        } else {
+            None
+        }
+    });
+    assert!(
+        turn_end_reason.is_some(),
+        "expected a TurnEnd event after cancellation, got: {events:?}"
+    );
+    assert_eq!(
+        turn_end_reason.unwrap(),
+        TurnEndReason::Cancelled,
+        "TurnEnd reason must be Cancelled when the token is cancelled"
+    );
+}
+
+/// Messages from two separate `run_turn()` calls on the same session must
+/// both appear in the DB afterward.
+#[tokio::test]
+async fn session_persists_messages_across_two_turns() {
+    let env = Env::new().await;
+
+    // --- Turn 1 ---
+    env.insert_user_message("first question").await;
+
+    let provider1 = Box::new(MockProvider::new(vec![MockResponse::Text(
+        "first answer".to_string(),
+    )]));
+    let (mut session1, _cancel1) = env.make_session(provider1);
+    let sink1 = TestSink::new();
+    let (_, mut cmd_rx1) = mpsc::channel::<EngineCommand>(1);
+    session1
+        .run_turn(&env.config, None, &sink1, &mut cmd_rx1)
+        .await
+        .expect("turn 1 should succeed");
+
+    // Verify turn 1 ended with Complete.
+    assert!(
+        sink1.events().iter().any(
+            |e| matches!(e, EngineEvent::TurnEnd { reason: TurnEndReason::Complete, .. })
+        ),
+        "turn 1 should end with Complete"
+    );
+
+    // --- Turn 2 ---
+    env.insert_user_message("second question").await;
+
+    let provider2 = Box::new(MockProvider::new(vec![MockResponse::Text(
+        "second answer".to_string(),
+    )]));
+    // A new KodaSession sharing the same DB and session_id represents the
+    // continuation of the conversation after, e.g., a model swap.
+    let (mut session2, _cancel2) = env.make_session(provider2);
+    let sink2 = TestSink::new();
+    let (_, mut cmd_rx2) = mpsc::channel::<EngineCommand>(1);
+    session2
+        .run_turn(&env.config, None, &sink2, &mut cmd_rx2)
+        .await
+        .expect("turn 2 should succeed");
+
+    // Verify both turns' messages are in the DB.
+    let messages: Vec<koda_core::persistence::Message> = env
+        .db
+        .load_context(&env.session_id, 100_000)
+        .await
+        .unwrap();
+    let contents: Vec<String> = messages
+        .iter()
+        .filter_map(|m: &koda_core::persistence::Message| m.content.clone())
+        .collect();
+
+    assert!(
+        contents.iter().any(|c: &String| c.contains("first question")),
+        "DB should contain first user message"
+    );
+    assert!(
+        contents.iter().any(|c: &String| c.contains("first answer")),
+        "DB should contain first assistant response"
+    );
+    assert!(
+        contents
+            .iter()
+            .any(|c: &String| c.contains("second question")),
+        "DB should contain second user message"
+    );
+    assert!(
+        contents
+            .iter()
+            .any(|c: &String| c.contains("second answer")),
+        "DB should contain second assistant response"
+    );
+}

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -71,9 +71,7 @@ impl Env {
             tool_defs: ToolRegistry::new(self.root.clone(), self.config.max_context_tokens)
                 .get_definitions(&[]),
             system_prompt: "You are a test assistant.".to_string(),
-            mcp_registry: Arc::new(tokio::sync::RwLock::new(
-                koda_core::mcp::McpRegistry::new(),
-            )),
+            mcp_registry: Arc::new(tokio::sync::RwLock::new(koda_core::mcp::McpRegistry::new())),
             mcp_statuses: vec![],
         });
 
@@ -116,7 +114,11 @@ async fn session_run_turn_emits_turn_start_and_end() {
     let result = session
         .run_turn(&env.config, None, &sink, &mut cmd_rx)
         .await;
-    assert!(result.is_ok(), "run_turn should succeed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "run_turn should succeed: {:?}",
+        result.err()
+    );
 
     let events = sink.events();
 
@@ -266,9 +268,13 @@ async fn session_persists_messages_across_two_turns() {
 
     // Verify turn 1 ended with Complete.
     assert!(
-        sink1.events().iter().any(
-            |e| matches!(e, EngineEvent::TurnEnd { reason: TurnEndReason::Complete, .. })
-        ),
+        sink1.events().iter().any(|e| matches!(
+            e,
+            EngineEvent::TurnEnd {
+                reason: TurnEndReason::Complete,
+                ..
+            }
+        )),
         "turn 1 should end with Complete"
     );
 
@@ -289,18 +295,17 @@ async fn session_persists_messages_across_two_turns() {
         .expect("turn 2 should succeed");
 
     // Verify both turns' messages are in the DB.
-    let messages: Vec<koda_core::persistence::Message> = env
-        .db
-        .load_context(&env.session_id, 100_000)
-        .await
-        .unwrap();
+    let messages: Vec<koda_core::persistence::Message> =
+        env.db.load_context(&env.session_id, 100_000).await.unwrap();
     let contents: Vec<String> = messages
         .iter()
         .filter_map(|m: &koda_core::persistence::Message| m.content.clone())
         .collect();
 
     assert!(
-        contents.iter().any(|c: &String| c.contains("first question")),
+        contents
+            .iter()
+            .any(|c: &String| c.contains("first question")),
         "DB should contain first user message"
     );
     assert!(

--- a/koda-email/src/config.rs
+++ b/koda-email/src/config.rs
@@ -25,7 +25,7 @@ impl std::fmt::Debug for EmailConfig {
             .field("imap_port", &self.imap_port)
             .field("smtp_host", &self.smtp_host)
             .field("smtp_port", &self.smtp_port)
-            .field("username", &self.username)
+            .field("username", &"[REDACTED]")
             .field("password", &"[REDACTED]")
             .finish()
     }


### PR DESCRIPTION
## Summary

- Add custom `Debug` impls to all three LLM providers (`GeminiProvider`, `AnthropicProvider`, `OpenAiCompatProvider`) redacting `api_key`; redact `username` in `EmailConfig::Debug`
- Add 15 SSE deserialization unit tests across all three providers covering text deltas, tool call accumulation, finish reasons, usage metadata, null/missing fields, and unknown event types
- Replace fake string-matching `dispatch()` helper in `regression_test.rs` with real `repl::handle_command()` calls asserting actual `ReplAction` enum variants; re-export `repl` module from `koda-cli` lib.rs for test access
- Add shell timeout tests: 1s timeout on `sleep 5`, custom timeout param, default fallback
- Add `session_test.rs` with `TurnStart`/`TurnEnd` event emission, cancellation → `TurnEnd { reason: Cancelled }`, and 2-turn message persistence verified against SQLite

Closes #384, #385, #386

## Test plan

- [ ] `cargo test --workspace --features koda-core/test-support` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)