### PR TITLE
P1: AskUser tool for explicit model clarification requests (#615)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -100,6 +100,9 @@ pub fn engine_event_to_acp(
 
         // Handled specially by AcpSink (bidirectional permission flow)
         EngineEvent::ApprovalRequest { .. } => None,
+        // AskUser not yet implemented in ACP protocol; filtered here.
+        // AcpSink::emit auto-responds with an empty string (fallback).
+        EngineEvent::AskUserRequest { .. } => None,
 
         EngineEvent::ActionBlocked {
             tool_name: _,
@@ -244,6 +247,15 @@ impl EngineSink for AcpSink {
         if matches!(event, EngineEvent::LoopCapReached { .. }) {
             let _ = self.cmd_tx.try_send(EngineCommand::LoopDecision {
                 action: koda_core::loop_guard::LoopContinuation::Continue200,
+            });
+            return;
+        }
+
+        // AskUser: no ACP protocol support yet — auto-respond with empty string.
+        if let EngineEvent::AskUserRequest { ref id, .. } = event {
+            let _ = self.cmd_tx.try_send(EngineCommand::AskUserResponse {
+                id: id.clone(),
+                answer: String::new(),
             });
             return;
         }
@@ -440,6 +452,11 @@ mod tests {
                 tool_name: "Bash".into(),
                 detail: "cmd".into(),
                 preview: None,
+            },
+            EngineEvent::AskUserRequest {
+                id: "b".into(),
+                question: "Which db?".into(),
+                options: vec![],
             },
             EngineEvent::StatusUpdate {
                 model: "m".into(),

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -125,6 +125,14 @@ impl EngineSink for HeadlessSink {
                     decision: ApprovalDecision::Approve,
                 });
             }
+            EngineEvent::AskUserRequest { id, question, .. } => {
+                // Headless: no user present, print the question and skip.
+                eprintln!("[koda] AskUser (no interactive session): {question}");
+                let _ = self.cmd_tx.blocking_send(EngineCommand::AskUserResponse {
+                    id,
+                    answer: String::new(),
+                });
+            }
             EngineEvent::LoopCapReached { .. } => {
                 let _ = self.cmd_tx.blocking_send(EngineCommand::LoopDecision {
                     action: koda_core::loop_guard::LoopContinuation::Continue200,

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -218,6 +218,7 @@ impl TuiContext {
             MenuContent::Session(dd) => nav!(dd),
             MenuContent::File { dropdown: dd, .. } => nav!(dd),
             MenuContent::Approval { .. }
+            | MenuContent::AskUser { .. }
             | MenuContent::LoopCap
             | MenuContent::PurgeConfirm { .. }
             | MenuContent::WizardTrail(_)
@@ -339,6 +340,7 @@ impl TuiContext {
                 }
             }
             MenuContent::Approval { .. }
+            | MenuContent::AskUser { .. }
             | MenuContent::LoopCap
             | MenuContent::PurgeConfirm { .. }
             | MenuContent::WizardTrail(_)

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -116,6 +116,7 @@ impl TuiContext {
                             ui_event,
                             &mut self.scroll_buffer,
                             &mut self.menu,
+                            &mut self.prompt_mode,
                             &mut self.renderer,
                         );
                         // Batch-drain queued engine events to reduce redraws.
@@ -129,6 +130,7 @@ impl TuiContext {
                                 extra,
                                 &mut self.scroll_buffer,
                                 &mut self.menu,
+                                &mut self.prompt_mode,
                                 &mut self.renderer,
                             );
                         }
@@ -408,6 +410,48 @@ async fn handle_inference_key_inline(
         return;
     }
 
+    // AskUser: freeform text input during inference.
+    // id is embedded in MenuContent::AskUser — no separate pending field needed.
+    if matches!(menu, MenuContent::AskUser { .. })
+        && matches!(prompt_mode, PromptMode::WizardInput { .. })
+    {
+        match (key.code, key.modifiers) {
+            (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
+                textarea.insert_newline();
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) => {
+                let answer = textarea.lines().join("\n");
+                textarea.select_all();
+                textarea.cut();
+                *prompt_mode = PromptMode::Chat;
+                if let MenuContent::AskUser { id, .. } = std::mem::replace(menu, MenuContent::None)
+                {
+                    let _ = cmd_tx
+                        .send(EngineCommand::AskUserResponse { id, answer })
+                        .await;
+                }
+            }
+            (KeyCode::Esc, _) => {
+                textarea.select_all();
+                textarea.cut();
+                *prompt_mode = PromptMode::Chat;
+                if let MenuContent::AskUser { id, .. } = std::mem::replace(menu, MenuContent::None)
+                {
+                    let _ = cmd_tx
+                        .send(EngineCommand::AskUserResponse {
+                            id,
+                            answer: String::new(),
+                        })
+                        .await;
+                }
+            }
+            _ => {
+                textarea.input(Event::Key(key));
+            }
+        }
+        return;
+    }
+
     // Feedback text input during inference
     if matches!(prompt_mode, PromptMode::WizardInput { .. }) && pending_approval_id.is_some() {
         match (key.code, key.modifiers) {
@@ -497,9 +541,24 @@ fn handle_inference_ui_inline(
     ui_event: UiEvent,
     buffer: &mut ScrollBuffer,
     menu: &mut MenuContent,
+    prompt_mode: &mut PromptMode,
     renderer: &mut crate::tui_render::TuiRenderer,
 ) {
     match ui_event {
+        UiEvent::Engine(EngineEvent::AskUserRequest {
+            id,
+            question,
+            options,
+        }) => {
+            *prompt_mode = PromptMode::WizardInput {
+                label: "Answer".into(),
+            };
+            *menu = MenuContent::AskUser {
+                id,
+                question,
+                options,
+            };
+        }
         UiEvent::Engine(EngineEvent::ApprovalRequest {
             id,
             tool_name,

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -183,6 +183,7 @@ impl TuiRenderer {
                 );
             }
             EngineEvent::ApprovalRequest { .. }
+            | EngineEvent::AskUserRequest { .. }
             | EngineEvent::StatusUpdate { .. }
             | EngineEvent::ContextUsage { .. }
             | EngineEvent::TurnStart { .. }

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -61,6 +61,12 @@ pub(crate) enum MenuContent {
         tool_name: String,
         detail: String,
     },
+    /// AskUser input bar — model is asking a clarifying question.
+    AskUser {
+        id: String,
+        question: String,
+        options: Vec<String>,
+    },
     /// Loop cap hotkey bar — continue or stop after iteration limit.
     LoopCap,
     /// Purge confirmation bar — \[y\] confirm / \[n\] cancel.

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -49,7 +49,10 @@ pub(crate) fn draw_viewport(
     // Determine menu height (only when active)
     let menu_height = match menu {
         MenuContent::None => 0u16,
-        MenuContent::Approval { .. } | MenuContent::LoopCap | MenuContent::PurgeConfirm { .. } => 2,
+        MenuContent::Approval { .. }
+        | MenuContent::LoopCap
+        | MenuContent::PurgeConfirm { .. }
+        | MenuContent::AskUser { .. } => 2,
         MenuContent::WizardTrail(trail) => (trail.len() as u16) + 1,
         MenuContent::Slash(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Model(dd) => dd.visible_count() as u16 + 1,
@@ -311,6 +314,36 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
                     Span::styled(" confirm  ", Style::default().fg(Color::DarkGray)),
                     Span::styled("[n]", Style::default().fg(Color::Red)),
                     Span::styled(" cancel", Style::default().fg(Color::DarkGray)),
+                ]),
+            ];
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::AskUser {
+            question, options, ..
+        } => {
+            let hint = if options.is_empty() {
+                "Type your answer and press Enter".to_string()
+            } else {
+                let choices = options
+                    .iter()
+                    .enumerate()
+                    .map(|(i, o)| format!("[{}] {}", i + 1, o))
+                    .collect::<Vec<_>>()
+                    .join("  ");
+                format!("Choices: {choices}")
+            };
+            let lines = vec![
+                Line::from(vec![
+                    Span::styled("  \u{2753} ", Style::default().fg(Color::Cyan)),
+                    Span::styled(question.clone(), Style::default().fg(Color::White)),
+                ]),
+                Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(hint, Style::default().fg(Color::DarkGray)),
+                    Span::styled(
+                        "  · Esc to skip",
+                        Style::default().fg(Color::Rgb(80, 80, 80)),
+                    ),
                 ]),
             ];
             frame.render_widget(Paragraph::new(lines), menu_area);

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -106,6 +106,20 @@ pub enum EngineEvent {
         preview: Option<crate::preview::DiffPreview>,
     },
 
+    /// The model needs a clarifying answer from the user before proceeding.
+    ///
+    /// The client must respond with `EngineCommand::AskUserResponse`
+    /// matching the same `id`. The answer is returned to the model as the
+    /// tool result, so inference can continue.
+    AskUserRequest {
+        /// Unique ID for this request.
+        id: String,
+        /// The question to ask.
+        question: String,
+        /// Optional answer choices (empty = freeform).
+        options: Vec<String>,
+    },
+
     /// An action was blocked by safe mode (shown but not executed).
     ActionBlocked {
         /// Tool name that was blocked.
@@ -277,6 +291,14 @@ pub enum EngineCommand {
     /// for streaming interruption.
     Interrupt,
 
+    /// Response to an `EngineEvent::AskUserRequest`.
+    AskUserResponse {
+        /// Must match the `id` from the `AskUserRequest`.
+        id: String,
+        /// The user's answer (empty string = cancelled).
+        answer: String,
+    },
+
     /// Response to an `EngineEvent::ApprovalRequest`.
     ApprovalResponse {
         /// Must match the `id` from the `ApprovalRequest`.
@@ -380,6 +402,35 @@ pub enum SlashCommand {
 mod tests {
     use super::*;
     use serde_json;
+
+    #[test]
+    fn test_ask_user_request_roundtrip() {
+        let event = EngineEvent::AskUserRequest {
+            id: "ask-1".into(),
+            question: "Which database?".into(),
+            options: vec!["SQLite".into(), "PostgreSQL".into()],
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("ask_user_request"));
+        let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();
+        assert!(
+            matches!(deserialized, EngineEvent::AskUserRequest { ref question, .. } if question == "Which database?")
+        );
+    }
+
+    #[test]
+    fn test_ask_user_response_roundtrip() {
+        let cmd = EngineCommand::AskUserResponse {
+            id: "ask-1".into(),
+            answer: "SQLite".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("ask_user_response"));
+        let deserialized: EngineCommand = serde_json::from_str(&json).unwrap();
+        assert!(
+            matches!(deserialized, EngineCommand::AskUserResponse { ref answer, .. } if answer == "SQLite")
+        );
+    }
 
     #[test]
     fn test_engine_event_text_delta_roundtrip() {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -436,6 +436,30 @@ pub(crate) async fn execute_tools_sequential(
             is_sub_agent: false,
         });
 
+        // AskUser: pause inference, show question in TUI, wait for typed answer.
+        // Handled here (not in execute_one_tool) because it needs sink + cmd_rx.
+        if tc.function_name == "AskUser" {
+            let answer = handle_ask_user(sink, cmd_rx, &cancel, &parsed_args).await;
+            let result = match answer {
+                Some(text) if !text.trim().is_empty() => text,
+                Some(_) => "User did not provide an answer.".into(),
+                None => return Ok(()), // cancelled
+            };
+            record_tool_result(
+                tc,
+                &result,
+                true,
+                db,
+                session_id,
+                tools.caps.tool_result_chars,
+                project_root,
+                file_tracker,
+                sink,
+            )
+            .await?;
+            continue;
+        }
+
         // Pre-flight validation: catch errors before bothering the user
         // with an approval prompt that will inevitably fail.
         if let Some(error) =
@@ -787,6 +811,50 @@ pub(crate) async fn execute_sub_agent(
         ),
     });
     Ok("(sub-agent reached maximum iterations)".to_string())
+}
+
+/// Emit an `AskUserRequest` and wait for the user's typed response.
+///
+/// Returns `None` if the session was interrupted or cancelled.
+pub(crate) async fn handle_ask_user(
+    sink: &dyn crate::engine::EngineSink,
+    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+    cancel: &CancellationToken,
+    args: &serde_json::Value,
+) -> Option<String> {
+    let question = args["question"].as_str().unwrap_or("").to_string();
+    let options: Vec<String> = args["options"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    sink.emit(EngineEvent::AskUserRequest {
+        id: request_id.clone(),
+        question,
+        options,
+    });
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => match cmd {
+                Some(EngineCommand::AskUserResponse { id, answer }) if id == request_id => {
+                    return Some(answer);
+                }
+                Some(EngineCommand::Interrupt) => {
+                    cancel.cancel();
+                    return None;
+                }
+                None => return None,
+                _ => continue,
+            },
+            _ = cancel.cancelled() => return None,
+        }
+    }
 }
 
 pub(crate) async fn request_approval(

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -24,6 +24,7 @@ use std::sync::LazyLock;
 /// All canonical (PascalCase) built-in tool names.
 const CANONICAL: &[&str] = &[
     "ActivateSkill",
+    "AskUser",
     "Bash",
     "Delete",
     "Edit",
@@ -70,6 +71,11 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     // Only include aliases where the mapping is unambiguous.
     // If a short name could plausibly mean multiple tools, leave it
     // out — an "Unknown tool" error is better than silent misrouting.
+
+    // AskUser
+    m.insert("ask_user".into(), "AskUser");
+    m.insert("ask_question".into(), "AskUser");
+    m.insert("askquestion".into(), "AskUser");
 
     // File tools
     m.insert("list_files".into(), "List");

--- a/koda-core/src/tools/ask_user.rs
+++ b/koda-core/src/tools/ask_user.rs
@@ -1,0 +1,38 @@
+//! AskUser tool: explicit clarification requests from the model.
+//!
+//! When the model needs information it cannot infer from context, it calls
+//! this tool instead of guessing or stalling. The question appears in the TUI
+//! menu area; the user types their answer and presses Enter.
+//!
+//! Classified as `ReadOnly` — no side effects, no approval prompt.
+//! Handled directly in `execute_tools_sequential` (needs `sink` + `cmd_rx`).
+
+use crate::providers::ToolDefinition;
+use serde_json::json;
+
+/// Return tool definitions for the LLM.
+pub fn definitions() -> Vec<ToolDefinition> {
+    vec![ToolDefinition {
+        name: "AskUser".to_string(),
+        description: "Ask the user a specific question when you need clarification \
+            before proceeding. Use this instead of guessing. \
+            Keep the question short and direct. \
+            Provide options when the answer is one of a known set of choices."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question to ask the user"
+                },
+                "options": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of answer choices (omit for freeform)"
+                }
+            },
+            "required": ["question"]
+        }),
+    }]
+}

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -29,7 +29,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
         "Read" | "List" | "Grep" | "Glob" | "MemoryRead" | "ListAgents" | "ListSkills"
-        | "ActivateSkill" | "RecallContext" => ToolEffect::ReadOnly,
+        | "ActivateSkill" | "RecallContext" | "AskUser" => ToolEffect::ReadOnly,
 
         // Remote actions — side-effects on remote services only
         "WebFetch" => ToolEffect::ReadOnly,    // GET-only fetch
@@ -63,6 +63,7 @@ pub fn is_mutating_tool(name: &str) -> bool {
 
 /// Sub-agent invocation tool (`InvokeAgent`, `ListAgents`).
 pub mod agent;
+pub mod ask_user;
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
 /// Glob pattern search tool (`Glob`).
@@ -170,6 +171,9 @@ impl ToolRegistry {
             definitions.insert(def.name.clone(), def);
         }
         for def in agent::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in ask_user::definitions() {
             definitions.insert(def.name.clone(), def);
         }
         for def in glob_tool::definitions() {
@@ -439,6 +443,15 @@ impl ToolRegistry {
                 // This branch should not be reached in normal flow.
                 return ToolResult {
                     output: "InvokeAgent is handled by the inference loop.".to_string(),
+                    success: false,
+                };
+            }
+
+            "AskUser" => {
+                // Handled by execute_tools_sequential (needs sink + cmd_rx).
+                // This branch should not be reached in normal flow.
+                return ToolResult {
+                    output: "AskUser is handled by the inference loop.".to_string(),
                     success: false,
                 };
             }

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -221,6 +221,7 @@ mod naming_convention {
     /// All built-in tool names must be PascalCase.
     const BUILTIN_TOOLS: &[&str] = &[
         "ActivateSkill",
+        "AskUser",
         "Bash",
         "Delete",
         "Edit",
@@ -271,8 +272,8 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 19 built-in tools (AstAnalysis removed in #608)
-        assert_eq!(BUILTIN_TOOLS.len(), 19);
+        // 20 built-in tools (AstAnalysis removed in #608, AskUser added)
+        assert_eq!(BUILTIN_TOOLS.len(), 20);
     }
 
     /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.


### PR DESCRIPTION
## Summary

Adds an `AskUser` tool that lets the model pause inference and ask the user a specific clarifying question before proceeding — instead of guessing or stalling.

## Motivation

Models sometimes make wrong assumptions when context is ambiguous (e.g. "should I use SQLite or PostgreSQL?", "overwrite or append?"). `AskUser` gives the model a structured escape hatch.

## How it works

```
AskUser { question: "Which database?", options: ["SQLite", "PostgreSQL"] }
```

1. Engine emits `AskUserRequest` and blocks on the command channel
2. TUI shows the question in the menu area, switches prompt to answer mode
3. User types answer + Enter (or Esc to skip)
4. `AskUserResponse` is sent back; inference continues with the answer as the tool result

## Changes

### Engine / Core
- `EngineEvent::AskUserRequest` + `EngineCommand::AskUserResponse`
- `tools/ask_user.rs` — tool definition (`ReadOnly`, no approval prompt)
- `tool_dispatch.rs` — `handle_ask_user()` helper + special branch in `execute_tools_sequential`
- `tool_normalize.rs` — CANONICAL entry + aliases (`ask_user`, `ask_question`)

### TUI
- `MenuContent::AskUser { id, question, options }`
- `handle_inference_ui_inline`: `AskUserRequest` sets `WizardInput` mode
- Key handler: Enter submits answer, Esc sends empty (skip)
- `tui_viewport.rs`: renders question + numbered choices or freeform hint
- Headless: auto-responds with empty string + stderr log
- ACP adapter: auto-responds (full ACP support is a future TODO)

## Tests
- Roundtrip serde tests for `AskUserRequest` / `AskUserResponse`
- `BUILTIN_TOOLS` count 19 → 20
- `test_none_events` in acp_adapter covers `AskUserRequest`
- Sentinel in `registry.execute()` so `tool_wiring_test` passes