### PR TITLE
ci(release): reject tags not on main to enforce PR-first workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Require tag on main
+        run: |
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag must point to a commit on main (merge the PR first)"
+            exit 1
+          fi
       - name: Check tag matches workspace versions
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"


### PR DESCRIPTION
Adds a guard to the release workflow that fails fast if the tag doesn't point to a commit on `main`.

**Problem:** v0.1.16 tag was pushed before the release PR was merged, so the release built from code that hadn't passed CI (clippy caught a `collapsible_if` lint).

**Fix:** `git merge-base --is-ancestor` check in `verify-version` job. No duplicate CI runs — we rely on the PR's CI results and only add the ancestry check.

Closes the process gap without running CI twice.