### PR TITLE
release: v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-03-14
+
+### Removed
+- **MCP client** — removed the entire MCP client module (`koda-core/src/mcp/`),
+  `/mcp` slash command, auto-provisioning, and all integration points.
+  First-party tools (koda-ast, koda-email) were already migrated to direct
+  library calls in v0.1.9. Standalone MCP server binaries remain for external
+  consumers. Net -1,719 lines across 34 files (#443, #444)
+- **Capability registry** — removed auto-provisioning of third-party MCP servers.
+  Closed #274 (Playwright MCP) as dependent on removed infrastructure
+- **`rmcp` dependency** — removed from koda-core (still used by koda-ast and
+  koda-email standalone binaries)
+
+### Fixed
+- **Stale documentation** — updated CLAUDE.md, DESIGN.md, README.md,
+  capabilities.md, and user-guide.md to remove all MCP client references
+
 ## [0.1.9] - 2026-03-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.1.9)
+10. Sync version with workspace (currently 0.1.10)
 11. Update this file (CLAUDE.md)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-ast/src/lib.rs
+++ b/koda-ast/src/lib.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 /// Re-export core analysis functions at the crate root for convenience.
 pub use ast::{analyze_file, get_call_graph};
 
-/// Tool definition metadata for consumers (koda-cli, capability_registry).
+/// Tool definition metadata for consumers (koda-core ToolRegistry).
 ///
 /// This is the single source of truth for the AstAnalysis tool schema.
 /// Both the MCP wrapper (`main.rs`) and direct integrations use this.

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.9" }
+koda-core = { path = "../koda-core", version = "0.1.10" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -13,8 +13,6 @@ fn all_tool_names() -> Vec<String> {
 
 /// Every tool must be routable in the dispatcher.
 /// Tools handled externally (InvokeAgent) return sentinel strings.
-/// Auto-provisioned tools (from capability registry) return install hints
-/// when the server binary isn't available.
 /// None should return "Unknown tool".
 #[tokio::test]
 async fn test_all_tools_routable_in_dispatcher() {

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"

--- a/koda-email/src/lib.rs
+++ b/koda-email/src/lib.rs
@@ -7,7 +7,7 @@ pub mod config;
 pub mod imap_client;
 pub mod smtp_client;
 
-/// Tool definition metadata for consumers (koda-cli, capability_registry).
+/// Tool definition metadata for consumers (koda-core ToolRegistry).
 ///
 /// This is the single source of truth for email tool schemas.
 /// Both the MCP wrapper (`main.rs`) and direct integrations use this.


### PR DESCRIPTION
## v0.1.10 Release

### Changes since v0.1.9

**Removed:**
- MCP client module and all integration points (-1,719 lines, #443/#444)
- Capability registry / auto-provisioning of third-party MCP servers
- `rmcp` dependency from koda-core
- `/mcp` slash command
- Closed #274 (Playwright MCP — depended on removed infrastructure)

**Fixed:**
- Stale MCP references in CLAUDE.md, DESIGN.md, README.md, capabilities.md, user-guide.md
- Stale `capability_registry` doc comments in koda-ast/koda-email lib.rs
- Stale auto-provisioning doc in tool_wiring_test.rs

### Release checklist
- [x] All 29 test suites pass (646 tests)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Versions bumped: 0.1.9 → 0.1.10 (all 4 crates)
- [x] CHANGELOG.md updated
- [x] CLAUDE.md version reference updated
- [x] No open blockers (2 open issues are enhancements)