### PR TITLE
P1: Edit tool replace_all parameter

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -90,6 +90,10 @@ pub fn definitions() -> Vec<ToolDefinition> {
                                 "new_str": {
                                     "type": "string",
                                     "description": "Text to replace it with"
+                                },
+                                "replace_all": {
+                                    "type": "boolean",
+                                    "description": "Replace all occurrences instead of just the first (default: false)"
                                 }
                             },
                             "required": ["old_str", "new_str"]
@@ -319,15 +323,30 @@ pub async fn edit_file(project_root: &Path, args: &Value) -> Result<String> {
             );
         }
 
-        // Replace only the first occurrence to be safe
-        content = content.replacen(old_str, new_str, 1);
+        let replace_all = replacement["replace_all"].as_bool().unwrap_or(false);
 
-        // Generate diff lines for display
-        for line in old_str.lines() {
-            changes.push(format!("-{line}"));
-        }
-        for line in new_str.lines() {
-            changes.push(format!("+{line}"));
+        if replace_all {
+            let count = content.matches(old_str).count();
+            content = content.replace(old_str, new_str);
+            // Generate diff lines for display
+            for line in old_str.lines() {
+                changes.push(format!("-{line}"));
+            }
+            for line in new_str.lines() {
+                changes.push(format!("+{line}"));
+            }
+            if count > 1 {
+                changes.push(format!("({count} occurrences replaced)"));
+            }
+        } else {
+            // Replace only the first occurrence (default, safe behavior)
+            content = content.replacen(old_str, new_str, 1);
+            for line in old_str.lines() {
+                changes.push(format!("-{line}"));
+            }
+            for line in new_str.lines() {
+                changes.push(format!("+{line}"));
+            }
         }
         if replacements.len() > 1 {
             changes.push(String::new()); // separator between replacements

--- a/koda-core/tests/file_tools_test.rs
+++ b/koda-core/tests/file_tools_test.rs
@@ -2,7 +2,9 @@
 //!
 //! Tests path safety, file CRUD, and directory listing.
 
+use koda_core::tools::file_tools;
 use koda_core::tools::safe_resolve_path;
+use serde_json::json;
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -36,30 +38,95 @@ fn test_nested_new_directories() {
     assert_eq!(std::fs::read_to_string(&path).unwrap(), "deep");
 }
 
-#[test]
-fn test_edit_file_replacement() {
+#[tokio::test]
+async fn test_edit_file_replacement() {
     let tmp = TempDir::new().unwrap();
-    let file = tmp.path().join("example.rs");
-    std::fs::write(&file, "fn main() {\n    println!(\"old\");\n}\n").unwrap();
-    let mut content = std::fs::read_to_string(&file).unwrap();
-    content = content.replacen("\"old\"", "\"new\"", 1);
-    std::fs::write(&file, &content).unwrap();
-    let result = std::fs::read_to_string(&file).unwrap();
+    std::fs::write(
+        tmp.path().join("example.rs"),
+        "fn main() {\n    println!(\"old\");\n}\n",
+    )
+    .unwrap();
+    let args = json!({
+        "path": "example.rs",
+        "replacements": [{"old_str": "\"old\"", "new_str": "\"new\""}]
+    });
+    file_tools::edit_file(tmp.path(), &args).await.unwrap();
+    let result = std::fs::read_to_string(tmp.path().join("example.rs")).unwrap();
     assert!(result.contains("\"new\""));
     assert!(!result.contains("\"old\""));
 }
 
-#[test]
-fn test_edit_file_delete_snippet() {
+#[tokio::test]
+async fn test_edit_file_delete_snippet() {
     let tmp = TempDir::new().unwrap();
-    let file = tmp.path().join("with_comment.rs");
-    std::fs::write(&file, "// TODO: remove this\nfn main() {}\n").unwrap();
-    let mut content = std::fs::read_to_string(&file).unwrap();
-    content = content.replacen("// TODO: remove this\n", "", 1);
-    std::fs::write(&file, &content).unwrap();
-    let result = std::fs::read_to_string(&file).unwrap();
+    std::fs::write(
+        tmp.path().join("with_comment.rs"),
+        "// TODO: remove this\nfn main() {}\n",
+    )
+    .unwrap();
+    let args = json!({
+        "path": "with_comment.rs",
+        "replacements": [{"old_str": "// TODO: remove this\n", "new_str": ""}]
+    });
+    file_tools::edit_file(tmp.path(), &args).await.unwrap();
+    let result = std::fs::read_to_string(tmp.path().join("with_comment.rs")).unwrap();
     assert!(!result.contains("TODO"));
     assert!(result.contains("fn main"));
+}
+
+#[tokio::test]
+async fn test_edit_replace_all_replaces_every_occurrence() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(
+        tmp.path().join("vars.rs"),
+        "let foo = 1;\nlet foo = 2;\nlet foo = 3;\n",
+    )
+    .unwrap();
+    let args = json!({
+        "path": "vars.rs",
+        "replacements": [{"old_str": "foo", "new_str": "bar", "replace_all": true}]
+    });
+    let result = file_tools::edit_file(tmp.path(), &args).await.unwrap();
+    let content = std::fs::read_to_string(tmp.path().join("vars.rs")).unwrap();
+    assert!(
+        !content.contains("foo"),
+        "all occurrences should be replaced"
+    );
+    assert_eq!(content.matches("bar").count(), 3);
+    assert!(result.contains("3 occurrences replaced"), "{result}");
+}
+
+#[tokio::test]
+async fn test_edit_without_replace_all_only_replaces_first() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("vars.rs"), "let foo = 1;\nlet foo = 2;\n").unwrap();
+    let args = json!({
+        "path": "vars.rs",
+        "replacements": [{"old_str": "foo", "new_str": "bar"}]
+    });
+    file_tools::edit_file(tmp.path(), &args).await.unwrap();
+    let content = std::fs::read_to_string(tmp.path().join("vars.rs")).unwrap();
+    assert_eq!(
+        content.matches("foo").count(),
+        1,
+        "second occurrence should remain"
+    );
+    assert_eq!(content.matches("bar").count(), 1, "only first replaced");
+}
+
+#[tokio::test]
+async fn test_edit_replace_all_single_occurrence_no_count_label() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("one.rs"), "let x = old;\n").unwrap();
+    let args = json!({
+        "path": "one.rs",
+        "replacements": [{"old_str": "old", "new_str": "new", "replace_all": true}]
+    });
+    let result = file_tools::edit_file(tmp.path(), &args).await.unwrap();
+    let content = std::fs::read_to_string(tmp.path().join("one.rs")).unwrap();
+    assert!(content.contains("new"));
+    // Single occurrence: no "(N occurrences replaced)" label needed
+    assert!(!result.contains("occurrences replaced"), "{result}");
 }
 
 #[test]


### PR DESCRIPTION
## Edit `replace_all` parameter

### Problem

Edit always replaces the **first** match only. When the model wants to rename a variable or fix a repeated pattern across a file, it has to either issue N separate Edit calls or fall back to Bash — both annoying.

### Solution

Add `replace_all: bool` (default: `false`) to each replacement entry:

```json
{"old_str": "foo", "new_str": "bar", "replace_all": true}
```

| `replace_all` | Behavior |
|---|---|
| `false` (default) | Replace first occurrence — safe, surgical |
| `true` | Replace all occurrences — for renames, global fixes |

The response includes an `(N occurrences replaced)` label when N > 1, so the model gets feedback on impact.

### Bonus: test quality improvement

The two pre-existing Edit tests in `file_tools_test.rs` were testing bare `str::replacen` from stdlib — they weren't calling `edit_file()` at all. Replaced them with real async integration tests through `file_tools::edit_file()`.

### Tests (4 new)

| Test | Covers |
|---|---|
| `test_edit_file_replacement` | basic replacement via `edit_file()` |
| `test_edit_file_delete_snippet` | snippet deletion via `edit_file()` |
| `test_edit_replace_all_replaces_every_occurrence` | all 3 occurrences replaced, label shown |
| `test_edit_without_replace_all_only_replaces_first` | default still first-match-only |
| `test_edit_replace_all_single_occurrence_no_count_label` | no label when count = 1 |

`cargo fmt --check` ✅ `cargo clippy` ✅ `cargo test --workspace` ✅