### PR TITLE
docs: document session_id printing as intentional UX

### DIFF
--- a/koda-cli/src/startup.rs
+++ b/koda-cli/src/startup.rs
@@ -170,6 +170,11 @@ pub fn home_dir_warning_lines(project_root: &std::path::Path) -> Vec<Line<'stati
 }
 
 /// Print session resume hint (after raw mode ends, to stdout).
+///
+/// NOTE: Session IDs are non-sensitive local identifiers (UUIDs stored in
+/// a local SQLite database). Printing them to stdout is intentional UX —
+/// the user needs the ID to resume their session. This is not a credential
+/// leak. (Addresses CodeQL alert #7 / `rust/cleartext-logging`.)
 pub fn print_resume_hint(session_id: &str) {
     println!("\nResume this session with:\n  koda --resume {session_id}");
 }


### PR DESCRIPTION
Session IDs are non-sensitive local UUIDs stored in a local SQLite database. Printing them to stdout is intentional UX — users need the ID to `koda --resume` their sessions.

Added a doc comment explaining the security rationale on `print_resume_hint()`.

Addresses CodeQL alert #7 (`rust/cleartext-logging`).

Closes #578