### PR TITLE
P1: Background Bash — run long-lived processes without blocking inference (#616)

### DIFF
--- a/koda-core/src/progress.rs
+++ b/koda-core/src/progress.rs
@@ -99,6 +99,22 @@ fn extract_delete_progress(result: &str) -> Option<String> {
 }
 
 fn extract_bash_progress(result: &str) -> Option<String> {
+    // Background process start
+    if result.contains("Background process started") {
+        // Extract the command from the result: "  Command: <cmd>"
+        let cmd = result
+            .lines()
+            .find(|l| l.trim_start().starts_with("Command:"))
+            .and_then(|l| l.split_once(':').map(|(_, v)| v))
+            .map(|s| s.trim())
+            .unwrap_or("?");
+        let short = if cmd.len() > 60 {
+            format!("{}...", &cmd[..60])
+        } else {
+            cmd.to_string()
+        };
+        return Some(format!("- \u{1f4e1} Started background: {short}"));
+    }
     // Track test results and build outcomes
     let lower = result.to_lowercase();
     if lower.contains("test result: ok") || lower.contains("tests passed") {

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -1,0 +1,97 @@
+//! Background process registry.
+//!
+//! Tracks processes spawned by `Bash { background: true }` so they can be
+//! listed, and so they are cleaned up (SIGTERM) when the session ends.
+//!
+//! Each `ToolRegistry` owns one `BgRegistry`.  All background processes for
+//! the session are keyed by PID.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use tokio::process::Child;
+
+/// Metadata stored alongside the child handle.
+pub struct BgEntry {
+    /// The original shell command string.
+    pub command: String,
+    /// The spawned child process handle (used for `start_kill` on drop).
+    pub child: Child,
+}
+
+/// Registry of running background processes, scoped to one session.
+///
+/// Drop kills all remaining processes (SIGTERM).
+pub struct BgRegistry {
+    inner: Mutex<HashMap<u32, BgEntry>>,
+}
+
+impl BgRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a spawned child.  Returns the PID.
+    pub fn insert(&self, pid: u32, command: String, child: Child) -> u32 {
+        self.inner
+            .lock()
+            .unwrap()
+            .insert(pid, BgEntry { command, child });
+        pid
+    }
+
+    /// Return a snapshot of running PIDs + commands for display.
+    pub fn list(&self) -> Vec<(u32, String)> {
+        self.inner
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(pid, e)| (*pid, e.command.clone()))
+            .collect()
+    }
+
+    /// How many processes are currently tracked.
+    pub fn len(&self) -> usize {
+        self.inner.lock().unwrap().len()
+    }
+
+    /// Returns `true` if no background processes are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().unwrap().is_empty()
+    }
+}
+
+impl Default for BgRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for BgRegistry {
+    /// Best-effort SIGTERM all tracked processes when the session ends.
+    fn drop(&mut self) {
+        let mut guard = self.inner.lock().unwrap();
+        for (pid, entry) in guard.iter_mut() {
+            // start_kill is sync (sends SIGTERM on Unix / TerminateProcess on Windows).
+            if let Err(e) = entry.child.start_kill() {
+                tracing::warn!("BgRegistry drop: failed to kill PID {pid}: {e}");
+            } else {
+                tracing::debug!("BgRegistry drop: sent SIGTERM to PID {pid}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_starts_empty() {
+        let reg = BgRegistry::new();
+        assert_eq!(reg.len(), 0);
+        assert!(reg.list().is_empty());
+    }
+}

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -64,6 +64,7 @@ pub fn is_mutating_tool(name: &str) -> bool {
 /// Sub-agent invocation tool (`InvokeAgent`, `ListAgents`).
 pub mod agent;
 pub mod ask_user;
+pub mod bg_process;
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
 /// Glob pattern search tool (`Glob`).
@@ -150,6 +151,9 @@ pub struct ToolRegistry {
     session_id: std::sync::RwLock<Option<String>>,
     /// Context-scaled output caps for all tools.
     pub caps: OutputCaps,
+    /// Background process registry — tracks processes spawned with `background: true`.
+    /// Dropped (SIGTERM all) when the session ends.
+    pub bg_registry: bg_process::BgRegistry,
 }
 
 impl ToolRegistry {
@@ -214,6 +218,7 @@ impl ToolRegistry {
             db: std::sync::RwLock::new(None),
             session_id: std::sync::RwLock::new(None),
             caps: OutputCaps::for_context(max_context_tokens),
+            bg_registry: bg_process::BgRegistry::new(),
         }
     }
 
@@ -350,8 +355,13 @@ impl ToolRegistry {
 
             // Shell
             "Bash" => {
-                shell::run_shell_command(&self.project_root, &args, self.caps.shell_output_lines)
-                    .await
+                shell::run_shell_command(
+                    &self.project_root,
+                    &args,
+                    self.caps.shell_output_lines,
+                    &self.bg_registry,
+                )
+                .await
             }
 
             // Web
@@ -590,7 +600,15 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
                 .or(args.get("cmd"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("?");
-            cmd.to_string()
+            let bg = args
+                .get("background")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if bg {
+                format!("[bg] {cmd}")
+            } else {
+                cmd.to_string()
+            }
         }
         "Delete" => {
             let path = args

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -2,8 +2,13 @@
 //!
 //! Runs commands as child processes with timeout protection.
 //! Output line cap is set by `OutputCaps` (context-scaled).
+//!
+//! When `background: true` the command is spawned detached and control returns
+//! immediately with the PID.  The process is tracked in `BgRegistry` and
+//! SIGTERMed when the session ends.
 
 use crate::providers::ToolDefinition;
+use crate::tools::bg_process::BgRegistry;
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::path::Path;
@@ -20,7 +25,9 @@ pub fn definitions() -> Vec<ToolDefinition> {
         description: "Execute a shell command. Use ONLY for builds, tests, git, \
             and commands without a dedicated tool. Never use for file ops \
             (use Read/Write/Edit/Grep/List instead). Suppress verbose output: \
-            pipe to tail, use --quiet, avoid -v flags."
+            pipe to tail, use --quiet, avoid -v flags. \
+            Set background=true for long-running processes (dev servers, watchers) \
+            — returns immediately with the PID."
             .to_string(),
         parameters: json!({
             "type": "object",
@@ -31,7 +38,12 @@ pub fn definitions() -> Vec<ToolDefinition> {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (default: 60)"
+                    "description": "Timeout in seconds (default: 60, ignored when background=true)"
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": "Run in background and return immediately with PID (default: false). \
+                        Use for dev servers, file watchers, and other long-running processes."
                 }
             },
             "required": ["command"]
@@ -40,20 +52,34 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Execute a shell command with timeout and output capping.
+///
+/// When `args["background"]` is `true`, the process is spawned detached and
+/// this function returns immediately with the PID.  The `BgRegistry` tracks
+/// the child so it is cleaned up (SIGTERM) when the session ends.
 pub async fn run_shell_command(
     project_root: &Path,
     args: &Value,
     max_output_lines: usize,
+    bg: &BgRegistry,
 ) -> Result<String> {
     let command = args["command"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'command' argument"))?;
+    let background = args["background"].as_bool().unwrap_or(false);
+
+    tracing::info!(
+        "Running shell command (background={background}): [{} chars]",
+        command.len()
+    );
+
+    if background {
+        return spawn_background(project_root, command, bg);
+    }
+
     let timeout_secs = args["timeout"]
         .as_u64()
         .unwrap_or(DEFAULT_TIMEOUT_SECS)
         .min(MAX_TIMEOUT_SECS);
-
-    tracing::info!("Running shell command: [{} chars]", command.len());
 
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(timeout_secs),
@@ -91,6 +117,36 @@ pub async fn run_shell_command(
     }
 }
 
+/// Spawn a command in the background and register it.
+///
+/// Returns immediately with PID + instructions. Sync because `spawn()` doesn't
+/// need to await — only `output()` / `wait()` block.
+fn spawn_background(project_root: &Path, command: &str, bg: &BgRegistry) -> Result<String> {
+    let child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_root)
+        // Detach stdio so the process doesn't block on terminal I/O.
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn background command: {e}"))?;
+
+    let pid = child
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("Spawned process has no PID (already exited)"))?;
+
+    bg.insert(pid, command.to_string(), child);
+
+    Ok(format!(
+        "Background process started.\n  PID:     {pid}\n  Command: {command}\n\
+         To stop:  Bash{{command: \"kill {pid}\"}}\n\
+         To force: Bash{{command: \"kill -9 {pid}\"}}\n\
+         Note: process will be stopped automatically when the session ends."
+    ))
+}
+
 /// Cap output to the last N lines to protect the context window.
 fn cap_output(output: &str, max_lines: usize) -> String {
     let lines: Vec<&str> = output.lines().collect();
@@ -108,13 +164,19 @@ fn cap_output(output: &str, max_lines: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::bg_process::BgRegistry;
+
+    fn bg() -> BgRegistry {
+        BgRegistry::new()
+    }
 
     #[tokio::test]
     async fn shell_timeout_returns_timeout_message() {
-        // Run a command that sleeps longer than the timeout (1 second) to keep the test fast.
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "sleep 5", "timeout": 1});
-        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+            .await
+            .unwrap();
         assert!(
             result.contains("timed out"),
             "Expected timeout message, got: {result}"
@@ -123,25 +185,56 @@ mod tests {
 
     #[tokio::test]
     async fn shell_respects_custom_timeout_parameter() {
-        // A fast command should succeed even with a short timeout.
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo hello", "timeout": 5});
-        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+            .await
+            .unwrap();
         assert!(
             result.contains("hello"),
-            "Fast command should succeed within timeout: {result}"
+            "Fast command should succeed: {result}"
         );
     }
 
     #[tokio::test]
     async fn shell_default_timeout_is_applied_when_not_specified() {
-        // Verify a normal command works when no timeout parameter is given.
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo world"});
-        let result = run_shell_command(tmp.path(), &args, 256).await.unwrap();
+        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+            .await
+            .unwrap();
         assert!(
             result.contains("world"),
             "Command without explicit timeout should work: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn background_spawn_returns_pid() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BgRegistry::new();
+        let args = serde_json::json!({"command": "sleep 60", "background": true});
+        let result = run_shell_command(tmp.path(), &args, 256, &registry)
+            .await
+            .unwrap();
+        assert!(result.contains("Background process started"), "{result}");
+        assert!(result.contains("PID:"), "{result}");
+        assert!(result.contains("kill"), "{result}");
+        assert_eq!(registry.len(), 1);
+        // Drop kills it cleanly
+    }
+
+    #[tokio::test]
+    async fn background_false_runs_synchronously() {
+        let tmp = tempfile::tempdir().unwrap();
+        let args = serde_json::json!({"command": "echo sync", "background": false});
+        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+            .await
+            .unwrap();
+        assert!(result.contains("sync"), "{result}");
+        assert!(
+            !result.contains("PID:"),
+            "foreground should not have PID line: {result}"
         );
     }
 
@@ -154,34 +247,25 @@ mod tests {
     #[test]
     fn test_cap_output_long() {
         let lines: Vec<String> = (0..500).map(|i| format!("line {i}")).collect();
-        let input = lines.join("\n");
-        let capped = cap_output(&input, 256);
-
-        // Should contain the truncation notice
+        let capped = cap_output(&lines.join("\n"), 256);
         assert!(capped.contains("truncated"));
-        // Should contain the last line
         assert!(capped.contains("line 499"));
-        // Should NOT contain the first line
         assert!(!capped.contains("line 0\n"));
     }
 
     #[test]
     fn test_cap_output_exactly_at_limit() {
         let lines: Vec<String> = (0..256).map(|i| format!("line {i}")).collect();
-        let input = lines.join("\n");
-        let capped = cap_output(&input, 256);
-        // Exactly at limit, no truncation
-        assert!(!capped.contains("truncated"));
+        assert!(!cap_output(&lines.join("\n"), 256).contains("truncated"));
     }
 
     #[test]
     fn test_timeout_capped_at_max() {
-        // Verify the timeout is clamped to MAX_TIMEOUT_SECS
         let args = serde_json::json!({"command": "echo hi", "timeout": 99999});
-        let timeout_secs = args["timeout"]
+        let t = args["timeout"]
             .as_u64()
             .unwrap_or(DEFAULT_TIMEOUT_SECS)
             .min(MAX_TIMEOUT_SECS);
-        assert_eq!(timeout_secs, MAX_TIMEOUT_SECS);
+        assert_eq!(t, MAX_TIMEOUT_SECS);
     }
 }


### PR DESCRIPTION
## Summary

Adds `background: bool` to the `Bash` tool. When `true`, the command is spawned detached and inference continues immediately with the PID. The process is tracked in a session-scoped `BgRegistry` and SIGTERMed when the session ends.

Closes part of #592.

## Usage

```json
Bash { "command": "npm run dev", "background": true }
```

Returns:
```
Background process started.
  PID:     12345
  Command: npm run dev
To stop:  Bash{command: "kill 12345"}
To force: Bash{command: "kill -9 12345"}
Note: process will be stopped automatically when the session ends.
```

## Changes

### `tools/bg_process.rs` (new)
- `BgRegistry`: session-scoped `Mutex<HashMap<u32, BgEntry>>`
- `Drop` impl sends SIGTERM to all tracked processes on session end
- `insert()`, `list()`, `len()`, `is_empty()`

### `tools/shell.rs`
- `background: bool` parameter added to tool definition
- `run_shell_command` takes `&BgRegistry`
- `spawn_background()`: stdio=null, registers PID, returns instructions
- Timeout documented as ignored when `background=true`
- Tests: `background_spawn_returns_pid`, `background_false_runs_synchronously`

### `tools/mod.rs`
- `bg_registry: BgRegistry` field on `ToolRegistry` (one per session)
- `describe_action` prefixes with `[bg]` in the approval bar

### `progress.rs`
- Tracks background starts as `📡 Started background: <cmd>` entries