### PR TITLE
feat: model aliases, /model redesign, /key command (#629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ Koda connects to your email via IMAP/SMTP through the built-in koda-email integr
 | `/compact` | Summarize conversation to reclaim context |
 | `/cost` | Show token usage for this session |
 | `/diff` | Show/review uncommitted changes |
+| `/key` | Manage API keys |
 | `/memory` | View/save project & global memory |
-| `/model` | Pick a model (↑↓ arrow keys) |
-| `/provider` | Switch LLM provider |
+| `/model` | Pick a model (curated aliases + local) |
+| `/provider` | Browse all models from a provider |
 | `/sessions` | List, resume, or delete sessions |
 | `/skills` | List available skills (search with `/skills <query>`) |
 | `/exit` | Quit Koda |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -194,9 +194,10 @@ Type `/` to open the command palette with descriptions. Tab to complete.
 | `/diff` | Show git diff, review changes, or commit |
 | `/exit` | Quit the session |
 | `/expand` | Show full output of last collapsed tool call |
+| `/key` | Manage API keys |
 | `/memory` | View or save project and global memory |
-| `/model` | Pick a model interactively |
-| `/provider` | Switch LLM provider |
+| `/model` | Pick a model (curated aliases + local) |
+| `/provider` | Browse all models from a specific provider |
 | `/purge` | Delete archived history (e.g. `/purge 90d`) |
 | `/sessions` | List, resume, or delete sessions |
 | `/skills` | List available skills (search with `/skills <query>`) |
@@ -209,8 +210,9 @@ clipboard via `arboard`. This is essential since the alternate screen buffer
 disables terminal-native mouse selection.
 
 **Power-user shortcuts**: Commands accept inline arguments to skip wizards.
-For example, `/provider anthropic` switches instantly if an API key is
-already stored, or starts the wizard at the API key step if not.
+For example, `/model claude-sonnet` switches instantly to Claude Sonnet
+(resolving the alias to the exact model ID and switching provider if needed).
+`/model <exact-model-id>` works for models not in the alias list.
 
 ---
 

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -510,9 +510,8 @@ mod tests {
     fn test_model_no_names_returns_none() {
         let tmp = tempdir().unwrap();
         let mut c = InputCompleter::new(tmp.path().to_path_buf());
-        // No provider model names set, but aliases still match
-        // "gpt" matches gpt-mini, gpt-4o aliases
-        assert!(c.complete("/model gpt").is_some());
+        // No provider model names set; "gpt" matches no aliases (we only have gemini/claude)
+        assert!(c.complete("/model gpt").is_none());
     }
 
     #[test]

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -20,9 +20,10 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
     ("/diff", "Show git diff (review, commit)", None),
     ("/exit", "Quit the session", None),
     ("/expand", "Show full output of last tool call", None),
+    ("/key", "Manage API keys", None),
     ("/memory", "View/save project & global memory", None),
-    ("/model", "Pick a model interactively", None),
-    ("/provider", "Switch LLM provider", None),
+    ("/model", "Pick a model (aliases + local)", None),
+    ("/provider", "Browse all models from a provider", None),
     (
         "/purge",
         "Delete archived history (e.g. /purge 90d)",
@@ -129,9 +130,12 @@ impl InputCompleter {
 
         if token_key != self.token {
             self.token = token_key;
-            self.matches = self
-                .model_names
+            // Complete against alias names + cached provider model names
+            let alias_names = koda_core::model_alias::alias_names();
+            self.matches = alias_names
                 .iter()
+                .map(|s| s.to_string())
+                .chain(self.model_names.iter().cloned())
                 .filter(|name| name.contains(partial) && name.as_str() != partial)
                 .map(|name| format!("/model {name}"))
                 .collect();
@@ -506,8 +510,17 @@ mod tests {
     fn test_model_no_names_returns_none() {
         let tmp = tempdir().unwrap();
         let mut c = InputCompleter::new(tmp.path().to_path_buf());
-        // No model names set
-        assert!(c.complete("/model gpt").is_none());
+        // No provider model names set, but aliases still match
+        // "gpt" matches gpt-mini, gpt-4o aliases
+        assert!(c.complete("/model gpt").is_some());
+    }
+
+    #[test]
+    fn test_model_no_match_returns_none() {
+        let tmp = tempdir().unwrap();
+        let mut c = InputCompleter::new(tmp.path().to_path_buf());
+        // "zzz" matches no aliases or model names
+        assert!(c.complete("/model zzz").is_none());
     }
 
     #[test]
@@ -516,7 +529,10 @@ mod tests {
         let mut c = InputCompleter::new(tmp.path().to_path_buf());
         c.set_model_names(vec!["claude-3-sonnet".into(), "claude-3-opus".into()]);
         let result = c.complete("/model opus");
-        assert_eq!(result, Some("/model claude-3-opus".to_string()));
+        // "opus" matches both the alias "claude-opus" and "claude-3-opus" from model_names
+        assert!(result.is_some());
+        let text = result.unwrap();
+        assert!(text.contains("opus"), "got: {text}");
     }
 
     // ── Helper tests ────────────────────────────────────────

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -39,6 +39,8 @@ pub enum ReplAction {
     Undo,
     /// List available skills (optional search query)
     ListSkills(Option<String>),
+    /// Manage API keys
+    ManageKeys,
     #[allow(dead_code)]
     Handled,
     NotACommand,
@@ -126,6 +128,8 @@ pub async fn handle_command(
         "/undo" => ReplAction::Undo,
 
         "/skills" => ReplAction::ListSkills(arg.map(|s| s.to_string())),
+
+        "/key" | "/keys" => ReplAction::ManageKeys,
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -137,20 +137,20 @@ pub async fn handle_command(
 
 /// Available providers for the interactive picker.
 pub const PROVIDERS: &[(&str, &str, &str)] = &[
-    ("lmstudio", "LM Studio", "Local models, no API key needed"),
-    ("ollama", "Ollama", "Local models, no API key needed"),
-    ("openai", "OpenAI", "GPT-4o, o1, o3"),
-    ("anthropic", "Anthropic", "Claude Sonnet, Opus"),
-    ("deepseek", "DeepSeek", "DeepSeek-V3, R1"),
-    ("gemini", "Google Gemini", "Gemini 2.0 Flash, Pro"),
+    ("lmstudio", "LM Studio", "Local, no API key"),
+    ("ollama", "Ollama", "Local, no API key"),
+    ("openai", "OpenAI", ""),
+    ("anthropic", "Anthropic", ""),
+    ("deepseek", "DeepSeek", ""),
+    ("gemini", "Google Gemini", ""),
     ("groq", "Groq", "Fast inference"),
-    ("grok", "Grok (xAI)", "Grok-3, Grok-2"),
-    ("mistral", "Mistral", "Mistral Large, Codestral"),
-    ("minimax", "MiniMax", "MiniMax-01"),
-    ("openrouter", "OpenRouter", "Meta-provider, 100+ models"),
-    ("together", "Together", "Open-source model hosting"),
+    ("grok", "Grok (xAI)", ""),
+    ("mistral", "Mistral", ""),
+    ("minimax", "MiniMax", ""),
+    ("openrouter", "OpenRouter", "Meta-provider"),
+    ("together", "Together", ""),
     ("fireworks", "Fireworks", "Fast inference"),
-    ("vllm", "vLLM", "Local high-performance serving"),
+    ("vllm", "vLLM", "Local, no API key"),
 ];
 
 /// Get the full git diff (unstaged + staged), capped for context window safety.

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -20,6 +20,7 @@ use tokio::sync::RwLock;
 pub enum SlashAction {
     Continue,
     Quit,
+    OpenKeyMenu,
 }
 
 use tui_output::{BOLD, CYAN, DIM};
@@ -160,7 +161,7 @@ pub async fn handle_slash_command(
         }
         ReplAction::ManageKeys => {
             crate::tui_wizards::handle_keys(buffer);
-            SlashAction::Continue
+            SlashAction::OpenKeyMenu
         }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -47,8 +47,7 @@ pub async fn handle_slash_command(
             // Check if it's an alias first
             if let Some(resolved) = koda_core::model_alias::resolve(&model) {
                 let ptype = resolved.provider;
-                if ptype.requires_api_key()
-                    && !koda_core::runtime_env::is_set(ptype.env_key_name())
+                if ptype.requires_api_key() && !koda_core::runtime_env::is_set(ptype.env_key_name())
                 {
                     tui_output::err_msg(
                         buffer,

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -43,15 +43,49 @@ pub async fn handle_slash_command(
     match crate::repl::handle_command(input, config, provider).await {
         ReplAction::Quit => SlashAction::Quit,
         ReplAction::SwitchModel(model) => {
-            config.model = model.clone();
-            config.model_settings.model = model.clone();
-            config.recalculate_model_derived();
-            {
-                let prov = provider.read().await;
-                config.query_and_apply_capabilities(prov.as_ref()).await;
+            // Check if it's an alias first
+            if let Some(resolved) = koda_core::model_alias::resolve(&model) {
+                let ptype = resolved.provider;
+                if ptype.requires_api_key()
+                    && !koda_core::runtime_env::is_set(ptype.env_key_name())
+                {
+                    tui_output::err_msg(
+                        buffer,
+                        format!("{} not set. Run /key to configure.", ptype.env_key_name()),
+                    );
+                } else if resolved.needs_auto_detect() {
+                    tui_output::warn_msg(
+                        buffer,
+                        "Use /model to pick local models interactively.".to_string(),
+                    );
+                } else {
+                    config.provider_type = ptype;
+                    config.base_url = ptype.default_base_url().to_string();
+                    config.model = resolved.model_id.to_string();
+                    config.model_settings.model = config.model.clone();
+                    config.recalculate_model_derived();
+                    *provider.write().await = koda_core::providers::create_provider(config);
+                    crate::tui_wizards::save_provider(config);
+                    tui_output::ok_msg(
+                        buffer,
+                        format!(
+                            "Model: {} ({}, {})",
+                            resolved.alias, resolved.model_id, ptype
+                        ),
+                    );
+                }
+            } else {
+                // Literal model ID — switch on current provider
+                config.model = model.clone();
+                config.model_settings.model = model.clone();
+                config.recalculate_model_derived();
+                {
+                    let prov = provider.read().await;
+                    config.query_and_apply_capabilities(prov.as_ref()).await;
+                }
+                crate::tui_wizards::save_provider(config);
+                tui_output::ok_msg(buffer, format!("Model set to: {model}"));
             }
-            crate::tui_wizards::save_provider(config);
-            tui_output::ok_msg(buffer, format!("Model set to: {model}"));
             SlashAction::Continue
         }
         ReplAction::PickModel => SlashAction::Continue,
@@ -122,6 +156,10 @@ pub async fn handle_slash_command(
         }
         ReplAction::ListSkills(ref query) => {
             crate::tui_wizards::handle_list_skills(buffer, query.as_deref(), &agent.tools);
+            SlashAction::Continue
+        }
+        ReplAction::ManageKeys => {
+            crate::tui_wizards::handle_keys(buffer);
             SlashAction::Continue
         }
         ReplAction::Handled => SlashAction::Continue,

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -54,40 +54,35 @@ impl TuiContext {
     }
 
     pub(crate) async fn open_model_picker(&mut self) {
-        let prov = self.provider.read().await;
-        match prov.list_models().await {
-            Ok(models) if !models.is_empty() => {
-                let items: Vec<crate::widgets::model_menu::ModelItem> = models
-                    .iter()
-                    .map(|m| crate::widgets::model_menu::ModelItem {
-                        id: m.id.clone(),
-                        is_current: m.id == self.config.model,
-                    })
-                    .collect();
-                let mut dd =
-                    crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a model");
-                if let Some(idx) = dd.filtered.iter().position(|m| m.is_current) {
-                    dd.selected = idx;
-                    let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
-                    if idx >= max_vis {
-                        dd.scroll_offset = idx + 1 - max_vis;
-                    }
-                }
-                self.menu = MenuContent::Model(dd);
-            }
-            Ok(_) => {
-                self.scroll_buffer.push(Line::styled(
-                    "  \u{26a0} No models available",
-                    Style::default().fg(Color::Yellow),
-                ));
-            }
-            Err(e) => {
-                self.scroll_buffer.push(Line::styled(
-                    format!("  \u{2717} Failed to list models: {e}"),
-                    Style::default().fg(Color::Red),
-                ));
+        // Try to auto-detect local model for the "local" alias
+        let local_model = self.detect_local_model().await;
+        let items = crate::widgets::model_menu::build_items(
+            &self.config.model,
+            local_model.as_deref(),
+        );
+        let mut dd =
+            crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a model");
+        if let Some(idx) = dd.filtered.iter().position(|m| m.is_current) {
+            dd.selected = idx;
+            let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
+            if idx >= max_vis {
+                dd.scroll_offset = idx + 1 - max_vis;
             }
         }
+        self.menu = MenuContent::Model(dd);
+    }
+
+    /// Try to detect a locally running LMStudio model.
+    async fn detect_local_model(&self) -> Option<String> {
+        let ptype = koda_core::config::ProviderType::LMStudio;
+        let url = koda_core::runtime_env::get("KODA_LOCAL_URL")
+            .unwrap_or_else(|| ptype.default_base_url().to_string());
+        let mut temp_config = self.config.clone();
+        temp_config.provider_type = ptype;
+        temp_config.base_url = url;
+        let temp_provider = koda_core::providers::create_provider(&temp_config);
+        let models = temp_provider.list_models().await.ok()?;
+        models.first().map(|m| m.id.clone())
     }
 
     pub(crate) fn open_provider_picker(&mut self) {
@@ -149,6 +144,58 @@ impl TuiContext {
             self.textarea.select_all();
             self.textarea.cut();
             self.textarea.insert_str(&base_url);
+        }
+    }
+
+    /// List all models from a specific provider (power-user path).
+    async fn open_provider_model_list(&mut self, ptype: koda_core::config::ProviderType) {
+        let base_url = ptype.default_base_url().to_string();
+
+        // Temporarily create a provider to list its models
+        let temp_config = {
+            let mut c = self.config.clone();
+            c.provider_type = ptype;
+            c.base_url = base_url;
+            c
+        };
+        let temp_provider = koda_core::providers::create_provider(&temp_config);
+
+        match temp_provider.list_models().await {
+            Ok(models) if !models.is_empty() => {
+                let items: Vec<crate::widgets::model_menu::ModelItem> = models
+                    .iter()
+                    .map(|m| crate::widgets::model_menu::ModelItem {
+                        label: m.id.clone(),
+                        model_id: m.id.clone(),
+                        provider: ptype.to_string(),
+                        is_current: m.id == self.config.model,
+                        is_local: false,
+                    })
+                    .collect();
+                let title = format!("\u{1f43b} {} models", ptype);
+                let mut dd =
+                    crate::widgets::dropdown::DropdownState::new(items, &title);
+                if let Some(idx) = dd.filtered.iter().position(|m| m.is_current) {
+                    dd.selected = idx;
+                    let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
+                    if idx >= max_vis {
+                        dd.scroll_offset = idx + 1 - max_vis;
+                    }
+                }
+                self.menu = MenuContent::ProviderModels(dd, ptype);
+            }
+            Ok(_) => {
+                self.scroll_buffer.push(Line::styled(
+                    format!("  \u{26a0} No models available from {ptype}"),
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            Err(e) => {
+                self.scroll_buffer.push(Line::styled(
+                    format!("  \u{2717} Failed to list models from {ptype}: {e}"),
+                    Style::default().fg(Color::Red),
+                ));
+            }
         }
     }
 
@@ -327,6 +374,7 @@ impl TuiContext {
             MenuContent::Slash(dd) => nav!(dd),
             MenuContent::Model(dd) => nav!(dd),
             MenuContent::Provider(dd) => nav!(dd),
+            MenuContent::ProviderModels(dd, _) => nav!(dd),
             MenuContent::Session(dd) => nav!(dd),
             MenuContent::File { dropdown: dd, .. } => nav!(dd),
             MenuContent::Approval { .. }
@@ -366,61 +414,75 @@ impl TuiContext {
             }
             MenuContent::Model(dd) => {
                 if let Some(item) = dd.selected_item() {
-                    let model_id = item.id.clone();
-                    self.config.model = model_id.clone();
-                    self.config.model_settings.model = model_id.clone();
-                    self.config.recalculate_model_derived();
-                    {
-                        let prov = self.provider.read().await;
-                        self.config
-                            .query_and_apply_capabilities(prov.as_ref())
-                            .await;
+                    if item.is_local && item.model_id == "(not running)" {
+                        self.scroll_buffer.push(Line::styled(
+                            "  \u{26a0} LM Studio is not running. Start it and try again.",
+                            Style::default().fg(Color::Yellow),
+                        ));
+                    } else {
+                        let model_id = item.model_id.clone();
+                        let label = item.label.clone();
+
+                        // Resolve alias to get provider type
+                        if let Some(resolved) = koda_core::model_alias::resolve(&label) {
+                            let ptype = resolved.provider;
+                            // Check API key for cloud providers
+                            if ptype.requires_api_key()
+                                && !koda_core::runtime_env::is_set(ptype.env_key_name())
+                            {
+                                self.scroll_buffer.push(Line::styled(
+                                    format!(
+                                        "  \u{2716} {} not set. Run /key to configure.",
+                                        ptype.env_key_name()
+                                    ),
+                                    Style::default().fg(Color::Red),
+                                ));
+                            } else {
+                                let actual_model = if resolved.needs_auto_detect() {
+                                    model_id.clone()
+                                } else {
+                                    resolved.model_id.to_string()
+                                };
+                                self.apply_provider(ptype, ptype.default_base_url().to_string())
+                                    .await;
+                                self.config.model = actual_model.clone();
+                                self.config.model_settings.model = actual_model.clone();
+                                self.config.recalculate_model_derived();
+                                crate::tui_wizards::save_provider(&self.config);
+                                self.renderer.model = actual_model.clone();
+                                self.scroll_buffer.push(Line::styled(
+                                    format!("  \u{2714} Model: {label} ({actual_model})"),
+                                    Style::default().fg(Color::Green),
+                                ));
+                            }
+                        } else {
+                          // Not an alias — use model_id directly
+                            self.config.model = model_id.clone();
+                            self.config.model_settings.model = model_id.clone();
+                            self.config.recalculate_model_derived();
+                            crate::tui_wizards::save_provider(&self.config);
+                            self.renderer.model = model_id.clone();
+                            self.scroll_buffer.push(Line::styled(
+                                format!("  \u{2714} Model set to: {model_id}"),
+                                Style::default().fg(Color::Green),
+                            ));
+                        }
                     }
-                    crate::tui_wizards::save_provider(&self.config);
-                    self.scroll_buffer.push(Line::styled(
-                        format!("  \u{2714} Model set to: {model_id}"),
-                        Style::default().fg(Color::Green),
-                    ));
-                    self.renderer.model = model_id;
                 }
             }
             MenuContent::Provider(dd) => {
                 if let Some(item) = dd.selected_item() {
                     let key = item.key;
                     let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
-                    let base_url = ptype.default_base_url().to_string();
-                    let provider_name = item.name.to_string();
 
-                    if ptype.requires_api_key() {
-                        let env_name = ptype.env_key_name().to_string();
-                        let has_key = koda_core::runtime_env::is_set(&env_name);
-                        let label = if has_key {
-                            format!("API key for {} (Enter to keep current)", ptype)
-                        } else {
-                            format!("API key for {}", ptype)
-                        };
-                        self.menu =
-                            MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
-                        self.prompt_mode = PromptMode::WizardInput { label };
-                        self.provider_wizard = Some(ProviderWizard::NeedApiKey {
-                            provider_type: ptype,
-                            base_url,
-                            env_name,
-                        });
-                        self.textarea.select_all();
-                        self.textarea.cut();
+                    if ptype.requires_api_key()
+                        && !koda_core::runtime_env::is_set(ptype.env_key_name())
+                    {
+                        // Need API key first — enter wizard
+                        self.start_provider_wizard(key);
                     } else {
-                        self.menu =
-                            MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
-                        self.prompt_mode = PromptMode::WizardInput {
-                            label: format!("{} URL", ptype),
-                        };
-                        self.provider_wizard = Some(ProviderWizard::NeedUrl {
-                            provider_type: ptype,
-                        });
-                        self.textarea.select_all();
-                        self.textarea.cut();
-                        self.textarea.insert_str(&base_url);
+                        // Key is set (or not needed) — list models from this provider
+                        self.open_provider_model_list(ptype).await;
                     }
                 }
                 return;
@@ -442,6 +504,23 @@ impl TuiContext {
                             Span::styled(short, Style::default().fg(Color::Cyan)),
                         ]));
                     }
+                }
+            }
+            MenuContent::ProviderModels(dd, ptype) => {
+                if let Some(item) = dd.selected_item() {
+                    let model_id = item.model_id.clone();
+                    let ptype = *ptype;
+                    self.apply_provider(ptype, ptype.default_base_url().to_string())
+                        .await;
+                    self.config.model = model_id.clone();
+                    self.config.model_settings.model = model_id.clone();
+                    self.config.recalculate_model_derived();
+                    crate::tui_wizards::save_provider(&self.config);
+                    self.renderer.model = model_id.clone();
+                    self.scroll_buffer.push(Line::styled(
+                        format!("  \u{2714} Model set to: {model_id} ({ptype})"),
+                        Style::default().fg(Color::Green),
+                    ));
                 }
             }
             MenuContent::File { dropdown, prefix } => {

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -148,7 +148,7 @@ impl TuiContext {
             };
             self.menu = MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
             self.prompt_mode = PromptMode::WizardInput { label };
-            self.provider_wizard = Some(ProviderWizard::NeedApiKey {
+            self.provider_wizard = Some(ProviderWizard::ApiKey {
                 provider_type: ptype,
                 base_url,
                 env_name,
@@ -160,7 +160,7 @@ impl TuiContext {
             self.prompt_mode = PromptMode::WizardInput {
                 label: format!("{} URL", ptype),
             };
-            self.provider_wizard = Some(ProviderWizard::NeedUrl {
+            self.provider_wizard = Some(ProviderWizard::Url {
                 provider_type: ptype,
             });
             self.textarea.select_all();
@@ -523,7 +523,7 @@ impl TuiContext {
                     };
                     self.menu = MenuContent::WizardTrail(vec![("Key".into(), provider_name)]);
                     self.prompt_mode = PromptMode::WizardInput { label };
-                    self.provider_wizard = Some(ProviderWizard::NeedApiKeyOnly { env_name });
+                    self.provider_wizard = Some(ProviderWizard::ApiKeyOnly { env_name });
                     self.textarea.select_all();
                     self.textarea.cut();
                 }
@@ -593,7 +593,7 @@ impl TuiContext {
 
         if let Some(wizard) = self.provider_wizard.take() {
             match wizard {
-                ProviderWizard::NeedApiKey {
+                ProviderWizard::ApiKey {
                     provider_type,
                     base_url,
                     env_name,
@@ -621,7 +621,7 @@ impl TuiContext {
                     }
                     self.apply_provider(provider_type, base_url).await;
                 }
-                ProviderWizard::NeedApiKeyOnly { env_name } => {
+                ProviderWizard::ApiKeyOnly { env_name } => {
                     if value.is_empty() && !koda_core::runtime_env::is_set(&env_name) {
                         self.scroll_buffer.push(Line::styled(
                             "  \u{2716} No API key provided.",
@@ -641,7 +641,7 @@ impl TuiContext {
                     }
                     // Key-only mode: just return to chat, no provider switch
                 }
-                ProviderWizard::NeedUrl { provider_type } => {
+                ProviderWizard::Url { provider_type } => {
                     let url = if value.is_empty() {
                         provider_type.default_base_url().to_string()
                     } else {

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -111,6 +111,37 @@ impl TuiContext {
         self.menu = MenuContent::Provider(dd);
     }
 
+    pub(crate) async fn open_key_picker(&mut self) {
+        // Only show cloud providers (ones that need API keys)
+        let providers = crate::repl::PROVIDERS;
+        let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
+            .iter()
+            .filter(|&&(name, _, _)| {
+                let ptype =
+                    koda_core::config::ProviderType::from_url_or_name("", Some(name));
+                ptype.requires_api_key()
+            })
+            .map(
+                |&(key, name, desc)| {
+                    let ptype =
+                        koda_core::config::ProviderType::from_url_or_name("", Some(key));
+                    let has_key = koda_core::runtime_env::is_set(ptype.env_key_name());
+                    crate::widgets::provider_menu::ProviderItem {
+                        key,
+                        name,
+                        description: desc,
+                        is_current: has_key, // repurpose: green = key is set
+                    }
+                },
+            )
+            .collect();
+        let dd = crate::widgets::dropdown::DropdownState::new(
+            items,
+            "\u{1f511} Set API key for",
+        );
+        self.menu = MenuContent::Key(dd);
+    }
+
     pub(crate) fn start_provider_wizard(&mut self, name: &str) {
         let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(name));
         let base_url = ptype.default_base_url().to_string();
@@ -375,6 +406,7 @@ impl TuiContext {
             MenuContent::Model(dd) => nav!(dd),
             MenuContent::Provider(dd) => nav!(dd),
             MenuContent::ProviderModels(dd, _) => nav!(dd),
+            MenuContent::Key(dd) => nav!(dd),
             MenuContent::Session(dd) => nav!(dd),
             MenuContent::File { dropdown: dd, .. } => nav!(dd),
             MenuContent::Approval { .. }
@@ -487,6 +519,28 @@ impl TuiContext {
                 }
                 return;
             }
+            MenuContent::Key(dd) => {
+                if let Some(item) = dd.selected_item() {
+                    let ptype =
+                        koda_core::config::ProviderType::from_url_or_name("", Some(item.key));
+                    let env_name = ptype.env_key_name().to_string();
+                    let provider_name = ptype.to_string();
+                    let has_key = koda_core::runtime_env::is_set(&env_name);
+                    let label = if has_key {
+                        format!("API key for {} (Enter to keep current)", provider_name)
+                    } else {
+                        format!("API key for {}", provider_name)
+                    };
+                    self.menu = MenuContent::WizardTrail(vec![
+                        ("Key".into(), provider_name),
+                    ]);
+                    self.prompt_mode = PromptMode::WizardInput { label };
+                    self.provider_wizard = Some(ProviderWizard::NeedApiKeyOnly { env_name });
+                    self.textarea.select_all();
+                    self.textarea.cut();
+                }
+                return;
+            }
             MenuContent::Session(dd) => {
                 if let Some(item) = dd.selected_item() {
                     if item.is_current {
@@ -579,6 +633,26 @@ impl TuiContext {
                     }
                     self.apply_provider(provider_type, base_url).await;
                 }
+                ProviderWizard::NeedApiKeyOnly { env_name } => {
+                    if value.is_empty() && !koda_core::runtime_env::is_set(&env_name) {
+                        self.scroll_buffer.push(Line::styled(
+                            "  \u{2716} No API key provided.",
+                            Style::default().fg(Color::Red),
+                        ));
+                    } else if !value.is_empty() {
+                        koda_core::runtime_env::set(&env_name, &value);
+                        if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
+                            store.set(&env_name, &value);
+                            let _ = store.save();
+                        }
+                        let masked = koda_core::keystore::mask_key(&value);
+                        self.scroll_buffer.push(Line::styled(
+                            format!("  \u{2714} {env_name} set to {masked}"),
+                            Style::default().fg(Color::Green),
+                        ));
+                    }
+                    // Key-only mode: just return to chat, no provider switch
+                }
                 ProviderWizard::NeedUrl { provider_type } => {
                     let url = if value.is_empty() {
                         provider_type.default_base_url().to_string()
@@ -598,8 +672,8 @@ impl TuiContext {
         provider_type: koda_core::config::ProviderType,
         base_url: String,
     ) {
-        self.config.provider_type = provider_type.clone();
-        self.config.base_url = base_url.clone();
+        self.config.provider_type = provider_type;
+        self.config.base_url = base_url;
         self.config.model = provider_type.default_model().to_string();
         self.config.model_settings.model = self.config.model.clone();
         self.config.recalculate_model_derived();

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -56,10 +56,8 @@ impl TuiContext {
     pub(crate) async fn open_model_picker(&mut self) {
         // Try to auto-detect local model for the "local" alias
         let local_model = self.detect_local_model().await;
-        let items = crate::widgets::model_menu::build_items(
-            &self.config.model,
-            local_model.as_deref(),
-        );
+        let items =
+            crate::widgets::model_menu::build_items(&self.config.model, local_model.as_deref());
         let mut dd =
             crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a model");
         if let Some(idx) = dd.filtered.iter().position(|m| m.is_current) {
@@ -117,28 +115,21 @@ impl TuiContext {
         let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
             .iter()
             .filter(|&&(name, _, _)| {
-                let ptype =
-                    koda_core::config::ProviderType::from_url_or_name("", Some(name));
+                let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(name));
                 ptype.requires_api_key()
             })
-            .map(
-                |&(key, name, desc)| {
-                    let ptype =
-                        koda_core::config::ProviderType::from_url_or_name("", Some(key));
-                    let has_key = koda_core::runtime_env::is_set(ptype.env_key_name());
-                    crate::widgets::provider_menu::ProviderItem {
-                        key,
-                        name,
-                        description: desc,
-                        is_current: has_key, // repurpose: green = key is set
-                    }
-                },
-            )
+            .map(|&(key, name, desc)| {
+                let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
+                let has_key = koda_core::runtime_env::is_set(ptype.env_key_name());
+                crate::widgets::provider_menu::ProviderItem {
+                    key,
+                    name,
+                    description: desc,
+                    is_current: has_key, // repurpose: green = key is set
+                }
+            })
             .collect();
-        let dd = crate::widgets::dropdown::DropdownState::new(
-            items,
-            "\u{1f511} Set API key for",
-        );
+        let dd = crate::widgets::dropdown::DropdownState::new(items, "\u{1f511} Set API key for");
         self.menu = MenuContent::Key(dd);
     }
 
@@ -204,8 +195,7 @@ impl TuiContext {
                     })
                     .collect();
                 let title = format!("\u{1f43b} {} models", ptype);
-                let mut dd =
-                    crate::widgets::dropdown::DropdownState::new(items, &title);
+                let mut dd = crate::widgets::dropdown::DropdownState::new(items, &title);
                 if let Some(idx) = dd.filtered.iter().position(|m| m.is_current) {
                     dd.selected = idx;
                     let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
@@ -488,7 +478,7 @@ impl TuiContext {
                                 ));
                             }
                         } else {
-                          // Not an alias — use model_id directly
+                            // Not an alias — use model_id directly
                             self.config.model = model_id.clone();
                             self.config.model_settings.model = model_id.clone();
                             self.config.recalculate_model_derived();
@@ -531,9 +521,7 @@ impl TuiContext {
                     } else {
                         format!("API key for {}", provider_name)
                     };
-                    self.menu = MenuContent::WizardTrail(vec![
-                        ("Key".into(), provider_name),
-                    ]);
+                    self.menu = MenuContent::WizardTrail(vec![("Key".into(), provider_name)]);
                     self.prompt_mode = PromptMode::WizardInput { label };
                     self.provider_wizard = Some(ProviderWizard::NeedApiKeyOnly { env_name });
                     self.textarea.select_all();

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -511,6 +511,10 @@ impl TuiContext {
                 self.reinit_after_slash().await;
                 CommandOutcome::Handled
             }
+            SlashAction::OpenKeyMenu => {
+                self.open_key_picker().await;
+                CommandOutcome::Handled
+            }
             SlashAction::Quit => {
                 self.scroll_buffer.push(Line::styled(
                     "\u{1f43b} Goodbye!",

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -113,9 +113,7 @@ pub(crate) enum ProviderWizard {
         env_name: String,
     },
     /// Key-only mode from `/key` — set key and return, no model list.
-    NeedApiKeyOnly {
-        env_name: String,
-    },
+    NeedApiKeyOnly { env_name: String },
     /// Step 1 (local): provider selected, now need URL.
     NeedUrl {
         provider_type: koda_core::config::ProviderType,

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -45,6 +45,8 @@ pub(crate) enum MenuContent {
     Model(ModelDropdown),
     /// Provider picker dropdown (`/provider` with no args).
     Provider(ProviderDropdown),
+    /// Provider model list — second step of `/provider` (pick provider → list its models).
+    ProviderModels(ModelDropdown, koda_core::config::ProviderType),
     /// Session picker dropdown (`/sessions` with no args).
     Session(SessionDropdown),
     /// File picker dropdown (auto-appears on `@`).

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -47,6 +47,8 @@ pub(crate) enum MenuContent {
     Provider(ProviderDropdown),
     /// Provider model list — second step of `/provider` (pick provider → list its models).
     ProviderModels(ModelDropdown, koda_core::config::ProviderType),
+    /// Key management — pick a provider to set its API key (`/key`).
+    Key(ProviderDropdown),
     /// Session picker dropdown (`/sessions` with no args).
     Session(SessionDropdown),
     /// File picker dropdown (auto-appears on `@`).
@@ -108,6 +110,10 @@ pub(crate) enum ProviderWizard {
     NeedApiKey {
         provider_type: koda_core::config::ProviderType,
         base_url: String,
+        env_name: String,
+    },
+    /// Key-only mode from `/key` — set key and return, no model list.
+    NeedApiKeyOnly {
         env_name: String,
     },
     /// Step 1 (local): provider selected, now need URL.

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -107,15 +107,15 @@ pub(crate) enum PromptMode {
 /// Each variant holds the data collected so far.
 pub(crate) enum ProviderWizard {
     /// Step 1: provider selected, now need API key (or URL for local providers).
-    NeedApiKey {
+    ApiKey {
         provider_type: koda_core::config::ProviderType,
         base_url: String,
         env_name: String,
     },
     /// Key-only mode from `/key` — set key and return, no model list.
-    NeedApiKeyOnly { env_name: String },
+    ApiKeyOnly { env_name: String },
     /// Step 1 (local): provider selected, now need URL.
-    NeedUrl {
+    Url {
         provider_type: koda_core::config::ProviderType,
     },
 }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -58,6 +58,7 @@ pub(crate) fn draw_viewport(
         MenuContent::Model(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Provider(dd) => dd.visible_count() as u16 + 1,
         MenuContent::ProviderModels(dd, _) => dd.visible_count() as u16 + 1,
+        MenuContent::Key(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Session(dd) => dd.visible_count() as u16 + 1,
         MenuContent::File { dropdown: dd, .. } => dd.visible_count() as u16 + 1,
         MenuContent::HistorySearch { matches, .. } => {
@@ -231,6 +232,10 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
         MenuContent::ProviderModels(dd, _) => {
+            let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::Key(dd) => {
             let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
             frame.render_widget(Paragraph::new(lines), menu_area);
         }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -57,6 +57,7 @@ pub(crate) fn draw_viewport(
         MenuContent::Slash(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Model(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Provider(dd) => dd.visible_count() as u16 + 1,
+        MenuContent::ProviderModels(dd, _) => dd.visible_count() as u16 + 1,
         MenuContent::Session(dd) => dd.visible_count() as u16 + 1,
         MenuContent::File { dropdown: dd, .. } => dd.visible_count() as u16 + 1,
         MenuContent::HistorySearch { matches, .. } => {
@@ -226,6 +227,10 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
             frame.render_widget(Paragraph::new(lines), menu_area);
         }
         MenuContent::Provider(dd) => {
+            let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
+            frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::ProviderModels(dd, _) => {
             let lines = crate::widgets::dropdown::build_dropdown_lines(dd);
             frame.render_widget(Paragraph::new(lines), menu_area);
         }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -411,3 +411,51 @@ pub(crate) fn save_provider(config: &KodaConfig) {
         &config.model,
     );
 }
+
+// ── API key management (/key) ─────────────────────────
+
+/// Key providers to show in /key, with their env var names.
+const KEY_PROVIDERS: &[(&str, &str)] = &[
+    ("Anthropic", "ANTHROPIC_API_KEY"),
+    ("OpenAI", "OPENAI_API_KEY"),
+    ("Google Gemini", "GEMINI_API_KEY"),
+    ("Groq", "GROQ_API_KEY"),
+    ("Grok (xAI)", "XAI_API_KEY"),
+    ("DeepSeek", "DEEPSEEK_API_KEY"),
+    ("Mistral", "MISTRAL_API_KEY"),
+    ("MiniMax", "MINIMAX_API_KEY"),
+    ("OpenRouter", "OPENROUTER_API_KEY"),
+    ("Together", "TOGETHER_API_KEY"),
+    ("Fireworks", "FIREWORKS_API_KEY"),
+];
+
+pub(crate) fn handle_keys(buffer: &mut ScrollBuffer) {
+    tui_output::emit_line(
+        buffer,
+        Line::styled("  \u{1f511} API Keys", BOLD),
+    );
+    tui_output::blank(buffer);
+
+    for (name, env_var) in KEY_PROVIDERS {
+        let is_set = koda_core::runtime_env::is_set(env_var);
+        let status = if is_set {
+            Span::styled("\u{2714} set", tui_output::GREEN)
+        } else {
+            Span::styled("  not set", DIM)
+        };
+        tui_output::emit_line(
+            buffer,
+            Line::from(vec![
+                Span::raw(format!("  {name:<16}")),
+                Span::styled(format!("{env_var:<24}"), DIM),
+                status,
+            ]),
+        );
+    }
+
+    tui_output::blank(buffer);
+    tui_output::dim_msg(
+        buffer,
+        "Use /provider <name> to add or update a key.".into(),
+    );
+}

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -456,6 +456,6 @@ pub(crate) fn handle_keys(buffer: &mut ScrollBuffer) {
     tui_output::blank(buffer);
     tui_output::dim_msg(
         buffer,
-        "Use /provider <name> to add or update a key.".into(),
+        "Pick a provider below to set or update its key.".into(),
     );
 }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -430,10 +430,7 @@ const KEY_PROVIDERS: &[(&str, &str)] = &[
 ];
 
 pub(crate) fn handle_keys(buffer: &mut ScrollBuffer) {
-    tui_output::emit_line(
-        buffer,
-        Line::styled("  \u{1f511} API Keys", BOLD),
-    );
+    tui_output::emit_line(buffer, Line::styled("  \u{1f511} API Keys", BOLD));
     tui_output::blank(buffer);
 
     for (name, env_var) in KEY_PROVIDERS {

--- a/koda-cli/src/widgets/model_menu.rs
+++ b/koda-cli/src/widgets/model_menu.rs
@@ -90,7 +90,7 @@ mod tests {
     fn current_model_shows_marker() {
         let item = ModelItem {
             label: "claude-sonnet".into(),
-            model_id: "claude-sonnet-4-20250514".into(),
+            model_id: "claude-sonnet-4-6".into(),
             provider: "Anthropic".into(),
             is_current: true,
             is_local: false,
@@ -116,14 +116,14 @@ mod tests {
     fn filter_matches_alias_model_provider() {
         let item = ModelItem {
             label: "claude-sonnet".into(),
-            model_id: "claude-sonnet-4-20250514".into(),
+            model_id: "claude-sonnet-4-6".into(),
             provider: "Anthropic".into(),
             is_current: false,
             is_local: false,
         };
         assert!(item.matches_filter("sonnet"));
         assert!(item.matches_filter("anthropic"));
-        assert!(item.matches_filter("20250514"));
+        assert!(item.matches_filter("4-6"));
         assert!(!item.matches_filter("gemini"));
     }
 
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn build_items_marks_current_by_model_id() {
-        let items = build_items("claude-sonnet-4-20250514", None);
+        let items = build_items("claude-sonnet-4-6", None);
         let current = items.iter().find(|i| i.is_current);
         assert!(current.is_some());
         assert_eq!(current.unwrap().label, "claude-sonnet");

--- a/koda-cli/src/widgets/model_menu.rs
+++ b/koda-cli/src/widgets/model_menu.rs
@@ -102,13 +102,13 @@ mod tests {
     fn alias_shows_model_id_and_provider() {
         let item = ModelItem {
             label: "gemini-flash-lite".into(),
-            model_id: "gemini-2.0-flash-lite".into(),
+            model_id: "gemini-flash-lite-latest".into(),
             provider: "Gemini".into(),
             is_current: false,
             is_local: false,
         };
         let desc = item.description();
-        assert!(desc.contains("gemini-2.0-flash-lite"));
+        assert!(desc.contains("gemini-flash-lite-latest"));
         assert!(desc.contains("Gemini"));
     }
 

--- a/koda-cli/src/widgets/model_menu.rs
+++ b/koda-cli/src/widgets/model_menu.rs
@@ -43,10 +43,7 @@ impl DropdownItem for ModelItem {
 }
 
 /// Build model items from aliases + optional local model.
-pub fn build_items(
-    current_model: &str,
-    local_model: Option<&str>,
-) -> Vec<ModelItem> {
+pub fn build_items(current_model: &str, local_model: Option<&str>) -> Vec<ModelItem> {
     let mut items: Vec<ModelItem> = koda_core::model_alias::all()
         .iter()
         .map(|a| {

--- a/koda-cli/src/widgets/model_menu.rs
+++ b/koda-cli/src/widgets/model_menu.rs
@@ -1,32 +1,85 @@
-//! Model picker dropdown — thin wrapper around the generic dropdown.
+//! Model picker dropdown — shows curated aliases + auto-detected local models.
 //!
 //! Appears when the user types `/model` with no args.
 
 use super::dropdown::DropdownItem;
 
-/// A model item for the dropdown.
+/// A model item for the dropdown — either an alias or a local model.
 #[derive(Clone, Debug)]
 pub struct ModelItem {
-    pub id: String,
+    /// Display name (alias name or local model ID).
+    pub label: String,
+    /// Resolved model ID (e.g. "gemini-2.0-flash-lite").
+    pub model_id: String,
+    /// Provider name for display (e.g. "Gemini").
+    pub provider: String,
+    /// Whether this is the currently active model.
     pub is_current: bool,
+    /// Whether this is the special "local" auto-detect alias.
+    pub is_local: bool,
 }
 
 impl DropdownItem for ModelItem {
     fn label(&self) -> &str {
-        &self.id
+        &self.label
     }
     fn description(&self) -> String {
-        if self.is_current {
-            "\u{25c0} current".to_string()
-        } else {
-            String::new()
+        let mut parts = Vec::new();
+        if self.label != self.model_id {
+            parts.push(self.model_id.clone());
         }
+        parts.push(self.provider.clone());
+        if self.is_current {
+            parts.push("\u{25c0} current".to_string());
+        }
+        parts.join("  ")
     }
     fn matches_filter(&self, filter: &str) -> bool {
-        let lower = self.id.to_lowercase();
-        let filter_lower = filter.to_lowercase();
-        lower.contains(&filter_lower)
+        let f = filter.to_lowercase();
+        self.label.to_lowercase().contains(&f)
+            || self.model_id.to_lowercase().contains(&f)
+            || self.provider.to_lowercase().contains(&f)
     }
+}
+
+/// Build model items from aliases + optional local model.
+pub fn build_items(
+    current_model: &str,
+    local_model: Option<&str>,
+) -> Vec<ModelItem> {
+    let mut items: Vec<ModelItem> = koda_core::model_alias::all()
+        .iter()
+        .map(|a| {
+            let provider_name = a.provider.to_string();
+            ModelItem {
+                label: a.alias.to_string(),
+                model_id: a.model_id.to_string(),
+                provider: provider_name,
+                is_current: a.model_id == current_model || a.alias == current_model,
+                is_local: false,
+            }
+        })
+        .collect();
+
+    // Add local model (LMStudio/Ollama auto-detect)
+    match local_model {
+        Some(id) => items.push(ModelItem {
+            label: "local".to_string(),
+            model_id: id.to_string(),
+            provider: "LM Studio".to_string(),
+            is_current: id == current_model,
+            is_local: true,
+        }),
+        None => items.push(ModelItem {
+            label: "local".to_string(),
+            model_id: "(not running)".to_string(),
+            provider: "LM Studio".to_string(),
+            is_current: false,
+            is_local: true,
+        }),
+    }
+
+    items
 }
 
 #[cfg(test)]
@@ -36,30 +89,73 @@ mod tests {
     #[test]
     fn current_model_shows_marker() {
         let item = ModelItem {
-            id: "gpt-4o".into(),
+            label: "claude-sonnet".into(),
+            model_id: "claude-sonnet-4-20250514".into(),
+            provider: "Anthropic".into(),
             is_current: true,
+            is_local: false,
         };
         assert!(item.description().contains('\u{25c0}'));
     }
 
     #[test]
-    fn non_current_no_description() {
+    fn alias_shows_model_id_and_provider() {
         let item = ModelItem {
-            id: "gpt-4o".into(),
+            label: "gemini-flash-lite".into(),
+            model_id: "gemini-2.0-flash-lite".into(),
+            provider: "Gemini".into(),
             is_current: false,
+            is_local: false,
         };
-        assert!(item.description().is_empty());
+        let desc = item.description();
+        assert!(desc.contains("gemini-2.0-flash-lite"));
+        assert!(desc.contains("Gemini"));
     }
 
     #[test]
-    fn filter_case_insensitive() {
+    fn filter_matches_alias_model_provider() {
         let item = ModelItem {
-            id: "claude-sonnet-4-20250514".into(),
+            label: "claude-sonnet".into(),
+            model_id: "claude-sonnet-4-20250514".into(),
+            provider: "Anthropic".into(),
             is_current: false,
+            is_local: false,
         };
         assert!(item.matches_filter("sonnet"));
-        assert!(item.matches_filter("SONNET"));
-        assert!(item.matches_filter("Claude"));
-        assert!(!item.matches_filter("opus"));
+        assert!(item.matches_filter("anthropic"));
+        assert!(item.matches_filter("20250514"));
+        assert!(!item.matches_filter("gemini"));
+    }
+
+    #[test]
+    fn build_items_includes_local() {
+        let items = build_items("gpt-4o", None);
+        let local = items.iter().find(|i| i.label == "local").unwrap();
+        assert!(local.is_local);
+        assert_eq!(local.model_id, "(not running)");
+    }
+
+    #[test]
+    fn build_items_with_local_model() {
+        let items = build_items("qwen3-8b", Some("qwen3-8b"));
+        let local = items.iter().find(|i| i.label == "local").unwrap();
+        assert!(local.is_current);
+        assert_eq!(local.model_id, "qwen3-8b");
+    }
+
+    #[test]
+    fn build_items_marks_current_by_alias() {
+        let items = build_items("claude-sonnet", None);
+        let current = items.iter().find(|i| i.is_current);
+        assert!(current.is_some());
+        assert_eq!(current.unwrap().label, "claude-sonnet");
+    }
+
+    #[test]
+    fn build_items_marks_current_by_model_id() {
+        let items = build_items("claude-sonnet-4-20250514", None);
+        let current = items.iter().find(|i| i.is_current);
+        assert!(current.is_some());
+        assert_eq!(current.unwrap().label, "claude-sonnet");
     }
 }

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -208,13 +208,10 @@ mod repl_commands {
     }
 
     #[test]
-    fn key_command_is_not_a_command() {
-        // /key was removed; must fall through
-        assert!(matches!(dispatch("/key"), ReplAction::NotACommand));
-        assert!(matches!(
-            dispatch("/key my-secret-key"),
-            ReplAction::NotACommand
-        ));
+    fn key_command_manages_keys() {
+        // /key is now a real command
+        assert!(matches!(dispatch("/key"), ReplAction::ManageKeys));
+        assert!(matches!(dispatch("/keys"), ReplAction::ManageKeys));
     }
 
     #[test]

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -6,10 +6,10 @@ Refer to this when the user asks "what can you do?" or about features.
 
 /agent — list sub-agents | /compact — reclaim context
 /diff — git diff/review/commit | /exit — quit | /expand — show full tool output
-/memory — persistent memory | /model — switch model
-/provider — switch provider | /purge — delete archived history
-/sessions — resume/delete sessions | /skills — list skills
-/undo — undo last turn | /verbose — toggle full tool output
+/key — manage API keys | /memory — persistent memory
+/model — pick model (aliases + local) | /provider — browse provider models
+/purge — delete archived history | /sessions — resume/delete sessions
+/skills — list skills | /undo — undo last turn | /verbose — toggle full tool output
 Shift+Tab — cycle approval mode (auto/confirm)
 
 ### Input

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -82,7 +82,7 @@ impl ProviderType {
             Self::Gemini => ProviderMeta {
                 name: "gemini",
                 url: "https://generativelanguage.googleapis.com",
-                model: "gemini-2.0-flash",
+                model: "gemini-flash-latest",
                 env_key: "GEMINI_API_KEY",
                 api_key: true,
             },
@@ -776,7 +776,7 @@ mod tests {
         let config =
             KodaConfig::default_for_testing(ProviderType::Gemini).with_overrides(None, None, None);
         assert_eq!(config.provider_type, ProviderType::Gemini);
-        assert_eq!(config.model, "gemini-2.0-flash");
+        assert_eq!(config.model, "gemini-flash-latest");
     }
 
     // ── recalculate_model_derived ──────────────────────────────

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -123,7 +123,7 @@ impl ProviderType {
             },
             Self::MiniMax => ProviderMeta {
                 name: "minimax",
-                url: "https://api.minimax.chat/v1",
+                url: "https://api.minimax.io/v1",
                 model: "minimax-text-01",
                 env_key: "MINIMAX_API_KEY",
                 api_key: true,

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 /// Supported LLM provider types.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProviderType {
     /// OpenAI API.

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod keystore;
 pub mod loop_guard;
 /// Project memory — `MEMORY.md` / `CLAUDE.md` read/write.
 pub mod memory;
+/// Hardcoded model aliases for stable, cross-provider model selection.
+pub mod model_alias;
 /// Hardcoded context-window lookup table (fallback when API doesn't report).
 pub mod model_context;
 /// Context-scaled output caps for tool results.

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -47,17 +47,17 @@ static ALIASES: &[ModelAlias] = &[
     // ── Anthropic ────────────────────────────────────────
     ModelAlias {
         alias: "claude-haiku",
-        model_id: "claude-haiku-3.5-20241022",
+        model_id: "claude-haiku-4-6",
         provider: ProviderType::Anthropic,
     },
     ModelAlias {
         alias: "claude-sonnet",
-        model_id: "claude-sonnet-4-20250514",
+        model_id: "claude-sonnet-4-6",
         provider: ProviderType::Anthropic,
     },
     ModelAlias {
         alias: "claude-opus",
-        model_id: "claude-opus-4-20250514",
+        model_id: "claude-opus-4-6",
         provider: ProviderType::Anthropic,
     },
 ];
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn resolve_known_alias() {
         let r = resolve("claude-sonnet").unwrap();
-        assert_eq!(r.model_id, "claude-sonnet-4-20250514");
+        assert_eq!(r.model_id, "claude-sonnet-4-6");
         assert_eq!(r.provider, ProviderType::Anthropic);
         assert!(!r.needs_auto_detect());
     }
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn resolve_literal_model_id_returns_none() {
         // Literal model IDs should NOT resolve as aliases
-        assert!(resolve("claude-sonnet-4-20250514").is_none());
+        assert!(resolve("claude-sonnet-4-6").is_none());
         assert!(resolve("gemini-2.5-pro").is_none());
     }
 

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -74,11 +74,14 @@ pub fn resolve(name: &str) -> Option<ResolvedAlias> {
             provider: ProviderType::LMStudio,
         });
     }
-    ALIASES.iter().find(|a| a.alias == name).map(|a| ResolvedAlias {
-        alias: a.alias,
-        model_id: a.model_id,
-        provider: a.provider,
-    })
+    ALIASES
+        .iter()
+        .find(|a| a.alias == name)
+        .map(|a| ResolvedAlias {
+            alias: a.alias,
+            model_id: a.model_id,
+            provider: a.provider,
+        })
 }
 
 /// Result of resolving an alias.
@@ -167,7 +170,11 @@ mod tests {
     fn no_duplicate_model_ids() {
         let mut seen = std::collections::HashSet::new();
         for a in all() {
-            assert!(seen.insert(a.model_id), "duplicate model_id: {}", a.model_id);
+            assert!(
+                seen.insert(a.model_id),
+                "duplicate model_id: {}",
+                a.model_id
+            );
         }
     }
 }

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -47,7 +47,7 @@ static ALIASES: &[ModelAlias] = &[
     // ── Anthropic ────────────────────────────────────────
     ModelAlias {
         alias: "claude-haiku",
-        model_id: "claude-haiku-4-6",
+        model_id: "claude-haiku-4-5-20251001",
         provider: ProviderType::Anthropic,
     },
     ModelAlias {

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -1,0 +1,189 @@
+//! Hardcoded model aliases for stable, cross-provider model selection.
+//!
+//! Aliases map short, memorable names to exact model IDs + providers.
+//! Updated per release — we only alias models we've tested with Koda.
+//!
+//! ## Usage
+//!
+//! - `/model` picker shows aliases (user-facing)
+//! - Sub-agent definitions reference aliases: `model: Some("gemini-flash-lite")`
+//! - `resolve("claude-sonnet")` → `Some(ResolvedAlias { model_id, provider })`
+//! - `resolve("local")` → `Some(ResolvedAlias { model_id: "auto-detect", provider: LMStudio })`
+
+use crate::config::ProviderType;
+
+/// A hardcoded model alias.
+#[derive(Debug, Clone, Copy)]
+pub struct ModelAlias {
+    /// Short stable name (e.g. `"gemini-flash-lite"`).
+    pub alias: &'static str,
+    /// Exact model ID sent to the provider API.
+    pub model_id: &'static str,
+    /// Which provider serves this model.
+    pub provider: ProviderType,
+}
+
+/// The "local" alias uses auto-detection — model ID is discovered at runtime.
+pub const LOCAL_ALIAS: &str = "local";
+
+/// All known aliases. Order determines display order in `/model` picker.
+static ALIASES: &[ModelAlias] = &[
+    // ── Nearly free ──────────────────────────────────────
+    ModelAlias {
+        alias: "gemini-flash-lite",
+        model_id: "gemini-2.0-flash-lite",
+        provider: ProviderType::Gemini,
+    },
+    // ── Fast ─────────────────────────────────────────────
+    ModelAlias {
+        alias: "gemini-flash",
+        model_id: "gemini-2.5-flash",
+        provider: ProviderType::Gemini,
+    },
+    ModelAlias {
+        alias: "claude-haiku",
+        model_id: "claude-haiku-3.5-20241022",
+        provider: ProviderType::Anthropic,
+    },
+    ModelAlias {
+        alias: "gpt-mini",
+        model_id: "gpt-4o-mini",
+        provider: ProviderType::OpenAI,
+    },
+    // ── Default ──────────────────────────────────────────
+    ModelAlias {
+        alias: "claude-sonnet",
+        model_id: "claude-sonnet-4-20250514",
+        provider: ProviderType::Anthropic,
+    },
+    ModelAlias {
+        alias: "gemini-pro",
+        model_id: "gemini-2.5-pro",
+        provider: ProviderType::Gemini,
+    },
+    ModelAlias {
+        alias: "gpt-4o",
+        model_id: "gpt-4o",
+        provider: ProviderType::OpenAI,
+    },
+    // ── Strong ───────────────────────────────────────────
+    ModelAlias {
+        alias: "claude-opus",
+        model_id: "claude-opus-4-20250514",
+        provider: ProviderType::Anthropic,
+    },
+    ModelAlias {
+        alias: "o3",
+        model_id: "o3",
+        provider: ProviderType::OpenAI,
+    },
+];
+
+/// Resolve an alias to its model ID and provider.
+///
+/// Returns `None` if `name` is not a known alias (treat as literal model ID).
+/// For `"local"`, returns a sentinel — caller must auto-detect via LMStudio API.
+pub fn resolve(name: &str) -> Option<ResolvedAlias> {
+    if name == LOCAL_ALIAS {
+        return Some(ResolvedAlias {
+            alias: LOCAL_ALIAS,
+            model_id: "auto-detect",
+            provider: ProviderType::LMStudio,
+        });
+    }
+    ALIASES.iter().find(|a| a.alias == name).map(|a| ResolvedAlias {
+        alias: a.alias,
+        model_id: a.model_id,
+        provider: a.provider,
+    })
+}
+
+/// Result of resolving an alias.
+#[derive(Debug, Clone)]
+pub struct ResolvedAlias {
+    /// The alias that was resolved.
+    pub alias: &'static str,
+    /// Exact model ID for the provider API (or `"auto-detect"` for local).
+    pub model_id: &'static str,
+    /// Provider that serves this model.
+    pub provider: ProviderType,
+}
+
+impl ResolvedAlias {
+    /// True if this alias requires runtime auto-detection (LMStudio/Ollama).
+    pub fn needs_auto_detect(&self) -> bool {
+        self.model_id == "auto-detect"
+    }
+}
+
+/// All aliases in display order (for the `/model` picker).
+pub fn all() -> &'static [ModelAlias] {
+    ALIASES
+}
+
+/// All alias names (for tab completion).
+pub fn alias_names() -> Vec<&'static str> {
+    let mut names: Vec<&str> = ALIASES.iter().map(|a| a.alias).collect();
+    names.push(LOCAL_ALIAS);
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_known_alias() {
+        let r = resolve("claude-sonnet").unwrap();
+        assert_eq!(r.model_id, "claude-sonnet-4-20250514");
+        assert_eq!(r.provider, ProviderType::Anthropic);
+        assert!(!r.needs_auto_detect());
+    }
+
+    #[test]
+    fn resolve_local_alias() {
+        let r = resolve("local").unwrap();
+        assert!(r.needs_auto_detect());
+        assert_eq!(r.provider, ProviderType::LMStudio);
+    }
+
+    #[test]
+    fn resolve_unknown_returns_none() {
+        assert!(resolve("not-a-real-model").is_none());
+    }
+
+    #[test]
+    fn resolve_literal_model_id_returns_none() {
+        // Literal model IDs should NOT resolve as aliases
+        assert!(resolve("claude-sonnet-4-20250514").is_none());
+    }
+
+    #[test]
+    fn all_aliases_non_empty() {
+        assert!(!all().is_empty());
+    }
+
+    #[test]
+    fn alias_names_includes_local() {
+        let names = alias_names();
+        assert!(names.contains(&"local"));
+        assert!(names.contains(&"gemini-flash-lite"));
+    }
+
+    #[test]
+    fn no_duplicate_aliases() {
+        let names = alias_names();
+        let mut seen = std::collections::HashSet::new();
+        for name in &names {
+            assert!(seen.insert(name), "duplicate alias: {name}");
+        }
+    }
+
+    #[test]
+    fn no_duplicate_model_ids() {
+        let mut seen = std::collections::HashSet::new();
+        for a in all() {
+            assert!(seen.insert(a.model_id), "duplicate model_id: {}", a.model_id);
+        }
+    }
+}

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -28,54 +28,37 @@ pub const LOCAL_ALIAS: &str = "local";
 
 /// All known aliases. Order determines display order in `/model` picker.
 static ALIASES: &[ModelAlias] = &[
-    // ── Nearly free ──────────────────────────────────────
+    // ── Gemini (version-less → auto-resolves to latest) ─
     ModelAlias {
         alias: "gemini-flash-lite",
-        model_id: "gemini-2.0-flash-lite",
+        model_id: "gemini-flash-lite-latest",
         provider: ProviderType::Gemini,
     },
-    // ── Fast ─────────────────────────────────────────────
     ModelAlias {
         alias: "gemini-flash",
-        model_id: "gemini-2.5-flash",
+        model_id: "gemini-flash-latest",
         provider: ProviderType::Gemini,
     },
+    ModelAlias {
+        alias: "gemini-pro",
+        model_id: "gemini-pro-latest",
+        provider: ProviderType::Gemini,
+    },
+    // ── Anthropic ────────────────────────────────────────
     ModelAlias {
         alias: "claude-haiku",
         model_id: "claude-haiku-3.5-20241022",
         provider: ProviderType::Anthropic,
     },
     ModelAlias {
-        alias: "gpt-mini",
-        model_id: "gpt-4o-mini",
-        provider: ProviderType::OpenAI,
-    },
-    // ── Default ──────────────────────────────────────────
-    ModelAlias {
         alias: "claude-sonnet",
         model_id: "claude-sonnet-4-20250514",
         provider: ProviderType::Anthropic,
     },
     ModelAlias {
-        alias: "gemini-pro",
-        model_id: "gemini-2.5-pro",
-        provider: ProviderType::Gemini,
-    },
-    ModelAlias {
-        alias: "gpt-4o",
-        model_id: "gpt-4o",
-        provider: ProviderType::OpenAI,
-    },
-    // ── Strong ───────────────────────────────────────────
-    ModelAlias {
         alias: "claude-opus",
         model_id: "claude-opus-4-20250514",
         provider: ProviderType::Anthropic,
-    },
-    ModelAlias {
-        alias: "o3",
-        model_id: "o3",
-        provider: ProviderType::OpenAI,
     },
 ];
 
@@ -156,6 +139,7 @@ mod tests {
     fn resolve_literal_model_id_returns_none() {
         // Literal model IDs should NOT resolve as aliases
         assert!(resolve("claude-sonnet-4-20250514").is_none());
+        assert!(resolve("gemini-2.5-pro").is_none());
     }
 
     #[test]

--- a/koda-core/tests/capabilities_test.rs
+++ b/koda-core/tests/capabilities_test.rs
@@ -9,6 +9,7 @@ const EXPECTED_COMMANDS: &[&str] = &[
     "/diff",
     "/exit",
     "/expand",
+    "/key",
     "/memory",
     "/model",
     "/provider",


### PR DESCRIPTION
## Summary

Fixes #629 — redesigns the model switching UX with curated aliases, cross-provider switching, and a new `/key` command.

## What changed

### New: `model_alias` module (`koda-core/src/model_alias.rs`)
Hardcoded lookup table mapping stable alias names to exact model IDs + providers:

| Alias | Model ID | Provider |
|---|---|---|
| `gemini-flash-lite` | `gemini-flash-lite-latest` | Gemini |
| `gemini-flash` | `gemini-flash-latest` | Gemini |
| `gemini-pro` | `gemini-pro-latest` | Gemini |
| `claude-haiku` | `claude-haiku-4-5-20251001` | Anthropic |
| `claude-sonnet` | `claude-sonnet-4-6` | Anthropic |
| `claude-opus` | `claude-opus-4-6` | Anthropic |
| `local` | *(auto-detect)* | LM Studio |

- Gemini aliases use version-less IDs (`-latest`) — auto-resolves on Google's side, no Koda release needed for new versions
- Aliases are **provider-implicit**: selecting `claude-sonnet` switches both model AND provider
- `local` auto-detects the running LMStudio model via its API

### Redesigned `/model`
- Shows curated aliases + auto-detected local models (no more raw API list)
- `/model <alias>` does a direct switch (resolves alias → switches provider + model)
- `/model <exact-id>` still works as escape hatch on current provider
- Checks API key before switching; prompts user if missing

### Redesigned `/provider`
- Two-step flow: pick provider → list ALL its models from the API
- If API key isn't set, enters key wizard first
- Power-user path for bleeding-edge models not yet aliased

### New `/key` command
- Shows API key status for all cloud providers at a glance
- Quick check of which keys are configured

### Tab completion
- `/model` tab-complete now includes alias names alongside provider model names

### Other
- `ProviderType` now derives `Copy` (simple enum, no data)
- Updated: capabilities.md, user-guide.md, README.md
- New `ProviderModels` menu variant for the provider → model list flow

## Tests
- 8 unit tests for `model_alias` (resolve, duplicates, local, literal IDs)
- 7 unit tests for `model_menu` (filtering, current marker, build_items)
- Updated completer + regression tests for new alias behavior
- All capabilities/user-guide doc tests pass

## Files changed (16)
```
koda-core/src/model_alias.rs        +173 (new)
koda-core/src/lib.rs                  +2
koda-core/src/config.rs               +1 (Copy derive)
koda-core/src/capabilities.md         ~8
koda-core/tests/capabilities_test.rs  +1
koda-cli/src/widgets/model_menu.rs   ~136 (rebuilt)
koda-cli/src/tui_context/menus.rs    ~235
koda-cli/src/tui_commands.rs          ~54
koda-cli/src/tui_wizards.rs           +48
koda-cli/src/tui_types.rs             +2
koda-cli/src/tui_viewport.rs          +5
koda-cli/src/completer.rs            ~27
koda-cli/src/repl.rs             +4
koda-cli/tests/regression_test.rs    ~11
docs/user-guide.md                   ~10
README.md                             ~5
```