### PR TITLE
P1: Write tool requires overwrite=true to replace existing files

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -38,7 +38,8 @@ pub fn definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "Write".to_string(),
-            description: "Create a new file or fully overwrite an existing file. \
+            description: "Create a new file or overwrite an existing one. \
+                Set overwrite=true to replace an existing file. \
                 For targeted edits to existing files, prefer Edit instead."
                 .to_string(),
             parameters: json!({
@@ -51,6 +52,10 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "content": {
                         "type": "string",
                         "description": "The full content to write"
+                    },
+                    "overwrite": {
+                        "type": "boolean",
+                        "description": "Must be true to overwrite an existing file (default: false)"
                     }
                 },
                 "required": ["path", "content"]
@@ -248,6 +253,7 @@ pub async fn read_file(
 }
 
 /// Write content to a file, creating parent directories as needed.
+/// Refuses to overwrite existing files unless `overwrite=true`.
 pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
     let path_str = args["path"]
         .as_str()
@@ -255,10 +261,20 @@ pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
     let content = args["content"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'content' argument"))?;
+    let overwrite = args["overwrite"].as_bool().unwrap_or(false);
 
     let resolved = safe_resolve_path(project_root, path_str)?;
 
-    // Ensure parent directory exists (the canonicalize fix!)
+    // Overwrite protection: refuse to clobber existing files without explicit opt-in
+    if resolved.exists() && !overwrite {
+        anyhow::bail!(
+            "File '{}' already exists. Set overwrite=true to replace it, \
+             or use Edit for targeted changes.",
+            path_str
+        );
+    }
+
+    // Ensure parent directory exists
     if let Some(parent) = resolved.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -18,6 +18,7 @@ pub async fn validate_tool_call(
 ) -> Option<String> {
     match tool_name {
         "Edit" => validate_edit(args, project_root).await,
+        "Write" => validate_write(args, project_root).await,
         "Delete" => validate_delete(args, project_root).await,
         "Bash" => validate_bash(args),
         _ => None,
@@ -78,6 +79,34 @@ async fn validate_edit(args: &serde_json::Value, project_root: &Path) -> Option<
                 path_str
             ));
         }
+    }
+
+    None
+}
+
+/// Write: catch overwrite-without-flag before approval.
+async fn validate_write(args: &serde_json::Value, project_root: &Path) -> Option<String> {
+    let path_str = args["path"].as_str().unwrap_or("");
+    if path_str.is_empty() {
+        return Some("Missing 'path' argument.".into());
+    }
+
+    if args["content"].as_str().is_none() {
+        return Some("Missing 'content' argument.".into());
+    }
+
+    let resolved = match safe_resolve_path(project_root, path_str) {
+        Ok(p) => p,
+        Err(e) => return Some(format!("Invalid path: {e}")),
+    };
+
+    let overwrite = args["overwrite"].as_bool().unwrap_or(false);
+    if resolved.exists() && !overwrite {
+        return Some(format!(
+            "File '{}' already exists. Set overwrite=true to replace it, \
+             or use Edit for targeted changes.",
+            path_str
+        ));
     }
 
     None
@@ -220,6 +249,39 @@ mod tests {
         });
         let err = validate_edit(&args, dir.path()).await.unwrap();
         assert!(err.contains("new_str"), "{err}");
+    }
+
+    // ── Write validation ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn write_new_file_valid() {
+        let dir = setup();
+        let args = json!({"path": "brand_new.txt", "content": "hello"});
+        assert!(validate_write(&args, dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn write_existing_without_overwrite() {
+        let dir = setup();
+        let args = json!({"path": "hello.txt", "content": "replaced"});
+        let err = validate_write(&args, dir.path()).await.unwrap();
+        assert!(err.contains("already exists"), "{err}");
+        assert!(err.contains("overwrite=true"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn write_existing_with_overwrite() {
+        let dir = setup();
+        let args = json!({"path": "hello.txt", "content": "replaced", "overwrite": true});
+        assert!(validate_write(&args, dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn write_missing_content() {
+        let dir = setup();
+        let args = json!({"path": "foo.txt"});
+        let err = validate_write(&args, dir.path()).await.unwrap();
+        assert!(err.contains("content"), "{err}");
     }
 
     // ── Delete validation ─────────────────────────────────────


### PR DESCRIPTION
## Write tool overwrite protection

### Problem

`Write` silently overwrites existing files. The model can nuke a file it never `Read` — no guard rail, no warning.

### Solution

Add `overwrite: bool` parameter (default: `false`):

| Scenario | Before | After |
|----------|--------|-------|
| Write new file | ✅ works | ✅ works (no change) |
| Write existing file, no flag | ⚠️ silently overwrites | ❌ validation error |
| Write existing file, `overwrite=true` | N/A | ✅ works |

The error message suggests both `overwrite=true` and `Edit` as alternatives, so the model can self-correct.

### Architecture

Validation runs in two layers (belt and suspenders):
1. **Pre-flight** (`validate.rs`): catches it before the approval prompt (no wasted user interaction)
2. **Handler** (`file_tools.rs`): enforces it at execution time (defense in depth)

### Changes

| File | Change |
|------|--------|
| `file_tools.rs` | Add `overwrite` param to definition + enforce in handler |
| `validate.rs` | Pre-flight check for overwrite-without-flag |

### Testing

- 4 new unit tests for `validate_write`
- `cargo fmt --check` ✅
- `cargo clippy` ✅  
- `cargo test --workspace --features koda-core/test-support` — all pass ✅