### PR TITLE
P3: remove hardcoded planning instructions from system prompt

### DIFF
--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -13,15 +13,6 @@ pub fn build_system_prompt(
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
-    // Planning and self-review instructions (#156 P0)
-    prompt.push_str(
-        "\n\n## Planning\n\
-         For complex tasks (>3 steps), outline your plan before executing. \
-         Review feasibility before proceeding.\n\
-         Before executing a multi-step plan, briefly verify each step is \
-         feasible with the information you have.\n",
-    );
-
     // Embed the capabilities reference
     prompt.push_str("\n\n");
     prompt.push_str(include_str!("capabilities.md"));
@@ -104,7 +95,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let result = build_system_prompt("You are helpful.", "", dir.path(), &[]);
         assert!(result.starts_with("You are helpful."));
-        assert!(result.contains("Planning"));
+        assert!(result.contains("Koda Quick Reference"));
         assert!(!result.contains("Project Memory"));
     }
 


### PR DESCRIPTION
The Planning section was added in #156 when Claude 3 Opus sometimes skipped planning steps. Modern models (Claude 4.x with extended thinking, GPT-4.1, Gemini 2.5) plan naturally.

**P3: Don't scaffold around weakness.** This is the engine telling the model how to think. The model already knows.

If a weaker local model needs planning instructions, add them to `CLAUDE.md` — project-level customization (P1), not engine-level scaffolding.

Closes #530