### PR TITLE
release: v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.17] - 2026-03-22
+
+### Fixed
+- **Mouse scroll escape sequences leaking into prompt** (#540) — during
+  inference streaming, `tokio::select!` used random fairness, letting engine
+  events starve terminal input processing. Mouse escape sequences piled up
+  and leaked into the prompt as raw text. Fixed with biased select (terminal
+  input first) and batch-draining engine events to reduce redraws.
+
+### Changed
+- **Remove hardcoded planning instructions from system prompt** (#530, P3) —
+  the Planning section was scaffolding from the Claude 3 Opus era. Modern models
+  (Claude 4.x, GPT-4.1, Gemini 2.5) plan natively. Users who need planning
+  instructions for weaker local models can add them to `CLAUDE.md`.
+- **Context usage via EngineEvent protocol** (#532, P2) — context window
+  tracking now flows through `EngineEvent::ContextUsage` instead of global
+  `AtomicUsize` statics. The `context` module is now `pub(crate)`. CLI reads
+  context percentage from local state updated by events, not from engine globals.
+- **DRY: extract `record_tool_result` helper** (#533, P2) — the 5-step
+  post-execution sequence (emit result, truncate, persist, track progress,
+  track file lifecycle) was duplicated across three execution strategies.
+  Now lives in a single function.
+- **Clarify "zero IO" in design.md** (#534, P2) — replaced misleading "zero IO"
+  with precise statement: zero stdio, direct filesystem access, assumes POSIX.
+
+### Removed
+- **Dead code: `ask_continue_or_stop`** (#531, P1) — replaced by async
+  `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision` flow. Zero callers.
+
 ## [0.1.16] - 2026-03-20
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.16" }
+koda-core = { path = "../koda-core", version = "0.1.17" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.16", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.17", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.16" }
-koda-email = { path = "../koda-email", version = "0.1.16" }
+koda-ast = { path = "../koda-ast", version = "0.1.17" }
+koda-email = { path = "../koda-email", version = "0.1.17" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## v0.1.17

### Fixed
- **Mouse scroll escape sequences leaking into prompt** (#540) — biased `tokio::select!` + batch-drain engine events to prevent terminal input starvation during streaming.

### Changed
- **Remove hardcoded planning instructions from system prompt** (#530, P3) — scaffolding from Claude 3 Opus era. Modern models plan natively.
- **Context usage via EngineEvent protocol** (#532, P2) — replaces global `AtomicUsize` statics with `EngineEvent::ContextUsage`.
- **DRY: extract `record_tool_result` helper** (#533, P2) — deduplicated 5-step post-execution sequence from 3 strategies into 1 function.
- **Clarify "zero IO" in design.md** (#534, P2) — zero stdio, direct filesystem access, assumes POSIX.

### Removed
- **Dead code: `ask_continue_or_stop`** (#531, P1) — replaced by async `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`.

### Housekeeping
- CI: auto-merge Dependabot PRs (#527)
- CI: reject tags not on main (#526)
- Docs: restructure design.md with principles + traceability (#528, #529)