### PR TITLE
refactor: split tool_dispatch.rs into three focused modules

### DIFF
--- a/koda-core/src/approval_flow.rs
+++ b/koda-core/src/approval_flow.rs
@@ -1,0 +1,90 @@
+//! Approval flow and user interaction during tool execution.
+//!
+//! Extracted from `tool_dispatch.rs` — handles the async request/response
+//! dance for tool approvals and the `AskUser` tool.
+
+use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+/// Emit an `AskUserRequest` and wait for the user's typed response.
+///
+/// Returns `None` if the session was interrupted or cancelled.
+pub(crate) async fn handle_ask_user(
+    sink: &dyn crate::engine::EngineSink,
+    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+    cancel: &CancellationToken,
+    args: &serde_json::Value,
+) -> Option<String> {
+    let question = args["question"].as_str().unwrap_or("").to_string();
+    let options: Vec<String> = args["options"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    sink.emit(EngineEvent::AskUserRequest {
+        id: request_id.clone(),
+        question,
+        options,
+    });
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => match cmd {
+                Some(EngineCommand::AskUserResponse { id, answer }) if id == request_id => {
+                    return Some(answer);
+                }
+                Some(EngineCommand::Interrupt) => {
+                    cancel.cancel();
+                    return None;
+                }
+                None => return None,
+                _ => continue,
+            },
+            _ = cancel.cancelled() => return None,
+        }
+    }
+}
+
+/// Emit an `ApprovalRequest` and wait for the user's decision.
+///
+/// Returns `None` if the session was interrupted or cancelled.
+pub(crate) async fn request_approval(
+    sink: &dyn crate::engine::EngineSink,
+    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+    cancel: &CancellationToken,
+    tool_name: &str,
+    detail: &str,
+    preview: Option<crate::preview::DiffPreview>,
+) -> Option<ApprovalDecision> {
+    let approval_id = uuid::Uuid::new_v4().to_string();
+    sink.emit(EngineEvent::ApprovalRequest {
+        id: approval_id.clone(),
+        tool_name: tool_name.to_string(),
+        detail: detail.to_string(),
+        preview,
+    });
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => match cmd {
+                Some(EngineCommand::ApprovalResponse { id, decision }) if id == approval_id => {
+                    return Some(decision);
+                }
+                Some(EngineCommand::Interrupt) => {
+                    cancel.cancel();
+                    return None;
+                }
+                None => return None,  // channel closed
+                _ => continue,        // ignore unrelated commands
+            },
+            _ = cancel.cancelled() => return None,
+        }
+    }
+}

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -12,6 +12,8 @@
 pub mod agent;
 /// Tool approval modes, safety gates, and shared mode state.
 pub mod approval;
+/// Approval flow and user interaction during tool execution.
+pub(crate) mod approval_flow;
 /// Heuristic path-escape detection for bash commands.
 pub mod bash_path_lint;
 /// Bash command safety classification (destructive, mutating, read-only).
@@ -72,6 +74,8 @@ pub mod settings;
 pub mod skills;
 /// Cache for sub-agent provider/model config across invocations.
 pub mod sub_agent_cache;
+/// Sub-agent invocation and lifecycle management.
+pub(crate) mod sub_agent_dispatch;
 /// Tool dispatch — routes tool calls from inference to the registry.
 pub mod tool_dispatch;
 /// Tool name normalization — maps model-emitted variants to canonical PascalCase.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -1,0 +1,410 @@
+//! Sub-agent invocation and lifecycle management.
+//!
+//! Extracted from `tool_dispatch.rs` — handles `InvokeAgent` execution,
+//! background agent spawning, worktree provisioning, and sub-agent caching.
+
+use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
+use crate::approval_flow::request_approval;
+use crate::config::KodaConfig;
+use crate::db::{Database, Role};
+use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
+use crate::loop_guard;
+use crate::memory;
+use crate::persistence::Persistence;
+use crate::preview;
+use crate::prompt::build_system_prompt;
+use crate::providers::{ChatMessage, ToolCall};
+use crate::sub_agent_cache::SubAgentCache;
+use crate::tools::{self, ToolRegistry};
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+/// Run a sub-agent in the background. Owns all data (no borrows).
+///
+/// This is a standalone async fn so the future is `Send + 'static`,
+/// which `tokio::spawn` requires.
+async fn run_bg_agent(
+    project_root: std::path::PathBuf,
+    parent_config: KodaConfig,
+    db: Database,
+    arguments: String,
+    sub_agent_cache: SubAgentCache,
+    parent_session: String,
+    tx: tokio::sync::oneshot::Sender<Result<String, String>>,
+) {
+    let mut settings = Settings::default();
+    let cancel = CancellationToken::new();
+    let (_, mut cmd_rx) = mpsc::channel(1);
+    let null_sink = crate::engine::sink::NullSink;
+    let nested_bg = crate::bg_agent::new_shared();
+
+    // Override background=false to prevent infinite spawn
+    let mut sync_args: serde_json::Value = serde_json::from_str(&arguments).unwrap_or_default();
+    sync_args["background"] = serde_json::Value::Bool(false);
+    let sync_arguments = serde_json::to_string(&sync_args).unwrap();
+
+    let result = execute_sub_agent(
+        &project_root,
+        &parent_config,
+        &db,
+        &sync_arguments,
+        ApprovalMode::Auto,
+        &mut settings,
+        &null_sink,
+        cancel,
+        &mut cmd_rx,
+        None,
+        &sub_agent_cache,
+        &parent_session,
+        &nested_bg,
+    )
+    .await;
+
+    let _ = match result {
+        Ok(output) => tx.send(Ok(output)),
+        Err(e) => tx.send(Err(format!("Error: {e}"))),
+    };
+}
+
+/// Execute a sub-agent in its own isolated event loop.
+///
+/// When `parent_cache` is provided, the sub-agent shares the parent's
+/// file-read cache so reads by one agent benefit all others.
+///
+/// Results are cached in `sub_agent_cache` keyed by `(agent_name, prompt_hash)`.
+/// On cache hit, returns immediately without any LLM calls.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_sub_agent(
+    project_root: &Path,
+    parent_config: &KodaConfig,
+    db: &Database,
+    arguments: &str,
+    mode: ApprovalMode,
+    _settings: &mut Settings,
+    sink: &dyn crate::engine::EngineSink,
+    cancel: CancellationToken,
+    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+    parent_cache: Option<crate::tools::FileReadCache>,
+    sub_agent_cache: &SubAgentCache,
+    parent_session_id: &str,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+) -> Result<String> {
+    let args: serde_json::Value = serde_json::from_str(arguments)?;
+    let agent_name = args["agent_name"].as_str().unwrap_or("task");
+    let prompt = args["prompt"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
+    let session_id = args["session_id"].as_str().map(|s| s.to_string());
+    let is_fork = agent_name == "fork";
+    let background = args["background"].as_bool().unwrap_or(false);
+
+    // Background mode: spawn and return immediately
+    if background {
+        let (task_id, tx) = bg_agents.register(agent_name, prompt);
+        let project_root = project_root.to_path_buf();
+        let parent_config = parent_config.clone();
+        let agent_name_owned = agent_name.to_string();
+        let arguments = arguments.to_string();
+        let sub_agent_cache = sub_agent_cache.clone();
+        let parent_session = parent_session_id.to_string();
+        let bg_db = db.clone();
+
+        sink.emit(EngineEvent::Info {
+            message: format!("  \u{1f680} {agent_name} launched in background (task {task_id})"),
+        });
+
+        tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("bg agent runtime");
+            rt.block_on(run_bg_agent(
+                project_root,
+                parent_config,
+                bg_db,
+                arguments,
+                sub_agent_cache,
+                parent_session,
+                tx,
+            ));
+        });
+
+        return Ok(format!(
+            "Background agent '{agent_name_owned}' started (task {task_id}). \
+             Results will be injected when complete."
+        ));
+    }
+    // Check result cache (only for stateless calls without a session_id,
+    // since session continuations need fresh execution).
+    if session_id.is_none()
+        && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
+    {
+        sink.emit(EngineEvent::Info {
+            message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
+        });
+        return Ok(cached);
+    }
+
+    sink.emit(EngineEvent::SubAgentStart {
+        agent_name: agent_name.to_string(),
+    });
+
+    // Fork inherits parent config; named agents load their own.
+    let sub_config = if is_fork {
+        parent_config.clone()
+    } else {
+        let cfg = crate::config::KodaConfig::load(project_root, agent_name)
+            .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
+        // Inherit parent's base_url if same provider (respect agent-level routing).
+        if cfg.provider_type == parent_config.provider_type {
+            cfg.with_overrides(Some(parent_config.base_url.clone()), None, None)
+        } else {
+            cfg
+        }
+    };
+
+    let sub_session = match session_id {
+        Some(id) => id,
+        None => {
+            let sid = db
+                .create_session(&sub_config.agent_name, project_root)
+                .await?;
+            // Fork: copy parent conversation history into the new session
+            if is_fork {
+                let parent_history = db.load_context(parent_session_id).await?;
+                for msg in &parent_history {
+                    db.insert_message(
+                        &sid,
+                        &msg.role,
+                        msg.content.as_deref(),
+                        msg.tool_calls.as_deref(),
+                        msg.tool_call_id.as_deref(),
+                        None, // don't duplicate usage stats
+                    )
+                    .await?;
+                }
+            }
+            sid
+        }
+    };
+
+    db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)
+        .await?;
+
+    let provider = crate::providers::create_provider(&sub_config);
+    // Provision a git worktree for agents that can write files.
+    // Read-only agents (explore, plan, verify) skip this.
+    let has_write_tools = !sub_config
+        .disallowed_tools
+        .iter()
+        .any(|t| t == "Write" || t == "Edit");
+    let (effective_root, worktree_path) = if has_write_tools {
+        match crate::worktree::provision(project_root, &sub_session).await {
+            Ok(crate::worktree::WorktreeResult::Created(wt)) => {
+                sink.emit(EngineEvent::Info {
+                    message: format!("  \u{1f333} {agent_name}: isolated in worktree"),
+                });
+                (wt.clone(), Some(wt))
+            }
+            Ok(_) => (project_root.to_path_buf(), None), // not a git repo / no git
+            Err(e) => {
+                tracing::warn!("Worktree provision failed: {e}");
+                (project_root.to_path_buf(), None)
+            }
+        }
+    } else {
+        (project_root.to_path_buf(), None)
+    };
+    let effective_root_ref = effective_root.as_path();
+
+    let tools = {
+        let registry = ToolRegistry::new(effective_root.clone(), sub_config.max_context_tokens);
+        match parent_cache {
+            Some(cache) => registry.with_shared_cache(cache),
+            None => registry,
+        }
+    };
+    let tool_defs = {
+        let mut denied = sub_config.disallowed_tools.clone();
+        // Anti-recursion: fork children cannot spawn sub-agents
+        if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
+            denied.push("InvokeAgent".to_string());
+        }
+        tools.get_definitions(&sub_config.allowed_tools, &denied)
+    };
+    let semantic_memory = memory::load(project_root)?;
+    let env = crate::prompt::EnvironmentInfo {
+        project_root: effective_root_ref,
+        model: &sub_config.model,
+        platform: std::env::consts::OS,
+    };
+    let system_prompt = build_system_prompt(
+        &sub_config.system_prompt,
+        &semantic_memory,
+        &sub_config.agents_dir,
+        &tool_defs,
+        &env,
+    );
+
+    for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
+        // Respect parent cancellation (#286)
+        if cancel.is_cancelled() {
+            // Clean up worktree on cancellation
+            if let Some(ref wt) = worktree_path {
+                let _ = crate::worktree::cleanup(project_root, wt).await;
+            }
+            return Ok("[cancelled by parent]".to_string());
+        }
+        let history = db.load_context(&sub_session).await?;
+        let mut messages = vec![ChatMessage::text("system", &system_prompt)];
+        for msg in &history {
+            let tool_calls: Option<Vec<ToolCall>> = msg
+                .tool_calls
+                .as_deref()
+                .and_then(|tc| serde_json::from_str(tc).ok());
+            messages.push(ChatMessage {
+                role: msg.role.as_str().to_string(),
+                content: msg.content.clone(),
+                tool_calls,
+                tool_call_id: msg.tool_call_id.clone(),
+                images: None,
+            });
+        }
+
+        sink.emit(EngineEvent::SpinnerStart {
+            message: format!("  🦥 {agent_name} thinking..."),
+        });
+        let response = provider
+            .chat(&messages, &tool_defs, &sub_config.model_settings)
+            .await?;
+        sink.emit(EngineEvent::SpinnerStop);
+
+        let tool_calls_json = if response.tool_calls.is_empty() {
+            None
+        } else {
+            Some(serde_json::to_string(&response.tool_calls)?)
+        };
+
+        db.insert_message(
+            &sub_session,
+            &Role::Assistant,
+            response.content.as_deref(),
+            tool_calls_json.as_deref(),
+            None,
+            Some(&response.usage),
+        )
+        .await?;
+
+        if response.tool_calls.is_empty() {
+            let result = response
+                .content
+                .unwrap_or_else(|| "(no output)".to_string());
+            // Cache the result for future identical calls
+            sub_agent_cache.put(agent_name, prompt, &result);
+            // Clean up worktree
+            if let Some(ref wt) = worktree_path
+                && let Ok(Some(changes)) = crate::worktree::cleanup(project_root, wt).await
+            {
+                sink.emit(EngineEvent::Info {
+                    message: format!("  \u{1f333} {agent_name}: {changes}"),
+                });
+            }
+            return Ok(result);
+        }
+
+        for tc in &response.tool_calls {
+            sink.emit(EngineEvent::ToolCallStart {
+                id: tc.id.clone(),
+                name: tc.function_name.clone(),
+                args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
+                is_sub_agent: true,
+            });
+
+            // Sub-agents inherit the parent's approval mode
+            let parsed_args: serde_json::Value =
+                serde_json::from_str(&tc.arguments).unwrap_or_default();
+            let approval = approval::check_tool(
+                &tc.function_name,
+                &parsed_args,
+                mode,
+                Some(effective_root_ref),
+            );
+
+            let output = match approval {
+                ToolApproval::AutoApprove => {
+                    tools
+                        .execute(&tc.function_name, &tc.arguments, None)
+                        .await
+                        .output
+                }
+                ToolApproval::Blocked => {
+                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                    let diff_preview =
+                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
+                    sink.emit(EngineEvent::ActionBlocked {
+                        tool_name: tc.function_name.clone(),
+                        detail,
+                        preview: diff_preview,
+                    });
+                    "[safe mode] Action blocked.".to_string()
+                }
+                ToolApproval::NeedsConfirmation => {
+                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                    let diff_preview =
+                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
+                    match request_approval(
+                        sink,
+                        cmd_rx,
+                        &cancel,
+                        &tc.function_name,
+                        &detail,
+                        diff_preview,
+                    )
+                    .await
+                    {
+                        Some(ApprovalDecision::Approve) => {
+                            tools
+                                .execute(&tc.function_name, &tc.arguments, None)
+                                .await
+                                .output
+                        }
+                        Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
+                        Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
+                            format!("[rejected: {feedback}]")
+                        }
+                        None => "[cancelled]".to_string(),
+                    }
+                }
+            };
+
+            db.insert_message(
+                &sub_session,
+                &Role::Tool,
+                Some(&output),
+                None,
+                Some(&tc.id),
+                None,
+            )
+            .await?;
+        }
+    }
+
+    sink.emit(EngineEvent::Warn {
+        message: format!(
+            "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
+            loop_guard::MAX_SUB_AGENT_ITERATIONS
+        ),
+    });
+    // Clean up worktree on exit
+    if let Some(ref wt) = worktree_path
+        && let Ok(Some(changes)) = crate::worktree::cleanup(project_root, wt).await
+    {
+        sink.emit(EngineEvent::Info {
+            message: format!("  \u{1f333} {agent_name}: {changes}"),
+        });
+    }
+    Ok("(sub-agent reached maximum iterations)".to_string())
+}

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -1,30 +1,31 @@
-//! Tool execution dispatch — sequential, parallel, and sub-agent.
+//! Tool execution dispatch — sequential, parallel, and split-batch.
 //!
-//! Handles tool call execution, approval flow, and sub-agent delegation.
+//! Routes tool calls from the inference loop to execution, handling
+//! approval flow, parallelization, and result recording.
+//!
+//! Sub-agent invocation lives in `sub_agent_dispatch.rs`.
+//! Approval request/response lives in `approval_flow.rs`.
 //!
 //! ## Design (docs/design.md)
 //!
 //! - **Tool Dispatch: Match Statement (P2)**: Tools are dispatched via a
 //!   `match` in `ToolRegistry::execute()`, not a `HashMap<String, Box<dyn Tool>>`.
 //!   Rust's exhaustive matching catches missing handlers at compile time.
-//! - **Sub-Agent Model Routing (P1, P3)**: Sub-agents respect their own
-//!   provider/model config. The parent's prompt cache is unaffected.
 
 use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
+use crate::approval_flow::{handle_ask_user, request_approval};
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
 use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
 use crate::file_tracker::FileTracker;
-use crate::loop_guard;
-use crate::memory;
 use crate::persistence::Persistence;
 use crate::preview;
-use crate::prompt::build_system_prompt;
-use crate::providers::{ChatMessage, ToolCall};
+use crate::providers::ToolCall;
 use crate::sub_agent_cache::SubAgentCache;
-use crate::tools::{self, ToolRegistry};
+use crate::sub_agent_dispatch;
+use crate::tools;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -141,53 +142,6 @@ async fn track_file_lifecycle(
     }
 }
 
-/// Run a sub-agent in the background. Owns all data (no borrows).
-///
-/// This is a standalone async fn so the future is `Send + 'static`,
-/// which `tokio::spawn` requires.
-async fn run_bg_agent(
-    project_root: std::path::PathBuf,
-    parent_config: KodaConfig,
-    db: Database,
-    arguments: String,
-    sub_agent_cache: SubAgentCache,
-    parent_session: String,
-    tx: tokio::sync::oneshot::Sender<Result<String, String>>,
-) {
-    let mut settings = Settings::default();
-    let cancel = CancellationToken::new();
-    let (_, mut cmd_rx) = mpsc::channel(1);
-    let null_sink = crate::engine::sink::NullSink;
-    let nested_bg = crate::bg_agent::new_shared();
-
-    // Override background=false to prevent infinite spawn
-    let mut sync_args: serde_json::Value = serde_json::from_str(&arguments).unwrap_or_default();
-    sync_args["background"] = serde_json::Value::Bool(false);
-    let sync_arguments = serde_json::to_string(&sync_args).unwrap();
-
-    let result = execute_sub_agent(
-        &project_root,
-        &parent_config,
-        &db,
-        &sync_arguments,
-        ApprovalMode::Auto,
-        &mut settings,
-        &null_sink,
-        cancel,
-        &mut cmd_rx,
-        None,
-        &sub_agent_cache,
-        &parent_session,
-        &nested_bg,
-    )
-    .await;
-
-    let _ = match result {
-        Ok(output) => tx.send(Ok(output)),
-        Err(e) => tx.send(Err(format!("Error: {e}"))),
-    };
-}
-
 pub(crate) fn can_parallelize(
     tool_calls: &[ToolCall],
     mode: ApprovalMode,
@@ -240,7 +194,7 @@ pub(crate) async fn execute_one_tool(
     let (result, success, full_output) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
         let mut sub_settings = Settings::default();
-        match execute_sub_agent(
+        match sub_agent_dispatch::execute_sub_agent(
             project_root,
             config,
             db,
@@ -677,426 +631,6 @@ pub(crate) async fn execute_tools_sequential(
         .await?;
     }
     Ok(())
-}
-
-// ── Sub-agent execution ───────────────────────────────────────
-
-/// Execute a sub-agent in its own isolated event loop.
-///
-/// When `parent_cache` is provided, the sub-agent shares the parent's
-/// file-read cache so reads by one agent benefit all others.
-///
-/// Results are cached in `sub_agent_cache` keyed by `(agent_name, prompt_hash)`.
-/// On cache hit, returns immediately without any LLM calls.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn execute_sub_agent(
-    project_root: &Path,
-    parent_config: &KodaConfig,
-    db: &Database,
-    arguments: &str,
-    mode: ApprovalMode,
-    _settings: &mut Settings,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
-    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    parent_cache: Option<crate::tools::FileReadCache>,
-    sub_agent_cache: &SubAgentCache,
-    parent_session_id: &str,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
-) -> Result<String> {
-    let args: serde_json::Value = serde_json::from_str(arguments)?;
-    let agent_name = args["agent_name"].as_str().unwrap_or("task");
-    let prompt = args["prompt"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
-    let session_id = args["session_id"].as_str().map(|s| s.to_string());
-    let is_fork = agent_name == "fork";
-    let background = args["background"].as_bool().unwrap_or(false);
-
-    // Background mode: spawn and return immediately
-    if background {
-        let (task_id, tx) = bg_agents.register(agent_name, prompt);
-        let project_root = project_root.to_path_buf();
-        let parent_config = parent_config.clone();
-        let agent_name_owned = agent_name.to_string();
-        let arguments = arguments.to_string();
-        let sub_agent_cache = sub_agent_cache.clone();
-        let parent_session = parent_session_id.to_string();
-        let bg_db = db.clone();
-
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{1f680} {agent_name} launched in background (task {task_id})"),
-        });
-
-        tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("bg agent runtime");
-            rt.block_on(run_bg_agent(
-                project_root,
-                parent_config,
-                bg_db,
-                arguments,
-                sub_agent_cache,
-                parent_session,
-                tx,
-            ));
-        });
-
-        return Ok(format!(
-            "Background agent '{agent_name_owned}' started (task {task_id}). \
-             Results will be injected when complete."
-        ));
-    }
-    // Check result cache (only for stateless calls without a session_id,
-    // since session continuations need fresh execution).
-    if session_id.is_none()
-        && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
-    {
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
-        });
-        return Ok(cached);
-    }
-
-    sink.emit(EngineEvent::SubAgentStart {
-        agent_name: agent_name.to_string(),
-    });
-
-    // Fork inherits parent config; named agents load their own.
-    let sub_config = if is_fork {
-        parent_config.clone()
-    } else {
-        let cfg = crate::config::KodaConfig::load(project_root, agent_name)
-            .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
-        // Inherit parent's base_url if same provider (respect agent-level routing).
-        if cfg.provider_type == parent_config.provider_type {
-            cfg.with_overrides(Some(parent_config.base_url.clone()), None, None)
-        } else {
-            cfg
-        }
-    };
-
-    let sub_session = match session_id {
-        Some(id) => id,
-        None => {
-            let sid = db
-                .create_session(&sub_config.agent_name, project_root)
-                .await?;
-            // Fork: copy parent conversation history into the new session
-            if is_fork {
-                let parent_history = db.load_context(parent_session_id).await?;
-                for msg in &parent_history {
-                    db.insert_message(
-                        &sid,
-                        &msg.role,
-                        msg.content.as_deref(),
-                        msg.tool_calls.as_deref(),
-                        msg.tool_call_id.as_deref(),
-                        None, // don't duplicate usage stats
-                    )
-                    .await?;
-                }
-            }
-            sid
-        }
-    };
-
-    db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)
-        .await?;
-
-    let provider = crate::providers::create_provider(&sub_config);
-    // Provision a git worktree for agents that can write files.
-    // Read-only agents (explore, plan, verify) skip this.
-    let has_write_tools = !sub_config
-        .disallowed_tools
-        .iter()
-        .any(|t| t == "Write" || t == "Edit");
-    let (effective_root, worktree_path) = if has_write_tools {
-        match crate::worktree::provision(project_root, &sub_session).await {
-            Ok(crate::worktree::WorktreeResult::Created(wt)) => {
-                sink.emit(EngineEvent::Info {
-                    message: format!("  \u{1f333} {agent_name}: isolated in worktree"),
-                });
-                (wt.clone(), Some(wt))
-            }
-            Ok(_) => (project_root.to_path_buf(), None), // not a git repo / no git
-            Err(e) => {
-                tracing::warn!("Worktree provision failed: {e}");
-                (project_root.to_path_buf(), None)
-            }
-        }
-    } else {
-        (project_root.to_path_buf(), None)
-    };
-    let effective_root_ref = effective_root.as_path();
-
-    let tools = {
-        let registry = ToolRegistry::new(effective_root.clone(), sub_config.max_context_tokens);
-        match parent_cache {
-            Some(cache) => registry.with_shared_cache(cache),
-            None => registry,
-        }
-    };
-    let tool_defs = {
-        let mut denied = sub_config.disallowed_tools.clone();
-        // Anti-recursion: fork children cannot spawn sub-agents
-        if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
-            denied.push("InvokeAgent".to_string());
-        }
-        tools.get_definitions(&sub_config.allowed_tools, &denied)
-    };
-    let semantic_memory = memory::load(project_root)?;
-    let env = crate::prompt::EnvironmentInfo {
-        project_root: effective_root_ref,
-        model: &sub_config.model,
-        platform: std::env::consts::OS,
-    };
-    let system_prompt = build_system_prompt(
-        &sub_config.system_prompt,
-        &semantic_memory,
-        &sub_config.agents_dir,
-        &tool_defs,
-        &env,
-    );
-
-    for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
-        // Respect parent cancellation (#286)
-        if cancel.is_cancelled() {
-            // Clean up worktree on cancellation
-            if let Some(ref wt) = worktree_path {
-                let _ = crate::worktree::cleanup(project_root, wt).await;
-            }
-            return Ok("[cancelled by parent]".to_string());
-        }
-        let history = db.load_context(&sub_session).await?;
-        let mut messages = vec![ChatMessage::text("system", &system_prompt)];
-        for msg in &history {
-            let tool_calls: Option<Vec<ToolCall>> = msg
-                .tool_calls
-                .as_deref()
-                .and_then(|tc| serde_json::from_str(tc).ok());
-            messages.push(ChatMessage {
-                role: msg.role.as_str().to_string(),
-                content: msg.content.clone(),
-                tool_calls,
-                tool_call_id: msg.tool_call_id.clone(),
-                images: None,
-            });
-        }
-
-        sink.emit(EngineEvent::SpinnerStart {
-            message: format!("  🦥 {agent_name} thinking..."),
-        });
-        let response = provider
-            .chat(&messages, &tool_defs, &sub_config.model_settings)
-            .await?;
-        sink.emit(EngineEvent::SpinnerStop);
-
-        let tool_calls_json = if response.tool_calls.is_empty() {
-            None
-        } else {
-            Some(serde_json::to_string(&response.tool_calls)?)
-        };
-
-        db.insert_message(
-            &sub_session,
-            &Role::Assistant,
-            response.content.as_deref(),
-            tool_calls_json.as_deref(),
-            None,
-            Some(&response.usage),
-        )
-        .await?;
-
-        if response.tool_calls.is_empty() {
-            let result = response
-                .content
-                .unwrap_or_else(|| "(no output)".to_string());
-            // Cache the result for future identical calls
-            sub_agent_cache.put(agent_name, prompt, &result);
-            // Clean up worktree
-            if let Some(ref wt) = worktree_path
-                && let Ok(Some(changes)) = crate::worktree::cleanup(project_root, wt).await
-            {
-                sink.emit(EngineEvent::Info {
-                    message: format!("  \u{1f333} {agent_name}: {changes}"),
-                });
-            }
-            return Ok(result);
-        }
-
-        for tc in &response.tool_calls {
-            sink.emit(EngineEvent::ToolCallStart {
-                id: tc.id.clone(),
-                name: tc.function_name.clone(),
-                args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
-                is_sub_agent: true,
-            });
-
-            // Sub-agents inherit the parent's approval mode
-            let parsed_args: serde_json::Value =
-                serde_json::from_str(&tc.arguments).unwrap_or_default();
-            let approval = approval::check_tool(
-                &tc.function_name,
-                &parsed_args,
-                mode,
-                Some(effective_root_ref),
-            );
-
-            let output = match approval {
-                ToolApproval::AutoApprove => {
-                    tools
-                        .execute(&tc.function_name, &tc.arguments, None)
-                        .await
-                        .output
-                }
-                ToolApproval::Blocked => {
-                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                    let diff_preview =
-                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
-                    sink.emit(EngineEvent::ActionBlocked {
-                        tool_name: tc.function_name.clone(),
-                        detail,
-                        preview: diff_preview,
-                    });
-                    "[safe mode] Action blocked.".to_string()
-                }
-                ToolApproval::NeedsConfirmation => {
-                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                    let diff_preview =
-                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
-                    match request_approval(
-                        sink,
-                        cmd_rx,
-                        &cancel,
-                        &tc.function_name,
-                        &detail,
-                        diff_preview,
-                    )
-                    .await
-                    {
-                        Some(ApprovalDecision::Approve) => {
-                            tools
-                                .execute(&tc.function_name, &tc.arguments, None)
-                                .await
-                                .output
-                        }
-                        Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
-                        Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
-                            format!("[rejected: {feedback}]")
-                        }
-                        None => "[cancelled]".to_string(),
-                    }
-                }
-            };
-
-            db.insert_message(
-                &sub_session,
-                &Role::Tool,
-                Some(&output),
-                None,
-                Some(&tc.id),
-                None,
-            )
-            .await?;
-        }
-    }
-
-    sink.emit(EngineEvent::Warn {
-        message: format!(
-            "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
-            loop_guard::MAX_SUB_AGENT_ITERATIONS
-        ),
-    });
-    // Clean up worktree on exit
-    if let Some(ref wt) = worktree_path
-        && let Ok(Some(changes)) = crate::worktree::cleanup(project_root, wt).await
-    {
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{1f333} {agent_name}: {changes}"),
-        });
-    }
-    Ok("(sub-agent reached maximum iterations)".to_string())
-}
-
-/// Emit an `AskUserRequest` and wait for the user's typed response.
-///
-/// Returns `None` if the session was interrupted or cancelled.
-pub(crate) async fn handle_ask_user(
-    sink: &dyn crate::engine::EngineSink,
-    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    cancel: &CancellationToken,
-    args: &serde_json::Value,
-) -> Option<String> {
-    let question = args["question"].as_str().unwrap_or("").to_string();
-    let options: Vec<String> = args["options"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let request_id = uuid::Uuid::new_v4().to_string();
-    sink.emit(EngineEvent::AskUserRequest {
-        id: request_id.clone(),
-        question,
-        options,
-    });
-
-    loop {
-        tokio::select! {
-            cmd = cmd_rx.recv() => match cmd {
-                Some(EngineCommand::AskUserResponse { id, answer }) if id == request_id => {
-                    return Some(answer);
-                }
-                Some(EngineCommand::Interrupt) => {
-                    cancel.cancel();
-                    return None;
-                }
-                None => return None,
-                _ => continue,
-            },
-            _ = cancel.cancelled() => return None,
-        }
-    }
-}
-
-pub(crate) async fn request_approval(
-    sink: &dyn crate::engine::EngineSink,
-    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    cancel: &CancellationToken,
-    tool_name: &str,
-    detail: &str,
-    preview: Option<crate::preview::DiffPreview>,
-) -> Option<ApprovalDecision> {
-    let approval_id = uuid::Uuid::new_v4().to_string();
-    sink.emit(EngineEvent::ApprovalRequest {
-        id: approval_id.clone(),
-        tool_name: tool_name.to_string(),
-        detail: detail.to_string(),
-        preview,
-    });
-
-    loop {
-        tokio::select! {
-            cmd = cmd_rx.recv() => match cmd {
-                Some(EngineCommand::ApprovalResponse { id, decision }) if id == approval_id => {
-                    return Some(decision);
-                }
-                Some(EngineCommand::Interrupt) => {
-                    cancel.cancel();
-                    return None;
-                }
-                None => return None,  // channel closed
-                _ => continue,        // ignore unrelated commands
-            },
-            _ = cancel.cancelled() => return None,
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Extract sub-agent invocation and approval flow from `tool_dispatch.rs` (1,243 lines) into two focused modules. Pure refactor — no behavior change.

### Before

```
tool_dispatch.rs (1,243 lines) — sequential, parallel, split-batch,
    sub-agent, background agents, approval, ask-user, result recording
```

### After

```
tool_dispatch.rs       (777 lines) — dispatch execution strategies + result recording
sub_agent_dispatch.rs  (410 lines) — InvokeAgent, background spawning, worktree, caching
approval_flow.rs        (90 lines) — request_approval, handle_ask_user
```

### Dependency graph

```
tool_dispatch → sub_agent_dispatch → approval_flow
             → approval_flow
```

### What moved where

| Function | From | To |
|---|---|---|
| `execute_sub_agent` | tool_dispatch | sub_agent_dispatch |
| `run_bg_agent` | tool_dispatch | sub_agent_dispatch |
| `request_approval` | tool_dispatch | approval_flow |
| `handle_ask_user` | tool_dispatch | approval_flow |

### What stayed

- `record_tool_result`, `truncate_for_history`, `resolve_tool_path`, `track_file_lifecycle` — dispatch internals
- `can_parallelize`, `execute_one_tool` — dispatch classification
- `execute_tools_parallel`, `execute_tools_split_batch`, `execute_tools_sequential` — execution strategies
- All tests — they test `can_parallelize` which stayed

### Verification

- All 286 tests pass
- Clean build with no warnings
- `inference.rs` imports unchanged (still imports from `tool_dispatch`)

Closes #643
