### PR TITLE
chore: release prep v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-03-18
+
+### Fixed
+- **Startup warnings invisible in fullscreen TUI** (#510, #512) — the home-directory
+  warning was printed via `eprintln!` before the TUI took over the screen, so users
+  never saw it. Warnings are now rendered as styled lines in the TUI scroll buffer,
+  consistent with all other startup messages.
+- **Empty tool arguments cause JSON parse error** (#513, #514) — when the LLM
+  (observed with Anthropic) returned empty or whitespace-only `arguments` for a
+  tool call, koda surfaced a raw "Invalid JSON arguments: EOF" error and wasted
+  a retry round-trip. Empty args now default to `{}` so tools fall through to
+  their own defaults.
+
 ## [0.1.14] - 2026-03-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "imap",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ powered by the same engine. This focus drives every design decision:
 ## Install
 
 ```bash
+# Homebrew (macOS / Linux)
+brew tap lijunzh/koda
+brew install koda
+
 # From crates.io
 cargo install koda-cli
 

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.14" }
+koda-core = { path = "../koda-core", version = "0.1.15" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.14", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.15", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.14" }
-koda-email = { path = "../koda-email", version = "0.1.14" }
+koda-ast = { path = "../koda-ast", version = "0.1.15" }
+koda-email = { path = "../koda-email", version = "0.1.15" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.15

### Changes since v0.1.14

#### Fixed
- **Startup warnings invisible in fullscreen TUI** (#510) — warnings now render as styled lines in the TUI scroll buffer instead of `eprintln!` to stderr.
- **Empty tool arguments cause JSON parse error** (#513) — empty/whitespace args default to `{}` so tools fall through to their own defaults.

#### Changed
- **README** — added Homebrew install option (`brew tap lijunzh/koda && brew install koda`).

### Release checklist
- ✅ 771 tests pass (0 failures)
- ✅ `cargo fmt` clean
- ✅ `cargo clippy -D warnings` clean
- ✅ Version bumped to 0.1.15 across all 4 crates
- ✅ CHANGELOG updated
- ✅ Cargo.lock updated