### PR TITLE
feat(#590): session titles, mode persistence, richer listing

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -77,7 +77,7 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
         ReplAction::ResumeSession(ref id) => {
-            handle_resume_session(buffer, session, id, project_root).await;
+            handle_resume_session(buffer, session, id, project_root, shared_mode).await;
             SlashAction::Continue
         }
         ReplAction::InjectPrompt(prompt) => {
@@ -172,6 +172,7 @@ async fn handle_resume_session(
     session: &mut KodaSession,
     id: &str,
     project_root: &std::path::Path,
+    shared_mode: &approval::SharedMode,
 ) {
     use tui_output::GREEN;
     if session.id.starts_with(id) {
@@ -185,9 +186,17 @@ async fn handle_resume_session(
                     1 => {
                         let target = &matches[0];
                         session.id = target.id.clone();
+                        session.title_set = true;
                         let short_id = target.id[..8].to_string();
-                        let detail =
-                            format!("  {}  {} msgs", target.created_at, target.message_count);
+                        let title_part = target
+                            .title
+                            .as_deref()
+                            .map(|t| format!(" — {}", t.chars().take(40).collect::<String>()))
+                            .unwrap_or_default();
+                        let detail = format!(
+                            "{title_part}  {}  {} msgs",
+                            target.created_at, target.message_count
+                        );
                         tui_output::emit_line(
                             buffer,
                             Line::from(vec![
@@ -197,6 +206,12 @@ async fn handle_resume_session(
                                 Span::styled(detail, DIM),
                             ]),
                         );
+                        // Restore persisted approval mode (#590)
+                        if let Ok(Some(mode_str)) = session.db.get_session_mode(&session.id).await
+                            && let Some(m) = approval::ApprovalMode::parse(&mode_str)
+                        {
+                            approval::set_mode(shared_mode, m);
+                        }
                         // Detect interrupted turns and show a banner (#594)
                         if let Ok(msgs) = session.db.load_context(&session.id).await
                             && let Some(kind) = koda_core::db::queries::detect_interruption(&msgs)

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -135,7 +135,12 @@ impl TuiContext {
                 self.copy_to_clipboard(true);
             }
             (KeyCode::BackTab, _) => {
-                approval::cycle_mode(&self.shared_mode);
+                let new_mode = approval::cycle_mode(&self.shared_mode);
+                let _ = self
+                    .session
+                    .db
+                    .set_session_mode(&self.session.id, new_mode.as_str())
+                    .await;
             }
             (KeyCode::Tab, KeyModifiers::NONE) => {
                 let current = self.textarea.lines().join("\n");

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -118,6 +118,7 @@ impl TuiContext {
                         message_count: s.message_count,
                         total_tokens: s.total_tokens,
                         is_current: s.id == self.session.id,
+                        title: s.title.clone(),
                     })
                     .collect();
                 let mut dd =

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -178,7 +178,7 @@ impl TuiContext {
         let agent =
             Arc::new(koda_core::agent::KodaAgent::new(&config, project_root.clone()).await?);
 
-        let session = KodaSession::new(
+        let mut session = KodaSession::new(
             session_id,
             agent.clone(),
             db.clone(),
@@ -189,7 +189,15 @@ impl TuiContext {
 
         crate::startup::purge_nudge(&db, &mut startup_lines).await;
 
-        let shared_mode = approval::new_shared_mode(ApprovalMode::Auto);
+        // Restore persisted approval mode on resume (#590)
+        let initial_mode = {
+            use koda_core::persistence::Persistence;
+            match session.db.get_session_mode(&session.id).await {
+                Ok(Some(mode_str)) => ApprovalMode::parse(&mode_str).unwrap_or(ApprovalMode::Auto),
+                _ => ApprovalMode::Auto,
+            }
+        };
+        let shared_mode = approval::new_shared_mode(initial_mode);
 
         // Terminal + textarea
         let terminal = init_terminal()?;
@@ -243,6 +251,7 @@ impl TuiContext {
             use koda_core::persistence::Persistence;
             match session.db.load_context(&session.id).await {
                 Ok(msgs) if !msgs.is_empty() => {
+                    session.title_set = true; // resumed session already has a title
                     let oldest_id = msgs.first().map(|m| m.id);
                     let interrupted = detect_interruption(&msgs);
                     let lines = crate::history_render::render_history_messages(&msgs);
@@ -549,6 +558,17 @@ impl TuiContext {
             .await
         {
             tracing::warn!("Failed to persist user message: {e}");
+        }
+
+        // Auto-set session title from first user message (#590)
+        if !self.session.title_set {
+            self.session.title_set = true;
+            let title: String = user_message.chars().take(50).collect();
+            let _ = self
+                .session
+                .db
+                .set_session_title(&self.session.id, &title)
+                .await;
         }
 
         let pending_images = if processed.images.is_empty() {

--- a/koda-cli/src/widgets/session_menu.rs
+++ b/koda-cli/src/widgets/session_menu.rs
@@ -13,6 +13,7 @@ pub struct SessionItem {
     pub message_count: i64,
     pub total_tokens: i64,
     pub is_current: bool,
+    pub title: Option<String>,
 }
 
 impl DropdownItem for SessionItem {
@@ -20,12 +21,17 @@ impl DropdownItem for SessionItem {
         &self.short_id
     }
     fn description(&self) -> String {
-        let mut desc = format!(
-            "{}  {} msgs  {}k tok",
-            self.created_at,
-            self.message_count,
-            self.total_tokens / 1000
-        );
+        let mut desc = if let Some(title) = &self.title {
+            let t: String = title.chars().take(30).collect();
+            format!("{t}  {} msgs", self.message_count)
+        } else {
+            format!(
+                "{}  {} msgs  {}k tok",
+                self.created_at,
+                self.message_count,
+                self.total_tokens / 1000
+            )
+        };
         if self.is_current {
             desc.push_str(" \u{25c0} current");
         }
@@ -33,7 +39,12 @@ impl DropdownItem for SessionItem {
     }
     fn matches_filter(&self, filter: &str) -> bool {
         let f = filter.to_lowercase();
-        self.id.to_lowercase().contains(&f) || self.created_at.to_lowercase().contains(&f)
+        self.id.to_lowercase().contains(&f)
+            || self.created_at.to_lowercase().contains(&f)
+            || self
+                .title
+                .as_deref()
+                .is_some_and(|t| t.to_lowercase().contains(&f))
     }
 }
 
@@ -50,6 +61,7 @@ mod tests {
             message_count: 5,
             total_tokens: 12000,
             is_current: true,
+            title: None,
         };
         assert!(item.description().contains('\u{25c0}'));
     }
@@ -63,9 +75,11 @@ mod tests {
             message_count: 5,
             total_tokens: 12000,
             is_current: false,
+            title: Some("refactor auth module".into()),
         };
         assert!(item.matches_filter("abc"));
         assert!(item.matches_filter("2026"));
+        assert!(item.matches_filter("refactor"));
         assert!(!item.matches_filter("xyz"));
     }
 }

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -43,6 +43,14 @@ impl ApprovalMode {
         }
     }
 
+    /// Stable string representation for persistence.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Confirm => "confirm",
+        }
+    }
+
     /// Short label for display.
     pub fn label(self) -> &'static str {
         match self {

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -93,7 +93,11 @@ impl Database {
             "CREATE TABLE IF NOT EXISTS sessions (
                 id TEXT PRIMARY KEY,
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                agent_name TEXT NOT NULL
+                agent_name TEXT NOT NULL,
+                project_root TEXT,
+                last_accessed_at TEXT,
+                title TEXT,
+                mode TEXT
             );",
         )
         .execute(pool)
@@ -143,24 +147,6 @@ impl Database {
         )
         .execute(pool)
         .await?;
-
-        // Additive migration: add project_root to sessions
-        let sql = "ALTER TABLE sessions ADD COLUMN project_root TEXT";
-        if let Err(e) = sqlx::query(sql).execute(pool).await {
-            let msg = e.to_string();
-            if !msg.contains("duplicate column name") {
-                return Err(e.into());
-            }
-        }
-
-        // Additive migration: track last activity per session (#429)
-        let sql = "ALTER TABLE sessions ADD COLUMN last_accessed_at TEXT";
-        if let Err(e) = sqlx::query(sql).execute(pool).await {
-            let msg = e.to_string();
-            if !msg.contains("duplicate column name") {
-                return Err(e.into());
-            }
-        }
 
         // File lifecycle tracking (#465): files created by Koda in a session.
         sqlx::query(
@@ -276,6 +262,8 @@ pub(crate) struct SessionInfoRow {
     pub created_at: String,
     pub message_count: i64,
     pub total_tokens: i64,
+    pub title: Option<String>,
+    pub mode: Option<String>,
 }
 
 impl From<SessionInfoRow> for SessionInfo {
@@ -286,6 +274,8 @@ impl From<SessionInfoRow> for SessionInfo {
             created_at: r.created_at,
             message_count: r.message_count,
             total_tokens: r.total_tokens,
+            title: r.title,
+            mode: r.mode,
         }
     }
 }

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -381,7 +381,8 @@ impl Persistence for Database {
         let rows: Vec<SessionInfoRow> = sqlx::query_as(
             "SELECT s.id, s.agent_name, s.created_at,
                     COUNT(m.id) as message_count,
-                    COALESCE(SUM(m.prompt_tokens), 0) + COALESCE(SUM(m.completion_tokens), 0) as total_tokens
+                    COALESCE(SUM(m.prompt_tokens), 0) + COALESCE(SUM(m.completion_tokens), 0) as total_tokens,
+                    s.title, s.mode
              FROM sessions s
              LEFT JOIN messages m ON m.session_id = s.id
              WHERE s.project_root = ? OR s.project_root IS NULL
@@ -449,6 +450,33 @@ impl Persistence for Database {
             .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    async fn set_session_title(&self, session_id: &str, title: &str) -> Result<()> {
+        sqlx::query("UPDATE sessions SET title = ? WHERE id = ?")
+            .bind(title)
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn set_session_mode(&self, session_id: &str, mode: &str) -> Result<()> {
+        sqlx::query("UPDATE sessions SET mode = ? WHERE id = ?")
+            .bind(mode)
+            .bind(session_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn get_session_mode(&self, session_id: &str) -> Result<Option<String>> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT mode FROM sessions WHERE id = ?")
+                .bind(session_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.and_then(|r| r.0))
     }
 
     /// Compact a session: summarize old messages while preserving the most recent ones.

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -148,6 +148,10 @@ pub struct SessionInfo {
     pub message_count: i64,
     /// Cumulative token count.
     pub total_tokens: i64,
+    /// Auto-generated title from first user message.
+    pub title: Option<String>,
+    /// Last active approval mode (for restore on resume).
+    pub mode: Option<String>,
 }
 
 /// Stats about compacted (archived) messages in the database.
@@ -174,6 +178,12 @@ pub trait Persistence: Send + Sync {
     async fn list_sessions(&self, limit: i64, project_root: &Path) -> Result<Vec<SessionInfo>>;
     /// Delete a session by ID. Returns `true` if it existed.
     async fn delete_session(&self, session_id: &str) -> Result<bool>;
+    /// Set the auto-generated title for a session.
+    async fn set_session_title(&self, session_id: &str, title: &str) -> Result<()>;
+    /// Persist the current approval mode for a session (restored on resume).
+    async fn set_session_mode(&self, session_id: &str, mode: &str) -> Result<()>;
+    /// Get the stored approval mode for a session.
+    async fn get_session_mode(&self, session_id: &str) -> Result<Option<String>>;
 
     // ── Messages ──
 

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -40,6 +40,8 @@ pub struct KodaSession {
     pub cancel: CancellationToken,
     /// File lifecycle tracker — tracks files created by Koda (#465).
     pub file_tracker: FileTracker,
+    /// Whether the session title has already been set (first-message guard).
+    pub title_set: bool,
 }
 
 impl KodaSession {
@@ -65,6 +67,7 @@ impl KodaSession {
             settings,
             cancel: CancellationToken::new(),
             file_tracker,
+            title_set: false,
         }
     }
 

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -93,6 +93,7 @@ impl Env {
             settings: Settings::load(),
             cancel: cancel.clone(),
             file_tracker,
+            title_set: false,
         };
         (session, cancel)
     }


### PR DESCRIPTION
## Summary

First batch of #590 — the three tightly-coupled P2 items: session titles, mode persistence, and richer session listing.

### Session titles
- Auto-generated from the first user message (50-char capture, set-once guard via `title_set` flag)
- Shown in `/sessions` dropdown with 30-char truncation
- Searchable via dropdown filter
- Displayed in `/sessions resume` confirmation line

### Mode persistence
- `ApprovalMode` saved to DB via `set_session_mode()` on every Shift+Tab cycle
- Restored on `--resume` startup and `/sessions resume` command
- Added `ApprovalMode::as_str()` for stable serialization (`"auto"` / `"confirm"`)

### Schema cleanup
Since there's only one user (hi Lijun 👋), moved `project_root`, `last_accessed_at`, `title`, and `mode` columns directly into the `CREATE TABLE sessions` statement. Removed all 4 `ALTER TABLE` migrations. **You'll need to delete your local `.koda.db` file** for the schema to take effect.

### Richer session listing
- `SessionInfo` / `SessionInfoRow` now include `title` and `mode`
- `list_sessions` query pulls both columns
- Dropdown shows title when available, falls back to date/token display

### Changes

| File | What |
|---|---|
| `db/mod.rs` | Schema: inline columns, remove ALTER migrations |
| `persistence.rs` | `SessionInfo` + `set_session_title/mode` + `get_session_mode` |
| `db/queries.rs` | Trait impl for new methods + updated query |
| `approval.rs` | `as_str()` method |
| `session.rs` | `title_set: bool` field |
| `tui_context/mod.rs` | Title set-once, mode restore on startup |
| `tui_context/events.rs` | Mode persist on Shift+Tab |
| `tui_commands.rs` | Mode restore + title display on `/sessions resume` |
| `widgets/session_menu.rs` | Title in dropdown + filter + tests |
| `tui_context/menus.rs` | Pass title through to SessionItem |

### Remaining #590 items
- [ ] P1: Ctrl+R history search (separate PR — needs search overlay UI)
- [ ] P2: Away summary on resume
- [ ] P2: Detached headless mode (`--background`)