### PR TITLE
refactor: wire AST and email tools as direct library calls (#431)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,6 +1745,8 @@ dependencies = [
  "futures-util",
  "glob",
  "ignore",
+ "koda-ast",
+ "koda-email",
  "path-clean",
  "regex",
  "reqwest",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -131,9 +131,9 @@ are instant.
 
 **Dependency graph**:
 ```
-koda-cli → koda-core  (inference engine, zero domain deps)
-         → koda-ast   (direct library call)
-         → koda-email (direct library call)
+koda-cli → koda-core  (inference engine + first-party tool calls)
+                    → koda-ast   (direct library call from ToolRegistry)
+                    → koda-email (direct library call from ToolRegistry)
 
 koda-ast/main.rs  → thin MCP wrapper (for external use)
 koda-email/main.rs → thin MCP wrapper (for external use)
@@ -141,9 +141,8 @@ koda-email/main.rs → thin MCP wrapper (for external use)
 
 **Rationale**: MCP is the right protocol for *external* tool integration —
 not for in-repo capabilities that share the same workspace and release cycle.
-First-party libraries eliminate IPC overhead while preserving clean boundaries:
-`koda-core` has zero domain-specific deps, and each library is independently
-testable and usable via MCP by external consumers.
+First-party libraries eliminate IPC overhead while keeping each domain
+independently testable and usable via MCP by external consumers.
 
 **MCP server language**: Default to Rust (`cargo binstall`) for koda-maintained
 servers. Use Node/Python when critical libraries only exist in those ecosystems.

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -57,6 +57,10 @@ futures-util = "0.3"
 anyhow = "1"
 which = "8"
 
+# First-party workspace libraries (direct calls, no MCP IPC)
+koda-ast = { path = "../koda-ast" }
+koda-email = { path = "../koda-email" }
+
 # Async trait support
 async-trait = "0.1"
 

--- a/koda-core/src/mcp/capability_registry.rs
+++ b/koda-core/src/mcp/capability_registry.rs
@@ -24,47 +24,11 @@ pub struct CapabilityEntry {
 }
 
 /// Built-in capability registry — auto-provisionable MCP servers.
-const REGISTRY: &[CapabilityEntry] = &[
-    CapabilityEntry {
-        server_name: "koda-ast",
-        command: "koda-ast",
-        tools: &["AstAnalysis"],
-        description: "Tree-sitter AST analysis for Rust, Python, JS, TS",
-        install_hint: "brew install koda (includes koda-ast) or cargo install koda-ast",
-        tool_definitions: &[(
-            "AstAnalysis",
-            "Read-only AST code analysis. Supports .rs, .py, .js, .ts. \
-             Use action 'analyze_file' for structure summary or 'get_call_graph' with a symbol.",
-            r#"{"type":"object","properties":{"action":{"type":"string","description":"'analyze_file' or 'get_call_graph'"},"file_path":{"type":"string","description":"Path to file"},"symbol":{"type":"string","description":"Symbol for get_call_graph"}},"required":["action","file_path"]}"#,
-        )],
-    },
-    CapabilityEntry {
-        server_name: "koda-email",
-        command: "koda-email",
-        tools: &["EmailRead", "EmailSend", "EmailSearch"],
-        description: "Email read/send/search via IMAP/SMTP",
-        install_hint: "brew install koda (includes koda-email) or cargo install koda-email",
-        tool_definitions: &[
-            (
-                "EmailRead",
-                "Read recent emails from INBOX. Returns subject, sender, date, and a text snippet. \
-                 Use 'count' to control how many (default 5, max 20).",
-                r#"{"type":"object","properties":{"count":{"type":"integer","description":"Number of recent emails to fetch (default 5, max 20)"}},"required":[]}"#,
-            ),
-            (
-                "EmailSend",
-                "Send an email via SMTP. Requires 'to' (recipient), 'subject', and 'body'.",
-                r#"{"type":"object","properties":{"to":{"type":"string","description":"Recipient email address"},"subject":{"type":"string","description":"Email subject line"},"body":{"type":"string","description":"Email body text"}},"required":["to","subject","body"]}"#,
-            ),
-            (
-                "EmailSearch",
-                "Search emails in INBOX. Plain text searches subject and body. \
-                 Use 'from:addr' to search by sender, 'subject:text' to search by subject.",
-                r#"{"type":"object","properties":{"query":{"type":"string","description":"Search query. Use 'from:' or 'subject:' prefixes for targeted search."},"max_results":{"type":"integer","description":"Max results (default 10, max 50)"}},"required":["query"]}"#,
-            ),
-        ],
-    },
-];
+///
+/// Note: koda-ast and koda-email are now first-party library calls
+/// (see `ToolRegistry::execute` match arms). Only third-party / external
+/// MCP servers belong here.
+const REGISTRY: &[CapabilityEntry] = &[];
 
 /// Get tool definitions from all capability registry entries.
 ///
@@ -113,10 +77,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_find_ast_analysis() {
-        let entry = find_server_for_tool("AstAnalysis");
-        assert!(entry.is_some());
-        assert_eq!(entry.unwrap().server_name, "koda-ast");
+    fn test_registry_is_empty_after_library_migration() {
+        // koda-ast and koda-email are now direct library calls,
+        // so the MCP capability registry should be empty.
+        assert!(REGISTRY.is_empty());
+        assert!(tool_definitions().is_empty());
     }
 
     #[test]
@@ -125,47 +90,14 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_definitions_include_ast() {
-        let defs = tool_definitions();
-        assert!(!defs.is_empty());
-        let ast = defs.iter().find(|d| d.name == "AstAnalysis");
-        assert!(ast.is_some(), "AstAnalysis should be in tool definitions");
+    fn test_ast_no_longer_in_mcp_registry() {
+        assert!(find_server_for_tool("AstAnalysis").is_none());
     }
 
     #[test]
-    fn test_find_email_tools() {
-        for tool_name in &["EmailRead", "EmailSend", "EmailSearch"] {
-            let entry = find_server_for_tool(tool_name);
-            assert!(entry.is_some(), "{tool_name} should be in registry");
-            assert_eq!(entry.unwrap().server_name, "koda-email");
-        }
-    }
-
-    #[test]
-    fn test_tool_definitions_include_email() {
-        let defs = tool_definitions();
+    fn test_email_no_longer_in_mcp_registry() {
         for name in &["EmailRead", "EmailSend", "EmailSearch"] {
-            let found = defs.iter().find(|d| d.name == *name);
-            assert!(found.is_some(), "{name} should be in tool definitions");
+            assert!(find_server_for_tool(name).is_none());
         }
-    }
-
-    #[tokio::test]
-    async fn test_auto_provision_returns_install_hint() {
-        // When koda-ast is not on PATH and MCP registry is None,
-        // executing AstAnalysis should return an install hint, not "Unknown tool"
-        let registry =
-            crate::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"), 100_000);
-        let result = registry.execute("AstAnalysis", "{}").await;
-        assert!(
-            !result.output.contains("Unknown tool"),
-            "Should not return 'Unknown tool', got: {}",
-            result.output
-        );
-        assert!(
-            result.output.contains("koda-ast"),
-            "Should mention koda-ast server, got: {}",
-            result.output
-        );
     }
 }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -160,6 +160,28 @@ impl ToolRegistry {
         // RecallContext — on-demand history retrieval
         let recall_def = recall::definition();
         definitions.insert(recall_def.name.clone(), recall_def);
+        // First-party library tools (direct calls, no MCP IPC)
+        for td in koda_ast::tool_definitions() {
+            definitions.insert(
+                td.name.to_string(),
+                ToolDefinition {
+                    name: td.name.to_string(),
+                    description: td.description.to_string(),
+                    parameters: serde_json::from_str(td.parameters_json).unwrap_or_default(),
+                },
+            );
+        }
+        for td in koda_email::tool_definitions() {
+            definitions.insert(
+                td.name.to_string(),
+                ToolDefinition {
+                    name: td.name.to_string(),
+                    description: td.description.to_string(),
+                    parameters: serde_json::from_str(td.parameters_json).unwrap_or_default(),
+                },
+            );
+        }
+
         // Auto-provisionable MCP tools (registered so the LLM knows they exist)
         for def in crate::mcp::capability_registry::tool_definitions() {
             definitions.insert(def.name.clone(), def);
@@ -392,6 +414,82 @@ impl ToolRegistry {
                 }
             }
 
+            // First-party library tools — direct calls, no MCP IPC
+            "AstAnalysis" => {
+                let action = args["action"].as_str().unwrap_or("");
+                let file_path = args["file_path"].as_str().unwrap_or("");
+                let symbol = args["symbol"].as_str();
+                koda_ast::execute(&self.project_root, action, file_path, symbol)
+                    .map_err(|e| anyhow::anyhow!(e))
+            }
+
+            "EmailRead" => {
+                let config = match koda_email::config::EmailConfig::from_env() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return ToolResult {
+                            output: format!(
+                                "Email not configured: {e:#}\n\n{}",
+                                koda_email::config::EmailConfig::setup_instructions()
+                            ),
+                        };
+                    }
+                };
+                let count = args["count"].as_u64().unwrap_or(5).clamp(1, 20) as u32;
+                match koda_email::imap_client::read_emails(&config, count).await {
+                    Ok(emails) if emails.is_empty() => Ok("No emails found in INBOX.".to_string()),
+                    Ok(emails) => Ok(format_email_list(&emails)),
+                    Err(e) => Err(anyhow::anyhow!("Error reading emails: {e:#}")),
+                }
+            }
+
+            "EmailSend" => {
+                let config = match koda_email::config::EmailConfig::from_env() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return ToolResult {
+                            output: format!(
+                                "Email not configured: {e:#}\n\n{}",
+                                koda_email::config::EmailConfig::setup_instructions()
+                            ),
+                        };
+                    }
+                };
+                let to = args["to"].as_str().unwrap_or("");
+                let subject = args["subject"].as_str().unwrap_or("");
+                let body = args["body"].as_str().unwrap_or("");
+                koda_email::smtp_client::send_email(&config, to, subject, body)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("Error sending email: {e:#}"))
+            }
+
+            "EmailSearch" => {
+                let config = match koda_email::config::EmailConfig::from_env() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return ToolResult {
+                            output: format!(
+                                "Email not configured: {e:#}\n\n{}",
+                                koda_email::config::EmailConfig::setup_instructions()
+                            ),
+                        };
+                    }
+                };
+                let query = args["query"].as_str().unwrap_or("");
+                let max = args["max_results"].as_u64().unwrap_or(10).clamp(1, 50) as u32;
+                match koda_email::imap_client::search_emails(&config, query, max).await {
+                    Ok(emails) if emails.is_empty() => {
+                        Ok(format!("No emails found matching: {query}"))
+                    }
+                    Ok(emails) => Ok(format!(
+                        "Found {} result(s) for \"{query}\":\n\n{}",
+                        emails.len(),
+                        format_email_list(&emails)
+                    )),
+                    Err(e) => Err(anyhow::anyhow!("Error searching emails: {e:#}")),
+                }
+            }
+
             "InvokeAgent" => {
                 // Handled by tool_dispatch.rs before reaching here.
                 // This branch should not be reached in normal flow.
@@ -500,6 +598,30 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
     }
 
     Ok(resolved)
+}
+
+/// Format email summaries for LLM-friendly output.
+fn format_email_list(emails: &[koda_email::imap_client::EmailSummary]) -> String {
+    emails
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            format!(
+                "{}. [{}] {}\n   From: {}\n   Date: {}\n   {}\n",
+                i + 1,
+                e.uid,
+                e.subject,
+                e.from,
+                e.date,
+                if e.snippet.is_empty() {
+                    "(no preview)"
+                } else {
+                    &e.snippet
+                }
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Completes #431 — AST and email tools are now direct library calls in `ToolRegistry::execute()`, eliminating MCP IPC overhead for first-party capabilities.

## Changes

| File | What changed |
|---|---|
| `koda-core/Cargo.toml` | Added `koda-ast` and `koda-email` as workspace deps |
| `koda-core/src/tools/mod.rs` | Match arms for `AstAnalysis`, `EmailRead/Send/Search`; tool defs sourced from library `tool_definitions()` |
| `koda-core/src/mcp/capability_registry.rs` | Removed AST/email entries (empty registry, ready for future external servers) |
| `DESIGN.md` | Updated §3 dependency graph |

## Before → After

| | Before | After |
|---|---|---|
| **AstAnalysis** | koda-cli → koda-core → MCP stdio → koda-ast binary | koda-core → `koda_ast::execute()` |
| **Email tools** | koda-cli → koda-core → MCP stdio → koda-email binary | koda-core → `koda_email::imap_client/smtp_client` |
| **Tool schemas** | Duplicated in capability_registry + MCP `#[tool]` attrs | Single source: `tool_definitions()` in each library |

## Testing

- 441 tests pass across all workspace crates
- Full workspace builds clean
- `cargo fmt --check --all` clean