### PR TITLE
docs: sharpen design.md + add source code traceability

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -18,6 +18,27 @@ designed for broad adoption with configuration surfaces for many users.
 Koda is the opposite: hyper-specific, opinionated, and changeable with a
 few prompts and a recompile.
 
+What koda specifically rejects from existing tools:
+
+- **Cursor/Windsurf**: Extension and plugin systems, marketplace
+  ecosystems, multi-user configuration surfaces. These create complexity
+  that serves breadth of adoption, not depth of capability. Koda compiles
+  decisions in, it doesn't configure them at runtime (P1)
+- **Claude Code/Codex**: Vendor lock-in to a single provider. Tight
+  coupling to one company's API means the tool's ceiling is set by that
+  company's roadmap. Koda treats providers as interchangeable (P1)
+- **Goose**: Stepped wizards and fullscreen forms that obscure the
+  conversation. Multi-frontend architecture (Electron, Ink TUI, CLI)
+  that adds process management overhead for frontends that don't get
+  used. Koda keeps the conversation as the primary surface and ships
+  one binary (P2)
+- **Aider**: Git-centric workflow that couples the tool to a specific
+  development methodology. Koda is a general assistant, not a git
+  workflow tool (P3)
+
+These aren't aesthetic preferences — each rejection traces to a
+principle.
+
 ## Execution Modes
 
 ```bash
@@ -57,8 +78,11 @@ and a recompile.
 ### P2: Simple enough to own alone
 
 One person builds it, one person maintains it, one person debugs it.
-Every design choice must be easy to reason about. Acceptable rough edges
-are better than polished complexity.
+This is the principle that prevents koda from becoming Cursor. Cursor is
+capable but complex — extension systems, agent modes, model routing
+tiers, configuration surfaces. Koda chooses simplicity: fewer concepts,
+one binary, match dispatch, two approval modes. We'd rather be slightly
+less capable than incomprehensible.
 
 - **Easy to reason about.** If you can't hold the component's behavior in
   your head, it's too complex. Clear component boundaries — engine, UI,
@@ -85,6 +109,15 @@ limitations — they'll be obsolete before they're stable.
   verbose fallback prompts are building for today. Delete them
 - **Expand the surface.** Email, calendar, knowledge management — these
   are bets on where AI will be, not where it is
+
+### When principles conflict
+
+P1 says "build only what we need." P3 says "expand the surface." These
+can conflict. When they do: P1 wins on **timing** (don't build it yet),
+but P3 wins on **architecture** (design so it's easy to add). The
+`Persistence` trait exists because P3 says the storage backend will
+change — but there's only one implementation because P1 says we don't
+need a second one yet.
 
 ---
 

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -6,6 +6,13 @@
 //!
 //! Tool effects are classified via [`crate::tools::ToolEffect`] and bash commands are
 //! further refined by [`crate::bash_safety::classify_bash_command`].
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Security Model (P2)**: Two modes + hardcoded floors. Hardcoded floors
+//!   override mode settings for destructive ops — this is not configurable.
+//! - **File Lifecycle Tracking (P2)**: Auto-approve deleting files koda
+//!   created in the same turn. See [`crate::file_tracker::FileTracker`].
 
 use crate::bash_safety::classify_bash_command;
 use crate::file_tracker::FileTracker;

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -5,6 +5,15 @@
 //!
 //! Design: simple allowlist for safe commands, blocklist for dangerous ones,
 //! everything else defaults to LocalMutation. No hand-rolled parser.
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Folder-Scoped Permissions (P2)**: Bash commands are linted for path
+//!   escapes before execution. This is heuristic — complex pipelines can
+//!   bypass it. The principled fix is kernel-level sandboxing (v1.0 concern).
+//! - **Security Model (P2)**: Three classification tiers feed into the
+//!   approval flow. The LLM is semi-trusted (capable of mistakes, not
+//!   adversarial).
 
 use crate::tools::ToolEffect;
 

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -4,7 +4,15 @@
 //! They are serde-serializable so they can be sent over in-process channels
 //! (CLI mode) or over the wire (ACP server mode).
 //!
-//! # Design Principles
+//! ## Design (docs/design.md)
+//!
+//! - **Engine as a Library, Not a Process (P2, P3)**: The engine communicates
+//!   exclusively through these enums. Zero IO in the engine crate.
+//! - **Async Approval Flow (P3)**: `ApprovalRequest` / `ApprovalResponse` is
+//!   async request/response, not a blocking call. Works identically over
+//!   in-process channels or network transport.
+//!
+//! ### Principles
 //!
 //! - **Semantic, not presentational**: Events describe *what happened*, not
 //!   *how to render it*. The client decides formatting.

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -2,6 +2,14 @@
 //!
 //! Runs the streaming inference → tool execution → re-inference loop
 //! until the LLM produces a final text response.
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Let the model drive (P3)**: The engine is a mechanical loop. It does
+//!   not plan, verify, or make decisions — the model does. This loop streams
+//!   the response, dispatches tool calls, and feeds results back.
+//! - **Rate Limit Retry (P2)**: Exponential backoff for 429 errors. Long
+//!   sessions with Opus hit rate limits regularly.
 
 use crate::approval::ApprovalMode;
 use crate::config::KodaConfig;

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -4,6 +4,14 @@
 //! depends on this trait, not the concrete SQLite implementation.
 //!
 //! The default implementation is `Database` in `db.rs`.
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Database Backend: SQLite + Persistence Trait (P3)**: This trait
+//!   exists because P3 says the storage backend will change. But there's
+//!   only one real implementation because P1 says we don't need a second
+//!   one yet. When P1 and P3 conflict: P1 wins on timing, P3 wins on
+//!   architecture.
 
 use anyhow::Result;
 use std::path::Path;

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -1,6 +1,14 @@
 //! LLM provider abstraction layer.
 //!
 //! Defines a common trait for all providers and re-exports the default.
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Any model, any provider (P1)**: 15 provider types, cloud and local.
+//!   No vendor lock-in. The tool serves the person, not the platform.
+//! - **Context Window Auto-Detection (P1, P3)**: Capabilities are queried
+//!   from the provider API at startup. Hardcoded lookup is the fallback,
+//!   not the primary source.
 
 /// Anthropic Claude API provider.
 pub mod anthropic;

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -1,7 +1,14 @@
 //! Tool execution dispatch — sequential, parallel, and sub-agent.
 //!
-//! Extracted from inference.rs for clarity. Handles tool call
-//! execution, approval flow, and sub-agent delegation.
+//! Handles tool call execution, approval flow, and sub-agent delegation.
+//!
+//! ## Design (docs/design.md)
+//!
+//! - **Tool Dispatch: Match Statement (P2)**: Tools are dispatched via a
+//!   `match` in `ToolRegistry::execute()`, not a `HashMap<String, Box<dyn Tool>>`.
+//!   Rust's exhaustive matching catches missing handlers at compile time.
+//! - **Sub-Agent Model Routing (P1, P3)**: Sub-agents respect their own
+//!   provider/model config. The parent's prompt cache is unaffected.
 
 use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
 use crate::config::KodaConfig;


### PR DESCRIPTION
## What

Borrowed patterns from hunch #77–#79 design.md evolution to sharpen koda's design doc and create live links between source code and architecture.

## Changes

### Vision — articulate what koda specifically rejects

Not just "we're different from Cursor" but *what specifically* we reject and *which principle* drives each rejection:

- **Cursor/Windsurf** → P1: plugin systems and configuration surfaces serve breadth, not depth
- **Claude Code/Codex** → P1: vendor lock-in sets ceiling at one company's roadmap
- **Goose** → P2: stepped wizards and multi-frontend architecture add complexity for unused frontends
- **Aider** → P3: git-centric workflow couples the tool to a specific methodology

### P2 — elevate "easy to reason about"

Added the anti-Cursor framing, parallel to hunch's anti-guessit framing:

> *This is the principle that prevents koda from becoming Cursor. Cursor is capable but complex — extension systems, agent modes, model routing tiers, configuration surfaces. Koda chooses simplicity: fewer concepts, one binary, match dispatch, two approval modes.*

### Principle conflict resolution

Explicit rule for when P1 and P3 disagree:

> *P1 wins on **timing** (don't build it yet), but P3 wins on **architecture** (design so it's easy to add). The `Persistence` trait exists because P3 says the storage backend will change — but there's only one implementation because P1 says we don't need a second one yet.*

### Source code ↔ design doc traceability (7 files)

Each file now references the design decisions that shape it:

| File | Decisions referenced |
|------|---------------------|
| `approval.rs` | Security Model (P2), File Lifecycle Tracking (P2) |
| `tool_dispatch.rs` | Match Statement Dispatch (P2), Sub-Agent Routing (P1, P3) |
| `inference.rs` | Let the Model Drive (P3), Rate Limit Retry (P2) |
| `bash_safety.rs` | Folder-Scoped Permissions (P2), Security Model (P2) |
| `providers/mod.rs` | Any Model Any Provider (P1), Context Window Auto-Detection (P1, P3) |
| `persistence.rs` | SQLite + Persistence Trait (P3), P1 vs P3 conflict resolution |
| `engine/event.rs` | Engine as Library (P2, P3), Async Approval Flow (P3) |

## What we didn't borrow

- Numbered decisions (D1–D9) — koda has 17, topic grouping works better
- The Boundary concept — hunch tried and abandoned it in the same week
- Three-level hierarchy separation — koda's sections blend naturally at current scale

## References

- hunch #77: restructure design.md — principles vs decisions vs boundaries
- hunch #78: flatten Boundary N grouping into numbered decisions
- hunch #79: add Mission section, P1 (easy to reason about), D8–D9