### PR TITLE
fix: drop Shift+Enter, standardize on Alt+Enter for newlines (#503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -392,7 +392,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   - `@file` paths: `@src/m` + Tab → dropdown with filesystem walking (case-insensitive)
   - `/model` names: `/model gpt` + Tab → dropdown with substring matching
 - **Compaction module** — `koda-core::compact` with pure logic, zero UI deps. Shared by TUI and headless modes
-- **Alt+Enter** for multi-line input (Shift+Enter on terminals with kitty protocol)
+- **Alt+Enter** for multi-line input
 
 ### Fixed
 - **TUI auto-compaction** — was calling `println!` inside raw mode, corrupting the viewport

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -163,6 +163,26 @@ requires two approvals.
 
 ---
 
+## Keyboard Shortcuts
+
+| Key | Context | Action |
+|-----|---------|--------|
+| **Enter** | At prompt | Submit prompt |
+| **Alt+Enter** | At prompt | Insert newline (multi-line input) |
+| **Tab** | At prompt | Autocomplete (`@file`, `/command`) |
+| **Shift+Tab** | Anywhere | Cycle approval mode (auto ↔ confirm) |
+| **Esc** | At prompt | Clear input |
+| **Esc** | During inference | Cancel current turn |
+| **Ctrl+C** | Anywhere | Cancel / interrupt |
+| **Ctrl+D** | Empty prompt | Quit koda |
+| **Ctrl+L** | Anywhere | Scroll to bottom |
+| **Ctrl+Y** | Anywhere | Copy last code block |
+| **Ctrl+U** | Anywhere | Copy last response |
+| **↑ / ↓** | At prompt | History navigation |
+| **PageUp / PageDown** | Anywhere | Scroll output |
+
+---
+
 ## Slash Commands
 
 Type `/` to open the command palette with descriptions. Tab to complete.

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -500,7 +500,7 @@ mod tests {
         assert_eq!(find_last_at_token("email@domain"), None); // no space before @
         assert_eq!(find_last_at_token("a @b @c"), Some(5)); // last @
         assert_eq!(find_last_at_token("no at here"), None);
-        // @ after newline (multi-line input via Shift+Enter)
+        // @ after newline (multi-line input via Alt+Enter)
         assert_eq!(find_last_at_token("line1\n@file"), Some(6));
         assert_eq!(find_last_at_token("a\nb\n@c"), Some(4));
     }

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -67,9 +67,7 @@ impl TuiContext {
         }
 
         match (key.code, key.modifiers) {
-            (KeyCode::Enter, m)
-                if m.contains(KeyModifiers::SHIFT) || m.contains(KeyModifiers::ALT) =>
-            {
+            (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
                 self.textarea.insert_newline();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -344,8 +344,11 @@ async fn handle_inference_key_inline(
 
     // Feedback text input during inference
     if matches!(prompt_mode, PromptMode::WizardInput { .. }) && pending_approval_id.is_some() {
-        match key.code {
-            KeyCode::Enter => {
+        match (key.code, key.modifiers) {
+            (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
+                textarea.insert_newline();
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) => {
                 let feedback = textarea.lines().join("\n");
                 textarea.select_all();
                 textarea.cut();
@@ -362,7 +365,7 @@ async fn handle_inference_key_inline(
                         .await;
                 }
             }
-            KeyCode::Esc => {
+            (KeyCode::Esc, _) => {
                 textarea.select_all();
                 textarea.cut();
                 *prompt_mode = PromptMode::Chat;
@@ -385,6 +388,9 @@ async fn handle_inference_key_inline(
 
     // General keys during inference
     match (key.code, key.modifiers) {
+        (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
+            textarea.insert_newline();
+        }
         (KeyCode::Enter, KeyModifiers::NONE) => {
             let text = textarea.lines().join("\n");
             if !text.trim().is_empty() {

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -15,6 +15,7 @@ Shift+Tab — cycle approval mode (auto/confirm)
 ### Input
 
 - `@file.rs` attaches file context, `@image.png` for multi-modal analysis
+- `Alt+Enter` inserts a newline for multi-line prompts
 - Piped input: `echo "explain" | koda` or `koda -p "prompt"` for headless/CI
 
 ### Approval


### PR DESCRIPTION
## Summary

Shift+Enter never worked reliably — most terminals send it as plain Enter without modifier flags. Only the Kitty keyboard protocol distinguishes them, and enabling that adds complexity for one user.

**Alt+Enter works universally** (terminals encode Alt as an escape prefix).

## What Changed

- **Idle handler**: removed `KeyModifiers::SHIFT` guard, Alt+Enter only
- **WizardInput handler**: fixed bug where `KeyCode::Enter` matched ALL modifiers → submitted on Shift/Alt+Enter instead of inserting newline. Now uses `(KeyCode::Enter, KeyModifiers::NONE)` for submit.
- **Inference handler**: added explicit `Alt+Enter → insert_newline()` (was relying on textarea fallthrough)
- Updated comments and CHANGELOG

## Why Not Kitty Protocol?

YAGNI. Kitty protocol would make Shift+Enter work in modern terminals but adds complexity, requires graceful fallback for older terminals, and Alt+Enter already covers the use case. One user, one keybind.

Closes #503