### PR TITLE
feat(#636 P4): streaming Bash output — line-by-line tool output events

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -70,6 +70,9 @@ pub fn engine_event_to_acp(
             ))
         }
 
+        // Streaming output lines — not mapped to ACP events (yet).
+        EngineEvent::ToolOutputLine { .. } => None,
+
         EngineEvent::ToolCallResult {
             id,
             name: _,

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -159,6 +159,15 @@ impl EngineSink for HeadlessSink {
             EngineEvent::ToolCallStart { name, .. } => {
                 eprintln!("\x1b[36m  \u{26a1} {name}\x1b[0m");
             }
+            EngineEvent::ToolOutputLine {
+                line, is_stderr, ..
+            } => {
+                if is_stderr {
+                    eprintln!("  \u{2502}e {line}");
+                } else {
+                    eprintln!("  \u{2502} {line}");
+                }
+            }
             EngineEvent::ToolCallResult { name, output, .. } => {
                 use koda_core::truncate::{Truncated, truncate_for_display};
                 eprintln!("\x1b[32m  \u{2713} {name}\x1b[0m");

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -39,6 +39,9 @@ pub struct TuiRenderer {
     /// Pending tool call args: maps tool_call_id → (tool_name, args_json).
     /// Used to extract file paths for syntax highlighting Read/Grep results.
     pending_tool_args: HashMap<String, (String, String)>,
+    /// Tool IDs that emitted streaming output lines.
+    /// Used to avoid re-rendering the full output in ToolCallResult.
+    streaming_tool_ids: std::collections::HashSet<String>,
 }
 
 impl TuiRenderer {
@@ -55,6 +58,7 @@ impl TuiRenderer {
             response_started: false,
             md: crate::md_render::MarkdownRenderer::new(),
             pending_tool_args: HashMap::new(),
+            streaming_tool_ids: std::collections::HashSet::new(),
         }
     }
 
@@ -148,28 +152,64 @@ impl TuiRenderer {
                     ]),
                 );
             }
+            EngineEvent::ToolOutputLine {
+                id,
+                line,
+                is_stderr,
+            } => {
+                self.streaming_tool_ids.insert(id);
+                let (prefix, style) = if is_stderr {
+                    ("  \u{2502}e ", RED)
+                } else {
+                    ("  \u{2502} ", DIM)
+                };
+                tui_output::emit_line(
+                    buffer,
+                    Line::from(vec![Span::styled(prefix, DIM), Span::styled(line, style)]),
+                );
+            }
             EngineEvent::ToolCallResult { id, name, output } => {
-                // Extract file path from pending args for syntax highlighting
+                // If we streamed output lines, skip rendering the full result
+                // (the user already saw it in real-time). Just show exit code.
+                let streamed = self.streaming_tool_ids.remove(&id);
                 let file_ext = self
                     .pending_tool_args
                     .remove(&id)
                     .and_then(|(_, args)| extract_file_extension(&args));
 
                 self.tool_history.push(&name, &output);
-                let is_diff_tool =
-                    matches!(name.as_str(), "Write" | "Edit" | "Delete" | "MemoryWrite");
-                if self.preview_shown && is_diff_tool {
-                    // Compact: just show line count
-                    let line_count = output.lines().count();
+                if streamed {
+                    // Already streamed line-by-line — just show exit code summary.
+                    let exit_line = output.lines().next().unwrap_or("");
                     tui_output::emit_line(
                         buffer,
                         Line::from(vec![
                             Span::styled("  \u{2514} ", DIM),
-                            Span::styled(format!("{name}: {line_count} line(s)"), DIM),
+                            Span::styled(exit_line.to_string(), DIM),
                         ]),
                     );
                 } else {
-                    render_tool_output(buffer, &name, &output, self.verbose, file_ext.as_deref());
+                    let is_diff_tool =
+                        matches!(name.as_str(), "Write" | "Edit" | "Delete" | "MemoryWrite");
+                    if self.preview_shown && is_diff_tool {
+                        // Compact: just show line count
+                        let line_count = output.lines().count();
+                        tui_output::emit_line(
+                            buffer,
+                            Line::from(vec![
+                                Span::styled("  \u{2514} ", DIM),
+                                Span::styled(format!("{name}: {line_count} line(s)"), DIM),
+                            ]),
+                        );
+                    } else {
+                        render_tool_output(
+                            buffer,
+                            &name,
+                            &output,
+                            self.verbose,
+                            file_ext.as_deref(),
+                        );
+                    }
                 }
                 self.preview_shown = false;
             }

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -81,6 +81,19 @@ pub enum EngineEvent {
         output: String,
     },
 
+    /// A line of streaming output from a tool (currently Bash only).
+    ///
+    /// Emitted as each line arrives from stdout/stderr, before `ToolCallResult`.
+    /// Clients can render these in real-time for a "live terminal" feel.
+    ToolOutputLine {
+        /// Matches the `id` from `ToolCallStart`.
+        id: String,
+        /// The output line (no trailing newline).
+        line: String,
+        /// Whether this line came from stderr.
+        is_stderr: bool,
+    },
+
     // ── Sub-agent delegation ──────────────────────────────────────────
     /// A sub-agent is being invoked.
     SubAgentStart {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -256,7 +256,14 @@ pub(crate) async fn execute_one_tool(
         if crate::tools::is_mutating_tool(&tc.function_name) {
             sub_agent_cache.invalidate();
         }
-        let r = tools.execute(&tc.function_name, &tc.arguments).await;
+        let streaming = if tc.function_name == "Bash" {
+            Some((sink, tc.id.as_str()))
+        } else {
+            None
+        };
+        let r = tools
+            .execute(&tc.function_name, &tc.arguments, streaming)
+            .await;
         (r.output, r.success)
     };
 
@@ -925,7 +932,10 @@ pub(crate) async fn execute_sub_agent(
 
             let output = match approval {
                 ToolApproval::AutoApprove => {
-                    tools.execute(&tc.function_name, &tc.arguments).await.output
+                    tools
+                        .execute(&tc.function_name, &tc.arguments, None)
+                        .await
+                        .output
                 }
                 ToolApproval::Blocked => {
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
@@ -953,7 +963,10 @@ pub(crate) async fn execute_sub_agent(
                     .await
                     {
                         Some(ApprovalDecision::Approve) => {
-                            tools.execute(&tc.function_name, &tc.arguments).await.output
+                            tools
+                                .execute(&tc.function_name, &tc.arguments, None)
+                                .await
+                                .output
                         }
                         Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
                         Some(ApprovalDecision::RejectWithFeedback { feedback }) => {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -331,7 +331,16 @@ impl ToolRegistry {
     /// Empty or whitespace-only `arguments` are treated as `{}` (no args)
     /// so that tools can fall through to their own defaults instead of
     /// surfacing a raw JSON parse error.  See #513.
-    pub async fn execute(&self, name: &str, arguments: &str) -> ToolResult {
+    ///
+    /// `sink_for_streaming` is an optional `(sink, call_id)` pair. When
+    /// provided, the Bash tool streams each output line as a
+    /// `ToolOutputLine` event in real-time.
+    pub async fn execute(
+        &self,
+        name: &str,
+        arguments: &str,
+        sink_for_streaming: Option<(&dyn crate::engine::EngineSink, &str)>,
+    ) -> ToolResult {
         let raw = arguments.trim();
         let raw = if raw.is_empty() { "{}" } else { raw };
         let args: Value = match serde_json::from_str(raw) {
@@ -383,6 +392,7 @@ impl ToolRegistry {
                     &args,
                     self.caps.shell_output_lines,
                     &self.bg_registry,
+                    sink_for_streaming,
                 )
                 .await
             }

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -7,11 +7,13 @@
 //! immediately with the PID.  The process is tracked in `BgRegistry` and
 //! SIGTERMed when the session ends.
 
+use crate::engine::{EngineEvent, EngineSink};
 use crate::providers::ToolDefinition;
 use crate::tools::bg_process::BgRegistry;
 use anyhow::Result;
 use serde_json::{Value, json};
 use std::path::Path;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
@@ -51,7 +53,11 @@ pub fn definitions() -> Vec<ToolDefinition> {
     }]
 }
 
-/// Execute a shell command with timeout and output capping.
+/// Execute a shell command with timeout, output capping, and optional streaming.
+///
+/// When `sink` is provided, each line of stdout/stderr is emitted as a
+/// `ToolOutputLine` event as it arrives — giving the TUI a live terminal feel.
+/// The full output is still collected and returned as the tool result.
 ///
 /// When `args["background"]` is `true`, the process is spawned detached and
 /// this function returns immediately with the PID.  The `BgRegistry` tracks
@@ -61,6 +67,7 @@ pub async fn run_shell_command(
     args: &Value,
     max_output_lines: usize,
     bg: &BgRegistry,
+    sink: Option<(&dyn EngineSink, &str)>,
 ) -> Result<String> {
     let command = args["command"]
         .as_str()
@@ -81,24 +88,47 @@ pub async fn run_shell_command(
         .unwrap_or(DEFAULT_TIMEOUT_SECS)
         .min(MAX_TIMEOUT_SECS);
 
+    // Spawn with piped stdout/stderr for line-by-line streaming.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_root)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to execute command: {e}"))?;
+
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+
+    let mut stdout_lines: Vec<String> = Vec::new();
+    let mut stderr_lines: Vec<String> = Vec::new();
+
+    // Read stdout and stderr concurrently, streaming lines as they arrive.
+    let sink_info = sink.map(|(s, id)| (s, id.to_string()));
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(timeout_secs),
-        Command::new("sh")
-            .arg("-c")
-            .arg(command)
-            .current_dir(project_root)
-            .output(),
+        read_streams(
+            stdout,
+            stderr,
+            &mut stdout_lines,
+            &mut stderr_lines,
+            &sink_info,
+        ),
     )
     .await;
 
     match result {
-        Ok(Ok(output)) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let exit_code = output.status.code().unwrap_or(-1);
+        Ok(Ok(())) => {
+            // Wait for exit status after streams are drained.
+            let status = child
+                .wait()
+                .await
+                .map_err(|e| anyhow::anyhow!("wait: {e}"))?;
+            let exit_code = status.code().unwrap_or(-1);
 
-            let stdout_capped = cap_output(&stdout, max_output_lines);
-            let stderr_capped = cap_output(&stderr, max_output_lines);
+            let stdout_capped = cap_lines(&stdout_lines, max_output_lines);
+            let stderr_capped = cap_lines(&stderr_lines, max_output_lines);
 
             let mut response = format!("Exit code: {exit_code}\n");
             if !stdout_capped.is_empty() {
@@ -107,14 +137,68 @@ pub async fn run_shell_command(
             if !stderr_capped.is_empty() {
                 response.push_str(&format!("\n--- stderr ---\n{stderr_capped}"));
             }
-
             Ok(response)
         }
-        Ok(Err(e)) => Err(anyhow::anyhow!("Failed to execute command: {e}")),
-        Err(_) => Ok(format!(
-            "Command timed out after {timeout_secs}s: {command}"
-        )),
+        Ok(Err(e)) => Err(anyhow::anyhow!("Stream read error: {e}")),
+        Err(_) => {
+            // Timeout — kill the child.
+            let _ = child.kill().await;
+            Ok(format!(
+                "Command timed out after {timeout_secs}s: {command}"
+            ))
+        }
     }
+}
+
+/// Read stdout and stderr concurrently, collecting lines and optionally streaming them.
+async fn read_streams(
+    stdout: tokio::process::ChildStdout,
+    stderr: tokio::process::ChildStderr,
+    stdout_lines: &mut Vec<String>,
+    stderr_lines: &mut Vec<String>,
+    sink_info: &Option<(&dyn EngineSink, String)>,
+) -> std::io::Result<()> {
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut stderr_reader = BufReader::new(stderr).lines();
+
+    let mut stdout_done = false;
+    let mut stderr_done = false;
+
+    while !stdout_done || !stderr_done {
+        tokio::select! {
+            line = stdout_reader.next_line(), if !stdout_done => {
+                match line? {
+                    Some(l) => {
+                        if let Some((sink, id)) = sink_info {
+                            sink.emit(EngineEvent::ToolOutputLine {
+                                id: id.clone(),
+                                line: l.clone(),
+                                is_stderr: false,
+                            });
+                        }
+                        stdout_lines.push(l);
+                    }
+                    None => stdout_done = true,
+                }
+            }
+            line = stderr_reader.next_line(), if !stderr_done => {
+                match line? {
+                    Some(l) => {
+                        if let Some((sink, id)) = sink_info {
+                            sink.emit(EngineEvent::ToolOutputLine {
+                                id: id.clone(),
+                                line: l.clone(),
+                                is_stderr: true,
+                            });
+                        }
+                        stderr_lines.push(l);
+                    }
+                    None => stderr_done = true,
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Spawn a command in the background and register it.
@@ -148,8 +232,10 @@ fn spawn_background(project_root: &Path, command: &str, bg: &BgRegistry) -> Resu
 }
 
 /// Cap output to the last N lines to protect the context window.
-fn cap_output(output: &str, max_lines: usize) -> String {
-    let lines: Vec<&str> = output.lines().collect();
+fn cap_lines(lines: &[String], max_lines: usize) -> String {
+    if lines.is_empty() {
+        return String::new();
+    }
     if lines.len() > max_lines {
         let skipped = lines.len() - max_lines;
         format!(
@@ -157,7 +243,7 @@ fn cap_output(output: &str, max_lines: usize) -> String {
             lines[lines.len() - max_lines..].join("\n")
         )
     } else {
-        output.to_string()
+        lines.join("\n")
     }
 }
 
@@ -174,7 +260,7 @@ mod tests {
     async fn shell_timeout_returns_timeout_message() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "sleep 5", "timeout": 1});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
             .await
             .unwrap();
         assert!(
@@ -187,7 +273,7 @@ mod tests {
     async fn shell_respects_custom_timeout_parameter() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo hello", "timeout": 5});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
             .await
             .unwrap();
         assert!(
@@ -200,7 +286,7 @@ mod tests {
     async fn shell_default_timeout_is_applied_when_not_specified() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo world"});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
             .await
             .unwrap();
         assert!(
@@ -214,21 +300,20 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let registry = BgRegistry::new();
         let args = serde_json::json!({"command": "sleep 60", "background": true});
-        let result = run_shell_command(tmp.path(), &args, 256, &registry)
+        let result = run_shell_command(tmp.path(), &args, 256, &registry, None)
             .await
             .unwrap();
         assert!(result.contains("Background process started"), "{result}");
         assert!(result.contains("PID:"), "{result}");
         assert!(result.contains("kill"), "{result}");
         assert_eq!(registry.len(), 1);
-        // Drop kills it cleanly
     }
 
     #[tokio::test]
     async fn background_false_runs_synchronously() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo sync", "background": false});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg())
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
             .await
             .unwrap();
         assert!(result.contains("sync"), "{result}");
@@ -239,24 +324,27 @@ mod tests {
     }
 
     #[test]
-    fn test_cap_output_short() {
-        let input = "line1\nline2\nline3";
-        assert_eq!(cap_output(input, 256), input);
+    fn test_cap_lines_short() {
+        let lines: Vec<String> = vec!["line1", "line2", "line3"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(cap_lines(&lines, 256), "line1\nline2\nline3");
     }
 
     #[test]
-    fn test_cap_output_long() {
+    fn test_cap_lines_long() {
         let lines: Vec<String> = (0..500).map(|i| format!("line {i}")).collect();
-        let capped = cap_output(&lines.join("\n"), 256);
+        let capped = cap_lines(&lines, 256);
         assert!(capped.contains("truncated"));
         assert!(capped.contains("line 499"));
         assert!(!capped.contains("line 0\n"));
     }
 
     #[test]
-    fn test_cap_output_exactly_at_limit() {
+    fn test_cap_lines_exactly_at_limit() {
         let lines: Vec<String> = (0..256).map(|i| format!("line {i}")).collect();
-        assert!(!cap_output(&lines.join("\n"), 256).contains("truncated"));
+        assert!(!cap_lines(&lines, 256).contains("truncated"));
     }
 
     #[test]
@@ -267,5 +355,57 @@ mod tests {
             .unwrap_or(DEFAULT_TIMEOUT_SECS)
             .min(MAX_TIMEOUT_SECS);
         assert_eq!(t, MAX_TIMEOUT_SECS);
+    }
+
+    #[tokio::test]
+    async fn streaming_emits_lines_to_sink() {
+        use std::sync::{Arc, Mutex};
+
+        /// Collects ToolOutputLine events for testing.
+        #[derive(Debug, Default)]
+        struct CaptureSink {
+            lines: Mutex<Vec<(String, bool)>>,
+        }
+        impl crate::engine::EngineSink for CaptureSink {
+            fn emit(&self, event: EngineEvent) {
+                if let EngineEvent::ToolOutputLine {
+                    line, is_stderr, ..
+                } = event
+                {
+                    self.lines.lock().unwrap().push((line, is_stderr));
+                }
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let sink = Arc::new(CaptureSink::default());
+        let args = serde_json::json!({
+            "command": "echo alpha && echo bravo && echo charlie >&2"
+        });
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &bg(),
+            Some((sink.as_ref(), "test_id")),
+        )
+        .await
+        .unwrap();
+
+        // Full result should still be collected
+        assert!(result.contains("alpha"));
+        assert!(result.contains("bravo"));
+        assert!(result.contains("charlie"));
+
+        // Streaming lines should have been emitted
+        let lines = sink.lines.lock().unwrap();
+        assert!(
+            lines.len() >= 3,
+            "Expected at least 3 streamed lines, got {}: {lines:?}",
+            lines.len()
+        );
+        // At least one stdout and one stderr line
+        assert!(lines.iter().any(|(_, is_stderr)| !is_stderr));
+        assert!(lines.iter().any(|(_, is_stderr)| *is_stderr));
     }
 }

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -38,7 +38,7 @@ async fn normalized_lowercase_names_are_routable() {
             registry.has_tool(&canonical),
             "Normalized '{raw_name}' -> '{canonical}' is not in the registry"
         );
-        let result = registry.execute(&canonical, "{}").await;
+        let result = registry.execute(&canonical, "{}", None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw_name}' normalized to '{canonical}' but dispatcher rejected it: {}",
@@ -77,7 +77,7 @@ async fn normalized_snake_case_names_are_routable() {
             canonical, expected,
             "'{raw}' should normalize to '{expected}', got '{canonical}'"
         );
-        let result = registry.execute(&canonical, "{}").await;
+        let result = registry.execute(&canonical, "{}", None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw}' -> '{canonical}' rejected by dispatcher: {}",

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -18,7 +18,7 @@ fn all_tool_names() -> Vec<String> {
 async fn test_all_tools_routable_in_dispatcher() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for name in all_tool_names() {
-        let result = registry.execute(&name, "{}").await;
+        let result = registry.execute(&name, "{}", None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "Tool '{name}' is not routed in the dispatcher (tools/mod.rs execute()). \
@@ -34,7 +34,7 @@ async fn test_all_tools_routable_in_dispatcher() {
 async fn test_empty_args_default_to_empty_object() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for input in ["", "  ", "\n", "\t "] {
-        let result = registry.execute("List", input).await;
+        let result = registry.execute("List", input, None).await;
         assert!(
             !result.output.contains("Invalid JSON"),
             "Empty args '{input:?}' should not produce a JSON parse error. Got: {}",


### PR DESCRIPTION
## What

Bash output now streams line-by-line to the TUI as it's produced, instead of appearing all at once after the command completes.

## Why

**Before**: `cargo build` runs for 30 seconds → screen shows nothing → then dumps 200 lines at once. Feels frozen.

**After**: Each line of stdout/stderr appears immediately. You see compiler warnings as they happen, test results as they pass, and build progress in real-time.

## How

Replaced `Command::output()` (blocks until completion) with `Command::spawn()` + `BufReader::lines()` + `tokio::select!` for concurrent stdout/stderr streaming.

```
┌─ Model calls Bash ────────────────────────────────┐
│ ⚡ Bash                                           │
│  │ Compiling koda-core v0.1.20                    │  ← ToolOutputLine (stdout)
│  │ Compiling koda-cli v0.1.20                     │  ← ToolOutputLine (stdout)
│  │e warning: unused import                        │  ← ToolOutputLine (stderr)
│  └ Exit code: 0                                   │  ← ToolCallResult (summary)
└───────────────────────────────────────────────────┘
```

## Changes

| File | Lines | What |
|---|---|---|
| `engine/event.rs` | +13 | New `ToolOutputLine { id, line, is_stderr }` event |
| `tools/shell.rs` | +206/-45 | `spawn()` + async line streaming; `cap_output` → `cap_lines` |
| `tools/mod.rs` | +12 | `execute()` takes optional `sink_for_streaming` |
| `tool_dispatch.rs` | +19 | Passes `(sink, call_id)` for Bash |
| `tui_render.rs` | +56 | Renders streaming lines; skips redundant full output |
| `headless.rs` | +9 | Prints streaming lines to stderr |
| `acp_adapter.rs` | +3 | Ignores `ToolOutputLine` (no ACP mapping yet) |

## Design decisions

- **Only Bash streams** — other tools return instantly, no benefit from streaming
- **Full output still collected** — `ToolCallResult` has the complete output for DB storage and model context
- **TUI deduplicates** — tracks `streaming_tool_ids`; when `ToolCallResult` arrives for a streamed tool, only shows the exit code line
- **Stderr in red** — visual distinction between stdout (dim) and stderr (red)

## Tests (10 total, 1 new)

- `streaming_emits_lines_to_sink` — runs `echo alpha && echo bravo && echo charlie >&2`, verifies stdout + stderr lines emitted to sink, full result still collected
- All existing shell tests updated for new signature, still passing

## Refs

- Part of #636 (P4 checklist item)
- Closes #636 — all 5 items now addressed
