### PR TITLE
fix: default empty tool args to {} instead of erroring (#513)

### DIFF
--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -303,8 +303,14 @@ impl ToolRegistry {
     }
 
     /// Execute a tool by name with the given JSON arguments.
+    ///
+    /// Empty or whitespace-only `arguments` are treated as `{}` (no args)
+    /// so that tools can fall through to their own defaults instead of
+    /// surfacing a raw JSON parse error.  See #513.
     pub async fn execute(&self, name: &str, arguments: &str) -> ToolResult {
-        let args: Value = match serde_json::from_str(arguments) {
+        let raw = arguments.trim();
+        let raw = if raw.is_empty() { "{}" } else { raw };
+        let args: Value = match serde_json::from_str(raw) {
             Ok(v) => v,
             Err(e) => {
                 return ToolResult {

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -28,6 +28,21 @@ async fn test_all_tools_routable_in_dispatcher() {
     }
 }
 
+/// Empty/whitespace-only arguments should be treated as `{}`, not error.
+/// Regression test for #513.
+#[tokio::test]
+async fn test_empty_args_default_to_empty_object() {
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
+    for input in ["", "  ", "\n", "\t "] {
+        let result = registry.execute("List", input).await;
+        assert!(
+            !result.output.contains("Invalid JSON"),
+            "Empty args '{input:?}' should not produce a JSON parse error. Got: {}",
+            result.output
+        );
+    }
+}
+
 /// Every tool must be classified in the approval system.
 /// It should be either in READ_ONLY_TOOLS (auto-approved) or
 /// return NeedsConfirmation/AutoApproved — never panic or crash.


### PR DESCRIPTION
## Summary

Fixes #513 (split from #511).

When the LLM (observed with Anthropic) returns empty or whitespace-only `arguments` for a tool call, koda now treats them as `{}` (empty object) instead of surfacing a raw JSON parse error like:

```
● List
  │    Invalid JSON arguments: EOF while parsing a value at line 1 column 0
```

## Changes

| File | What |
|------|------|
| `tools/mod.rs` | Trim + default empty args to `{}` before parsing |
| `tool_wiring_test.rs` | Regression test: empty/whitespace args don't error |

## Testing

- `cargo clippy` — clean
- `cargo test -p koda-core --test tool_wiring_test` — 3/3 pass
- Covers: `""`, `"  "`, `"\n"`, `"\t "` inputs