### PR TITLE
chore: document Windows keystore ACL gap

### DIFF
--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -65,6 +65,11 @@ impl KeyStore {
 
         #[cfg(not(unix))]
         {
+            // TODO: Windows ACL — std::fs::write inherits parent directory ACLs,
+            // which typically grants read access to the Users group. API keys are
+            // readable by any local user. Low risk for single-user dev machines,
+            // but if koda ever runs on shared workstations or as a service,
+            // restrict the DACL to the current user SID via SetNamedSecurityInfoW.
             std::fs::write(&path, &content)?;
         }
 


### PR DESCRIPTION
Adds a TODO comment to the `#[cfg(not(unix))]` path in `keystore.rs` documenting that `std::fs::write()` inherits parent directory ACLs on Windows, making `keys.toml` readable by any local user.

Low risk for single-user dev machines (koda's current use case). Comment documents the gap and the fix path (`SetNamedSecurityInfoW` with user-only DACL) for if this ever matters.

No code changes, no behavior changes — comment only.