### PR TITLE
docs: clarify 'zero IO' — means zero stdio, not zero fs

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -125,9 +125,11 @@ need a second one yet.
 
 ### Engine as a Library, Not a Process (P2, P3)
 
-The engine is a Rust library crate (`koda-core`) with zero IO.
-It communicates exclusively through `EngineEvent` (output) and `EngineCommand`
-(input) enums. See `koda-core/src/engine/event.rs` for the protocol definition.
+The engine is a Rust library crate (`koda-core`). It communicates
+exclusively through `EngineEvent` (output) and `EngineCommand` (input)
+enums — it never touches stdout, stdin, or stderr. Filesystem access
+for configuration, memory, and tool execution is direct (assumes POSIX).
+See `koda-core/src/engine/event.rs` for the protocol definition.
 
 Studied four projects:
 - **xi-editor**: Used stdio JSON-RPC. Discontinued. Lesson: protocol becomes


### PR DESCRIPTION
The engine never touches stdout/stdin/stderr, but it does read/write config files, memory files, and agent JSON from disk. The previous phrasing 'zero IO' was misleading.

Replaced with a precise statement: zero stdio, direct filesystem access, assumes POSIX.

Closes #534