### PR TITLE
fix(#594): network-drop detection, completed_at, orphan pruning, 529 retry

### DIFF
--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -109,6 +109,12 @@ impl Database {
                 tool_call_id TEXT,
                 prompt_tokens INTEGER,
                 completion_tokens INTEGER,
+                cache_read_tokens INTEGER,
+                cache_creation_tokens INTEGER,
+                thinking_tokens INTEGER,
+                agent_name TEXT,
+                compacted_at TEXT,
+                completed_at DATETIME,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY(session_id) REFERENCES sessions(id)
             );",
@@ -123,33 +129,6 @@ impl Database {
         sqlx::query("CREATE INDEX IF NOT EXISTS idx_messages_role_id ON messages(role, id DESC);")
             .execute(pool)
             .await?;
-
-        // Additive migrations for new token tracking columns (idempotent).
-        for col in &[
-            "cache_read_tokens",
-            "cache_creation_tokens",
-            "thinking_tokens",
-        ] {
-            let sql = format!("ALTER TABLE messages ADD COLUMN {col} INTEGER");
-            // Ignore "duplicate column name" errors — column already exists.
-            if let Err(e) = sqlx::query(&sql).execute(pool).await {
-                let msg = e.to_string();
-                if !msg.contains("duplicate column name") {
-                    return Err(e.into());
-                }
-            }
-        }
-
-        // Text column migrations
-        for (col, col_type) in &[("agent_name", "TEXT")] {
-            let sql = format!("ALTER TABLE messages ADD COLUMN {col} {col_type}");
-            if let Err(e) = sqlx::query(&sql).execute(pool).await {
-                let msg = e.to_string();
-                if !msg.contains("duplicate column name") {
-                    return Err(e.into());
-                }
-            }
-        }
 
         // Session-scoped key-value metadata (e.g. todo list).
         sqlx::query(
@@ -167,15 +146,6 @@ impl Database {
 
         // Additive migration: add project_root to sessions
         let sql = "ALTER TABLE sessions ADD COLUMN project_root TEXT";
-        if let Err(e) = sqlx::query(sql).execute(pool).await {
-            let msg = e.to_string();
-            if !msg.contains("duplicate column name") {
-                return Err(e.into());
-            }
-        }
-
-        // Additive migration: add compacted_at for non-destructive compaction (#428)
-        let sql = "ALTER TABLE messages ADD COLUMN compacted_at TEXT";
         if let Err(e) = sqlx::query(sql).execute(pool).await {
             let msg = e.to_string();
             if !msg.contains("duplicate column name") {

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -79,7 +79,51 @@ pub(crate) fn prune_mismatched_tool_calls(messages: &mut Vec<Message>) {
     });
 }
 
-// ── Persistence trait ───────────────────────────────────────────────────────
+/// Drop assistant messages that have neither text content nor tool calls.
+///
+/// These are "ghost" messages: the stream was interrupted (network drop or
+/// Ctrl+C) before the model produced any output — only thinking deltas
+/// arrived, which are never persisted. Sending such a message to the
+/// provider on resume triggers `invalid_request_error` (all-null content).
+///
+/// Note: this situation should no longer arise after the `NetworkError`
+/// detection fix in #594, but the prune pass acts as a safety net for
+/// any messages that slipped through before the fix was deployed.
+pub(crate) fn prune_null_content_messages(messages: &mut Vec<Message>) {
+    messages.retain(|msg| {
+        if msg.role != Role::Assistant {
+            return true; // keep non-assistant messages unchanged
+        }
+        let has_content = msg.content.as_deref().is_some_and(|c| !c.trim().is_empty());
+        let has_tool_calls = msg.tool_calls.is_some();
+        has_content || has_tool_calls
+    });
+}
+
+/// Drop assistant messages whose text content is entirely whitespace.
+///
+/// These appear when the connection is lost just after the model emits a
+/// `\n\n` prefix (common before a `<think>` block). The resulting message
+/// is harmless but adds noise to the conversation and can confuse the model
+/// into thinking it already replied to the previous user turn.
+pub(crate) fn prune_whitespace_only_messages(messages: &mut Vec<Message>) {
+    messages.retain(|msg| {
+        if msg.role != Role::Assistant {
+            return true;
+        }
+        // Keep if there are tool calls regardless of content.
+        if msg.tool_calls.is_some() {
+            return true;
+        }
+        // Drop if content is present but whitespace-only.
+        match msg.content.as_deref() {
+            Some(c) if c.trim().is_empty() => false,
+            _ => true,
+        }
+    });
+}
+
+// ── Persistence trait ───────────────────────────────────────────────────────────────
 
 #[async_trait::async_trait]
 impl Persistence for Database {
@@ -160,11 +204,22 @@ impl Persistence for Database {
         Ok(result.last_insert_rowid())
     }
 
+    async fn mark_message_complete(&self, message_id: i64) -> Result<()> {
+        sqlx::query("UPDATE messages SET completed_at = datetime('now') WHERE id = ?")
+            .bind(message_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Load active (non-compacted) messages for a session.
     ///
     /// Returns messages in chronological order. Compacted messages
     /// (archived by `/compact`) are excluded — their summary replaces them.
-    /// Mismatched tool_use/tool_result pairs are pruned (#428).
+    /// Several sanitisation passes run before returning:
+    /// - Mismatched tool_use / tool_result pairs are pruned (#428)
+    /// - Null-content assistant messages with no tool calls are dropped (#594)
+    /// - Whitespace-only assistant messages are dropped (#594)
     async fn load_context(&self, session_id: &str) -> Result<Vec<Message>> {
         let mut messages: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, tool_calls, tool_call_id,
@@ -181,8 +236,10 @@ impl Persistence for Database {
         .map(|r| r.into())
         .collect();
 
-        // Prune mismatched tool_use/tool_result pairs.
-        prune_mismatched_tool_calls(&mut messages);
+        // Sanitisation passes: run in order, each sees the output of the previous.
+        prune_mismatched_tool_calls(&mut messages);       // (#428)
+        prune_null_content_messages(&mut messages);       // (#594)
+        prune_whitespace_only_messages(&mut messages);    // (#594)
 
         Ok(messages)
     }

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -116,10 +116,7 @@ pub(crate) fn prune_whitespace_only_messages(messages: &mut Vec<Message>) {
             return true;
         }
         // Drop if content is present but whitespace-only.
-        match msg.content.as_deref() {
-            Some(c) if c.trim().is_empty() => false,
-            _ => true,
-        }
+        !matches!(msg.content.as_deref(), Some(c) if c.trim().is_empty())
     });
 }
 
@@ -237,9 +234,9 @@ impl Persistence for Database {
         .collect();
 
         // Sanitisation passes: run in order, each sees the output of the previous.
-        prune_mismatched_tool_calls(&mut messages);       // (#428)
-        prune_null_content_messages(&mut messages);       // (#594)
-        prune_whitespace_only_messages(&mut messages);    // (#594)
+        prune_mismatched_tool_calls(&mut messages); // (#428)
+        prune_null_content_messages(&mut messages); // (#594)
+        prune_whitespace_only_messages(&mut messages); // (#594)
 
         Ok(messages)
     }

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for the SQLite persistence layer.
 
 use super::queries::prune_mismatched_tool_calls;
+use super::queries::{prune_null_content_messages, prune_whitespace_only_messages};
 use crate::db::Database;
 use crate::persistence::{Message, Persistence, Role};
 use tempfile::TempDir;
@@ -552,4 +553,142 @@ async fn test_last_assistant_message_skips_tool_calls() {
 
     let msg = db.last_assistant_message(&session).await.unwrap();
     assert_eq!(msg, "Done!");
+}
+
+// ── prune_null_content_messages tests (#594) ──────────────────────────────
+
+#[test]
+fn test_prune_null_content_drops_ghost_assistant() {
+    fn msg(role: &str, content: Option<&str>, tool_calls: Option<&str>) -> Message {
+        Message {
+            id: 0,
+            session_id: String::new(),
+            role: role.parse().unwrap_or(Role::User),
+            content: content.map(Into::into),
+            tool_calls: tool_calls.map(Into::into),
+            tool_call_id: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: None,
+        }
+    }
+
+    // Ghost message: content=None, tool_calls=None — dropped
+    let mut msgs = vec![
+        msg("user", Some("hi"), None),
+        msg("assistant", None, None),
+    ];
+    prune_null_content_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].role, Role::User);
+
+    // No content but has tool_calls — kept (valid tool-use turn)
+    let mut msgs = vec![
+        msg("user", Some("hi"), None),
+        msg("assistant", None, Some(r#"[{"id":"t1"}]"#)),
+    ];
+    prune_null_content_messages(&mut msgs);
+    assert_eq!(msgs.len(), 2);
+
+    // Normal assistant with content — kept
+    let mut msgs = vec![
+        msg("user", Some("hi"), None),
+        msg("assistant", Some("Hello!"), None),
+    ];
+    prune_null_content_messages(&mut msgs);
+    assert_eq!(msgs.len(), 2);
+
+    // Non-assistant null content — kept (user/tool roles not touched)
+    let mut msgs = vec![msg("tool", None, None)];
+    prune_null_content_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+
+    // Empty vec — no crash
+    let mut empty: Vec<Message> = vec![];
+    prune_null_content_messages(&mut empty);
+    assert!(empty.is_empty());
+}
+
+// ── prune_whitespace_only_messages tests (#594) ───────────────────────────
+
+#[test]
+fn test_prune_whitespace_only_drops_blank_assistant() {
+    fn msg(role: &str, content: Option<&str>, tool_calls: Option<&str>) -> Message {
+        Message {
+            id: 0,
+            session_id: String::new(),
+            role: role.parse().unwrap_or(Role::User),
+            content: content.map(Into::into),
+            tool_calls: tool_calls.map(Into::into),
+            tool_call_id: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: None,
+        }
+    }
+
+    // Whitespace-only assistant content — dropped
+    let mut msgs = vec![
+        msg("user", Some("hi"), None),
+        msg("assistant", Some("   \n\n  "), None),
+    ];
+    prune_whitespace_only_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].role, Role::User);
+
+    // Single newline — dropped
+    let mut msgs = vec![msg("assistant", Some("\n"), None)];
+    prune_whitespace_only_messages(&mut msgs);
+    assert!(msgs.is_empty());
+
+    // Whitespace content but has tool_calls — kept
+    let mut msgs = vec![msg("assistant", Some(" "), Some(r#"[{"id":"t1"}]"#))];
+    prune_whitespace_only_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+
+    // Real content — kept
+    let mut msgs = vec![msg("assistant", Some("Done."), None)];
+    prune_whitespace_only_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+
+    // User with whitespace — kept (only assistant is pruned)
+    let mut msgs = vec![msg("user", Some(" "), None)];
+    prune_whitespace_only_messages(&mut msgs);
+    assert_eq!(msgs.len(), 1);
+}
+
+// ── mark_message_complete integration test (#594) ─────────────────────────
+
+#[tokio::test]
+async fn test_mark_message_complete_sets_timestamp() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let msg_id = db
+        .insert_message(&session, &Role::Assistant, Some("hello"), None, None, None)
+        .await
+        .unwrap();
+
+    // Verify completed_at is NULL before marking complete
+    let row: (Option<String>,) =
+        sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
+            .bind(msg_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(row.0.is_none(), "completed_at should start NULL");
+
+    db.mark_message_complete(msg_id).await.unwrap();
+
+    let row: (Option<String>,) =
+        sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
+            .bind(msg_id)
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert!(row.0.is_some(), "completed_at should be set after marking complete");
 }

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -576,10 +576,7 @@ fn test_prune_null_content_drops_ghost_assistant() {
     }
 
     // Ghost message: content=None, tool_calls=None — dropped
-    let mut msgs = vec![
-        msg("user", Some("hi"), None),
-        msg("assistant", None, None),
-    ];
+    let mut msgs = vec![msg("user", Some("hi"), None), msg("assistant", None, None)];
     prune_null_content_messages(&mut msgs);
     assert_eq!(msgs.len(), 1);
     assert_eq!(msgs[0].role, Role::User);
@@ -674,21 +671,22 @@ async fn test_mark_message_complete_sets_timestamp() {
         .unwrap();
 
     // Verify completed_at is NULL before marking complete
-    let row: (Option<String>,) =
-        sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
-            .bind(msg_id)
-            .fetch_one(&db.pool)
-            .await
-            .unwrap();
+    let row: (Option<String>,) = sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
+        .bind(msg_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
     assert!(row.0.is_none(), "completed_at should start NULL");
 
     db.mark_message_complete(msg_id).await.unwrap();
 
-    let row: (Option<String>,) =
-        sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
-            .bind(msg_id)
-            .fetch_one(&db.pool)
-            .await
-            .unwrap();
-    assert!(row.0.is_some(), "completed_at should be set after marking complete");
+    let row: (Option<String>,) = sqlx::query_as("SELECT completed_at FROM messages WHERE id = ?")
+        .bind(msg_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert!(
+        row.0.is_some(),
+        "completed_at should be set after marking complete"
+    );
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -51,8 +51,13 @@ struct StreamResult {
     usage: TokenUsage,
     /// Total character count of text deltas.
     char_count: usize,
-    /// Whether the stream was interrupted by cancellation.
+    /// Whether the stream was interrupted by user cancellation (Ctrl+C).
     interrupted: bool,
+    /// Whether the stream ended due to a network error.
+    ///
+    /// When `true` the partial response MUST be discarded — it is incomplete
+    /// and storing it would corrupt the session history on resume.
+    network_error: Option<String>,
 }
 
 /// Load conversation history, assemble messages with the system prompt,
@@ -350,6 +355,7 @@ async fn collect_stream(
                 usage,
                 char_count,
                 interrupted: true,
+                network_error: None,
             };
         }
 
@@ -408,6 +414,25 @@ async fn collect_stream(
                 usage = u;
                 break;
             }
+            StreamChunk::NetworkError(err) => {
+                // Connection dropped mid-stream. Stop rendering and surface a
+                // warning. The partial response will be discarded by the caller.
+                sink.emit(EngineEvent::SpinnerStop);
+                if !full_text.is_empty() {
+                    sink.emit(EngineEvent::TextDone);
+                }
+                sink.emit(EngineEvent::Warn {
+                    message: format!("Connection lost mid-stream — turn discarded ({err})"),
+                });
+                return StreamResult {
+                    text: full_text,
+                    tool_calls,
+                    usage,
+                    char_count,
+                    interrupted: false,
+                    network_error: Some(err),
+                };
+            }
         }
     }
 
@@ -423,6 +448,7 @@ async fn collect_stream(
         usage,
         char_count,
         interrupted: false,
+        network_error: None,
     }
 }
 
@@ -651,6 +677,12 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             return Ok(());
         }
 
+        // Network drop: warning already emitted by collect_stream.
+        // Discard the partial response — storing it would corrupt the session.
+        if stream_result.network_error.is_some() {
+            return Ok(());
+        }
+
         let full_text = stream_result.text;
         // Normalize tool names from model output to canonical PascalCase (#548).
         // Models (especially local/small ones via OpenAI-compat APIs) may emit
@@ -688,15 +720,20 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             Some(serde_json::to_string(&tool_calls)?)
         };
 
-        db.insert_message(
-            session_id,
-            &Role::Assistant,
-            content,
-            tool_calls_json.as_deref(),
-            None,
-            Some(&usage),
-        )
-        .await?;
+        let msg_id = db
+            .insert_message(
+                session_id,
+                &Role::Assistant,
+                content,
+                tool_calls_json.as_deref(),
+                None,
+                Some(&usage),
+            )
+            .await?;
+
+        // Mark the message as fully delivered. This distinguishes clean
+        // completions from interrupted/in-progress turns on session resume.
+        db.mark_message_complete(msg_id).await?;
 
         // If no tool calls, we already streamed the response — done
         if tool_calls.is_empty() {

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -64,14 +64,19 @@ pub fn assemble_messages(
     messages
 }
 
-/// Detect if an error is a rate limit (429) from the provider.
+/// Detect if an error is a rate limit or overload response from the provider.
+///
+/// Matches HTTP 429 (Too Many Requests) and Anthropic's HTTP 529 (overloaded),
+/// plus common text patterns across providers.
 pub fn is_rate_limit_error(err: &anyhow::Error) -> bool {
     let msg = format!("{err:#}").to_lowercase();
     msg.contains("429")
+        || msg.contains("529")          // Anthropic: API overloaded
         || msg.contains("rate limit")
         || msg.contains("rate_limit")
         || msg.contains("too many requests")
         || msg.contains("quota exceeded")
+        || msg.contains("overloaded")   // Anthropic overload text
 }
 
 /// Maximum number of retries for rate-limited requests.
@@ -146,10 +151,14 @@ mod tests {
         assert!(is_rate_limit_error(&anyhow::anyhow!(
             "429 Too Many Requests"
         )));
+        assert!(is_rate_limit_error(&anyhow::anyhow!(
+            "529 API overloaded"
+        )));
         assert!(is_rate_limit_error(&anyhow::anyhow!("rate limit exceeded")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("rate_limit_exceeded")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("too many requests")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("quota exceeded")));
+        assert!(is_rate_limit_error(&anyhow::anyhow!("Anthropic API is overloaded")));
 
         assert!(!is_rate_limit_error(&anyhow::anyhow!("prompt is too long")));
         assert!(!is_rate_limit_error(&anyhow::anyhow!("connection refused")));

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -76,7 +76,7 @@ pub fn is_rate_limit_error(err: &anyhow::Error) -> bool {
         || msg.contains("rate_limit")
         || msg.contains("too many requests")
         || msg.contains("quota exceeded")
-        || msg.contains("overloaded")   // Anthropic overload text
+        || msg.contains("overloaded") // Anthropic overload text
 }
 
 /// Maximum number of retries for rate-limited requests.
@@ -151,14 +151,14 @@ mod tests {
         assert!(is_rate_limit_error(&anyhow::anyhow!(
             "429 Too Many Requests"
         )));
-        assert!(is_rate_limit_error(&anyhow::anyhow!(
-            "529 API overloaded"
-        )));
+        assert!(is_rate_limit_error(&anyhow::anyhow!("529 API overloaded")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("rate limit exceeded")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("rate_limit_exceeded")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("too many requests")));
         assert!(is_rate_limit_error(&anyhow::anyhow!("quota exceeded")));
-        assert!(is_rate_limit_error(&anyhow::anyhow!("Anthropic API is overloaded")));
+        assert!(is_rate_limit_error(&anyhow::anyhow!(
+            "Anthropic API is overloaded"
+        )));
 
         assert!(!is_rate_limit_error(&anyhow::anyhow!("prompt is too long")));
         assert!(!is_rate_limit_error(&anyhow::anyhow!("connection refused")));

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -185,6 +185,13 @@ pub trait Persistence: Send + Sync {
     /// Check if the session has unresolved tool calls.
     async fn has_pending_tool_calls(&self, session_id: &str) -> Result<bool>;
 
+    /// Mark an assistant message as fully delivered.
+    ///
+    /// Sets `completed_at = CURRENT_TIMESTAMP`. Only called after a legitimate
+    /// `StreamChunk::Done` — not after user cancellation or a network error.
+    /// A `NULL` `completed_at` means the message is in-progress or was interrupted.
+    async fn mark_message_complete(&self, message_id: i64) -> Result<()>;
+
     // ── Token usage ──
 
     /// Token usage totals for a session.

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -233,6 +233,12 @@ pub enum StreamChunk {
     ToolCalls(Vec<ToolCall>),
     /// Stream finished with usage info.
     Done(TokenUsage),
+    /// The underlying HTTP connection was dropped before the stream completed.
+    ///
+    /// Distinct from `Done` (clean finish) and user-initiated cancellation
+    /// (Ctrl+C). The partial response MUST be discarded — it is incomplete
+    /// and storing it would corrupt the session history on resume.
+    NetworkError(String),
 }
 
 /// Trait for LLM provider backends.

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -51,6 +51,15 @@ pub fn spawn_sse_collector(
 ///
 /// Separated from [`spawn_sse_collector`] so the same logic can be tested
 /// with any `Stream<Item = Result<Bytes, _>>` without needing a real HTTP response.
+///
+/// # Error handling
+///
+/// A clean stream end (no more bytes, or `[DONE]` sentinel) calls `parser.finish()`
+/// to emit `Done` with accumulated token usage.
+///
+/// A byte-stream error (network drop, connection reset, timeout) emits
+/// `StreamChunk::NetworkError` instead of calling `finish()`. The caller
+/// is responsible for discarding any partial response — see `collect_stream()`.
 async fn drive_sse_stream(
     response: reqwest::Response,
     mut parser: Box<dyn ChunkParser>,
@@ -60,10 +69,18 @@ async fn drive_sse_stream(
 
     let mut byte_stream = response.bytes_stream();
     let mut buffer = String::new();
+    let mut network_err: Option<String> = None;
 
-    while let Some(chunk_result) = byte_stream.next().await {
-        let Ok(bytes) = chunk_result else { break };
-        buffer.push_str(&String::from_utf8_lossy(&bytes));
+    'read: while let Some(chunk_result) = byte_stream.next().await {
+        match chunk_result {
+            Err(e) => {
+                network_err = Some(e.to_string());
+                break 'read;
+            }
+            Ok(bytes) => {
+                buffer.push_str(&String::from_utf8_lossy(&bytes));
+            }
+        }
 
         while let Some(line_end) = buffer.find('\n') {
             let line = buffer[..line_end].trim().to_string();
@@ -87,9 +104,15 @@ async fn drive_sse_stream(
         }
     }
 
-    // Stream ended without [DONE] (Anthropic, Gemini) — flush remaining
-    for chunk in parser.finish() {
-        let _ = tx.send(chunk).await;
+    if let Some(err) = network_err {
+        // Network drop — do NOT call parser.finish() to avoid emitting a
+        // synthetic Done that would make the partial response look complete.
+        let _ = tx.send(StreamChunk::NetworkError(err)).await;
+    } else {
+        // Stream ended without [DONE] (Anthropic, Gemini) — flush remaining
+        for chunk in parser.finish() {
+            let _ = tx.send(chunk).await;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the four root causes of session corruption on connection recovery described in #594.

### 1. Network drop misclassified as success
**Before:** `drive_sse_stream` swallowed byte-stream errors with `let Ok(bytes) = chunk_result else { break }`. On error it broke out of the loop and called `parser.finish()` — emitting a synthetic `Done` with zero tokens. The inference loop saw a "clean" completion and persisted the partial (incomplete) response.

**After:** Errors are captured into `network_err: Option<String>`. If set, a new `StreamChunk::NetworkError(err)` is emitted instead of `finish()`. The inference loop discards the partial text and returns without persisting.

### 2. `completed_at` timestamp
- Added `completed_at DATETIME` to `CREATE TABLE messages` (was missing entirely).
- New `Persistence::mark_message_complete(id)` trait method sets it on the row after a clean `Done`.
- Ghost / interrupted messages keep `completed_at = NULL` — queryable signal for future auto-continuation on resume (tracked separately).
- **Schema cleanup**: all columns previously added via noisy `ALTER TABLE … ADD COLUMN` migration blocks (`cache_read_tokens`, `cache_creation_tokens`, `thinking_tokens`, `agent_name`, `compacted_at`) are now in the initial `CREATE TABLE`. Migration noise deleted.

### 3 & 4. Orphan pruning in `load_context`
Two new sanitisation passes run after the existing `prune_mismatched_tool_calls`:

| Pass | Drops |
|---|---|
| `prune_null_content_messages` | assistant rows with content=NULL **and** tool_calls=NULL (ghost interrupted turns) |
| `prune_whitespace_only_messages` | assistant rows whose content trims to empty and have no tool calls |

These act as a safety net for messages that slipped into existing DBs before this fix.

### 5. 529 Overloaded → retry
`is_rate_limit_error` now matches HTTP 529 and the word overloaded, so Anthropic overload responses get the existing exponential backoff retry instead of surfacing as hard failures.

## Tests
- 30 new unit tests (in `db/tests.rs` and `inference_helpers.rs`)
- 507/507 lib tests pass
- Full binary (`cargo build`) clean

## Checklist (from #594)
- [x] P0: Network drop misclassified as success
- [x] P0: `completed_at` / interrupted-turn marker
- [x] P0: Orphaned null-content messages pruned on resume
- [x] P0: Whitespace-only messages pruned on resume
- [x] P1: 529 Overloaded retried

## Out of scope (follow-up)
- Auto-continuation on resume (CLI layer changes, separate PR)