### PR TITLE
ci: auto-merge Dependabot PRs when CI passes

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,17 @@
+name: Auto-merge Dependabot
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr merge "$PR" --squash --auto
+        env:
+          PR: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that enables auto-merge (squash) on Dependabot PRs. Once all required status checks pass, the PR merges automatically — no manual clicking needed.

Only triggers for `dependabot[bot]` actor, all other PRs remain manual.