### PR TITLE
fix: remove post-edit AST syntax verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Remove post-edit AST syntax verification** (#544) — `verify_syntax_post_edit()`
+  no longer runs after Write/Edit. Tree-sitter false positives (for example,
+  valid Rust 2024 `&raw[...]`) were worse than no check at all because they
+  derailed the model into trying to "fix" correct code. Compiler/runtime checks
+  remain the authoritative validation path.
+
 ## [0.1.17] - 2026-03-22
 
 ### Fixed

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -938,5 +938,4 @@ mod tests {
             Path::new("/test/project")
         ));
     }
-
 }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -105,33 +105,6 @@ fn resolve_tool_path(
     crate::file_tracker::resolve_file_path_from_args(args, project_root)
 }
 
-/// Post-edit AST syntax check (#467).
-///
-/// After a successful Write/Edit, parse the file with tree-sitter and
-/// append any syntax errors to the tool result. This gives the LLM
-/// immediate feedback to self-correct without user intervention.
-///
-/// Returns the original result unmodified if:
-/// - the file extension isn't supported by koda-ast
-/// - the file can't be read (e.g., binary)
-/// - the file parses cleanly (no errors)
-fn verify_syntax_post_edit(arguments: &str, project_root: &Path, result: &str) -> String {
-    let args: serde_json::Value = match serde_json::from_str(arguments) {
-        Ok(v) => v,
-        Err(_) => return result.to_string(),
-    };
-    let path = match crate::file_tracker::resolve_file_path_from_args(&args, project_root) {
-        Some(p) => p,
-        None => return result.to_string(),
-    };
-    match koda_ast::syntax_check(&path) {
-        Some(errors) => {
-            format!("{result}\n\n{errors}\nFix the syntax errors above before proceeding.")
-        }
-        None => result.to_string(),
-    }
-}
-
 /// Update file lifecycle tracker after a tool execution (#465).
 ///
 /// - Write → track as owned (Koda created it)
@@ -235,13 +208,6 @@ pub(crate) async fn execute_one_tool(
         }
         let r = tools.execute(&tc.function_name, &tc.arguments).await;
         (r.output, r.success)
-    };
-
-    // Post-edit AST verification (#467): if Write/Edit succeeded, check syntax.
-    let result = if success && matches!(tc.function_name.as_str(), "Write" | "Edit") {
-        verify_syntax_post_edit(&tc.arguments, project_root, &result)
-    } else {
-        result
     };
 
     (tc.id.clone(), result, success)
@@ -973,97 +939,4 @@ mod tests {
         ));
     }
 
-    // ── verify_syntax_post_edit tests (#467) ──────────────────────
-
-    #[test]
-    fn test_verify_syntax_clean_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("ok.rs");
-        std::fs::write(&file, "fn main() {}").unwrap();
-        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote ok.rs");
-        assert!(!out.contains("syntax error"), "got: {out}");
-        assert!(out.starts_with("✓ Wrote ok.rs"));
-    }
-
-    #[test]
-    fn test_verify_syntax_broken_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("bad.rs");
-        std::fs::write(&file, "fn main() { let x = ; }").unwrap();
-        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote bad.rs");
-        assert!(out.contains("syntax error"), "got: {out}");
-        assert!(out.contains("Fix the syntax errors"), "got: {out}");
-    }
-
-    #[test]
-    fn test_verify_syntax_unsupported_ext() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("data.csv");
-        std::fs::write(&file, "a,b,c").unwrap();
-        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Wrote data.csv");
-        assert_eq!(out, "✓ Wrote data.csv");
-    }
-
-    #[test]
-    fn test_verify_syntax_bad_json_args() {
-        let out = verify_syntax_post_edit("not json", Path::new("/tmp"), "ok");
-        assert_eq!(out, "ok");
-    }
-
-    /// Simulate the realistic flow: start with valid code, apply a bad edit,
-    /// verify the hook catches the regression.
-    #[test]
-    fn test_verify_syntax_edit_introduces_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("lib.rs");
-
-        // Start with valid code
-        std::fs::write(&file, "fn hello() { println!(\"hi\"); }\n").unwrap();
-        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
-        assert!(
-            !out.contains("syntax error"),
-            "should be clean before edit: {out}"
-        );
-
-        // Simulate a bad edit that breaks the syntax
-        std::fs::write(&file, "fn hello( { println!(\"hi\"); }\n").unwrap();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
-        assert!(
-            out.contains("syntax error"),
-            "should catch regression: {out}"
-        );
-        assert!(
-            out.contains("Fix the syntax errors"),
-            "should instruct LLM: {out}"
-        );
-    }
-
-    /// Opposite flow: start with broken code, apply a fix, verify clean result.
-    #[test]
-    fn test_verify_syntax_edit_fixes_error() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("lib.rs");
-
-        // Start with broken code
-        std::fs::write(&file, "fn hello( { println!(\"hi\"); }\n").unwrap();
-        let args = serde_json::json!({"path": file.to_str().unwrap()}).to_string();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
-        assert!(
-            out.contains("syntax error"),
-            "should be broken before fix: {out}"
-        );
-
-        // Fix the syntax
-        std::fs::write(&file, "fn hello() { println!(\"hi\"); }\n").unwrap();
-        let out = verify_syntax_post_edit(&args, dir.path(), "✓ Edited lib.rs");
-        assert!(
-            !out.contains("syntax error"),
-            "should be clean after fix: {out}"
-        );
-        assert_eq!(out, "✓ Edited lib.rs");
-    }
 }

--- a/koda-core/tests/e2e_tools_test.rs
+++ b/koda-core/tests/e2e_tools_test.rs
@@ -266,10 +266,10 @@ async fn test_write_valid_rust_no_ast_warning() {
     );
 }
 
-/// Regression: Write of broken Rust → tool result SHOULD contain
-/// a syntax error warning appended by the post-edit hook (#504).
+/// Regression: Write of broken Rust should still return the normal Write result.
+/// Post-edit AST verification was removed in #544, so no syntax warning is appended.
 #[tokio::test]
-async fn test_write_broken_rust_gets_ast_warning() {
+async fn test_write_broken_rust_has_no_ast_warning() {
     let env = Env::new().await;
     let target = env.root.join("broken.rs");
 
@@ -283,8 +283,7 @@ async fn test_write_broken_rust_gets_ast_warning() {
                 "content": "fn main() {\n    let x = \n}\n"  // missing expr
             }),
         ),
-        // After seeing the error, LLM responds
-        MockResponse::Text("Oops, syntax error detected.".into()),
+        MockResponse::Text("Write completed.".into()),
     ]);
     let events = env.run_inference(&provider).await;
 
@@ -301,14 +300,19 @@ async fn test_write_broken_rust_gets_ast_warning() {
         .expect("expected Write tool result");
 
     assert!(
-        write_output.contains("SYNTAX ERROR") || write_output.contains("syntax error"),
-        "broken Rust should trigger AST warning in tool result: {write_output}"
+        !write_output.contains("SYNTAX ERROR") && !write_output.contains("syntax error"),
+        "broken Rust should not trigger AST warning in tool result: {write_output}"
+    );
+    assert!(
+        write_output.contains("Written") || write_output.contains("Wrote"),
+        "should still report successful write output: {write_output}"
     );
 }
 
-/// Regression: Edit that introduces a syntax error → AST warning.
+/// Regression: Edit that introduces a syntax error should still return
+/// the normal Edit result without post-edit AST warnings.
 #[tokio::test]
-async fn test_edit_introduces_syntax_error_gets_warning() {
+async fn test_edit_introduces_syntax_error_has_no_ast_warning() {
     let env = Env::new().await;
     let target = env.root.join("fixme.rs");
     std::fs::write(&target, "fn main() {\n    println!(\"ok\");\n}\n").unwrap();
@@ -325,7 +329,7 @@ async fn test_edit_introduces_syntax_error_gets_warning() {
                 ]
             }),
         ),
-        MockResponse::Text("Syntax error introduced.".into()),
+        MockResponse::Text("Edit completed.".into()),
     ]);
     let events = env.run_inference(&provider).await;
 
@@ -342,12 +346,16 @@ async fn test_edit_introduces_syntax_error_gets_warning() {
         .expect("expected Edit tool result");
 
     assert!(
-        edit_output.contains("SYNTAX ERROR") || edit_output.contains("syntax error"),
-        "edit introducing syntax error should be flagged: {edit_output}"
+        !edit_output.contains("SYNTAX ERROR") && !edit_output.contains("syntax error"),
+        "edit introducing syntax error should not be flagged by AST: {edit_output}"
+    );
+    assert!(
+        edit_output.contains("Applied 1 edit(s)"),
+        "should still report successful edit output: {edit_output}"
     );
 }
 
-/// Non-Rust files (e.g., .csv) should NOT trigger AST verification.
+/// Non-Rust files (e.g., .csv) should not trigger any AST verification.
 #[tokio::test]
 async fn test_write_non_parseable_file_no_ast_check() {
     let env = Env::new().await;


### PR DESCRIPTION
## Summary
- remove post-edit AST syntax verification from the Write/Edit execution path
- delete the now-unused `verify_syntax_post_edit()` helper and its unit tests
- update e2e coverage to assert the new behavior: Write/Edit return their normal tool output without tree-sitter syntax warnings
- document the rollback in the changelog

## Why
Per the discussion on #544, AST-based post-edit syntax checks were producing false positives in valid Rust 2024 code like `&raw[...]`, which actively derailed the model into trying to fix correct code. Compiler/runtime checks are the authoritative validation path, so the safest fix is to stop appending AST syntax errors after edits.

Closes #544.

## Testing
- `cargo test -p koda-core --lib tool_dispatch -- --nocapture`
- `cargo test -p koda-core --test e2e_tools_test --features test-support`
- `cargo test --workspace --features test-support`
