### PR TITLE
release: v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-03-17
+
+### Fixed
+- **Model output truncated after tool calls** — `CliSink` used `try_send()`
+  on a bounded 256-slot channel. When the TUI couldn't drain fast enough
+  (e.g., slow terminal redraw during large tool output), `TextDelta` events
+  were silently dropped, causing responses to appear cut off (sometimes to a
+  single character). Switched to an unbounded channel — the engine produces
+  events sequentially and is I/O-bound on LLM streaming, so backlog is
+  naturally small.
+- **Mouse copy unstable during inference** — the `to_buffer_row` closure
+  recalculated scroll position on every Drag event. During inference (sticky
+  mode), buffer growth shifted coordinates between MouseDown and MouseUp,
+  causing wrong or empty text to be copied. Scroll position is now captured
+  once at MouseDown and stored in the `Selection` struct.
+- **Scroll position miscalculated** — `scroll_up()` used the full terminal
+  height instead of the history area height, both in the idle and inference
+  event loops. This caused `max_offset` to be too small.
+- **`last_response()` matched markdown HRs** — the separator check accepted
+  any line of `─` chars (≥3), including 60-char markdown HRs. Now matches
+  exactly 3 `─` characters (the ResponseStart separator).
+- **Ctrl+Shift+Y broken on macOS** — most macOS terminals don't distinguish
+  Ctrl+Shift+Y from Ctrl+Y. Added **Ctrl+U** as a reliable alternative for
+  "copy last response".
+- **Drag-selection couldn't cross page boundary** — the `in_history` guard
+  on Drag events silently dropped them when the cursor left the viewport.
+  Removed the guard; added auto-scroll (1 row/event) at viewport edges.
+
+### Changed
+- **Code quality: `tui_context.rs` split** — the 1,355-line god-struct was
+  split into `tui_context/{mod.rs, events.rs, menus.rs}` (all under 600
+  lines). The `db.rs` monolith was split into `db/{mod.rs, queries.rs,
+  tests.rs}`.
+- **History navigation refactored** — extracted pure `history_up_index()` /
+  `history_down_index()` functions for testability.
+
+### Added
+- 10 new unit tests for `tui_context::events` (history persistence,
+  truncation, index navigation).
+- 8 new unit tests for mouse selection and scroll buffer (cross-page
+  selection, rendered content detection, markdown HR regression).
+- `cargo audit` verified clean (0 vulnerabilities, 1 allowed warning for
+  unmaintained `bincode` via `syntect`).
+
 ## [0.1.12] - 2026-03-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,10 @@ koda/
 │   │   ├── compact.rs      # Session compaction (summarize old messages)
 │   │   ├── config.rs       # Agent/provider config + provider metadata
 │   │   ├── context.rs      # Context window token tracking
-│   │   ├── db.rs           # SQLite persistence (WAL mode, parameterized queries)
+│   │   ├── db/             # SQLite persistence (split into submodules)
+│   │   │   ├── mod.rs      # Database struct, migrations, schema (WAL mode)
+│   │   │   ├── queries.rs  # Persistence trait impl (all SQL queries)
+│   │   │   └── tests.rs    # Database integration tests
 │   │   ├── file_tracker.rs # File lifecycle tracking (create/edit/delete ownership)
 │   │   ├── git.rs          # Git checkpointing + rollback
 │   │   ├── inference.rs    # Streaming inference loop + tool execution
@@ -139,7 +142,10 @@ koda/
 │   │   ├── main.rs         # CLI entry point (clap)
 │   │   ├── lib.rs          # Crate root (exports acp_adapter)
 │   │   ├── tui_app.rs      # Main TUI event loop (ratatui Viewport::Fullscreen)
-│   │   ├── tui_context.rs  # TUI shared mutable state struct
+│   │   ├── tui_context/    # TUI shared mutable state (split into submodules)
+│   │   │   ├── mod.rs      # TuiContext struct, event loop, command dispatch
+│   │   │   ├── events.rs   # Key/mouse handling, clipboard, history persistence
+│   │   │   └── menus.rs    # Model/provider/session pickers, provider wizard
 │   │   ├── tui_handlers_inference.rs # Inference event handling (extracted from context)
 │   │   ├── tui_render.rs   # EngineEvent → ratatui Line/Span rendering
 │   │   ├── tui_commands.rs # Slash command dispatch (/help, /model, /sessions, etc.)
@@ -154,16 +160,12 @@ koda/
 │   │   ├── md_render.rs    # Streaming markdown → ratatui renderer
 │   │   ├── completer.rs    # Tab completion (/commands, @files, /model names)
 │   │   ├── diff_render.rs  # Diff preview → ratatui renderer (syntax highlighted)
-│   │   ├── ansi_parse.rs   # ANSI escape code → ratatui Span conversion
 │   │   ├── highlight.rs    # Syntax highlighting via syntect
-│   │   ├── history_render.rs # Render DB messages → styled Lines for session resume
-│   │   ├── mouse_select.rs # Mouse text selection + clipboard copy in fullscreen
-│   │   ├── scroll_buffer.rs # Render cache + virtual scrolling for fullscreen history
 │   │   ├── startup.rs      # Startup banner rendering
 │   │   ├── repl.rs         # Slash command parsing + provider/model lists
 │   │   ├── input.rs        # @file reference processing + image loading
 │   │   ├── headless.rs     # Single-prompt headless mode
-│   │   ├── sink.rs         # CliSink (channel forwarding for TUI)
+│   │   ├── sink.rs         # CliSink (unbounded channel forwarding for TUI)
 │   │   ├── server.rs       # ACP server over stdio JSON-RPC
 │   │   ├── acp_adapter.rs  # ACP protocol adapter
 │   │   ├── onboarding.rs   # First-run wizard (provider + API key setup)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.12" }
+koda-core = { path = "../koda-core", version = "0.1.13" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.12", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.13", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -327,11 +327,7 @@ impl TuiContext {
     // ── History ────────────────────────────────────────────────
 
     fn history_up(&mut self) {
-        if !self.history.is_empty() {
-            let idx = match self.history_idx {
-                None => self.history.len() - 1,
-                Some(i) => i.saturating_sub(1),
-            };
+        if let Some(idx) = history_up_index(self.history_idx, self.history.len()) {
             self.history_idx = Some(idx);
             self.textarea.select_all();
             self.textarea.cut();
@@ -340,17 +336,12 @@ impl TuiContext {
     }
 
     fn history_down(&mut self) {
-        if let Some(idx) = self.history_idx {
-            if idx + 1 < self.history.len() {
-                self.history_idx = Some(idx + 1);
-                self.textarea.select_all();
-                self.textarea.cut();
-                self.textarea.insert_str(&self.history[idx + 1]);
-            } else {
-                self.history_idx = None;
-                self.textarea.select_all();
-                self.textarea.cut();
-            }
+        let next = history_down_index(self.history_idx, self.history.len());
+        self.history_idx = next;
+        self.textarea.select_all();
+        self.textarea.cut();
+        if let Some(idx) = next {
+            self.textarea.insert_str(&self.history[idx]);
         }
     }
 
@@ -410,8 +401,11 @@ fn history_file_path() -> std::path::PathBuf {
 }
 
 pub(crate) fn load_history() -> Vec<String> {
-    let path = history_file_path();
-    match std::fs::read_to_string(&path) {
+    load_history_from(&history_file_path())
+}
+
+fn load_history_from(path: &std::path::Path) -> Vec<String> {
+    match std::fs::read_to_string(path) {
         Ok(content) => content
             .lines()
             .filter(|l| !l.is_empty())
@@ -422,11 +416,129 @@ pub(crate) fn load_history() -> Vec<String> {
 }
 
 pub(crate) fn save_history(history: &[String]) {
-    let path = history_file_path();
+    save_history_to(history, &history_file_path());
+}
+
+fn save_history_to(history: &[String], path: &std::path::Path) {
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
     let start = history.len().saturating_sub(MAX_HISTORY);
     let content = history[start..].join("\n");
-    let _ = std::fs::write(&path, content);
+    let _ = std::fs::write(path, content);
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: history index navigation
+// ---------------------------------------------------------------------------
+
+/// Compute the next history index when pressing Up (older).
+///
+/// Returns `None` if the history is empty.
+pub(crate) fn history_up_index(current: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+    Some(match current {
+        None => len - 1,
+        Some(i) => i.saturating_sub(1),
+    })
+}
+
+/// Compute the next history index when pressing Down (newer).
+///
+/// Returns `None` when moving past the most recent entry (back to
+/// empty input).
+pub(crate) fn history_down_index(current: Option<usize>, len: usize) -> Option<usize> {
+    match current {
+        Some(i) if i + 1 < len => Some(i + 1),
+        _ => None,
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════
+//  Tests
+// ═══════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── History index navigation ──────────────────────────────
+
+    #[test]
+    fn test_history_up_from_none() {
+        assert_eq!(history_up_index(None, 5), Some(4));
+    }
+
+    #[test]
+    fn test_history_up_from_middle() {
+        assert_eq!(history_up_index(Some(3), 5), Some(2));
+    }
+
+    #[test]
+    fn test_history_up_at_top() {
+        // Saturates at 0
+        assert_eq!(history_up_index(Some(0), 5), Some(0));
+    }
+
+    #[test]
+    fn test_history_up_empty() {
+        assert_eq!(history_up_index(None, 0), None);
+    }
+
+    #[test]
+    fn test_history_down_from_middle() {
+        assert_eq!(history_down_index(Some(2), 5), Some(3));
+    }
+
+    #[test]
+    fn test_history_down_at_bottom() {
+        // Past the last entry → back to empty input
+        assert_eq!(history_down_index(Some(4), 5), None);
+    }
+
+    #[test]
+    fn test_history_down_from_none() {
+        assert_eq!(history_down_index(None, 5), None);
+    }
+
+    // ── History file persistence ──────────────────────────────
+
+    #[test]
+    fn test_history_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("koda").join("history");
+
+        let input = vec!["hello".into(), "world".into(), "/model gpt-4".into()];
+        save_history_to(&input, &path);
+
+        let loaded = load_history_from(&path);
+        assert_eq!(loaded, input);
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_history_truncation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("koda").join("history");
+
+        let big: Vec<String> = (0..MAX_HISTORY + 100).map(|i| format!("cmd {i}")).collect();
+        save_history_to(&big, &path);
+
+        let loaded = load_history_from(&path);
+        assert_eq!(loaded.len(), MAX_HISTORY);
+        // Should keep the LATEST entries (tail)
+        assert_eq!(loaded[0], format!("cmd {}", 100));
+        assert_eq!(loaded[MAX_HISTORY - 1], format!("cmd {}", MAX_HISTORY + 99));
+    }
+
+    #[test]
+    fn test_load_history_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent").join("history");
+
+        let loaded = load_history_from(&path);
+        assert!(loaded.is_empty());
+    }
 }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.12" }
-koda-email = { path = "../koda-email", version = "0.1.12" }
+koda-ast = { path = "../koda-ast", version = "0.1.13" }
+koda-email = { path = "../koda-email", version = "0.1.13" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.13

Closes #483 (v0.1.13 code review checklist).

### What's in this release

#### Bug Fixes
- **Model output truncated after tool calls** — `CliSink` used `try_send()` on a bounded 256-slot channel, silently dropping `TextDelta` events. Switched to unbounded channel.
- **Mouse copy unstable during inference** — scroll position captured at MouseDown, stored in `Selection` struct for stable coordinates.
- **Scroll position miscalculated** — `scroll_up()` used full terminal height instead of history area height (both idle and inference handlers).
- **`last_response()` matched markdown HRs** — now matches exactly 3 `─` chars.
- **Ctrl+Shift+Y broken on macOS** — added **Ctrl+U** as reliable alternative.
- **Drag-selection couldn't cross page boundary** — removed `in_history` guard, added auto-scroll at edges.

#### Code Quality
- `tui_context.rs` split into `tui_context/{mod,events,menus}.rs` (all under 600 lines)
- `db.rs` split into `db/{mod,queries,tests}.rs`
- Extracted pure `history_up_index()` / `history_down_index()` for testability

#### QA
- 10 new tests for `tui_context::events` (history persistence, truncation, navigation)
- 8 new tests for mouse selection + scroll buffer
- `cargo audit` clean (0 vulnerabilities)

#### Docs
- Version bump 0.1.12 → 0.1.13 (all 4 Cargo.toml files)
- CHANGELOG updated with full release notes
- CLAUDE.md architecture tree synced (tui_context/, db/ modules)

### Checklist from #483
- [x] CQ-1: Split large files ✅
- [x] CQ-2: Fix production unwrap() ✅
- [x] CQ-3: Clean dead code ✅
- [x] SEC-1: Windows keystore (deferred v0.1.14) ⏭️
- [x] SEC-2: sed safety comment ✅
- [x] SEC-3: cargo audit ✅
- [x] QA-1: FIXME blocking read ✅
- [x] QA-2: DB migration pattern (deferred v0.1.14) ⏭️
- [x] QA-3: tui_context tests ✅
- [x] DOC-1: Version bump ✅
- [x] DOC-2: CLAUDE.md sync ✅