### PR TITLE
docs: add doc-tests for key public APIs in koda-core

### DIFF
--- a/koda-core/src/bash_path_lint.rs
+++ b/koda-core/src/bash_path_lint.rs
@@ -26,6 +26,19 @@ impl BashPathLint {
 }
 
 /// Lint a bash command for paths that escape project_root.
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+/// use koda_core::bash_path_lint::lint_bash_paths;
+///
+/// let lint = lint_bash_paths("cat src/main.rs", Path::new("/project"));
+/// assert!(!lint.has_warnings());
+///
+/// let lint = lint_bash_paths("cat /etc/passwd", Path::new("/project"));
+/// assert!(lint.has_warnings());
+/// ```
 pub fn lint_bash_paths(command: &str, project_root: &Path) -> BashPathLint {
     let mut lint = BashPathLint::default();
     let trimmed = command.trim();

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -152,12 +152,26 @@ const DANGEROUS_PATTERNS: &[&str] = &[
 
 /// Classify a bash command's effect.
 ///
+/// Classify a bash command by its side-effect severity.
+///
 /// Returns the *most dangerous* effect found across all pipeline/chain
 /// segments:
 /// 1. Dangerous patterns → Destructive
 /// 2. Write side-effects (`>`, `>>`, `| tee`) → LocalMutation
 /// 3. Read-only prefix match → ReadOnly
 /// 4. Everything else → LocalMutation (conservative default)
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::bash_safety::classify_bash_command;
+/// use koda_core::tools::ToolEffect;
+///
+/// assert_eq!(classify_bash_command("ls -la"), ToolEffect::ReadOnly);
+/// assert_eq!(classify_bash_command("git status"), ToolEffect::ReadOnly);
+/// assert_eq!(classify_bash_command("cargo build"), ToolEffect::LocalMutation);
+/// assert_eq!(classify_bash_command("rm -rf /"), ToolEffect::Destructive);
+/// ```
 pub fn classify_bash_command(command: &str) -> ToolEffect {
     let trimmed = command.trim();
     if trimmed.is_empty() {
@@ -281,6 +295,15 @@ fn matches_prefix_list(seg: &str, prefixes: &[&str]) -> bool {
 
 /// Split a command into segments on `|`, `&&`, `||`, `;`.
 /// Respects single and double quotes.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::bash_safety::split_command_segments;
+///
+/// assert_eq!(split_command_segments("ls | grep foo"), vec!["ls ", " grep foo"]);
+/// assert_eq!(split_command_segments("a && b || c"), vec!["a ", " b ", " c"]);
+/// ```
 pub fn split_command_segments(command: &str) -> Vec<&str> {
     let mut segments = Vec::new();
     let mut start = 0;
@@ -323,6 +346,15 @@ pub fn split_command_segments(command: &str) -> Vec<&str> {
 }
 
 /// Strip leading environment variable assignments (e.g., `FOO=bar command`).
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::bash_safety::strip_env_vars;
+///
+/// assert_eq!(strip_env_vars("FOO=bar cargo build"), "cargo build");
+/// assert_eq!(strip_env_vars("ls -la"), "ls -la");
+/// ```
 pub fn strip_env_vars(segment: &str) -> String {
     let mut rest = segment;
     loop {

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -73,6 +73,17 @@ pub const RATE_LIMIT_MAX_RETRIES: u32 = 5;
 
 /// Compute exponential backoff delay for a retry attempt (1-indexed).
 /// Returns duration in seconds: 2, 4, 8, 16, 32 (capped at 32s).
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::rate_limit_backoff;
+/// use std::time::Duration;
+///
+/// assert_eq!(rate_limit_backoff(1), Duration::from_secs(2));
+/// assert_eq!(rate_limit_backoff(3), Duration::from_secs(8));
+/// assert_eq!(rate_limit_backoff(10), Duration::from_secs(32)); // capped
+/// ```
 pub fn rate_limit_backoff(attempt: u32) -> std::time::Duration {
     let secs = 2u64.pow(attempt).min(32);
     std::time::Duration::from_secs(secs)

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -111,7 +111,16 @@ fn dirs_config_dir() -> Option<PathBuf> {
         .or_else(|| std::env::var("APPDATA").ok().map(PathBuf::from))
 }
 
-/// Mask a key for display: "sk-ant-abc...xyz"
+/// Mask a key for display: shows first 4 and last 4 characters.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::keystore::mask_key;
+///
+/// assert_eq!(mask_key("sk-ant-api03-longkey1234"), "sk-a...1234");
+/// assert_eq!(mask_key("short"), "****");
+/// ```
 pub fn mask_key(key: &str) -> String {
     if key.len() > 8 {
         format!("{}...{}", &key[..4], &key[key.len() - 4..])

--- a/koda-core/src/truncate.rs
+++ b/koda-core/src/truncate.rs
@@ -34,6 +34,29 @@ pub enum Truncated<'a> {
 ///
 /// Returns `Truncated::Full` if output is within the threshold,
 /// or `Truncated::Split` with head/tail lines and hidden count.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::truncate::truncate_for_display;
+/// use koda_core::truncate::Truncated;
+///
+/// // Short output is returned as-is
+/// let short = "line1\nline2\nline3";
+/// assert!(matches!(truncate_for_display(short), Truncated::Full(_)));
+///
+/// // Long output is split into head + tail
+/// let long = (0..100).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n");
+/// match truncate_for_display(&long) {
+///     Truncated::Split { head, tail, hidden, total } => {
+///         assert_eq!(total, 100);
+///         assert_eq!(head.len(), 20);
+///         assert_eq!(tail.len(), 20);
+///         assert_eq!(hidden, 60);
+///     }
+///     _ => panic!("expected Split"),
+/// }
+/// ```
 pub fn truncate_for_display(output: &str) -> Truncated<'_> {
     let lines: Vec<&str> = output.lines().collect();
     let total = lines.len();


### PR DESCRIPTION
## Summary

Adds 7 doc-tests to pure, side-effect-free public functions in `koda-core`. These serve as executable documentation that catches drift — if a function's behavior changes, the doc-test fails at compile time.

### Functions covered

| Function | Module | What it tests |
|----------|--------|---------------|
| `mask_key()` | `keystore` | Key masking for display |
| `classify_bash_command()` | `bash_safety` | Shell command safety classification |
| `split_command_segments()` | `bash_safety` | Pipeline/chain splitting |
| `strip_env_vars()` | `bash_safety` | Env var prefix stripping |
| `rate_limit_backoff()` | `inference_helpers` | Exponential backoff computation |
| `truncate_for_display()` | `truncate` | Output head/tail truncation |
| `lint_bash_paths()` | `bash_path_lint` | Project root escape detection |

### Why these functions

Selected for doc-tests because they are:
- **Pure** — no side effects, no async, no DB
- **Public API** — used by other modules and potentially by downstream consumers
- **Behavior-critical** — incorrect behavior in these functions causes silent correctness bugs (wrong safety classification, lost output, leaked keys)

### Validation

- [x] `cargo test --doc -p koda-core` — 7/7 pass
- [x] `cargo test --workspace` — all 660+ tests pass