### PR TITLE
feat: polish skills system — docs, /skills command, E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,34 @@ echo "explain this" | koda        # Piped input
 - **Headless mode** — `koda -p "prompt"` with JSON output for CI/CD
 - **Persistent memory** — project (`MEMORY.md`) and global (`~/.config/koda/memory.md`)
 - **Cost tracking** — per-turn and per-session cost estimation including thinking tokens
+- **Skills** — built-in expertise modules (code review, security audit) + user-created skills for repeatable analysis
+
+### 📚 Skills
+
+Skills inject expert instructions into context — zero cost, instant activation.
+Koda includes built-in skills for common analysis tasks, and you can create your own.
+
+**Built-in skills:**
+- `code-review` — senior code review (bugs, anti-patterns, improvements)
+- `security-audit` — security vulnerability scan (OWASP checklist)
+
+**Create custom skills:** add a `SKILL.md` file with YAML frontmatter to:
+- `.koda/skills/<name>/SKILL.md` — project-level (shared with team)
+- `~/.config/koda/skills/<name>/SKILL.md` — user-level (global)
+
+```markdown
+---
+name: my-skill
+description: What this skill does
+tags: [tag1, tag2]
+---
+
+# Instructions for the agent
+
+Your expert guidance here...
+```
+
+Use `/skills` to list available skills, or ask Koda to "use the code review skill".
 
 ### 🌳 AST Code Analysis
 
@@ -97,6 +125,7 @@ Koda connects to your email via IMAP/SMTP through the koda-email MCP server.
 | `/model` | Pick a model (↑↓ arrow keys) |
 | `/provider` | Switch LLM provider |
 | `/sessions` | List, resume, or delete sessions |
+| `/skills` | List available skills (search with `/skills <query>`) |
 | `/exit` | Quit Koda |
 
 **Tips:** `@file` to attach context · Tab to autocomplete · `Shift+Tab` to cycle mode · `Alt+Enter` for multi-line

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -78,6 +78,7 @@ Type `/` to open the command palette with descriptions. Tab to complete.
 | `/model` | Pick a model interactively |
 | `/provider` | Switch LLM provider |
 | `/sessions` | List, resume, or delete sessions |
+| `/skills` | List available skills (search with `/skills <query>`) |
 | `/undo` | Undo last turn's file changes |
 | `/verbose` | Toggle full tool output display |
 

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -20,6 +20,7 @@ pub const SLASH_COMMANDS: &[(&str, &str)] = &[
     ("/model", "Pick a model interactively"),
     ("/provider", "Switch LLM provider"),
     ("/sessions", "List/resume/delete sessions"),
+    ("/skills", "List available skills (search with query)"),
     ("/undo", "Undo last turn's file changes"),
     ("/verbose", "Toggle full tool output"),
 ];

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -39,6 +39,8 @@ pub enum ReplAction {
     MemoryCommand(Option<String>),
     /// Undo last turn's file mutations
     Undo,
+    /// List available skills (optional search query)
+    ListSkills(Option<String>),
     #[allow(dead_code)]
     Handled,
     NotACommand,
@@ -127,6 +129,8 @@ pub async fn handle_command(
         "/memory" => ReplAction::MemoryCommand(arg.map(|s| s.to_string())),
 
         "/undo" => ReplAction::Undo,
+
+        "/skills" => ReplAction::ListSkills(arg.map(|s| s.to_string())),
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -149,6 +149,10 @@ pub async fn handle_slash_command(
             crate::tui_wizards::handle_memory(terminal, arg.as_deref(), project_root);
             SlashAction::Continue
         }
+        ReplAction::ListSkills(ref query) => {
+            crate::tui_wizards::handle_list_skills(terminal, query.as_deref(), &agent.tools);
+            SlashAction::Continue
+        }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
     }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -237,6 +237,51 @@ pub(crate) fn handle_list_agents(terminal: &mut Term, project_root: &std::path::
     dim_msg("Need a specialist? Ask Koda to create one for recurring tasks".into());
 }
 
+// ── Skills ───────────────────────────────────────────────
+
+#[allow(unused_variables)]
+pub(crate) fn handle_list_skills(
+    terminal: &mut Term,
+    query: Option<&str>,
+    tools: &koda_core::tools::ToolRegistry,
+) {
+    let skills = match query {
+        Some(q) if !q.is_empty() => tools.search_skills(q),
+        _ => tools.list_skills(),
+    };
+
+    tui_output::write_blank();
+    tui_output::write_line(&Line::styled("  \u{1f4da} Skills", BOLD));
+    tui_output::write_blank();
+
+    if skills.is_empty() {
+        match query {
+            Some(q) => dim_msg(format!("No skills matching '{q}'.")),
+            None => dim_msg("No skills available.".into()),
+        }
+    } else {
+        for (name, description, source) in &skills {
+            let tag = match source.as_str() {
+                "user" => " [user]",
+                "project" => " [project]",
+                _ => "",
+            };
+            tui_output::write_line(&Line::from(vec![
+                Span::styled(format!("  {name}"), CYAN),
+                Span::raw(format!(" \u{2014} {description}")),
+                Span::styled(tag, DIM),
+            ]));
+        }
+    }
+
+    tui_output::write_blank();
+    dim_msg("Ask Koda to activate a skill, or use ActivateSkill tool directly.".into());
+    dim_msg(
+        "Create your own: .koda/skills/<name>/SKILL.md or ~/.config/koda/skills/<name>/SKILL.md"
+            .into(),
+    );
+}
+
 // ── Diff (native TUI) ────────────────────────────────────
 
 #[allow(unused_variables)]

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -210,6 +210,22 @@ mod repl_commands {
     }
 
     #[test]
+    fn skills_bare_returns_list_skills_none() {
+        assert!(matches!(dispatch("/skills"), ReplAction::ListSkills(None)));
+    }
+
+    #[test]
+    fn skills_with_query_returns_list_skills_some() {
+        assert!(matches!(
+            dispatch("/skills review"),
+            ReplAction::ListSkills(Some(_))
+        ));
+        if let ReplAction::ListSkills(Some(q)) = dispatch("/skills review") {
+            assert_eq!(q, "review");
+        }
+    }
+
+    #[test]
     fn key_command_is_not_a_command() {
         // /key was removed; must fall through
         assert!(matches!(dispatch("/key"), ReplAction::NotACommand));
@@ -330,6 +346,7 @@ mod completions {
         "/model",
         "/provider",
         "/sessions",
+        "/skills",
     ];
 
     /// Commands that should NOT appear in completions.
@@ -337,7 +354,7 @@ mod completions {
 
     #[test]
     fn test_expected_commands_present() {
-        assert_eq!(EXPECTED_COMMANDS.len(), 10, "Expected 10 slash commands");
+        assert_eq!(EXPECTED_COMMANDS.len(), 11, "Expected 11 slash commands");
         for cmd in EXPECTED_COMMANDS {
             assert!(
                 EXPECTED_COMMANDS.contains(cmd),

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -7,8 +7,8 @@ Refer to this when the user asks "what can you do?" or about features.
 /agent — list sub-agents | /compact — reclaim context | /cost — token usage & cost
 /diff — git diff/review/commit | /exit — quit | /expand — show full tool output
 /mcp — MCP server management | /memory — persistent memory | /model — switch model
-/provider — switch provider | /sessions — resume/delete sessions | /undo — undo last turn
-/verbose — toggle full tool output
+/provider — switch provider | /sessions — resume/delete sessions | /skills — list skills
+/undo — undo last turn | /verbose — toggle full tool output
 Shift+Tab — cycle approval mode (auto/strict/safe)
 
 ### Input
@@ -29,6 +29,14 @@ Auto-snapshots working tree before each turn. `/undo` to rollback.
 
 On session start, Koda runs a one-time structured output test to verify the model
 can produce valid tool calls. Skip with `--skip-probe`.
+
+### Skills
+
+Expert instruction modules — zero cost, instant activation via `ActivateSkill`.
+- **Built-in:** `code-review` (bugs, anti-patterns), `security-audit` (OWASP checklist)
+- **Custom:** `.koda/skills/<name>/SKILL.md` (project) or `~/.config/koda/skills/<name>/SKILL.md` (global)
+- Use `ListSkills` to browse, `ActivateSkill` to load expert guidance into context.
+- `/skills` lists all available skills from the REPL.
 
 ### Agents
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -255,6 +255,38 @@ impl ToolRegistry {
         self.definitions.contains_key(name)
     }
 
+    /// List all available skills as `(name, description, source)` tuples.
+    pub fn list_skills(&self) -> Vec<(String, String, String)> {
+        self.skill_registry
+            .list()
+            .into_iter()
+            .map(|m| {
+                let source = match m.source {
+                    crate::skills::SkillSource::BuiltIn => "built-in",
+                    crate::skills::SkillSource::User => "user",
+                    crate::skills::SkillSource::Project => "project",
+                };
+                (m.name.clone(), m.description.clone(), source.to_string())
+            })
+            .collect()
+    }
+
+    /// Search skills by query, returning `(name, description, source)` tuples.
+    pub fn search_skills(&self, query: &str) -> Vec<(String, String, String)> {
+        self.skill_registry
+            .search(query)
+            .into_iter()
+            .map(|m| {
+                let source = match m.source {
+                    crate::skills::SkillSource::BuiltIn => "built-in",
+                    crate::skills::SkillSource::User => "user",
+                    crate::skills::SkillSource::Project => "project",
+                };
+                (m.name.clone(), m.description.clone(), source.to_string())
+            })
+            .collect()
+    }
+
     /// Get tool definitions, optionally filtered by an allow-list.
     /// Includes MCP tools merged with built-in tools.
     pub fn get_definitions(&self, allowed: &[String]) -> Vec<ToolDefinition> {

--- a/koda-core/tests/capabilities_test.rs
+++ b/koda-core/tests/capabilities_test.rs
@@ -15,6 +15,7 @@ const EXPECTED_COMMANDS: &[&str] = &[
     "/model",
     "/provider",
     "/sessions",
+    "/skills",
     "/undo",
     "/verbose",
 ];
@@ -46,6 +47,9 @@ fn test_capabilities_mentions_key_features() {
         "--skip-probe",
         "koda-ast",
         "koda-email",
+        "Skills",
+        "ActivateSkill",
+        "ListSkills",
     ];
     for feature in must_mention {
         assert!(

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -712,3 +712,166 @@ async fn test_compact_skips_short_conversation() {
         "should skip compaction for short conversations"
     );
 }
+
+// ── Skill tools ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_skills_returns_builtins() {
+    let env = Env::new().await;
+    env.insert_user_message("list skills").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("ListSkills", serde_json::json!({})),
+        MockResponse::Text("Here are the available skills.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "ListSkills"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected ListSkills result");
+    let output = tool_result.unwrap();
+    assert!(
+        output.contains("code-review"),
+        "should list built-in code-review skill: {output}"
+    );
+    assert!(
+        output.contains("security-audit"),
+        "should list built-in security-audit skill: {output}"
+    );
+}
+
+#[tokio::test]
+async fn test_list_skills_with_search_query() {
+    let env = Env::new().await;
+    env.insert_user_message("find security skills").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("ListSkills", serde_json::json!({"query": "security"})),
+        MockResponse::Text("Found security skills.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "ListSkills"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected ListSkills result");
+    let output = tool_result.unwrap();
+    assert!(
+        output.contains("security-audit"),
+        "should find security-audit: {output}"
+    );
+    assert!(
+        !output.contains("code-review"),
+        "should NOT find code-review when searching 'security': {output}"
+    );
+}
+
+#[tokio::test]
+async fn test_activate_skill_injects_content() {
+    let env = Env::new().await;
+    env.insert_user_message("review my code").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "ActivateSkill",
+            serde_json::json!({"skill_name": "code-review"}),
+        ),
+        MockResponse::Text("Starting code review per the skill instructions.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "ActivateSkill"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected ActivateSkill result");
+    let output = tool_result.unwrap();
+    assert!(
+        output.contains("Skill 'code-review' activated"),
+        "should confirm activation: {output}"
+    );
+    assert!(
+        output.contains("# Code Review"),
+        "should inject full skill content: {output}"
+    );
+    assert!(
+        output.contains("Principles"),
+        "should include skill guidance sections: {output}"
+    );
+}
+
+#[tokio::test]
+async fn test_activate_skill_not_found() {
+    let env = Env::new().await;
+    env.insert_user_message("use nonexistent skill").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "ActivateSkill",
+            serde_json::json!({"skill_name": "nonexistent"}),
+        ),
+        MockResponse::Text("That skill doesn't exist.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "ActivateSkill"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected ActivateSkill result");
+    let output = tool_result.unwrap();
+    assert!(
+        output.contains("not found"),
+        "should report skill not found: {output}"
+    );
+    assert!(
+        output.contains("code-review"),
+        "should suggest available skills: {output}"
+    );
+}
+
+#[tokio::test]
+async fn test_activate_skill_missing_parameter() {
+    let env = Env::new().await;
+    env.insert_user_message("activate skill").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("ActivateSkill", serde_json::json!({})),
+        MockResponse::Text("Missing parameter.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let tool_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "ActivateSkill"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(tool_result.is_some(), "expected ActivateSkill result");
+    let output = tool_result.unwrap();
+    assert!(
+        output.contains("Missing"),
+        "should report missing parameter: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #367. The skill system backend was fully implemented but invisible to users. This PR closes the four gaps:

- **Documentation**: Skills section in README (creation guide, SKILL.md format, built-in catalog) + capabilities.md (system prompt self-knowledge) + user-guide.md
- **`/skills` command**: New slash command with optional search query, tab completion, and TUI output via `handle_list_skills()` in tui_wizards
- **E2E tests**: 5 new tests exercising `ListSkills` and `ActivateSkill` through the full inference loop with MockProvider (list builtins, search filtering, activation with content injection, not-found error, missing parameter)
- **Public API**: `list_skills()` / `search_skills()` on `ToolRegistry` for CLI access to the skill registry

### Files changed (11)

| File | Change |
|------|--------|
| `README.md` | Skills section + `/skills` in command table |
| `docs/user-guide.md` | `/skills` in command table |
| `koda-core/src/capabilities.md` | Skills section + `/skills` in command list |
| `koda-core/src/tools/mod.rs` | `list_skills()` / `search_skills()` on ToolRegistry |
| `koda-core/tests/capabilities_test.rs` | `/skills`, `Skills`, `ActivateSkill`, `ListSkills` assertions |
| `koda-core/tests/e2e_test.rs` | 5 skill E2E tests |
| `koda-cli/src/repl.rs` | `ListSkills(Option<String>)` variant + `/skills` dispatch |
| `koda-cli/src/tui_commands.rs` | Route `ListSkills` to wizard handler |
| `koda-cli/src/tui_wizards.rs` | `handle_list_skills()` implementation |
| `koda-cli/src/completer.rs` | `/skills` in SLASH_COMMANDS |
| `koda-cli/tests/regression_test.rs` | 2 new tests + updated command counts |

## Test plan

- [x] All 719 workspace tests pass (including 5 new E2E skill tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Capabilities freshness test validates `/skills`, `Skills`, `ActivateSkill`, `ListSkills`
- [x] Regression tests verify `/skills` and `/skills <query>` dispatch
- [ ] Manual: run `/skills` in TUI, verify output lists code-review and security-audit