### PR TITLE
fix: move logs from .koda_logs/ to ~/.config/koda/logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ Thumbs.db
 # Logs
 logs/
 *.log
-.koda_logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   prompts and scrollback corruption on resize (#415, #417)
 - **Ctrl+L screen refresh** — standard Unix convention cleans up visual
   artifacts from resize reflow; resize warning guides users (#418, #420)
+- **Logs moved to `~/.config/koda/logs/`** — no longer creates `.koda_logs/`
+  in the project directory
 
 ## [0.1.7] - 2026-03-12
 

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -164,7 +164,7 @@ async fn main() -> Result<()> {
     let project_root = std::fs::canonicalize(&project_root)?;
 
     // Initialize logging to file (invisible to user)
-    let log_dir = project_root.join(".koda_logs");
+    let log_dir = koda_core::db::config_dir()?.join("logs");
     std::fs::create_dir_all(&log_dir)?;
     let file_appender = tracing_appender::rolling::daily(&log_dir, "koda.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);


### PR DESCRIPTION
## Summary
- Move log directory from `<project>/.koda_logs/` to `~/.config/koda/logs/`
- Remove `.koda_logs/` from `.gitignore` (no longer needed)
- Update CHANGELOG

Logs are koda's internal concern, not project data. Every other piece of koda state already lives under `~/.config/koda/` (keys, db, settings, memory, history, agents, skills, mcp config). The log directory was the sole outlier.

## Test plan
- [x] `cargo test --workspace --features koda-core/test-support` — all pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Run `koda` and verify logs appear in `~/.config/koda/logs/` instead of `.koda_logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)