### PR TITLE
feat(#465): file lifecycle tracker — auto-approve deletion of Koda-created files

### DIFF
--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -31,7 +31,7 @@ pub async fn run_headless(
 
     let agent = Arc::new(KodaAgent::new(&config, project_root.clone()).await?);
     let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
-    let mut session = KodaSession::new(session_id, agent, db, &config, ApprovalMode::Auto);
+    let mut session = KodaSession::new(session_id, agent, db, &config, ApprovalMode::Auto).await;
 
     // Process @file references and images
     let processed = input::process_input(&prompt, &project_root);

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -275,7 +275,8 @@ async fn handle_new_session(
         state.db.clone(),
         &state.config,
         ApprovalMode::Auto,
-    );
+    )
+    .await;
 
     state.active = Some(ActiveSession {
         session,

--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -176,7 +176,8 @@ impl TuiContext {
             db.clone(),
             &config,
             ApprovalMode::Auto,
-        );
+        )
+        .await;
 
         crate::startup::print_purge_nudge_if_needed(&db).await;
 

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -180,10 +180,9 @@ pub fn check_tool_with_tracker(
         && let Some(tracker) = file_tracker
         && let Some(root) = project_root
         && let Some(abs_path) = crate::file_tracker::resolve_file_path_from_args(args, root)
+        && tracker.is_owned(&abs_path)
     {
-        if tracker.is_owned(&abs_path) {
-            return ToolApproval::AutoApprove;
-        }
+        return ToolApproval::AutoApprove;
     }
 
     // Apply the ToolEffect × ApprovalMode matrix

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -8,6 +8,7 @@
 //! further refined by [`crate::bash_safety::classify_bash_command`].
 
 use crate::bash_safety::classify_bash_command;
+use crate::file_tracker::FileTracker;
 use crate::tools::ToolEffect;
 use path_clean::PathClean;
 use std::path::Path;
@@ -125,11 +126,27 @@ pub enum ToolApproval {
 /// Additional hardcoded floors:
 /// - Writes outside project root → NeedsConfirmation (#218)
 /// - Bash path escapes → NeedsConfirmation
+/// - Delete of Koda-owned file → AutoApprove (#465)
 pub fn check_tool(
     tool_name: &str,
     args: &serde_json::Value,
     mode: ApprovalMode,
     project_root: Option<&Path>,
+) -> ToolApproval {
+    check_tool_with_tracker(tool_name, args, mode, project_root, None)
+}
+
+/// Like [`check_tool`] but with an optional file tracker for ownership checks.
+///
+/// When a `FileTracker` is provided and the tool is `Delete` targeting a file
+/// that Koda created in this session, the destructive classification is
+/// downgraded to auto-approve (net-zero effect: Koda created it, Koda removes it).
+pub fn check_tool_with_tracker(
+    tool_name: &str,
+    args: &serde_json::Value,
+    mode: ApprovalMode,
+    project_root: Option<&Path>,
+    file_tracker: Option<&FileTracker>,
 ) -> ToolApproval {
     // Classify the tool's effect
     let effect = resolve_effect(tool_name, args);
@@ -154,6 +171,29 @@ pub fn check_tool(
             let lint = crate::bash_path_lint::lint_bash_paths(command, root);
             if lint.has_warnings() {
                 return ToolApproval::NeedsConfirmation;
+            }
+        }
+    }
+
+    // File lifecycle: Koda-owned files bypass destructive gate (#465)
+    if tool_name == "Delete" {
+        if let Some(tracker) = file_tracker {
+            if let Some(root) = project_root {
+                let path_arg = args
+                    .get("path")
+                    .or(args.get("file_path"))
+                    .and_then(|v| v.as_str());
+                if let Some(p) = path_arg {
+                    let requested = Path::new(p);
+                    let abs_path = if requested.is_absolute() {
+                        requested.to_path_buf()
+                    } else {
+                        root.join(requested)
+                    };
+                    if tracker.is_owned(&abs_path) {
+                        return ToolApproval::AutoApprove;
+                    }
+                }
             }
         }
     }
@@ -443,6 +483,98 @@ mod tests {
         assert_eq!(
             check_tool("Write", &args, ApprovalMode::Auto, None),
             ToolApproval::AutoApprove,
+        );
+    }
+
+    // ── File lifecycle (#465) tests ──
+
+    #[tokio::test]
+    async fn test_delete_owned_file_auto_approved() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let mut tracker = FileTracker::new("test-sess", db).await;
+        let root = Path::new("/home/user/project");
+        let owned_path = root.join("temp_output.md");
+        tracker.track_created(owned_path).await;
+
+        let args = serde_json::json!({"path": "temp_output.md"});
+        assert_eq!(
+            check_tool_with_tracker(
+                "Delete",
+                &args,
+                ApprovalMode::Auto,
+                Some(root),
+                Some(&tracker),
+            ),
+            ToolApproval::AutoApprove,
+            "Delete of Koda-owned file should auto-approve"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_unowned_file_needs_confirmation() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let tracker = FileTracker::new("test-sess", db).await;
+        let root = Path::new("/home/user/project");
+
+        let args = serde_json::json!({"path": "user_file.rs"});
+        assert_eq!(
+            check_tool_with_tracker(
+                "Delete",
+                &args,
+                ApprovalMode::Auto,
+                Some(root),
+                Some(&tracker),
+            ),
+            ToolApproval::NeedsConfirmation,
+            "Delete of unowned file should still need confirmation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_owned_file_confirm_mode_auto_approved() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let mut tracker = FileTracker::new("test-sess", db).await;
+        let root = Path::new("/home/user/project");
+        let owned_path = root.join("scratch.txt");
+        tracker.track_created(owned_path).await;
+
+        let args = serde_json::json!({"path": "scratch.txt"});
+        assert_eq!(
+            check_tool_with_tracker(
+                "Delete",
+                &args,
+                ApprovalMode::Confirm,
+                Some(root),
+                Some(&tracker),
+            ),
+            ToolApproval::AutoApprove,
+            "Delete of Koda-owned file should auto-approve even in Confirm mode"
+        );
+    }
+
+    #[test]
+    fn test_no_tracker_falls_back_to_normal() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"path": "some_file.rs"});
+        assert_eq!(
+            check_tool_with_tracker(
+                "Delete",
+                &args,
+                ApprovalMode::Auto,
+                Some(root),
+                None,
+            ),
+            ToolApproval::NeedsConfirmation,
+            "Without tracker, Delete should still need confirmation"
         );
     }
 }

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -176,25 +176,22 @@ pub fn check_tool_with_tracker(
     }
 
     // File lifecycle: Koda-owned files bypass destructive gate (#465)
-    if tool_name == "Delete" {
-        if let Some(tracker) = file_tracker {
-            if let Some(root) = project_root {
-                let path_arg = args
-                    .get("path")
-                    .or(args.get("file_path"))
-                    .and_then(|v| v.as_str());
-                if let Some(p) = path_arg {
-                    let requested = Path::new(p);
-                    let abs_path = if requested.is_absolute() {
-                        requested.to_path_buf()
-                    } else {
-                        root.join(requested)
-                    };
-                    if tracker.is_owned(&abs_path) {
-                        return ToolApproval::AutoApprove;
-                    }
-                }
-            }
+    if tool_name == "Delete"
+        && let Some(tracker) = file_tracker
+        && let Some(root) = project_root
+        && let Some(p) = args
+            .get("path")
+            .or(args.get("file_path"))
+            .and_then(|v| v.as_str())
+    {
+        let requested = Path::new(p);
+        let abs_path = if requested.is_absolute() {
+            requested.to_path_buf()
+        } else {
+            root.join(requested)
+        };
+        if tracker.is_owned(&abs_path) {
+            return ToolApproval::AutoApprove;
         }
     }
 
@@ -566,13 +563,7 @@ mod tests {
         let root = Path::new("/home/user/project");
         let args = serde_json::json!({"path": "some_file.rs"});
         assert_eq!(
-            check_tool_with_tracker(
-                "Delete",
-                &args,
-                ApprovalMode::Auto,
-                Some(root),
-                None,
-            ),
+            check_tool_with_tracker("Delete", &args, ApprovalMode::Auto, Some(root), None,),
             ToolApproval::NeedsConfirmation,
             "Without tracker, Delete should still need confirmation"
         );

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -179,17 +179,8 @@ pub fn check_tool_with_tracker(
     if tool_name == "Delete"
         && let Some(tracker) = file_tracker
         && let Some(root) = project_root
-        && let Some(p) = args
-            .get("path")
-            .or(args.get("file_path"))
-            .and_then(|v| v.as_str())
+        && let Some(abs_path) = crate::file_tracker::resolve_file_path_from_args(args, root)
     {
-        let requested = Path::new(p);
-        let abs_path = if requested.is_absolute() {
-            requested.to_path_buf()
-        } else {
-            root.join(requested)
-        };
         if tracker.is_owned(&abs_path) {
             return ToolApproval::AutoApprove;
         }

--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -178,7 +178,61 @@ impl Database {
             }
         }
 
+        // File lifecycle tracking (#465): files created by Koda in a session.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS owned_files (
+                session_id TEXT NOT NULL,
+                path TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY(session_id, path)
+            );",
+        )
+        .execute(pool)
+        .await?;
+
         Ok(())
+    }
+}
+
+// ── File lifecycle tracking (#465) ──────────────────────────────────────────
+
+impl Database {
+    /// Record that Koda created a file in this session.
+    pub async fn insert_owned_file(&self, session_id: &str, path: &Path) -> Result<()> {
+        sqlx::query(
+            "INSERT OR IGNORE INTO owned_files (session_id, path) VALUES (?, ?)",
+        )
+        .bind(session_id)
+        .bind(path.to_string_lossy().as_ref())
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Remove a file from the owned set.
+    pub async fn delete_owned_file(&self, session_id: &str, path: &Path) -> Result<()> {
+        sqlx::query("DELETE FROM owned_files WHERE session_id = ? AND path = ?")
+            .bind(session_id)
+            .bind(path.to_string_lossy().as_ref())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Load all owned file paths for a session (used on session resume).
+    pub async fn load_owned_files(
+        &self,
+        session_id: &str,
+    ) -> Result<std::collections::HashSet<std::path::PathBuf>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT path FROM owned_files WHERE session_id = ?")
+                .bind(session_id)
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows
+            .into_iter()
+            .map(|(p,)| std::path::PathBuf::from(p))
+            .collect())
     }
 }
 

--- a/koda-core/src/db.rs
+++ b/koda-core/src/db.rs
@@ -199,13 +199,11 @@ impl Database {
 impl Database {
     /// Record that Koda created a file in this session.
     pub async fn insert_owned_file(&self, session_id: &str, path: &Path) -> Result<()> {
-        sqlx::query(
-            "INSERT OR IGNORE INTO owned_files (session_id, path) VALUES (?, ?)",
-        )
-        .bind(session_id)
-        .bind(path.to_string_lossy().as_ref())
-        .execute(&self.pool)
-        .await?;
+        sqlx::query("INSERT OR IGNORE INTO owned_files (session_id, path) VALUES (?, ?)")
+            .bind(session_id)
+            .bind(path.to_string_lossy().as_ref())
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 

--- a/koda-core/src/file_tracker.rs
+++ b/koda-core/src/file_tracker.rs
@@ -70,6 +70,12 @@ impl FileTracker {
     pub fn len(&self) -> usize {
         self.owned.len()
     }
+
+    /// Whether the tracker has no owned files.
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.owned.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/koda-core/src/file_tracker.rs
+++ b/koda-core/src/file_tracker.rs
@@ -67,19 +67,19 @@ impl FileTracker {
     ///
     /// The path should be the resolved absolute path.
     pub async fn track_created(&mut self, path: PathBuf) {
-        if self.owned.insert(path.clone()) {
-            if let Err(e) = self.db.insert_owned_file(&self.session_id, &path).await {
-                tracing::warn!("file_tracker: failed to persist owned file {:?}: {e}", path);
-            }
+        if self.owned.insert(path.clone())
+            && let Err(e) = self.db.insert_owned_file(&self.session_id, &path).await
+        {
+            tracing::warn!("file_tracker: failed to persist owned file {:?}: {e}", path);
         }
     }
 
     /// Remove a file from the owned set (after successful deletion).
     pub async fn untrack(&mut self, path: &Path) {
-        if self.owned.remove(path) {
-            if let Err(e) = self.db.delete_owned_file(&self.session_id, path).await {
-                tracing::warn!("file_tracker: failed to remove owned file {:?}: {e}", path);
-            }
+        if self.owned.remove(path)
+            && let Err(e) = self.db.delete_owned_file(&self.session_id, path).await
+        {
+            tracing::warn!("file_tracker: failed to remove owned file {:?}: {e}", path);
         }
     }
 
@@ -216,7 +216,7 @@ mod tests {
 
     #[tokio::test]
     async fn cross_session_resume_preserves_ownership_for_approval() {
-        use crate::approval::{check_tool_with_tracker, ApprovalMode, ToolApproval};
+        use crate::approval::{ApprovalMode, ToolApproval, check_tool_with_tracker};
 
         let (db, _dir) = test_db().await;
         let session_id = "resume-test";

--- a/koda-core/src/file_tracker.rs
+++ b/koda-core/src/file_tracker.rs
@@ -16,6 +16,28 @@ use std::path::{Path, PathBuf};
 
 use crate::db::Database;
 
+/// Extract and resolve a file path from tool call arguments.
+///
+/// Looks for `"path"` or `"file_path"` in the JSON args, then resolves
+/// relative paths against `project_root`. Used by both the approval
+/// system and the file lifecycle tracker (#465).
+pub(crate) fn resolve_file_path_from_args(
+    args: &serde_json::Value,
+    project_root: &Path,
+) -> Option<PathBuf> {
+    let path_str = args
+        .get("path")
+        .or(args.get("file_path"))
+        .and_then(|v| v.as_str())?;
+    let requested = Path::new(path_str);
+    let abs_path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        project_root.join(requested)
+    };
+    Some(abs_path)
+}
+
 /// Tracks files created by Koda in the current session.
 ///
 /// In-memory `HashSet` for fast lookups, with DB persistence for
@@ -46,14 +68,18 @@ impl FileTracker {
     /// The path should be the resolved absolute path.
     pub async fn track_created(&mut self, path: PathBuf) {
         if self.owned.insert(path.clone()) {
-            let _ = self.db.insert_owned_file(&self.session_id, &path).await;
+            if let Err(e) = self.db.insert_owned_file(&self.session_id, &path).await {
+                tracing::warn!("file_tracker: failed to persist owned file {:?}: {e}", path);
+            }
         }
     }
 
     /// Remove a file from the owned set (after successful deletion).
     pub async fn untrack(&mut self, path: &Path) {
         if self.owned.remove(path) {
-            let _ = self.db.delete_owned_file(&self.session_id, path).await;
+            if let Err(e) = self.db.delete_owned_file(&self.session_id, path).await {
+                tracing::warn!("file_tracker: failed to remove owned file {:?}: {e}", path);
+            }
         }
     }
 
@@ -168,5 +194,63 @@ mod tests {
         let path = PathBuf::from("/tmp/never_tracked.md");
         tracker.untrack(&path).await; // should not panic
         assert_eq!(tracker.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn absolute_path_ownership() {
+        let (db, _dir) = test_db().await;
+        let mut tracker = FileTracker::new("test-session", db).await;
+
+        let abs = PathBuf::from("/home/user/project/output.csv");
+        tracker.track_created(abs.clone()).await;
+        assert!(tracker.is_owned(&abs));
+
+        // Same absolute path via different PathBuf instance still matches
+        let abs2 = PathBuf::from("/home/user/project/output.csv");
+        assert!(tracker.is_owned(&abs2));
+
+        // Different path is not owned
+        let other = PathBuf::from("/home/user/project/readme.md");
+        assert!(!tracker.is_owned(&other));
+    }
+
+    #[tokio::test]
+    async fn cross_session_resume_preserves_ownership_for_approval() {
+        use crate::approval::{check_tool_with_tracker, ApprovalMode, ToolApproval};
+
+        let (db, _dir) = test_db().await;
+        let session_id = "resume-test";
+        let root = Path::new("/home/user/project");
+        let owned_path = root.join("ephemeral.md");
+
+        // Session 1: track a created file, then "crash"
+        {
+            let mut tracker = FileTracker::new(session_id, db.clone()).await;
+            tracker.track_created(owned_path.clone()).await;
+            assert!(tracker.is_owned(&owned_path));
+        }
+
+        // Session 2: resume — tracker should load from DB and still
+        // auto-approve deletion of the owned file
+        {
+            let tracker = FileTracker::new(session_id, db.clone()).await;
+            assert!(
+                tracker.is_owned(&owned_path),
+                "Resumed tracker should still own the file"
+            );
+
+            let args = serde_json::json!({"path": "ephemeral.md"});
+            assert_eq!(
+                check_tool_with_tracker(
+                    "Delete",
+                    &args,
+                    ApprovalMode::Auto,
+                    Some(root),
+                    Some(&tracker),
+                ),
+                ToolApproval::AutoApprove,
+                "Delete of resumed owned file should auto-approve"
+            );
+        }
     }
 }

--- a/koda-core/src/file_tracker.rs
+++ b/koda-core/src/file_tracker.rs
@@ -1,0 +1,166 @@
+//! File lifecycle tracker — tracks files created by Koda during a session.
+//!
+//! Inspired by Rust's ownership model (#465):
+//! - **Ownership**: files created via `Write` are "owned" by the session.
+//! - **Auto-approve cleanup**: deleting an owned file skips the destructive
+//!   confirmation gate (the net effect is zero — Koda created it, Koda removes it).
+//! - **Persistence**: state is backed by SQLite so it survives compaction,
+//!   token limits, and process crashes.
+//!
+//! Ownership is deliberately narrow: only `Write` (create) confers ownership.
+//! `Edit` of a user's file does not. Editing an already-owned file preserves
+//! ownership (Koda still created the file).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::db::Database;
+
+/// Tracks files created by Koda in the current session.
+///
+/// In-memory `HashSet` for fast lookups, with DB persistence for
+/// crash recovery and session resume.
+#[derive(Debug)]
+pub struct FileTracker {
+    /// Files owned (created) by Koda in this session.
+    owned: HashSet<PathBuf>,
+    /// Session ID for DB persistence.
+    session_id: String,
+    /// Database handle.
+    db: Database,
+}
+
+impl FileTracker {
+    /// Create a new tracker, loading any persisted state from a previous run.
+    pub async fn new(session_id: &str, db: Database) -> Self {
+        let owned = db.load_owned_files(session_id).await.unwrap_or_default();
+        Self {
+            owned,
+            session_id: session_id.to_string(),
+            db,
+        }
+    }
+
+    /// Record that Koda created a file via `Write`.
+    ///
+    /// The path should be the resolved absolute path.
+    pub async fn track_created(&mut self, path: PathBuf) {
+        if self.owned.insert(path.clone()) {
+            let _ = self.db.insert_owned_file(&self.session_id, &path).await;
+        }
+    }
+
+    /// Remove a file from the owned set (after successful deletion).
+    pub async fn untrack(&mut self, path: &Path) {
+        if self.owned.remove(path) {
+            let _ = self.db.delete_owned_file(&self.session_id, path).await;
+        }
+    }
+
+    /// Check whether Koda owns (created) this file.
+    ///
+    /// Used by the approval system to auto-approve deletion of
+    /// files that Koda itself created.
+    pub fn is_owned(&self, path: &Path) -> bool {
+        self.owned.contains(path)
+    }
+
+    /// Return the number of currently owned files (for diagnostics).
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.owned.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::Persistence;
+    use tempfile::TempDir;
+
+    async fn test_db() -> (Database, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let db = Database::open(&dir.path().join("test.db")).await.unwrap();
+        db.create_session("test-agent", dir.path()).await.unwrap();
+        (db, dir)
+    }
+
+    #[tokio::test]
+    async fn track_and_check_ownership() {
+        let (db, _dir) = test_db().await;
+        let mut tracker = FileTracker::new("test-session", db).await;
+
+        let path = PathBuf::from("/tmp/koda_test_file.md");
+        assert!(!tracker.is_owned(&path));
+
+        tracker.track_created(path.clone()).await;
+        assert!(tracker.is_owned(&path));
+        assert_eq!(tracker.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn untrack_removes_ownership() {
+        let (db, _dir) = test_db().await;
+        let mut tracker = FileTracker::new("test-session", db).await;
+
+        let path = PathBuf::from("/tmp/koda_test_file.md");
+        tracker.track_created(path.clone()).await;
+        assert!(tracker.is_owned(&path));
+
+        tracker.untrack(&path).await;
+        assert!(!tracker.is_owned(&path));
+        assert_eq!(tracker.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn persists_across_tracker_instances() {
+        let (db, _dir) = test_db().await;
+        let session_id = "persist-test";
+        let path = PathBuf::from("/tmp/koda_persist.md");
+
+        // Create and track
+        {
+            let mut tracker = FileTracker::new(session_id, db.clone()).await;
+            tracker.track_created(path.clone()).await;
+        }
+
+        // New tracker for same session — should see the file
+        {
+            let tracker = FileTracker::new(session_id, db.clone()).await;
+            assert!(tracker.is_owned(&path));
+        }
+    }
+
+    #[tokio::test]
+    async fn different_sessions_isolated() {
+        let (db, _dir) = test_db().await;
+        let path = PathBuf::from("/tmp/koda_isolated.md");
+
+        let mut tracker_a = FileTracker::new("session-a", db.clone()).await;
+        tracker_a.track_created(path.clone()).await;
+
+        let tracker_b = FileTracker::new("session-b", db).await;
+        assert!(!tracker_b.is_owned(&path));
+    }
+
+    #[tokio::test]
+    async fn duplicate_track_is_idempotent() {
+        let (db, _dir) = test_db().await;
+        let mut tracker = FileTracker::new("test-session", db).await;
+
+        let path = PathBuf::from("/tmp/koda_dup.md");
+        tracker.track_created(path.clone()).await;
+        tracker.track_created(path.clone()).await;
+        assert_eq!(tracker.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn untrack_nonexistent_is_noop() {
+        let (db, _dir) = test_db().await;
+        let mut tracker = FileTracker::new("test-session", db).await;
+
+        let path = PathBuf::from("/tmp/never_tracked.md");
+        tracker.untrack(&path).await; // should not panic
+        assert_eq!(tracker.len(), 0);
+    }
+}

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -7,6 +7,7 @@ use crate::approval::ApprovalMode;
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
 use crate::engine::{EngineCommand, EngineEvent, EngineSink};
+use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
     PREFLIGHT_COMPACT_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages, estimate_tokens,
     is_context_overflow_error, is_rate_limit_error, rate_limit_backoff,
@@ -419,6 +420,8 @@ pub struct InferenceContext<'a> {
     pub cancel: CancellationToken,
     /// Channel for receiving client commands (approval responses, etc.).
     pub cmd_rx: &'a mut mpsc::Receiver<EngineCommand>,
+    /// File lifecycle tracker for ownership-aware approval (#465).
+    pub file_tracker: &'a mut FileTracker,
 }
 
 /// Run the inference loop: send messages, stream responses, dispatch tool calls.
@@ -438,6 +441,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         sink,
         cancel,
         cmd_rx,
+        file_tracker,
     } = ctx;
 
     // Hard cap is configurable per-agent; user can extend it interactively.
@@ -724,6 +728,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sink,
                 cancel.clone(),
                 &sub_agent_cache,
+                file_tracker,
             )
             .await?;
         } else if tool_calls.len() > 1 {
@@ -740,6 +745,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 cancel.clone(),
                 cmd_rx,
                 &sub_agent_cache,
+                file_tracker,
             )
             .await?;
         } else {
@@ -756,6 +762,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 cancel.clone(),
                 cmd_rx,
                 &sub_agent_cache,
+                file_tracker,
             )
             .await?;
         }

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -26,6 +26,8 @@ pub mod context;
 pub mod db;
 /// Engine protocol: `EngineEvent` / `EngineCommand` enums.
 pub mod engine;
+/// File lifecycle tracker — tracks files created by Koda per session (#465).
+pub mod file_tracker;
 /// Git helpers — status, diff, blame, log.
 pub mod git;
 /// The main inference loop — send messages, stream responses, dispatch tools.

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -9,6 +9,7 @@ use crate::approval::ApprovalMode;
 use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
+use crate::file_tracker::FileTracker;
 use crate::inference::InferenceContext;
 use crate::providers::{self, ImageData, LlmProvider};
 use crate::settings::Settings;
@@ -37,11 +38,13 @@ pub struct KodaSession {
     pub settings: Settings,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
+    /// File lifecycle tracker — tracks files created by Koda (#465).
+    pub file_tracker: FileTracker,
 }
 
 impl KodaSession {
     /// Create a new session from an agent, config, and database.
-    pub fn new(
+    pub async fn new(
         id: String,
         agent: Arc<KodaAgent>,
         db: Database,
@@ -52,6 +55,7 @@ impl KodaSession {
         let settings = Settings::load();
         // Wire db+session into ToolRegistry for RecallContext
         agent.tools.set_session(Arc::new(db.clone()), id.clone());
+        let file_tracker = FileTracker::new(&id, db.clone()).await;
         Self {
             id,
             agent,
@@ -60,6 +64,7 @@ impl KodaSession {
             mode,
             settings,
             cancel: CancellationToken::new(),
+            file_tracker,
         }
     }
 
@@ -95,6 +100,7 @@ impl KodaSession {
             sink,
             cancel: self.cancel.clone(),
             cmd_rx,
+            file_tracker: &mut self.file_tracker,
         })
         .await;
 

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -7,6 +7,7 @@ use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
 use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
+use crate::file_tracker::FileTracker;
 use crate::loop_guard;
 use crate::memory;
 use crate::persistence::Persistence;
@@ -17,7 +18,7 @@ use crate::sub_agent_cache::SubAgentCache;
 use crate::tools::{self, ToolRegistry};
 
 use anyhow::{Context, Result};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -37,6 +38,51 @@ fn truncate_for_history(output: &str, max_chars: usize) -> String {
         &output[..end],
         output.len() - end
     )
+}
+
+/// Resolve the file path from a tool call's arguments.
+///
+/// Used by the file lifecycle tracker to record which paths
+/// Koda creates or deletes (#465).
+fn resolve_tool_path(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> Option<PathBuf> {
+    if !matches!(tool_name, "Write" | "Edit" | "Delete") {
+        return None;
+    }
+    let path_str = args
+        .get("path")
+        .or(args.get("file_path"))
+        .and_then(|v| v.as_str())?;
+    let requested = Path::new(path_str);
+    let abs_path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        project_root.join(requested)
+    };
+    Some(abs_path)
+}
+
+/// Update file lifecycle tracker after a successful tool execution (#465).
+///
+/// - Write → track as owned (Koda created it)
+/// - Delete → untrack (file no longer exists)
+async fn track_file_lifecycle(
+    tool_name: &str,
+    args: &serde_json::Value,
+    project_root: &Path,
+    file_tracker: &mut FileTracker,
+    result: &str,
+) {
+    // Only track successful operations (result doesn't start with "Error")
+    if result.starts_with("Error") || result.starts_with("Failed") {
+        return;
+    }
+    if let Some(path) = resolve_tool_path(tool_name, args, project_root) {
+        match tool_name {
+            "Write" => file_tracker.track_created(path).await,
+            "Delete" => file_tracker.untrack(&path).await,
+            _ => {}
+        }
+    }
 }
 
 pub(crate) fn can_parallelize(
@@ -133,6 +179,7 @@ pub(crate) async fn execute_tools_parallel(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
+    file_tracker: &mut FileTracker,
 ) -> Result<()> {
     let count = tool_calls.len();
     sink.emit(EngineEvent::Info {
@@ -191,6 +238,17 @@ pub(crate) async fn execute_tools_parallel(
             &result,
         )
         .await;
+        // File lifecycle tracking (#465)
+        let parsed_args: serde_json::Value =
+            serde_json::from_str(&tool_calls[i].arguments).unwrap_or_default();
+        track_file_lifecycle(
+            &tool_calls[i].function_name,
+            &parsed_args,
+            project_root,
+            file_tracker,
+            &result,
+        )
+        .await;
     }
     Ok(())
 }
@@ -215,6 +273,7 @@ pub(crate) async fn execute_tools_split_batch(
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
+    file_tracker: &mut FileTracker,
 ) -> Result<()> {
     // Partition into parallelizable vs sequential
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
@@ -280,6 +339,17 @@ pub(crate) async fn execute_tools_split_batch(
                 &result,
             )
             .await;
+            // File lifecycle tracking (#465)
+            let parsed_args: serde_json::Value =
+                serde_json::from_str(&parallel[j].arguments).unwrap_or_default();
+            track_file_lifecycle(
+                &parallel[j].function_name,
+                &parsed_args,
+                project_root,
+                file_tracker,
+                &result,
+            )
+            .await;
         }
     } else {
         // 0–1 parallelizable tools — just run sequentially
@@ -298,6 +368,7 @@ pub(crate) async fn execute_tools_split_batch(
                 cancel.clone(),
                 cmd_rx,
                 sub_agent_cache,
+                file_tracker,
             )
             .await?;
         }
@@ -319,6 +390,7 @@ pub(crate) async fn execute_tools_split_batch(
             cancel.clone(),
             cmd_rx,
             sub_agent_cache,
+            file_tracker,
         )
         .await?;
     }
@@ -341,6 +413,7 @@ pub(crate) async fn execute_tools_sequential(
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
+    file_tracker: &mut FileTracker,
 ) -> Result<()> {
     for tc in tool_calls {
         // Check for interrupt before each tool
@@ -361,9 +434,14 @@ pub(crate) async fn execute_tools_sequential(
             is_sub_agent: false,
         });
 
-        // Check approval for this tool call
-        let approval =
-            approval::check_tool(&tc.function_name, &parsed_args, mode, Some(project_root));
+        // Check approval for this tool call (with file ownership awareness, #465)
+        let approval = approval::check_tool_with_tracker(
+            &tc.function_name,
+            &parsed_args,
+            mode,
+            Some(project_root),
+            Some(file_tracker),
+        );
 
         match approval {
             ToolApproval::AutoApprove => {
@@ -471,6 +549,15 @@ pub(crate) async fn execute_tools_sequential(
         // Track progress for file mutations and test results
         crate::progress::track_progress(db, session_id, &tc.function_name, &tc.arguments, &result)
             .await;
+        // File lifecycle tracking (#465)
+        track_file_lifecycle(
+            &tc.function_name,
+            &parsed_args,
+            project_root,
+            file_tracker,
+            &result,
+        )
+        .await;
     }
     Ok(())
 }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -44,7 +44,11 @@ fn truncate_for_history(output: &str, max_chars: usize) -> String {
 ///
 /// Used by the file lifecycle tracker to record which paths
 /// Koda creates or deletes (#465).
-fn resolve_tool_path(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> Option<PathBuf> {
+fn resolve_tool_path(
+    tool_name: &str,
+    args: &serde_json::Value,
+    project_root: &Path,
+) -> Option<PathBuf> {
     if !matches!(tool_name, "Write" | "Edit" | "Delete") {
         return None;
     }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -43,26 +43,16 @@ fn truncate_for_history(output: &str, max_chars: usize) -> String {
 /// Resolve the file path from a tool call's arguments.
 ///
 /// Used by the file lifecycle tracker to record which paths
-/// Koda creates or deletes (#465).
+/// Koda creates or deletes (#465). Only relevant for Write and Delete.
 fn resolve_tool_path(
     tool_name: &str,
     args: &serde_json::Value,
     project_root: &Path,
 ) -> Option<PathBuf> {
-    if !matches!(tool_name, "Write" | "Edit" | "Delete") {
+    if !matches!(tool_name, "Write" | "Delete") {
         return None;
     }
-    let path_str = args
-        .get("path")
-        .or(args.get("file_path"))
-        .and_then(|v| v.as_str())?;
-    let requested = Path::new(path_str);
-    let abs_path = if requested.is_absolute() {
-        requested.to_path_buf()
-    } else {
-        project_root.join(requested)
-    };
-    Some(abs_path)
+    crate::file_tracker::resolve_file_path_from_args(args, project_root)
 }
 
 /// Update file lifecycle tracker after a successful tool execution (#465).

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -75,6 +75,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
     let cancel = CancellationToken::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     let mut settings = koda_core::approval::Settings::load();
+    let mut file_tracker = koda_core::file_tracker::FileTracker::new(&session_id, db.clone()).await;
 
     // Cancel after 100ms — well before SlowProvider's 60s sleep
     let cancel_clone = cancel.clone();
@@ -100,6 +101,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         sink: &sink,
         cancel,
         cmd_rx: &mut cmd_rx,
+        file_tracker: &mut file_tracker,
     })
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -74,6 +74,8 @@ impl Env {
         let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
         let mut settings = Settings::load();
         let tool_defs = self.tool_defs();
+        let mut file_tracker =
+            koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
 
         let result = inference::inference_loop(InferenceContext {
             project_root: &self.root,
@@ -90,6 +92,7 @@ impl Env {
             sink: &sink,
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,
+            file_tracker: &mut file_tracker,
         })
         .await;
 
@@ -245,6 +248,8 @@ async fn test_provider_error_emits_error_event() {
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     let mut settings = Settings::load();
     let tool_defs = env.tool_defs();
+    let mut file_tracker =
+        koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
 
     let result = inference::inference_loop(InferenceContext {
         project_root: &env.root,
@@ -261,6 +266,7 @@ async fn test_provider_error_emits_error_event() {
         sink: &sink,
         cancel: CancellationToken::new(),
         cmd_rx: &mut cmd_rx,
+        file_tracker: &mut file_tracker,
     })
     .await;
 
@@ -350,6 +356,8 @@ async fn test_cancel_during_streaming() {
     let mut settings = Settings::load();
     let tool_defs = env.tool_defs();
     let cancel = CancellationToken::new();
+    let mut file_tracker =
+        koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
 
     // Cancel after 100ms
     let cancel_clone = cancel.clone();
@@ -374,6 +382,7 @@ async fn test_cancel_during_streaming() {
         sink: &sink,
         cancel,
         cmd_rx: &mut cmd_rx,
+        file_tracker: &mut file_tracker,
     })
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -881,3 +881,63 @@ async fn test_activate_skill_missing_parameter() {
         "should report missing parameter: {output}"
     );
 }
+
+/// E2E: Write creates a file, then Delete of that file auto-approves
+/// without user confirmation because Koda owns it (#465).
+#[tokio::test]
+async fn test_write_then_delete_auto_approves_owned_file() {
+    let env = Env::new().await;
+    let target = env.root.join("ephemeral_draft.md");
+    env.insert_user_message("create then cleanup").await;
+
+    // Mock: Write the file, then Delete it, then respond with text.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Write",
+            serde_json::json!({
+                "path": target.to_string_lossy(),
+                "content": "draft content"
+            }),
+        ),
+        MockResponse::tool_call(
+            "Delete",
+            serde_json::json!({"path": target.to_string_lossy()}),
+        ),
+        MockResponse::Text("Cleaned up.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Write should have executed
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, EngineEvent::ToolCallResult { name, .. } if name == "Write")),
+        "expected Write tool result"
+    );
+
+    // Delete should have auto-approved (no NeedsConfirmation / approval prompt)
+    // — it should appear as a successful ToolCallResult, not blocked.
+    let delete_result = events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == "Delete"
+        {
+            return Some(output.clone());
+        }
+        None
+    });
+    assert!(
+        delete_result.is_some(),
+        "Delete should have executed (auto-approved for owned file)"
+    );
+    // The file should no longer exist
+    assert!(
+        !target.exists(),
+        "ephemeral file should be deleted after cleanup"
+    );
+
+    // Final text response should be present
+    assert!(
+        events.iter().any(|e| matches!(e, EngineEvent::TextDone)),
+        "expected TextDone after cleanup"
+    );
+}

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -67,6 +67,8 @@ impl Env {
         let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
         let mut settings = Settings::load();
         let tool_defs = self.tool_defs();
+        let mut file_tracker =
+            koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
 
         let result = inference::inference_loop(InferenceContext {
             project_root: &self.root,
@@ -83,6 +85,7 @@ impl Env {
             sink: &sink,
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,
+            file_tracker: &mut file_tracker,
         })
         .await;
 

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -61,7 +61,7 @@ impl Env {
     /// Bypasses `KodaSession::new()` (which calls `create_provider` internally)
     /// so tests can supply a pre-configured MockProvider.  A fresh ToolRegistry
     /// is created each call because ToolRegistry does not implement Clone.
-    fn make_session(&self, provider: Box<dyn LlmProvider>) -> (KodaSession, CancellationToken) {
+    async fn make_session(&self, provider: Box<dyn LlmProvider>) -> (KodaSession, CancellationToken) {
         let cancel = CancellationToken::new();
         let tools = ToolRegistry::new(self.root.clone(), self.config.max_context_tokens);
 
@@ -78,6 +78,12 @@ impl Env {
             .tools
             .set_session(Arc::new(self.db.clone()), self.session_id.clone());
 
+        let file_tracker = koda_core::file_tracker::FileTracker::new(
+            &self.session_id,
+            self.db.clone(),
+        )
+        .await;
+
         let session = KodaSession {
             id: self.session_id.clone(),
             agent,
@@ -86,6 +92,7 @@ impl Env {
             mode: ApprovalMode::Auto,
             settings: Settings::load(),
             cancel: cancel.clone(),
+            file_tracker,
         };
         (session, cancel)
     }
@@ -103,7 +110,7 @@ async fn session_run_turn_emits_turn_start_and_end() {
     let provider = Box::new(MockProvider::new(vec![MockResponse::Text(
         "Hello!".to_string(),
     )]));
-    let (mut session, _cancel) = env.make_session(provider);
+    let (mut session, _cancel) = env.make_session(provider).await;
 
     let sink = TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
@@ -195,7 +202,7 @@ async fn session_cancellation_produces_turn_end_cancelled() {
         }
     }
 
-    let (mut session, cancel) = env.make_session(Box::new(HangingProvider));
+    let (mut session, cancel) = env.make_session(Box::new(HangingProvider)).await;
 
     // Cancel after 100 ms so the test completes quickly.
     let cancel_clone = cancel.clone();
@@ -255,7 +262,7 @@ async fn session_persists_messages_across_two_turns() {
     let provider1 = Box::new(MockProvider::new(vec![MockResponse::Text(
         "first answer".to_string(),
     )]));
-    let (mut session1, _cancel1) = env.make_session(provider1);
+    let (mut session1, _cancel1) = env.make_session(provider1).await;
     let sink1 = TestSink::new();
     let (_, mut cmd_rx1) = mpsc::channel::<EngineCommand>(1);
     session1
@@ -283,7 +290,7 @@ async fn session_persists_messages_across_two_turns() {
     )]));
     // A new KodaSession sharing the same DB and session_id represents the
     // continuation of the conversation after, e.g., a model swap.
-    let (mut session2, _cancel2) = env.make_session(provider2);
+    let (mut session2, _cancel2) = env.make_session(provider2).await;
     let sink2 = TestSink::new();
     let (_, mut cmd_rx2) = mpsc::channel::<EngineCommand>(1);
     session2

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -61,7 +61,10 @@ impl Env {
     /// Bypasses `KodaSession::new()` (which calls `create_provider` internally)
     /// so tests can supply a pre-configured MockProvider.  A fresh ToolRegistry
     /// is created each call because ToolRegistry does not implement Clone.
-    async fn make_session(&self, provider: Box<dyn LlmProvider>) -> (KodaSession, CancellationToken) {
+    async fn make_session(
+        &self,
+        provider: Box<dyn LlmProvider>,
+    ) -> (KodaSession, CancellationToken) {
         let cancel = CancellationToken::new();
         let tools = ToolRegistry::new(self.root.clone(), self.config.max_context_tokens);
 
@@ -78,11 +81,8 @@ impl Env {
             .tools
             .set_session(Arc::new(self.db.clone()), self.session_id.clone());
 
-        let file_tracker = koda_core::file_tracker::FileTracker::new(
-            &self.session_id,
-            self.db.clone(),
-        )
-        .await;
+        let file_tracker =
+            koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
 
         let session = KodaSession {
             id: self.session_id.clone(),


### PR DESCRIPTION
## Summary

Closes #465. Implements Rust-inspired ownership tracking so Koda auto-approves deletion of files it created — no more pointless confirmation prompts for cleanup of ephemeral files.

## Problem

When Koda creates a temp file (e.g. a scratch script, a generated report), then later tries to delete it, the user gets a destructive-action confirmation prompt. This is annoying because the net effect is zero: Koda created it, Koda removes it.

## Solution

### New module: `file_tracker.rs`
- In-memory `HashSet<PathBuf>` for O(1) ownership checks
- SQLite-backed persistence (`owned_files` table) so state survives compaction, token limits, and process crashes
- Session-scoped isolation — session A's files are invisible to session B

### Approval integration
- New `check_tool_with_tracker()` in `approval.rs`
- When `Delete` targets a Koda-owned file → `AutoApprove` (bypasses the destructive gate)
- Works in both Auto and Confirm modes
- Original `check_tool()` still works without a tracker (backward-compatible)

### Tool dispatch hooks
- `Write` → `track_created()` (file is now owned)
- `Delete` → `untrack()` (file no longer exists)
- Only tracks successful operations (error results are ignored)
- Hooks in all 3 execution paths: sequential, parallel, split-batch

### Session wiring
- `FileTracker` lives on `KodaSession`
- `KodaSession::new()` is now `async` (loads persisted tracker state on resume)
- Threaded through `InferenceContext` → tool dispatch

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Ownership via `Write` only | Editing a user's file doesn't confer ownership |
| DB-backed, not context-backed | Survives compaction + crashes |
| No hash verification (v1) | Low risk for v1; can add borrow-checker semantics later |
| `check_tool` backward-compat | Existing callers (sub-agents, `can_parallelize`) unaffected |

## Test coverage (10 new tests)

- **6 unit tests** (`file_tracker.rs`): ownership, untrack, persistence across restarts, session isolation, idempotency, noop untrack
- **4 approval tests** (`approval.rs`): owned-file auto-approve (Auto + Confirm modes), unowned-file still confirms, no-tracker fallback

## Files changed

| File | Change |
|------|--------|
| `file_tracker.rs` | **New** — core tracker module |
| `db.rs` | `owned_files` table migration + CRUD |
| `approval.rs` | `check_tool_with_tracker()` |
| `tool_dispatch.rs` | `track_file_lifecycle()` + hooks |
| `inference.rs` | Thread tracker through `InferenceContext` |
| `session.rs` | `FileTracker` field, async `new()` |
| `lib.rs` | Module registration |
| 3 CLI files | `.await` on `KodaSession::new()` |
| `session_test.rs` | Updated test harness |
