### PR TITLE
ci: add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]    # PR status checks
   workflow_call:        # Called by other workflows
 
+permissions:
+  contents: read        # Least-privilege for all jobs
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Add top-level `permissions: contents: read` to the CI workflow, restricting `GITHUB_TOKEN` to read-only access across all 6 jobs. This follows the principle of least privilege.

The other workflows (`release.yml`, `auto-merge-dependabot.yml`) already have explicit permissions blocks.

Closes #576