### PR TITLE
fix: sync docs and tests with post-#431 state

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -107,10 +107,10 @@ search, web fetch, memory, agents). Domain-specific capabilities are split
 into two tiers:
 
 - **First-party libraries** (AST analysis, email): Ship in the same workspace
-  as library crates with thin MCP binary wrappers. `koda-cli` calls the
+  as library crates with thin MCP binary wrappers. `koda-core` calls the
   library functions directly — zero IPC, zero process management. The MCP
   binaries remain available for external consumers (other editors, standalone
-  use). `koda-core` stays dependency-free from these domains.
+  use).
 - **Third-party / external capabilities** (browser, calendar, etc.): Delivered
   as auto-provisioned MCP servers, installed on demand.
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -749,6 +749,19 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
             let url = args.get("url").and_then(|v| v.as_str()).unwrap_or("?");
             format!("Fetch URL: {url}")
         }
+        "AstAnalysis" => {
+            let action = args.get("action").and_then(|v| v.as_str()).unwrap_or("?");
+            let file = args
+                .get("file_path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            format!("AST {action}: {file}")
+        }
+        "EmailSend" => {
+            let to = args.get("to").and_then(|v| v.as_str()).unwrap_or("?");
+            let subject = args.get("subject").and_then(|v| v.as_str()).unwrap_or("?");
+            format!("Send email to {to}: {subject}")
+        }
         _ => format!("Execute: {tool_name}"),
     }
 }

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -220,20 +220,26 @@ mod web_fetch {
 mod naming_convention {
     /// All built-in tool names must be PascalCase.
     const BUILTIN_TOOLS: &[&str] = &[
-        "Read",
-        "Write",
-        "Edit",
-        "Delete",
-        "List",
-        "Grep",
-        "Glob",
+        "ActivateSkill",
+        "AstAnalysis",
         "Bash",
-        "WebFetch",
+        "Delete",
+        "Edit",
+        "EmailRead",
+        "EmailSearch",
+        "EmailSend",
+        "Glob",
+        "Grep",
+        "InvokeAgent",
+        "List",
+        "ListAgents",
+        "ListSkills",
         "MemoryRead",
         "MemoryWrite",
-        "ShareReasoning",
-        "InvokeAgent",
-        "ListAgents",
+        "Read",
+        "RecallContext",
+        "WebFetch",
+        "Write",
     ];
 
     #[test]
@@ -266,7 +272,29 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 14 built-in tools as of this version
-        assert_eq!(BUILTIN_TOOLS.len(), 14);
+        // 20 built-in tools as of v0.1.9+
+        assert_eq!(BUILTIN_TOOLS.len(), 20);
+    }
+
+    /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.
+    /// If this fails, a tool was added/removed without updating BUILTIN_TOOLS above.
+    #[test]
+    fn test_builtin_list_matches_registry() {
+        let registry =
+            koda_core::tools::ToolRegistry::new(std::path::PathBuf::from("/tmp/test"), 100_000);
+        let actual: std::collections::HashSet<String> =
+            registry.all_builtin_tool_names().into_iter().collect();
+        let expected: std::collections::HashSet<String> =
+            BUILTIN_TOOLS.iter().map(|s| s.to_string()).collect();
+
+        let missing: Vec<_> = actual.difference(&expected).collect();
+        let extra: Vec<_> = expected.difference(&actual).collect();
+
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "BUILTIN_TOOLS is out of sync with the registry!\n  \
+             In registry but not in list: {missing:?}\n  \
+             In list but not in registry: {extra:?}"
+        );
     }
 }


### PR DESCRIPTION
## Found during compliance review

Post-v0.1.9 review against DESIGN.md principles found 3 issues:

### 1. 🔴 DESIGN.md §3 — stale claim (Medium)
Said `koda-core stays dependency-free from these domains` — false since #431 added koda-ast/koda-email as direct deps. Fixed: removed the stale sentence.

### 2. 🔴 `new_tools_test.rs` — stale tool list (Medium)
`BUILTIN_TOOLS` listed 14 tools, actual registry has 20. Included `ShareReasoning` (removed) and missed 7 tools added over time. Fixed: updated list + **added a guard test** that validates `BUILTIN_TOOLS` against the real `ToolRegistry` — can never go stale again.

### 3. 🟡 `describe_action()` — generic fallback for new tools (Low)
AstAnalysis and EmailSend fell through to `Execute: {name}` in approval prompts. Added specific descriptions: `AST analyze_file: src/main.rs`, `Send email to user@x: Subject`.

## All 5 commits since v0.1.9 reviewed ✅

| Commit | Verdict |
|---|---|
| CI workflow upgrade | ✅ No concerns |
| Empty response retry | ✅ §2 Clear Boundaries |
| Parallel mutation guard | ✅ §7, §18 |
| Library extraction | ✅ §3, §7 |
| Direct library wiring | ✅ §1, §3, §7 |