### PR TITLE
fix: add version specifiers to workspace deps and fix publish order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      # Publish order follows dependency graph:
+      # koda-ast, koda-email (no workspace deps) → koda-core → koda-cli
+      - name: Publish koda-ast
+        run: cargo publish -p koda-ast
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Publish koda-email
+        run: cargo publish -p koda-email
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Wait for crates.io index
+        run: sleep 30
       - name: Publish koda-core
         run: cargo publish -p koda-core
         env:
@@ -148,14 +160,6 @@ jobs:
         run: sleep 30
       - name: Publish koda-cli
         run: cargo publish -p koda-cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish koda-ast
-        run: cargo publish -p koda-ast
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish koda-email
-        run: cargo publish -p koda-email
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -59,6 +59,6 @@ rpassword = "7.4.0"
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.10", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast" }
-koda-email = { path = "../koda-email" }
+koda-ast = { path = "../koda-ast", version = "0.1.10" }
+koda-email = { path = "../koda-email", version = "0.1.10" }
 
 # Async trait support
 async-trait = "0.1"


### PR DESCRIPTION
## Summary
- Add `version = "0.1.10"` to koda-core's dependencies on koda-ast and koda-email (required by `cargo publish`)
- Add `version = "0.1.10"` to koda-cli's dev-dependency on koda-core
- Reorder publish steps to match the dependency graph: koda-ast/koda-email → koda-core → koda-cli

Fixes the `cargo publish -p koda-core` failure in the v0.1.10 release workflow:
```
all dependencies must have a version requirement specified when publishing.
dependency `koda-ast` does not specify a version
```

## Test plan
- [ ] CI passes
- [ ] `cargo publish --dry-run --allow-dirty` succeeds for all 4 crates (will still fail version lookup against crates.io since 0.1.10 isn't published yet, but manifest verification passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)