### PR TITLE
fix(tui): replace blocking purge confirmation with menu-based flow

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -38,6 +38,7 @@ pub async fn handle_slash_command(
     project_root: &std::path::Path,
     agent: &Arc<KodaAgent>,
     pending_command: &mut Option<String>,
+    menu: &mut crate::tui_types::MenuContent,
 ) -> SlashAction {
     match crate::repl::handle_command(input, config, provider).await {
         ReplAction::Quit => SlashAction::Quit,
@@ -88,7 +89,7 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
         ReplAction::Purge(ref age_filter) => {
-            crate::tui_wizards::handle_purge(buffer, session, age_filter.as_deref()).await;
+            crate::tui_wizards::handle_purge(buffer, session, age_filter.as_deref(), menu).await;
             SlashAction::Continue
         }
         ReplAction::Expand(n) => {

--- a/koda-cli/src/tui_context.rs
+++ b/koda-cli/src/tui_context.rs
@@ -454,6 +454,7 @@ impl TuiContext {
             &self.project_root,
             &self.agent,
             &mut self.pending_command,
+            &mut self.menu,
         )
         .await;
 
@@ -855,6 +856,24 @@ impl TuiContext {
     // ── Menu navigation ───────────────────────────────────────
 
     async fn handle_menu_key(&mut self, key: crossterm::event::KeyEvent) -> Option<bool> {
+        // Purge confirmation: only y/n/Esc are meaningful.
+        if let MenuContent::PurgeConfirm { min_age_days, .. } = &self.menu {
+            let days = *min_age_days;
+            match key.code {
+                KeyCode::Char('y' | 'Y') => {
+                    crate::tui_wizards::execute_purge(&mut self.scroll_buffer, &self.session, days)
+                        .await;
+                    self.menu = MenuContent::None;
+                }
+                KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+                    crate::tui_output::dim_msg(&mut self.scroll_buffer, "Purge cancelled.".into());
+                    self.menu = MenuContent::None;
+                }
+                _ => {}
+            }
+            return Some(true);
+        }
+
         let is_up = key.code == KeyCode::Up
             || (key.code == KeyCode::Char('k') && key.modifiers.contains(KeyModifiers::CONTROL));
         let is_down = key.code == KeyCode::Down
@@ -904,6 +923,7 @@ impl TuiContext {
             MenuContent::File { dropdown: dd, .. } => nav!(dd),
             MenuContent::Approval { .. }
             | MenuContent::LoopCap
+            | MenuContent::PurgeConfirm { .. }
             | MenuContent::WizardTrail(_)
             | MenuContent::None => {}
         }
@@ -1009,6 +1029,7 @@ impl TuiContext {
             }
             MenuContent::Approval { .. }
             | MenuContent::LoopCap
+            | MenuContent::PurgeConfirm { .. }
             | MenuContent::WizardTrail(_)
             | MenuContent::None => {}
         }

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -63,6 +63,8 @@ pub(crate) enum MenuContent {
     },
     /// Loop cap hotkey bar — continue or stop after iteration limit.
     LoopCap,
+    /// Purge confirmation bar — \[y\] confirm / \[n\] cancel.
+    PurgeConfirm { min_age_days: u32, detail: String },
 }
 
 impl MenuContent {

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -45,7 +45,7 @@ pub(crate) fn draw_viewport(
     // Determine menu height (only when active)
     let menu_height = match menu {
         MenuContent::None => 0u16,
-        MenuContent::Approval { .. } | MenuContent::LoopCap => 2,
+        MenuContent::Approval { .. } | MenuContent::LoopCap | MenuContent::PurgeConfirm { .. } => 2,
         MenuContent::WizardTrail(trail) => (trail.len() as u16) + 1,
         MenuContent::Slash(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Model(dd) => dd.visible_count() as u16 + 1,
@@ -284,6 +284,24 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
                     Span::styled(" continue  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("[n]", Style::default().fg(Color::Red)),
                     Span::styled(" stop", Style::default().fg(Color::DarkGray)),
+                ]),
+            ];
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::PurgeConfirm { detail, .. } => {
+            let lines = vec![
+                Line::from(vec![
+                    Span::styled("  \u{1f9f9} ", Style::default().fg(Color::Yellow)),
+                    Span::styled(
+                        format!("Permanently delete? {detail}"),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("  [y]", Style::default().fg(Color::Green)),
+                    Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("[n]", Style::default().fg(Color::Red)),
+                    Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
                 ]),
             ];
             frame.render_widget(Paragraph::new(lines), menu_area);

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -5,6 +5,8 @@
 use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_output;
 
+use crate::tui_types::MenuContent;
+
 use koda_core::config::KodaConfig;
 use koda_core::providers::LlmProvider;
 use koda_core::session::KodaSession;
@@ -80,6 +82,7 @@ pub(crate) async fn handle_purge(
     buffer: &mut ScrollBuffer,
     session: &KodaSession,
     age_filter: Option<&str>,
+    menu: &mut MenuContent,
 ) {
     use koda_core::persistence::Persistence;
 
@@ -121,39 +124,32 @@ pub(crate) async fn handle_purge(
         String::new()
     };
 
+    let detail = format!(
+        "{} compacted messages across {} sessions ({size_str}), oldest from {oldest_str}{age_str}",
+        stats.message_count, stats.session_count
+    );
+
     tui_output::emit_line(
         buffer,
         Line::from(vec![
             Span::styled("  \u{1f9f9} ", BOLD),
-            Span::styled(
-                format!(
-                    "{} compacted messages across {} sessions ({size_str}), oldest from {oldest_str}{age_str}",
-                    stats.message_count, stats.session_count
-                ),
-                CYAN,
-            ),
+            Span::styled(detail.clone(), CYAN),
         ]),
     );
 
-    // FIXME(#472): blocking read() inside fullscreen event loop.
-    // This works because raw mode is still active, but the UI won't
-    // redraw until confirmation. Move to menu-based confirmation later.
-    tui_output::dim_msg(
-        buffer,
-        "Permanently delete? This cannot be undone. [y/N] ".into(),
-    );
-
-    use crossterm::event::{self, Event, KeyCode};
-    let confirmed = loop {
-        if let Ok(Event::Key(key)) = event::read() {
-            break matches!(key.code, KeyCode::Char('y' | 'Y'));
-        }
+    *menu = MenuContent::PurgeConfirm {
+        min_age_days,
+        detail,
     };
+}
 
-    if !confirmed {
-        tui_output::dim_msg(buffer, "Purge cancelled.".into());
-        return;
-    }
+/// Execute the purge after user confirms via menu.
+pub(crate) async fn execute_purge(
+    buffer: &mut ScrollBuffer,
+    session: &KodaSession,
+    min_age_days: u32,
+) {
+    use koda_core::persistence::Persistence;
 
     match session.db.purge_compacted(min_age_days).await {
         Ok(deleted) => tui_output::ok_msg(buffer, format!("Purged {deleted} archived messages.")),


### PR DESCRIPTION
## Changes

### QA-1: Replace blocking purge confirmation with menu-based flow

The `/purge` command used a **blocking** `crossterm::event::read()` loop for y/N confirmation. In fullscreen alternate-screen mode (#472), this froze the entire TUI event loop — the UI couldn't redraw until the user pressed a key.

**Fix:** Replace with a non-blocking `MenuContent::PurgeConfirm` variant that follows the same pattern as `Approval` and `LoopCap` menus:

1. `/purge` shows stats in the scroll buffer and sets `menu = PurgeConfirm { min_age_days, detail }`
2. The menu area renders a `[y] confirm  [n] cancel` hotkey bar
3. `handle_menu_key` intercepts y/n/Esc keypresses and either executes or cancels
4. The UI remains fully responsive during confirmation

**Files changed:**
- `tui_types.rs` — add `MenuContent::PurgeConfirm` variant
- `tui_wizards.rs` — split `handle_purge` into show-stats + `execute_purge`
- `tui_context.rs` — handle PurgeConfirm keypresses + pass menu to slash commands
- `tui_commands.rs` — accept `menu` parameter, pass to `handle_purge`
- `tui_viewport.rs` — render PurgeConfirm hotkey bar

### Verification

- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace --features koda-core/test-support` ✅

Fixes `FIXME(#472)` in `tui_wizards.rs`. Part of #483.
