### PR TITLE
feat: post-edit AST syntax verification (#467)

### DIFF
--- a/koda-ast/src/ast.rs
+++ b/koda-ast/src/ast.rs
@@ -357,6 +357,87 @@ fn format_graph_output(
     Ok(output)
 }
 
+/// Quick syntax check — parse a file and report any syntax errors.
+///
+/// Returns `None` if the file is syntactically valid or has an unsupported
+/// extension. Returns `Some(description)` with error locations if the
+/// tree-sitter parse tree contains ERROR or MISSING nodes.
+///
+/// This is designed for the post-edit verification harness (#467):
+/// fast, non-blocking, and zero config.
+pub fn syntax_check(file_path: &Path) -> Option<String> {
+    let extension = file_path.extension().and_then(|s| s.to_str()).unwrap_or("");
+    let language = get_language(extension).ok()?;
+    let source_code = std::fs::read_to_string(file_path).ok()?;
+
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&language).ok()?;
+    let tree = parser.parse(&source_code, None)?;
+
+    if !tree.root_node().has_error() {
+        return None;
+    }
+
+    let errors = collect_syntax_errors(&tree, source_code.as_bytes());
+    if errors.is_empty() {
+        return None;
+    }
+    Some(errors)
+}
+
+/// Walk the parse tree and collect ERROR/MISSING node locations.
+fn collect_syntax_errors(tree: &tree_sitter::Tree, source: &[u8]) -> String {
+    let mut errors = Vec::new();
+    let mut cursor = tree.root_node().walk();
+    walk_errors(&mut cursor, source, &mut errors);
+
+    // Cap at 5 errors to avoid flooding the LLM context
+    let total = errors.len();
+    errors.truncate(5);
+    let mut out = format!("⚠ Syntax errors ({total}):\n");
+    for e in &errors {
+        out.push_str(e);
+        out.push('\n');
+    }
+    if total > 5 {
+        out.push_str(&format!("  ...and {} more\n", total - 5));
+    }
+    out
+}
+
+/// Recursively collect error descriptions from the parse tree.
+fn walk_errors(cursor: &mut tree_sitter::TreeCursor, source: &[u8], errors: &mut Vec<String>) {
+    loop {
+        let node = cursor.node();
+        if node.is_error() || node.is_missing() {
+            let start = node.start_position();
+            let line = start.row + 1;
+            let col = start.column + 1;
+            // Grab the snippet around the error (up to 60 chars)
+            let snippet: String = node
+                .utf8_text(source)
+                .unwrap_or("")
+                .chars()
+                .take(60)
+                .collect();
+            let kind = if node.is_missing() {
+                format!("missing {}", node.kind())
+            } else {
+                "syntax error".to_string()
+            };
+            errors.push(format!("  line {line}:{col}: {kind}: `{snippet}`"));
+        } else if node.has_error() && cursor.goto_first_child() {
+            // Recurse into children only if this subtree has errors
+            walk_errors(cursor, source, errors);
+            cursor.goto_parent();
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -491,5 +572,65 @@ mod tests {
             result.contains("esModule"),
             "Should find esModule: {result}"
         );
+    }
+
+    // ── syntax_check tests (#467) ────────────────────────────────
+
+    #[test]
+    fn test_syntax_check_valid_rust() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".rs").unwrap();
+        write!(tmp, "fn main() {{ println!(\"hello\"); }}").unwrap();
+        assert!(syntax_check(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_syntax_check_invalid_rust() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".rs").unwrap();
+        write!(tmp, "fn main() {{ let x = ; }}").unwrap();
+        let err = syntax_check(tmp.path()).expect("should report error");
+        assert!(err.contains("syntax error"), "got: {err}");
+        assert!(err.contains("line"), "got: {err}");
+    }
+
+    #[test]
+    fn test_syntax_check_valid_python() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".py").unwrap();
+        write!(tmp, "def hello():\n    return 42\n").unwrap();
+        assert!(syntax_check(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_syntax_check_invalid_python() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".py").unwrap();
+        write!(tmp, "def hello(\n    return 42\n").unwrap();
+        let err = syntax_check(tmp.path()).expect("should report error");
+        assert!(err.contains("line"), "got: {err}");
+    }
+
+    #[test]
+    fn test_syntax_check_unsupported_extension() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".xyz").unwrap();
+        write!(tmp, "not a real language").unwrap();
+        assert!(syntax_check(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_syntax_check_nonexistent_file() {
+        assert!(syntax_check(Path::new("/tmp/does_not_exist_467.rs")).is_none());
+    }
+
+    #[test]
+    fn test_syntax_check_valid_typescript() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".ts").unwrap();
+        write!(tmp, "const x: number = 42;").unwrap();
+        assert!(syntax_check(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn test_syntax_check_invalid_typescript() {
+        let mut tmp = tempfile::NamedTempFile::with_suffix(".ts").unwrap();
+        write!(tmp, "const x: number = ;").unwrap();
+        let err = syntax_check(tmp.path()).expect("should report error");
+        assert!(err.contains("line"), "got: {err}");
     }
 }

--- a/koda-ast/src/lib.rs
+++ b/koda-ast/src/lib.rs
@@ -10,7 +10,7 @@ pub mod ast;
 use std::path::{Path, PathBuf};
 
 /// Re-export core analysis functions at the crate root for convenience.
-pub use ast::{analyze_file, get_call_graph};
+pub use ast::{analyze_file, get_call_graph, syntax_check};
 
 /// Tool definition metadata for consumers (koda-core ToolRegistry).
 ///

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -1023,4 +1023,58 @@ mod tests {
         let out = verify_syntax_post_edit("not json", Path::new("/tmp"), "ok");
         assert_eq!(out, "ok");
     }
+
+    /// Simulate the realistic flow: start with valid code, apply a bad edit,
+    /// verify the hook catches the regression.
+    #[test]
+    fn test_verify_syntax_edit_introduces_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("lib.rs");
+
+        // Start with valid code
+        std::fs::write(&file, "fn hello() { println!(\"hi\"); }\n").unwrap();
+        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
+        assert!(
+            !out.contains("syntax error"),
+            "should be clean before edit: {out}"
+        );
+
+        // Simulate a bad edit that breaks the syntax
+        std::fs::write(&file, "fn hello( { println!(\"hi\"); }\n").unwrap();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
+        assert!(
+            out.contains("syntax error"),
+            "should catch regression: {out}"
+        );
+        assert!(
+            out.contains("Fix the syntax errors"),
+            "should instruct LLM: {out}"
+        );
+    }
+
+    /// Opposite flow: start with broken code, apply a fix, verify clean result.
+    #[test]
+    fn test_verify_syntax_edit_fixes_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("lib.rs");
+
+        // Start with broken code
+        std::fs::write(&file, "fn hello( { println!(\"hi\"); }\n").unwrap();
+        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
+        assert!(
+            out.contains("syntax error"),
+            "should be broken before fix: {out}"
+        );
+
+        // Fix the syntax
+        std::fs::write(&file, "fn hello() { println!(\"hi\"); }\n").unwrap();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
+        assert!(
+            !out.contains("syntax error"),
+            "should be clean after fix: {out}"
+        );
+        assert_eq!(out, "✓ Edited lib.rs");
+    }
 }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -55,6 +55,33 @@ fn resolve_tool_path(
     crate::file_tracker::resolve_file_path_from_args(args, project_root)
 }
 
+/// Post-edit AST syntax check (#467).
+///
+/// After a successful Write/Edit, parse the file with tree-sitter and
+/// append any syntax errors to the tool result. This gives the LLM
+/// immediate feedback to self-correct without user intervention.
+///
+/// Returns the original result unmodified if:
+/// - the file extension isn't supported by koda-ast
+/// - the file can't be read (e.g., binary)
+/// - the file parses cleanly (no errors)
+fn verify_syntax_post_edit(arguments: &str, project_root: &Path, result: &str) -> String {
+    let args: serde_json::Value = match serde_json::from_str(arguments) {
+        Ok(v) => v,
+        Err(_) => return result.to_string(),
+    };
+    let path = match crate::file_tracker::resolve_file_path_from_args(&args, project_root) {
+        Some(p) => p,
+        None => return result.to_string(),
+    };
+    match koda_ast::syntax_check(&path) {
+        Some(errors) => {
+            format!("{result}\n\n{errors}\nFix the syntax errors above before proceeding.")
+        }
+        None => result.to_string(),
+    }
+}
+
 /// Update file lifecycle tracker after a tool execution (#465).
 ///
 /// - Write → track as owned (Koda created it)
@@ -159,6 +186,14 @@ pub(crate) async fn execute_one_tool(
         let r = tools.execute(&tc.function_name, &tc.arguments).await;
         (r.output, r.success)
     };
+
+    // Post-edit AST verification (#467): if Write/Edit succeeded, check syntax.
+    let result = if success && matches!(tc.function_name.as_str(), "Write" | "Edit") {
+        verify_syntax_post_edit(&tc.arguments, project_root, &result)
+    } else {
+        result
+    };
+
     (tc.id.clone(), result, success)
 }
 
@@ -947,5 +982,45 @@ mod tests {
             ApprovalMode::Auto,
             Path::new("/test/project")
         ));
+    }
+
+    // ── verify_syntax_post_edit tests (#467) ──────────────────────
+
+    #[test]
+    fn test_verify_syntax_clean_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("ok.rs");
+        std::fs::write(&file, "fn main() {}").unwrap();
+        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote ok.rs");
+        assert!(!out.contains("syntax error"), "got: {out}");
+        assert!(out.starts_with("✓ Wrote ok.rs"));
+    }
+
+    #[test]
+    fn test_verify_syntax_broken_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("bad.rs");
+        std::fs::write(&file, "fn main() { let x = ; }").unwrap();
+        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote bad.rs");
+        assert!(out.contains("syntax error"), "got: {out}");
+        assert!(out.contains("Fix the syntax errors"), "got: {out}");
+    }
+
+    #[test]
+    fn test_verify_syntax_unsupported_ext() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("data.csv");
+        std::fs::write(&file, "a,b,c").unwrap();
+        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
+        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote data.csv");
+        assert_eq!(out, "✓ Wrote data.csv");
+    }
+
+    #[test]
+    fn test_verify_syntax_bad_json_args() {
+        let out = verify_syntax_post_edit("not json", Path::new("/tmp"), "ok");
+        assert_eq!(out, "ok");
     }
 }


### PR DESCRIPTION
## Summary

Adds a harness-level verification hook that automatically checks files for syntax errors after `Write`/`Edit` operations using tree-sitter. When syntax errors are found, they're appended to the tool result so the LLM gets immediate feedback and can self-correct without user intervention.

**Zero config. Fully deterministic. Pure harness logic.**

## How It Works

1. LLM calls `Write` or `Edit` → tool executes successfully
2. `verify_syntax_post_edit()` runs `koda_ast::syntax_check()` on the file
3. If tree-sitter finds ERROR/MISSING nodes → errors are appended to the tool result
4. LLM sees the errors in its next turn and fixes them

Gracefully no-ops for unsupported file extensions, binary files, or parse failures.

## Changes

### koda-ast
- `syntax_check(path) -> Option<String>` — parses file, walks for ERROR/MISSING nodes, returns error details with line numbers
- Caps at 5 errors to avoid flooding context
- 8 new tests (valid/invalid Rust, Python, TypeScript + edge cases)

### koda-core (tool_dispatch)
- `verify_syntax_post_edit()` — runs after successful Write/Edit in `execute_one_tool`
- 4 new tests (clean file, broken file, unsupported ext, bad JSON args)

## Design Decisions

- **Part 2 (custom linters) dropped** — putting verify commands in `MEMORY.md` is unreliable (LLM context ≠ harness guarantee), and a config file (`.koda/harness.toml`) contradicts Koda's config-free design
- Hook is in `execute_one_tool` so both parallel and sequential execution paths benefit
- Uses `tree-sitter::has_error()` + tree walk (not full AST analysis) for speed

Closes #467
Part of #464 (AI Harness Engineering)