### PR TITLE
P2: Fuzzy old_str matching for Edit tool

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -316,38 +316,59 @@ pub async fn edit_file(project_root: &Path, args: &Value) -> Result<String> {
             anyhow::bail!("Replacement {i}: 'old_str' cannot be empty");
         }
 
-        if !content.contains(old_str) {
-            anyhow::bail!(
-                "Replacement {i}: 'old_str' not found in file. \
-                 Read the file first to get the exact text."
-            );
-        }
-
         let replace_all = replacement["replace_all"].as_bool().unwrap_or(false);
 
-        if replace_all {
-            let count = content.matches(old_str).count();
-            content = content.replace(old_str, new_str);
-            // Generate diff lines for display
-            for line in old_str.lines() {
-                changes.push(format!("-{line}"));
-            }
-            for line in new_str.lines() {
-                changes.push(format!("+{line}"));
-            }
-            if count > 1 {
-                changes.push(format!("({count} occurrences replaced)"));
+        // ── Exact match path ──────────────────────────────────────────────
+        if content.contains(old_str) {
+            if replace_all {
+                let count = content.matches(old_str).count();
+                content = content.replace(old_str, new_str);
+                for line in old_str.lines() {
+                    changes.push(format!("-{line}"));
+                }
+                for line in new_str.lines() {
+                    changes.push(format!("+{line}"));
+                }
+                if count > 1 {
+                    changes.push(format!("({count} occurrences replaced)"));
+                }
+            } else {
+                content = content.replacen(old_str, new_str, 1);
+                for line in old_str.lines() {
+                    changes.push(format!("-{line}"));
+                }
+                for line in new_str.lines() {
+                    changes.push(format!("+{line}"));
+                }
             }
         } else {
-            // Replace only the first occurrence (default, safe behavior)
-            content = content.replacen(old_str, new_str, 1);
-            for line in old_str.lines() {
-                changes.push(format!("-{line}"));
-            }
-            for line in new_str.lines() {
-                changes.push(format!("+{line}"));
+            // ── Fuzzy fallback (trailing-whitespace-normalized) ──────────
+            let ranges = super::fuzzy::fuzzy_match_ranges(old_str, &content);
+            match ranges.len() {
+                0 => anyhow::bail!(
+                    "Replacement {i}: 'old_str' not found in '{}'. \
+                     Read the file first to get the exact text.",
+                    path_str
+                ),
+                1 => {
+                    let r = ranges.into_iter().next().unwrap();
+                    for line in old_str.lines() {
+                        changes.push(format!("-{line}"));
+                    }
+                    for line in new_str.lines() {
+                        changes.push(format!("+{line}"));
+                    }
+                    changes.push("(fuzzy match: trailing whitespace ignored)".into());
+                    content = format!("{}{}{}", &content[..r.start], new_str, &content[r.end..]);
+                }
+                n => anyhow::bail!(
+                    "Replacement {i}: 'old_str' is ambiguous — {n} fuzzy matches in '{}'. \
+                     Use a more specific snippet.",
+                    path_str
+                ),
             }
         }
+
         if replacements.len() > 1 {
             changes.push(String::new()); // separator between replacements
         }

--- a/koda-core/src/tools/fuzzy.rs
+++ b/koda-core/src/tools/fuzzy.rs
@@ -1,0 +1,178 @@
+//! Fuzzy (whitespace-normalized) text matching for the Edit tool.
+//!
+//! When `old_str` fails an exact match, we try a line-by-line comparison that
+//! strips trailing whitespace from every line.  This handles the most common
+//! model failure modes:
+//!
+//! * Trailing spaces/tabs the model silently dropped
+//! * CRLF vs LF line endings (`\r` is whitespace, so `trim_end` handles it)
+//!
+//! **Safety:** we only proceed if there is *exactly one* fuzzy match.
+//! Zero matches → hard fail (no match at all).
+//! Two or more matches → hard fail with "ambiguous" message.
+
+use std::ops::Range;
+
+/// Locate `needle` inside `haystack` using trailing-whitespace-stripped line
+/// comparison.  Returns byte ranges **in the original `haystack`** that match.
+///
+/// Never called when `haystack.contains(needle)` — exact matching is always
+/// tried first so this is the fallback path only.
+pub fn fuzzy_match_ranges(needle: &str, haystack: &str) -> Vec<Range<usize>> {
+    // Strip trailing whitespace from every needle line.
+    let norm_needle: Vec<&str> = needle.lines().map(str::trim_end).collect();
+    if norm_needle.is_empty() {
+        return vec![];
+    }
+    let n = norm_needle.len();
+
+    // Build (start_byte, end_byte, line_content) for each haystack line.
+    // end_byte points to the last character of the line, NOT the '\n'.
+    let hay_lines = collect_lines(haystack);
+    let h = hay_lines.len();
+
+    let mut matches = Vec::new();
+
+    for start in 0..h {
+        if start + n > h {
+            break;
+        }
+
+        let hit = norm_needle
+            .iter()
+            .enumerate()
+            .all(|(j, &nline)| hay_lines[start + j].2.trim_end() == nline);
+
+        if hit {
+            let match_start = hay_lines[start].0;
+            let match_end = hay_lines[start + n - 1].1;
+            // If the needle ended with '\n', include the newline so the
+            // replacement length is consistent with what exact-match would do.
+            let end = if needle.ends_with('\n') && match_end < haystack.len() {
+                match_end + 1
+            } else {
+                match_end
+            };
+            matches.push(match_start..end);
+        }
+    }
+
+    matches
+}
+
+/// Split `text` into `(start_byte, end_byte_excl_newline, &str)` triples.
+///
+/// `end_byte_excl_newline` is the byte position *after* the last character of
+/// the line, not counting the `\n` itself.  For a CRLF file the `\r` is part
+/// of the line content and will be stripped by `trim_end`.
+fn collect_lines(text: &str) -> Vec<(usize, usize, &str)> {
+    let mut result = Vec::new();
+    let mut offset = 0usize;
+    let mut rest = text;
+
+    loop {
+        match rest.find('\n') {
+            Some(nl) => {
+                let line = &rest[..nl];
+                result.push((offset, offset + line.len(), line));
+                offset += nl + 1;
+                rest = &rest[nl + 1..];
+            }
+            None => {
+                // Final line with no trailing newline.
+                result.push((offset, offset + rest.len(), rest));
+                break;
+            }
+        }
+    }
+
+    result
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_one(needle: &str, haystack: &str, replacement: &str) -> String {
+        let ranges = fuzzy_match_ranges(needle, haystack);
+        assert_eq!(ranges.len(), 1, "expected exactly one fuzzy match");
+        let r = ranges.into_iter().next().unwrap();
+        format!(
+            "{}{}{}",
+            &haystack[..r.start],
+            replacement,
+            &haystack[r.end..]
+        )
+    }
+
+    #[test]
+    fn exact_match_returns_nothing_here() {
+        // fuzzy_match_ranges is only called when exact fails; if the text IS
+        // present we still get a result — that's fine, callers guard on exact first.
+        let hay = "fn foo() {\n    let x = 1;\n}\n";
+        let needle = "    let x = 1;";
+        let r = fuzzy_match_ranges(needle, hay);
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn trailing_space_on_needle_matches() {
+        // Model strips trailing space; file has "let x = 1;   "
+        let hay = "fn foo() {\n    let x = 1;   \n}\n";
+        let needle = "    let x = 1;";
+        let result = apply_one(needle, hay, "    let x = 2;");
+        assert_eq!(result, "fn foo() {\n    let x = 2;\n}\n");
+    }
+
+    #[test]
+    fn trailing_space_on_file_multiline() {
+        let hay = "a  \nb  \nc\n";
+        let needle = "a\nb";
+        let result = apply_one(needle, hay, "X\nY");
+        assert_eq!(result, "X\nY\nc\n");
+    }
+
+    #[test]
+    fn crlf_file_matches_lf_needle() {
+        // File has CRLF; model sends LF-only needle
+        let hay = "fn foo() {\r\n    let x = 1;\r\n}\r\n";
+        let needle = "    let x = 1;";
+        let ranges = fuzzy_match_ranges(needle, hay);
+        assert_eq!(ranges.len(), 1, "CRLF file should match LF needle");
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        let hay = "hello world\n";
+        let needle = "does not exist";
+        assert!(fuzzy_match_ranges(needle, hay).is_empty());
+    }
+
+    #[test]
+    fn ambiguous_match_returns_multiple() {
+        let hay = "foo  \nbar\nfoo  \nbar\n";
+        let needle = "foo\nbar";
+        let ranges = fuzzy_match_ranges(needle, hay);
+        assert_eq!(ranges.len(), 2, "should detect ambiguity");
+    }
+
+    #[test]
+    fn needle_with_trailing_newline_includes_newline_in_range() {
+        let hay = "a\nb\nc\n";
+        let needle = "a\nb\n";
+        let ranges = fuzzy_match_ranges(needle, hay);
+        assert_eq!(ranges.len(), 1);
+        // Should include up to and including the '\n' after 'b'
+        assert_eq!(&hay[ranges[0].clone()], "a\nb\n");
+    }
+
+    #[test]
+    fn single_line_trailing_space() {
+        let hay = "    return Ok(value);   \n";
+        let needle = "    return Ok(value);";
+        let result = apply_one(needle, hay, "    return Ok(new_value);");
+        assert_eq!(result, "    return Ok(new_value);\n");
+    }
+}

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -67,6 +67,7 @@ pub mod ask_user;
 pub mod bg_process;
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
+pub mod fuzzy;
 /// Glob pattern search tool (`Glob`).
 pub mod glob_tool;
 /// Recursive text search tool (`Grep`).

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -72,12 +72,25 @@ async fn validate_edit(args: &serde_json::Value, project_root: &Path) -> Option<
         }
 
         if !content.contains(old_str) {
-            // Provide a helpful snippet of what's near the expected location
-            return Some(format!(
-                "Replacement {i}: 'old_str' not found in '{}'. \
-                 Read the file first to get the exact text.",
-                path_str
-            ));
+            // Try fuzzy (whitespace-normalized) before hard-failing.
+            let ranges = super::fuzzy::fuzzy_match_ranges(old_str, &content);
+            if ranges.is_empty() {
+                return Some(format!(
+                    "Replacement {i}: 'old_str' not found in '{}'. \
+                     Read the file first to get the exact text.",
+                    path_str
+                ));
+            }
+            // 2+ fuzzy matches is also a problem — flag it now so the model
+            // can tighten the snippet before burning an approval prompt.
+            if ranges.len() > 1 {
+                return Some(format!(
+                    "Replacement {i}: 'old_str' is ambiguous — {} fuzzy matches in '{}'. \
+                     Use a more specific snippet.",
+                    ranges.len(),
+                    path_str
+                ));
+            }
         }
     }
 
@@ -227,6 +240,25 @@ mod tests {
         });
         let err = validate_edit(&args, dir.path()).await.unwrap();
         assert!(err.contains("empty"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn edit_old_str_fuzzy_match_passes_validation() {
+        // File has trailing spaces; model sends clean needle — should pass pre-flight.
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join("hello.txt"),
+            "line one   \nline two   \nline three\n",
+        )
+        .unwrap();
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
+        });
+        assert!(
+            validate_edit(&args, dir.path()).await.is_none(),
+            "fuzzy match should pass validation"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

When `old_str` fails an exact match in the Edit tool, fall through to a line-by-line whitespace-normalized search before hard-failing. Handles the #1 model failure mode: trailing spaces the model silently drops, plus CRLF vs LF mismatches.

Closes part of #592.

## Safety invariants

- **Exact match always tried first** — zero behavior change for clean edits
- **Fuzzy accepted on exactly ONE match** — 0 → not-found error, 2+ → ambiguous error with actionable message
- **Replacement applied to original bytes** — trailing whitespace in the file is replaced too, leaving the file clean
- **Pre-flight validation aligned** — `validate_edit` now accepts fuzzy matches so it doesn't block what `edit_file` would succeed on

## Changes

### `tools/fuzzy.rs` (new)
- `fuzzy_match_ranges(needle, haystack) → Vec<Range<usize>>`
- Line-by-line `trim_end` comparison; CRLF-safe (`\r` is whitespace)
- Handles needle-with-trailing-newline by including the newline in the range
- 8 unit tests: exact, trailing space, CRLF, no match, ambiguous, multiline, trailing-newline, single-line

### `tools/file_tools.rs`
- `edit_file`: exact path → fuzzy fallback in else branch
- Emits `(fuzzy match: trailing whitespace ignored)` in diff output

### `tools/validate.rs`
- `validate_edit`: accepts fuzzy matches, flags ambiguous matches early
- 1 new test: `edit_old_str_fuzzy_match_passes_validation`

## Test results
```
test result: ok. 479 passed; 0 failed
```