### PR TITLE
P1: TodoWrite tool + context warning at 80% (CC parity gaps)

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -354,7 +354,14 @@ mod tests {
 
     #[test]
     fn test_write_tools_need_confirmation_in_confirm() {
-        for tool in ["Write", "Edit", "Delete", "MemoryWrite", "EmailSend"] {
+        for tool in [
+            "Write",
+            "Edit",
+            "Delete",
+            "MemoryWrite",
+            "EmailSend",
+            "TodoWrite",
+        ] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), ApprovalMode::Confirm, None),
                 ToolApproval::NeedsConfirmation,
@@ -365,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_auto_approves_non_destructive() {
-        for tool in ["Write", "Edit", "Bash", "WebFetch"] {
+        for tool in ["Write", "Edit", "Bash", "WebFetch", "TodoWrite"] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), ApprovalMode::Auto, None),
                 ToolApproval::AutoApprove,

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -17,8 +17,8 @@ use crate::db::{Database, Role};
 use crate::engine::{EngineCommand, EngineEvent, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
-    PREFLIGHT_COMPACT_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages, estimate_tokens,
-    is_context_overflow_error, is_rate_limit_error, rate_limit_backoff,
+    CONTEXT_WARN_THRESHOLD, PREFLIGHT_COMPACT_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
+    estimate_tokens, is_context_overflow_error, is_rate_limit_error, rate_limit_backoff,
 };
 use crate::loop_guard::LoopDetector;
 use crate::persistence::Persistence;
@@ -87,6 +87,18 @@ async fn assemble_context(
         used: context_used,
         max: max_context_tokens,
     });
+
+    // Warn users when approaching the context limit (headless mode silently
+    // drops ContextUsage events, so this Warn is the only signal they get).
+    let ctx_pct = crate::context::percentage();
+    if (CONTEXT_WARN_THRESHOLD..PREFLIGHT_COMPACT_THRESHOLD).contains(&ctx_pct) {
+        sink.emit(EngineEvent::Warn {
+            message: format!(
+                "Context at {ctx_pct}% — approaching limit. \
+                 Run /compact to free up space."
+            ),
+        });
+    }
 
     Ok(messages)
 }
@@ -521,14 +533,15 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             hard_cap += extra;
         }
 
-        // Build system prompt with progress + git context
+        // Build system prompt with progress + todo + git context
         let progress = crate::progress::get_progress_summary(db, session_id)
             .await
             .unwrap_or_default();
+        let todo_section = crate::tools::todo::get_todo_section(db, session_id).await;
         let git_line = crate::git::git_context(project_root)
             .map(|ctx| format!("\n{ctx}"))
             .unwrap_or_default();
-        let system_prompt_full = format!("{base_system_prompt}{progress}{git_line}");
+        let system_prompt_full = format!("{base_system_prompt}{progress}{todo_section}{git_line}");
         let system_message = ChatMessage::text("system", &system_prompt_full);
 
         // Assemble context (load history, attach images, track usage)

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -5,7 +5,13 @@ use crate::providers::{ChatMessage, ToolCall};
 
 /// Pre-flight context budget threshold (percentage).
 /// If context usage exceeds this before calling the provider, auto-compact first.
+/// Context usage % at which a pre-flight auto-compact fires (engine-side).
 pub const PREFLIGHT_COMPACT_THRESHOLD: usize = 90;
+/// Context usage % at which a user-visible warning is emitted.
+///
+/// Sits below `PREFLIGHT_COMPACT_THRESHOLD` so users see the warning
+/// 1–2 turns before compaction fires automatically.
+pub const CONTEXT_WARN_THRESHOLD: usize = 80;
 
 /// Characters-per-token ratio for heuristic estimation.
 /// 3.5 aligns better with provider-reported counts for code-heavy sessions

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -41,6 +41,7 @@ const CANONICAL: &[&str] = &[
     "MemoryWrite",
     "Read",
     "RecallContext",
+    "TodoWrite",
     "WebFetch",
     "WebSearch",
     "Write",
@@ -115,6 +116,9 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     m.insert("run_command".into(), "Bash");
     m.insert("run_shell_command".into(), "Bash");
 
+    m.insert("todo_write".into(), "TodoWrite");
+    m.insert("update_todos".into(), "TodoWrite");
+    m.insert("todo".into(), "TodoWrite");
     // Web
     m.insert("web_fetch".into(), "WebFetch");
     m.insert("http_get".into(), "WebFetch");

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -37,7 +37,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
         "InvokeAgent" => ToolEffect::ReadOnly, // sub-agents inherit parent's mode
 
         // Local mutations — write to filesystem or local state
-        "Write" | "Edit" | "MemoryWrite" => ToolEffect::LocalMutation,
+        "Write" | "Edit" | "MemoryWrite" | "TodoWrite" => ToolEffect::LocalMutation,
 
         // Bash — default to LocalMutation; refined by classify_bash_command()
         "Bash" => ToolEffect::LocalMutation,
@@ -81,6 +81,8 @@ pub mod recall;
 pub mod shell;
 /// Skill discovery and activation tools (`ListSkills`, `ActivateSkill`).
 pub mod skill_tools;
+/// Session-scoped task list tool (`TodoWrite`).
+pub mod todo;
 /// Pre-flight validation for tool calls (runs before approval).
 pub mod validate;
 /// HTTP fetch tool (`WebFetch`).
@@ -191,6 +193,9 @@ impl ToolRegistry {
             definitions.insert(def.name.clone(), def);
         }
         for def in web_search::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in todo::definitions() {
             definitions.insert(def.name.clone(), def);
         }
         for def in memory::definitions() {
@@ -374,6 +379,14 @@ impl ToolRegistry {
             // Web
             "WebFetch" => web_fetch::web_fetch(&args, self.caps.web_body_chars).await,
             "WebSearch" => web_search::web_search(&args).await,
+            "TodoWrite" => {
+                let db_opt = self.db.read().ok().and_then(|g| g.clone());
+                let sid_opt = self.session_id.read().ok().and_then(|g| g.clone());
+                match (db_opt, sid_opt) {
+                    (Some(db), Some(sid)) => todo::todo_write(&db, &sid, &args).await,
+                    _ => Ok("TodoWrite requires an active session.".to_string()),
+                }
+            }
 
             // Memory
             "MemoryRead" => memory::memory_read(&self.project_root).await,
@@ -672,6 +685,14 @@ pub fn describe_action(tool_name: &str, args: &serde_json::Value) -> String {
         "WebSearch" => {
             let q = args.get("query").and_then(|v| v.as_str()).unwrap_or("?");
             format!("Web search: {q}")
+        }
+        "TodoWrite" => {
+            let n = args
+                .get("todos")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0);
+            format!("Update todo list ({n} tasks)")
         }
         "EmailSend" => {
             let to = args.get("to").and_then(|v| v.as_str()).unwrap_or("?");

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -1,0 +1,385 @@
+//! TodoWrite tool — session-scoped task list.
+//!
+//! The model maintains the full todo list by rewriting it on every call.
+//! Items are persisted to session metadata (survives compaction) and injected
+//! into the system prompt each turn so the model always has its plan in view.
+//!
+//! ## Schema (matches Claude Code's TodoWrite)
+//!
+//! Each item has:
+//! - `content`  — what to do (non-empty string)
+//! - `status`   — `"pending"` | `"in_progress"` | `"completed"`
+//! - `priority` — `"high"` | `"medium"` | `"low"`
+
+use crate::db::Database;
+use crate::persistence::Persistence as _;
+use crate::providers::ToolDefinition;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+// ── Schema ─────────────────────────────────────────────────────────────────
+
+/// Completion state of a todo item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    /// Not started.
+    Pending,
+    /// Currently being worked on (at most one task should be in this state).
+    InProgress,
+    /// Finished.
+    Completed,
+}
+
+impl TodoStatus {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(Self::Pending),
+            "in_progress" => Some(Self::InProgress),
+            "completed" => Some(Self::Completed),
+            _ => None,
+        }
+    }
+
+    fn emoji(&self) -> &'static str {
+        match self {
+            Self::Pending => "○",
+            Self::InProgress => "◑",
+            Self::Completed => "●",
+        }
+    }
+}
+
+/// Relative importance of a todo item.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoPriority {
+    /// Must be done first.
+    High,
+    /// Normal importance.
+    Medium,
+    /// Nice-to-have.
+    Low,
+}
+
+impl TodoPriority {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "high" => Some(Self::High),
+            "medium" => Some(Self::Medium),
+            "low" => Some(Self::Low),
+            _ => None,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::High => "!",
+            Self::Medium => "·",
+            Self::Low => " ",
+        }
+    }
+}
+
+/// A single task in the session todo list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TodoItem {
+    /// Human-readable task description.
+    pub content: String,
+    /// Current completion state.
+    pub status: TodoStatus,
+    /// Relative importance.
+    pub priority: TodoPriority,
+}
+
+// ── Tool definition ─────────────────────────────────────────────────────────
+
+/// Return the tool definition for the LLM.
+pub fn definitions() -> Vec<ToolDefinition> {
+    vec![ToolDefinition {
+        name: "TodoWrite".to_string(),
+        description: "Create and manage a structured task list for the current session. \
+            Rewrite the full list on every call — include all tasks, not just changed ones. \
+            Use proactively for: multi-step tasks (3+ steps), complex refactors, or when \
+            the user provides a list of things to do. Mark tasks `in_progress` BEFORE \
+            starting and `completed` immediately after finishing. Only one task should be \
+            `in_progress` at a time."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "todos": {
+                    "type": "array",
+                    "description": "The complete todo list (replaces any previous list)",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "string",
+                                "description": "Actionable task description in imperative form"
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed"],
+                                "description": "Current status of the task"
+                            },
+                            "priority": {
+                                "type": "string",
+                                "enum": ["high", "medium", "low"],
+                                "description": "Task priority"
+                            }
+                        },
+                        "required": ["content", "status", "priority"]
+                    }
+                }
+            },
+            "required": ["todos"]
+        }),
+    }]
+}
+
+// ── Handler ─────────────────────────────────────────────────────────────────
+
+/// Write the full todo list for this session.
+pub async fn todo_write(db: &Database, session_id: &str, args: &Value) -> Result<String> {
+    let raw = args
+        .get("todos")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'todos' array"))?;
+
+    let mut todos: Vec<TodoItem> = Vec::with_capacity(raw.len());
+    for (i, item) in raw.iter().enumerate() {
+        let content = item
+            .get("content")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.trim().is_empty())
+            .ok_or_else(|| anyhow::anyhow!("todos[{i}]: 'content' must be a non-empty string"))?
+            .to_string();
+
+        let status_str = item
+            .get("status")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("todos[{i}]: missing 'status'"))?;
+        let status = TodoStatus::from_str(status_str).ok_or_else(|| {
+            anyhow::anyhow!(
+                "todos[{i}]: invalid status '{status_str}' — use pending/in_progress/completed"
+            )
+        })?;
+
+        let priority_str = item
+            .get("priority")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("todos[{i}]: missing 'priority'"))?;
+        let priority = TodoPriority::from_str(priority_str).ok_or_else(|| {
+            anyhow::anyhow!("todos[{i}]: invalid priority '{priority_str}' — use high/medium/low")
+        })?;
+
+        todos.push(TodoItem {
+            content,
+            status,
+            priority,
+        });
+    }
+
+    let json = serde_json::to_string(&todos)?;
+    db.set_todo(session_id, &json).await?;
+
+    Ok(format_todo_list(&todos))
+}
+
+/// Load the todo section for injection into the system prompt.
+///
+/// Returns an empty string when no todos are stored (zero cost).
+pub async fn get_todo_section(db: &Database, session_id: &str) -> String {
+    let Ok(Some(raw)) = db.get_todo(session_id).await else {
+        return String::new();
+    };
+    let Ok(todos) = serde_json::from_str::<Vec<TodoItem>>(&raw) else {
+        return String::new();
+    };
+    if todos.is_empty() {
+        return String::new();
+    }
+
+    // Only surface non-completed tasks in the prompt (completed ones are noise).
+    let active: Vec<&TodoItem> = todos
+        .iter()
+        .filter(|t| t.status != TodoStatus::Completed)
+        .collect();
+
+    if active.is_empty() {
+        return String::new();
+    }
+
+    let mut out = "\n## Current Tasks\n".to_string();
+    for t in &active {
+        out.push_str(&format!(
+            "{} [{}] {}\n",
+            t.status.emoji(),
+            t.priority.label(),
+            t.content
+        ));
+    }
+    out
+}
+
+// ── Formatting ──────────────────────────────────────────────────────────────
+
+fn format_todo_list(todos: &[TodoItem]) -> String {
+    if todos.is_empty() {
+        return "Todo list cleared.".to_string();
+    }
+
+    let mut out = format!(
+        "Todo list updated ({} task{}):\n",
+        todos.len(),
+        if todos.len() == 1 { "" } else { "s" }
+    );
+    for t in todos {
+        out.push_str(&format!(
+            "  {} [{}] {}\n",
+            t.status.emoji(),
+            t.priority.label(),
+            t.content
+        ));
+    }
+    out
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    async fn test_db() -> (Database, TempDir, String) {
+        let dir = TempDir::new().unwrap();
+        let db = Database::open(&dir.path().join("test.db")).await.unwrap();
+        use crate::persistence::Persistence;
+        let sid = db.create_session("koda", dir.path()).await.unwrap();
+        (db, dir, sid)
+    }
+
+    #[tokio::test]
+    async fn write_and_read_back() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "Add tests", "status": "pending", "priority": "high"},
+                {"content": "Write docs", "status": "in_progress", "priority": "medium"},
+            ]
+        });
+        let out = todo_write(&db, &sid, &args).await.unwrap();
+        assert!(out.contains("2 tasks"));
+        assert!(out.contains("Add tests"));
+
+        let section = get_todo_section(&db, &sid).await;
+        assert!(section.contains("Add tests"));
+        assert!(section.contains("Write docs"));
+    }
+
+    #[tokio::test]
+    async fn completed_tasks_hidden_from_section() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "Done task", "status": "completed", "priority": "low"},
+                {"content": "Active task", "status": "pending", "priority": "high"},
+            ]
+        });
+        todo_write(&db, &sid, &args).await.unwrap();
+        let section = get_todo_section(&db, &sid).await;
+        assert!(
+            !section.contains("Done task"),
+            "completed tasks should be hidden"
+        );
+        assert!(section.contains("Active task"));
+    }
+
+    #[tokio::test]
+    async fn all_completed_returns_empty_section() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "Done", "status": "completed", "priority": "medium"}
+            ]
+        });
+        todo_write(&db, &sid, &args).await.unwrap();
+        assert!(get_todo_section(&db, &sid).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_list_clears_todos() {
+        let (db, _dir, sid) = test_db().await;
+        // First write something
+        let args = json!({ "todos": [
+            {"content": "Task", "status": "pending", "priority": "low"}
+        ]});
+        todo_write(&db, &sid, &args).await.unwrap();
+        // Then clear it
+        let clear = json!({ "todos": [] });
+        let out = todo_write(&db, &sid, &clear).await.unwrap();
+        assert!(out.contains("cleared"));
+        assert!(get_todo_section(&db, &sid).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_status_returns_error() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [{"content": "Task", "status": "doing", "priority": "high"}]
+        });
+        let err = todo_write(&db, &sid, &args).await.unwrap_err();
+        assert!(err.to_string().contains("invalid status"));
+    }
+
+    #[tokio::test]
+    async fn invalid_priority_returns_error() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [{"content": "Task", "status": "pending", "priority": "urgent"}]
+        });
+        let err = todo_write(&db, &sid, &args).await.unwrap_err();
+        assert!(err.to_string().contains("invalid priority"));
+    }
+
+    #[tokio::test]
+    async fn empty_content_returns_error() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [{"content": "  ", "status": "pending", "priority": "low"}]
+        });
+        let err = todo_write(&db, &sid, &args).await.unwrap_err();
+        assert!(err.to_string().contains("non-empty"));
+    }
+
+    #[tokio::test]
+    async fn missing_todos_field_returns_error() {
+        let (db, _dir, sid) = test_db().await;
+        let err = todo_write(&db, &sid, &json!({})).await.unwrap_err();
+        assert!(err.to_string().contains("todos"));
+    }
+
+    #[test]
+    fn format_single_task() {
+        let todos = vec![TodoItem {
+            content: "Ship it".into(),
+            status: TodoStatus::InProgress,
+            priority: TodoPriority::High,
+        }];
+        let out = format_todo_list(&todos);
+        assert!(out.contains("1 task)"));
+        assert!(out.contains("◑"));
+        assert!(out.contains("Ship it"));
+    }
+
+    #[test]
+    fn status_emoji_coverage() {
+        assert_eq!(TodoStatus::Pending.emoji(), "○");
+        assert_eq!(TodoStatus::InProgress.emoji(), "◑");
+        assert_eq!(TodoStatus::Completed.emoji(), "●");
+    }
+}

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -238,6 +238,7 @@ mod naming_convention {
         "MemoryWrite",
         "Read",
         "RecallContext",
+        "TodoWrite",
         "WebFetch",
         "WebSearch",
         "Write",
@@ -273,8 +274,8 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 21 built-in tools (AstAnalysis removed in #608, AskUser + WebSearch added)
-        assert_eq!(BUILTIN_TOOLS.len(), 21);
+        // 22 built-in tools (AstAnalysis removed in #608, AskUser + WebSearch + TodoWrite added)
+        assert_eq!(BUILTIN_TOOLS.len(), 22);
     }
 
     /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.


### PR DESCRIPTION
## Summary

Two targeted gaps from the CC parity review:

1. **TodoWrite** — the DB has had `get_todo`/`set_todo` since day one but the model couldn't touch it. This exposes the missing tool.
2. **Context warning at 80%** — headless and ACP users were blind to context growth; the `ContextUsage` event was silently dropped in both modes.

> The third item from the review (strip images in compaction) turned out to be a false gap — Koda never persists images to DB, so compaction already never sees them by design.

---

## TodoWrite

Schema is identical to Claude Code's `TodoWrite`:
```json
{
  "todos": [
    { "content": "...", "status": "pending|in_progress|completed", "priority": "high|medium|low" }
  ]
}
```

**Rewrite semantics** — the model sends the full list every call. Simpler than partial-update and robust to model state drift.

**System prompt injection** — active (non-completed) tasks are injected between the progress block and git context each turn. Completed tasks are filtered to save tokens.

### Wiring (7 files, standard pattern)

| File | Change |
|---|---|
| `tools/todo.rs` | New (385 lines, 11 tests) |
| `tools/mod.rs` | `pub mod`, classify → `LocalMutation`, register, dispatch, `describe_action` |
| `tool_normalize.rs` | `TodoWrite` canonical + aliases `todo_write`/`update_todos`/`todo` |
| `approval.rs` | Added to confirm + auto-approve tests |
| `inference.rs` | `get_todo_section()` injected between progress and git line |
| `inference_helpers.rs` | `CONTEXT_WARN_THRESHOLD = 80` constant |
| `tests/new_tools_test.rs` | Add to `BUILTIN_TOOLS`, count 21 → 22 |

---

## Context warning at 80%

When context enters the 80–90% band, `assemble_context()` emits `EngineEvent::Warn`:
- **Headless**: printed as `⚠ Context at N% — approaching limit.` in yellow (existing handler)
- **ACP**: surfaced as `[warn]` content block (existing handler)
- **TUI**: TUI already shows its own auto-compact message at 85% — the warn fires too but is benign

`CONTEXT_WARN_THRESHOLD = 80` sits below `PREFLIGHT_COMPACT_THRESHOLD = 90` giving 1–2 turn notice before auto-compact fires.

---

## Test results
```
test result: ok. 504 passed; 0 failed
```