### PR TITLE
feat(approval): allow /tmp and /dev/* without confirmation

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -230,6 +230,8 @@ fn resolve_effect(tool_name: &str, args: &serde_json::Value) -> ToolEffect {
 
 /// Whether a file tool targets a path outside the project root (#218).
 /// Hardcoded floor: always NeedsConfirmation regardless of mode.
+///
+/// Temp directories (`/tmp`, `$TMPDIR`) are explicitly allowed (#560).
 fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &Path) -> bool {
     let path_arg = match tool_name {
         "Write" | "Edit" | "Delete" => args
@@ -260,7 +262,12 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
             let canon_root = project_root
                 .canonicalize()
                 .unwrap_or_else(|_| project_root.to_path_buf());
-            !resolved.starts_with(&canon_root)
+            let outside = !resolved.starts_with(&canon_root);
+            // Allow temp directories (#560)
+            if outside && crate::bash_path_lint::is_safe_external_path(&resolved) {
+                return false;
+            }
+            outside
         }
         None => false,
     }
@@ -513,7 +520,7 @@ mod tests {
     #[test]
     fn test_bash_cd_outside_needs_confirmation() {
         let root = Path::new("/home/user/project");
-        let args = serde_json::json!({"command": "cd /tmp && ls"});
+        let args = serde_json::json!({"command": "cd /etc && ls"});
         assert_eq!(
             check_tool("Bash", &args, ApprovalMode::Auto, Some(root),),
             ToolApproval::NeedsConfirmation,
@@ -536,6 +543,41 @@ mod tests {
         assert_eq!(
             check_tool("Write", &args, ApprovalMode::Auto, None),
             ToolApproval::AutoApprove,
+        );
+    }
+
+    // ── Temp path allowlist (#560) ──
+
+    #[test]
+    fn test_write_to_tmp_auto_approved() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"path": "/tmp/issue-draft.md"});
+        assert_eq!(
+            check_tool("Write", &args, ApprovalMode::Auto, Some(root)),
+            ToolApproval::AutoApprove,
+            "/tmp writes should auto-approve"
+        );
+    }
+
+    #[test]
+    fn test_bash_cd_tmp_auto_approved() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"command": "cd /tmp && ls"});
+        assert_eq!(
+            check_tool("Bash", &args, ApprovalMode::Auto, Some(root)),
+            ToolApproval::AutoApprove,
+            "cd /tmp should auto-approve"
+        );
+    }
+
+    #[test]
+    fn test_write_to_etc_still_blocked() {
+        let root = Path::new("/home/user/project");
+        let args = serde_json::json!({"path": "/etc/hosts"});
+        assert_eq!(
+            check_tool("Write", &args, ApprovalMode::Auto, Some(root)),
+            ToolApproval::NeedsConfirmation,
+            "/etc writes should still need confirmation"
         );
     }
 

--- a/koda-core/src/bash_path_lint.rs
+++ b/koda-core/src/bash_path_lint.rs
@@ -4,10 +4,44 @@
 //! Dynamic targets (`cd $VAR`, `cd $(cmd)`) are intentionally ignored.
 
 use path_clean::PathClean;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::bash_safety::split_command_segments;
 use crate::bash_safety::strip_env_vars;
+
+/// Whether `resolved` is a path that is safe to access outside the project root.
+///
+/// Safe paths include:
+/// - Temp directories: `/tmp`, `$TMPDIR` (on macOS `/tmp` → `/private/tmp`,
+///   `$TMPDIR` → `/private/var/folders/.../T/`)
+/// - Device files: `/dev/null`, `/dev/stdout`, `/dev/stderr`
+pub fn is_safe_external_path(resolved: &Path) -> bool {
+    // Device files — not real filesystem writes
+    if resolved.starts_with("/dev/") {
+        return true;
+    }
+
+    // Canonical /tmp (covers /private/tmp on macOS via symlink)
+    let canonical_tmp = PathBuf::from("/tmp")
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from("/tmp"));
+    if resolved.starts_with(&canonical_tmp) || resolved.starts_with("/tmp") {
+        return true;
+    }
+
+    // $TMPDIR (e.g. /var/folders/.../T/ on macOS)
+    if let Ok(tmpdir) = std::env::var("TMPDIR") {
+        let tmpdir_path = PathBuf::from(&tmpdir);
+        let canonical_tmpdir = tmpdir_path
+            .canonicalize()
+            .unwrap_or_else(|_| tmpdir_path.clone());
+        if resolved.starts_with(&canonical_tmpdir) || resolved.starts_with(&tmpdir_path) {
+            return true;
+        }
+    }
+
+    false
+}
 
 /// Result of linting a bash command for path escapes.
 #[derive(Debug, Clone, Default)]
@@ -63,7 +97,7 @@ pub fn lint_bash_paths(command: &str, project_root: &Path) -> BashPathLint {
                     } else {
                         project_root.join(&p).clean()
                     };
-                    if !resolved.starts_with(project_root) {
+                    if !resolved.starts_with(project_root) && !is_safe_external_path(&resolved) {
                         lint.outside_paths.push(p);
                     }
                 }
@@ -77,13 +111,13 @@ pub fn lint_bash_paths(command: &str, project_root: &Path) -> BashPathLint {
             }
             if token.starts_with('/') {
                 let resolved = Path::new(token).to_path_buf().clean();
-                if !resolved.starts_with(project_root) {
+                if !resolved.starts_with(project_root) && !is_safe_external_path(&resolved) {
                     lint.outside_paths.push(token.to_string());
                 }
             }
             if token.contains("..") {
                 let resolved = project_root.join(token).clean();
-                if !resolved.starts_with(project_root) {
+                if !resolved.starts_with(project_root) && !is_safe_external_path(&resolved) {
                     lint.outside_paths.push(token.to_string());
                 }
             }
@@ -155,9 +189,9 @@ mod tests {
 
     #[test]
     fn test_lint_cd_outside_project() {
-        let lint = lint_bash_paths("cd /tmp && ls", &project());
+        let lint = lint_bash_paths("cd /etc && ls", &project());
         assert!(lint.has_warnings());
-        assert!(lint.outside_paths.contains(&"/tmp".to_string()));
+        assert!(lint.outside_paths.contains(&"/etc".to_string()));
     }
 
     #[test]
@@ -211,8 +245,40 @@ mod tests {
 
     #[test]
     fn test_lint_deduplicates() {
-        let lint = lint_bash_paths("cp /tmp/a /tmp/b", &project());
+        let lint = lint_bash_paths("cp /etc/a /etc/b", &project());
         assert!(lint.has_warnings());
         assert_eq!(lint.outside_paths.len(), 2);
+    }
+
+    // ── Temp path allowlist (#560) ──
+
+    #[test]
+    fn test_lint_tmp_path_allowed() {
+        let lint = lint_bash_paths("cat /tmp/issue-draft.md", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_cd_tmp_allowed() {
+        let lint = lint_bash_paths("cd /tmp && ls", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_tmp_subdir_allowed() {
+        let lint = lint_bash_paths("cp file.txt /tmp/koda/output.md", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_dev_null_allowed() {
+        let lint = lint_bash_paths("echo test > /dev/null", &project());
+        assert!(!lint.has_warnings());
+    }
+
+    #[test]
+    fn test_lint_etc_still_blocked() {
+        let lint = lint_bash_paths("cat /etc/passwd", &project());
+        assert!(lint.has_warnings());
     }
 }

--- a/koda-core/tests/guarantee_matrix_test.rs
+++ b/koda-core/tests/guarantee_matrix_test.rs
@@ -13,7 +13,7 @@
 //!  6. Safe bash (git status, grep)
 //!  7. Bash with write side-effect (echo > file)
 //!  8. Destructive bash (rm -rf, git push --force)
-//!  9. Bash with path escape (cd /tmp)
+//!  9. Bash with path escape (cd /etc)
 //! 10. Sub-agent invocation (InvokeAgent)
 //! 11. MemoryWrite
 //! 12. WebFetch (GET)
@@ -121,7 +121,8 @@ fn matrix_destructive_bash() {
 
 #[test]
 fn matrix_bash_path_escape() {
-    let args = serde_json::json!({"command": "cd /tmp && ls"});
+    // /etc is still blocked; /tmp is now allowed (#560)
+    let args = serde_json::json!({"command": "cd /etc && ls"});
     let (auto, confirm) = check_both("Bash", &args);
     assert_eq!(auto, ToolApproval::NeedsConfirmation);
     assert_eq!(confirm, ToolApproval::NeedsConfirmation);


### PR DESCRIPTION
## Summary

Closes #560.

- Add `is_safe_external_path()` helper that recognizes temp dirs (`/tmp`, `$TMPDIR`, `/private/tmp` on macOS) and device files (`/dev/null`, `/dev/stdout`, `/dev/stderr`)
- Apply exemption in both `bash_path_lint::lint_bash_paths()` (cd/path arguments) and `approval::is_outside_project()` (Write/Edit/Delete file tools)
- System paths like `/etc`, `/usr`, `~/.bashrc` still require confirmation as before

## Test plan

- [x] `test_lint_tmp_path_allowed` — `/tmp/file.md` no longer flagged
- [x] `test_lint_cd_tmp_allowed` — `cd /tmp && ls` no longer flagged
- [x] `test_lint_tmp_subdir_allowed` — `/tmp/koda/output.md` no longer flagged
- [x] `test_lint_dev_null_allowed` — `> /dev/null` no longer flagged
- [x] `test_write_to_tmp_auto_approved` — Write tool to `/tmp` auto-approves
- [x] `test_bash_cd_tmp_auto_approved` — Bash `cd /tmp` auto-approves
- [x] `test_lint_etc_still_blocked` — `/etc/passwd` still blocked
- [x] `test_write_to_etc_still_blocked` — Write to `/etc` still needs confirmation
- [x] Guarantee matrix test updated (row 9 uses `/etc` instead of `/tmp`)
- [x] All 63 affected tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)