### PR TITLE
feat(#590): away-summary banner on session resume

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -212,11 +212,34 @@ async fn handle_resume_session(
                         {
                             approval::set_mode(shared_mode, m);
                         }
-                        // Detect interrupted turns and show a banner (#594)
-                        if let Ok(msgs) = session.db.load_context(&session.id).await
-                            && let Some(kind) = koda_core::db::queries::detect_interruption(&msgs)
-                        {
-                            buffer.push_lines(tui_output::interrupted_turn_banner(&kind));
+                        // Read idle time BEFORE load_context updates last_accessed_at.
+                        let idle_secs = session
+                            .db
+                            .get_session_idle_secs(&session.id)
+                            .await
+                            .ok()
+                            .flatten();
+                        // Show away-summary + interrupted-turn banners (#590, #594)
+                        if let Ok(msgs) = session.db.load_context(&session.id).await {
+                            use koda_core::persistence::Role;
+                            let user_msgs = msgs.iter().filter(|m| m.role == Role::User).count();
+                            let tool_calls = msgs.iter().filter(|m| m.role == Role::Tool).count();
+                            let total_tokens: i64 = msgs
+                                .iter()
+                                .map(|m| {
+                                    m.prompt_tokens.unwrap_or(0) + m.completion_tokens.unwrap_or(0)
+                                })
+                                .sum();
+                            buffer.push_lines(tui_output::away_summary_banner(
+                                idle_secs,
+                                None, // title already in the confirmation line above
+                                user_msgs,
+                                tool_calls,
+                                total_tokens,
+                            ));
+                            if let Some(kind) = koda_core::db::queries::detect_interruption(&msgs) {
+                                buffer.push_lines(tui_output::interrupted_turn_banner(&kind));
+                            }
                         }
                     }
                     n => tui_output::err_msg(

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -246,18 +246,39 @@ impl TuiContext {
         }
 
         // Load and render historical conversation on session resume
-        let (history_lines, oldest_msg_id, interruption) = {
+        let (history_lines, oldest_msg_id, interruption, away_banner) = {
             use koda_core::db::queries::detect_interruption;
-            use koda_core::persistence::Persistence;
+            use koda_core::persistence::{Persistence, Role};
+            // Read idle time BEFORE load_context updates last_accessed_at.
+            let idle_secs = session
+                .db
+                .get_session_idle_secs(&session.id)
+                .await
+                .ok()
+                .flatten();
             match session.db.load_context(&session.id).await {
                 Ok(msgs) if !msgs.is_empty() => {
                     session.title_set = true; // resumed session already has a title
                     let oldest_id = msgs.first().map(|m| m.id);
                     let interrupted = detect_interruption(&msgs);
+                    // Compute stats for the away-summary banner.
+                    let user_msgs = msgs.iter().filter(|m| m.role == Role::User).count();
+                    let tool_calls = msgs.iter().filter(|m| m.role == Role::Tool).count();
+                    let total_tokens: i64 = msgs
+                        .iter()
+                        .map(|m| m.prompt_tokens.unwrap_or(0) + m.completion_tokens.unwrap_or(0))
+                        .sum();
+                    let banner = crate::tui_output::away_summary_banner(
+                        idle_secs,
+                        None, // title visible in startup hint; keep banner slim
+                        user_msgs,
+                        tool_calls,
+                        total_tokens,
+                    );
                     let lines = crate::history_render::render_history_messages(&msgs);
-                    (lines, oldest_id, interrupted)
+                    (lines, oldest_id, interrupted, banner)
                 }
-                _ => (Vec::new(), None, None),
+                _ => (Vec::new(), None, None, Vec::new()),
             }
         };
 
@@ -273,6 +294,9 @@ impl TuiContext {
                 }
                 if let Some(id) = oldest_msg_id {
                     buf.set_oldest_message_id(id);
+                }
+                if !away_banner.is_empty() {
+                    buf.push_lines(away_banner);
                 }
                 if let Some(kind) = &interruption {
                     buf.push_lines(crate::tui_output::interrupted_turn_banner(kind));

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -119,3 +119,125 @@ pub fn interrupted_turn_banner(
     lines.push(Line::default());
     lines
 }
+
+/// Format seconds of idle time into a human-readable "away" string.
+/// Returns `None` for trivially short gaps (< 5 min) to avoid noise.
+fn format_idle(secs: i64) -> Option<String> {
+    match secs {
+        ..=299 => None, // < 5 minutes — not worth showing
+        300..=3599 => Some(format!("{} min", secs / 60)),
+        3600..=86399 => {
+            let h = secs / 3600;
+            Some(format!("{} h", h))
+        }
+        86400..=604799 => {
+            let d = secs / 86400;
+            Some(format!("{} day{}", d, if d == 1 { "" } else { "s" }))
+        }
+        _ => {
+            let w = secs / 604800;
+            Some(format!("{} week{}", w, if w == 1 { "" } else { "s" }))
+        }
+    }
+}
+
+/// One-line summary banner shown at the top of a resumed session.
+///
+/// Shows session title, message + tool-call counts, token usage, and
+/// how long the session was idle. Returns an empty `Vec` if there are
+/// no meaningful stats to display (e.g. brand-new session).
+pub fn away_summary_banner(
+    idle_secs: Option<i64>,
+    title: Option<&str>,
+    user_msg_count: usize,
+    tool_call_count: usize,
+    total_tokens: i64,
+) -> Vec<Line<'static>> {
+    let mut parts: Vec<String> = Vec::new();
+
+    if user_msg_count > 0 {
+        let msgs_label = match user_msg_count {
+            1 => "1 msg".to_string(),
+            n => format!("{n} msgs"),
+        };
+        parts.push(msgs_label);
+    }
+
+    if tool_call_count > 0 {
+        parts.push(format!(
+            "{tool_call_count} tool call{}",
+            if tool_call_count == 1 { "" } else { "s" }
+        ));
+    }
+
+    if total_tokens > 0 {
+        parts.push(format!("{}k tok", total_tokens / 1000));
+    }
+
+    if let Some(secs) = idle_secs
+        && let Some(away) = format_idle(secs)
+    {
+        parts.push(format!("away {away}"));
+    }
+
+    // Nothing useful to show—skip the banner entirely
+    if parts.is_empty() {
+        return Vec::new();
+    }
+
+    let stats: String = parts.join(" \u{00b7} "); // middot separator
+    let title_span = title
+        .map(|t| {
+            let t: String = t.chars().take(50).collect();
+            Span::styled(format!("“{t}”  "), WARM_ACCENT)
+        })
+        .unwrap_or_else(|| Span::raw(""));
+
+    vec![
+        Line::default(),
+        Line::from(vec![
+            Span::styled("  \u{1f4cb} ", CYAN),
+            title_span,
+            Span::styled(stats, WARM_MUTED),
+        ]),
+        Line::default(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_thresholds() {
+        assert!(format_idle(0).is_none());
+        assert!(format_idle(299).is_none()); // < 5 min — silent
+        assert_eq!(format_idle(300).as_deref(), Some("5 min"));
+        assert_eq!(format_idle(3600).as_deref(), Some("1 h"));
+        assert_eq!(format_idle(86400).as_deref(), Some("1 day"));
+        assert_eq!(format_idle(172800).as_deref(), Some("2 days"));
+        assert_eq!(format_idle(604800).as_deref(), Some("1 week"));
+        assert_eq!(format_idle(1209600).as_deref(), Some("2 weeks"));
+    }
+
+    #[test]
+    fn banner_empty_for_zero_messages() {
+        let lines = away_summary_banner(None, None, 0, 0, 0);
+        // No stats → no banner
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn banner_shows_with_messages() {
+        let lines = away_summary_banner(Some(7200), None, 5, 3, 15000);
+        // blank + content + blank = 3 lines
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn banner_silent_for_short_idle() {
+        // < 5 min away — the "away X" part is suppressed but msgs still show
+        let lines = away_summary_banner(Some(30), None, 2, 0, 0);
+        assert_eq!(lines.len(), 3); // banner still appears (has msg count)
+    }
+}

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -479,6 +479,18 @@ impl Persistence for Database {
         Ok(row.and_then(|r| r.0))
     }
 
+    async fn get_session_idle_secs(&self, session_id: &str) -> Result<Option<i64>> {
+        // julianday diff * 86400 gives whole seconds; NULL when never accessed.
+        let row: Option<(Option<i64>,)> = sqlx::query_as(
+            "SELECT CAST((julianday('now') - julianday(last_accessed_at)) * 86400 AS INTEGER)
+             FROM sessions WHERE id = ?",
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.and_then(|r| r.0))
+    }
+
     /// Compact a session: summarize old messages while preserving the most recent ones.
     ///
     /// Keeps the last `preserve_count` messages intact, deletes the rest, and

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -184,6 +184,9 @@ pub trait Persistence: Send + Sync {
     async fn set_session_mode(&self, session_id: &str, mode: &str) -> Result<()>;
     /// Get the stored approval mode for a session.
     async fn get_session_mode(&self, session_id: &str) -> Result<Option<String>>;
+    /// Seconds elapsed since the session was last accessed (`last_accessed_at`).
+    /// Returns `None` if the column is NULL (session never had a context load).
+    async fn get_session_idle_secs(&self, session_id: &str) -> Result<Option<i64>>;
 
     // ── Messages ──
 


### PR DESCRIPTION
## Summary

Adds a lightweight, instant away-summary banner shown at the bottom of history every time you resume a session — either via `--resume` on startup or `/sessions resume` in-session.

No LLM call. No latency. All data comes from the local SQLite DB and the messages already loaded at resume time.

### What it looks like

```
  📋  5 msgs · 3 tool calls · 12k tok · away 2 days
```

Appears sandwiched between the last history line and any interrupted-turn banner.

### Rules

| Condition | Behaviour |
|---|---|
| No messages in session | Banner suppressed entirely |
| Idle < 5 min | "away X" part omitted (noise) |
| Zero tool calls | Tool-call stat omitted |
| Zero tokens | Token stat omitted |

### Persistence

Added `Persistence::get_session_idle_secs(session_id)` — a single SQL query using SQLite's `julianday()` arithmetic. Read **before** `load_context()` so we capture the *previous* access time before it gets updated to now.

### Time thresholds

| Range | Display |
|---|---|
| < 5 min | silent |
| 5 min – 1 h | `X min` |
| 1 – 24 h | `X h` |
| 1 – 7 days | `X day(s)` |
| 7+ days | `X week(s)` |

### Tests (4 new)

- `idle_thresholds` — every boundary of `format_idle()`
- `banner_empty_for_zero_messages`
- `banner_shows_with_messages`
- `banner_silent_for_short_idle`

### Closes

Remaining P2 item from #590 (the last one — detached `--background` mode is filed separately as it's a substantially larger feature).