### PR TITLE
release: v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.16] - 2026-03-20
+
+### Security
+- **EmailSend reclassified to LocalMutation** (#525) — previously classified as
+  RemoteAction (auto-approved in all modes), EmailSend now requires confirmation
+  in Confirm mode to prevent prompt-injection data exfiltration.
+- **Bash classifier hardening** (#525) — added interpreter commands (`python -c`,
+  `perl -e`, `ruby -e`, `node -e`), nested shells (`sh -c`, `bash -c`),
+  `gh api`, `gh auth`, `gh release delete`, and `git clean -f` to
+  DANGEROUS_PATTERNS. These bypass vectors now require user confirmation.
+- **Bash timeout capped at 300s** (#525) — prevents LLM-controlled DoS via
+  arbitrarily large timeout values.
+- **DNS rebinding SSRF protection** (#526) — after URL validation passes,
+  the hostname is now resolved and all resulting IPs are checked against
+  private/internal ranges before the HTTP request is made. Prevents TOCTOU
+  attacks where DNS re-resolves to 169.254.169.254 etc.
+- **Symlink read bypass** (#526) — `read_file` now canonicalizes the resolved
+  path and verifies it still falls within the project root, preventing symlink
+  traversal attacks (e.g. `project/link → /etc/passwd`).
+- **IMAP search injection** (#529) — user-supplied search queries are now
+  sanitized (backslashes and double-quotes escaped) before interpolation
+  into IMAP SEARCH commands.
+
+### Fixed
+- **Scroll buffer eviction drift** (#528) — `enforce_capacity()` now subtracts
+  the visual height (wrapped line count) of each evicted line instead of a flat
+  1, preventing scroll position drift with long wrapped lines.
+- **`paragraph_scroll()` u16 overflow** (#528) — visual line offset is now
+  clamped to `u16::MAX` to prevent silent truncation at narrow terminal widths
+  with large buffers.
+- **Missing `gh` CLI classifications** (#525) — added `gh repo clone`,
+  `gh run watch` (read-only), `gh pr review/comment/close/reopen`,
+  `gh issue close/reopen`, `gh release create`, `gh workflow run` (mutation).
+
+### Changed
+- **DRY: shared word-wrap algorithm** (#527) — extracted duplicate word-boundary
+  wrapping logic from `scroll_buffer` and `wrap_input` into a single
+  `wrap_util::visual_line_count()` function.
+- **Deduplicate `config_dir`** (#529) — `keystore.rs` now delegates to
+  `db::config_dir()` instead of maintaining its own platform-detection code.
+
 ## [0.1.15] - 2026-03-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.15" }
+koda-core = { path = "../koda-core", version = "0.1.16" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.15", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.16", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -29,6 +29,7 @@ mod tui_viewport;
 mod tui_wizards;
 mod widgets;
 mod wrap_input;
+mod wrap_util;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -280,11 +280,11 @@ impl ScrollBuffer {
     fn enforce_capacity(&mut self) {
         let w = self.cached_term_width.max(1);
         while self.lines.len() > MAX_CACHE_LINES {
-            if let Some(evicted) = self.lines.pop_front() {
-                if self.scroll_offset > 0 {
-                    let vis = visual_height(&evicted, w);
-                    self.scroll_offset = self.scroll_offset.saturating_sub(vis);
-                }
+            if let Some(evicted) = self.lines.pop_front()
+                && self.scroll_offset > 0
+            {
+                let vis = visual_height(&evicted, w);
+                self.scroll_offset = self.scroll_offset.saturating_sub(vis);
             }
         }
     }

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -32,6 +32,11 @@ pub struct ScrollBuffer {
     /// Used by virtual scroll to know which page to fetch next.
     /// `None` means no DB messages have been loaded yet.
     oldest_message_id: Option<i64>,
+
+    /// Cached terminal width for eviction offset adjustment.
+    /// Updated on scroll operations and used by `enforce_capacity()`
+    /// to compute visual height of evicted lines.
+    cached_term_width: usize,
 }
 
 impl ScrollBuffer {
@@ -41,6 +46,7 @@ impl ScrollBuffer {
             scroll_offset: 0,
             sticky_bottom: true,
             oldest_message_id: None,
+            cached_term_width: 80,
         }
     }
 
@@ -73,6 +79,7 @@ impl ScrollBuffer {
 
     /// Scroll up by `n` visual lines. Disengages sticky bottom.
     pub fn scroll_up(&mut self, n: usize, term_width: usize, viewport_height: usize) {
+        self.cached_term_width = term_width;
         let total = self.total_visual_lines(term_width);
         let max_offset = total.saturating_sub(viewport_height);
         self.scroll_offset = (self.scroll_offset + n).min(max_offset);
@@ -92,6 +99,7 @@ impl ScrollBuffer {
     /// terminal dimensions. Must be called after any resize so the
     /// offset doesn't exceed `total_visual - viewport_height`.
     pub fn clamp_offset(&mut self, term_width: usize, viewport_height: usize) {
+        self.cached_term_width = term_width;
         let total = self.total_visual_lines(term_width);
         let max_offset = total.saturating_sub(viewport_height);
         if self.scroll_offset > max_offset {
@@ -110,6 +118,7 @@ impl ScrollBuffer {
 
     /// Jump to the top of the buffer.
     pub fn scroll_to_top(&mut self, term_width: usize, viewport_height: usize) {
+        self.cached_term_width = term_width;
         if !self.lines.is_empty() {
             let total = self.total_visual_lines(term_width);
             self.scroll_offset = total.saturating_sub(viewport_height);
@@ -155,7 +164,8 @@ impl ScrollBuffer {
         let from_top = total
             .saturating_sub(viewport_height)
             .saturating_sub(self.scroll_offset);
-        (from_top as u16, 0)
+        // Clamp to u16::MAX to prevent silent truncation (#528).
+        (from_top.min(u16::MAX as usize) as u16, 0)
     }
 
     /// Total number of lines in the buffer.
@@ -263,12 +273,18 @@ impl ScrollBuffer {
     }
 
     /// Evict oldest lines if we exceed capacity.
+    ///
+    /// Adjusts `scroll_offset` by the evicted line's visual height
+    /// (not a flat 1) to prevent scroll position drift when wrapped
+    /// lines are evicted (#528).
     fn enforce_capacity(&mut self) {
+        let w = self.cached_term_width.max(1);
         while self.lines.len() > MAX_CACHE_LINES {
-            self.lines.pop_front();
-            // Adjust scroll offset since lines shifted
-            if self.scroll_offset > 0 {
-                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+            if let Some(evicted) = self.lines.pop_front() {
+                if self.scroll_offset > 0 {
+                    let vis = visual_height(&evicted, w);
+                    self.scroll_offset = self.scroll_offset.saturating_sub(vis);
+                }
             }
         }
     }

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -299,74 +299,10 @@ fn line_text(line: &Line<'_>) -> String {
 
 /// Compute how many visual rows a `Line` occupies at the given terminal width.
 ///
-/// Uses word-boundary wrapping logic consistent with
-/// `Paragraph::wrap(Wrap { trim: false })` — when a word would overflow
-/// the current row, it breaks *before* the word, potentially leaving a
-/// shorter first row and producing more visual lines than simple
-/// `char_width / term_width` division.
-///
-/// The algorithm processes the text word-by-word (split on whitespace).
-/// If a word fits on the current row (with a space prefix if not first),
-/// it's added. If a word doesn't fit:
-///   - Row has content → start a new row with this word
-///   - Row is empty (word longer than width) → force-break mid-word
+/// Delegates to `wrap_util::visual_line_count` — the single source of truth
+/// for word-boundary wrapping consistent with `Wrap { trim: false }`.
 fn visual_height(line: &Line<'_>, term_width: usize) -> usize {
-    let text = line_text(line);
-    if text.is_empty() {
-        return 1;
-    }
-    let w = term_width.max(1);
-    let mut rows = 1usize;
-    let mut col = 0usize;
-
-    // Process word-by-word to match ratatui's Wrap { trim: false } behavior.
-    // We iterate characters but track word boundaries (spaces).
-    let mut word_start_col = 0usize; // col at start of current word
-    let mut in_word = false;
-
-    for ch in text.chars() {
-        let char_w = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
-        let is_space = ch == ' ' || ch == '\t';
-
-        if is_space {
-            // Space: just advance, marking end of word
-            in_word = false;
-            if col + char_w > w {
-                rows += 1;
-                col = char_w;
-            } else {
-                col += char_w;
-            }
-            word_start_col = col;
-        } else {
-            if !in_word {
-                // Starting a new word: check if it's worth staying on this row
-                word_start_col = col;
-                in_word = true;
-            }
-
-            if col + char_w > w {
-                if word_start_col > 0 && word_start_col <= w {
-                    // Word doesn't fit but row had prior content:
-                    // wrap *before* this word (at word_start_col)
-                    rows += 1;
-                    // Recalculate: the word chars from word_start_col
-                    // to now are on the new row
-                    let word_len_so_far = col - word_start_col;
-                    col = word_len_so_far + char_w;
-                    word_start_col = 0;
-                } else {
-                    // Word is at column 0 (longer than width): force-break
-                    rows += 1;
-                    col = char_w;
-                    word_start_col = 0;
-                }
-            } else {
-                col += char_w;
-            }
-        }
-    }
-    rows
+    crate::wrap_util::visual_line_count(&line_text(line), term_width)
 }
 
 #[cfg(test)]

--- a/koda-cli/src/wrap_input.rs
+++ b/koda-cli/src/wrap_input.rs
@@ -94,52 +94,9 @@ fn logical_to_visual(
 
 /// Compute how many visual lines a text line occupies at a given width.
 ///
-/// Uses word-boundary wrapping consistent with `Wrap { trim: false }`.
+/// Delegates to `wrap_util::visual_line_count` — single source of truth.
 fn visual_line_count(line: &str, width: usize) -> usize {
-    if line.is_empty() {
-        return 1;
-    }
-    let w = width.max(1);
-    let mut rows = 1usize;
-    let mut col = 0usize;
-    let mut word_start_col = 0usize;
-    let mut in_word = false;
-
-    for ch in line.chars() {
-        let char_w = ch.width().unwrap_or(0);
-        let is_space = ch == ' ' || ch == '\t';
-
-        if is_space {
-            in_word = false;
-            if col + char_w > w {
-                rows += 1;
-                col = char_w;
-            } else {
-                col += char_w;
-            }
-            word_start_col = col;
-        } else {
-            if !in_word {
-                word_start_col = col;
-                in_word = true;
-            }
-            if col + char_w > w {
-                if word_start_col > 0 && word_start_col <= w {
-                    rows += 1;
-                    let word_len_so_far = col - word_start_col;
-                    col = word_len_so_far + char_w;
-                    word_start_col = 0;
-                } else {
-                    rows += 1;
-                    col = char_w;
-                    word_start_col = 0;
-                }
-            } else {
-                col += char_w;
-            }
-        }
-    }
-    rows
+    crate::wrap_util::visual_line_count(line, width)
 }
 
 /// For a given cursor column position in a line, compute:

--- a/koda-cli/src/wrap_util.rs
+++ b/koda-cli/src/wrap_util.rs
@@ -1,0 +1,113 @@
+//! Shared word-wrap line counting.
+//!
+//! Single source of truth for the word-boundary wrapping algorithm
+//! used by both `scroll_buffer` (history panel) and `wrap_input`
+//! (input area). Must match ratatui's `Wrap { trim: false }` behavior.
+//!
+//! Extracted from duplicated implementations (#527).
+
+use unicode_width::UnicodeWidthChar;
+
+/// Compute how many visual lines a text string occupies at a given width.
+///
+/// Uses word-boundary wrapping consistent with ratatui's
+/// `Paragraph::wrap(Wrap { trim: false })`. When a word would overflow
+/// the current row, it breaks *before* the word.
+///
+/// For words longer than the terminal width, force-breaks mid-word.
+pub fn visual_line_count(text: &str, width: usize) -> usize {
+    if text.is_empty() {
+        return 1;
+    }
+    let w = width.max(1);
+    let mut rows = 1usize;
+    let mut col = 0usize;
+    let mut word_start_col = 0usize;
+    let mut in_word = false;
+
+    for ch in text.chars() {
+        let char_w = ch.width().unwrap_or(0);
+        let is_space = ch == ' ' || ch == '\t';
+
+        if is_space {
+            in_word = false;
+            if col + char_w > w {
+                rows += 1;
+                col = char_w;
+            } else {
+                col += char_w;
+            }
+            word_start_col = col;
+        } else {
+            if !in_word {
+                word_start_col = col;
+                in_word = true;
+            }
+            if col + char_w > w {
+                if word_start_col > 0 && word_start_col <= w {
+                    // Word doesn't fit but row had prior content:
+                    // wrap *before* this word.
+                    rows += 1;
+                    let word_len_so_far = col - word_start_col;
+                    col = word_len_so_far + char_w;
+                    word_start_col = 0;
+                } else {
+                    // Word at column 0 (longer than width): force-break.
+                    rows += 1;
+                    col = char_w;
+                    word_start_col = 0;
+                }
+            } else {
+                col += char_w;
+            }
+        }
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_line() {
+        assert_eq!(visual_line_count("hello", 80), 1);
+    }
+
+    #[test]
+    fn empty_line() {
+        assert_eq!(visual_line_count("", 80), 1);
+    }
+
+    #[test]
+    fn char_wrap() {
+        assert_eq!(visual_line_count(&"x".repeat(160), 80), 2);
+    }
+
+    #[test]
+    fn word_wrap() {
+        let line = format!("{} {}", "a".repeat(75), "b".repeat(75));
+        assert_eq!(visual_line_count(&line, 80), 2);
+    }
+
+    #[test]
+    fn word_longer_than_width() {
+        assert_eq!(visual_line_count(&"x".repeat(200), 80), 3);
+    }
+
+    #[test]
+    fn exact_width() {
+        assert_eq!(visual_line_count(&"x".repeat(80), 80), 1);
+    }
+
+    #[test]
+    fn exact_width_plus_one() {
+        assert_eq!(visual_line_count(&"x".repeat(81), 80), 2);
+    }
+
+    #[test]
+    fn word_wrap_breaks_before_word() {
+        let text = format!("{}  foobar", "a".repeat(76));
+        assert_eq!(visual_line_count(&text, 80), 2);
+    }
+}

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.15" }
-koda-email = { path = "../koda-email", version = "0.1.15" }
+koda-ast = { path = "../koda-ast", version = "0.1.16" }
+koda-email = { path = "../koda-email", version = "0.1.16" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -127,6 +127,8 @@ pub enum ToolApproval {
 /// - Writes outside project root → NeedsConfirmation (#218)
 /// - Bash path escapes → NeedsConfirmation
 /// - Delete of Koda-owned file → AutoApprove (#465)
+/// - EmailSend → LocalMutation (not RemoteAction) to prevent
+///   prompt-injection data exfiltration (#525)
 pub fn check_tool(
     tool_name: &str,
     args: &serde_json::Value,
@@ -337,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_write_tools_need_confirmation_in_confirm() {
-        for tool in ["Write", "Edit", "Delete", "MemoryWrite"] {
+        for tool in ["Write", "Edit", "Delete", "MemoryWrite", "EmailSend"] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), ApprovalMode::Confirm, None),
                 ToolApproval::NeedsConfirmation,

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -95,7 +95,7 @@ const READ_ONLY_PREFIXES: &[&str] = &[
     "false",
     "test ",
     "[ ",
-    // GitHub CLI read-only (#518)
+    // GitHub CLI read-only (#518, #525)
     "gh issue view",
     "gh issue list",
     "gh issue status",
@@ -105,10 +105,12 @@ const READ_ONLY_PREFIXES: &[&str] = &[
     "gh pr checks",
     "gh pr diff",
     "gh repo view",
+    "gh repo clone",
     "gh release list",
     "gh release view",
     "gh run view",
     "gh run list",
+    "gh run watch",
 ];
 
 // ── Dangerous patterns (always need confirmation) ────────────
@@ -162,10 +164,31 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     // Package publishing
     "npm publish",
     "cargo publish",
-    // GitHub CLI destructive (#518)
+    // Interpreter-based command execution (prompt injection vector)
+    "python -c ",
+    "python -c'",
+    "python3 -c ",
+    "python3 -c'",
+    "perl -e ",
+    "perl -e'",
+    "ruby -e ",
+    "ruby -e'",
+    "node -e ",
+    "node -e'",
+    // Nested shells (bypass classifier)
+    "sh -c ",
+    "sh -c'",
+    "bash -c ",
+    "bash -c'",
+    // Git destructive (missing variant)
+    "git clean -f",
+    // GitHub CLI destructive (#518, #525)
     "gh pr merge",
     "gh issue delete",
     "gh repo delete",
+    "gh release delete",
+    "gh api",
+    "gh auth ",
 ];
 
 // ── Classification ───────────────────────────────────────────
@@ -465,6 +488,9 @@ mod tests {
             "gh release view v1.0",
             "gh run view 123",
             "gh run list",
+            // #525 additions
+            "gh repo clone owner/repo",
+            "gh run watch 123",
         ] {
             assert_eq!(
                 classify_bash_command(cmd),
@@ -491,6 +517,15 @@ mod tests {
             "gh issue close 42",
             "gh pr create --title 'feat'",
             "gh pr edit 42 --title 'new title'",
+            // #525: additional gh mutation commands
+            "gh pr review 42 --approve",
+            "gh pr comment 42 --body 'looks good'",
+            "gh pr close 42",
+            "gh pr reopen 42",
+            "gh issue close 42",
+            "gh issue reopen 42",
+            "gh release create v1.0",
+            "gh workflow run ci.yml",
             "curl https://api.example.com",
             "wget https://example.com/file.txt",
         ] {
@@ -517,6 +552,23 @@ mod tests {
             "gh pr merge 42 --squash",
             "gh issue delete 42",
             "gh repo delete owner/repo",
+            // Interpreter-based execution (#525)
+            "python -c 'import os; os.remove(\"/tmp/x\")'" ,
+            "python3 -c 'import shutil; shutil.rmtree(\"/tmp\")'",
+            "perl -e 'unlink(\"/tmp/x\")'",
+            "ruby -e 'File.delete(\"/tmp/x\")'",
+            "node -e 'require(\"fs\").rmSync(\"/tmp\")'",
+            // Nested shell bypass (#525)
+            "sh -c 'rm -rf /'",
+            "bash -c 'dangerous command'",
+            // GitHub CLI destructive (#525)
+            "gh api -X DELETE /repos/owner/repo",
+            "gh api --method DELETE /repos/owner/repo",
+            "gh release delete v1.0",
+            "gh auth login --with-token",
+            // Git clean variants (#525)
+            "git clean -f",
+            "git clean -fd",
         ] {
             assert_eq!(
                 classify_bash_command(cmd),

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -553,7 +553,7 @@ mod tests {
             "gh issue delete 42",
             "gh repo delete owner/repo",
             // Interpreter-based execution (#525)
-            "python -c 'import os; os.remove(\"/tmp/x\")'" ,
+            "python -c 'import os; os.remove(\"/tmp/x\")'",
             "python3 -c 'import shutil; shutil.rmtree(\"/tmp\")'",
             "perl -e 'unlink(\"/tmp/x\")'",
             "ruby -e 'File.delete(\"/tmp/x\")'",

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-const CONFIG_DIR: &str = "koda";
 const KEYS_FILE: &str = "keys.toml";
 
 /// Stored API keys, keyed by env var name (e.g. "ANTHROPIC_API_KEY").
@@ -97,24 +96,11 @@ impl KeyStore {
 
     /// Path to the keys file: ~/.config/koda/keys.toml
     pub fn keys_path() -> Result<PathBuf> {
-        let config_dir = dirs_config_dir().context("Could not determine config directory")?;
-        Ok(config_dir.join(CONFIG_DIR).join(KEYS_FILE))
+        let config_dir = crate::db::config_dir()?;
+        Ok(config_dir.join(KEYS_FILE))
     }
 }
 
-/// Cross-platform config directory.
-fn dirs_config_dir() -> Option<PathBuf> {
-    // $XDG_CONFIG_HOME or ~/.config on unix, AppData on windows
-    std::env::var("XDG_CONFIG_HOME")
-        .ok()
-        .map(PathBuf::from)
-        .or_else(|| {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| PathBuf::from(h).join(".config"))
-        })
-        .or_else(|| std::env::var("APPDATA").ok().map(PathBuf::from))
-}
 
 /// Mask a key for display: shows first 4 and last 4 characters.
 ///

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -101,7 +101,6 @@ impl KeyStore {
     }
 }
 
-
 /// Mask a key for display: shows first 4 and last 4 characters.
 ///
 /// # Examples

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -147,6 +147,24 @@ pub async fn read_file(
         .ok_or_else(|| anyhow::anyhow!("Missing 'path' argument"))?;
     let resolved = safe_resolve_path(project_root, path_str)?;
 
+    // Symlink traversal protection (#526): safe_resolve_path uses lexical
+    // normalization (path_clean) which can't detect symlinks. Since reads
+    // target existing files, we can canonicalize and verify the real path
+    // is still inside the project root.
+    if resolved.exists() {
+        let canon = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
+        let canon_root = project_root
+            .canonicalize()
+            .unwrap_or_else(|_| project_root.to_path_buf());
+        if !canon.starts_with(&canon_root) {
+            anyhow::bail!(
+                "Path escapes project root via symlink. Requested: {path_str:?}, \
+                 Real path: {}",
+                canon.display()
+            );
+        }
+    }
+
     let start_line = args["start_line"].as_u64();
     let num_lines = args["num_lines"].as_u64();
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -46,7 +46,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
 
         // Email tools
         "EmailRead" | "EmailSearch" => ToolEffect::ReadOnly,
-        "EmailSend" => ToolEffect::RemoteAction,
+        "EmailSend" => ToolEffect::LocalMutation,
 
         // Unknown tools — default to LocalMutation (conservative)
         _ => ToolEffect::LocalMutation,

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -10,6 +10,8 @@ use std::path::Path;
 use tokio::process::Command;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
+/// Hard ceiling to prevent LLM-controlled DoS via huge timeout values.
+const MAX_TIMEOUT_SECS: u64 = 300;
 
 /// Return tool definitions for the LLM.
 pub fn definitions() -> Vec<ToolDefinition> {
@@ -46,7 +48,10 @@ pub async fn run_shell_command(
     let command = args["command"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'command' argument"))?;
-    let timeout_secs = args["timeout"].as_u64().unwrap_or(DEFAULT_TIMEOUT_SECS);
+    let timeout_secs = args["timeout"]
+        .as_u64()
+        .unwrap_or(DEFAULT_TIMEOUT_SECS)
+        .min(MAX_TIMEOUT_SECS);
 
     tracing::info!("Running shell command: [{} chars]", command.len());
 
@@ -167,5 +172,16 @@ mod tests {
         let capped = cap_output(&input, 256);
         // Exactly at limit, no truncation
         assert!(!capped.contains("truncated"));
+    }
+
+    #[test]
+    fn test_timeout_capped_at_max() {
+        // Verify the timeout is clamped to MAX_TIMEOUT_SECS
+        let args = serde_json::json!({"command": "echo hi", "timeout": 99999});
+        let timeout_secs = args["timeout"]
+            .as_u64()
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .min(MAX_TIMEOUT_SECS);
+        assert_eq!(timeout_secs, MAX_TIMEOUT_SECS);
     }
 }

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -51,6 +51,38 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
         );
     }
 
+    // DNS rebinding protection: resolve the hostname and verify the IP
+    // is not private/internal before making the request. This prevents
+    // TOCTOU attacks where DNS re-resolves to a different IP.
+    if let Ok(parsed) = url::Url::parse(url)
+        && let Some(host) = parsed.host_str()
+    {
+        // Only resolve domain names (IPs are already checked above)
+        if parsed.host().is_some_and(|h| matches!(h, url::Host::Domain(_))) {
+            match tokio::net::lookup_host(format!(
+                "{}:{}",
+                host,
+                parsed.port_or_known_default().unwrap_or(80)
+            ))
+            .await
+            {
+                Ok(addrs) => {
+                    for addr in addrs {
+                        if !is_safe_ip(addr.ip()) {
+                            anyhow::bail!(
+                                "URL blocked: domain '{host}' resolves to private/internal IP {}.",
+                                addr.ip()
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    anyhow::bail!("DNS resolution failed for '{host}': {e}");
+                }
+            }
+        }
+    }
+
     static HTTP_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
     let client = HTTP_CLIENT
         .get_or_init(|| crate::providers::build_http_client(None))
@@ -90,6 +122,35 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
     }
 }
 
+/// Check if an IP address is safe (not private/internal/loopback).
+fn is_safe_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(ipv4) => {
+            let octets = ipv4.octets();
+            // Loopback, private, link-local, unspecified
+            if octets[0] == 127
+                || octets[0] == 10
+                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 168)
+                || (octets[0] == 169 && octets[1] == 254)
+                || ipv4.is_unspecified()
+            {
+                return false;
+            }
+            true
+        }
+        std::net::IpAddr::V6(ipv6) => {
+            if ipv6.is_loopback() || ipv6.is_unspecified() {
+                return false;
+            }
+            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
+                return is_safe_ip(std::net::IpAddr::V4(ipv4));
+            }
+            true
+        }
+    }
+}
+
 /// Check if a URL is safe to fetch (not internal/private network).
 /// Uses the `url` crate for robust parsing (handles userinfo@, IPv6, etc.).
 fn is_safe_url(url_str: &str) -> bool {
@@ -120,58 +181,18 @@ fn is_safe_url(url_str: &str) -> bool {
     // Block private/reserved IPs using the parsed host
     match parsed.host() {
         Some(url::Host::Ipv4(ip)) => {
-            let octets = ip.octets();
-            // Loopback (127.0.0.0/8)
-            if octets[0] == 127 {
-                return false;
-            }
-            // Private 10.0.0.0/8
-            if octets[0] == 10 {
-                return false;
-            }
-            // Private 172.16.0.0/12
-            if octets[0] == 172 && (16..=31).contains(&octets[1]) {
-                return false;
-            }
-            // Private 192.168.0.0/16
-            if octets[0] == 192 && octets[1] == 168 {
-                return false;
-            }
-            // Link-local 169.254.0.0/16
-            if octets[0] == 169 && octets[1] == 254 {
-                return false;
-            }
-            // Unspecified
-            if ip.is_unspecified() {
+            if !is_safe_ip(std::net::IpAddr::V4(ip)) {
                 return false;
             }
         }
         Some(url::Host::Ipv6(ip)) => {
-            if ip.is_loopback() || ip.is_unspecified() {
+            if !is_safe_ip(std::net::IpAddr::V6(ip)) {
                 return false;
-            }
-            // Check for IPv4-mapped IPv6 (::ffff:x.x.x.x)
-            if let Some(ipv4) = ip.to_ipv4_mapped() {
-                let octets = ipv4.octets();
-                if octets[0] == 127 {
-                    return false;
-                }
-                if octets[0] == 10 {
-                    return false;
-                }
-                if octets[0] == 172 && (16..=31).contains(&octets[1]) {
-                    return false;
-                }
-                if octets[0] == 192 && octets[1] == 168 {
-                    return false;
-                }
-                if octets[0] == 169 && octets[1] == 254 {
-                    return false;
-                }
             }
         }
         Some(url::Host::Domain(_)) => {
             // Domain names — hostname checks above are sufficient
+            // (DNS resolution check happens separately in web_fetch)
         }
         None => return false,
     }
@@ -354,6 +375,29 @@ mod tests {
         assert!(is_safe_url("https://docs.rs/tokio/latest/tokio/"));
         assert!(is_safe_url("https://api.github.com/repos"));
         assert!(is_safe_url("https://example.com"));
+    }
+
+    // ── is_safe_ip tests (#526) ──
+
+    #[test]
+    fn test_is_safe_ip_blocks_private() {
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1))));
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::new(169, 254, 169, 254))));
+        assert!(!is_safe_ip(IpAddr::V4(Ipv4Addr::UNSPECIFIED)));
+        assert!(!is_safe_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(!is_safe_ip(IpAddr::V6(Ipv6Addr::UNSPECIFIED)));
+    }
+
+    #[test]
+    fn test_is_safe_ip_allows_public() {
+        use std::net::{IpAddr, Ipv4Addr};
+        assert!(is_safe_ip(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(is_safe_ip(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+        assert!(is_safe_ip(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))));
     }
 
     #[tokio::test]

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -58,7 +58,10 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
         && let Some(host) = parsed.host_str()
     {
         // Only resolve domain names (IPs are already checked above)
-        if parsed.host().is_some_and(|h| matches!(h, url::Host::Domain(_))) {
+        if parsed
+            .host()
+            .is_some_and(|h| matches!(h, url::Host::Domain(_)))
+        {
             match tokio::net::lookup_host(format!(
                 "{}:{}",
                 host,

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"

--- a/koda-email/src/imap_client.rs
+++ b/koda-email/src/imap_client.rs
@@ -105,8 +105,11 @@ fn search_emails_sync(
 /// - Plain text → searches subject + body via OR
 /// - "from:user@example.com" → FROM filter
 /// - "subject:keyword" → SUBJECT filter
+///
+/// Input is sanitized to prevent IMAP search injection (#529):
+/// backslashes and double-quotes are escaped.
 fn build_search_query(query: &str) -> String {
-    let q = query.trim();
+    let q = sanitize_imap_string(query.trim());
 
     if let Some(addr) = q.strip_prefix("from:") {
         return format!("FROM \"{}\"", addr.trim());
@@ -117,6 +120,11 @@ fn build_search_query(query: &str) -> String {
 
     // Default: search subject OR body
     format!("OR SUBJECT \"{}\" BODY \"{}\"", q, q)
+}
+
+/// Escape backslashes and double-quotes for safe IMAP string interpolation.
+fn sanitize_imap_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Fetch messages by sequence range and parse into summaries.
@@ -223,6 +231,33 @@ mod tests {
             build_search_query("subject:quarterly review"),
             "SUBJECT \"quarterly review\""
         );
+    }
+
+    #[test]
+    fn test_build_search_query_escapes_quotes() {
+        // Injected quotes should be escaped to prevent IMAP injection (#529).
+        // Input: hello" BODY "injected
+        // Without sanitization this would break out of the SUBJECT string
+        // and inject a separate BODY clause.
+        let result = build_search_query("hello\" BODY \"injected");
+        // The escaped output should contain \" (backslash-quote) inside the string
+        assert!(
+            result.contains(r#"\""#),
+            "Should contain escaped quotes: {result}"
+        );
+        // Verify the overall structure is still a single OR SUBJECT/BODY pair
+        // (not broken into separate clauses)
+        assert!(
+            result.starts_with("OR SUBJECT \""),
+            "Should start with OR SUBJECT: {result}"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_imap_string() {
+        assert_eq!(sanitize_imap_string("hello"), "hello");
+        assert_eq!(sanitize_imap_string("say \"hi\""), "say \\\"hi\\\"");
+        assert_eq!(sanitize_imap_string("back\\slash"), "back\\\\slash");
     }
 
     #[test]


### PR DESCRIPTION
## v0.1.16

### Security (6 fixes)
- **EmailSend** reclassified to LocalMutation — requires confirmation in Confirm mode to prevent prompt-injection data exfiltration
- **Bash classifier hardening** — added interpreter commands (`python -c`, `perl -e`, `ruby -e`, `node -e`), nested shells (`sh -c`, `bash -c`), `gh api`, `gh auth`, `gh release delete`, `git clean -f` to DANGEROUS_PATTERNS
- **Bash timeout capped at 300s** — prevents LLM-controlled DoS
- **DNS rebinding SSRF protection** — post-resolution IP validation prevents TOCTOU attacks
- **Symlink read bypass** — canonicalize check after safe_resolve_path for reads
- **IMAP search injection** — quote/backslash escaping in search queries

### Fixed (3)
- **Scroll buffer eviction drift** — `enforce_capacity()` subtracts visual height, not 1
- **`paragraph_scroll()` u16 overflow** — clamps to `u16::MAX`
- **Missing `gh` CLI classifications** — added repo clone, run watch, pr review/comment/close, issue close/reopen, release create, workflow run

### Changed (2)
- **DRY: shared `wrap_util`** — extracted duplicate word-wrap algorithm
- **`config_dir` dedup** — keystore delegates to `db::config_dir()`

### Version bump
`0.1.15` → `0.1.16` across all 4 crates (koda-core, koda-cli, koda-ast, koda-email)

Full test suite passes ✅