### PR TITLE
chore: upgrade release workflow actions to Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           cp README.md LICENSE koda-${{ matrix.target }}/
           7z a koda-${{ matrix.target }}.zip koda-${{ matrix.target }}/
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: koda-${{ matrix.target }}
           path: |
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
@@ -187,7 +187,7 @@ jobs:
           cat release_body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.5.0
         with:
           body_path: release_body.md
           files: |
@@ -199,7 +199,7 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary
- Upgrade `actions/upload-artifact` v6 → v7 (Node.js 24)
- Upgrade `actions/download-artifact` v6 → v7 (Node.js 24)
- Upgrade `softprops/action-gh-release` v2 → v2.5.0 (Node.js 24)

Fixes Node.js 20 deprecation warnings in the **GitHub Release** and **Update Homebrew Tap** jobs.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm no Node.js 20 deprecation warnings on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)