### PR TITLE
P2: replace global context atomics with EngineEvent::ContextUsage

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -117,6 +117,7 @@ pub fn engine_event_to_acp(
         }
 
         EngineEvent::StatusUpdate { .. } => None,
+        EngineEvent::ContextUsage { .. } => None,
         EngineEvent::Footer { .. } => None,
         EngineEvent::SpinnerStart { .. } => None,
         EngineEvent::SpinnerStop => None,

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -208,6 +208,7 @@ impl EngineSink for HeadlessSink {
             EngineEvent::SpinnerStart { .. } => {}
             EngineEvent::SpinnerStop => {}
             EngineEvent::StatusUpdate { .. } => {}
+            EngineEvent::ContextUsage { .. } => {}
             EngineEvent::TurnStart { .. } => {}
             EngineEvent::TurnEnd { .. } => {}
             EngineEvent::Footer {

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -70,6 +70,8 @@ pub(crate) struct TuiContext {
     pub should_quit: bool,
     pub silent_compact_deferred: bool,
     pub inference_start: Option<std::time::Instant>,
+    /// Context window usage percentage (0-100), updated via EngineEvent::ContextUsage.
+    pub context_pct: u32,
     pub history: Vec<String>,
     pub history_idx: Option<usize>,
     pub completer: crate::completer::InputCompleter,
@@ -275,6 +277,7 @@ impl TuiContext {
             should_quit: false,
             silent_compact_deferred: false,
             inference_start: None,
+            context_pct: 0,
             history: load_history(),
             history_idx: None,
             completer,
@@ -298,7 +301,7 @@ impl TuiContext {
         self.scroll_buffer.clamp_offset(w, h);
 
         let mode = approval::read_mode(&self.shared_mode);
-        let ctx = koda_core::context::percentage() as u32;
+        let ctx = self.context_pct;
         let tui_state = self.tui_state;
         let prompt_mode = &self.prompt_mode;
         let queue_len = self.input_queue.len();

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -58,7 +58,7 @@ impl TuiContext {
 
                 // Redraw viewport
                 let mode = approval::read_mode(&self.shared_mode);
-                let ctx = koda_core::context::percentage() as u32;
+                let ctx = self.context_pct;
                 let _ = self.terminal.draw(|f| {
                     draw_viewport(
                         f,
@@ -155,6 +155,10 @@ impl TuiContext {
                         }
                     }
                     Some(ui_event) = ui_rx.recv() => {
+                        // Extract context usage before rendering
+                        if let UiEvent::Engine(EngineEvent::ContextUsage { used, max }) = &ui_event {
+                            self.context_pct = if *max > 0 { (used * 100 / max) as u32 } else { 0 };
+                        }
                         handle_inference_ui_inline(
                             ui_event,
                             &mut self.scroll_buffer,
@@ -185,6 +189,9 @@ impl TuiContext {
 
         // Drain remaining UI events
         while let Ok(UiEvent::Engine(e)) = ui_rx.try_recv() {
+            if let EngineEvent::ContextUsage { used, max } = &e {
+                self.context_pct = if *max > 0 { (used * 100 / max) as u32 } else { 0 };
+            }
             self.renderer.render_to_buffer(e, &mut self.scroll_buffer);
         }
 
@@ -197,7 +204,7 @@ impl TuiContext {
             return;
         }
 
-        let ctx_pct = koda_core::context::percentage();
+        let ctx_pct = self.context_pct as usize;
         if ctx_pct < self.config.auto_compact_threshold {
             return;
         }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -190,7 +190,11 @@ impl TuiContext {
         // Drain remaining UI events
         while let Ok(UiEvent::Engine(e)) = ui_rx.try_recv() {
             if let EngineEvent::ContextUsage { used, max } = &e {
-                self.context_pct = if *max > 0 { (used * 100 / max) as u32 } else { 0 };
+                self.context_pct = if *max > 0 {
+                    (used * 100 / max) as u32
+                } else {
+                    0
+                };
             }
             self.renderer.render_to_buffer(e, &mut self.scroll_buffer);
         }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -184,6 +184,7 @@ impl TuiRenderer {
             }
             EngineEvent::ApprovalRequest { .. }
             | EngineEvent::StatusUpdate { .. }
+            | EngineEvent::ContextUsage { .. }
             | EngineEvent::TurnStart { .. }
             | EngineEvent::TurnEnd { .. }
             | EngineEvent::LoopCapReached { .. } => {

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -117,6 +117,18 @@ pub enum EngineEvent {
     },
 
     // ── Session metadata ──────────────────────────────────────────────
+    /// Context window usage updated after assembling messages.
+    ///
+    /// Emitted once per inference turn so the client can display
+    /// context percentage and trigger auto-compaction without reading
+    /// engine-internal global state.
+    ContextUsage {
+        /// Tokens used in the current context window.
+        used: usize,
+        /// Maximum context window size.
+        max: usize,
+    },
+
     /// Progress/status update for the persistent status bar.
     StatusUpdate {
         /// Current model identifier.

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -67,6 +67,7 @@ async fn assemble_context(
     pending_images: Option<&[ImageData]>,
     iteration: u32,
     max_context_tokens: usize,
+    sink: &dyn EngineSink,
 ) -> Result<Vec<ChatMessage>> {
     let history = db.load_context(session_id).await?;
     let mut messages = assemble_messages(system_message, &history);
@@ -82,6 +83,10 @@ async fn assemble_context(
 
     let context_used = estimate_tokens(&messages);
     crate::context::update(context_used, max_context_tokens);
+    sink.emit(EngineEvent::ContextUsage {
+        used: context_used,
+        max: max_context_tokens,
+    });
 
     Ok(messages)
 }
@@ -135,6 +140,7 @@ async fn preflight_compact_if_needed(
                 pending_images,
                 iteration,
                 config.max_context_tokens,
+                sink,
             )
             .await
         }
@@ -260,6 +266,7 @@ async fn try_overflow_recovery(
         pending_images,
         iteration,
         config.max_context_tokens,
+        sink,
     )
     .await?;
 
@@ -519,6 +526,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             pending_images.as_deref(),
             iteration,
             config.max_context_tokens,
+            sink,
         )
         .await?;
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -20,8 +20,8 @@ pub mod bash_safety;
 pub mod compact;
 /// Global configuration: provider, model, model settings, CLI flags.
 pub mod config;
-/// Context window management and token budgeting.
-pub mod context;
+/// Context window management and token budgeting (engine-internal).
+pub(crate) mod context;
 /// SQLite persistence layer — sessions, messages, usage tracking.
 pub mod db;
 /// Engine protocol: `EngineEvent` / `EngineCommand` enums.


### PR DESCRIPTION
The `context` module used global `AtomicUsize` statics written by the engine and read by the CLI — a hidden side channel that bypassed the `EngineEvent`/`EngineCommand` protocol.

### Changes
- Add `EngineEvent::ContextUsage { used, max }`
- Emit from `assemble_context()` after computing token usage
- CLI stores `context_pct` in `TuiContext`, reads from local state
- Make `context` module `pub(crate)` — CLI can no longer access it

### Data flow

**Before:** `inference.rs → writes global atomic → TUI reads global atomic`
**After:** `inference.rs → emit ContextUsage → TUI receives event → local state`

The engine still uses `context::percentage()` internally for pre-flight compact checks — that's engine-internal state, not a protocol violation.

8 files, +38/-5 lines. All tests pass.

Closes #532