### PR TITLE
fix(#594): interrupted turn detection banner on session resume

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -197,6 +197,12 @@ async fn handle_resume_session(
                                 Span::styled(detail, DIM),
                             ]),
                         );
+                        // Detect interrupted turns and show a banner (#594)
+                        if let Ok(msgs) = session.db.load_context(&session.id).await
+                            && let Some(kind) = koda_core::db::queries::detect_interruption(&msgs)
+                        {
+                            buffer.push_lines(tui_output::interrupted_turn_banner(&kind));
+                        }
                     }
                     n => tui_output::err_msg(
                         buffer,

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -238,15 +238,17 @@ impl TuiContext {
         }
 
         // Load and render historical conversation on session resume
-        let (history_lines, oldest_msg_id) = {
+        let (history_lines, oldest_msg_id, interruption) = {
+            use koda_core::db::queries::detect_interruption;
             use koda_core::persistence::Persistence;
             match session.db.load_context(&session.id).await {
                 Ok(msgs) if !msgs.is_empty() => {
                     let oldest_id = msgs.first().map(|m| m.id);
+                    let interrupted = detect_interruption(&msgs);
                     let lines = crate::history_render::render_history_messages(&msgs);
-                    (lines, oldest_id)
+                    (lines, oldest_id, interrupted)
                 }
-                _ => (Vec::new(), None),
+                _ => (Vec::new(), None, None),
             }
         };
 
@@ -262,6 +264,9 @@ impl TuiContext {
                 }
                 if let Some(id) = oldest_msg_id {
                     buf.set_oldest_message_id(id);
+                }
+                if let Some(kind) = &interruption {
+                    buf.push_lines(crate::tui_output::interrupted_turn_banner(kind));
                 }
                 buf
             },

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -73,3 +73,49 @@ pub fn warn_msg(buffer: &mut ScrollBuffer, msg: String) {
 pub fn blank(buffer: &mut ScrollBuffer) {
     buffer.push(Line::default());
 }
+
+/// Build a banner for an interrupted turn on session resume.
+///
+/// Returns styled `Line`s ready to push into a `ScrollBuffer`.
+/// The banner tells the user what was interrupted and how to continue.
+pub fn interrupted_turn_banner(
+    kind: &koda_core::persistence::InterruptionKind,
+) -> Vec<Line<'static>> {
+    use koda_core::persistence::InterruptionKind;
+
+    let mut lines = vec![Line::default()];
+
+    match kind {
+        InterruptionKind::Prompt(preview) => {
+            lines.push(Line::from(vec![
+                Span::styled("  ↻ ", AMBER),
+                Span::styled(
+                    "Last turn was interrupted — your prompt was never answered:",
+                    AMBER,
+                ),
+            ]));
+            let display = if preview.len() >= 77 {
+                format!("  \u{201c}{}\u{2026}\u{201d}", &preview[..77])
+            } else {
+                format!("  \u{201c}{}\u{201d}", preview)
+            };
+            lines.push(Line::styled(display, DIM));
+        }
+        InterruptionKind::Tool => {
+            lines.push(Line::from(vec![
+                Span::styled("  ↻ ", AMBER),
+                Span::styled(
+                    "Last turn was interrupted — tool result was never processed.",
+                    AMBER,
+                ),
+            ]));
+        }
+    }
+
+    lines.push(Line::styled(
+        "  Type \"continue\" to resume, or start a new message.",
+        DIM,
+    ));
+    lines.push(Line::default());
+    lines
+}

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -8,7 +8,7 @@
 //! - **mod.rs** — `Database` struct, init/open, schema migrations, row types
 //! - **queries.rs** — `Persistence` trait implementation (all SQL queries)
 
-mod queries;
+pub mod queries;
 #[cfg(test)]
 mod tests;
 

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -7,7 +7,9 @@ use anyhow::Result;
 use std::path::Path;
 
 use super::{Database, MessageRow, SessionInfoRow};
-use crate::persistence::{CompactedStats, Message, Persistence, Role, SessionInfo, SessionUsage};
+use crate::persistence::{
+    CompactedStats, InterruptionKind, Message, Persistence, Role, SessionInfo, SessionUsage,
+};
 
 // ── Private helpers ─────────────────────────────────────────────────────────
 
@@ -118,6 +120,35 @@ pub(crate) fn prune_whitespace_only_messages(messages: &mut Vec<Message>) {
         // Drop if content is present but whitespace-only.
         !matches!(msg.content.as_deref(), Some(c) if c.trim().is_empty())
     });
+}
+
+// ── Interrupted turn detection (#594) ─────────────────────────────────────
+
+/// Inspect the tail of a message history to detect an interrupted turn.
+///
+/// Returns `None` when the conversation ended cleanly (last meaningful
+/// message is an assistant response). Returns `Some(kind)` when the
+/// user’s prompt was never answered or a tool result was never processed.
+///
+/// System messages are skipped — they’re injected by the engine and
+/// don’t reflect user or model activity.
+pub fn detect_interruption(messages: &[Message]) -> Option<InterruptionKind> {
+    let last = messages.iter().rev().find(|m| m.role != Role::System)?;
+
+    match last.role {
+        Role::User => {
+            let preview = last
+                .content
+                .as_deref()
+                .unwrap_or("")
+                .chars()
+                .take(80)
+                .collect::<String>();
+            Some(InterruptionKind::Prompt(preview))
+        }
+        Role::Tool => Some(InterruptionKind::Tool),
+        _ => None,
+    }
 }
 
 // ── Persistence trait ───────────────────────────────────────────────────────────────

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1,9 +1,11 @@
 //! Tests for the SQLite persistence layer.
 
 use super::queries::prune_mismatched_tool_calls;
-use super::queries::{prune_null_content_messages, prune_whitespace_only_messages};
+use super::queries::{
+    detect_interruption, prune_null_content_messages, prune_whitespace_only_messages,
+};
 use crate::db::Database;
-use crate::persistence::{Message, Persistence, Role};
+use crate::persistence::{InterruptionKind, Message, Persistence, Role};
 use tempfile::TempDir;
 
 async fn setup() -> (Database, TempDir) {
@@ -689,4 +691,76 @@ async fn test_mark_message_complete_sets_timestamp() {
         row.0.is_some(),
         "completed_at should be set after marking complete"
     );
+}
+
+// ── detect_interruption (#594) ──────────────────────────────
+
+fn msg(role: Role, content: &str) -> Message {
+    Message {
+        id: 0,
+        session_id: String::new(),
+        role,
+        content: Some(content.to_string()),
+        tool_calls: None,
+        tool_call_id: None,
+        prompt_tokens: None,
+        completion_tokens: None,
+        cache_read_tokens: None,
+        cache_creation_tokens: None,
+        thinking_tokens: None,
+    }
+}
+
+#[test]
+fn detect_interruption_clean_end() {
+    let msgs = vec![msg(Role::User, "hello"), msg(Role::Assistant, "hi there")];
+    assert_eq!(detect_interruption(&msgs), None);
+}
+
+#[test]
+fn detect_interruption_unanswered_prompt() {
+    let msgs = vec![
+        msg(Role::Assistant, "done"),
+        msg(Role::User, "do something else"),
+    ];
+    assert_eq!(
+        detect_interruption(&msgs),
+        Some(InterruptionKind::Prompt("do something else".into()))
+    );
+}
+
+#[test]
+fn detect_interruption_orphaned_tool_result() {
+    let mut tool_msg = msg(Role::Tool, "ok");
+    tool_msg.tool_call_id = Some("call_123".into());
+    let msgs = vec![msg(Role::Assistant, "calling tool"), tool_msg];
+    assert_eq!(detect_interruption(&msgs), Some(InterruptionKind::Tool));
+}
+
+#[test]
+fn detect_interruption_skips_system() {
+    let msgs = vec![
+        msg(Role::User, "hello"),
+        msg(Role::Assistant, "hi"),
+        msg(Role::System, "injected context"),
+    ];
+    // System message at the end should be ignored — assistant is last real msg
+    assert_eq!(detect_interruption(&msgs), None);
+}
+
+#[test]
+fn detect_interruption_prompt_truncated() {
+    let long = "x".repeat(200);
+    let msgs = vec![msg(Role::User, &long)];
+    match detect_interruption(&msgs) {
+        Some(InterruptionKind::Prompt(preview)) => {
+            assert_eq!(preview.len(), 80, "preview should truncate to 80 chars");
+        }
+        other => panic!("expected Prompt, got {other:?}"),
+    }
+}
+
+#[test]
+fn detect_interruption_empty() {
+    assert_eq!(detect_interruption(&[]), None);
 }

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -89,6 +89,35 @@ pub struct Message {
     pub thinking_tokens: Option<i64>,
 }
 
+/// Detected interruption state for a resumed session.
+///
+/// Returned by [`detect_interruption`](crate::db::queries::detect_interruption)
+/// after inspecting the tail of the message history.
+///
+/// ## Design decision: banner, not auto-resume
+///
+/// Claude Code auto-continues interrupted turns (re-sends the prompt or
+/// injects "Continue from where you left off"). Koda deliberately shows a
+/// banner and lets the user decide, for three reasons:
+///
+/// 1. **Safety** — auto-resuming a destructive tool call (e.g. `rm -rf`)
+///    after a VPN drop is surprising. The user should see the state first.
+/// 2. **Stale context** — the user may have fixed the issue manually while
+///    Koda was disconnected. Auto-resume wastes tokens re-doing work.
+/// 3. **Cost** — resuming to *check history* shouldn't burn an API call.
+///
+/// A single "type `continue` or rephrase" banner is near-zero friction
+/// (one word + Enter) and handles all three cases.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InterruptionKind {
+    /// The user's prompt was never answered (last message is `Role::User`).
+    /// Contains a preview of the unanswered prompt.
+    Prompt(String),
+    /// A tool finished but the assistant never processed the result
+    /// (last message is `Role::Tool`).
+    Tool,
+}
+
 /// Token usage totals for a session.
 #[derive(Debug, Clone, Default)]
 pub struct SessionUsage {


### PR DESCRIPTION
## Summary

Closes the last open item in #594 — **P1: interrupted turn detection on resume**.

### What it does

When resuming a session (via `--resume` or `/sessions resume`), inspects the tail of the message history to detect:

| State | Condition | Banner shown |
|---|---|---|
| Clean | Last msg is assistant | None |
| Interrupted prompt | Last msg is user | `↻ Last turn was interrupted — your prompt was never answered: "…"` |
| Interrupted tool | Last msg is tool result | `↻ Last turn was interrupted — tool result was never processed.` |

Both cases show a dim hint: `Type "continue" to resume, or start a new message.`

### Design decision: banner, not auto-resume

Claude Code auto-continues interrupted turns. Koda deliberately shows a banner and lets the user decide:

1. **Safety** — auto-resuming a destructive tool call after a VPN drop is surprising
2. **Stale context** — user may have fixed things manually while Koda was down
3. **Cost** — resuming to check history shouldn't burn an API call

Rationale is documented inline on `InterruptionKind` in `persistence.rs`.

### Changes

| File | What |
|---|---|
| `persistence.rs` | `InterruptionKind` enum with design doc |
| `db/queries.rs` | `detect_interruption()` — pure fn on `&[Message]` |
| `db/tests.rs` | 6 unit tests covering all cases |
| `tui_output.rs` | `interrupted_turn_banner()` — styled Line builder |
| `tui_context/mod.rs` | Wired into startup resume |
| `tui_commands.rs` | Wired into `/sessions resume` |
| `db/mod.rs` | Made `queries` module pub |

### #594 completion status

All items are now shipped:
- [x] P0: Network drop misclassified as success (#622)
- [x] P0: `completed_at` column (#622)
- [x] P0: Orphaned thinking-only messages (#622)
- [x] P1: 529 Overloaded (#622)
- [x] P1: **Interrupted turn detection** (this PR)
- [x] P2: Whitespace-only messages (#622)