### PR TITLE
fix: normalize tool names from model output to canonical PascalCase (#548)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -627,8 +627,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
         let full_text = stream_result.text;
         // Normalize tool names from model output to canonical PascalCase (#548).
-        // Models (especially local/small ones) may emit lowercase or snake_case
-        // names; this must happen before dispatch, approval, or persistence.
+        // Models (especially local/small ones via OpenAI-compat APIs) may emit
+        // lowercase or snake_case names ("list", "read_file"). This runs for all
+        // providers — the canonical fast-path is a single HashMap lookup — and
+        // must happen here (not in providers) so dispatch, approval, loop guard,
+        // undo, and persistence all see consistent canonical names.
         let tool_calls = crate::tool_normalize::normalize_tool_calls(stream_result.tool_calls);
         let usage = stream_result.usage;
         let char_count = stream_result.char_count;

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -626,7 +626,10 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
 
         let full_text = stream_result.text;
-        let tool_calls = stream_result.tool_calls;
+        // Normalize tool names from model output to canonical PascalCase (#548).
+        // Models (especially local/small ones) may emit lowercase or snake_case
+        // names; this must happen before dispatch, approval, or persistence.
+        let tool_calls = crate::tool_normalize::normalize_tool_calls(stream_result.tool_calls);
         let usage = stream_result.usage;
         let char_count = stream_result.char_count;
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -66,6 +66,8 @@ pub mod skills;
 pub mod sub_agent_cache;
 /// Tool dispatch — routes tool calls from inference to the registry.
 pub mod tool_dispatch;
+/// Tool name normalization — maps model-emitted variants to canonical PascalCase.
+pub mod tool_normalize;
 /// Tool registry, definitions, execution, and path safety.
 pub mod tools;
 /// Token-safe output truncation.

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -244,7 +244,15 @@ mod tests {
     fn ambiguous_names_not_mapped() {
         // These could plausibly map to multiple tools.
         // Better to surface "Unknown tool" than silently misroute.
-        for name in ["search", "execute", "exec", "patch", "terminal", "find_files", "fetch"] {
+        for name in [
+            "search",
+            "execute",
+            "exec",
+            "patch",
+            "terminal",
+            "find_files",
+            "fetch",
+        ] {
             let result = normalize_tool_name(name);
             assert_eq!(
                 result, name,
@@ -323,8 +331,7 @@ mod tests {
 
     #[test]
     fn all_alias_targets_are_canonical() {
-        let canonical_set: std::collections::HashSet<&str> =
-            CANONICAL.iter().copied().collect();
+        let canonical_set: std::collections::HashSet<&str> = CANONICAL.iter().copied().collect();
         for (alias, &target) in ALIASES.iter() {
             assert!(
                 canonical_set.contains(target),

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -1,0 +1,315 @@
+//! Tool name normalization — maps model-emitted variants to canonical PascalCase.
+//!
+//! Models (especially smaller/local ones via OpenAI-compatible APIs) sometimes
+//! emit tool names in lowercase (`list`, `read`) or snake_case (`list_files`,
+//! `read_file`) instead of the canonical PascalCase (`List`, `Read`). This
+//! module provides a single normalization point at the API boundary so all
+//! downstream code (dispatch, approval, loop guard, undo) sees canonical names.
+//!
+//! ## Design
+//!
+//! - Normalization is applied *once*, in `inference.rs`, after collecting
+//!   the streamed response — before dispatch, approval, or persistence.
+//! - Unknown names pass through unchanged so the dispatcher can surface
+//!   a clear `Unknown tool` error.
+//! - The alias map covers lowercase, snake_case, and camelCase variants.
+//!
+//! See: <https://github.com/lijunzh/koda/issues/548>
+//!      <https://github.com/lijunzh/koda/issues/49>
+
+use crate::providers::ToolCall;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// All canonical (PascalCase) built-in tool names.
+const CANONICAL: &[&str] = &[
+    "ActivateSkill",
+    "AstAnalysis",
+    "Bash",
+    "Delete",
+    "Edit",
+    "EmailRead",
+    "EmailSearch",
+    "EmailSend",
+    "Glob",
+    "Grep",
+    "InvokeAgent",
+    "List",
+    "ListAgents",
+    "ListSkills",
+    "MemoryRead",
+    "MemoryWrite",
+    "Read",
+    "RecallContext",
+    "WebFetch",
+    "Write",
+];
+
+/// Static alias map: lowercased variant → canonical name.
+///
+/// Built once on first access.  Includes:
+/// - lowercase of every canonical name  (`"list"` → `"List"`)
+/// - common snake_case alternatives     (`"list_files"` → `"List"`)
+/// - common camelCase alternatives       (`"listFiles"` → `"List"`)
+static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+
+    // Auto-generate lowercase mappings for every canonical name.
+    for &name in CANONICAL {
+        m.insert(name.to_lowercase(), name);
+    }
+
+    // ── Additional snake_case / camelCase aliases ────────────────
+    //
+    // These cover names models commonly hallucinate based on training
+    // data from other tool-calling frameworks.
+
+    // File tools
+    m.insert("list_files".into(), "List");
+    m.insert("listfiles".into(), "List");
+    m.insert("list_directory".into(), "List");
+    m.insert("ls".into(), "List");
+
+    m.insert("read_file".into(), "Read");
+    m.insert("readfile".into(), "Read");
+    m.insert("file_read".into(), "Read");
+
+    m.insert("write_file".into(), "Write");
+    m.insert("writefile".into(), "Write");
+    m.insert("create_file".into(), "Write");
+    m.insert("file_write".into(), "Write");
+
+    m.insert("edit_file".into(), "Edit");
+    m.insert("editfile".into(), "Edit");
+    m.insert("file_edit".into(), "Edit");
+    m.insert("patch".into(), "Edit");
+
+    m.insert("delete_file".into(), "Delete");
+    m.insert("deletefile".into(), "Delete");
+    m.insert("remove_file".into(), "Delete");
+    m.insert("rm".into(), "Delete");
+
+    // Search tools
+    m.insert("grep_search".into(), "Grep");
+    m.insert("search".into(), "Grep");
+    m.insert("ripgrep".into(), "Grep");
+    m.insert("rg".into(), "Grep");
+
+    m.insert("glob_search".into(), "Glob");
+    m.insert("glob_pattern".into(), "Glob");
+    m.insert("find_files".into(), "Glob");
+
+    // Shell
+    m.insert("shell".into(), "Bash");
+    m.insert("run_command".into(), "Bash");
+    m.insert("run_shell_command".into(), "Bash");
+    m.insert("execute".into(), "Bash");
+    m.insert("exec".into(), "Bash");
+    m.insert("terminal".into(), "Bash");
+
+    // Web
+    m.insert("web_fetch".into(), "WebFetch");
+    m.insert("webfetch".into(), "WebFetch");
+    m.insert("fetch".into(), "WebFetch");
+    m.insert("http_get".into(), "WebFetch");
+    m.insert("curl".into(), "WebFetch");
+
+    // Memory
+    m.insert("memory_read".into(), "MemoryRead");
+    m.insert("memory_write".into(), "MemoryWrite");
+
+    // Agent tools
+    m.insert("list_agents".into(), "ListAgents");
+    m.insert("invoke_agent".into(), "InvokeAgent");
+    m.insert("invokeagent".into(), "InvokeAgent");
+
+    // Skill tools
+    m.insert("list_skills".into(), "ListSkills");
+    m.insert("activate_skill".into(), "ActivateSkill");
+    m.insert("activateskill".into(), "ActivateSkill");
+
+    // AST
+    m.insert("ast_analysis".into(), "AstAnalysis");
+    m.insert("astanalysis".into(), "AstAnalysis");
+    m.insert("analyze_ast".into(), "AstAnalysis");
+
+    // Email
+    m.insert("email_read".into(), "EmailRead");
+    m.insert("email_send".into(), "EmailSend");
+    m.insert("email_search".into(), "EmailSearch");
+
+    // Recall
+    m.insert("recall_context".into(), "RecallContext");
+    m.insert("recallcontext".into(), "RecallContext");
+    m.insert("recall".into(), "RecallContext");
+
+    m
+});
+
+/// Normalize a single tool name to its canonical PascalCase form.
+///
+/// Returns the canonical name if a mapping exists, otherwise returns
+/// the input unchanged (so the dispatcher can surface a proper error).
+pub fn normalize_tool_name(name: &str) -> String {
+    // Fast path: already canonical (avoids allocation + lookup)
+    if CANONICAL.contains(&name) {
+        return name.to_string();
+    }
+
+    // Lookup by lowercased input
+    let lower = name.to_lowercase();
+    if let Some(&canonical) = ALIASES.get(&lower) {
+        return canonical.to_string();
+    }
+
+    // Unknown — pass through for the dispatcher to handle
+    name.to_string()
+}
+
+/// Normalize all tool calls in a batch.
+///
+/// Called once after `collect_stream()` returns, before dispatch/approval.
+pub fn normalize_tool_calls(tool_calls: Vec<ToolCall>) -> Vec<ToolCall> {
+    tool_calls
+        .into_iter()
+        .map(|mut tc| {
+            tc.function_name = normalize_tool_name(&tc.function_name);
+            tc
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Canonical names pass through unchanged ──────────────────
+
+    #[test]
+    fn canonical_names_unchanged() {
+        for &name in CANONICAL {
+            assert_eq!(normalize_tool_name(name), name);
+        }
+    }
+
+    // ── Lowercase variants ──────────────────────────────────────
+
+    #[test]
+    fn lowercase_variants() {
+        assert_eq!(normalize_tool_name("list"), "List");
+        assert_eq!(normalize_tool_name("read"), "Read");
+        assert_eq!(normalize_tool_name("write"), "Write");
+        assert_eq!(normalize_tool_name("edit"), "Edit");
+        assert_eq!(normalize_tool_name("delete"), "Delete");
+        assert_eq!(normalize_tool_name("bash"), "Bash");
+        assert_eq!(normalize_tool_name("grep"), "Grep");
+        assert_eq!(normalize_tool_name("glob"), "Glob");
+        assert_eq!(normalize_tool_name("webfetch"), "WebFetch");
+    }
+
+    // ── Snake_case variants ─────────────────────────────────────
+
+    #[test]
+    fn snake_case_variants() {
+        assert_eq!(normalize_tool_name("list_files"), "List");
+        assert_eq!(normalize_tool_name("read_file"), "Read");
+        assert_eq!(normalize_tool_name("write_file"), "Write");
+        assert_eq!(normalize_tool_name("edit_file"), "Edit");
+        assert_eq!(normalize_tool_name("delete_file"), "Delete");
+        assert_eq!(normalize_tool_name("run_shell_command"), "Bash");
+        assert_eq!(normalize_tool_name("grep_search"), "Grep");
+        assert_eq!(normalize_tool_name("glob_search"), "Glob");
+        assert_eq!(normalize_tool_name("web_fetch"), "WebFetch");
+        assert_eq!(normalize_tool_name("list_agents"), "ListAgents");
+        assert_eq!(normalize_tool_name("invoke_agent"), "InvokeAgent");
+        assert_eq!(normalize_tool_name("list_skills"), "ListSkills");
+        assert_eq!(normalize_tool_name("activate_skill"), "ActivateSkill");
+        assert_eq!(normalize_tool_name("email_read"), "EmailRead");
+        assert_eq!(normalize_tool_name("email_send"), "EmailSend");
+        assert_eq!(normalize_tool_name("email_search"), "EmailSearch");
+        assert_eq!(normalize_tool_name("memory_read"), "MemoryRead");
+        assert_eq!(normalize_tool_name("memory_write"), "MemoryWrite");
+        assert_eq!(normalize_tool_name("recall_context"), "RecallContext");
+        assert_eq!(normalize_tool_name("ast_analysis"), "AstAnalysis");
+    }
+
+    // ── Short aliases (model hallucinations) ────────────────────
+
+    #[test]
+    fn short_aliases() {
+        assert_eq!(normalize_tool_name("ls"), "List");
+        assert_eq!(normalize_tool_name("rm"), "Delete");
+        assert_eq!(normalize_tool_name("rg"), "Grep");
+        assert_eq!(normalize_tool_name("search"), "Grep");
+        assert_eq!(normalize_tool_name("shell"), "Bash");
+        assert_eq!(normalize_tool_name("exec"), "Bash");
+        assert_eq!(normalize_tool_name("fetch"), "WebFetch");
+        assert_eq!(normalize_tool_name("recall"), "RecallContext");
+    }
+
+    // ── Case insensitivity ──────────────────────────────────────
+
+    #[test]
+    fn mixed_case_normalized() {
+        assert_eq!(normalize_tool_name("LIST"), "List");
+        assert_eq!(normalize_tool_name("List"), "List");
+        assert_eq!(normalize_tool_name("lIsT"), "List");
+        assert_eq!(normalize_tool_name("READ"), "Read");
+        assert_eq!(normalize_tool_name("BASH"), "Bash");
+        assert_eq!(normalize_tool_name("LIST_FILES"), "List");
+        assert_eq!(normalize_tool_name("Read_File"), "Read");
+    }
+
+    // ── Unknown names pass through ──────────────────────────────
+
+    #[test]
+    fn unknown_names_pass_through() {
+        assert_eq!(normalize_tool_name("FooBar"), "FooBar");
+        assert_eq!(normalize_tool_name("totally_unknown"), "totally_unknown");
+        assert_eq!(normalize_tool_name(""), "");
+    }
+
+    // ── Batch normalization ─────────────────────────────────────
+
+    #[test]
+    fn normalize_batch() {
+        let calls = vec![
+            ToolCall {
+                id: "1".into(),
+                function_name: "list".into(),
+                arguments: "{}".into(),
+                thought_signature: None,
+            },
+            ToolCall {
+                id: "2".into(),
+                function_name: "read_file".into(),
+                arguments: r#"{"path":"x"}"#.into(),
+                thought_signature: None,
+            },
+            ToolCall {
+                id: "3".into(),
+                function_name: "Read".into(), // already canonical
+                arguments: r#"{"path":"y"}"#.into(),
+                thought_signature: None,
+            },
+        ];
+        let normalized = normalize_tool_calls(calls);
+        assert_eq!(normalized[0].function_name, "List");
+        assert_eq!(normalized[1].function_name, "Read");
+        assert_eq!(normalized[2].function_name, "Read");
+    }
+
+    // ── Every canonical name has a lowercase alias ──────────────
+
+    #[test]
+    fn all_canonical_names_have_lowercase_alias() {
+        for &name in CANONICAL {
+            let lower = name.to_lowercase();
+            assert_eq!(
+                normalize_tool_name(&lower),
+                name,
+                "Missing lowercase alias for '{name}'"
+            );
+        }
+    }
+}

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -48,21 +48,29 @@ const CANONICAL: &[&str] = &[
 /// Static alias map: lowercased variant → canonical name.
 ///
 /// Built once on first access.  Includes:
-/// - lowercase of every canonical name  (`"list"` → `"List"`)
-/// - common snake_case alternatives     (`"list_files"` → `"List"`)
-/// - common camelCase alternatives       (`"listFiles"` → `"List"`)
+/// - self-mappings for every canonical name (lowercased key → itself)
+/// - unambiguous snake_case alternatives   (`"list_files"` → `"List"`)
+///
+/// **Only unambiguous aliases are included.** If a name could plausibly
+/// map to more than one tool (e.g. `"search"` → Grep or Glob?), it is
+/// intentionally omitted — surfacing an `Unknown tool` error is better
+/// than silently misrouting to the wrong tool.
 static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     let mut m = HashMap::new();
 
-    // Auto-generate lowercase mappings for every canonical name.
+    // Self-mappings: canonical names (lowercased) → themselves.
+    // This lets normalize_tool_name() do a single O(1) lookup for
+    // every path, including the fast-path where the name is already
+    // canonical.
     for &name in CANONICAL {
         m.insert(name.to_lowercase(), name);
     }
 
-    // ── Additional snake_case / camelCase aliases ────────────────
+    // ── Unambiguous snake_case / camelCase aliases ───────────────
     //
-    // These cover names models commonly hallucinate based on training
-    // data from other tool-calling frameworks.
+    // Only include aliases where the mapping is unambiguous.
+    // If a short name could plausibly mean multiple tools, leave it
+    // out — an "Unknown tool" error is better than silent misrouting.
 
     // File tools
     m.insert("list_files".into(), "List");
@@ -82,7 +90,6 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     m.insert("edit_file".into(), "Edit");
     m.insert("editfile".into(), "Edit");
     m.insert("file_edit".into(), "Edit");
-    m.insert("patch".into(), "Edit");
 
     m.insert("delete_file".into(), "Delete");
     m.insert("deletefile".into(), "Delete");
@@ -91,26 +98,19 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
 
     // Search tools
     m.insert("grep_search".into(), "Grep");
-    m.insert("search".into(), "Grep");
     m.insert("ripgrep".into(), "Grep");
     m.insert("rg".into(), "Grep");
 
     m.insert("glob_search".into(), "Glob");
     m.insert("glob_pattern".into(), "Glob");
-    m.insert("find_files".into(), "Glob");
 
-    // Shell
+    // Shell — only unambiguous aliases
     m.insert("shell".into(), "Bash");
     m.insert("run_command".into(), "Bash");
     m.insert("run_shell_command".into(), "Bash");
-    m.insert("execute".into(), "Bash");
-    m.insert("exec".into(), "Bash");
-    m.insert("terminal".into(), "Bash");
 
     // Web
     m.insert("web_fetch".into(), "WebFetch");
-    m.insert("webfetch".into(), "WebFetch");
-    m.insert("fetch".into(), "WebFetch");
     m.insert("http_get".into(), "WebFetch");
     m.insert("curl".into(), "WebFetch");
 
@@ -121,16 +121,13 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     // Agent tools
     m.insert("list_agents".into(), "ListAgents");
     m.insert("invoke_agent".into(), "InvokeAgent");
-    m.insert("invokeagent".into(), "InvokeAgent");
 
     // Skill tools
     m.insert("list_skills".into(), "ListSkills");
     m.insert("activate_skill".into(), "ActivateSkill");
-    m.insert("activateskill".into(), "ActivateSkill");
 
     // AST
     m.insert("ast_analysis".into(), "AstAnalysis");
-    m.insert("astanalysis".into(), "AstAnalysis");
     m.insert("analyze_ast".into(), "AstAnalysis");
 
     // Email
@@ -140,7 +137,6 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
 
     // Recall
     m.insert("recall_context".into(), "RecallContext");
-    m.insert("recallcontext".into(), "RecallContext");
     m.insert("recall".into(), "RecallContext");
 
     m
@@ -151,12 +147,9 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
 /// Returns the canonical name if a mapping exists, otherwise returns
 /// the input unchanged (so the dispatcher can surface a proper error).
 pub fn normalize_tool_name(name: &str) -> String {
-    // Fast path: already canonical (avoids allocation + lookup)
-    if CANONICAL.contains(&name) {
-        return name.to_string();
-    }
-
-    // Lookup by lowercased input
+    // Single O(1) lookup: lowercase the input and check the alias map.
+    // Canonical names are self-mapped (e.g. "list" → "List"), so this
+    // handles both the fast-path and the alias-path in one operation.
     let lower = name.to_lowercase();
     if let Some(&canonical) = ALIASES.get(&lower) {
         return canonical.to_string();
@@ -240,11 +233,24 @@ mod tests {
         assert_eq!(normalize_tool_name("ls"), "List");
         assert_eq!(normalize_tool_name("rm"), "Delete");
         assert_eq!(normalize_tool_name("rg"), "Grep");
-        assert_eq!(normalize_tool_name("search"), "Grep");
         assert_eq!(normalize_tool_name("shell"), "Bash");
-        assert_eq!(normalize_tool_name("exec"), "Bash");
-        assert_eq!(normalize_tool_name("fetch"), "WebFetch");
+        assert_eq!(normalize_tool_name("curl"), "WebFetch");
         assert_eq!(normalize_tool_name("recall"), "RecallContext");
+    }
+
+    // ── Ambiguous names are NOT mapped (silent misrouting prevention) ──
+
+    #[test]
+    fn ambiguous_names_not_mapped() {
+        // These could plausibly map to multiple tools.
+        // Better to surface "Unknown tool" than silently misroute.
+        for name in ["search", "execute", "exec", "patch", "terminal", "find_files", "fetch"] {
+            let result = normalize_tool_name(name);
+            assert_eq!(
+                result, name,
+                "'{name}' should NOT be mapped — it's ambiguous"
+            );
+        }
     }
 
     // ── Case insensitivity ──────────────────────────────────────
@@ -309,6 +315,20 @@ mod tests {
                 normalize_tool_name(&lower),
                 name,
                 "Missing lowercase alias for '{name}'"
+            );
+        }
+    }
+
+    // ── Every alias target must be a canonical tool name ────────
+
+    #[test]
+    fn all_alias_targets_are_canonical() {
+        let canonical_set: std::collections::HashSet<&str> =
+            CANONICAL.iter().copied().collect();
+        for (alias, &target) in ALIASES.iter() {
+            assert!(
+                canonical_set.contains(target),
+                "Alias '{alias}' maps to '{target}' which is not in CANONICAL"
             );
         }
     }

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -1,0 +1,112 @@
+//! Integration tests for tool name normalization (#548).
+//!
+//! Verifies that lowercase and snake_case tool names are properly
+//! normalized before reaching the dispatcher.
+
+use std::path::PathBuf;
+
+/// After normalization, every canonical tool should be routable.
+/// This catches regressions where a new tool is added to the registry
+/// but forgotten in the normalizer's CANONICAL list.
+#[tokio::test]
+async fn normalized_lowercase_names_are_routable() {
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
+
+    // These are the exact names a small model might emit (the #548 repro).
+    let lowercase_names = [
+        "list",
+        "read",
+        "write",
+        "edit",
+        "delete",
+        "bash",
+        "grep",
+        "glob",
+        "webfetch",
+        "memoryread",
+        "memorywrite",
+        "listagents",
+        "listskills",
+        "activateskill",
+        "recallcontext",
+        "astanalysis",
+    ];
+
+    for raw_name in lowercase_names {
+        let canonical = koda_core::tool_normalize::normalize_tool_name(raw_name);
+        assert!(
+            registry.has_tool(&canonical),
+            "Normalized '{raw_name}' -> '{canonical}' is not in the registry"
+        );
+        let result = registry.execute(&canonical, "{}").await;
+        assert!(
+            !result.output.contains("Unknown tool"),
+            "'{raw_name}' normalized to '{canonical}' but dispatcher rejected it: {}",
+            result.output
+        );
+    }
+}
+
+/// Snake_case names (common in OpenAI-compatible model output) should resolve.
+#[tokio::test]
+async fn normalized_snake_case_names_are_routable() {
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
+
+    let snake_names = [
+        ("list_files", "List"),
+        ("read_file", "Read"),
+        ("write_file", "Write"),
+        ("edit_file", "Edit"),
+        ("delete_file", "Delete"),
+        ("run_shell_command", "Bash"),
+        ("grep_search", "Grep"),
+        ("web_fetch", "WebFetch"),
+        ("list_agents", "ListAgents"),
+        ("invoke_agent", "InvokeAgent"),
+        ("email_read", "EmailRead"),
+        ("email_send", "EmailSend"),
+        ("email_search", "EmailSearch"),
+        ("memory_read", "MemoryRead"),
+        ("memory_write", "MemoryWrite"),
+        ("recall_context", "RecallContext"),
+    ];
+
+    for (raw, expected) in snake_names {
+        let canonical = koda_core::tool_normalize::normalize_tool_name(raw);
+        assert_eq!(
+            canonical, expected,
+            "'{raw}' should normalize to '{expected}', got '{canonical}'"
+        );
+        let result = registry.execute(&canonical, "{}").await;
+        assert!(
+            !result.output.contains("Unknown tool"),
+            "'{raw}' -> '{canonical}' rejected by dispatcher: {}",
+            result.output
+        );
+    }
+}
+
+/// The normalizer's CANONICAL list must stay in sync with the actual registry.
+/// If this fails, a tool was added to the registry but not to the normalizer.
+#[test]
+fn normalizer_covers_all_registry_tools() {
+    let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
+    let registry_names: std::collections::HashSet<String> =
+        registry.all_builtin_tool_names().into_iter().collect();
+
+    for name in &registry_names {
+        let roundtripped = koda_core::tool_normalize::normalize_tool_name(name);
+        assert_eq!(
+            &roundtripped, name,
+            "Registry tool '{name}' is not in normalizer CANONICAL list"
+        );
+
+        // Lowercase variant should also resolve
+        let lower = name.to_lowercase();
+        let from_lower = koda_core::tool_normalize::normalize_tool_name(&lower);
+        assert_eq!(
+            &from_lower, name,
+            "Lowercase '{lower}' should normalize to '{name}'"
+        );
+    }
+}

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -26,6 +26,7 @@ async fn normalized_lowercase_names_are_routable() {
         "memoryread",
         "memorywrite",
         "listagents",
+        "invokeagent",
         "listskills",
         "activateskill",
         "recallcontext",


### PR DESCRIPTION
## Summary

Fixes #548 — Models (especially local/small ones via LM Studio) emit lowercase or snake_case tool names (`list`, `list_files`, `read_file`) instead of PascalCase (`List`, `Read`). This caused `Unknown tool` errors and infinite retry loops.

## Root cause

The dispatcher (`tools/mod.rs`) and approval system (`approval.rs`) do exact PascalCase matching, but the OpenAI-compatible provider path returns raw model-emitted names with no normalization. Issue #49 identified this class of bug but the fix was incomplete.

## What this PR does

**New module: `koda-core/src/tool_normalize.rs`** (315 lines)

- `LazyLock<HashMap>` alias map covering:
  - Automatic lowercase mappings for all 20 canonical tools
  - Common snake_case variants (`list_files` → `List`, `read_file` → `Read`, etc.)
  - Short aliases models hallucinate (`ls` → `List`, `rm` → `Delete`, `rg` → `Grep`)
- `normalize_tool_name()` — single name normalization with fast-path for canonical names
- `normalize_tool_calls()` — batch normalization for tool call vectors

**Modified: `koda-core/src/inference.rs`** (4-line change)

- Normalize tool calls once after `collect_stream()` returns, before dispatch/approval/persistence
- Single boundary normalization point (DRY, not scattered across consumers)

## Design decisions

| Decision | Rationale |
|----------|-----------|
| **Keep PascalCase** | Already embedded in 20 tools, dispatch, approval, tests. Would be massive refactor. |
| **Normalize at boundary** | Single point in inference.rs, not at every consumer. DRY + SRP. |
| **Unknown passthrough** | Unknown names pass through so dispatcher gives clear errors. |
| **Static alias map** | `LazyLock<HashMap>` — O(1) lookup, built once, zero runtime cost after init. |

## Tests

**8 unit tests** (in `tool_normalize.rs`):
- Canonical passthrough, lowercase, snake_case, short aliases, mixed case, unknowns, batch, sync check

**3 integration tests** (in `tests/tool_normalize_test.rs`):
- Lowercase names routable through dispatcher
- Snake_case names routable through dispatcher
- Normalizer CANONICAL list synced with registry

All existing tests pass (tool_wiring_test, new_tools_test).

## Repro from the issue

```
Provider: lm-studio (zai-org/glm-4.6v-flash)
> ls
● list
│ Error: Unknown tool: list
⚠ Loop detected: list is repeating with identical arguments.
```

After this fix: `list` → `List` → dispatched correctly ✅
