### PR TITLE
feat: background sub-agent execution (#628 Phase 2b)

### DIFF
--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -1,0 +1,202 @@
+//! Background sub-agent registry.
+//!
+//! Tracks sub-agents spawned with `background: true` in `InvokeAgent`.
+//! The inference loop drains completed results and injects them as
+//! user-role messages so the model sees them on the next iteration.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+
+/// A completed background agent result.
+#[derive(Debug)]
+pub struct BgAgentResult {
+    /// The agent name that produced this result.
+    pub agent_name: String,
+    /// The original prompt that was delegated.
+    pub prompt: String,
+    /// The agent's output (or error message).
+    pub output: String,
+    /// Whether the agent succeeded.
+    pub success: bool,
+}
+
+/// Handle returned when a background agent is spawned.
+struct BgAgentEntry {
+    agent_name: String,
+    prompt: String,
+    rx: oneshot::Receiver<Result<String, String>>,
+}
+
+/// Registry of running background sub-agents.
+///
+/// Shared via `Arc` between the inference loop (which drains results)
+/// and the tool dispatch (which spawns agents).
+pub struct BgAgentRegistry {
+    pending: Mutex<HashMap<u32, BgAgentEntry>>,
+    next_id: Mutex<u32>,
+}
+
+impl BgAgentRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(HashMap::new()),
+            next_id: Mutex::new(1),
+        }
+    }
+
+    /// Register a background agent task. Returns the task ID and a sender
+    /// that the spawned task uses to deliver the result.
+    pub fn register(
+        &self,
+        agent_name: &str,
+        prompt: &str,
+    ) -> (u32, oneshot::Sender<Result<String, String>>) {
+        let (tx, rx) = oneshot::channel();
+        let mut id = self.next_id.lock().unwrap();
+        let task_id = *id;
+        *id += 1;
+        drop(id);
+
+        self.pending.lock().unwrap().insert(
+            task_id,
+            BgAgentEntry {
+                agent_name: agent_name.to_string(),
+                prompt: prompt.to_string(),
+                rx,
+            },
+        );
+
+        (task_id, tx)
+    }
+
+    /// Drain all completed background agents. Non-blocking — only takes
+    /// entries whose oneshot has already resolved.
+    pub fn drain_completed(&self) -> Vec<BgAgentResult> {
+        let mut guard = self.pending.lock().unwrap();
+        let mut completed = Vec::new();
+        let mut done_ids = Vec::new();
+
+        for (id, entry) in guard.iter_mut() {
+            match entry.rx.try_recv() {
+                Ok(Ok(output)) => {
+                    done_ids.push(*id);
+                    completed.push(BgAgentResult {
+                        agent_name: entry.agent_name.clone(),
+                        prompt: entry.prompt.clone(),
+                        output,
+                        success: true,
+                    });
+                }
+                Ok(Err(err)) => {
+                    done_ids.push(*id);
+                    completed.push(BgAgentResult {
+                        agent_name: entry.agent_name.clone(),
+                        prompt: entry.prompt.clone(),
+                        output: err,
+                        success: false,
+                    });
+                }
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    // Still running
+                }
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    // Sender dropped without sending — task panicked or was cancelled
+                    done_ids.push(*id);
+                    completed.push(BgAgentResult {
+                        agent_name: entry.agent_name.clone(),
+                        prompt: entry.prompt.clone(),
+                        output: "[background agent task was cancelled]".to_string(),
+                        success: false,
+                    });
+                }
+            }
+        }
+
+        for id in done_ids {
+            guard.remove(&id);
+        }
+
+        completed
+    }
+
+    /// How many background agents are still running.
+    pub fn pending_count(&self) -> usize {
+        self.pending.lock().unwrap().len()
+    }
+}
+
+impl Default for BgAgentRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wrap in Arc for sharing between inference loop and tool dispatch.
+pub fn new_shared() -> Arc<BgAgentRegistry> {
+    Arc::new(BgAgentRegistry::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_and_complete() {
+        let reg = BgAgentRegistry::new();
+        let (task_id, tx) = reg.register("explore", "find all tests");
+        assert_eq!(task_id, 1);
+        assert_eq!(reg.pending_count(), 1);
+
+        // Not yet complete
+        assert!(reg.drain_completed().is_empty());
+
+        // Complete it
+        tx.send(Ok("found 42 tests".to_string())).unwrap();
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].agent_name, "explore");
+        assert_eq!(results[0].output, "found 42 tests");
+        assert!(results[0].success);
+        assert_eq!(reg.pending_count(), 0);
+    }
+
+    #[test]
+    fn drain_only_completed() {
+        let reg = BgAgentRegistry::new();
+        let (_id1, tx1) = reg.register("task", "build");
+        let (_id2, _tx2) = reg.register("explore", "search");
+
+        tx1.send(Ok("done".to_string())).unwrap();
+
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].agent_name, "task");
+        assert_eq!(reg.pending_count(), 1); // explore still pending
+    }
+
+    #[test]
+    fn dropped_sender_reports_cancelled() {
+        let reg = BgAgentRegistry::new();
+        let (_id, tx) = reg.register("task", "build");
+        drop(tx); // simulate task panic/cancel
+
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(results[0].output.contains("cancelled"));
+    }
+
+    #[test]
+    fn error_result() {
+        let reg = BgAgentRegistry::new();
+        let (_id, tx) = reg.register("verify", "check");
+        tx.send(Err("test failures".to_string())).unwrap();
+
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert_eq!(results[0].output, "test failures");
+    }
+}

--- a/koda-core/src/capabilities.md
+++ b/koda-core/src/capabilities.md
@@ -43,6 +43,7 @@ Built-in sub-agents (use `InvokeAgent` / `ListAgents`):
 - **plan** — architecture planner (read-only). Returns structured implementation plans.
 - **verify** — adversarial tester (read-only + Bash). Runs tests/linters, finds bugs, returns PASS/FAIL/PARTIAL verdict.
 - **fork** — not a named agent. Set `agent_name: "fork"` to spawn a clone that inherits your full conversation context. Fork children cannot spawn sub-agents (anti-recursion).
+- **background** — any agent can run in background with `background: true`. Returns immediately; results are injected when complete.
 - Custom agents: JSON files in `agents/` or `~/.config/koda/agents/`
 - Omit `agent_name` to default to `task`.
 

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -19,6 +19,13 @@ pub trait EngineSink: Send + Sync {
     fn emit(&self, event: EngineEvent);
 }
 
+/// A no-op sink that discards all events. Used by background sub-agents.
+pub struct NullSink;
+
+impl EngineSink for NullSink {
+    fn emit(&self, _event: EngineEvent) {}
+}
+
 /// A sink that collects events into a Vec for testing.
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Default)]

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -517,6 +517,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let mut retried_empty = false;
     let mut loop_detector = LoopDetector::new();
     let sub_agent_cache = crate::sub_agent_cache::SubAgentCache::new();
+    let bg_agents = crate::bg_agent::new_shared();
     let mut total_prompt_tokens: i64 = 0;
     let mut total_completion_tokens: i64 = 0;
     let mut total_cache_read_tokens: i64 = 0;
@@ -528,6 +529,29 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let base_system_prompt = system_prompt.to_string();
 
     loop {
+        // Inject completed background agent results as user messages
+        for bg_result in bg_agents.drain_completed() {
+            let status = if bg_result.success {
+                "completed"
+            } else {
+                "failed"
+            };
+            let injection = format!(
+                "[Background agent '{}' {status}]\n\
+                 Original task: {}\n\
+                 Result:\n{}",
+                bg_result.agent_name, bg_result.prompt, bg_result.output
+            );
+            sink.emit(EngineEvent::Info {
+                message: format!(
+                    "  \u{2705} Background agent '{}' {status}",
+                    bg_result.agent_name
+                ),
+            });
+            db.insert_message(session_id, &Role::User, Some(&injection), None, None, None)
+                .await?;
+        }
+
         if iteration >= hard_cap {
             let recent = loop_detector.recent_names();
             sink.emit(EngineEvent::LoopCapReached {
@@ -814,6 +838,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 cancel.clone(),
                 &sub_agent_cache,
                 file_tracker,
+                &bg_agents,
             )
             .await?;
         } else if tool_calls.len() > 1 {
@@ -831,6 +856,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 cmd_rx,
                 &sub_agent_cache,
                 file_tracker,
+                &bg_agents,
             )
             .await?;
         } else {
@@ -848,6 +874,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 cmd_rx,
                 &sub_agent_cache,
                 file_tracker,
+                &bg_agents,
             )
             .await?;
         }

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod approval;
 pub mod bash_path_lint;
 /// Bash command safety classification (destructive, mutating, read-only).
 pub mod bash_safety;
+/// Background sub-agent registry — tracks agents spawned with `background: true`.
+pub mod bg_agent;
 /// Context compaction — summarise old messages to reclaim token budget.
 pub mod compact;
 /// Global configuration: provider, model, model settings, CLI flags.

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -131,6 +131,53 @@ async fn track_file_lifecycle(
     }
 }
 
+/// Run a sub-agent in the background. Owns all data (no borrows).
+///
+/// This is a standalone async fn so the future is `Send + 'static`,
+/// which `tokio::spawn` requires.
+async fn run_bg_agent(
+    project_root: std::path::PathBuf,
+    parent_config: KodaConfig,
+    db: Database,
+    arguments: String,
+    sub_agent_cache: SubAgentCache,
+    parent_session: String,
+    tx: tokio::sync::oneshot::Sender<Result<String, String>>,
+) {
+    let mut settings = Settings::default();
+    let cancel = CancellationToken::new();
+    let (_, mut cmd_rx) = mpsc::channel(1);
+    let null_sink = crate::engine::sink::NullSink;
+    let nested_bg = crate::bg_agent::new_shared();
+
+    // Override background=false to prevent infinite spawn
+    let mut sync_args: serde_json::Value = serde_json::from_str(&arguments).unwrap_or_default();
+    sync_args["background"] = serde_json::Value::Bool(false);
+    let sync_arguments = serde_json::to_string(&sync_args).unwrap();
+
+    let result = execute_sub_agent(
+        &project_root,
+        &parent_config,
+        &db,
+        &sync_arguments,
+        ApprovalMode::Auto,
+        &mut settings,
+        &null_sink,
+        cancel,
+        &mut cmd_rx,
+        None,
+        &sub_agent_cache,
+        &parent_session,
+        &nested_bg,
+    )
+    .await;
+
+    let _ = match result {
+        Ok(output) => tx.send(Ok(output)),
+        Err(e) => tx.send(Err(format!("Error: {e}"))),
+    };
+}
+
 pub(crate) fn can_parallelize(
     tool_calls: &[ToolCall],
     mode: ApprovalMode,
@@ -178,6 +225,7 @@ pub(crate) async fn execute_one_tool(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> (String, String, bool) {
     let (result, success) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
@@ -196,6 +244,7 @@ pub(crate) async fn execute_one_tool(
             Some(tools.file_read_cache()),
             sub_agent_cache,
             _session_id,
+            bg_agents,
         )
         .await
         {
@@ -228,6 +277,7 @@ pub(crate) async fn execute_tools_parallel(
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> Result<()> {
     let count = tool_calls.len();
     sink.emit(EngineEvent::Info {
@@ -249,6 +299,7 @@ pub(crate) async fn execute_tools_parallel(
                 sink,
                 cancel.clone(),
                 sub_agent_cache,
+                bg_agents,
             )
         })
         .collect();
@@ -299,6 +350,7 @@ pub(crate) async fn execute_tools_split_batch(
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> Result<()> {
     // Partition into parallelizable vs sequential
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
@@ -329,6 +381,7 @@ pub(crate) async fn execute_tools_split_batch(
                     sink,
                     cancel.clone(),
                     sub_agent_cache,
+                    bg_agents,
                 )
             })
             .collect();
@@ -372,6 +425,7 @@ pub(crate) async fn execute_tools_split_batch(
                 cmd_rx,
                 sub_agent_cache,
                 file_tracker,
+                bg_agents,
             )
             .await?;
         }
@@ -394,6 +448,7 @@ pub(crate) async fn execute_tools_split_batch(
             cmd_rx,
             sub_agent_cache,
             file_tracker,
+            bg_agents,
         )
         .await?;
     }
@@ -417,6 +472,7 @@ pub(crate) async fn execute_tools_sequential(
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> Result<()> {
     for tc in tool_calls {
         // Check for interrupt before each tool
@@ -582,6 +638,7 @@ pub(crate) async fn execute_tools_sequential(
             sink,
             cancel.clone(),
             sub_agent_cache,
+            bg_agents,
         )
         .await;
         record_tool_result(
@@ -623,6 +680,7 @@ pub(crate) async fn execute_sub_agent(
     parent_cache: Option<crate::tools::FileReadCache>,
     sub_agent_cache: &SubAgentCache,
     parent_session_id: &str,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"].as_str().unwrap_or("task");
@@ -631,7 +689,44 @@ pub(crate) async fn execute_sub_agent(
         .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
     let session_id = args["session_id"].as_str().map(|s| s.to_string());
     let is_fork = agent_name == "fork";
+    let background = args["background"].as_bool().unwrap_or(false);
 
+    // Background mode: spawn and return immediately
+    if background {
+        let (task_id, tx) = bg_agents.register(agent_name, prompt);
+        let project_root = project_root.to_path_buf();
+        let parent_config = parent_config.clone();
+        let agent_name_owned = agent_name.to_string();
+        let arguments = arguments.to_string();
+        let sub_agent_cache = sub_agent_cache.clone();
+        let parent_session = parent_session_id.to_string();
+        let bg_db = db.clone();
+
+        sink.emit(EngineEvent::Info {
+            message: format!("  \u{1f680} {agent_name} launched in background (task {task_id})"),
+        });
+
+        tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("bg agent runtime");
+            rt.block_on(run_bg_agent(
+                project_root,
+                parent_config,
+                bg_db,
+                arguments,
+                sub_agent_cache,
+                parent_session,
+                tx,
+            ));
+        });
+
+        return Ok(format!(
+            "Background agent '{agent_name_owned}' started (task {task_id}). \
+             Results will be injected when complete."
+        ));
+    }
     // Check result cache (only for stateless calls without a session_id,
     // since session continuations need fresh execution).
     if session_id.is_none()

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -33,6 +33,12 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "session_id": {
                         "type": "string",
                         "description": "Optional session ID to continue a previous sub-agent conversation"
+                    },
+                    "background": {
+                        "type": "boolean",
+                        "description": "Run in background and return immediately (default: false). \
+                            Results are injected when complete. Use for independent tasks \
+                            that don't block your current work."
                     }
                 },
                 "required": ["prompt"]


### PR DESCRIPTION
## What

Phase 2b of #628 — background execution for sub-agents.

### Background execution

```
InvokeAgent({ agent_name: "explore", prompt: "...", background: true })
```

- Sub-agent spawns in a **separate thread**, returns immediately with task ID
- Results are automatically **injected as user messages** when complete
- Background agents run with `Auto` approval mode and `NullSink` (silent)
- `BgAgentRegistry` tracks pending oneshot channels, drains completed results
- Anti-infinite-spawn: `background=false` override on re-entry

### Implementation

- **`BgAgentRegistry`** (`bg_agent.rs`): oneshot channel-based registry with non-blocking `drain_completed()`
- **`NullSink`** (`engine/sink.rs`): no-op event sink for silent background execution
- **`run_bg_agent`** (`tool_dispatch.rs`): standalone async fn with owned data, run via `spawn_blocking` + `current_thread` runtime (async recursion through inference→dispatch→sub-agent isn't `Send`)
- **Inference loop injection**: `drain_completed()` called at top of every iteration; results become user messages

### Files changed

| File | Change |
|---|---|
| `bg_agent.rs` | New: registry + 4 tests |
| `engine/sink.rs` | New: `NullSink` |
| `tool_dispatch.rs` | Background spawn + `bg_agents` threading |
| `inference.rs` | Drain + inject at loop top |
| `tools/agent.rs` | `background` param on schema |
| `capabilities.md` | Document background mode |
| `lib.rs` | Register `bg_agent` module |

### Tests

- 528 core lib tests passing (4 new bg_agent tests)
- fmt + clippy clean

Part of #628