### PR TITLE
release: v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-03-14
+
+### Fixed
+- **Security: drop `sqlx-mysql` transitive dependency** — sqlx default features
+  pulled in `sqlx-mysql`, which transitively brought in the `rsa` crate
+  (RUSTSEC-2023-0071, timing side-channel). Koda only uses SQLite — set
+  `default-features = false` on sqlx, removing `rsa`, `sqlx-mysql`, and ~460
+  lines from Cargo.lock. `cargo audit` now shows 0 vulnerabilities (#459)
+
+### Changed
+- **Refactor: decompose `inference_loop()`** — extracted token estimation,
+  message assembly, overflow detection, and rate-limit helpers into focused
+  functions in `inference_helpers.rs` (#455)
+- **Refactor: extract `ChunkParser` trait** — unified SSE stream collection
+  across all three providers (Anthropic, Gemini, OpenAI-compat) into a shared
+  `stream_collector.rs` with per-provider `ChunkParser` implementations (#457)
+- **Refactor: extract TUI event loop handlers** — decomposed the 1,200-line
+  `tui_context.rs` into `tui_handlers_inference.rs` for inference event
+  processing (#458)
+
+### Added
+- **Doc-tests** — 7 doc-tests on key pure public APIs: `classify_bash_command`,
+  `split_command_segments`, `strip_env_vars`, `mask_key`, `rate_limit_backoff`,
+  `truncate_for_display`, `lint_bash_paths` (#461)
+- **Dependabot** — enabled vulnerability alerts; created missing `ci`,
+  `dependencies`, and `rust` labels for dependabot PRs
+
+### Documentation
+- **CLAUDE.md** — rebuilt architecture tree from filesystem (removed 5 stale
+  files, added ~15 missing files from v0.1.9–v0.1.10 refactors) (#459)
+- **Windows keystore ACL** — documented that `keys.toml` on Windows inherits
+  parent directory ACLs (low risk for single-user machines) (#460)
+
 ## [0.1.10] - 2026-03-14
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.10" }
+koda-core = { path = "../koda-core", version = "0.1.11" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -59,6 +59,6 @@ rpassword = "7.4.0"
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.10", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.11", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.10" }
-koda-email = { path = "../koda-email", version = "0.1.10" }
+koda-ast = { path = "../koda-ast", version = "0.1.11" }
+koda-email = { path = "../koda-email", version = "0.1.11" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.11

Version bump for all 4 workspace crates (0.1.10 → 0.1.11).

### Checklist

- [x] All crate versions bumped to 0.1.11
- [x] Cross-references updated (koda-core → koda-ast/koda-email, koda-cli → koda-core)
- [x] CHANGELOG.md updated
- [x] Cargo.lock regenerated
- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — 660+ tests pass (including 7 new doc-tests)
- [x] `cargo audit` — 0 vulnerabilities

### What's in this release

**Security**
- Drop `sqlx-mysql` transitive dep → eliminates `rsa` vulnerability (RUSTSEC-2023-0071) (#459)

**Refactoring**
- Decompose `inference_loop()` into focused helpers (#455)
- Extract `ChunkParser` trait + shared SSE stream collector (#457)
- Extract TUI event loop handlers from `tui_context.rs` (#458)

**Documentation**
- 7 doc-tests on key pure public APIs (#461)
- Rebuilt CLAUDE.md architecture tree (#459)
- Documented Windows keystore ACL gap (#460)

**Infrastructure**
- Enabled dependabot vulnerability alerts
- Created `ci`, `dependencies`, `rust` labels for dependabot PRs

### Post-merge

After merging, tag and push to trigger the release workflow:
```bash
git tag v0.1.11
git push origin v0.1.11
```