### PR TITLE
fix(memory): merge sections by heading instead of appending duplicates

### DIFF
--- a/koda-core/src/memory.rs
+++ b/koda-core/src/memory.rs
@@ -110,9 +110,7 @@ fn write_or_replace_section(path: &Path, entry: &str) -> Result<()> {
     };
 
     let new_content = match heading {
-        Some(ref h) if section_exists(&existing, h) => {
-            replace_section(&existing, h, entry)
-        }
+        Some(ref h) if section_exists(&existing, h) => replace_section(&existing, h, entry),
         _ => {
             // No heading or heading not found → append
             let mut buf = existing;
@@ -357,9 +355,18 @@ mod tests {
         let result = replace_section(content, "## Workflow Preferences", replacement);
         assert!(result.contains("- new item1"), "Should contain new content");
         assert!(result.contains("- new item3"), "Should contain new content");
-        assert!(!result.contains("- old item1"), "Should not contain old content");
-        assert!(result.contains("## Other Section"), "Should preserve other sections");
-        assert!(result.contains("- keep this"), "Should preserve other section content");
+        assert!(
+            !result.contains("- old item1"),
+            "Should not contain old content"
+        );
+        assert!(
+            result.contains("## Other Section"),
+            "Should preserve other sections"
+        );
+        assert!(
+            result.contains("- keep this"),
+            "Should preserve other section content"
+        );
     }
 
     #[test]
@@ -368,7 +375,10 @@ mod tests {
         let replacement = "## Second\n- new";
         let result = replace_section(content, "## Second", replacement);
         assert!(result.contains("## First"), "Should preserve first section");
-        assert!(result.contains("- a"), "Should preserve first section content");
+        assert!(
+            result.contains("- a"),
+            "Should preserve first section content"
+        );
         assert!(result.contains("- new"), "Should contain replacement");
         assert!(!result.contains("- old"), "Should not contain old content");
     }
@@ -379,12 +389,22 @@ mod tests {
         let existing = "## Workflow Preferences\n- old item\n";
         std::fs::write(tmp.path().join("MEMORY.md"), existing).unwrap();
 
-        append(tmp.path(), "## Workflow Preferences\n- updated item\n- new item").unwrap();
+        append(
+            tmp.path(),
+            "## Workflow Preferences\n- updated item\n- new item",
+        )
+        .unwrap();
 
         let content = std::fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
-        assert!(content.contains("- updated item"), "Should contain new content");
+        assert!(
+            content.contains("- updated item"),
+            "Should contain new content"
+        );
         assert!(content.contains("- new item"), "Should contain new content");
-        assert!(!content.contains("- old item"), "Should not contain old content");
+        assert!(
+            !content.contains("- old item"),
+            "Should not contain old content"
+        );
         // Should only have one copy of the heading
         assert_eq!(
             content.matches("## Workflow Preferences").count(),

--- a/koda-core/src/memory.rs
+++ b/koda-core/src/memory.rs
@@ -52,24 +52,19 @@ pub fn load(project_root: &Path) -> Result<String> {
     Ok(parts.join("\n\n"))
 }
 
-/// Append a new entry to the project's MEMORY.md.
+/// Write an entry to the project's memory file.
 ///
-/// Always writes to `MEMORY.md` (Koda native), even if the project
-/// currently uses `CLAUDE.md` or `AGENTS.md` for reading.
+/// If the entry starts with a `## Heading`, and a section with that
+/// heading already exists in the file, the existing section is
+/// **replaced** (updated in place). Otherwise the entry is appended.
+///
+/// Always targets the active memory file (or `MEMORY.md` if none exists).
 pub fn append(project_root: &Path, entry: &str) -> Result<()> {
-    use std::io::Write;
-
-    // Determine the active file, or default to MEMORY.md
     let target_filename =
         active_project_file(project_root).unwrap_or_else(|| KODA_MEMORY_FILE.to_string());
-
     let path = project_root.join(&target_filename);
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    writeln!(file, "\n- {entry}")?;
-    tracing::info!("Appended to {target_filename}: {entry}");
+    write_or_replace_section(&path, entry)?;
+    tracing::info!("Wrote to {target_filename}: {entry}");
     Ok(())
 }
 
@@ -83,24 +78,113 @@ pub fn active_project_file(project_root: &Path) -> Option<String> {
     None
 }
 
-/// Append a new entry to the global memory file (~/.config/koda/memory.md).
+/// Write an entry to the global memory file (~/.config/koda/memory.md).
+///
+/// If the entry starts with a `## Heading` that already exists, the
+/// section is replaced. Otherwise the entry is appended.
 pub fn append_global(entry: &str) -> Result<()> {
-    use std::io::Write;
     let path = global_memory_path()
         .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory for global memory"))?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)?;
-    writeln!(file, "\n- {entry}")?;
-    tracing::info!("Appended to global memory: {entry}");
+    write_or_replace_section(&path, entry)?;
+    tracing::info!("Wrote to global memory: {entry}");
     Ok(())
 }
 
 // ── Internal helpers ──────────────────────────────────────────────────────
+
+/// Write an entry to a memory file, merging by `## Heading` if possible.
+///
+/// If `entry` starts with `## <heading>`, we look for an existing section
+/// with the same heading. If found, the old section (heading through to
+/// the next `##` heading or EOF) is replaced with `entry`. If not found
+/// (or `entry` has no heading), the entry is appended.
+fn write_or_replace_section(path: &Path, entry: &str) -> Result<()> {
+    let heading = extract_heading(entry);
+    let existing = if path.exists() {
+        std::fs::read_to_string(path)?
+    } else {
+        String::new()
+    };
+
+    let new_content = match heading {
+        Some(ref h) if section_exists(&existing, h) => {
+            replace_section(&existing, h, entry)
+        }
+        _ => {
+            // No heading or heading not found → append
+            let mut buf = existing;
+            if !buf.is_empty() && !buf.ends_with('\n') {
+                buf.push('\n');
+            }
+            buf.push_str(&format!("\n- {entry}"));
+            buf.push('\n');
+            buf
+        }
+    };
+
+    std::fs::write(path, new_content)?;
+    Ok(())
+}
+
+/// Extract a `## Heading` from the first line of an entry.
+fn extract_heading(entry: &str) -> Option<String> {
+    let first_line = entry.lines().next()?.trim();
+    if first_line.starts_with("## ") {
+        Some(first_line.to_string())
+    } else {
+        None
+    }
+}
+
+/// Check if a `## Heading` section already exists in the content.
+fn section_exists(content: &str, heading: &str) -> bool {
+    content.lines().any(|line| line.trim() == heading)
+}
+
+/// Replace a `## Heading` section with new content.
+///
+/// The section spans from the heading line to (but not including)
+/// the next `## ` heading or EOF.
+fn replace_section(content: &str, heading: &str, replacement: &str) -> String {
+    let mut result = String::new();
+    let mut in_target_section = false;
+    let mut replaced = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == heading && !replaced {
+            // Start of the section we want to replace
+            in_target_section = true;
+            // Emit the replacement content
+            result.push_str(replacement);
+            if !replacement.ends_with('\n') {
+                result.push('\n');
+            }
+            replaced = true;
+            continue;
+        }
+
+        if in_target_section {
+            // Check if we've hit the next section heading
+            if trimmed.starts_with("## ") {
+                in_target_section = false;
+                result.push_str(line);
+                result.push('\n');
+            }
+            // else: skip old section content
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
 
 /// Load global memory from `~/.config/koda/memory.md`.
 fn load_global() -> Result<Option<String>> {
@@ -243,5 +327,94 @@ mod tests {
             active_project_file(tmp.path()),
             Some("MEMORY.md".to_string())
         );
+    }
+
+    // ── Section merge tests (#519) ──
+
+    #[test]
+    fn test_extract_heading() {
+        assert_eq!(
+            extract_heading("## Workflow Preferences\n- item"),
+            Some("## Workflow Preferences".to_string())
+        );
+        assert_eq!(extract_heading("just a plain note"), None);
+        assert_eq!(extract_heading("# Top level heading"), None); // only ## is matched
+        assert_eq!(extract_heading(""), None);
+    }
+
+    #[test]
+    fn test_section_exists() {
+        let content = "# Title\n## Workflow Preferences\n- item1\n## Other\n- item2";
+        assert!(section_exists(content, "## Workflow Preferences"));
+        assert!(section_exists(content, "## Other"));
+        assert!(!section_exists(content, "## Missing"));
+    }
+
+    #[test]
+    fn test_replace_section() {
+        let content = "# Title\n## Workflow Preferences\n- old item1\n- old item2\n## Other Section\n- keep this\n";
+        let replacement = "## Workflow Preferences\n- new item1\n- new item2\n- new item3";
+        let result = replace_section(content, "## Workflow Preferences", replacement);
+        assert!(result.contains("- new item1"), "Should contain new content");
+        assert!(result.contains("- new item3"), "Should contain new content");
+        assert!(!result.contains("- old item1"), "Should not contain old content");
+        assert!(result.contains("## Other Section"), "Should preserve other sections");
+        assert!(result.contains("- keep this"), "Should preserve other section content");
+    }
+
+    #[test]
+    fn test_replace_section_at_end() {
+        let content = "## First\n- a\n## Second\n- old\n";
+        let replacement = "## Second\n- new";
+        let result = replace_section(content, "## Second", replacement);
+        assert!(result.contains("## First"), "Should preserve first section");
+        assert!(result.contains("- a"), "Should preserve first section content");
+        assert!(result.contains("- new"), "Should contain replacement");
+        assert!(!result.contains("- old"), "Should not contain old content");
+    }
+
+    #[test]
+    fn test_append_merges_existing_section() {
+        let tmp = TempDir::new().unwrap();
+        let existing = "## Workflow Preferences\n- old item\n";
+        std::fs::write(tmp.path().join("MEMORY.md"), existing).unwrap();
+
+        append(tmp.path(), "## Workflow Preferences\n- updated item\n- new item").unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+        assert!(content.contains("- updated item"), "Should contain new content");
+        assert!(content.contains("- new item"), "Should contain new content");
+        assert!(!content.contains("- old item"), "Should not contain old content");
+        // Should only have one copy of the heading
+        assert_eq!(
+            content.matches("## Workflow Preferences").count(),
+            1,
+            "Should have exactly one copy of the heading"
+        );
+    }
+
+    #[test]
+    fn test_append_new_section_still_appends() {
+        let tmp = TempDir::new().unwrap();
+        let existing = "## Existing Section\n- item\n";
+        std::fs::write(tmp.path().join("MEMORY.md"), existing).unwrap();
+
+        append(tmp.path(), "## New Section\n- new item").unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+        assert!(content.contains("## Existing Section"));
+        assert!(content.contains("## New Section"));
+        assert!(content.contains("- new item"));
+    }
+
+    #[test]
+    fn test_append_plain_entry_still_appends() {
+        let tmp = TempDir::new().unwrap();
+        append(tmp.path(), "just a plain note").unwrap();
+        append(tmp.path(), "another plain note").unwrap();
+
+        let content = std::fs::read_to_string(tmp.path().join("MEMORY.md")).unwrap();
+        assert!(content.contains("just a plain note"));
+        assert!(content.contains("another plain note"));
     }
 }


### PR DESCRIPTION
Closes #519

## Problem

`MemoryWrite` blindly appends new entries to memory files. When the LLM writes an updated version of a `## Heading` section, the old section stays and a duplicate appears at the end. Over time this creates 3+ copies of the same section.

## Solution

Before writing, extract the `## Heading` from the first line of the entry. If that heading already exists in the file, **replace** the old section (heading through next `##` or EOF) with the new content. If no heading match, fall back to appending.

## Changes

- `memory.rs`: Refactor `append()` and `append_global()` to use `write_or_replace_section()`
- New helpers: `extract_heading()`, `section_exists()`, `replace_section()`
- 7 new tests + all 20 existing memory tests still pass

## Behavior

| Entry | Existing heading? | Action |
|-------|-------------------|--------|
| `## Workflow Preferences\n- item` | Yes | Replace old section |
| `## New Section\n- item` | No | Append |
| `just a plain note` | N/A | Append |