### PR TITLE
chore(release): v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-03-12
+
 ### Added
 - **Horizontal overflow indicators** — textarea input shows dim `→` / `←` arrows
   at the edges when content extends beyond the visible width (#416)
+- **Paste as collapsible block** — pasted content is inserted as a collapsible
+  `<details>` block reference, keeping the input area clean (#244)
+
+### Changed
+- **`#![warn(missing_docs)]` on koda-core** — all public items in the engine
+  crate now require documentation; ~235 doc comments added (#300)
+
+### Fixed
+- **Terminal resize stability** — cursor-aware viewport erase prevents ghost
+  prompts and scrollback corruption on resize (#415, #417)
+- **Ctrl+L screen refresh** — standard Unix convention cleans up visual
+  artifacts from resize reflow; resize warning guides users (#418, #420)
 
 ## [0.1.7] - 2026-03-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,5 +324,5 @@ See `koda-ast/tests/mcp_integration_test.rs` for the reference implementation.
 4. Add `--version` flag to `main()`
 5. Write MCP integration tests in `tests/mcp_integration_test.rs`
 6. Update `release.yml`: version verify, build, package, publish, Homebrew
-7. Sync version with workspace (currently 0.1.6)
+7. Sync version with workspace (currently 0.1.8)
 8. Update this file (claude.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.6" }
+koda-core = { path = "../koda-core", version = "0.1.8" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.8 in all 4 crates (koda-core, koda-cli, koda-ast, koda-email)
- Fix stale koda-core dependency version in koda-cli (was 0.1.6 → 0.1.8)
- Finalize CHANGELOG `[Unreleased]` → `[0.1.8]`
- Update CLAUDE.md workspace version reference

## What's in v0.1.8

### Added
- **Horizontal overflow indicators** — dim `→`/`←` arrows on textarea edges (#416)
- **Paste as collapsible block** — pasted content as `<details>` block reference (#244)

### Changed
- **`#![warn(missing_docs)]` on koda-core** — ~235 doc comments added (#300)

### Fixed
- **Terminal resize stability** — cursor-aware viewport erase (#415)
- **Ctrl+L screen refresh** + resize warning (#418)

## Test plan
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --features koda-core/test-support` — all pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] All 4 crate versions at 0.1.8
- [x] CHANGELOG entries match commits since v0.1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)