### PR TITLE
fix: route home-directory warning through TUI instead of stderr (#510)

### DIFF
--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -177,18 +177,6 @@ async fn main() -> Result<()> {
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);
 
-    // Footgun detection: warn if project_root is the home directory
-    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        let home_path = std::fs::canonicalize(home).unwrap_or_default();
-        if project_root == home_path {
-            eprintln!(
-                "\n\x1b[33m⚠️  Project root is your home directory ({}).\n   \
-                koda can modify any file in this tree.\n   \
-                Consider running from a project subdirectory.\x1b[0m\n",
-                project_root.display()
-            );
-        }
-    }
 
     // Load and inject stored API keys (env vars take precedence)
     match koda_core::keystore::KeyStore::load() {

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -177,7 +177,6 @@ async fn main() -> Result<()> {
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);
 
-
     // Load and inject stored API keys (env vars take precedence)
     match koda_core::keystore::KeyStore::load() {
         Ok(store) => store.inject_into_env(),

--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -154,7 +154,10 @@ pub fn home_dir_warning_lines(project_root: &std::path::Path) -> Vec<Line<'stati
         Line::from(vec![
             Span::styled("  \u{26a0}\u{fe0f}  ", Style::new().fg(Color::Yellow)),
             Span::styled(
-                format!("Project root is your home directory ({}).", project_root.display()),
+                format!(
+                    "Project root is your home directory ({}).",
+                    project_root.display()
+                ),
                 Style::new().fg(Color::Yellow),
             ),
         ]),
@@ -222,7 +225,10 @@ mod tests {
     fn home_dir_warning_when_at_home() {
         // Use a path that definitely is NOT the home dir so we get empty.
         let lines = home_dir_warning_lines(std::path::Path::new("/tmp/definitely-not-home"));
-        assert!(lines.is_empty(), "Should produce no warning for non-home dir");
+        assert!(
+            lines.is_empty(),
+            "Should produce no warning for non-home dir"
+        );
     }
 
     #[test]
@@ -232,8 +238,14 @@ mod tests {
             if let Ok(home_path) = std::fs::canonicalize(&home) {
                 let lines = home_dir_warning_lines(&home_path);
                 let text = lines_to_text(&lines);
-                assert!(text.contains("home directory"), "Warning should mention home directory");
-                assert!(text.contains("subdirectory"), "Warning should suggest subdirectory");
+                assert!(
+                    text.contains("home directory"),
+                    "Warning should mention home directory"
+                );
+                assert!(
+                    text.contains("subdirectory"),
+                    "Warning should suggest subdirectory"
+                );
             }
         }
     }

--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -234,19 +234,19 @@ mod tests {
     #[test]
     fn home_dir_warning_contains_text() {
         // When project_root == home, we should get warning lines.
-        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-            if let Ok(home_path) = std::fs::canonicalize(&home) {
-                let lines = home_dir_warning_lines(&home_path);
-                let text = lines_to_text(&lines);
-                assert!(
-                    text.contains("home directory"),
-                    "Warning should mention home directory"
-                );
-                assert!(
-                    text.contains("subdirectory"),
-                    "Warning should suggest subdirectory"
-                );
-            }
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"))
+            && let Ok(home_path) = std::fs::canonicalize(&home)
+        {
+            let lines = home_dir_warning_lines(&home_path);
+            let text = lines_to_text(&lines);
+            assert!(
+                text.contains("home directory"),
+                "Warning should mention home directory"
+            );
+            assert!(
+                text.contains("subdirectory"),
+                "Warning should suggest subdirectory"
+            );
         }
     }
 

--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -135,6 +135,37 @@ pub fn purge_nudge_lines(size_str: &str) -> Vec<Line<'static>> {
     ])]
 }
 
+/// Build home-directory footgun warning lines.
+///
+/// Returns empty vec when project root is NOT the home directory.
+pub fn home_dir_warning_lines(project_root: &std::path::Path) -> Vec<Line<'static>> {
+    let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+        Ok(h) => h,
+        Err(_) => return vec![],
+    };
+    let home_path = match std::fs::canonicalize(&home) {
+        Ok(p) => p,
+        Err(_) => return vec![],
+    };
+    if project_root != home_path {
+        return vec![];
+    }
+    vec![
+        Line::from(vec![
+            Span::styled("  \u{26a0}\u{fe0f}  ", Style::new().fg(Color::Yellow)),
+            Span::styled(
+                format!("Project root is your home directory ({}).", project_root.display()),
+                Style::new().fg(Color::Yellow),
+            ),
+        ]),
+        Line::styled(
+            "     koda can modify any file in this tree. Consider running from a project subdirectory.",
+            Style::new().fg(Color::Yellow),
+        ),
+        Line::default(),
+    ]
+}
+
 /// Print session resume hint (after raw mode ends, to stdout).
 pub fn print_resume_hint(session_id: &str) {
     println!("\nResume this session with:\n  koda --resume {session_id}");
@@ -186,6 +217,26 @@ pub(crate) fn lines_to_text(lines: &[Line]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn home_dir_warning_when_at_home() {
+        // Use a path that definitely is NOT the home dir so we get empty.
+        let lines = home_dir_warning_lines(std::path::Path::new("/tmp/definitely-not-home"));
+        assert!(lines.is_empty(), "Should produce no warning for non-home dir");
+    }
+
+    #[test]
+    fn home_dir_warning_contains_text() {
+        // When project_root == home, we should get warning lines.
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            if let Ok(home_path) = std::fs::canonicalize(&home) {
+                let lines = home_dir_warning_lines(&home_path);
+                let text = lines_to_text(&lines);
+                assert!(text.contains("home directory"), "Warning should mention home directory");
+                assert!(text.contains("subdirectory"), "Warning should suggest subdirectory");
+            }
+        }
+    }
 
     #[test]
     fn banner_contains_model_name() {

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -165,6 +165,7 @@ impl TuiContext {
         // Collect startup lines (will be pushed into scroll buffer after init)
         let recent = db.recent_user_messages(3).await.unwrap_or_default();
         let mut startup_lines = crate::startup::collect_startup_lines(&config, &recent);
+        startup_lines.extend(crate::startup::home_dir_warning_lines(&project_root));
 
         if let Ok(Some(latest)) = version_check.await
             && let Some((current, latest)) = koda_core::version::update_available(&latest)


### PR DESCRIPTION
## Summary

Fixes #510.

Since v0.1.13 switched to fullscreen TUI, the home-directory `eprintln!` warning was immediately covered by the TUI rendering. Users never saw it until after exiting koda.

## Changes

| File | What |
|------|------|
| `main.rs` | Removed the `eprintln!` footgun warning |
| `startup.rs` | Added `home_dir_warning_lines()` builder + 2 unit tests |
| `tui_context/mod.rs` | Wired the new warning into startup line collection |

The warning now renders as yellow styled lines in the scroll buffer, right after the banner and model notices — consistent with every other startup message.

## Testing

- `cargo check` — clean
- `cargo test -p koda-cli --bin koda` — 171 tests pass (including 2 new ones)
- Manual: running `koda` from `$HOME` shows the warning inline in the TUI