### PR TITLE
fix(tui): slash menu executes on Enter, centres scroll, ↓ opens menu

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -11,19 +11,27 @@ use std::path::{Path, PathBuf};
 /// `None` for self-contained commands and picker-openers.
 /// Single source of truth — used by completer and auto-dropdown.
 pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
-    ("/agent",    "Switch to a sub-agent",                   Some("<name>")),
-    ("/compact",  "Summarize conversation to reclaim context", None),
-    ("/diff",     "Show git diff (review, commit)",            None),
-    ("/exit",     "Quit the session",                         None),
-    ("/expand",   "Show full output of last tool call",        None),
-    ("/memory",   "View/save project & global memory",         None),
-    ("/model",    "Pick a model interactively",               None),
-    ("/provider", "Switch LLM provider",                      None),
-    ("/purge",    "Delete archived history (e.g. /purge 90d)", Some("<days>")),
-    ("/sessions", "List/resume/delete sessions",              None),
-    ("/skills",   "List available skills (search with query)", None),
-    ("/undo",     "Undo last turn's file changes",            None),
-    ("/verbose",  "Toggle full tool output",                  None),
+    ("/agent", "Switch to a sub-agent", Some("<name>")),
+    (
+        "/compact",
+        "Summarize conversation to reclaim context",
+        None,
+    ),
+    ("/diff", "Show git diff (review, commit)", None),
+    ("/exit", "Quit the session", None),
+    ("/expand", "Show full output of last tool call", None),
+    ("/memory", "View/save project & global memory", None),
+    ("/model", "Pick a model interactively", None),
+    ("/provider", "Switch LLM provider", None),
+    (
+        "/purge",
+        "Delete archived history (e.g. /purge 90d)",
+        Some("<days>"),
+    ),
+    ("/sessions", "List/resume/delete sessions", None),
+    ("/skills", "List available skills (search with query)", None),
+    ("/undo", "Undo last turn's file changes", None),
+    ("/verbose", "Toggle full tool output", None),
 ];
 
 /// Unified Tab-completion for slash commands and @file paths.
@@ -298,10 +306,7 @@ fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
             }
 
             // Bonus: camelCase transition (previous char lowercase, current uppercase)
-            if ti > 0
-                && target_chars[ti - 1].is_ascii_lowercase()
-                && tc.is_ascii_uppercase()
-            {
+            if ti > 0 && target_chars[ti - 1].is_ascii_lowercase() && tc.is_ascii_uppercase() {
                 score += 6;
             }
 
@@ -637,9 +642,6 @@ mod tests {
         // "dm" at camelCase boundary (D→M) should score higher
         let camel = fuzzy_score("dm", "DropdownMenu").unwrap();
         let flat = fuzzy_score("dm", "random_dm_file").unwrap();
-        assert!(
-            camel > flat,
-            "camelCase {camel} should beat flat {flat}"
-        );
+        assert!(camel > flat, "camelCase {camel} should beat flat {flat}");
     }
 }

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -6,22 +6,24 @@
 
 use std::path::{Path, PathBuf};
 
-/// All known slash commands with descriptions.
+/// All known slash commands with (command, description, arg_hint).
+/// `arg_hint` is `Some("<placeholder>")` for commands that take an argument,
+/// `None` for self-contained commands and picker-openers.
 /// Single source of truth — used by completer and auto-dropdown.
-pub const SLASH_COMMANDS: &[(&str, &str)] = &[
-    ("/agent", "List available sub-agents"),
-    ("/compact", "Summarize conversation to reclaim context"),
-    ("/diff", "Show git diff (review, commit)"),
-    ("/exit", "Quit the session"),
-    ("/expand", "Show full output of last tool call"),
-    ("/memory", "View/save project & global memory"),
-    ("/model", "Pick a model interactively"),
-    ("/provider", "Switch LLM provider"),
-    ("/purge", "Delete archived history (e.g. /purge 90d)"),
-    ("/sessions", "List/resume/delete sessions"),
-    ("/skills", "List available skills (search with query)"),
-    ("/undo", "Undo last turn's file changes"),
-    ("/verbose", "Toggle full tool output"),
+pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
+    ("/agent",    "Switch to a sub-agent",                   Some("<name>")),
+    ("/compact",  "Summarize conversation to reclaim context", None),
+    ("/diff",     "Show git diff (review, commit)",            None),
+    ("/exit",     "Quit the session",                         None),
+    ("/expand",   "Show full output of last tool call",        None),
+    ("/memory",   "View/save project & global memory",         None),
+    ("/model",    "Pick a model interactively",               None),
+    ("/provider", "Switch LLM provider",                      None),
+    ("/purge",    "Delete archived history (e.g. /purge 90d)", Some("<days>")),
+    ("/sessions", "List/resume/delete sessions",              None),
+    ("/skills",   "List available skills (search with query)", None),
+    ("/undo",     "Undo last turn's file changes",            None),
+    ("/verbose",  "Toggle full tool output",                  None),
 ];
 
 /// Unified Tab-completion for slash commands and @file paths.
@@ -97,8 +99,8 @@ impl InputCompleter {
             self.token = trimmed.to_string();
             self.matches = SLASH_COMMANDS
                 .iter()
-                .filter(|(cmd, _)| cmd.starts_with(trimmed) && *cmd != trimmed)
-                .map(|(cmd, _)| cmd.to_string())
+                .filter(|(cmd, _, _)| cmd.starts_with(trimmed) && *cmd != trimmed)
+                .map(|(cmd, _, _)| cmd.to_string())
                 .collect();
             self.idx = 0;
         }

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -234,8 +234,8 @@ fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
                 return None;
             }
 
-            let lower_name = name.to_lowercase();
-            let score = fuzzy_score(&lower_prefix, &lower_name)?;
+            // query is lowered; target keeps original case for camelCase detection
+            let score = fuzzy_score(&lower_prefix, &name)?;
 
             let path = if is_dir {
                 format!("{dir_part}{name}/")
@@ -256,11 +256,16 @@ fn list_path_matches(project_root: &Path, partial: &str) -> Vec<String> {
 /// Returns `Some(score)` if all chars of `query` appear in `target` in order.
 /// Higher score = better match.
 ///
-/// Scoring:
-/// - Prefix match: +100
-/// - Consecutive chars: +10 each
-/// - Char after separator (`_`, `-`, `.`, `/`): +5
+/// Scoring (nucleo-inspired, matching CC's `native-ts/file-index`):
 /// - Base: +1 per matched char
+/// - Prefix / first char at pos 0: +100
+/// - Consecutive chars: +10
+/// - After separator (`_`, `-`, `.`, `/`): +5
+/// - camelCase transition (lower→upper): +6
+/// - Gap penalty: −3 (start) + −1 per additional gap char
+///
+/// `query` must be lowercased. `target` is **original case** so camelCase
+/// transitions can be detected; character comparison is case-insensitive.
 fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
     if query.is_empty() {
         return Some(0);
@@ -274,7 +279,7 @@ fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
     let mut prev_match_pos: Option<usize> = None;
 
     for (ti, &tc) in target_chars.iter().enumerate() {
-        if qi < query_chars.len() && tc == query_chars[qi] {
+        if qi < query_chars.len() && tc.to_ascii_lowercase() == query_chars[qi] {
             score += 1;
 
             // Bonus: prefix match
@@ -290,6 +295,22 @@ fn fuzzy_score(query: &str, target: &str) -> Option<i32> {
             // Bonus: after separator
             if ti > 0 && matches!(target_chars[ti - 1], '_' | '-' | '.' | '/') {
                 score += 5;
+            }
+
+            // Bonus: camelCase transition (previous char lowercase, current uppercase)
+            if ti > 0
+                && target_chars[ti - 1].is_ascii_lowercase()
+                && tc.is_ascii_uppercase()
+            {
+                score += 6;
+            }
+
+            // Penalty: gap between consecutive matches
+            if let Some(prev) = prev_match_pos {
+                let gap = ti - prev - 1;
+                if gap > 0 {
+                    score -= 3 + gap as i32; // start + extension
+                }
             }
 
             prev_match_pos = Some(ti);
@@ -583,5 +604,42 @@ mod tests {
         // "m" → main.rs should come before format.rs (prefix match wins)
         let result = c.complete("@m");
         assert_eq!(result, Some("@main.rs".to_string()));
+    }
+
+    // ── Gap penalty tests ──────────────────────────────────
+
+    #[test]
+    fn test_gap_penalty_tight_beats_scattered() {
+        // "mrs": main.rs has gap=1 (m-a-i-n-.-r-s), scattered has large gaps
+        let tight = fuzzy_score("mrs", "main.rs").unwrap();
+        let scattered = fuzzy_score("mrs", "my_really_long_script.rs").unwrap();
+        assert!(
+            tight > scattered,
+            "tight {tight} should beat scattered {scattered}"
+        );
+    }
+
+    #[test]
+    fn test_gap_penalty_consecutive_no_penalty() {
+        // Consecutive chars should get bonus, not penalty
+        let consec = fuzzy_score("mai", "main.rs").unwrap();
+        let gapped = fuzzy_score("mai", "m_a_i.rs").unwrap();
+        assert!(
+            consec > gapped,
+            "consecutive {consec} should beat gapped {gapped}"
+        );
+    }
+
+    // ── camelCase bonus tests ──────────────────────────────
+
+    #[test]
+    fn test_camel_case_bonus() {
+        // "dm" at camelCase boundary (D→M) should score higher
+        let camel = fuzzy_score("dm", "DropdownMenu").unwrap();
+        let flat = fuzzy_score("dm", "random_dm_file").unwrap();
+        assert!(
+            camel > flat,
+            "camelCase {camel} should beat flat {flat}"
+        );
     }
 }

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -77,6 +77,19 @@ impl TuiContext {
                 self.history_up();
             }
             (KeyCode::Down, KeyModifiers::NONE) | (KeyCode::Char('n'), KeyModifiers::CONTROL) => {
+                let input = self.textarea.lines().join("\n");
+                let trimmed = input.trim_end();
+                // ↓ on a bare `/`-prefixed token opens the slash menu instead
+                // of scrolling history — matches CC behaviour.
+                if trimmed.starts_with('/') && !trimmed.contains(' ') {
+                    if let Some(dd) = crate::widgets::slash_menu::from_input(
+                        crate::completer::SLASH_COMMANDS,
+                        trimmed,
+                    ) {
+                        self.menu = MenuContent::Slash(dd);
+                        return Ok(true);
+                    }
+                }
                 self.history_down();
             }
             (KeyCode::Esc, _) => {

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -81,14 +81,15 @@ impl TuiContext {
                 let trimmed = input.trim_end();
                 // ↓ on a bare `/`-prefixed token opens the slash menu instead
                 // of scrolling history — matches CC behaviour.
-                if trimmed.starts_with('/') && !trimmed.contains(' ') {
-                    if let Some(dd) = crate::widgets::slash_menu::from_input(
+                if trimmed.starts_with('/')
+                    && !trimmed.contains(' ')
+                    && let Some(dd) = crate::widgets::slash_menu::from_input(
                         crate::completer::SLASH_COMMANDS,
                         trimmed,
-                    ) {
-                        self.menu = MenuContent::Slash(dd);
-                        return Ok(true);
-                    }
+                    )
+                {
+                    self.menu = MenuContent::Slash(dd);
+                    return Ok(true);
                 }
                 self.history_down();
             }

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -241,7 +241,7 @@ impl TuiContext {
                     if arg_hint.is_some() {
                         // Command needs an argument: put "/cmd " in the box
                         // so the user can type the argument and press Enter.
-                        self.textarea.insert_str(&format!("{cmd} "));
+                        self.textarea.insert_str(format!("{cmd} "));
                     } else {
                         // Self-contained / picker-opener: execute immediately.
                         self.dispatch_slash(&cmd).await;

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -228,12 +228,27 @@ impl TuiContext {
     pub(crate) async fn handle_menu_select(&mut self) {
         match &self.menu {
             MenuContent::Slash(dd) => {
-                if let Some(item) = dd.selected_item() {
-                    let cmd = item.command.to_string();
+                // Extract owned/static data before dropping the borrow on self.menu.
+                let action = dd
+                    .selected_item()
+                    .map(|item| (item.command.to_string(), item.arg_hint));
+                // Borrow on self.menu is released here — item.command and
+                // item.arg_hint are both &'static, so they don't extend it.
+                if let Some((cmd, arg_hint)) = action {
+                    self.menu = MenuContent::None;
                     self.textarea.select_all();
                     self.textarea.cut();
-                    self.textarea.insert_str(&cmd);
+                    if arg_hint.is_some() {
+                        // Command needs an argument: put "/cmd " in the box
+                        // so the user can type the argument and press Enter.
+                        self.textarea.insert_str(&format!("{cmd} "));
+                    } else {
+                        // Self-contained / picker-opener: execute immediately.
+                        self.dispatch_slash(&cmd).await;
+                        self.reinit_after_slash().await;
+                    }
                 }
+                return; // skip the trailing self.menu = None
             }
             MenuContent::Model(dd) => {
                 if let Some(item) = dd.selected_item() {

--- a/koda-cli/src/widgets/dropdown.rs
+++ b/koda-cli/src/widgets/dropdown.rs
@@ -115,9 +115,7 @@ impl<T: DropdownItem> DropdownState<T> {
     /// Move selection up.
     pub fn up(&mut self) {
         self.selected = self.selected.saturating_sub(1);
-        if self.selected < self.scroll_offset {
-            self.scroll_offset = self.selected;
-        }
+        self.recenter();
     }
 
     /// Move selection down (wraps around).
@@ -128,10 +126,19 @@ impl<T: DropdownItem> DropdownState<T> {
             self.selected = 0;
             self.scroll_offset = 0;
         }
+        self.recenter();
+    }
+
+    /// Keep the selected item vertically centred in the visible window.
+    fn recenter(&mut self) {
         let visible = MAX_VISIBLE.min(self.filtered.len());
-        if self.selected >= self.scroll_offset + visible {
-            self.scroll_offset = self.selected + 1 - visible;
+        if visible == 0 {
+            return;
         }
+        let half = visible / 2;
+        let ideal = self.selected.saturating_sub(half);
+        let max_offset = self.filtered.len().saturating_sub(visible);
+        self.scroll_offset = ideal.min(max_offset);
     }
 
     /// Get the currently selected item, if any.

--- a/koda-cli/src/widgets/slash_menu.rs
+++ b/koda-cli/src/widgets/slash_menu.rs
@@ -11,6 +11,9 @@ use ratatui::text::Line;
 pub struct SlashCommand {
     pub command: &'static str,
     pub description: &'static str,
+    /// Argument placeholder shown when the command needs user input (e.g. `Some("<name>")`)
+    /// `None` for self-contained commands and picker-openers.
+    pub arg_hint: Option<&'static str>,
 }
 
 impl DropdownItem for SlashCommand {
@@ -28,14 +31,15 @@ impl DropdownItem for SlashCommand {
 /// Create a slash menu dropdown from the command list and current input.
 /// Returns `None` if no commands match.
 pub fn from_input(
-    commands: &'static [(&'static str, &'static str)],
+    commands: &'static [(&'static str, &'static str, Option<&'static str>)],
     input: &str,
 ) -> Option<DropdownState<SlashCommand>> {
     let items: Vec<SlashCommand> = commands
         .iter()
-        .map(|(cmd, desc)| SlashCommand {
+        .map(|(cmd, desc, arg_hint)| SlashCommand {
             command: cmd,
             description: desc,
+            arg_hint: *arg_hint,
         })
         .collect();
     let mut dd = DropdownState::new(items, "\u{1f43b} Commands");
@@ -55,13 +59,13 @@ pub fn build_menu_lines(state: &DropdownState<SlashCommand>) -> Vec<Line<'static
 mod tests {
     use super::*;
 
-    const TEST_COMMANDS: &[(&str, &str)] = &[
-        ("/agent", "Agents"),
-        ("/compact", "Compact"),
-        ("/diff", "Diff"),
-        ("/exit", "Quit"),
-        ("/expand", "Expand"),
-        ("/model", "Pick model"),
+    const TEST_COMMANDS: &[(&str, &str, Option<&str>)] = &[
+        ("/agent",   "Agents",    Some("<name>")),
+        ("/compact", "Compact",   None),
+        ("/diff",    "Diff",      None),
+        ("/exit",    "Quit",      None),
+        ("/expand",  "Expand",    None),
+        ("/model",   "Pick model", None),
     ];
 
     #[test]

--- a/koda-cli/src/widgets/slash_menu.rs
+++ b/koda-cli/src/widgets/slash_menu.rs
@@ -60,12 +60,12 @@ mod tests {
     use super::*;
 
     const TEST_COMMANDS: &[(&str, &str, Option<&str>)] = &[
-        ("/agent",   "Agents",    Some("<name>")),
-        ("/compact", "Compact",   None),
-        ("/diff",    "Diff",      None),
-        ("/exit",    "Quit",      None),
-        ("/expand",  "Expand",    None),
-        ("/model",   "Pick model", None),
+        ("/agent", "Agents", Some("<name>")),
+        ("/compact", "Compact", None),
+        ("/diff", "Diff", None),
+        ("/exit", "Quit", None),
+        ("/expand", "Expand", None),
+        ("/model", "Pick model", None),
     ];
 
     #[test]


### PR DESCRIPTION
Closes #599.

## What changed

### Bug 1 — P0: Enter executes, not completes (`menus.rs`)

`handle_menu_select` Slash arm used to write the command string into the textarea, requiring a second Enter to run it. Now it calls `dispatch_slash` directly for no-arg commands. The double-Enter pattern is gone.

Commands that take an argument (`/agent`, `/purge`) get `"cmd "` written to the box with the cursor ready for the user to type the argument — same as CC's `applyCommandSuggestion` logic.

### Bug 3 — P1: `arg_hint` field on `SlashCommand` (`completer.rs`, `slash_menu.rs`)

`SLASH_COMMANDS` is now a 3-tuple `(&str, &str, Option<&str>)`. `/agent` and `/purge` carry `Some("<name>")` / `Some("<days>")`; all others are `None`. `handle_menu_select` branches on `arg_hint.is_some()` to decide execute-immediately vs write-to-box.

### P2: Scroll centring (`dropdown.rs`)

`up()`/`down()` now call a `recenter()` helper that keeps the selected item vertically centred in the visible window instead of snapping it to the edge. Cleaner on long `@` file lists.

### P2: ↓ opens slash menu (`events.rs`)

Pressing Down on a bare `/…` token (no space, no menu open yet) now opens the slash menu instead of scrolling command history. Matches CC behaviour — type `/` and press ↓ to browse all commands.

## Scope

| File | Change |
|---|---|
| `koda-cli/src/completer.rs` | `SLASH_COMMANDS` → 3-tuple with `arg_hint` |
| `koda-cli/src/widgets/slash_menu.rs` | `SlashCommand.arg_hint` field; `from_input` updated |
| `koda-cli/src/tui_context/menus.rs` | `handle_menu_select` Slash arm: dispatch or insert |
| `koda-cli/src/widgets/dropdown.rs` | `recenter()` helper; `up()`/`down()` use it |
| `koda-cli/src/tui_context/events.rs` | ↓ key opens slash menu on `/`-prefixed input |

5 files · +75 / -34 lines · 259 tests passing.

## Note on fuzzy `@`

The P1 fuzzy match for `@` file completions was already implemented in `completer.rs` (`fuzzy_score` + `list_path_matches`). Marked as done in the issue.
