### PR TITLE
feat(compact): circuit breaker + no-tools preamble

### DIFF
--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -13,10 +13,40 @@ use crate::persistence::Persistence;
 use crate::providers::{ChatMessage, LlmProvider};
 use anyhow::{Result, bail};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::sync::RwLock;
 
 /// Number of recent messages to keep verbatim during compaction.
 pub const COMPACT_PRESERVE_COUNT: usize = 4;
+
+/// Stop auto-compacting after this many consecutive failures.
+/// Prevents wasting an API call every turn when compaction is stuck
+/// (e.g. history too large for the model, persistent API errors).
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
+/// Global consecutive failure counter. Shared across the session.
+static CONSECUTIVE_FAILURES: AtomicU32 = AtomicU32::new(0);
+
+/// Reset the failure counter (call after successful compaction or new session).
+pub fn reset_compact_failures() {
+    CONSECUTIVE_FAILURES.store(0, Ordering::Relaxed);
+}
+
+/// Check if the circuit breaker is tripped.
+pub fn is_compact_circuit_broken() -> bool {
+    CONSECUTIVE_FAILURES.load(Ordering::Relaxed) >= MAX_CONSECUTIVE_FAILURES
+}
+
+/// Record a compaction failure. Returns true if the circuit breaker just tripped.
+pub fn record_compact_failure() -> bool {
+    let prev = CONSECUTIVE_FAILURES.fetch_add(1, Ordering::Relaxed);
+    prev + 1 >= MAX_CONSECUTIVE_FAILURES
+}
+
+/// Record a compaction success — resets the failure counter.
+fn record_compact_success() {
+    reset_compact_failures();
+}
 
 /// Result of a successful compaction.
 #[derive(Debug)]
@@ -115,6 +145,8 @@ pub async fn compact_session_with_provider(
     let deleted = db
         .compact_session(session_id, &compact_message, COMPACT_PRESERVE_COUNT)
         .await?;
+
+    record_compact_success();
 
     Ok(Ok(CompactResult {
         deleted,
@@ -272,6 +304,25 @@ mod tests {
             cache_creation_tokens: None,
             thinking_tokens: None,
         }
+    }
+
+    #[test]
+    fn test_circuit_breaker() {
+        reset_compact_failures();
+        assert!(!is_compact_circuit_broken());
+
+        assert!(!record_compact_failure()); // 1st
+        assert!(!is_compact_circuit_broken());
+
+        assert!(!record_compact_failure()); // 2nd
+        assert!(!is_compact_circuit_broken());
+
+        assert!(record_compact_failure()); // 3rd — trips
+        assert!(is_compact_circuit_broken());
+
+        // Reset should untrip
+        reset_compact_failures();
+        assert!(!is_compact_circuit_broken());
     }
 
     #[test]

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -112,6 +112,12 @@ async fn preflight_compact_if_needed(
         return Ok(messages);
     }
 
+    // Circuit breaker: stop wasting API calls after repeated failures
+    if crate::compact::is_compact_circuit_broken() {
+        tracing::warn!("Pre-flight: context at {ctx_pct}% but circuit breaker tripped — skipping");
+        return Ok(messages);
+    }
+
     tracing::warn!("Pre-flight: context at {ctx_pct}%, attempting auto-compact");
     sink.emit(EngineEvent::Info {
         message: format!("\u{1f4e6} Context at {ctx_pct}% \u{2014} compacting before sending..."),
@@ -147,6 +153,7 @@ async fn preflight_compact_if_needed(
         Ok(Err(skip)) => {
             tracing::info!("Pre-flight compact skipped: {skip:?}");
             if matches!(skip, crate::compact::CompactSkip::HistoryTooLarge) {
+                crate::compact::record_compact_failure();
                 sink.emit(EngineEvent::Warn {
                     message: "\u{26a0}\u{fe0f} Context is full but history is too large for \
                               this model to summarize. Start a new session (/session) or \
@@ -158,8 +165,14 @@ async fn preflight_compact_if_needed(
         }
         Err(e) => {
             tracing::warn!("Pre-flight compact failed: {e:#}");
+            let tripped = crate::compact::record_compact_failure();
+            let suffix = if tripped {
+                " Auto-compact disabled after repeated failures."
+            } else {
+                " Continuing anyway..."
+            };
             sink.emit(EngineEvent::Warn {
-                message: format!("Compact failed: {e:#}. Continuing anyway..."),
+                message: format!("Compact failed: {e:#}.{suffix}"),
             });
             Ok(messages)
         }


### PR DESCRIPTION
## What

- **Circuit breaker**: Stop auto-compacting after 3 consecutive failures. Prevents wasting an API call every turn when compaction is stuck (CC found 1,279 sessions wasting ~250K API calls/day from this).
- **No-tools preamble**: Add `CRITICAL: Respond with TEXT ONLY` preamble + reminder trailer to the compaction prompt. CC saw 2.79% failure rate on Sonnet 4.6 from the model attempting tool calls during summarization.

## How

- Atomic `CONSECUTIVE_FAILURES` counter in `compact.rs`
- `is_compact_circuit_broken()` checked before attempting preflight compact
- `record_compact_failure()` called on errors and `HistoryTooLarge` skips
- `record_compact_success()` / `reset_compact_failures()` on success
- Preamble + trailer added to summarization prompt string

## Testing

- New unit test `test_circuit_breaker` verifies trip-at-3 and reset behavior
- All existing compact tests pass

Part of #588