### PR TITLE
release: v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.18] - 2026-03-23
+
 ### Fixed
 - **Remove post-edit AST syntax verification** (#544) — `verify_syntax_post_edit()`
   no longer runs after Write/Edit. Tree-sitter false positives (for example,
   valid Rust 2024 `&raw[...]`) were worse than no check at all because they
   derailed the model into trying to "fix" correct code. Compiler/runtime checks
   remain the authoritative validation path.
+- **Relax insert_message perf threshold on Windows CI** (#543) — avoids flaky
+  perf-test failures caused by slower Windows CI timing variance.
 
 ## [0.1.17] - 2026-03-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.17" }
+koda-core = { path = "../koda-core", version = "0.1.18" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.17", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.18", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.17" }
-koda-email = { path = "../koda-email", version = "0.1.17" }
+koda-ast = { path = "../koda-ast", version = "0.1.18" }
+koda-email = { path = "../koda-email", version = "0.1.18" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump all crate versions from `0.1.17` to `0.1.18`
- update `Cargo.lock` for the new crate versions
- roll current `CHANGELOG.md` Unreleased fixes into the `0.1.18` release section

## Included fixes
- #544 — remove post-edit AST syntax verification that produced false positives and derailed edit workflows
- #543 — relax `insert_message` perf threshold on Windows CI to reduce flaky failures

## Validation
- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test -p koda-cli test_cli_version`

## Release note
Do **not** tag before this PR merges. After merge, create the `v0.1.18` tag and let the GitHub release workflow handle the actual release.
