### PR TITLE
P2: Rename path → file_path in tool schemas; accept both names in handlers

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -20,7 +20,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "file_path": {
                         "type": "string",
                         "description": "Relative or absolute path to the file"
                     },
@@ -33,7 +33,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                         "description": "Number of lines to read from start_line"
                     }
                 },
-                "required": ["path"]
+                "required": ["file_path"]
             }),
         },
         ToolDefinition {
@@ -45,7 +45,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "file_path": {
                         "type": "string",
                         "description": "Relative or absolute path to the file"
                     },
@@ -58,7 +58,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                         "description": "Must be true to overwrite an existing file (default: false)"
                     }
                 },
-                "required": ["path", "content"]
+                "required": ["file_path", "content"]
             }),
         },
         ToolDefinition {
@@ -73,7 +73,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "file_path": {
                         "type": "string",
                         "description": "Path to the file to edit"
                     },
@@ -100,7 +100,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                         }
                     }
                 },
-                "required": ["path", "replacements"]
+                "required": ["file_path", "replacements"]
             }),
         },
         ToolDefinition {
@@ -111,7 +111,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "file_path": {
                         "type": "string",
                         "description": "Path to the file or directory to delete"
                     },
@@ -120,7 +120,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                         "description": "Required for deleting non-empty directories (default: false)"
                     }
                 },
-                "required": ["path"]
+                "required": ["file_path"]
             }),
         },
         ToolDefinition {
@@ -129,7 +129,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "path": {
+                    "file_path": {
                         "type": "string",
                         "description": "Directory to list (default: project root)"
                     },
@@ -151,9 +151,10 @@ pub async fn read_file(
     args: &Value,
     cache: &super::FileReadCache,
 ) -> Result<String> {
-    let path_str = args["path"]
+    let path_str = args["file_path"]
         .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'path' argument"))?;
+        .or_else(|| args["path"].as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
     let resolved = safe_resolve_path(project_root, path_str)?;
 
     // Symlink traversal protection (#526): safe_resolve_path uses lexical
@@ -259,9 +260,10 @@ pub async fn read_file(
 /// Write content to a file, creating parent directories as needed.
 /// Refuses to overwrite existing files unless `overwrite=true`.
 pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
-    let path_str = args["path"]
+    let path_str = args["file_path"]
         .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'path' argument"))?;
+        .or_else(|| args["path"].as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
     let content = args["content"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'content' argument"))?;
@@ -293,9 +295,10 @@ pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
 
 /// Apply targeted find-and-replace edits to an existing file.
 pub async fn edit_file(project_root: &Path, args: &Value) -> Result<String> {
-    let path_str = args["path"]
+    let path_str = args["file_path"]
         .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'path' argument"))?;
+        .or_else(|| args["path"].as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
     let replacements = args["replacements"]
         .as_array()
         .ok_or_else(|| anyhow::anyhow!("Missing 'replacements' argument"))?;
@@ -386,9 +389,10 @@ pub async fn edit_file(project_root: &Path, args: &Value) -> Result<String> {
 
 /// Delete a file and return confirmation.
 pub async fn delete_file(project_root: &Path, args: &Value) -> Result<String> {
-    let path_str = args["path"]
+    let path_str = args["file_path"]
         .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'path' argument"))?;
+        .or_else(|| args["path"].as_str())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
     let recursive = args["recursive"].as_bool().unwrap_or(false);
     let resolved = safe_resolve_path(project_root, path_str)?;
 
@@ -453,7 +457,10 @@ fn count_dir_entries(path: &Path) -> usize {
 /// List files in a directory, respecting .gitignore.
 /// Entry cap is set by `OutputCaps` (context-scaled).
 pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -> Result<String> {
-    let path_str = args["path"].as_str().unwrap_or(".");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or(".");
     let recursive = args["recursive"].as_bool().unwrap_or(false);
     let resolved = safe_resolve_path(project_root, path_str)?;
 

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -39,9 +39,12 @@ async fn validate_edit(
     project_root: &Path,
     read_cache: Option<&super::FileReadCache>,
 ) -> Option<String> {
-    let path_str = args["path"].as_str().unwrap_or("");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or("");
     if path_str.is_empty() {
-        return Some("Missing 'path' argument.".into());
+        return Some("Missing 'file_path' argument.".into());
     }
 
     let resolved = match safe_resolve_path(project_root, path_str) {
@@ -134,9 +137,12 @@ async fn validate_edit(
 
 /// Write: catch overwrite-without-flag before approval.
 async fn validate_write(args: &serde_json::Value, project_root: &Path) -> Option<String> {
-    let path_str = args["path"].as_str().unwrap_or("");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or("");
     if path_str.is_empty() {
-        return Some("Missing 'path' argument.".into());
+        return Some("Missing 'file_path' argument.".into());
     }
 
     if args["content"].as_str().is_none() {
@@ -162,9 +168,12 @@ async fn validate_write(args: &serde_json::Value, project_root: &Path) -> Option
 
 /// Delete: path must exist.
 async fn validate_delete(args: &serde_json::Value, project_root: &Path) -> Option<String> {
-    let path_str = args["path"].as_str().unwrap_or("");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or("");
     if path_str.is_empty() {
-        return Some("Missing 'path' argument.".into());
+        return Some("Missing 'file_path' argument.".into());
     }
 
     let resolved = match safe_resolve_path(project_root, path_str) {
@@ -380,6 +389,32 @@ mod tests {
     async fn delete_nonempty_dir_with_recursive() {
         let dir = setup();
         let args = json!({"path": "subdir", "recursive": true});
+        assert!(validate_delete(&args, dir.path()).await.is_none());
+    }
+
+    // ── file_path alias acceptance ──────────────────────────
+
+    #[tokio::test]
+    async fn edit_accepts_file_path_param() {
+        let dir = setup();
+        let args = json!({
+            "file_path": "hello.txt",
+            "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
+        });
+        assert!(validate_edit(&args, dir.path(), None).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn write_accepts_file_path_param() {
+        let dir = setup();
+        let args = json!({"file_path": "brand_new.txt", "content": "hello"});
+        assert!(validate_write(&args, dir.path()).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_accepts_file_path_param() {
+        let dir = setup();
+        let args = json!({"file_path": "hello.txt"});
         assert!(validate_delete(&args, dir.path()).await.is_none());
     }
 


### PR DESCRIPTION
## Summary

The LLM-facing parameter for all file-targeting tools (Read, Write, Edit, Delete, List) is now `file_path` instead of `path`. Consistent naming reduces model confusion and matches what most LLMs already naturally reach for.

Closes part of #592.

## Backward compat

Fully preserved — every handler and validator tries `file_path` first then falls back to `path`. Existing cached tool-call payloads work without any model prompt changes.

## Changes

### `tools/file_tools.rs`
- 5 `ToolDefinition` JSON schemas: `path` → `file_path` in property key and `required` array
- 5 handler functions: `args["file_path"].or(args["path"])` dual-accept

### `tools/validate.rs`
- 3 validators (`validate_edit`, `validate_write`, `validate_delete`): dual-accept
- Error messages updated: `'path'` → `'file_path'`
- +3 tests: `edit/write/delete_accepts_file_path_param` (verify new canonical name works)

### No change needed
- `describe_action` in `tools/mod.rs` — already dual-accept
- `extract_file_path` in `undo.rs` — already dual-accept

## Test results
```
test result: ok. 485 passed; 0 failed
```