### PR TITLE
docs: update README, DESIGN, CLAUDE, user guide for fullscreen TUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ koda/
 │   │   ├── config.rs       # Agent/provider config + provider metadata
 │   │   ├── context.rs      # Context window token tracking
 │   │   ├── db.rs           # SQLite persistence (WAL mode, parameterized queries)
+│   │   ├── file_tracker.rs # File lifecycle tracking (create/edit/delete ownership)
 │   │   ├── git.rs          # Git checkpointing + rollback
 │   │   ├── inference.rs    # Streaming inference loop + tool execution
 │   │   ├── inference_helpers.rs # Token estimation, message assembly, overflow detection
@@ -133,15 +134,19 @@ koda/
 │   ├── src/
 │   │   ├── main.rs         # CLI entry point (clap)
 │   │   ├── lib.rs          # Crate root (exports acp_adapter)
-│   │   ├── tui_app.rs      # Main TUI event loop (ratatui Viewport::Inline)
+│   │   ├── tui_app.rs      # Main TUI event loop (ratatui Viewport::Fullscreen)
 │   │   ├── tui_context.rs  # TUI shared mutable state struct
 │   │   ├── tui_handlers_inference.rs # Inference event handling (extracted from context)
 │   │   ├── tui_render.rs   # EngineEvent → ratatui Line/Span rendering
 │   │   ├── tui_commands.rs # Slash command dispatch (/help, /model, /sessions, etc.)
 │   │   ├── tui_wizards.rs  # Interactive wizards (/provider, /compact, /agent)
-│   │   ├── tui_output.rs   # Output bridge: emit_line (ratatui) + write_line (crossterm)
-│   │   ├── tui_viewport.rs # Viewport layout + menu_area rendering
+│   │   ├── tui_output.rs   # Output bridge: scroll_buffer push helpers
+│   │   ├── tui_viewport.rs # Fullscreen viewport layout + rendering
 │   │   ├── tui_types.rs    # MenuContent, PromptMode, TuiState, shared TUI types
+│   │   ├── scroll_buffer.rs# App-managed scrollback buffer with visual-line scroll
+│   │   ├── mouse_select.rs # Mouse text selection + clipboard copy
+│   │   ├── ansi_parse.rs   # ANSI escape code → ratatui Span conversion
+│   │   ├── history_render.rs # Session history → scroll_buffer replay
 │   │   ├── md_render.rs    # Streaming markdown → ratatui renderer
 │   │   ├── completer.rs    # Tab completion (/commands, @files, /model names)
 │   │   ├── diff_render.rs  # Diff preview → ratatui renderer (syntax highlighted)
@@ -154,7 +159,7 @@ koda/
 │   │   ├── server.rs       # ACP server over stdio JSON-RPC
 │   │   ├── acp_adapter.rs  # ACP protocol adapter
 │   │   ├── onboarding.rs   # First-run wizard (provider + API key setup)
-│   │   ├── tool_history.rs # Tool output history for /expand
+│   │   └── tool_history.rs # Tool output history for /expand
 │   │   └── widgets/        # TUI widgets
 │   │       ├── mod.rs      # Widget module root
 │   │       ├── dropdown.rs # Generic dropdown widget
@@ -186,22 +191,25 @@ koda/
 
 `main.rs` → `tui_app.rs` (TUI event loop) → `KodaSession::run_turn()` → `inference_loop()` (streaming LLM + tools)
 
-The TUI uses `ratatui::Viewport::Inline` with a fixed 12-line viewport.
-Engine output is rendered above the viewport via `insert_before()`. Slash commands use
-crossterm direct writes (`write_line()`). These two rendering paths must never be mixed
-within a single operation.
+The TUI uses `ratatui::Viewport::Fullscreen` (alternate screen buffer) with
+app-managed scrollback. All output flows through a single rendering path:
+`EngineEvent` → `tui_render.rs` → `ScrollBuffer` → `draw_viewport()`.
 
 **Viewport layout** (see DESIGN.md §14):
 ```
-[output scrollback]          ← insert_before()
+[history panel]                ← ScrollBuffer: scrollable, mouse-selectable
 ─── 🐻 ─                        ← separator
-⚡> input                      ← fixed position, sized to content
+⚡> input                      ← tui-textarea, sized to content
 ──────────────────────────────
-model │ auto │ 0%               ← status bar (hugs input)
+model │ auto │ ████ 42% │ 🐻 12s  ← status bar
 [menu_area]                    ← dropdown / approval / wizard (Min(0))
 ```
 
-All interactive UI renders in `menu_area`. The prompt and status bar never move.
+All interactive UI renders in `menu_area`. The history panel fills the
+remaining vertical space. Mouse scroll works during inference. Native
+clipboard (`arboard`) handles copy since alternate screen disables
+terminal-native mouse selection.
+
 See DESIGN.md §14 for the interaction system design and competitive analysis.
 
 The engine communicates through `EngineEvent` (output) and `EngineCommand` (input) enums.
@@ -228,9 +236,9 @@ Tools use PascalCase names. `mod.rs` has the registry, dispatcher, and `safe_res
 - All I/O is async (`tokio`)
 - Tool names: PascalCase; module names: snake_case
 - `koda-core` has zero terminal deps (no crossterm, no ratatui)
-- Two rendering paths in koda-cli (never mix within one operation):
-  - `emit_line()` / `emit_above()` — ratatui `insert_before()` for engine output
-  - `write_line()` — crossterm direct writes for slash commands
+- Single rendering path in koda-cli:
+  - All output → `ScrollBuffer` → `draw_viewport()` (fullscreen alternate screen)
+  - No `insert_before()`, no dual-path rendering
 - Engine → client: `EngineSink::emit(EngineEvent)`
 - Client → engine: `mpsc::Receiver<EngineCommand>`
 - Cancellation: `tokio_util::sync::CancellationToken`
@@ -366,5 +374,4 @@ For capabilities that ship in the koda workspace (same release cycle):
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
 10. Sync version with workspace (currently 0.1.10)
 11. Update this file (CLAUDE.md)
-
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -377,6 +377,62 @@ thinking IS the planning.
 
 **Archive**: Tag `v0.1.4-phase-system` preserves the full implementation.
 
+### 20. File Lifecycle Tracking (v0.1.11)
+
+**Decision**: Track file create/edit/delete ownership per turn to auto-approve
+deleting files that koda created in the same turn.
+
+**Rationale**: A common pattern — scaffold a temp file, use it, delete it —
+requires two confirmation prompts. The second ("approve delete?") is redundant
+when koda just created the file moments ago. The file tracker
+(`file_tracker.rs`) records which files were created/edited per turn.
+`check_tool()` in `approval.rs` queries the tracker: if a Delete targets a
+file koda created this turn, it's auto-approved.
+
+**Implementation choices**:
+- Paths are canonicalized (`std::fs::canonicalize()` + `path_clean::clean()`
+  fallback for not-yet-created files) to prevent `./foo/../bar.txt` vs
+  `bar.txt` mismatches
+- Success is tracked via `ToolResult.success: bool` (set by
+  `ToolRegistry::execute()`) — failed writes don't register ownership
+- Tracker resets per turn via `reset()` — no cross-turn state leakage
+- In-memory only — no persistence needed since ownership is turn-scoped
+
+**Design reference**: [#465](https://github.com/lijunzh/koda/issues/465),
+[#474](https://github.com/lijunzh/koda/issues/474),
+[#476](https://github.com/lijunzh/koda/issues/476)
+
+### 21. Fullscreen Viewport (v0.1.11)
+
+**Decision**: Switch from `Viewport::Inline` (terminal-native scrollback) to
+`Viewport::Fullscreen` (alternate screen buffer with app-managed scrollback).
+
+**Rationale**: Inline viewport had two fundamental bugs that couldn't be fixed
+within the inline model:
+- **DSR cursor position timeouts** ([#470]): `Viewport::Inline` relies on a
+  terminal DSR query to determine cursor position. Some terminals
+  (particularly over SSH or slow connections) fail to respond, causing
+  multi-second hangs at startup.
+- **Resize ghost fragments** ([#418]): When the terminal resizes, inline
+  viewport content already "scrolled off" into the terminal's native
+  scrollback can't be cleared — causing visual corruption.
+
+**What changed**:
+- `scroll_buffer.rs`: app-managed `VecDeque<Line>` with visual-line-aware
+  scrolling replaces terminal-native scrollback
+- `mouse_select.rs`: click-drag text selection + `arboard` clipboard copy
+  (essential — alternate screen disables terminal mouse selection)
+- `ansi_parse.rs`: ANSI escape → ratatui Span conversion for tool output
+- `history_render.rs`: session history replay into scroll buffer
+- Single rendering path: all output → `ScrollBuffer` → `draw_viewport()`
+
+**Design reference**: [#472]
+
+**What didn't change**: The interaction model. Conversation is still the
+primary surface. Menus, approvals, and wizards still render in `menu_area`.
+The layout is the same — just managed by the app instead of the terminal.
+
+
 ### 17. Folder-Scoped Permissions (v0.1.4)
 
 **Decision**: Writes outside `project_root` always require explicit
@@ -443,6 +499,8 @@ violate the principles are tracked as issues for future cleanup.
 | §16 Phase system retired | Clear Boundaries | Removed 4,308 lines of planning that reimplemented what the model does |
 | §17 Folder-scoped permissions | Software for One | Hardcoded safety floors, not configurable trust levels |
 | §18 Security model | Software for One | ToolEffect classification is compile-time; approval modes are the only runtime knob |
+| §20 File lifecycle tracking | Clear Boundaries | Tracker is engine-side (`koda-core`); approval queries it via trait — no UI coupling |
+| §21 Fullscreen viewport | Clear Boundaries | Rendering path simplified from dual (insert_before + write_line) to single (ScrollBuffer → draw) |
 
 ### Violations (tracked for cleanup)
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ echo "explain this" | koda        # Piped input
 - **Git checkpointing** — auto-snapshots before each turn for safe rollback
 - **Approval modes** — auto (default) / confirm (confirm writes) via `Shift+Tab`
 - **Per-tool safety gates** — destructive ops and outside-project writes always need confirmation; local mutations auto-approved in auto mode
+- **File ownership tracking** — files created by koda in a turn can be auto-approved for deletion in the same turn (no double-confirmation)
 - **Folder-scoped permissions** — writes outside `project_root` always require confirmation; bash commands with path escapes are flagged
 - **Diff preview** — see exactly what changes before approving Edit, Write, Delete
 - **Loop detection** — catches repeated tool calls with configurable iteration caps
 - **Parallel execution** — concurrent tool calls and sub-agent orchestration
 - **Extended thinking** — structured thinking block display with configurable budgets
 - **Image analysis** — `@image.png` or drag-and-drop for multi-modal input
+- **Fullscreen TUI** — alternate screen buffer with app-managed scrollback, mouse scroll during inference, native clipboard copy
 - **Git integration** — `/diff` review, commit message generation
 - **Headless mode** — `koda -p "prompt"` with JSON output for CI/CD
 - **Persistent memory** — project (`MEMORY.md`) and global (`~/.config/koda/memory.md`)
@@ -139,6 +141,8 @@ Koda connects to your email via IMAP/SMTP through the built-in koda-email integr
 | **Shift+Tab** | At prompt | Cycle mode (auto ↔ confirm) |
 | **Ctrl+D** | At prompt (empty) | Exit Koda |
 | **↑/↓** | At prompt | Browse command history |
+| **Mouse scroll** | History panel | Scroll output (works during inference) |
+| **Click+drag** | History panel | Select text for clipboard copy |
 
 ## Architecture
 
@@ -198,7 +202,7 @@ Use `/compact` manually, or let auto-compact handle it. The `/cost` command show
 ## Development
 
 ```bash
-cargo test --workspace --features koda-core/test-support  # Run all 432 tests
+cargo test --workspace --features koda-core/test-support  # Run all tests
 cargo clippy --workspace      # Lint
 cargo run -p koda-cli         # Run locally
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -149,6 +149,12 @@ Koda gates tool execution with two approval modes. Cycle with **Shift+Tab**.
 - Destructive bash commands (`rm -rf`, `git push --force`) always require confirmation
 - Bash commands that escape the project (`cd /tmp`, absolute paths outside project) always require confirmation
 
+**File ownership tracking**: When koda creates a file during a turn, it tracks
+ownership. If the model subsequently deletes that same file in the same turn,
+the deletion is auto-approved (no double-confirmation). This prevents the
+annoying pattern where creating a temporary file and then cleaning it up
+requires two approvals.
+
 **Approval hotkeys** (shown inline when a tool needs confirmation):
 - `y` — approve
 - `n` — reject
@@ -176,6 +182,11 @@ Type `/` to open the command palette with descriptions. Tab to complete.
 | `/skills` | List available skills (search with `/skills <query>`) |
 | `/undo` | Undo last turn's file changes |
 | `/verbose` | Toggle full tool output display |
+
+**Scrolling & selection**: Mouse scroll works in the history panel (including
+during inference). Click-drag to select text, which copies to the system
+clipboard via `arboard`. This is essential since the alternate screen buffer
+disables terminal-native mouse selection.
 
 **Power-user shortcuts**: Commands accept inline arguments to skip wizards.
 For example, `/provider anthropic` switches instantly if an API key is


### PR DESCRIPTION
## Summary

Brings all four documentation files in sync with the v0.1.11 fullscreen TUI migration (#472) and file lifecycle tracking (#465).

**No code changes** — docs only.

## What changed per file

### README.md
- Added **file ownership tracking** and **fullscreen TUI** to features list
- Added **mouse scroll** and **click-drag selection** to keyboard shortcuts table
- Removed hardcoded test count (was "432", now 724 — just says "all tests")

### CLAUDE.md
- Updated viewport from `Viewport::Inline` (12-line) → `Viewport::Fullscreen` (alternate screen buffer)
- Replaced **dual rendering path** (`insert_before` + `write_line`) with **single path** (`ScrollBuffer` → `draw_viewport()`)
- Added new files to koda-cli tree: `scroll_buffer.rs`, `mouse_select.rs`, `ansi_parse.rs`, `history_render.rs`
- Added `file_tracker.rs` to koda-core tree

### DESIGN.md
- Added **§20 File Lifecycle Tracking** — ownership tracking, path canonicalization, `ToolResult.success`
- Added **§21 Fullscreen Viewport** — DSR timeout fix, resize ghost fix, new module breakdown
- Added both to **Principles Audit** table (aligned with Clear Boundaries)

### docs/user-guide.md
- Added **file ownership tracking** to approval modes section
- Added **mouse scroll and text selection** note to slash commands section
