### PR TITLE
fix: v0.1.12 — hotfix for frozen input on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.12] - 2026-03-16
+
+### Fixed
+- **Input frozen on launch** — the #458 refactor accidentally dropped the
+  `self.draw()` call before the idle `tokio::select!` in the event loop.
+  Without it, the viewport never redraws after keystrokes, making the
+  textarea appear completely unresponsive. Hotfix release — v0.1.11 is
+  unusable.
+
 ## [0.1.11] - 2026-03-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.11" }
+koda-core = { path = "../koda-core", version = "0.1.12" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -59,6 +59,6 @@ rpassword = "7.4.0"
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.11", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.12", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -347,6 +347,9 @@ impl TuiContext {
                 }
             }
 
+            // Redraw viewport (resize if textarea grew/shrank)
+            self.draw()?;
+
             // ── Idle: wait for keyboard input ────────────────
             tokio::select! {
                 Some(Ok(ev)) = self.crossterm_events.next() => {

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -422,6 +422,46 @@ mod display_regression {
     }
 }
 
+mod event_loop_structure {
+    /// Regression test for the v0.1.11 frozen-input bug.
+    ///
+    /// The idle event loop in `run_event_loop` MUST call `self.draw()` before
+    /// blocking on `tokio::select!` for keyboard events. Without it the
+    /// viewport never redraws after keystrokes and input appears frozen.
+    ///
+    /// This is a source-level structural assertion — the only reliable way to
+    /// guard against accidental removal during refactors.
+    #[test]
+    fn draw_called_before_idle_select_in_event_loop() {
+        let source = include_str!("../src/tui_context.rs");
+
+        // Locate run_event_loop
+        let fn_start = source
+            .find("async fn run_event_loop")
+            .expect("run_event_loop function not found in tui_context.rs");
+        let body = &source[fn_start..];
+
+        // Find the idle select! block (the one with crossterm_events.next())
+        let select_marker = "self.crossterm_events.next()";
+        let select_pos = body
+            .find(select_marker)
+            .expect("idle select! with crossterm_events.next() not found in run_event_loop");
+
+        // self.draw() must appear (uncommented) between fn start and the select!
+        let before_select = &body[..select_pos];
+        let has_active_draw = before_select.lines().any(|line| {
+            let trimmed = line.trim();
+            !trimmed.starts_with("//") && trimmed.contains("self.draw()")
+        });
+        assert!(
+            has_active_draw,
+            "self.draw() must be called (uncommented) before the idle tokio::select! in \
+             run_event_loop. Without it the viewport never redraws and input appears \
+             frozen (v0.1.11 bug)."
+        );
+    }
+}
+
 mod provider_key_flow {
     #[test]
     fn test_same_provider_should_prompt_for_key() {

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.11" }
-koda-email = { path = "../koda-email", version = "0.1.11" }
+koda-ast = { path = "../koda-ast", version = "0.1.12" }
+koda-email = { path = "../koda-email", version = "0.1.12" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## 🚨 Emergency hotfix

### Bug
v0.1.11 shipped with **completely broken input** — the textarea appears frozen on launch. Users cannot type anything.

### Root cause
The #458 refactor (`79b7046`) extracted `run_event_loop` into a compact dispatcher but accidentally dropped the `self.draw()` call that preceded the `tokio::select!` in the idle loop. Without that call, the viewport never redraws after keystrokes.

### Fix
Restore the `self.draw()?;` call before the idle `tokio::select!` block, exactly where it was before the refactor.

### Regression test
Added `event_loop_structure::draw_called_before_idle_select_in_event_loop` — a source-level structural test that:
- Verifies `self.draw()` appears (uncommented) before the idle `tokio::select!` in `run_event_loop`
- Confirmed to **fail** when `draw()` is removed/commented out
- Confirmed to **pass** with the fix in place

### Checklist
- [x] `cargo check` — clean
- [x] `cargo test` — 185/185 pass (42 regression, +1 new)
- [x] Versions bumped to 0.1.12 (all 4 crates + internal deps)
- [x] CHANGELOG.md updated

Fixes the v0.1.11 regression. Tag `v0.1.12` after merge.