### PR TITLE
docs: sync CLAUDE.md architecture tree with v0.1.12 state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,11 @@ koda/
 │   │   ├── truncate.rs     # Token-safe output truncation
 │   │   ├── undo.rs         # Undo stack for file mutations
 │   │   ├── version.rs      # Background version checker (queries crates.io)
+│   │   ├── file_tracker.rs # File lifecycle tracker — auto-approve cleanup of Koda-created files
 │   │   ├── engine/         # EngineEvent, EngineCommand, EngineSink trait
+│   │   │   ├── mod.rs      # Module root + re-exports
+│   │   │   ├── event.rs    # EngineEvent + EngineCommand protocol types
+│   │   │   └── sink.rs     # EngineSink trait (how clients receive events)
 │   │   ├── providers/      # LLM providers
 │   │   │   ├── mod.rs      # LlmProvider trait, ChatMessage, HTTP client builder
 │   │   │   ├── anthropic.rs# Anthropic Claude (prompt caching, extended thinking)
@@ -145,7 +149,11 @@ koda/
 │   │   ├── md_render.rs    # Streaming markdown → ratatui renderer
 │   │   ├── completer.rs    # Tab completion (/commands, @files, /model names)
 │   │   ├── diff_render.rs  # Diff preview → ratatui renderer (syntax highlighted)
+│   │   ├── ansi_parse.rs   # ANSI escape code → ratatui Span conversion
 │   │   ├── highlight.rs    # Syntax highlighting via syntect
+│   │   ├── history_render.rs # Render DB messages → styled Lines for session resume
+│   │   ├── mouse_select.rs # Mouse text selection + clipboard copy in fullscreen
+│   │   ├── scroll_buffer.rs # Render cache + virtual scrolling for fullscreen history
 │   │   ├── startup.rs      # Startup banner rendering
 │   │   ├── repl.rs         # Slash command parsing + provider/model lists
 │   │   ├── input.rs        # @file reference processing + image loading
@@ -186,16 +194,16 @@ koda/
 
 `main.rs` → `tui_app.rs` (TUI event loop) → `KodaSession::run_turn()` → `inference_loop()` (streaming LLM + tools)
 
-The TUI uses `ratatui::Viewport::Inline` with a fixed 12-line viewport.
-Engine output is rendered above the viewport via `insert_before()`. Slash commands use
-crossterm direct writes (`write_line()`). These two rendering paths must never be mixed
-within a single operation.
+The TUI runs in fullscreen alternate-screen mode (#472). The scroll buffer
+holds rendered `Line`s with virtual scrolling and "sticky bottom" behavior.
+Mouse capture is enabled for scroll wheel; text selection is handled by
+`mouse_select.rs` with automatic clipboard copy.
 
 **Viewport layout** (see DESIGN.md §14):
 ```
-[output scrollback]          ← insert_before()
+[history scrollback]           ← ScrollBuffer (virtual scroll, DB-backed)
 ─── 🐻 ─                        ← separator
-⚡> input                      ← fixed position, sized to content
+⚡> input                      ← textarea, sized to content
 ──────────────────────────────
 model │ auto │ 0%               ← status bar (hugs input)
 [menu_area]                    ← dropdown / approval / wizard (Min(0))


### PR DESCRIPTION
## Changes

### DOC-2: Sync CLAUDE.md architecture tree

Add 6 source files missing from the architecture tree (added in v0.1.12 #472 and #465):

**koda-core:**
- `file_tracker.rs` — file lifecycle tracker, auto-approve cleanup of Koda-created files
- `engine/event.rs` — EngineEvent + EngineCommand protocol types
- `engine/sink.rs` — EngineSink trait

**koda-cli:**
- `scroll_buffer.rs` — render cache + virtual scrolling for fullscreen history
- `mouse_select.rs` — mouse text selection + clipboard copy in fullscreen
- `ansi_parse.rs` — ANSI escape code → ratatui Span conversion
- `history_render.rs` — render DB messages → styled Lines for session resume

### Update stale viewport description

Replaced the old `Viewport::Inline` (12-line fixed viewport) description with the fullscreen alternate-screen mode added in #472. The viewport now uses `ScrollBuffer` with virtual scrolling and mouse capture.

Part of #483.
