### PR TITLE
chore(release): v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-03-12
+
+### Added
+- **Context Management docs** — new user guide section explaining context loading,
+  compaction lifecycle, auto-compaction, purge, and design philosophy
+- **`/purge` command** — permanently delete archived (compacted) messages with
+  preview stats and y/N confirmation. Supports age filter: `/purge 90d` (#429)
+- **Startup nudge** — one-line hint when archived history exceeds 500MB:
+  `💡 523MB of archived history — run /purge to clean up`
+- **`last_accessed_at` tracking** — sessions table tracks actual activity
+  timestamps, enabling age-based purge filtering by real usage
+- **`CompactSkip::HistoryTooLarge`** — compaction refuses when history exceeds
+  model context window, with clear user-facing warning
+
+### Changed
+- **Non-destructive compaction** — `compact_session()` now archives messages
+  with `compacted_at` timestamp instead of permanently deleting them.
+  Original history preserved in DB for recovery (#428)
+- **No sliding window** — `load_context()` loads ALL active (non-compacted)
+  messages chronologically. Removed token budgeting, priority-based truncation,
+  and `LIMIT 200`. Full model context utilized (#428)
+- **Orphan pruning** — `prune_mismatched_tool_calls()` uses symmetric-difference
+  of tool_call IDs to drop mismatched tool_use/tool_result pairs. Fixes
+  Anthropic API 400 errors from interrupted sessions (#428)
+- **No conversation text cap** — removed 20K char cap on compaction
+  summarization input. Scales to model capacity instead of hardcoded limit
+
+### Removed
+- **Dollar cost estimation** — stripped `cost.rs` (219 lines) and `/cost`
+  command. Token counts shown in status bar are sufficient; dollar estimates
+  were unreliable across providers (#427)
+- **Sliding window** — removed token budgeting, `estimate_tokens()`, and
+  priority-based truncation from `load_context()`. Replaced by loading all
+  active messages (#428)
+
+### Fixed
+- **Orphaned tool_result blocks** — API 400 errors from Anthropic caused by
+  mismatched tool_use/tool_result pairs after session interruption or
+  compaction boundaries (#428)
+- **GitHub Actions Node.js deprecation** — bumped CI/release workflows to
+  actions v6 (Node.js 24) (#426)
+- **Logs directory** — moved from `.koda_logs/` in project root to
+  `~/.config/koda/logs/` (#425)
+
 ## [0.1.8] - 2026-03-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,5 +324,5 @@ See `koda-ast/tests/mcp_integration_test.rs` for the reference implementation.
 4. Add `--version` flag to `main()`
 5. Write MCP integration tests in `tests/mcp_integration_test.rs`
 6. Update `release.yml`: version verify, build, package, publish, Homebrew
-7. Sync version with workspace (currently 0.1.8)
+7. Sync version with workspace (currently 0.1.9)
 8. Update this file (claude.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.8" }
+koda-core = { path = "../koda-core", version = "0.1.9" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -78,7 +78,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     } = ctx;
 
     // Hard cap is configurable per-agent; user can extend it interactively.
-    let _hard_cap = config.max_iterations;
     let mut hard_cap = config.max_iterations;
     let mut iteration = 0u32;
     let mut made_tool_calls = false;

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -164,7 +164,7 @@ pub trait Persistence: Send + Sync {
         agent_name: Option<&str>,
     ) -> Result<i64>;
 
-    /// Load conversation context within a token budget.
+    /// Load active (non-compacted) conversation context for a session.
     async fn load_context(&self, session_id: &str) -> Result<Vec<Message>>;
     /// Load all messages in a session (no token limit).
     async fn load_all_messages(&self, session_id: &str) -> Result<Vec<Message>>;

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## v0.1.9 Release

### Pre-release fixes (this PR)
- Remove dead code: `let _hard_cap` leftover from clippy auto-fix
- Fix stale doc comment: `load_context` no longer has a token budget
- Version bump across all 4 crates

### What's new since v0.1.8

#### Context management overhaul (#428, #430)
- **Non-destructive compaction** — `compact_session()` archives messages with `compacted_at` instead of deleting
- **No sliding window** — `load_context()` loads ALL active messages. No token budgeting, no `LIMIT 200`, no priority truncation
- **Orphan pruning** — `prune_mismatched_tool_calls()` fixes Anthropic API 400 errors from mismatched tool_use/tool_result pairs
- **Capacity check** — compaction refuses when history exceeds model context (instead of silently losing data)

#### `/purge` command (#429, #432)
- `/purge` — delete all archived messages (y/N confirmation)
- `/purge 90d` — age-filtered deletion
- Preview stats before confirming
- Startup nudge at >500MB archived data
- `last_accessed_at` session tracking

#### Other
- Strip dollar cost estimation (`cost.rs` removed, -219 lines) (#427)
- GitHub Actions v6 / Node.js 24 (#426)
- Logs moved to `~/.config/koda/logs/` (#425)
- Context Management section in user guide

### QA Checklist

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -D warnings` — zero warnings
- [x] `RUSTDOCFLAGS="-Dwarnings" cargo doc` — all docs compile
- [x] `cargo test --workspace --features koda-core/test-support` — **684 tests, 0 failures**
- [x] Security audit: all SQL parameterized, purge requires confirmation
- [x] Design principles audit: aligned with Software for One, Clear Boundaries, MIWMIRMIF

### Stats (since v0.1.8)
- 27 files changed, +669 -552 (net +117)
- 5 PRs merged (#420, #427, #426, #430, #432)
- 2 new features, 3 fixes, 1 removal