### PR TITLE
fix: add --resume as primary CLI flag (#505)

### DIFF
--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -60,7 +60,7 @@ struct Cli {
     agent: String,
 
     /// Session ID to resume (omit to start a new session)
-    #[arg(short, long)]
+    #[arg(short, long = "resume", alias = "session")]
     session: Option<String>,
 
     /// Project root directory (defaults to current directory)

--- a/koda-cli/tests/cli_test.rs
+++ b/koda-cli/tests/cli_test.rs
@@ -46,8 +46,8 @@ fn test_cli_help() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--agent"), "Help should mention --agent");
     assert!(
-        stdout.contains("--session"),
-        "Help should mention --session"
+        stdout.contains("--resume"),
+        "Help should mention --resume"
     );
     assert!(
         stdout.contains("--provider"),

--- a/koda-cli/tests/cli_test.rs
+++ b/koda-cli/tests/cli_test.rs
@@ -45,10 +45,7 @@ fn test_cli_help() {
     assert!(output.status.success(), "koda --help should succeed");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("--agent"), "Help should mention --agent");
-    assert!(
-        stdout.contains("--resume"),
-        "Help should mention --resume"
-    );
+    assert!(stdout.contains("--resume"), "Help should mention --resume");
     assert!(
         stdout.contains("--provider"),
         "Help should mention --provider"


### PR DESCRIPTION
## Summary

`koda --resume <session_id>` failed with `unexpected argument` because the actual clap flag was `--session`, but `print_resume_hint()` told users to use `--resume`.

## Fix

One-line change: make `--resume` the primary flag name (shown in `--help`), keep `--session` as a hidden alias for backwards compat.

```
koda --resume <id>   # primary (shown in help)
koda --session <id>  # alias (still works)
koda -s <id>         # short form
```

## Files Changed

| File | Change |
|---|---|
| `main.rs` | `long = "resume", alias = "session"` |
| `cli_test.rs` | Update assertion to match renamed flag |

Closes #505