### PR TITLE
refactor: extract koda-ast and koda-email into library + binary crates (#431, PR 1/3)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -100,27 +100,50 @@ mode is optional for external clients.
 messages, tool calls with permissions, and status updates — exactly what
 Koda needs. Adopting ACP gives us Zed integration for free.
 
-### 3. Extensibility: Thin Core + Auto-Provisioned MCP
+### 3. Extensibility: Thin Core + First-Party Libraries + Auto-Provisioned MCP
 
 **Decision**: The core binary contains only essential tools (file ops, shell,
-search, web fetch, memory, agents). Domain-specific capabilities (AST analysis,
-email, calendar, browser) are delivered as MCP servers, auto-installed on demand.
+search, web fetch, memory, agents). Domain-specific capabilities are split
+into two tiers:
+
+- **First-party libraries** (AST analysis, email): Ship in the same workspace
+  as library crates with thin MCP binary wrappers. `koda-cli` calls the
+  library functions directly — zero IPC, zero process management. The MCP
+  binaries remain available for external consumers (other editors, standalone
+  use). `koda-core` stays dependency-free from these domains.
+- **Third-party / external capabilities** (browser, calendar, etc.): Delivered
+  as auto-provisioned MCP servers, installed on demand.
 
 **Principle evolution**: Early v0.1.x compiled everything into one binary.
-As the vision expanded beyond coding, we realized "everything just works"
-doesn't require "everything compiled in" — it requires "everything
-auto-provisioned with zero user config." The user experience is identical —
-zero friction — but the implementation scales to domains beyond coding.
+As the vision expanded beyond coding, we adopted MCP for all domain-specific
+capabilities ([#113](https://github.com/lijunzh/koda/issues/113)). In practice,
+routing in-repo capabilities through stdio JSON-RPC added process management
+overhead and IPC failure modes for functionality that ships in the same
+workspace. The current design distinguishes between first-party capabilities
+(library + optional MCP wrapper) and third-party capabilities (MCP only).
+See [#431](https://github.com/lijunzh/koda/issues/431) for the migration.
 
-**How it works**: When the LLM calls a tool that isn't built-in, koda checks
-an MCP capability registry, auto-installs the matching server, connects it,
-and retries — transparently. The user sees a brief spinner on first use;
-subsequent calls are instant.
+**How it works for third-party tools**: When the LLM calls a tool that isn't
+built-in or registered as a first-party library, koda checks an MCP capability
+registry, auto-installs the matching server, connects it, and retries —
+transparently. The user sees a brief spinner on first use; subsequent calls
+are instant.
 
-**Rationale**: As koda expands to email, calendar, and knowledge management,
-compiling every integration into one binary creates bloat. The MCP protocol
-is the contract; the implementation language and deployment model are details.
-AST analysis is the pilot for this pattern (see [#113](https://github.com/lijunzh/koda/issues/113)).
+**Dependency graph**:
+```
+koda-cli → koda-core  (inference engine, zero domain deps)
+         → koda-ast   (direct library call)
+         → koda-email (direct library call)
+
+koda-ast/main.rs  → thin MCP wrapper (for external use)
+koda-email/main.rs → thin MCP wrapper (for external use)
+```
+
+**Rationale**: MCP is the right protocol for *external* tool integration —
+not for in-repo capabilities that share the same workspace and release cycle.
+First-party libraries eliminate IPC overhead while preserving clean boundaries:
+`koda-core` has zero domain-specific deps, and each library is independently
+testable and usable via MCP by external consumers.
 
 **MCP server language**: Default to Rust (`cargo binstall`) for koda-maintained
 servers. Use Node/Python when critical libraries only exist in those ecosystems.

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 name = "koda-ast"
 path = "src/main.rs"
 
+[lib]
+name = "koda_ast"
+path = "src/lib.rs"
+
 [dependencies]
 rmcp = { version = "1.1", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }

--- a/koda-ast/src/lib.rs
+++ b/koda-ast/src/lib.rs
@@ -1,0 +1,71 @@
+//! koda-ast: Tree-sitter AST analysis library.
+//!
+//! Provides file structure analysis and call graph extraction
+//! for Rust, Python, JavaScript, TypeScript, Go, Java, C/C++, and Bash.
+//!
+//! This is the library crate. For the MCP server binary, see `main.rs`.
+
+pub mod ast;
+
+use std::path::{Path, PathBuf};
+
+/// Re-export core analysis functions at the crate root for convenience.
+pub use ast::{analyze_file, get_call_graph};
+
+/// Tool definition metadata for consumers (koda-cli, capability_registry).
+///
+/// This is the single source of truth for the AstAnalysis tool schema.
+/// Both the MCP wrapper (`main.rs`) and direct integrations use this.
+pub struct ToolDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub parameters_json: &'static str,
+}
+
+/// Returns tool definitions exported by this crate.
+pub fn tool_definitions() -> Vec<ToolDef> {
+    vec![ToolDef {
+        name: "AstAnalysis",
+        description: "Read-only AST code analysis. Use 'analyze_file' for functions/classes/structs \
+             summary, or 'get_call_graph' with a symbol name to find callers and callees. \
+             Supports .rs, .py, .pyi, .pyw, .js, .jsx, .mjs, .cjs, .ts, .mts, .cts, .tsx, \
+             .go, .java, .c, .h, .cpp, .cc, .cxx, .hpp, .hh, .sh, .bash files.",
+        parameters_json: r#"{"type":"object","properties":{"action":{"type":"string","description":"'analyze_file' or 'get_call_graph'"},"file_path":{"type":"string","description":"Path to file"},"symbol":{"type":"string","description":"Symbol for get_call_graph"}},"required":["action","file_path"]}"#,
+    }]
+}
+
+/// Execute an AST analysis action, returning the result as a string.
+///
+/// This is the unified entry point for both MCP and direct library usage.
+/// Handles path resolution relative to `project_root`, action dispatch,
+/// and error formatting.
+pub fn execute(
+    project_root: &Path,
+    action: &str,
+    file_path: &str,
+    symbol: Option<&str>,
+) -> Result<String, String> {
+    let path = if Path::new(file_path).is_absolute() {
+        PathBuf::from(file_path)
+    } else {
+        project_root.join(file_path)
+    };
+
+    if !path.exists() {
+        return Err(format!("File not found: {file_path}"));
+    }
+
+    match action {
+        "analyze_file" => analyze_file(&path).map_err(|e| e.to_string()),
+        "get_call_graph" => {
+            let sym = symbol.unwrap_or("");
+            if sym.is_empty() {
+                return Err("'symbol' is required for get_call_graph".to_string());
+            }
+            get_call_graph(&path, sym).map_err(|e| e.to_string())
+        }
+        other => Err(format!(
+            "Unknown action '{other}'. Use 'analyze_file' or 'get_call_graph'."
+        )),
+    }
+}

--- a/koda-ast/src/main.rs
+++ b/koda-ast/src/main.rs
@@ -1,9 +1,7 @@
 //! koda-ast: MCP server for tree-sitter AST analysis.
 //!
-//! Provides `AstAnalysis` tool via MCP stdio transport.
+//! Thin MCP wrapper around the `koda_ast` library crate.
 //! Part of the koda ecosystem — auto-provisioned on first use.
-
-mod ast;
 
 use rmcp::{
     ServerHandler, ServiceExt,
@@ -61,6 +59,9 @@ impl ServerHandler for AstServer {
 #[tool_router]
 impl AstServer {
     /// Read-only AST code analysis for Rust, Python, JavaScript, TypeScript.
+    ///
+    /// NOTE: The description below must stay in sync with
+    /// `koda_ast::tool_definitions()` in lib.rs (the authoritative source).
     #[tool(
         name = "AstAnalysis",
         description = "Read-only AST code analysis. Use 'analyze_file' for functions/classes/structs summary, or 'get_call_graph' with a symbol name to find callers and callees. Supports .rs, .py, .pyi, .pyw, .js, .jsx, .mjs, .cjs, .ts, .mts, .cts, .tsx, .go, .java, .c, .h, .cpp, .cc, .cxx, .hpp, .hh, .sh, .bash files."
@@ -70,36 +71,7 @@ impl AstServer {
         params: Parameters<AstAnalysisParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let p = &params.0;
-        let path = if PathBuf::from(&p.file_path).is_absolute() {
-            PathBuf::from(&p.file_path)
-        } else {
-            self.cwd.join(&p.file_path)
-        };
-
-        if !path.exists() {
-            return Ok(CallToolResult::error(vec![Content::text(format!(
-                "Error: File not found: {}",
-                p.file_path
-            ))]));
-        }
-
-        let result = match p.action.as_str() {
-            "analyze_file" => ast::analyze_file(&path),
-            "get_call_graph" => {
-                let sym = p.symbol.as_deref().unwrap_or("");
-                if sym.is_empty() {
-                    return Ok(CallToolResult::error(vec![Content::text(
-                        "Error: 'symbol' is required for get_call_graph",
-                    )]));
-                }
-                ast::get_call_graph(&path, sym)
-            }
-            other => Ok(format!(
-                "Error: Unknown action '{other}'. Use 'analyze_file' or 'get_call_graph'."
-            )),
-        };
-
-        match result {
+        match koda_ast::execute(&self.cwd, &p.action, &p.file_path, p.symbol.as_deref()) {
             Ok(output) => Ok(CallToolResult::success(vec![Content::text(output)])),
             Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
                 "Error: {e}"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 name = "koda-email"
 path = "src/main.rs"
 
+[lib]
+name = "koda_email"
+path = "src/lib.rs"
+
 [dependencies]
 rmcp = { version = "1.1", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }

--- a/koda-email/src/lib.rs
+++ b/koda-email/src/lib.rs
@@ -1,0 +1,43 @@
+//! koda-email: Email read/send/search library via IMAP/SMTP.
+//!
+//! Provides email operations for the koda ecosystem.
+//! This is the library crate. For the MCP server binary, see `main.rs`.
+
+pub mod config;
+pub mod imap_client;
+pub mod smtp_client;
+
+/// Tool definition metadata for consumers (koda-cli, capability_registry).
+///
+/// This is the single source of truth for email tool schemas.
+/// Both the MCP wrapper (`main.rs`) and direct integrations use this.
+pub struct ToolDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub parameters_json: &'static str,
+}
+
+/// Returns tool definitions exported by this crate.
+pub fn tool_definitions() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: "EmailRead",
+            description: "Read recent emails from INBOX. Returns subject, sender, date, \
+                 and a text snippet for each email. Use 'count' to control how many \
+                 (default 5, max 20).",
+            parameters_json: r#"{"type":"object","properties":{"count":{"type":"integer","description":"Number of recent emails to fetch (default 5, max 20)"}},"required":[]}"#,
+        },
+        ToolDef {
+            name: "EmailSend",
+            description: "Send an email via SMTP. Requires 'to' (recipient), 'subject', \
+                 and 'body'.",
+            parameters_json: r#"{"type":"object","properties":{"to":{"type":"string","description":"Recipient email address"},"subject":{"type":"string","description":"Email subject line"},"body":{"type":"string","description":"Email body text"}},"required":["to","subject","body"]}"#,
+        },
+        ToolDef {
+            name: "EmailSearch",
+            description: "Search emails in INBOX. Plain text searches subject and body. \
+                 Use 'from:addr' to search by sender, 'subject:text' to search by subject line.",
+            parameters_json: r#"{"type":"object","properties":{"query":{"type":"string","description":"Search query. Use 'from:' or 'subject:' prefixes for targeted search."},"max_results":{"type":"integer","description":"Max results (default 10, max 50)"}},"required":["query"]}"#,
+        },
+    ]
+}

--- a/koda-email/src/main.rs
+++ b/koda-email/src/main.rs
@@ -1,13 +1,12 @@
 //! koda-email: MCP server for email read/send/search via IMAP/SMTP.
 //!
-//! Provides `EmailRead`, `EmailSend`, and `EmailSearch` tools via MCP stdio.
+//! Thin MCP wrapper around the `koda_email` library crate.
 //! Part of the koda ecosystem — auto-provisioned on first use.
 
-mod config;
-mod imap_client;
-mod smtp_client;
+use koda_email::config::EmailConfig;
+use koda_email::imap_client;
+use koda_email::smtp_client;
 
-use config::EmailConfig;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -57,6 +56,9 @@ fn default_max_results() -> u32 {
 }
 
 // ── MCP Server ───────────────────────────────────────────
+//
+// NOTE: The #[tool(description = "...")] attributes below must stay in sync
+// with `koda_email::tool_definitions()` in lib.rs (the authoritative source).
 
 #[derive(Debug, Clone)]
 struct EmailServer {


### PR DESCRIPTION
## Summary

Restructures `koda-ast` and `koda-email` from standalone MCP binaries into **library + thin binary wrapper** crates, following the pattern established by `koda-core`.

Part of #431 (PR 1 of 3). Zero behavioral change.

## Changes

### koda-ast
- **New `lib.rs`**: Exports `analyze_file()`, `get_call_graph()`, `execute()`, and `tool_definitions()` as a public Rust API
- **`main.rs`**: Now a thin MCP wrapper that imports from the library — no duplicated logic
- **`Cargo.toml`**: Defines both `[lib]` and `[[bin]]` targets

### koda-email
- **New `lib.rs`**: Exports `config`, `imap_client`, `smtp_client` modules and `tool_definitions()`
- **`main.rs`**: Thin MCP wrapper importing from the library
- **`Cargo.toml`**: Defines both `[lib]` and `[[bin]]` targets

### DESIGN.md
- Updated §3 to codify the **first-party library vs third-party MCP** distinction
- First-party capabilities (AST, email) → library + optional MCP wrapper
- Third-party capabilities → auto-provisioned MCP servers

### Tool definition single source of truth
Both libraries export `ToolDef` structs with name, description, and parameter schema. These will be consumed by `koda-cli` in PR 3 to replace the duplicated definitions in `capability_registry.rs`.

## What's next
- **PR 2**: Add minimal extension mechanism to `ToolRegistry` (`HashMap<String, AsyncHandler>` + `register_tool()`)
- **PR 3**: Wire up in `koda-cli`, update `capability_registry` to use exported definitions

## Testing
- All 441 tests pass across all workspace crates
- MCP integration tests for both servers still pass
- Full workspace builds clean