### PR TITLE
fix: default List tool to non-recursive listing

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -126,7 +126,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     },
                     "recursive": {
                         "type": "boolean",
-                        "description": "Whether to recurse into subdirectories (default: true)"
+                        "description": "Whether to recurse into subdirectories (default: false)"
                     }
                 }
             }),
@@ -398,7 +398,7 @@ fn count_dir_entries(path: &Path) -> usize {
 /// Entry cap is set by `OutputCaps` (context-scaled).
 pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -> Result<String> {
     let path_str = args["path"].as_str().unwrap_or(".");
-    let recursive = args["recursive"].as_bool().unwrap_or(true);
+    let recursive = args["recursive"].as_bool().unwrap_or(false);
     let resolved = safe_resolve_path(project_root, path_str)?;
 
     let mut entries = Vec::new();


### PR DESCRIPTION
## Summary

Fixes #551 — a bare `ls` was producing a full recursive project dump instead of a simple top-level directory listing.

## Root cause

The `List` tool's `recursive` parameter defaulted to `true`. When a model omitted the optional parameter (perfectly reasonable for a bare `ls`), it triggered a full recursive walk.

## Changes

Two-line fix in `koda-core/src/tools/file_tools.rs`:

- Flip `recursive` default from `true` → `false` (line 401)
- Update the tool description to match: `(default: false)` (line 129)

## Why this is safe

- Models that need recursive listing can still explicitly set `recursive: true`
- Aligns with `Delete` tool, which already defaults `recursive` to `false`
- Matches shell-style user expectations (`ls` = top-level, `ls -R` = recursive)