### PR TITLE
fix(#418): Ctrl+L screen refresh and resize warning

### DIFF
--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -79,6 +79,8 @@ pub fn print_banner(config: &KodaConfig, recent_activity: &[String]) {
         Span::styled("mode", DIM),
         Span::styled("  Ctrl+C ", WARM_ACCENT),
         Span::styled("cancel", DIM),
+        Span::styled("  Ctrl+L ", WARM_ACCENT),
+        Span::styled("refresh", DIM),
         Span::styled("  Ctrl+D ", WARM_ACCENT),
         Span::styled("quit", DIM),
     ]));

--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -741,6 +741,19 @@ impl TuiContext {
                                                     &mut self.crossterm_events,
                                                     self.viewport_height,
                                                 )?;
+                                                emit_above(
+                                                    &mut self.terminal,
+                                                    Line::from(vec![
+                                                        Span::styled(
+                                                            "  \u{26a0} ",
+                                                            Style::default().fg(Color::Yellow),
+                                                        ),
+                                                        Span::styled(
+                                                            "Terminal resized \u{2014} visual artifacts may appear above. Press Ctrl+L to refresh.",
+                                                            Style::default().fg(Color::DarkGray),
+                                                        ),
+                                                    ]),
+                                                );
                                             } else if let Event::Paste(text) = ev {
                                                 // Bracketed paste during inference
                                                 let char_count = text.chars().count();
@@ -1526,6 +1539,16 @@ impl TuiContext {
                                 if self.textarea.lines().join("").trim().is_empty() {
                                     self.should_quit = true;
                                 }
+                            }
+                            (KeyCode::Char('l'), m) if m.contains(KeyModifiers::CONTROL) => {
+                                // Ctrl+L: clear visible screen and reinit viewport.
+                                // Standard Unix convention (bash, less, tmux).
+                                // Cleans up ghost fragments from resize reflow.
+                                scroll_past_and_reinit(
+                                    &mut self.terminal,
+                                    &mut self.crossterm_events,
+                                    self.viewport_height,
+                                )?;
                             }
                             (KeyCode::BackTab, _) => {
                                 approval::cycle_mode(&self.shared_mode);


### PR DESCRIPTION
## Summary

Graceful degradation for resize ghost fragments (Option 3 from #418 analysis).

## Changes

### `Ctrl+L` — clear screen and reinit viewport
Standard Unix convention (bash, less, tmux). Calls `scroll_past_and_reinit()` to clear the visible screen and create a fresh terminal. Instant cleanup of ghost fragments left by resize reflow.

### Resize warning during inference
After a resize event mid-inference, emits:
> ⚠ Terminal resized — visual artifacts may appear above. Press Ctrl+L to refresh.

Sets user expectations and tells them how to fix it.

### Startup banner hint
`Ctrl+L refresh` added to the keybinding tips shown on launch.

## What this does NOT do

The ghost problem is **inherent to `Viewport::Inline`** — no terminal API exists to query where content ended up after column reflow. This PR mitigates with user-triggered cleanup, not a perfect fix.

The proper architectural fix (switch to `Viewport::Fullscreen` with app-managed scrollback) is tracked in #419.

## Diff

- `koda-cli/src/tui_context.rs` — +23 lines (Ctrl+L handler + resize warning)
- `koda-cli/src/startup.rs` — +2 lines (banner hint)

Closes #418
Related: #415, #417, #419