### PR TITLE
Fix parallel tool output: pair each banner with its result

### DIFF
--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -473,8 +473,7 @@ fn render_list_line(terminal: &mut Term, line: &str) {
     };
 
     let style = if is_dir {
-        Style::default()
-            .add_modifier(ratatui::style::Modifier::BOLD)
+        Style::default().add_modifier(ratatui::style::Modifier::BOLD)
     } else {
         // Color files by extension category
         let ext = std::path::Path::new(path_str)

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -114,16 +114,6 @@ pub(crate) async fn execute_tools_parallel(
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
 ) -> Result<()> {
-    // Print all tool call banners upfront
-    for tc in tool_calls {
-        sink.emit(EngineEvent::ToolCallStart {
-            id: tc.id.clone(),
-            name: tc.function_name.clone(),
-            args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
-            is_sub_agent: false,
-        });
-    }
-
     let count = tool_calls.len();
     sink.emit(EngineEvent::Info {
         message: format!("Running {count} tools in parallel..."),
@@ -149,8 +139,14 @@ pub(crate) async fn execute_tools_parallel(
         .collect();
     let results = futures_util::future::join_all(futures).await;
 
-    // Store results and display output (in original order)
+    // Emit banner + result together so each tool's output is visually grouped
     for (i, (tc_id, result)) in results.into_iter().enumerate() {
+        sink.emit(EngineEvent::ToolCallStart {
+            id: tc_id.clone(),
+            name: tool_calls[i].function_name.clone(),
+            args: serde_json::from_str(&tool_calls[i].arguments).unwrap_or_default(),
+            is_sub_agent: false,
+        });
         sink.emit(EngineEvent::ToolCallResult {
             id: tc_id.clone(),
             name: tool_calls[i].function_name.clone(),
@@ -211,14 +207,6 @@ pub(crate) async fn execute_tools_split_batch(
 
     // Run parallelizable tools concurrently (if more than one)
     if parallel.len() > 1 {
-        for tc in &parallel {
-            sink.emit(EngineEvent::ToolCallStart {
-                id: tc.id.clone(),
-                name: tc.function_name.clone(),
-                args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
-                is_sub_agent: false,
-            });
-        }
         sink.emit(EngineEvent::Info {
             message: format!("Running {} tools in parallel...", parallel.len()),
         });
@@ -243,6 +231,12 @@ pub(crate) async fn execute_tools_split_batch(
         let results = futures_util::future::join_all(futures).await;
 
         for (j, (tc_id, result)) in results.into_iter().enumerate() {
+            sink.emit(EngineEvent::ToolCallStart {
+                id: tc_id.clone(),
+                name: parallel[j].function_name.clone(),
+                args: serde_json::from_str(&parallel[j].arguments).unwrap_or_default(),
+                is_sub_agent: false,
+            });
             sink.emit(EngineEvent::ToolCallResult {
                 id: tc_id.clone(),
                 name: parallel[j].function_name.clone(),


### PR DESCRIPTION
## Summary
- Fixes #410: when multiple tools run in parallel, all results were displayed under the first tool's header
- Moved `ToolCallStart` emission from before execution to right before each `ToolCallResult`, so each tool's banner and output are visually grouped
- Applied the same fix to both `execute_tools_parallel` and `execute_tools_split_batch`

## Before
```
● Edit koda-email/Cargo.toml
  Running 4 tools in parallel...
  │ Applied 1 edit(s) to koda-core/Cargo.toml
  │ Applied 1 edit(s) to koda-cli/Cargo.toml
  │ Applied 1 edit(s) to koda-ast/Cargo.toml
  │ Applied 1 edit(s) to koda-email/Cargo.toml
```

## After
```
  Running 4 tools in parallel...
● Edit koda-core/Cargo.toml
  │ Applied 1 edit(s) to koda-core/Cargo.toml
● Edit koda-cli/Cargo.toml
  │ Applied 1 edit(s) to koda-cli/Cargo.toml
● Edit koda-ast/Cargo.toml
  │ Applied 1 edit(s) to koda-ast/Cargo.toml
● Edit koda-email/Cargo.toml
  │ Applied 1 edit(s) to koda-email/Cargo.toml
```

## Test plan
- [x] `cargo test --workspace --features koda-core/test-support` — all tests pass
- [x] `cargo clippy --workspace -- -D warnings` — no warnings
- [ ] Manual test: run a prompt that triggers parallel Edit calls and verify each result has its own header

🤖 Generated with [Claude Code](https://claude.com/claude-code)