### PR TITLE
chore: release v0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-03-24
+
+### Fixed
+- **Filter `<|begin_of_box|>` / `<|end_of_box|>` tokens from streamed output**
+  (#550) — these special tokens were leaking into user-visible assistant
+  responses. Added to the `SPECIAL_TOKENS` list in `stream_tag_filter.rs` and
+  bumped `MAX_TAG_LEN` from 16 to 17. Includes regression tests for
+  single-chunk, cross-chunk, and multi-token scenarios.
+- **Default `List` tool to non-recursive listing** (#551) — a bare `ls` was
+  producing a full recursive project dump. Flipped the `recursive` parameter
+  default from `true` to `false` so omitting the parameter gives a shell-style
+  top-level listing. Models can still explicitly set `recursive=true`.
+- **Normalize tool names from model output to canonical PascalCase** (#548) —
+  models sometimes emit tool names in varying cases (e.g. `read`, `READ`,
+  `read_file`). Tool dispatch now normalizes to canonical names before lookup.
+
 ## [0.1.18] - 2026-03-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.18" }
+koda-core = { path = "../koda-core", version = "0.1.19" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.18", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.19", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.18" }
-koda-email = { path = "../koda-email", version = "0.1.18" }
+koda-ast = { path = "../koda-ast", version = "0.1.19" }
+koda-email = { path = "../koda-email", version = "0.1.19" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.1.19

Bumps all workspace crates from 0.1.18 → 0.1.19.

### What's included

| PR | Fix |
|----|-----|
| #549 | Normalize tool names to canonical PascalCase |
| #552 | Filter `<\|begin_of_box\|>` / `<\|end_of_box\|>` from streamed output |
| #553 | Default `List` tool to non-recursive listing |

### Checklist

- [x] All 4 crate versions bumped (koda-core, koda-cli, koda-ast, koda-email)
- [x] Cargo.lock updated
- [x] CHANGELOG.md updated
- [x] `cargo check` passes

### Post-merge

After merging, tag and push to trigger the release workflow:

```bash
git tag v0.1.19
git push origin v0.1.19
```