### PR TITLE
chore(release): v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-03-12
+
+### Added
+- **Skills system polish** — `/skills` REPL command, `ActivateSkill` tool, E2E tests
+  for built-in `code-review` and `security-audit` skills, skills documented in
+  system prompt and README (#367)
+
+### Changed
+- **Design principles rewritten** — DESIGN.md now states three clear principles:
+  Software for One, Clear Boundaries, Make It Work. Removed the old numbered
+  decision log in favour of focused architectural guidance (#404)
+- **Tool infrastructure simplified** — merged `bash_safety.rs` into `approval.rs`,
+  removed `normalize_tool_name()` indirection (tools are always PascalCase),
+  collapsed three approval-mode enums into two (Auto/Confirm) (#406, #407)
+
+### Removed
+- **Dead code cleanup** — removed `DiscoverTools` tool and trait, `DelegationScope`
+  enum, `CreateAgent` placeholder, `model_probe.rs` capability probing, and dead
+  git checkpoint/rollback + `FileWatcher` code. ~1,200 lines removed across the
+  workspace (#366, #272, #399, #401, #402, #403, #405, #408, #409)
+
+### Fixed
+- **Test reliability** — SSE parser tests, dispatch test fixes, session lifecycle
+  test with proper shell timeout handling (#384, #385, #386, #398)
+- **Parallel tool output** — each tool's banner now appears immediately before its
+  own result; previously all banners printed upfront under the first tool's header
+  (#410, #411)
+
 ## [0.1.6] - 2026-03-11
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary

Release v0.1.7. Merging this PR will trigger CI to tag and publish the release.

### What's in this release

**Added**
- Skills system polish — `/skills` REPL command, `ActivateSkill` tool, E2E tests for built-in `code-review` and `security-audit` skills (#367)

**Changed**
- Design principles rewritten in DESIGN.md: Software for One, Clear Boundaries, Make It Work (#404)
- Tool infrastructure simplified — merged `bash_safety.rs` into `approval.rs`, removed `normalize_tool_name()`, collapsed approval-mode enums to two (Auto/Confirm) (#406, #407)

**Removed**
- Dead code cleanup — `DiscoverTools`, `DelegationScope`, `CreateAgent`, `model_probe.rs`, dead git checkpoint/rollback + `FileWatcher` code (~1,200 lines) (#366, #272, #399, #401, #402, #403, #405, #408, #409)

**Fixed**
- Test reliability — SSE parser tests, dispatch test fixes, session lifecycle test (#384, #385, #386, #398)
- Parallel tool output — each tool's banner now appears before its own result (#410, #411)

## Test plan
- [x] All CI checks pass on `release/v0.1.7`
- [x] Version bumped to 0.1.7 in all four crates
- [x] CHANGELOG `[Unreleased]` moved to `[0.1.7]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)