### PR TITLE
chore: release prep v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.14] - 2026-03-18
+
+### Added
+- **Post-edit AST syntax verification** (#467, #504) — after Write/Edit, koda-ast
+  automatically parses the file with tree-sitter and appends syntax errors to the
+  tool result. The LLM gets immediate feedback to self-correct without user
+  intervention. Supports Rust, Python, TypeScript, JavaScript, Go, and more.
+- **`--resume` CLI flag** (#505, #507) — `--resume <id>` is now the primary flag
+  for session resumption (`--session` remains as an alias, `-s` as the short form).
+- **Keyboard shortcuts documentation** — user guide now includes a full key binding
+  reference table.
+- **E2E test suite expansion** (#508) — 13 new end-to-end tests covering Grep,
+  Edit, Delete, AST verification, multi-tool execution, and CLI flag regressions.
+  Split the 943-line `e2e_test.rs` into 5 focused files (all under 600 lines).
+
+### Fixed
+- **`tool_use.input` must be a JSON object** (#501, #502) — Anthropic API returned
+  400 errors when the LLM produced empty/null/non-object `arguments`. The provider
+  now coerces non-object values to `{}` before sending.
+- **Shift+Enter removed, Alt+Enter standardized** (#503, #506) — Shift+Enter was
+  unreliable across terminals. Alt+Enter is now the sole newline-insertion key,
+  consistently handled in idle, inference, and wizard-input contexts.
+
+### Changed
+- **Dependencies** — bumped clap 4.5→4.6, tokio-tungstenite 0.28→0.29,
+  unicode-width 0.2.0→0.2.2, tracing-subscriber 0.3.22→0.3.23,
+  once_cell 1.21.3→1.21.4, softprops/action-gh-release 2.5→2.6.
+
 ## [0.1.13] - 2026-03-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,14 +290,23 @@ from production builds to keep `koda-core`'s public API clean.
 - Context tracking, loop detection, config defaults, bash safety, etc.
 
 **E2E tests** (mock provider, CI) — require `test-support` feature:
-- `tests/e2e_test.rs` — full inference loop with real tools in sandboxed temp dirs
+- `tests/e2e_harness/mod.rs` — shared `Env` test harness (temp dir, DB, config)
+- `tests/e2e_test.rs` — core pipeline: text streaming, tool calls, errors, history, cancel
+- `tests/e2e_tools_test.rs` — tool coverage: Glob, Grep, Edit, Delete, AST verification
+- `tests/e2e_agent_test.rs` — sub-agent invocation + cache hit
+- `tests/e2e_skills_test.rs` — skills, compaction, file ownership
 - `tests/cancel_test.rs` — Ctrl+C interruption during inference
 
 **Integration tests** — no feature flag:
 - `tests/file_tools_test.rs` — path safety, file CRUD
 - `tests/new_tools_test.rs` — glob, tool naming
+- `tests/guarantee_matrix_test.rs` — approval mode × tool effect matrix
+- `tests/inference_recovery_test.rs` — rate-limit retry, context overflow
+- `tests/session_test.rs` — session lifecycle, TurnStart/TurnEnd events
+- `tests/purge_test.rs` — /purge feature (compacted stats, age filter)
 - `tests/perf_test.rs` — DB, grep, markdown throughput
 - `tests/capabilities_test.rs` — capabilities.md freshness
+- `tests/tool_wiring_test.rs` — every tool routable + approval-handled
 
 #### koda-cli
 
@@ -309,8 +318,8 @@ from production builds to keep `koda-core`'s public API clean.
 - `tests/regression_test.rs` — REPL dispatch, input processing
 - `tests/server_test.rs` — ACP server integration (JSON-RPC lifecycle)
 
-**Live smoke tests** (`#[ignore]`, local only):
-- `tests/smoke_test.rs` — headless prompt, tool use, session resume against LM Studio
+**Smoke tests** (MockProvider, CI-safe):
+- `tests/smoke_test.rs` — headless mode: text responses, tool use, session resume, `--resume` flag
 - Gated by `KODA_TEST_LMSTUDIO=1` env var; never runs in CI
 
 #### koda-ast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.13" }
+koda-core = { path = "../koda-core", version = "0.1.14" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.13", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.14", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.13" }
-koda-email = { path = "../koda-email", version = "0.1.13" }
+koda-ast = { path = "../koda-ast", version = "0.1.14" }
+koda-email = { path = "../koda-email", version = "0.1.14" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.14 — Code, Security & QA Review

### Version bump
`0.1.13` → `0.1.14` across all 4 crates (koda-ast, koda-cli, koda-core, koda-email).

### CHANGELOG
Full entry added covering all v0.1.14 features, fixes, and dependency bumps.

### Docs sync
Updated `CLAUDE.md` test tier docs to reflect the new E2E test file structure.

---

## QA Checklist

| Check | Status |
|-------|--------|
| **768 tests pass** | ✅ |
| `cargo fmt --check` | ✅ |
| No `todo!()`/`dbg!()`/`FIXME` in prod | ✅ |
| No `.unwrap()` in new prod code | ✅ |
| All new files under 600 lines | ✅ |
| No `eprintln!` leaks in new code | ✅ |

## Security Audit

| Vector | Finding |
|--------|---------|
| **Path traversal** | All file ops routed through `safe_resolve_path()` ✅ |
| **AST syntax_check** | Only reads files already validated within sandbox ✅ |
| **Anthropic input coercion** | Non-object JSON → `{}`, prevents 400s without data leak ✅ |
| **CLI --resume flag** | Session ID is validated by DB lookup, no injection risk ✅ |
| **Dep bumps** | Minor/patch only, no new crate additions ✅ |

## v0.1.14 Feature Summary

### Added
- Post-edit AST syntax verification (#467, #504)
- `--resume` CLI flag (#505, #507)
- Keyboard shortcuts docs
- 13 new E2E tests (#508)

### Fixed
- `tool_use.input` must be JSON object (#501, #502)
- Alt+Enter standardized, Shift+Enter removed (#503, #506)

### Changed
- Dependency bumps (clap, tokio-tungstenite, unicode-width, etc.)
