### PR TITLE
Remove AstAnalysis from koda-core tool registry (#608)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,7 +1768,6 @@ dependencies = [
  "futures-util",
  "glob",
  "ignore",
- "koda-ast",
  "koda-email",
  "path-clean",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "similar",
  "sqlx",
  "tempfile",
  "tokio",
@@ -3280,6 +3281,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/koda-cli/src/diff_render.rs
+++ b/koda-cli/src/diff_render.rs
@@ -9,8 +9,8 @@
 
 use crate::highlight;
 use koda_core::preview::{
-    DeleteDirPreview, DeleteFilePreview, DiffLine, DiffPreview, DiffTag,
-    UnifiedDiffPreview, WriteNewPreview,
+    DeleteDirPreview, DeleteFilePreview, DiffLine, DiffPreview, DiffTag, UnifiedDiffPreview,
+    WriteNewPreview,
 };
 use ratatui::{
     style::{Color, Modifier, Style},
@@ -64,10 +64,7 @@ fn render_unified_diff(diff: &UnifiedDiffPreview) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     // File header
-    lines.push(Line::styled(
-        format!("╭─── {} ───╮", diff.path),
-        DIM,
-    ));
+    lines.push(Line::styled(format!("╭─── {} ───╮", diff.path), DIM));
 
     for (i, hunk) in diff.hunks.iter().enumerate() {
         // Hunk separator (between hunks, not before the first)
@@ -92,10 +89,7 @@ fn render_unified_diff(diff: &UnifiedDiffPreview) -> Vec<Line<'static>> {
     }
 
     // Close frame
-    lines.push(Line::styled(
-        format!("╰─── {} ───╯", diff.path),
-        DIM,
-    ));
+    lines.push(Line::styled(format!("╰─── {} ───╯", diff.path), DIM));
 
     if diff.truncated {
         lines.push(Line::styled("... diff truncated (file too large)", DIM));
@@ -131,10 +125,11 @@ fn render_diff_line(
     let mut spans = Vec::new();
 
     // Gutter: line number + sigil (GUTTER_WIDTH chars total)
-    let gutter_style = Style::default()
-        .fg(sigil_color)
-        .add_modifier(Modifier::DIM);
-    spans.push(Span::styled(format!("{:>4} {} ", line_num, sigil), gutter_style));
+    let gutter_style = Style::default().fg(sigil_color).add_modifier(Modifier::DIM);
+    spans.push(Span::styled(
+        format!("{:>4} {} ", line_num, sigil),
+        gutter_style,
+    ));
 
     // Content: use pre-highlighted spans if available, with background tint
     let idx = line_num.saturating_sub(1); // 0-based index
@@ -197,10 +192,7 @@ fn render_write_new(w: &WriteNewPreview) -> Vec<Line<'static>> {
         ));
     }
 
-    lines.push(Line::styled(
-        format!("╰─── {} ───╯", w.path),
-        DIM,
-    ));
+    lines.push(Line::styled(format!("╰─── {} ───╯", w.path), DIM));
 
     lines
 }

--- a/koda-cli/src/diff_render.rs
+++ b/koda-cli/src/diff_render.rs
@@ -2,30 +2,42 @@
 //!
 //! Takes structured [`DiffPreview`] data from koda-core and produces
 //! `Vec<Line<'static>>` with:
-//! - Dark background tint for line-level diffs (red removed, green added)
-//! - Syntax highlighting (foreground colors via syntect)
+//! - Proper unified diff with hunk headers and context lines
+//! - Syntax highlighting with cross-hunk context (via pre-highlighted files)
+//! - Dark background tint for diff lines (red removed, green added)
+//! - Gutter metadata for NoSelect copy support
 
-use crate::highlight::CodeHighlighter;
+use crate::highlight;
 use koda_core::preview::{
-    DeleteDirPreview, DeleteFilePreview, DiffPreview, EditPreview, WriteOverwritePreview,
-    WritePreview,
+    DeleteDirPreview, DeleteFilePreview, DiffLine, DiffPreview, DiffTag,
+    UnifiedDiffPreview, WriteNewPreview,
 };
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
 
-// Background styles for diff lines
-const LINE_RED_BG: Style = Style::new().bg(Color::Rgb(50, 0, 0));
-const LINE_GREEN_BG: Style = Style::new().bg(Color::Rgb(0, 35, 0));
+// ── Styles ────────────────────────────────────────────────────
+
+const LINE_RED_BG: Color = Color::Rgb(50, 0, 0);
+const LINE_GREEN_BG: Color = Color::Rgb(0, 35, 0);
 const DIM: Style = Style::new().fg(Color::DarkGray);
+const HUNK_HEADER: Style = Style::new().fg(Color::Cyan);
+
+/// Width of the gutter: 4-digit line number + space + sigil + space = 7.
+/// Used by NoSelect to know how many leading columns to skip on copy.
+pub const GUTTER_WIDTH: u16 = 7;
+
+// ── Public API ────────────────────────────────────────────────
 
 /// Render a [`DiffPreview`] as native ratatui `Line`s.
+///
+/// Each diff line's gutter (line numbers + ±) occupies [`GUTTER_WIDTH`]
+/// columns. The caller can use this to implement NoSelect on copy.
 pub fn render_lines(preview: &DiffPreview) -> Vec<Line<'static>> {
     match preview {
-        DiffPreview::Edit(edit) => render_edit(edit),
+        DiffPreview::UnifiedDiff(diff) => render_unified_diff(diff),
         DiffPreview::WriteNew(w) => render_write_new(w),
-        DiffPreview::WriteOverwrite(w) => render_write_overwrite(w),
         DiffPreview::DeleteFile(d) => render_delete_file(d),
         DiffPreview::DeleteDir(d) => render_delete_dir(d),
         DiffPreview::FileNotYetExists => {
@@ -37,121 +49,168 @@ pub fn render_lines(preview: &DiffPreview) -> Vec<Line<'static>> {
     }
 }
 
-/// Legacy ANSI render — kept for `app.rs` / `confirm.rs` (legacy mode).
-pub fn render(preview: &DiffPreview) -> String {
-    // Delegate to the old ANSI rendering for backward compat
-    render_ansi(preview)
-}
+// ── Unified diff renderer ─────────────────────────────────────
 
-fn render_edit(edit: &EditPreview) -> Vec<Line<'static>> {
-    let ext = std::path::Path::new(&edit.path)
+fn render_unified_diff(diff: &UnifiedDiffPreview) -> Vec<Line<'static>> {
+    let ext = std::path::Path::new(&diff.path)
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
 
+    // Pre-highlight both files for cross-hunk syntax context
+    let old_highlights = highlight::pre_highlight(&diff.old_content, ext);
+    let new_highlights = highlight::pre_highlight(&diff.new_content, ext);
+
     let mut lines = Vec::new();
 
-    for r in &edit.replacements {
-        if r.total > 1 {
-            lines.push(Line::styled(
-                format!(
-                    "\u{2500}\u{2500} replacement {}/{} \u{2500}\u{2500}",
-                    r.index + 1,
-                    r.total
-                ),
-                DIM,
-            ));
+    // File header
+    lines.push(Line::styled(
+        format!("╭─── {} ───╮", diff.path),
+        DIM,
+    ));
+
+    for (i, hunk) in diff.hunks.iter().enumerate() {
+        // Hunk separator (between hunks, not before the first)
+        if i > 0 {
+            lines.push(Line::styled("  ⋯", DIM));
         }
 
-        let mut hl_old = CodeHighlighter::new(ext);
-        let mut hl_new = CodeHighlighter::new(ext);
+        // Hunk header: @@ -old_start,old_count +new_start,new_count @@
+        lines.push(Line::styled(
+            format!(
+                "@@ -{},{} +{},{} @@",
+                hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count
+            ),
+            HUNK_HEADER,
+        ));
 
-        for (j, old_line) in r.old_lines.iter().enumerate() {
-            let mut spans = vec![Span::styled(
-                format!("{:>4} - ", r.start_line + j),
-                Style::default().fg(Color::Red).add_modifier(Modifier::DIM),
-            )];
-            let highlighted = hl_old.highlight_spans(old_line);
-            for mut s in highlighted {
-                s.style = s.style.bg(Color::Rgb(50, 0, 0));
-                spans.push(s);
-            }
-            lines.push(Line::from(spans));
-        }
-
-        for (j, new_line) in r.new_lines.iter().enumerate() {
-            let mut spans = vec![Span::styled(
-                format!("{:>4} + ", r.start_line + j),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::DIM),
-            )];
-            let highlighted = hl_new.highlight_spans(new_line);
-            for mut s in highlighted {
-                s.style = s.style.bg(Color::Rgb(0, 35, 0));
-                spans.push(s);
-            }
-            lines.push(Line::from(spans));
+        // Hunk lines
+        for diff_line in &hunk.lines {
+            let rendered = render_diff_line(diff_line, &old_highlights, &new_highlights);
+            lines.push(rendered);
         }
     }
 
-    if edit.truncated_count > 0 {
-        lines.push(Line::styled(
-            format!("... and {} more replacement(s)", edit.truncated_count),
-            DIM,
-        ));
+    // Close frame
+    lines.push(Line::styled(
+        format!("╰─── {} ───╯", diff.path),
+        DIM,
+    ));
+
+    if diff.truncated {
+        lines.push(Line::styled("... diff truncated (file too large)", DIM));
     }
 
     lines
 }
 
-fn render_write_new(w: &WritePreview) -> Vec<Line<'static>> {
+/// Render a single diff line with gutter + syntax-highlighted content.
+///
+/// Uses pre-computed highlights from the full file for correct cross-hunk
+/// syntax context (multiline strings, comments, etc.).
+fn render_diff_line(
+    line: &DiffLine,
+    old_highlights: &[Vec<Span<'static>>],
+    new_highlights: &[Vec<Span<'static>>],
+) -> Line<'static> {
+    let (sigil, sigil_color, bg_color, highlights, line_num) = match line.tag {
+        DiffTag::Context => {
+            let num = line.old_line.unwrap_or(0);
+            (' ', Color::DarkGray, None, old_highlights, num)
+        }
+        DiffTag::Delete => {
+            let num = line.old_line.unwrap_or(0);
+            ('-', Color::Red, Some(LINE_RED_BG), old_highlights, num)
+        }
+        DiffTag::Insert => {
+            let num = line.new_line.unwrap_or(0);
+            ('+', Color::Green, Some(LINE_GREEN_BG), new_highlights, num)
+        }
+    };
+
+    let mut spans = Vec::new();
+
+    // Gutter: line number + sigil (GUTTER_WIDTH chars total)
+    let gutter_style = Style::default()
+        .fg(sigil_color)
+        .add_modifier(Modifier::DIM);
+    spans.push(Span::styled(format!("{:>4} {} ", line_num, sigil), gutter_style));
+
+    // Content: use pre-highlighted spans if available, with background tint
+    let idx = line_num.saturating_sub(1); // 0-based index
+    if idx < highlights.len() {
+        for hl_span in &highlights[idx] {
+            let mut style = hl_span.style;
+            if let Some(bg) = bg_color {
+                style = style.bg(bg);
+            }
+            spans.push(Span::styled(hl_span.content.clone(), style));
+        }
+    } else {
+        // Fallback: no highlighting available
+        let style = match bg_color {
+            Some(bg) => Style::default().bg(bg),
+            None => Style::default(),
+        };
+        spans.push(Span::styled(line.content.clone(), style));
+    }
+
+    Line::from(spans)
+}
+
+// ── Write new file ────────────────────────────────────────────
+
+fn render_write_new(w: &WriteNewPreview) -> Vec<Line<'static>> {
+    let ext = std::path::Path::new(&w.path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+
     let mut lines = vec![Line::styled(
-        format!("New file: {} lines ({} bytes)", w.line_count, w.byte_count),
+        format!(
+            "╭─── {} (new file: {} lines, {} bytes) ───╮",
+            w.path, w.line_count, w.byte_count
+        ),
         DIM,
     )];
-    for line in &w.first_lines {
-        lines.push(Line::from(vec![
-            Span::styled("+ ", Style::default().fg(Color::Green)),
-            Span::styled(line.clone(), LINE_GREEN_BG),
-        ]));
+
+    let mut hl = crate::highlight::CodeHighlighter::new(ext);
+    for (i, content) in w.first_lines.iter().enumerate() {
+        let mut spans = vec![Span::styled(
+            format!("{:>4} + ", i + 1),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::DIM),
+        )];
+        let highlighted = hl.highlight_spans(content);
+        for mut s in highlighted {
+            s.style = s.style.bg(LINE_GREEN_BG);
+            spans.push(s);
+        }
+        lines.push(Line::from(spans));
     }
+
     if w.truncated {
         lines.push(Line::styled(
             format!("... +{} more lines", w.line_count - w.first_lines.len()),
             DIM,
         ));
     }
+
+    lines.push(Line::styled(
+        format!("╰─── {} ───╯", w.path),
+        DIM,
+    ));
+
     lines
 }
 
-fn render_write_overwrite(w: &WriteOverwritePreview) -> Vec<Line<'static>> {
-    let mut lines = vec![Line::styled(
-        format!(
-            "Overwriting {} lines ({} bytes) \u{2192} {} lines ({} bytes)",
-            w.old_line_count, w.old_byte_count, w.new_line_count, w.new_byte_count
-        ),
-        DIM,
-    )];
-    for line in &w.first_lines {
-        lines.push(Line::from(vec![
-            Span::styled("+ ", Style::default().fg(Color::Green)),
-            Span::styled(line.clone(), LINE_GREEN_BG),
-        ]));
-    }
-    if w.truncated {
-        lines.push(Line::styled(
-            format!("... +{} more lines", w.new_line_count - w.first_lines.len()),
-            DIM,
-        ));
-    }
-    lines
-}
+// ── Delete ────────────────────────────────────────────────────
 
 fn render_delete_file(d: &DeleteFilePreview) -> Vec<Line<'static>> {
     vec![Line::styled(
         format!("Removing {} lines ({} bytes)", d.line_count, d.byte_count),
-        LINE_RED_BG,
+        Style::default().bg(LINE_RED_BG),
     )]
 }
 
@@ -159,156 +218,146 @@ fn render_delete_dir(d: &DeleteDirPreview) -> Vec<Line<'static>> {
     if d.recursive {
         vec![Line::styled(
             "Removing directory and all contents",
-            LINE_RED_BG,
+            Style::default().bg(LINE_RED_BG),
         )]
     } else {
-        vec![Line::styled("Removing empty directory", LINE_RED_BG)]
-    }
-}
-
-// ── Legacy ANSI rendering (kept for app.rs / confirm.rs) ────────
-
-const ANSI_LINE_RED: &str = "\x1b[48;2;50;0;0m";
-const ANSI_LINE_GREEN: &str = "\x1b[48;2;0;35;0m";
-const ANSI_DIM: &str = "\x1b[90m";
-const ANSI_RESET: &str = "\x1b[0m";
-
-fn render_ansi(preview: &DiffPreview) -> String {
-    match preview {
-        DiffPreview::Edit(edit) => {
-            let ext = std::path::Path::new(&edit.path)
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
-            let mut lines = Vec::new();
-            for r in &edit.replacements {
-                if r.total > 1 {
-                    lines.push(format!(
-                        "{ANSI_DIM}\u{2500}\u{2500} replacement {}/{} \u{2500}\u{2500}{ANSI_RESET}",
-                        r.index + 1,
-                        r.total
-                    ));
-                }
-                let mut hl = CodeHighlighter::new(ext);
-                for (j, line) in r.old_lines.iter().enumerate() {
-                    let h = hl.highlight_line(line).replace("\x1b[0m", "");
-                    lines.push(format!(
-                        "{ANSI_LINE_RED}{:>4} -\t{h}{ANSI_RESET}",
-                        r.start_line + j
-                    ));
-                }
-                let mut hl = CodeHighlighter::new(ext);
-                for (j, line) in r.new_lines.iter().enumerate() {
-                    let h = hl.highlight_line(line).replace("\x1b[0m", "");
-                    lines.push(format!(
-                        "{ANSI_LINE_GREEN}{:>4} +\t{h}{ANSI_RESET}",
-                        r.start_line + j
-                    ));
-                }
-            }
-            if edit.truncated_count > 0 {
-                lines.push(format!(
-                    "{ANSI_DIM}... and {} more replacement(s){ANSI_RESET}",
-                    edit.truncated_count
-                ));
-            }
-            lines.join("\n")
-        }
-        DiffPreview::WriteNew(w) => {
-            let mut lines = vec![format!(
-                "{ANSI_DIM}New file: {} lines ({} bytes){ANSI_RESET}",
-                w.line_count, w.byte_count
-            )];
-            for line in &w.first_lines {
-                lines.push(format!("{ANSI_LINE_GREEN}+\t{line}{ANSI_RESET}"));
-            }
-            if w.truncated {
-                lines.push(format!(
-                    "{ANSI_DIM}... +{} more lines{ANSI_RESET}",
-                    w.line_count - w.first_lines.len()
-                ));
-            }
-            lines.join("\n")
-        }
-        DiffPreview::WriteOverwrite(w) => {
-            let mut lines = vec![format!(
-                "{ANSI_DIM}Overwriting {} lines → {} lines{ANSI_RESET}",
-                w.old_line_count, w.new_line_count
-            )];
-            for line in &w.first_lines {
-                lines.push(format!("{ANSI_LINE_GREEN}+\t{line}{ANSI_RESET}"));
-            }
-            if w.truncated {
-                lines.push(format!(
-                    "{ANSI_DIM}... +{} more lines{ANSI_RESET}",
-                    w.new_line_count - w.first_lines.len()
-                ));
-            }
-            lines.join("\n")
-        }
-        DiffPreview::DeleteFile(d) => format!(
-            "{ANSI_LINE_RED}Removing {} lines ({} bytes){ANSI_RESET}",
-            d.line_count, d.byte_count
-        ),
-        DiffPreview::DeleteDir(d) => {
-            if d.recursive {
-                format!("{ANSI_LINE_RED}Removing directory and all contents{ANSI_RESET}")
-            } else {
-                format!("{ANSI_LINE_RED}Removing empty directory{ANSI_RESET}")
-            }
-        }
-        DiffPreview::FileNotYetExists => format!("{ANSI_DIM}(file does not exist yet){ANSI_RESET}"),
-        DiffPreview::PathNotFound => format!("{ANSI_DIM}(path does not exist){ANSI_RESET}"),
+        vec![Line::styled(
+            "Removing empty directory",
+            Style::default().bg(LINE_RED_BG),
+        )]
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use koda_core::preview::ReplacementPreview;
+    use koda_core::preview::*;
 
     #[test]
-    fn test_render_lines_edit_has_line_numbers() {
-        let preview = DiffPreview::Edit(EditPreview {
+    fn test_unified_diff_has_hunk_headers() {
+        let preview = DiffPreview::UnifiedDiff(UnifiedDiffPreview {
             path: "test.rs".into(),
-            replacements: vec![ReplacementPreview {
-                index: 0,
-                total: 1,
-                start_line: 2,
-                old_lines: vec!["println!(\"hello\");".into()],
-                new_lines: vec!["println!(\"world\");".into()],
+            old_content: "fn main() {\n    println!(\"hello\");\n}\n".into(),
+            new_content: "fn main() {\n    println!(\"world\");\n}\n".into(),
+            hunks: vec![DiffHunk {
+                old_start: 1,
+                old_count: 3,
+                new_start: 1,
+                new_count: 3,
+                lines: vec![
+                    DiffLine {
+                        tag: DiffTag::Context,
+                        content: "fn main() {".into(),
+                        old_line: Some(1),
+                        new_line: Some(1),
+                    },
+                    DiffLine {
+                        tag: DiffTag::Delete,
+                        content: "    println!(\"hello\");".into(),
+                        old_line: Some(2),
+                        new_line: None,
+                    },
+                    DiffLine {
+                        tag: DiffTag::Insert,
+                        content: "    println!(\"world\");".into(),
+                        old_line: None,
+                        new_line: Some(2),
+                    },
+                    DiffLine {
+                        tag: DiffTag::Context,
+                        content: "}".into(),
+                        old_line: Some(3),
+                        new_line: Some(3),
+                    },
+                ],
             }],
-            truncated_count: 0,
+            truncated: false,
         });
+
         let lines = render_lines(&preview);
-        assert_eq!(lines.len(), 2); // one removed + one added
-        // Check line numbers in first span
-        let first_span = &lines[0].spans[0];
-        assert!(first_span.content.contains("2 -"));
-        let second_span = &lines[1].spans[0];
-        assert!(second_span.content.contains("2 +"));
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+
+        // Should have file header
+        assert!(text[0].contains("test.rs"), "header: {}", text[0]);
+        // Should have hunk header
+        assert!(
+            text.iter().any(|t| t.contains("@@")),
+            "should have hunk header"
+        );
+        // Should have line numbers with sigils
+        assert!(
+            text.iter().any(|t| t.contains(" - ")),
+            "should have delete marker"
+        );
+        assert!(
+            text.iter().any(|t| t.contains(" + ")),
+            "should have insert marker"
+        );
     }
 
     #[test]
-    fn test_render_lines_write_new() {
-        let preview = DiffPreview::WriteNew(WritePreview {
+    fn test_write_new_rendering() {
+        let preview = DiffPreview::WriteNew(WriteNewPreview {
+            path: "new.rs".into(),
             line_count: 10,
             byte_count: 200,
-            first_lines: vec!["line 1".into(), "line 2".into()],
+            first_lines: vec!["fn main() {}".into()],
             truncated: true,
         });
         let lines = render_lines(&preview);
-        assert!(lines.len() >= 3); // header + 2 lines + truncation
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(text[0].contains("new.rs"));
+        assert!(text.iter().any(|t| t.contains("more lines")));
     }
 
     #[test]
-    fn test_legacy_render_still_works() {
-        let preview = DiffPreview::DeleteFile(DeleteFilePreview {
-            line_count: 5,
-            byte_count: 100,
+    fn test_hunk_separator_between_hunks() {
+        let preview = DiffPreview::UnifiedDiff(UnifiedDiffPreview {
+            path: "test.rs".into(),
+            old_content: String::new(),
+            new_content: String::new(),
+            hunks: vec![
+                DiffHunk {
+                    old_start: 1,
+                    old_count: 1,
+                    new_start: 1,
+                    new_count: 1,
+                    lines: vec![DiffLine {
+                        tag: DiffTag::Context,
+                        content: "a".into(),
+                        old_line: Some(1),
+                        new_line: Some(1),
+                    }],
+                },
+                DiffHunk {
+                    old_start: 50,
+                    old_count: 1,
+                    new_start: 50,
+                    new_count: 1,
+                    lines: vec![DiffLine {
+                        tag: DiffTag::Context,
+                        content: "b".into(),
+                        old_line: Some(50),
+                        new_line: Some(50),
+                    }],
+                },
+            ],
+            truncated: false,
         });
-        let ansi = render(&preview);
-        assert!(ansi.contains("\x1b["));
-        assert!(ansi.contains("Removing"));
+        let lines = render_lines(&preview);
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(
+            text.iter().any(|t| t.contains('⋯')),
+            "should have hunk separator"
+        );
     }
 }

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -191,9 +191,10 @@ impl EngineSink for HeadlessSink {
             } => {
                 eprintln!("\x1b[33m  \u{1f50d} Would execute: {detail}\x1b[0m");
                 if let Some(ref p) = preview {
-                    let rendered = crate::diff_render::render(p);
-                    for line in rendered.lines() {
-                        eprintln!("  {line}");
+                    let diff_lines = crate::diff_render::render_lines(p);
+                    for line in &diff_lines {
+                        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                        eprintln!("  {text}");
                     }
                 }
             }

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -6,7 +6,8 @@
 use once_cell::sync::Lazy;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
-use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::parsing::SyntaxSet;
+#[cfg(test)]
 use syntect::util::as_24_bit_terminal_escaped;
 
 /// Lazily loaded syntax definitions and theme.
@@ -18,32 +19,36 @@ static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
 /// Stores a reference to the static `SyntaxReference` and creates a fresh
 /// `HighlightLines` on demand — no unsafe code needed.
 pub struct CodeHighlighter {
-    syntax: Option<&'static SyntaxReference>,
+    /// Persistent parse state for stateful (cross-line) highlighting.
+    state: Option<HighlightLines<'static>>,
 }
 
 impl CodeHighlighter {
     /// Create a highlighter for the given language hint (e.g., "rust", "python").
-    /// Returns a no-op highlighter if the language is unknown.
+    ///
+    /// Maintains parse state across calls to `highlight_spans_stateful()`
+    /// so multiline strings, comments, and heredocs highlight correctly.
+    /// Use `highlight_spans()` for one-off single-line highlighting.
     pub fn new(lang: &str) -> Self {
         let syntax = SYNTAX_SET
             .find_syntax_by_token(lang)
             .or_else(|| SYNTAX_SET.find_syntax_by_extension(lang));
 
-        Self { syntax }
-    }
-
-    /// Create a fresh `HighlightLines` instance from the static theme.
-    fn highlighter(&self) -> Option<HighlightLines<'static>> {
-        self.syntax.map(|syn| {
+        let state = syntax.map(|syn| {
             let theme = &THEME_SET.themes["base16-ocean.dark"];
             HighlightLines::new(syn, theme)
-        })
+        });
+
+        Self { state }
     }
 
     /// Highlight a single line of code, returning ANSI-colored output.
+    ///
+    /// Stateful — parse state carries across calls.
+    #[cfg(test)]
     pub fn highlight_line(&mut self, line: &str) -> String {
-        match self.highlighter() {
-            Some(mut h) => {
+        match self.state.as_mut() {
+            Some(h) => {
                 let ranges = h.highlight_line(line, &SYNTAX_SET).unwrap_or_default();
                 let escaped = as_24_bit_terminal_escaped(&ranges[..], false);
                 format!("{escaped}\x1b[0m")
@@ -54,14 +59,16 @@ impl CodeHighlighter {
 
     /// Highlight a line and return ratatui `Span`s with foreground colors.
     ///
-    /// Each span gets the syntect foreground color mapped to `ratatui::style::Color::Rgb`.
+    /// **Stateful** — parse state carries across calls, so multiline
+    /// strings/comments highlight correctly. Call lines in order.
+    ///
     /// No background is set — the caller controls backgrounds for diff rendering.
     pub fn highlight_spans(&mut self, line: &str) -> Vec<ratatui::text::Span<'static>> {
         use ratatui::style::{Color, Style as RStyle};
         use ratatui::text::Span;
 
-        match self.highlighter() {
-            Some(mut h) => {
+        match self.state.as_mut() {
+            Some(h) => {
                 let ranges = h.highlight_line(line, &SYNTAX_SET).unwrap_or_default();
                 ranges
                     .into_iter()
@@ -75,6 +82,16 @@ impl CodeHighlighter {
             None => vec![Span::raw(line.to_string())],
         }
     }
+}
+
+/// Pre-highlight an entire file, returning styled spans per line.
+///
+/// Maintains syntect parse state across lines for correct multiline
+/// string / comment / heredoc highlighting. Used by the diff renderer
+/// to look up pre-computed highlights by line number.
+pub fn pre_highlight(content: &str, ext: &str) -> Vec<Vec<ratatui::text::Span<'static>>> {
+    let mut hl = CodeHighlighter::new(ext);
+    content.lines().map(|line| hl.highlight_spans(line)).collect()
 }
 
 #[cfg(test)]

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -91,7 +91,10 @@ impl CodeHighlighter {
 /// to look up pre-computed highlights by line number.
 pub fn pre_highlight(content: &str, ext: &str) -> Vec<Vec<ratatui::text::Span<'static>>> {
     let mut hl = CodeHighlighter::new(ext);
-    content.lines().map(|line| hl.highlight_spans(line)).collect()
+    content
+        .lines()
+        .map(|line| hl.highlight_spans(line))
+        .collect()
 }
 
 #[cfg(test)]

--- a/koda-cli/src/mouse_select.rs
+++ b/koda-cli/src/mouse_select.rs
@@ -65,24 +65,34 @@ impl Selection {
 /// Build ALL visual rows from logical lines, accounting for line wrapping.
 ///
 /// Returns one String per visual row across the entire scroll buffer.
+/// Also returns a parallel vec of gutter widths per visual row.
 /// Used for buffer-space text extraction during copy operations.
-pub(crate) fn build_all_visual_rows(lines: &[Line<'_>], viewport_width: usize) -> Vec<String> {
+pub(crate) fn build_all_visual_rows(
+    lines: &[Line<'_>],
+    gutter_widths: &[u16],
+    viewport_width: usize,
+) -> (Vec<String>, Vec<u16>) {
     let mut visual_rows: Vec<String> = Vec::new();
+    let mut visual_gutters: Vec<u16> = Vec::new();
     let w = viewport_width.max(1);
 
-    for line in lines {
+    for (i, line) in lines.iter().enumerate() {
+        let gw = gutter_widths.get(i).copied().unwrap_or(0);
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         if text.is_empty() {
             visual_rows.push(String::new());
+            visual_gutters.push(gw);
         } else {
             let chars: Vec<char> = text.chars().collect();
-            for chunk in chars.chunks(w) {
+            for (j, chunk) in chars.chunks(w).enumerate() {
                 visual_rows.push(chunk.iter().collect());
+                // Only the first visual row of a wrapped line has the gutter
+                visual_gutters.push(if j == 0 { gw } else { 0 });
             }
         }
     }
 
-    visual_rows
+    (visual_rows, visual_gutters)
 }
 
 /// Extract the plain text content visible in the history area.
@@ -123,12 +133,16 @@ fn extract_visible_text(
     }
 }
 
-/// Extract the selected text from a vec of visual rows.
+/// Extract the selected text from visual rows, skipping gutter columns.
 ///
-/// `rows` can be either the full buffer (from `build_all_visual_rows`) or
-/// a viewport slice (from `extract_visible_text`). The selection's row
-/// indices must be in the same coordinate space as `rows`.
-pub(crate) fn extract_selected_text(rows: &[String], selection: &Selection) -> String {
+/// `rows` and `gutters` must be parallel (from `build_all_visual_rows`).
+/// For each row with a non-zero gutter width, that many leading columns
+/// are excluded from the extracted text (NoSelect behavior).
+pub(crate) fn extract_selected_text(
+    rows: &[String],
+    gutters: &[u16],
+    selection: &Selection,
+) -> String {
     let (start, end) = selection.ordered();
     let mut result = String::new();
 
@@ -138,6 +152,7 @@ pub(crate) fn extract_selected_text(rows: &[String], selection: &Selection) -> S
             break;
         }
         let line = &rows[idx];
+        let gutter_w = gutters.get(idx).copied().unwrap_or(0) as usize;
         let chars: Vec<char> = line.chars().collect();
 
         let col_start = if row == start.row {
@@ -151,8 +166,12 @@ pub(crate) fn extract_selected_text(rows: &[String], selection: &Selection) -> S
             chars.len()
         };
 
-        if col_start < chars.len() {
-            let selected: String = chars[col_start..col_end.min(chars.len())].iter().collect();
+        // Skip gutter columns (NoSelect)
+        let effective_start = col_start.max(gutter_w);
+
+        if effective_start < chars.len() && effective_start < col_end {
+            let selected: String =
+                chars[effective_start..col_end.min(chars.len())].iter().collect();
             result.push_str(&selected);
         }
         if row < end.row {
@@ -293,6 +312,10 @@ mod tests {
         assert_eq!(visible[1], "12345");
     }
 
+    fn no_gutters(n: usize) -> Vec<u16> {
+        vec![0; n]
+    }
+
     #[test]
     fn test_extract_selected_text_single_line() {
         let rows = vec!["hello world".to_string()];
@@ -301,7 +324,7 @@ mod tests {
             cursor: VisualPos { row: 0, col: 10 },
             scroll_from_top: 0,
         };
-        let text = extract_selected_text(&rows, &sel);
+        let text = extract_selected_text(&rows, &no_gutters(1), &sel);
         assert_eq!(text, "world");
     }
 
@@ -317,20 +340,19 @@ mod tests {
             cursor: VisualPos { row: 2, col: 4 },
             scroll_from_top: 0,
         };
-        let text = extract_selected_text(&rows, &sel);
+        let text = extract_selected_text(&rows, &no_gutters(3), &sel);
         assert_eq!(text, "line\nsecond line\nthird");
     }
 
     #[test]
     fn test_copy_to_clipboard_format() {
-        // We can't test actual clipboard in CI, but we can test the extraction
         let rows = vec!["hello".to_string(), "world".to_string()];
         let sel = Selection {
             anchor: VisualPos { row: 0, col: 0 },
             cursor: VisualPos { row: 1, col: 4 },
             scroll_from_top: 0,
         };
-        let text = extract_selected_text(&rows, &sel);
+        let text = extract_selected_text(&rows, &no_gutters(2), &sel);
         assert_eq!(text, "hello\nworld");
     }
 
@@ -341,7 +363,7 @@ mod tests {
             make_line("line two"),
             make_line("line three"),
         ];
-        let rows = build_all_visual_rows(&lines, 80);
+        let (rows, _) = build_all_visual_rows(&lines, &no_gutters(3), 80);
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0], "line one");
         assert_eq!(rows[2], "line three");
@@ -350,7 +372,7 @@ mod tests {
     #[test]
     fn test_build_all_visual_rows_with_wrapping() {
         let lines = vec![make_line("abcdefghij12345")];
-        let rows = build_all_visual_rows(&lines, 10);
+        let (rows, _) = build_all_visual_rows(&lines, &no_gutters(1), 10);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0], "abcdefghij");
         assert_eq!(rows[1], "12345");
@@ -359,7 +381,7 @@ mod tests {
     #[test]
     fn test_build_all_visual_rows_empty_lines() {
         let lines = vec![make_line("hello"), make_line(""), make_line("world")];
-        let rows = build_all_visual_rows(&lines, 80);
+        let (rows, _) = build_all_visual_rows(&lines, &no_gutters(3), 80);
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0], "hello");
         assert_eq!(rows[1], "");
@@ -372,21 +394,47 @@ mod tests {
     #[test]
     fn test_cross_page_selection() {
         let lines: Vec<Line<'_>> = (0..20).map(|i| make_line(&format!("line {i}"))).collect();
-        let all_rows = build_all_visual_rows(&lines, 80);
+        let (all_rows, all_gutters) = build_all_visual_rows(&lines, &no_gutters(20), 80);
         assert_eq!(all_rows.len(), 20);
 
-        // Selection spans rows 2–8 in buffer space (would cross viewport boundary)
         let sel = Selection {
             anchor: VisualPos { row: 2, col: 0 },
             cursor: VisualPos { row: 8, col: 5 },
             scroll_from_top: 0,
         };
-        let text = extract_selected_text(&all_rows, &sel);
+        let text = extract_selected_text(&all_rows, &all_gutters, &sel);
         assert!(text.contains("line 2"));
         assert!(text.contains("line 5"));
         assert!(text.contains("line 8"));
         assert!(!text.contains("line 1\n"));
         assert!(!text.contains("line 9"));
-        assert_eq!(text.lines().count(), 7); // rows 2,3,4,5,6,7,8
+        assert_eq!(text.lines().count(), 7);
+    }
+
+    /// Test NoSelect: gutter columns are skipped during text extraction.
+    #[test]
+    fn test_noselect_gutter_skipped() {
+        // Simulate diff lines with 7-char gutter: "{:>4} {} "
+        // e.g. "   1   fn main() {" (context, sigil=' ')
+        let rows = vec![
+            "   1   fn main() {".to_string(),
+            "   2 - println!(\"hello\");".to_string(),
+            "   2 + println!(\"world\");".to_string(),
+            "   3   }".to_string(),
+        ];
+        let gutters = vec![7u16, 7, 7, 7];
+        let sel = Selection {
+            anchor: VisualPos { row: 0, col: 0 },
+            cursor: VisualPos { row: 3, col: 30 },
+            scroll_from_top: 0,
+        };
+        let text = extract_selected_text(&rows, &gutters, &sel);
+        // Should NOT contain line numbers or +/- markers
+        assert!(!text.contains("   1"), "should skip gutter: {text}");
+        assert!(!text.contains(" - "), "should skip sigil: {text}");
+        assert!(!text.contains(" + "), "should skip sigil: {text}");
+        // Should contain the code content
+        assert!(text.contains("fn main()"));
+        assert!(text.contains("println"));
     }
 }

--- a/koda-cli/src/mouse_select.rs
+++ b/koda-cli/src/mouse_select.rs
@@ -170,8 +170,9 @@ pub(crate) fn extract_selected_text(
         let effective_start = col_start.max(gutter_w);
 
         if effective_start < chars.len() && effective_start < col_end {
-            let selected: String =
-                chars[effective_start..col_end.min(chars.len())].iter().collect();
+            let selected: String = chars[effective_start..col_end.min(chars.len())]
+                .iter()
+                .collect();
             result.push_str(&selected);
         }
         if row < end.row {

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -19,6 +19,10 @@ pub struct ScrollBuffer {
     /// The rendered lines (ring buffer).
     lines: VecDeque<Line<'static>>,
 
+    /// Per-line gutter width (columns to skip during NoSelect copy).
+    /// 0 = no gutter (normal text). Parallel with `lines`.
+    gutter_widths: VecDeque<u16>,
+
     /// Scroll offset: number of lines scrolled UP from the bottom.
     /// 0 = viewing the bottom (latest content).
     scroll_offset: usize,
@@ -41,8 +45,10 @@ pub struct ScrollBuffer {
 
 impl ScrollBuffer {
     pub fn new(capacity: usize) -> Self {
+        let cap = capacity.min(4096);
         Self {
-            lines: VecDeque::with_capacity(capacity.min(4096)),
+            lines: VecDeque::with_capacity(cap),
+            gutter_widths: VecDeque::with_capacity(cap),
             scroll_offset: 0,
             sticky_bottom: true,
             oldest_message_id: None,
@@ -57,9 +63,21 @@ impl ScrollBuffer {
     /// lines are evicted from the front.
     pub fn push(&mut self, line: Line<'static>) {
         self.lines.push_back(line);
+        self.gutter_widths.push_back(0);
         self.enforce_capacity();
 
         // If sticky, keep scroll at bottom
+        if self.sticky_bottom {
+            self.scroll_offset = 0;
+        }
+    }
+
+    /// Append a line with a gutter width (for NoSelect diff lines).
+    pub fn push_with_gutter(&mut self, line: Line<'static>, gutter_width: u16) {
+        self.lines.push_back(line);
+        self.gutter_widths.push_back(gutter_width);
+        self.enforce_capacity();
+
         if self.sticky_bottom {
             self.scroll_offset = 0;
         }
@@ -69,6 +87,7 @@ impl ScrollBuffer {
     pub fn push_lines(&mut self, lines: impl IntoIterator<Item = Line<'static>>) {
         for line in lines {
             self.lines.push_back(line);
+            self.gutter_widths.push_back(0);
         }
         self.enforce_capacity();
 
@@ -147,6 +166,13 @@ impl ScrollBuffer {
         self.lines.iter()
     }
 
+    /// Return the per-line gutter widths (parallel with `all_lines()`).
+    ///
+    /// Used by mouse selection to skip gutter columns during copy.
+    pub fn gutter_widths(&self) -> &VecDeque<u16> {
+        &self.gutter_widths
+    }
+
     /// Compute the total number of visual (wrapped) lines at a given
     /// terminal width. Used for scrollbar state and offset clamping.
     pub fn total_visual_lines(&self, term_width: usize) -> usize {
@@ -204,6 +230,7 @@ impl ScrollBuffer {
     #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.lines.clear();
+        self.gutter_widths.clear();
         self.scroll_offset = 0;
         self.sticky_bottom = true;
     }
@@ -286,6 +313,7 @@ impl ScrollBuffer {
                 let vis = visual_height(&evicted, w);
                 self.scroll_offset = self.scroll_offset.saturating_sub(vis);
             }
+            self.gutter_widths.pop_front();
         }
     }
 
@@ -297,9 +325,9 @@ impl ScrollBuffer {
     pub fn prepend_lines(&mut self, lines: impl IntoIterator<Item = Line<'static>>) {
         let lines: Vec<_> = lines.into_iter().collect();
         let count = lines.len();
-        // Push in reverse so they appear in the original order at the front
         for line in lines.into_iter().rev() {
             self.lines.push_front(line);
+            self.gutter_widths.push_front(0);
         }
         // Adjust scroll offset to keep the viewport stable
         // (content shifted down by `count` logical lines)

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -262,8 +262,15 @@ impl TuiContext {
                     if sel.anchor != sel.cursor {
                         let lines: Vec<Line<'_>> =
                             self.scroll_buffer.all_lines().cloned().collect();
-                        let all_rows = crate::mouse_select::build_all_visual_rows(&lines, w);
-                        let text = crate::mouse_select::extract_selected_text(&all_rows, &sel);
+                        let gutter_ws: Vec<u16> =
+                            self.scroll_buffer.gutter_widths().iter().copied().collect();
+                        let (all_rows, all_gutters) =
+                            crate::mouse_select::build_all_visual_rows(&lines, &gutter_ws, w);
+                        let text = crate::mouse_select::extract_selected_text(
+                            &all_rows,
+                            &all_gutters,
+                            &sel,
+                        );
                         if !text.is_empty() {
                             match crate::mouse_select::copy_to_clipboard(&text) {
                                 Ok(msg) => {

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -511,8 +511,9 @@ fn handle_inference_ui_inline(
             }
             if let Some(ref prev) = preview {
                 let diff_lines = crate::diff_render::render_lines(prev);
-                for line in &diff_lines {
-                    buffer.push(line.clone());
+                let gutter = crate::diff_render::GUTTER_WIDTH;
+                for line in diff_lines {
+                    buffer.push_with_gutter(line, gutter);
                 }
             }
             *menu = MenuContent::Approval {

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -16,12 +16,6 @@ pub fn emit_line(buffer: &mut ScrollBuffer, line: Line<'static>) {
     buffer.push(line);
 }
 
-/// Append multiple `Line`s to the scroll buffer.
-pub fn emit_lines(buffer: &mut ScrollBuffer, lines: &[Line<'static>]) {
-    let owned: Vec<Line<'static>> = lines.to_vec();
-    buffer.push_lines(owned);
-}
-
 // ── Style constants ─────────────────────────────────────────
 // Centralized color palette for the TUI renderer.
 

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -204,7 +204,10 @@ impl TuiRenderer {
                 );
                 if let Some(preview) = preview {
                     let diff_lines = crate::diff_render::render_lines(&preview);
-                    tui_output::emit_lines(buffer, &diff_lines);
+                    let gutter = crate::diff_render::GUTTER_WIDTH;
+                    for line in diff_lines {
+                        buffer.push_with_gutter(line, gutter);
+                    }
                 }
             }
             EngineEvent::Footer {

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -60,7 +60,6 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-ast = { path = "../koda-ast", version = "0.1.20" }
 koda-email = { path = "../koda-email", version = "0.1.20" }
 
 # Async trait support

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -35,6 +35,9 @@ path-clean = "1"
 # Text search
 regex = "1"
 
+# Diff computation
+similar = "2"
+
 # File globbing
 glob = "0.3"
 

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -46,4 +46,4 @@ Expert instruction modules — zero cost, instant activation via `ActivateSkill`
 
 ### First-Party Libraries
 
-Direct library integrations (no IPC): `koda-ast` (AST analysis), `koda-email` (email via IMAP/SMTP).
+Direct library integrations (no IPC): `koda-email` (email via IMAP/SMTP). `koda-ast` available as a standalone MCP server.

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -48,6 +48,12 @@ fn record_compact_success() {
     reset_compact_failures();
 }
 
+/// Maximum number of head-truncation retries when history is too large.
+const MAX_TRUNCATION_RETRIES: usize = 3;
+
+/// Fraction of messages to drop on each truncation attempt.
+const TRUNCATION_DROP_FRACTION: f64 = 0.2;
+
 /// Result of a successful compaction.
 #[derive(Debug)]
 pub struct CompactResult {
@@ -115,11 +121,19 @@ pub async fn compact_session_with_provider(
         as usize
         + crate::inference_helpers::SYSTEM_PROMPT_OVERHEAD;
     let available = max_context_tokens.saturating_sub(4096);
-    if text_tokens > available {
-        return Ok(Err(CompactSkip::HistoryTooLarge));
-    }
 
-    let summary_prompt = build_summary_prompt(&conversation_text);
+    // If history fits, use it as-is. Otherwise, progressively truncate
+    // the oldest messages until it fits (up to MAX_TRUNCATION_RETRIES).
+    let final_text = if text_tokens <= available {
+        conversation_text
+    } else {
+        match truncate_until_fits(&history, available) {
+            Some(text) => text,
+            None => return Ok(Err(CompactSkip::HistoryTooLarge)),
+        }
+    };
+
+    let summary_prompt = build_summary_prompt(&final_text);
 
     let messages = vec![ChatMessage::text("user", &summary_prompt)];
     // Use reduced settings for compaction on the SAME model/provider.
@@ -261,6 +275,48 @@ pub fn strip_analysis_block(summary: &str) -> String {
         prev_empty = is_empty;
     }
     result.trim().to_string()
+}
+
+/// Progressively drop oldest messages until the conversation text fits
+/// in the available token budget. Keeps at least `COMPACT_PRESERVE_COUNT`
+/// recent messages. Returns `None` if it can't fit after max retries.
+fn truncate_until_fits(history: &[crate::db::Message], available_tokens: usize) -> Option<String> {
+    let total = history.len();
+    // Minimum messages to keep: the preserved tail + at least 1 to summarize
+    let min_keep = COMPACT_PRESERVE_COUNT + 1;
+    if total <= min_keep {
+        return None;
+    }
+
+    let mut drop_count = 0usize;
+    for attempt in 0..MAX_TRUNCATION_RETRIES {
+        // Drop 20% of remaining summarizable messages each attempt
+        let summarizable = total.saturating_sub(drop_count);
+        let to_drop = (summarizable as f64 * TRUNCATION_DROP_FRACTION).ceil() as usize;
+        drop_count += to_drop.max(1); // always drop at least 1
+
+        // Never drop so many that we have fewer than min_keep
+        if total.saturating_sub(drop_count) < min_keep {
+            drop_count = total - min_keep;
+        }
+
+        let truncated = &history[drop_count..];
+        let text = build_conversation_text(truncated);
+        let text_tokens = (text.len() as f64 / crate::inference_helpers::CHARS_PER_TOKEN) as usize
+            + crate::inference_helpers::SYSTEM_PROMPT_OVERHEAD;
+
+        tracing::info!(
+            "Truncation attempt {}: dropped {drop_count}/{total} messages, \
+             ~{text_tokens} tokens (budget: {available_tokens})",
+            attempt + 1,
+        );
+
+        if text_tokens <= available_tokens {
+            return Some(text);
+        }
+    }
+
+    None
 }
 
 /// Format conversation history into a single string for the summarizer.
@@ -411,5 +467,54 @@ mod tests {
         let input = "<summary>\nThe good stuff\n</summary>";
         let result = strip_analysis_block(input);
         assert_eq!(result, "The good stuff");
+    }
+
+    #[test]
+    fn test_truncate_until_fits_drops_oldest() {
+        // 20 messages, each ~50 chars
+        let msgs: Vec<_> = (0..20)
+            .map(|i| {
+                make_msg(
+                    "user",
+                    Some(&format!("Message number {i} with some padding text here")),
+                    None,
+                )
+            })
+            .collect();
+
+        // Budget: fits ~half the messages but not all 20
+        // 20 msgs × ~50 chars / 3.5 ≈ 286 tokens + 100 overhead ≈ 386
+        // Want to force truncation: set budget to ~250 tokens
+        let result = truncate_until_fits(&msgs, 250);
+        assert!(result.is_some(), "should succeed after truncation");
+        let text = result.unwrap();
+        // Should contain the last messages but not the first
+        assert!(text.contains("Message number 19"));
+        assert!(!text.contains("Message number 0"));
+    }
+
+    #[test]
+    fn test_truncate_until_fits_too_few_messages() {
+        // Only COMPACT_PRESERVE_COUNT + 1 = 5 messages, can't drop any
+        let msgs: Vec<_> = (0..5)
+            .map(|_| make_msg("user", Some(&"x".repeat(10_000)), None))
+            .collect();
+        // Tiny budget that can't fit even 5 messages
+        let result = truncate_until_fits(&msgs, 10);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_truncate_until_fits_already_fits() {
+        let msgs: Vec<_> = (0..10)
+            .map(|i| make_msg("user", Some(&format!("Short {i}")), None))
+            .collect();
+        // Huge budget
+        let result = truncate_until_fits(&msgs, 100_000);
+        assert!(result.is_some());
+        let text = result.unwrap();
+        // First attempt drops 20% but still fits, so it drops
+        // We just check it returns something valid
+        assert!(text.contains("Short 9"));
     }
 }

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -150,11 +150,7 @@ pub async fn compute(
 /// Build a unified diff from old and new content.
 ///
 /// Shared by Edit and Write-overwrite paths.
-fn build_unified_diff(
-    path: &str,
-    old_content: &str,
-    new_content: &str,
-) -> UnifiedDiffPreview {
+fn build_unified_diff(path: &str, old_content: &str, new_content: &str) -> UnifiedDiffPreview {
     let diff = TextDiff::from_lines(old_content, new_content);
     let mut hunks = Vec::new();
     let mut total_lines = 0usize;
@@ -192,19 +188,11 @@ fn build_unified_diff(
                     }
                     ChangeTag::Delete => {
                         old_count += 1;
-                        (
-                            DiffTag::Delete,
-                            change.old_index().map(|i| i + 1),
-                            None,
-                        )
+                        (DiffTag::Delete, change.old_index().map(|i| i + 1), None)
                     }
                     ChangeTag::Insert => {
                         new_count += 1;
-                        (
-                            DiffTag::Insert,
-                            None,
-                            change.new_index().map(|i| i + 1),
-                        )
+                        (DiffTag::Insert, None, change.new_index().map(|i| i + 1))
                     }
                 };
 
@@ -377,10 +365,18 @@ mod tests {
                 assert!(tags.contains(&DiffTag::Insert));
                 assert!(tags.contains(&DiffTag::Context));
                 // Deleted line should contain "hello"
-                let del = hunk.lines.iter().find(|l| l.tag == DiffTag::Delete).unwrap();
+                let del = hunk
+                    .lines
+                    .iter()
+                    .find(|l| l.tag == DiffTag::Delete)
+                    .unwrap();
                 assert!(del.content.contains("hello"));
                 // Inserted line should contain "world"
-                let ins = hunk.lines.iter().find(|l| l.tag == DiffTag::Insert).unwrap();
+                let ins = hunk
+                    .lines
+                    .iter()
+                    .find(|l| l.tag == DiffTag::Insert)
+                    .unwrap();
                 assert!(ins.content.contains("world"));
             }
             other => panic!("expected UnifiedDiff, got {other:?}"),
@@ -407,7 +403,12 @@ mod tests {
         let preview = compute("Edit", &args, tmp.path()).await.unwrap();
         match preview {
             DiffPreview::UnifiedDiff(diff) => {
-                assert_eq!(diff.hunks.len(), 2, "expected 2 hunks, got {:?}", diff.hunks);
+                assert_eq!(
+                    diff.hunks.len(),
+                    2,
+                    "expected 2 hunks, got {:?}",
+                    diff.hunks
+                );
             }
             other => panic!("expected UnifiedDiff, got {other:?}"),
         }

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -3,91 +3,111 @@
 //! Computes **structured** preview data before the user confirms an Edit,
 //! Write, or Delete.  The actual rendering (colors, syntax highlighting)
 //! is the client's responsibility — koda-core never emits ANSI codes.
+//!
+//! Edit and Write-overwrite produce a proper unified diff (via `similar`)
+//! with context lines and hunk headers — the same information you'd see
+//! in `git diff` output.
 
 use crate::tools::safe_resolve_path;
+use similar::{ChangeTag, TextDiff};
 use std::path::Path;
 
-/// Maximum diff lines before truncation.
-const MAX_PREVIEW_LINES: usize = 40;
+/// Number of context lines around each change (like `diff -U3`).
+const CONTEXT_LINES: usize = 3;
 
-/// Maximum first-lines in Write previews.
-const MAX_WRITE_PREVIEW_LINES: usize = 8;
+/// Maximum total diff lines before we truncate.
+const MAX_DIFF_LINES: usize = 120;
+
+/// Maximum lines shown for a new-file preview.
+const MAX_WRITE_NEW_LINES: usize = 60;
 
 // ── Data types ────────────────────────────────────────────────
 
 /// Structured diff preview produced by the engine.
 ///
-/// Clients render this however they want (ANSI, HTML, plain text, …).
+/// Clients render this however they want (ratatui, HTML, plain text, …).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind")]
 pub enum DiffPreview {
-    /// Replacement-based edit with context lines.
-    Edit(EditPreview),
+    /// Unified diff with context lines and hunk headers.
+    /// Used for both Edit and Write-overwrite.
+    UnifiedDiff(UnifiedDiffPreview),
     /// New file creation.
-    WriteNew(WritePreview),
-    /// Overwrite of an existing file.
-    WriteOverwrite(WriteOverwritePreview),
+    WriteNew(WriteNewPreview),
     /// Single file deletion.
     DeleteFile(DeleteFilePreview),
     /// Directory deletion.
     DeleteDir(DeleteDirPreview),
-    /// Target file doesn't exist yet (Write will create it).
+    /// Target file doesn't exist yet (for Edit on missing file).
     FileNotYetExists,
     /// Target path not found.
     PathNotFound,
 }
 
-/// Preview of an Edit (replacement-based) operation.
+/// A proper unified diff between old and new file content.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct EditPreview {
+pub struct UnifiedDiffPreview {
     /// File path (as given in the tool args).
     pub path: String,
-    /// Per-replacement data.
-    pub replacements: Vec<ReplacementPreview>,
-    /// Number of replacements omitted due to truncation.
-    pub truncated_count: usize,
+    /// Full old file content (for syntax-context highlighting).
+    pub old_content: String,
+    /// Full new file content (for syntax-context highlighting).
+    pub new_content: String,
+    /// Diff hunks with context.
+    pub hunks: Vec<DiffHunk>,
+    /// Whether hunks were truncated due to size limits.
+    pub truncated: bool,
 }
 
-/// A single replacement within an Edit operation.
+/// A single hunk in a unified diff.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ReplacementPreview {
-    /// 0-based index of this replacement.
-    pub index: usize,
-    /// Total number of replacements in the Edit call.
-    pub total: usize,
-    /// 1-based line number where `old_str` starts in the file.
-    pub start_line: usize,
-    /// Lines of the old (removed) text.
-    pub old_lines: Vec<String>,
-    /// Lines of the new (added) text.
-    pub new_lines: Vec<String>,
+pub struct DiffHunk {
+    /// 1-based starting line in the old file.
+    pub old_start: usize,
+    /// Number of lines from the old file in this hunk.
+    pub old_count: usize,
+    /// 1-based starting line in the new file.
+    pub new_start: usize,
+    /// Number of lines from the new file in this hunk.
+    pub new_count: usize,
+    /// The lines in this hunk (context + insertions + deletions).
+    pub lines: Vec<DiffLine>,
+}
+
+/// A single line within a diff hunk.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DiffLine {
+    /// Whether this line is context, inserted, or deleted.
+    pub tag: DiffTag,
+    /// The line content (without trailing newline).
+    pub content: String,
+    /// Line number in the old file (for Context/Delete lines).
+    pub old_line: Option<usize>,
+    /// Line number in the new file (for Context/Insert lines).
+    pub new_line: Option<usize>,
+}
+
+/// The type of a diff line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum DiffTag {
+    /// Unchanged context line.
+    Context,
+    /// Line was added.
+    Insert,
+    /// Line was removed.
+    Delete,
 }
 
 /// Preview of a Write (new file) operation.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct WritePreview {
+pub struct WriteNewPreview {
+    /// File path.
+    pub path: String,
     /// Total line count of the new file.
     pub line_count: usize,
     /// Total byte count.
     pub byte_count: usize,
-    /// First few lines (for preview display).
-    pub first_lines: Vec<String>,
-    /// Whether `first_lines` was truncated.
-    pub truncated: bool,
-}
-
-/// Preview of a Write (overwrite existing file) operation.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct WriteOverwritePreview {
-    /// Line count of the existing file.
-    pub old_line_count: usize,
-    /// Byte count of the existing file.
-    pub old_byte_count: usize,
-    /// Line count of the new content.
-    pub new_line_count: usize,
-    /// Byte count of the new content.
-    pub new_byte_count: usize,
-    /// First few lines of the new content.
+    /// First lines (for preview display).
     pub first_lines: Vec<String>,
     /// Whether `first_lines` was truncated.
     pub truncated: bool,
@@ -127,6 +147,103 @@ pub async fn compute(
     }
 }
 
+/// Build a unified diff from old and new content.
+///
+/// Shared by Edit and Write-overwrite paths.
+fn build_unified_diff(
+    path: &str,
+    old_content: &str,
+    new_content: &str,
+) -> UnifiedDiffPreview {
+    let diff = TextDiff::from_lines(old_content, new_content);
+    let mut hunks = Vec::new();
+    let mut total_lines = 0usize;
+    let mut truncated = false;
+
+    for group in diff.grouped_ops(CONTEXT_LINES) {
+        let mut hunk_lines = Vec::new();
+        let mut old_start = 0;
+        let mut new_start = 0;
+        let mut old_count = 0;
+        let mut new_count = 0;
+        let mut first = true;
+
+        for op in &group {
+            if first {
+                old_start = op.old_range().start + 1; // 1-based
+                new_start = op.new_range().start + 1;
+                first = false;
+            }
+
+            let old_lines = diff.old_slices();
+            let new_lines = diff.new_slices();
+
+            for change in diff.iter_changes(op) {
+                let content = change.value().trim_end_matches('\n').to_string();
+                let (tag, old_line, new_line) = match change.tag() {
+                    ChangeTag::Equal => {
+                        old_count += 1;
+                        new_count += 1;
+                        (
+                            DiffTag::Context,
+                            change.old_index().map(|i| i + 1),
+                            change.new_index().map(|i| i + 1),
+                        )
+                    }
+                    ChangeTag::Delete => {
+                        old_count += 1;
+                        (
+                            DiffTag::Delete,
+                            change.old_index().map(|i| i + 1),
+                            None,
+                        )
+                    }
+                    ChangeTag::Insert => {
+                        new_count += 1;
+                        (
+                            DiffTag::Insert,
+                            None,
+                            change.new_index().map(|i| i + 1),
+                        )
+                    }
+                };
+
+                hunk_lines.push(DiffLine {
+                    tag,
+                    content,
+                    old_line,
+                    new_line,
+                });
+            }
+
+            // Suppress unused-variable warnings — we use iter_changes instead.
+            let _ = (old_lines, new_lines);
+        }
+
+        total_lines += hunk_lines.len();
+        hunks.push(DiffHunk {
+            old_start,
+            old_count,
+            new_start,
+            new_count,
+            lines: hunk_lines,
+        });
+
+        if total_lines > MAX_DIFF_LINES {
+            truncated = true;
+            break;
+        }
+    }
+
+    UnifiedDiffPreview {
+        path: path.to_string(),
+        old_content: old_content.to_string(),
+        new_content: new_content.to_string(),
+        hunks,
+        truncated,
+    }
+}
+
 async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<DiffPreview> {
     let inner = args.get("payload").unwrap_or(args);
     let path_str = inner
@@ -139,53 +256,24 @@ async fn preview_edit(args: &serde_json::Value, project_root: &Path) -> Option<D
     if !resolved.exists() {
         return Some(DiffPreview::FileNotYetExists);
     }
-    let file_content = tokio::fs::read_to_string(&resolved).await.ok()?;
+    let old_content = tokio::fs::read_to_string(&resolved).await.ok()?;
 
-    let mut previews = Vec::new();
-    let mut total_lines = 0usize;
-    let mut truncated_count = 0usize;
-
-    for (i, replacement) in replacements.iter().enumerate() {
+    // Apply all replacements sequentially to produce new_content
+    let mut new_content = old_content.clone();
+    for replacement in replacements {
         let old_str = replacement.get("old_str")?.as_str()?;
         let new_str = replacement
             .get("new_str")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-
-        let start_line = file_content
-            .find(old_str)
-            .map(|byte_pos| {
-                file_content[..byte_pos]
-                    .bytes()
-                    .filter(|&b| b == b'\n')
-                    .count()
-                    + 1
-            })
-            .unwrap_or(1);
-
-        let old_lines: Vec<String> = old_str.lines().map(String::from).collect();
-        let new_lines: Vec<String> = new_str.lines().map(String::from).collect();
-        total_lines += old_lines.len() + new_lines.len();
-
-        previews.push(ReplacementPreview {
-            index: i,
-            total: replacements.len(),
-            start_line,
-            old_lines,
-            new_lines,
-        });
-
-        if total_lines > MAX_PREVIEW_LINES {
-            truncated_count = replacements.len() - i - 1;
-            break;
+        // Replace first occurrence only (matches Edit tool behavior)
+        if let Some(pos) = new_content.find(old_str) {
+            new_content.replace_range(pos..pos + old_str.len(), new_str);
         }
     }
 
-    Some(DiffPreview::Edit(EditPreview {
-        path: path_str.to_string(),
-        replacements: previews,
-        truncated_count,
-    }))
+    let preview = build_unified_diff(path_str, &old_content, &new_content);
+    Some(DiffPreview::UnifiedDiff(preview))
 }
 
 async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<DiffPreview> {
@@ -197,27 +285,24 @@ async fn preview_write(args: &serde_json::Value, project_root: &Path) -> Option<
     let content = inner.get("content").and_then(|v| v.as_str())?;
     let resolved = safe_resolve_path(project_root, path_str).ok()?;
 
-    let content_lines: Vec<&str> = content.lines().collect();
-    let line_count = content_lines.len();
-    let preview_count = line_count.min(MAX_WRITE_PREVIEW_LINES);
-    let first_lines: Vec<String> = content_lines[..preview_count]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
-    let truncated = line_count > MAX_WRITE_PREVIEW_LINES;
-
     if resolved.exists() {
-        let existing = tokio::fs::read_to_string(&resolved).await.ok()?;
-        Some(DiffPreview::WriteOverwrite(WriteOverwritePreview {
-            old_line_count: existing.lines().count(),
-            old_byte_count: existing.len(),
-            new_line_count: line_count,
-            new_byte_count: content.len(),
-            first_lines,
-            truncated,
-        }))
+        // Overwrite → produce a real unified diff
+        let old_content = tokio::fs::read_to_string(&resolved).await.ok()?;
+        let preview = build_unified_diff(path_str, &old_content, content);
+        Some(DiffPreview::UnifiedDiff(preview))
     } else {
-        Some(DiffPreview::WriteNew(WritePreview {
+        // New file → show content preview
+        let content_lines: Vec<&str> = content.lines().collect();
+        let line_count = content_lines.len();
+        let preview_count = line_count.min(MAX_WRITE_NEW_LINES);
+        let first_lines: Vec<String> = content_lines[..preview_count]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let truncated = line_count > MAX_WRITE_NEW_LINES;
+
+        Some(DiffPreview::WriteNew(WriteNewPreview {
+            path: path_str.to_string(),
             line_count,
             byte_count: content.len(),
             first_lines,
@@ -268,7 +353,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
-    async fn test_preview_edit_replacements() {
+    async fn test_edit_produces_unified_diff() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("test.rs");
         std::fs::write(&file, "fn main() {\n    println!(\"hello\");\n}\n").unwrap();
@@ -281,34 +366,67 @@ mod tests {
             }]
         });
 
-        let preview = compute("Edit", &args, tmp.path()).await;
-        let preview = preview.expect("should produce a preview");
+        let preview = compute("Edit", &args, tmp.path()).await.unwrap();
         match preview {
-            DiffPreview::Edit(edit) => {
-                assert_eq!(edit.replacements.len(), 1);
-                let r = &edit.replacements[0];
-                assert_eq!(r.start_line, 2);
-                assert_eq!(r.old_lines, vec!["println!(\"hello\");"]);
-                assert_eq!(r.new_lines, vec!["println!(\"world\");"]);
+            DiffPreview::UnifiedDiff(diff) => {
+                assert_eq!(diff.hunks.len(), 1);
+                let hunk = &diff.hunks[0];
+                // Should have context + delete + insert
+                let tags: Vec<_> = hunk.lines.iter().map(|l| l.tag).collect();
+                assert!(tags.contains(&DiffTag::Delete));
+                assert!(tags.contains(&DiffTag::Insert));
+                assert!(tags.contains(&DiffTag::Context));
+                // Deleted line should contain "hello"
+                let del = hunk.lines.iter().find(|l| l.tag == DiffTag::Delete).unwrap();
+                assert!(del.content.contains("hello"));
+                // Inserted line should contain "world"
+                let ins = hunk.lines.iter().find(|l| l.tag == DiffTag::Insert).unwrap();
+                assert!(ins.content.contains("world"));
             }
-            other => panic!("expected Edit preview, got {other:?}"),
+            other => panic!("expected UnifiedDiff, got {other:?}"),
         }
     }
 
     #[tokio::test]
-    async fn test_preview_write_new_file() {
+    async fn test_edit_multiple_replacements() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("test.rs");
+        // 20 lines — changes at line 2 and 19 are >6 lines apart,
+        // so with 3 context lines they produce separate hunks.
+        let content: String = (1..=20).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(&file, &content).unwrap();
+
+        let args = json!({
+            "path": file.to_str().unwrap(),
+            "replacements": [
+                { "old_str": "line 2", "new_str": "LINE TWO" },
+                { "old_str": "line 19", "new_str": "LINE NINETEEN" }
+            ]
+        });
+
+        let preview = compute("Edit", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::UnifiedDiff(diff) => {
+                assert_eq!(diff.hunks.len(), 2, "expected 2 hunks, got {:?}", diff.hunks);
+            }
+            other => panic!("expected UnifiedDiff, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_new_file() {
         let tmp = TempDir::new().unwrap();
         let args = json!({
             "path": "new_file.rs",
             "content": "fn main() {}\n"
         });
 
-        let preview = compute("Write", &args, tmp.path()).await;
-        assert!(matches!(preview, Some(DiffPreview::WriteNew(_))));
+        let preview = compute("Write", &args, tmp.path()).await.unwrap();
+        assert!(matches!(preview, DiffPreview::WriteNew(_)));
     }
 
     #[tokio::test]
-    async fn test_preview_write_overwrite() {
+    async fn test_write_overwrite_produces_unified_diff() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("existing.rs");
         std::fs::write(&file, "old content\n").unwrap();
@@ -318,29 +436,69 @@ mod tests {
             "content": "new content\nline 2\n"
         });
 
-        let preview = compute("Write", &args, tmp.path()).await;
-        assert!(matches!(preview, Some(DiffPreview::WriteOverwrite(_))));
+        let preview = compute("Write", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::UnifiedDiff(diff) => {
+                assert!(!diff.hunks.is_empty());
+            }
+            other => panic!("expected UnifiedDiff for overwrite, got {other:?}"),
+        }
     }
 
     #[tokio::test]
-    async fn test_preview_delete_file() {
+    async fn test_delete_file() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("doomed.rs");
         std::fs::write(&file, "goodbye\n").unwrap();
 
-        let args = json!({
-            "path": file.to_str().unwrap()
-        });
-
-        let preview = compute("Delete", &args, tmp.path()).await;
-        assert!(matches!(preview, Some(DiffPreview::DeleteFile(_))));
+        let args = json!({ "path": file.to_str().unwrap() });
+        let preview = compute("Delete", &args, tmp.path()).await.unwrap();
+        assert!(matches!(preview, DiffPreview::DeleteFile(_)));
     }
 
     #[tokio::test]
-    async fn test_preview_read_returns_none() {
+    async fn test_unknown_tool_returns_none() {
         let tmp = TempDir::new().unwrap();
         let args = json!({"path": "anything.rs"});
         let preview = compute("Read", &args, tmp.path()).await;
         assert!(preview.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_edit_missing_file() {
+        let tmp = TempDir::new().unwrap();
+        let args = json!({
+            "path": "nonexistent.rs",
+            "replacements": [{ "old_str": "x", "new_str": "y" }]
+        });
+        let preview = compute("Edit", &args, tmp.path()).await.unwrap();
+        assert!(matches!(preview, DiffPreview::FileNotYetExists));
+    }
+
+    #[tokio::test]
+    async fn test_unified_diff_has_line_numbers() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("test.txt");
+        std::fs::write(&file, "a\nb\nc\nd\ne\n").unwrap();
+
+        let args = json!({
+            "path": file.to_str().unwrap(),
+            "replacements": [{ "old_str": "c", "new_str": "C" }]
+        });
+
+        let preview = compute("Edit", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::UnifiedDiff(diff) => {
+                let hunk = &diff.hunks[0];
+                // Every line should have at least one line number
+                for line in &hunk.lines {
+                    assert!(
+                        line.old_line.is_some() || line.new_line.is_some(),
+                        "line should have a line number: {line:?}"
+                    );
+                }
+            }
+            other => panic!("expected UnifiedDiff, got {other:?}"),
+        }
     }
 }

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -24,7 +24,6 @@ use std::sync::LazyLock;
 /// All canonical (PascalCase) built-in tool names.
 const CANONICAL: &[&str] = &[
     "ActivateSkill",
-    "AstAnalysis",
     "Bash",
     "Delete",
     "Edit",
@@ -126,10 +125,6 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     m.insert("list_skills".into(), "ListSkills");
     m.insert("activate_skill".into(), "ActivateSkill");
 
-    // AST
-    m.insert("ast_analysis".into(), "AstAnalysis");
-    m.insert("analyze_ast".into(), "AstAnalysis");
-
     // Email
     m.insert("email_read".into(), "EmailRead");
     m.insert("email_send".into(), "EmailSend");
@@ -223,7 +218,6 @@ mod tests {
         assert_eq!(normalize_tool_name("memory_read"), "MemoryRead");
         assert_eq!(normalize_tool_name("memory_write"), "MemoryWrite");
         assert_eq!(normalize_tool_name("recall_context"), "RecallContext");
-        assert_eq!(normalize_tool_name("ast_analysis"), "AstAnalysis");
     }
 
     // ── Short aliases (model hallucinations) ────────────────────

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -29,7 +29,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
         "Read" | "List" | "Grep" | "Glob" | "MemoryRead" | "ListAgents" | "ListSkills"
-        | "ActivateSkill" | "RecallContext" | "AstAnalysis" => ToolEffect::ReadOnly,
+        | "ActivateSkill" | "RecallContext" => ToolEffect::ReadOnly,
 
         // Remote actions — side-effects on remote services only
         "WebFetch" => ToolEffect::ReadOnly,    // GET-only fetch
@@ -186,16 +186,6 @@ impl ToolRegistry {
         let recall_def = recall::definition();
         definitions.insert(recall_def.name.clone(), recall_def);
         // First-party library tools (direct calls)
-        for td in koda_ast::tool_definitions() {
-            definitions.insert(
-                td.name.to_string(),
-                ToolDefinition {
-                    name: td.name.to_string(),
-                    description: td.description.to_string(),
-                    parameters: serde_json::from_str(td.parameters_json).unwrap_or_default(),
-                },
-            );
-        }
         for td in koda_email::tool_definitions() {
             definitions.insert(
                 td.name.to_string(),
@@ -405,14 +395,6 @@ impl ToolRegistry {
             }
 
             // First-party library tools — direct calls
-            "AstAnalysis" => {
-                let action = args["action"].as_str().unwrap_or("");
-                let file_path = args["file_path"].as_str().unwrap_or("");
-                let symbol = args["symbol"].as_str();
-                koda_ast::execute(&self.project_root, action, file_path, symbol)
-                    .map_err(|e| anyhow::anyhow!(e))
-            }
-
             "EmailRead" => {
                 let config = require_email_config!(self);
                 let count = args["count"].as_u64().unwrap_or(5).clamp(1, 20) as u32;
@@ -645,14 +627,6 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
         "WebFetch" => {
             let url = args.get("url").and_then(|v| v.as_str()).unwrap_or("?");
             format!("Fetch URL: {url}")
-        }
-        "AstAnalysis" => {
-            let action = args.get("action").and_then(|v| v.as_str()).unwrap_or("?");
-            let file = args
-                .get("file_path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("?");
-            format!("AST {action}: {file}")
         }
         "EmailSend" => {
             let to = args.get("to").and_then(|v| v.as_str()).unwrap_or("?");

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -221,7 +221,6 @@ mod naming_convention {
     /// All built-in tool names must be PascalCase.
     const BUILTIN_TOOLS: &[&str] = &[
         "ActivateSkill",
-        "AstAnalysis",
         "Bash",
         "Delete",
         "Edit",
@@ -272,8 +271,8 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 20 built-in tools as of v0.1.9+
-        assert_eq!(BUILTIN_TOOLS.len(), 20);
+        // 19 built-in tools (AstAnalysis removed in #608)
+        assert_eq!(BUILTIN_TOOLS.len(), 19);
     }
 
     /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -30,7 +30,6 @@ async fn normalized_lowercase_names_are_routable() {
         "listskills",
         "activateskill",
         "recallcontext",
-        "astanalysis",
     ];
 
     for raw_name in lowercase_names {


### PR DESCRIPTION
## Remove AstAnalysis from koda-core tool registry

Closes #608

### What

Remove the `AstAnalysis` tool from koda-core's built-in tool set. `koda-ast` remains in the workspace as a standalone MCP server for anyone who wants it externally.

### Why

Per the tool audit in #592, the AST tool provides marginal value over existing tools:

- **`analyze_file`** — Returns function/class names with line numbers. The model gets better structural understanding from `Read` (sees types, doc comments, implementations) or `Grep`.
- **`get_call_graph`** — Single-file only. Cross-file symbol search via `Grep` is more useful.
- **`syntax_check`** — The one genuinely valuable feature, but wiring it into Edit/Write proved overly restrictive in practice.

### Cost savings

- **10 tree-sitter grammar crates** removed from koda-core's dependency tree (C compilation)
- **~100 tokens/turn** saved (tool definition no longer sent on every turn)
- **Reduced maintenance surface** for 8 language grammars

### Changes

| File | Change |
|------|--------|
| `koda-core/Cargo.toml` | Remove `koda-ast` dependency |
| `koda-core/src/tools/mod.rs` | Remove from `classify_tool`, `execute`, `describe_action` |
| `koda-core/src/tool_normalize.rs` | Remove from `CANONICAL` list and alias map |
| `koda-core/src/capabilities.md` | Update first-party libraries note |
| `koda-core/tests/new_tools_test.rs` | Update tool count (20 → 19) |

### Testing

- `cargo check -p koda-core` ✅
- `cargo check -p koda-cli` ✅  
- `cargo test -p koda-core --lib` — 446 passed ✅
- `cargo test -p koda-core --test new_tools_test` — 14 passed ✅
