### PR TITLE
chore: bump version to 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-03-28
+
+### Added
+- **Allow `/tmp`, `$TMPDIR`, and `/dev/*` without confirmation** (#560) —
+  temporary directories and device files are now auto-approved in Auto mode,
+  removing unnecessary confirmation prompts for common scratch-space operations.
+
+### Fixed
+- **Skip paths inside quoted strings in bash path lint** (#562) —
+  `lint_bash_paths()` now ignores paths embedded within single- or double-quoted
+  strings, eliminating false-positive "outside project" warnings for commands
+  like `grep "pattern" /some/path`.
+
 ## [0.1.19] - 2026-03-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.1.19" }
+koda-core = { path = "../koda-core", version = "0.1.20" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.1.19", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.1.20", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"
@@ -57,8 +57,8 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.19" }
-koda-email = { path = "../koda-email", version = "0.1.19" }
+koda-ast = { path = "../koda-ast", version = "0.1.20" }
+koda-email = { path = "../koda-email", version = "0.1.20" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump all 4 crate versions from 0.1.19 → 0.1.20
- Update CHANGELOG with entries for #560 (allow /tmp, $TMPDIR, /dev/* without confirmation) and #562 (skip quoted paths in bash lint)

## Post-merge
Tag `v0.1.20` to trigger release workflow.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)