### PR TITLE
fix(approval): classify gh CLI commands by risk level

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -373,6 +373,50 @@ mod tests {
         );
     }
 
+    /// gh read-only commands should auto-approve even in Confirm mode (#518).
+    #[test]
+    fn test_gh_read_only_auto_approved() {
+        for cmd in ["gh issue view 42", "gh pr view 99", "gh pr list", "gh issue list"] {
+            let args = serde_json::json!({"command": cmd});
+            assert_eq!(
+                check_tool("Bash", &args, ApprovalMode::Confirm, None),
+                ToolApproval::AutoApprove,
+                "{cmd} should auto-approve even in Confirm mode"
+            );
+        }
+    }
+
+    /// gh destructive commands need confirmation even in Auto mode (#518).
+    #[test]
+    fn test_gh_destructive_needs_confirmation() {
+        for cmd in ["gh pr merge 42 --squash", "gh issue delete 42", "gh repo delete owner/repo"] {
+            let args = serde_json::json!({"command": cmd});
+            assert_eq!(
+                check_tool("Bash", &args, ApprovalMode::Auto, None),
+                ToolApproval::NeedsConfirmation,
+                "{cmd} should need confirmation even in Auto mode"
+            );
+        }
+    }
+
+    /// gh mutation commands (create/edit/close) auto-approve in Auto, confirm in Confirm (#518).
+    #[test]
+    fn test_gh_mutation_auto_approved_in_auto() {
+        for cmd in ["gh issue create --title 'bug'", "gh issue edit 42", "gh pr create"] {
+            let args = serde_json::json!({"command": cmd});
+            assert_eq!(
+                check_tool("Bash", &args, ApprovalMode::Auto, None),
+                ToolApproval::AutoApprove,
+                "{cmd} should auto-approve in Auto mode"
+            );
+            assert_eq!(
+                check_tool("Bash", &args, ApprovalMode::Confirm, None),
+                ToolApproval::NeedsConfirmation,
+                "{cmd} should need confirmation in Confirm mode"
+            );
+        }
+    }
+
     #[test]
     fn test_dev_workflow_bash_needs_confirmation_in_confirm() {
         let args = serde_json::json!({"command": "cargo test --release"});

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -376,7 +376,12 @@ mod tests {
     /// gh read-only commands should auto-approve even in Confirm mode (#518).
     #[test]
     fn test_gh_read_only_auto_approved() {
-        for cmd in ["gh issue view 42", "gh pr view 99", "gh pr list", "gh issue list"] {
+        for cmd in [
+            "gh issue view 42",
+            "gh pr view 99",
+            "gh pr list",
+            "gh issue list",
+        ] {
             let args = serde_json::json!({"command": cmd});
             assert_eq!(
                 check_tool("Bash", &args, ApprovalMode::Confirm, None),
@@ -389,7 +394,11 @@ mod tests {
     /// gh destructive commands need confirmation even in Auto mode (#518).
     #[test]
     fn test_gh_destructive_needs_confirmation() {
-        for cmd in ["gh pr merge 42 --squash", "gh issue delete 42", "gh repo delete owner/repo"] {
+        for cmd in [
+            "gh pr merge 42 --squash",
+            "gh issue delete 42",
+            "gh repo delete owner/repo",
+        ] {
             let args = serde_json::json!({"command": cmd});
             assert_eq!(
                 check_tool("Bash", &args, ApprovalMode::Auto, None),
@@ -402,7 +411,11 @@ mod tests {
     /// gh mutation commands (create/edit/close) auto-approve in Auto, confirm in Confirm (#518).
     #[test]
     fn test_gh_mutation_auto_approved_in_auto() {
-        for cmd in ["gh issue create --title 'bug'", "gh issue edit 42", "gh pr create"] {
+        for cmd in [
+            "gh issue create --title 'bug'",
+            "gh issue edit 42",
+            "gh pr create",
+        ] {
             let args = serde_json::json!({"command": cmd});
             assert_eq!(
                 check_tool("Bash", &args, ApprovalMode::Auto, None),

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -95,6 +95,20 @@ const READ_ONLY_PREFIXES: &[&str] = &[
     "false",
     "test ",
     "[ ",
+    // GitHub CLI read-only (#518)
+    "gh issue view",
+    "gh issue list",
+    "gh issue status",
+    "gh pr view",
+    "gh pr list",
+    "gh pr status",
+    "gh pr checks",
+    "gh pr diff",
+    "gh repo view",
+    "gh release list",
+    "gh release view",
+    "gh run view",
+    "gh run list",
 ];
 
 // ── Dangerous patterns (always need confirmation) ────────────
@@ -148,6 +162,10 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     // Package publishing
     "npm publish",
     "cargo publish",
+    // GitHub CLI destructive (#518)
+    "gh pr merge",
+    "gh issue delete",
+    "gh repo delete",
 ];
 
 // ── Classification ───────────────────────────────────────────
@@ -433,6 +451,20 @@ mod tests {
             "rg pattern src/",
             "grep foo bar.txt",
             "git log --oneline",
+            // GitHub CLI read-only (#518)
+            "gh issue view 42",
+            "gh issue list",
+            "gh issue status",
+            "gh pr view 99",
+            "gh pr list",
+            "gh pr status",
+            "gh pr checks 42",
+            "gh pr diff 42",
+            "gh repo view owner/repo",
+            "gh release list",
+            "gh release view v1.0",
+            "gh run view 123",
+            "gh run list",
         ] {
             assert_eq!(
                 classify_bash_command(cmd),
@@ -455,7 +487,10 @@ mod tests {
             "npm install",
             "make",
             "gh issue create --title 'bug'",
-            "gh pr merge 42 --squash",
+            "gh issue edit 42 --title 'new title'",
+            "gh issue close 42",
+            "gh pr create --title 'feat'",
+            "gh pr edit 42 --title 'new title'",
             "curl https://api.example.com",
             "wget https://example.com/file.txt",
         ] {
@@ -479,6 +514,9 @@ mod tests {
             "sed -i 's/foo/bar/g' file.txt",
             "npm publish",
             "cargo publish",
+            "gh pr merge 42 --squash",
+            "gh issue delete 42",
+            "gh repo delete owner/repo",
         ] {
             assert_eq!(
                 classify_bash_command(cmd),


### PR DESCRIPTION
Closes #518

## What

Classifies `gh` CLI commands into three risk tiers instead of treating them all as `LocalMutation`:

| Tier | Commands | Effect |
|------|----------|--------|
| **ReadOnly** | `view`, `list`, `status`, `checks`, `diff` | Auto-approve in all modes |
| **LocalMutation** | `create`, `edit`, `close` | Auto in Auto mode, confirm in Confirm |
| **Destructive** | `pr merge`, `issue delete`, `repo delete` | Always needs confirmation |

## Changes

- `bash_safety.rs`: Add gh read-only to `READ_ONLY_PREFIXES`, gh destructive to `DANGEROUS_PATTERNS`
- `approval.rs`: Add integration tests for all three tiers
- 48 tests pass (22 bash_safety + 26 approval)