### PR TITLE
P0: Pre-flight input validation before approval prompts

### DIFF
--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -436,6 +436,30 @@ pub(crate) async fn execute_tools_sequential(
             is_sub_agent: false,
         });
 
+        // Pre-flight validation: catch errors before bothering the user
+        // with an approval prompt that will inevitably fail.
+        if let Some(error) = tools::validate::validate_tool_call(
+            &tc.function_name,
+            &parsed_args,
+            project_root,
+        )
+        .await
+        {
+            record_tool_result(
+                tc,
+                &format!("Validation error: {error}"),
+                false,
+                db,
+                session_id,
+                tools.caps.tool_result_chars,
+                project_root,
+                file_tracker,
+                sink,
+            )
+            .await?;
+            continue;
+        }
+
         // Check approval for this tool call (with file ownership awareness, #465)
         let approval = approval::check_tool_with_tracker(
             &tc.function_name,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -438,12 +438,8 @@ pub(crate) async fn execute_tools_sequential(
 
         // Pre-flight validation: catch errors before bothering the user
         // with an approval prompt that will inevitably fail.
-        if let Some(error) = tools::validate::validate_tool_call(
-            &tc.function_name,
-            &parsed_args,
-            project_root,
-        )
-        .await
+        if let Some(error) =
+            tools::validate::validate_tool_call(&tc.function_name, &parsed_args, project_root).await
         {
             record_tool_result(
                 tc,

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -77,6 +77,8 @@ pub mod recall;
 pub mod shell;
 /// Skill discovery and activation tools (`ListSkills`, `ActivateSkill`).
 pub mod skill_tools;
+/// Pre-flight validation for tool calls (runs before approval).
+pub mod validate;
 /// HTTP fetch tool (`WebFetch`).  
 pub mod web_fetch;
 

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -1,0 +1,282 @@
+//! Pre-flight validation for tool calls.
+//!
+//! Runs **before** the approval prompt so we never ask the user to approve
+//! an operation that will inevitably fail. Cheap checks only — no mutations.
+
+use super::safe_resolve_path;
+use std::path::Path;
+
+/// Validate a tool call before approval.
+///
+/// Returns `None` if the call looks valid, or `Some(error_message)` describing
+/// why it will fail. The error message is fed back to the model so it can
+/// self-correct without consuming an approval prompt.
+pub async fn validate_tool_call(
+    tool_name: &str,
+    args: &serde_json::Value,
+    project_root: &Path,
+) -> Option<String> {
+    match tool_name {
+        "Edit" => validate_edit(args, project_root).await,
+        "Delete" => validate_delete(args, project_root).await,
+        "Bash" => validate_bash(args),
+        _ => None,
+    }
+}
+
+/// Edit: file must exist, replacements must be non-empty, each old_str must
+/// be non-empty and actually present in the file.
+async fn validate_edit(args: &serde_json::Value, project_root: &Path) -> Option<String> {
+    let path_str = args["path"].as_str().unwrap_or("");
+    if path_str.is_empty() {
+        return Some("Missing 'path' argument.".into());
+    }
+
+    let resolved = match safe_resolve_path(project_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Some(format!("Invalid path: {e}")),
+    };
+
+    let replacements = match args["replacements"].as_array() {
+        Some(arr) if !arr.is_empty() => arr,
+        Some(_) => return Some("'replacements' array is empty.".into()),
+        None => return Some("Missing 'replacements' argument.".into()),
+    };
+
+    // File must exist (Edit is not Write)
+    let content = match tokio::fs::read_to_string(&resolved).await {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(format!(
+                "Cannot read '{}': {e}. Use Write to create new files.",
+                path_str
+            ));
+        }
+    };
+
+    // Validate each replacement
+    for (i, replacement) in replacements.iter().enumerate() {
+        let old_str = match replacement["old_str"].as_str() {
+            Some(s) if !s.is_empty() => s,
+            Some(_) => {
+                return Some(format!("Replacement {i}: 'old_str' cannot be empty."));
+            }
+            None => {
+                return Some(format!("Replacement {i}: missing 'old_str'."));
+            }
+        };
+
+        if replacement["new_str"].as_str().is_none() {
+            return Some(format!("Replacement {i}: missing 'new_str'."));
+        }
+
+        if !content.contains(old_str) {
+            // Provide a helpful snippet of what's near the expected location
+            return Some(format!(
+                "Replacement {i}: 'old_str' not found in '{}'. \
+                 Read the file first to get the exact text.",
+                path_str
+            ));
+        }
+    }
+
+    None
+}
+
+/// Delete: path must exist.
+async fn validate_delete(args: &serde_json::Value, project_root: &Path) -> Option<String> {
+    let path_str = args["path"].as_str().unwrap_or("");
+    if path_str.is_empty() {
+        return Some("Missing 'path' argument.".into());
+    }
+
+    let resolved = match safe_resolve_path(project_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Some(format!("Invalid path: {e}")),
+    };
+
+    if !resolved.exists() {
+        return Some(format!("Path not found: '{path_str}'. Nothing to delete."));
+    }
+
+    // Non-empty dir without recursive flag
+    if resolved.is_dir() {
+        let is_empty = resolved
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(false);
+        let recursive = args["recursive"].as_bool().unwrap_or(false);
+        if !is_empty && !recursive {
+            return Some(format!(
+                "Directory '{}' is not empty. Set recursive=true to delete it.",
+                path_str
+            ));
+        }
+    }
+
+    None
+}
+
+/// Bash: command must be non-empty.
+fn validate_bash(args: &serde_json::Value) -> Option<String> {
+    let cmd = args["command"]
+        .as_str()
+        .or_else(|| args["cmd"].as_str())
+        .unwrap_or("");
+    if cmd.trim().is_empty() {
+        return Some("Missing or empty 'command' argument.".into());
+    }
+    None
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn setup() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("hello.txt"),
+            "line one\nline two\nline three\n",
+        )
+        .unwrap();
+        std::fs::create_dir(dir.path().join("subdir")).unwrap();
+        std::fs::write(dir.path().join("subdir/nested.txt"), "nested").unwrap();
+        dir
+    }
+
+    // ── Edit validation ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn edit_valid_replacement() {
+        let dir = setup();
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "line two", "new_str": "line TWO"}]
+        });
+        assert!(validate_edit(&args, dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn edit_missing_path() {
+        let dir = setup();
+        let args = json!({"replacements": [{"old_str": "x", "new_str": "y"}]});
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("path"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn edit_file_not_found() {
+        let dir = setup();
+        let args = json!({
+            "path": "nope.txt",
+            "replacements": [{"old_str": "x", "new_str": "y"}]
+        });
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("Cannot read"), "{err}");
+        assert!(err.contains("Write"), "{err}"); // suggests Write
+    }
+
+    #[tokio::test]
+    async fn edit_empty_replacements() {
+        let dir = setup();
+        let args = json!({"path": "hello.txt", "replacements": []});
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("empty"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn edit_empty_old_str() {
+        let dir = setup();
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "", "new_str": "y"}]
+        });
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("empty"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn edit_old_str_not_found() {
+        let dir = setup();
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "does not exist", "new_str": "y"}]
+        });
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn edit_missing_new_str() {
+        let dir = setup();
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "line one"}]
+        });
+        let err = validate_edit(&args, dir.path()).await.unwrap();
+        assert!(err.contains("new_str"), "{err}");
+    }
+
+    // ── Delete validation ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_valid_file() {
+        let dir = setup();
+        let args = json!({"path": "hello.txt"});
+        assert!(validate_delete(&args, dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_not_found() {
+        let dir = setup();
+        let args = json!({"path": "nope.txt"});
+        let err = validate_delete(&args, dir.path()).await.unwrap();
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn delete_nonempty_dir_without_recursive() {
+        let dir = setup();
+        let args = json!({"path": "subdir"});
+        let err = validate_delete(&args, dir.path()).await.unwrap();
+        assert!(err.contains("recursive"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn delete_nonempty_dir_with_recursive() {
+        let dir = setup();
+        let args = json!({"path": "subdir", "recursive": true});
+        assert!(validate_delete(&args, dir.path()).await.is_none());
+    }
+
+    // ── Bash validation ───────────────────────────────────────
+
+    #[test]
+    fn bash_valid_command() {
+        let args = json!({"command": "echo hello"});
+        assert!(validate_bash(&args).is_none());
+    }
+
+    #[test]
+    fn bash_empty_command() {
+        let args = json!({"command": ""});
+        assert!(validate_bash(&args).unwrap().contains("empty"));
+    }
+
+    #[test]
+    fn bash_missing_command() {
+        let args = json!({});
+        assert!(validate_bash(&args).unwrap().contains("empty"));
+    }
+
+    #[test]
+    fn bash_cmd_alias() {
+        let args = json!({"cmd": "ls"});
+        assert!(validate_bash(&args).is_none());
+    }
+}

--- a/koda-core/tests/e2e_tools_test.rs
+++ b/koda-core/tests/e2e_tools_test.rs
@@ -482,3 +482,82 @@ async fn test_read_then_write_single_turn() {
         "original content (copy)"
     );
 }
+
+// ── Pre-flight validation (#612) ─────────────────────────────
+
+/// Edit with old_str not found should fail with a validation error
+/// and NOT prompt for approval.
+#[tokio::test]
+async fn test_edit_validation_old_str_not_found() {
+    let env = Env::new().await;
+    let file = env.root.join("greet.txt");
+    std::fs::write(&file, "hello world").unwrap();
+
+    env.insert_user_message("fix the greeting").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Edit",
+            serde_json::json!({
+                "path": "greet.txt",
+                "replacements": [{"old_str": "goodbye world", "new_str": "hi"}]
+            }),
+        ),
+        MockResponse::Text("I see the edit failed.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = events
+        .iter()
+        .find_map(|e| {
+            if let EngineEvent::ToolCallResult { output, .. } = e {
+                Some(output.clone())
+            } else {
+                None
+            }
+        })
+        .expect("expected tool result");
+
+    assert!(
+        output.contains("not found"),
+        "error should mention 'not found': {output}",
+    );
+    // File should be unchanged
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "hello world");
+}
+
+/// Edit on a non-existent file should fail validation.
+#[tokio::test]
+async fn test_edit_validation_file_not_found() {
+    let env = Env::new().await;
+
+    env.insert_user_message("edit missing file").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Edit",
+            serde_json::json!({
+                "path": "nope.txt",
+                "replacements": [{"old_str": "x", "new_str": "y"}]
+            }),
+        ),
+        MockResponse::Text("File doesn't exist.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = events
+        .iter()
+        .find_map(|e| {
+            if let EngineEvent::ToolCallResult { output, .. } = e {
+                Some(output.clone())
+            } else {
+                None
+            }
+        })
+        .expect("expected tool result");
+
+    assert!(
+        output.contains("Cannot read"),
+        "error should mention file not readable: {output}",
+    );
+}


### PR DESCRIPTION
## Pre-flight input validation before approval prompts

### Problem

When the model emits an Edit with an incorrect `old_str`, the user gets prompted
to approve it (in confirm mode) — only for the edit to fail after approval. This
wastes a human interaction and an inference loop.

Same issue with Delete on non-existent paths, or Bash with empty commands.

### Solution

New `tools/validate.rs` module with a `validate_tool_call()` dispatcher that runs
**after** `ToolCallStart` but **before** the approval check. If validation fails,
the error is recorded as a failed tool result and fed back to the model — no
approval prompt shown.

### Validated tools

| Tool | Checks |
|------|--------|
| **Edit** | File exists, replacements non-empty, each `old_str` non-empty + found in file, `new_str` present |
| **Delete** | Path exists, non-empty dir requires `recursive=true` |
| **Bash** | Command non-empty |

### Changes

| File | Change |
|------|--------|
| `koda-core/src/tools/validate.rs` | New module: validation logic + 15 unit tests |
| `koda-core/src/tools/mod.rs` | Register `validate` module |
| `koda-core/src/tool_dispatch.rs` | Wire validation before approval in `execute_tools_sequential` |
| `koda-core/tests/e2e_tools_test.rs` | 2 E2E tests: old_str not found, file not found |

### Testing

- `cargo test --workspace --features koda-core/test-support` — all pass ✅
- 15 unit tests + 2 E2E tests for validation scenarios