### PR TITLE
chore: remove dead WizardInput.masked field

### DIFF
--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -552,10 +552,7 @@ impl TuiContext {
                 format!("API key for {}", ptype)
             };
             self.menu = MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
-            self.prompt_mode = PromptMode::WizardInput {
-                label,
-                masked: true,
-            };
+            self.prompt_mode = PromptMode::WizardInput { label };
             self.provider_wizard = Some(ProviderWizard::NeedApiKey {
                 provider_type: ptype,
                 base_url,
@@ -567,7 +564,6 @@ impl TuiContext {
             self.menu = MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
             self.prompt_mode = PromptMode::WizardInput {
                 label: format!("{} URL", ptype),
-                masked: false,
             };
             self.provider_wizard = Some(ProviderWizard::NeedUrl {
                 provider_type: ptype,
@@ -961,10 +957,7 @@ impl TuiContext {
                         };
                         self.menu =
                             MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
-                        self.prompt_mode = PromptMode::WizardInput {
-                            label,
-                            masked: true,
-                        };
+                        self.prompt_mode = PromptMode::WizardInput { label };
                         self.provider_wizard = Some(ProviderWizard::NeedApiKey {
                             provider_type: ptype,
                             base_url,
@@ -977,7 +970,6 @@ impl TuiContext {
                             MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
                         self.prompt_mode = PromptMode::WizardInput {
                             label: format!("{} URL", ptype),
-                            masked: false,
                         };
                         self.provider_wizard = Some(ProviderWizard::NeedUrl {
                             provider_type: ptype,

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -298,7 +298,6 @@ async fn handle_inference_key_inline(
             KeyCode::Char('f') | KeyCode::Char('F') => {
                 *prompt_mode = PromptMode::WizardInput {
                     label: "Feedback".into(),
-                    masked: false,
                 };
                 *menu = MenuContent::WizardTrail(vec![(
                     "Action".into(),

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -78,12 +78,8 @@ impl MenuContent {
 pub(crate) enum PromptMode {
     /// Normal chat input: ⚡> █
     Chat,
-    /// Wizard text input: label: █ (or label: ••••█ when masked)
-    WizardInput {
-        label: String,
-        #[allow(dead_code)] // TODO: implement textarea masking for API keys
-        masked: bool,
-    },
+    /// Wizard text input: label: █
+    WizardInput { label: String },
 }
 
 /// Provider setup wizard state machine.


### PR DESCRIPTION
## Changes

### CQ-3: Remove dead `WizardInput.masked` field

The `masked: bool` field was set by 5 call sites (`true` for API keys, `false` for URLs) but **never read** by the viewport renderer. Instead of keeping dead code with `#[allow(dead_code)]`, remove it entirely per YAGNI.

If textarea masking is needed later, re-add the field with an actual rendering implementation.

**Files changed:**
- `tui_types.rs` — removed field + `#[allow(dead_code)]`
- `tui_context.rs` — removed `masked: true/false` from 4 call sites
- `tui_handlers_inference.rs` — removed `masked: false` from 1 call site

### Verification

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test -p koda-cli` ✅

Part of #483.
