### PR TITLE
fix(file_tracker): canonicalize paths + use ToolResult.success (#474, #476)

### DIFF
--- a/koda-core/src/file_tracker.rs
+++ b/koda-core/src/file_tracker.rs
@@ -14,13 +14,19 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use path_clean::PathClean;
+
 use crate::db::Database;
 
 /// Extract and resolve a file path from tool call arguments.
 ///
 /// Looks for `"path"` or `"file_path"` in the JSON args, then resolves
-/// relative paths against `project_root`. Used by both the approval
-/// system and the file lifecycle tracker (#465).
+/// relative paths against `project_root`. The result is cleaned
+/// (normalized) so that `./foo/../bar.txt` and `bar.txt` resolve to
+/// the same path, preventing duplicate tracking (#474).
+///
+/// Uses `canonicalize()` when the file already exists (resolves symlinks),
+/// falling back to `PathClean::clean()` for new files that don't exist yet.
 pub(crate) fn resolve_file_path_from_args(
     args: &serde_json::Value,
     project_root: &Path,
@@ -35,7 +41,9 @@ pub(crate) fn resolve_file_path_from_args(
     } else {
         project_root.join(requested)
     };
-    Some(abs_path)
+    // Prefer canonicalize (resolves symlinks, e.g. macOS /var → /private/var)
+    // but fall back to clean() for files that don't exist yet (Write creates them).
+    Some(abs_path.canonicalize().unwrap_or_else(|_| abs_path.clean()))
 }
 
 /// Tracks files created by Koda in the current session.

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -55,19 +55,21 @@ fn resolve_tool_path(
     crate::file_tracker::resolve_file_path_from_args(args, project_root)
 }
 
-/// Update file lifecycle tracker after a successful tool execution (#465).
+/// Update file lifecycle tracker after a tool execution (#465).
 ///
 /// - Write → track as owned (Koda created it)
 /// - Delete → untrack (file no longer exists)
+///
+/// Only tracks when `success` is true, using the structured boolean
+/// from `ToolResult` rather than fragile string-prefix matching (#476).
 async fn track_file_lifecycle(
     tool_name: &str,
     args: &serde_json::Value,
     project_root: &Path,
     file_tracker: &mut FileTracker,
-    result: &str,
+    success: bool,
 ) {
-    // Only track successful operations (result doesn't start with "Error")
-    if result.starts_with("Error") || result.starts_with("Failed") {
+    if !success {
         return;
     }
     if let Some(path) = resolve_tool_path(tool_name, args, project_root) {
@@ -113,7 +115,7 @@ pub(crate) fn can_parallelize(
     !has_conflict
 }
 
-/// Execute a single tool call, returning (tool_call_id, result).
+/// Execute a single tool call, returning (tool_call_id, result_output, success).
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_one_tool(
     tc: &ToolCall,
@@ -126,8 +128,8 @@ pub(crate) async fn execute_one_tool(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
-) -> (String, String) {
-    let result = if tc.function_name == "InvokeAgent" {
+) -> (String, String, bool) {
+    let (result, success) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
         let mut sub_settings = Settings::default();
         match execute_sub_agent(
@@ -146,8 +148,8 @@ pub(crate) async fn execute_one_tool(
         )
         .await
         {
-            Ok(output) => output,
-            Err(e) => format!("Error invoking sub-agent: {e}"),
+            Ok(output) => (output, true),
+            Err(e) => (format!("Error invoking sub-agent: {e}"), false),
         }
     } else {
         // Invalidate sub-agent cache on file mutations
@@ -155,9 +157,9 @@ pub(crate) async fn execute_one_tool(
             sub_agent_cache.invalidate();
         }
         let r = tools.execute(&tc.function_name, &tc.arguments).await;
-        r.output
+        (r.output, r.success)
     };
-    (tc.id.clone(), result)
+    (tc.id.clone(), result, success)
 }
 
 /// Run multiple tool calls concurrently and store results.
@@ -201,7 +203,7 @@ pub(crate) async fn execute_tools_parallel(
     let results = futures_util::future::join_all(futures).await;
 
     // Emit banner + result together so each tool's output is visually grouped
-    for (i, (tc_id, result)) in results.into_iter().enumerate() {
+    for (i, (tc_id, result, success)) in results.into_iter().enumerate() {
         sink.emit(EngineEvent::ToolCallStart {
             id: tc_id.clone(),
             name: tool_calls[i].function_name.clone(),
@@ -232,7 +234,7 @@ pub(crate) async fn execute_tools_parallel(
             &result,
         )
         .await;
-        // File lifecycle tracking (#465)
+        // File lifecycle tracking (#465, #476)
         let parsed_args: serde_json::Value =
             serde_json::from_str(&tool_calls[i].arguments).unwrap_or_default();
         track_file_lifecycle(
@@ -240,7 +242,7 @@ pub(crate) async fn execute_tools_parallel(
             &parsed_args,
             project_root,
             file_tracker,
-            &result,
+            success,
         )
         .await;
     }
@@ -303,7 +305,7 @@ pub(crate) async fn execute_tools_split_batch(
             .collect();
         let results = futures_util::future::join_all(futures).await;
 
-        for (j, (tc_id, result)) in results.into_iter().enumerate() {
+        for (j, (tc_id, result, success)) in results.into_iter().enumerate() {
             sink.emit(EngineEvent::ToolCallStart {
                 id: tc_id.clone(),
                 name: parallel[j].function_name.clone(),
@@ -333,7 +335,7 @@ pub(crate) async fn execute_tools_split_batch(
                 &result,
             )
             .await;
-            // File lifecycle tracking (#465)
+            // File lifecycle tracking (#465, #476)
             let parsed_args: serde_json::Value =
                 serde_json::from_str(&parallel[j].arguments).unwrap_or_default();
             track_file_lifecycle(
@@ -341,7 +343,7 @@ pub(crate) async fn execute_tools_split_batch(
                 &parsed_args,
                 project_root,
                 file_tracker,
-                &result,
+                success,
             )
             .await;
         }
@@ -511,7 +513,7 @@ pub(crate) async fn execute_tools_sequential(
             }
         }
 
-        let (_, result) = execute_one_tool(
+        let (_, result, success) = execute_one_tool(
             tc,
             project_root,
             config,
@@ -543,13 +545,13 @@ pub(crate) async fn execute_tools_sequential(
         // Track progress for file mutations and test results
         crate::progress::track_progress(db, session_id, &tc.function_name, &tc.arguments, &result)
             .await;
-        // File lifecycle tracking (#465)
+        // File lifecycle tracking (#465, #476)
         track_file_lifecycle(
             &tc.function_name,
             &parsed_args,
             project_root,
             file_tracker,
-            &result,
+            success,
         )
         .await;
     }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -104,6 +104,7 @@ macro_rules! require_email_config {
                         "Email not configured: {e:#}\n\n{}",
                         koda_email::config::EmailConfig::setup_instructions()
                     ),
+                    success: false,
                 };
             }
         }
@@ -123,6 +124,12 @@ pub type FileReadCache = Arc<std::sync::Mutex<HashMap<String, (u64, SystemTime)>
 pub struct ToolResult {
     /// The tool's output string.
     pub output: String,
+    /// Whether the tool executed successfully.
+    ///
+    /// Set automatically by `ToolRegistry::execute()` — `Ok(…)` → `true`,
+    /// `Err(…)` → `false`. Individual tools never set this directly;
+    /// they just return `Result<String>`.
+    pub success: bool,
 }
 
 /// The tool registry: maps tool names to their definitions and handlers.
@@ -302,6 +309,7 @@ impl ToolRegistry {
             Err(e) => {
                 return ToolResult {
                     output: format!("Invalid JSON arguments: {e}"),
+                    success: false,
                 };
             }
         };
@@ -441,6 +449,7 @@ impl ToolRegistry {
                 // This branch should not be reached in normal flow.
                 return ToolResult {
                     output: "InvokeAgent is handled by the inference loop.".to_string(),
+                    success: false,
                 };
             }
 
@@ -448,9 +457,13 @@ impl ToolRegistry {
         };
 
         match result {
-            Ok(output) => ToolResult { output },
+            Ok(output) => ToolResult {
+                output,
+                success: true,
+            },
             Err(e) => ToolResult {
                 output: format!("Error: {e}"),
+                success: false,
             },
         }
     }


### PR DESCRIPTION
## Summary

Two hardening fixes for the file lifecycle tracker. Both low-severity but defensive against future breakage.

Closes #474, closes #476

## Changes

### 1. Canonicalize paths (#474)

`resolve_file_path_from_args()` now normalizes paths so `./foo/../bar.txt` and `bar.txt` resolve identically:

- **`canonicalize()`** for files that already exist (resolves symlinks — important on macOS `/var` → `/private/var`)
- **`path_clean::clean()`** fallback for files that don't exist yet (`Write` creates them)

### 2. Structured success check (#476)

Replaced fragile string-prefix error detection with a typed boolean:

**Before:**
```rust
if result.starts_with("Error") || result.starts_with("Failed") {
    return; // skip tracking
}
```

**After:**
```rust
// ToolResult now carries success: bool
pub struct ToolResult {
    pub output: String,
    pub success: bool,  // ← set by execute(), not by individual tools
}

// track_file_lifecycle uses the structured flag
if !success { return; }
```

The `success` field is set automatically in `ToolRegistry::execute()` — the single `Result → ToolResult` conversion point:
- `Ok(output)` → `success: true`
- `Err(e)` → `success: false`

Individual tools just return `Result<String>` as before. The Rust compiler enforces that all `ToolResult` construction sites set the field — **zero risk of future tools forgetting**.

## Files changed

| File | Change |
|---|---|
| `file_tracker.rs` | Add `path_clean` import, canonicalize in `resolve_file_path_from_args` |
| `tools/mod.rs` | Add `success: bool` to `ToolResult`, set at all construction sites |
| `tool_dispatch.rs` | Thread `success` through `execute_one_tool` → `track_file_lifecycle` |

## Testing
- 221 tests passing, no new tests needed (existing file_tracker tests cover the paths)
- `cargo fmt` ✅ `cargo check` ✅ `cargo clippy` ✅
