### PR TITLE
feat: streaming tool executor — eager dispatch during streaming

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -65,6 +65,12 @@ struct StreamResult {
     text: String,
     /// Tool calls requested by the model.
     tool_calls: Vec<ToolCall>,
+    /// Results from tools executed eagerly during streaming.
+    ///
+    /// Contains `(tool_call_id, output, success, full_output)` for each
+    /// read-only auto-approved tool that finished before the stream ended.
+    /// These tools are skipped during normal dispatch.
+    eager_results: Vec<(String, String, bool, Option<String>)>,
     /// Token usage statistics.
     usage: TokenUsage,
     /// Total character count of text deltas.
@@ -313,18 +319,28 @@ async fn try_overflow_recovery(
     Ok(Some((rx, messages)))
 }
 
-/// Collect a streamed LLM response, emitting engine events for thinking/text/tool calls.
+/// Collect a streamed LLM response, executing read-only tools eagerly.
 ///
-/// Handles thinking ↔ response state transitions, cancellation via `CancellationToken`,
+/// When a `ToolCallReady` event arrives (Anthropic `content_block_stop`),
+/// and the tool is read-only + auto-approved, it executes immediately while
+/// subsequent tool call arguments are still being streamed. This overlaps
+/// tool execution with LLM generation time — the key latency optimization
+/// from Claude Code's `StreamingToolExecutor` pattern.
+///
+/// Handles thinking → response state transitions, cancellation via `CancellationToken`,
 /// and spinner lifecycle. Returns a `StreamResult` — the caller is responsible for
 /// persistence and early-return on interruption.
 async fn collect_stream(
     rx: &mut mpsc::Receiver<StreamChunk>,
     sink: &dyn EngineSink,
     cancel: &CancellationToken,
+    tools: &ToolRegistry,
+    mode: ApprovalMode,
+    project_root: &Path,
 ) -> StreamResult {
     let mut full_text = String::new();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
+    let mut eager_results: Vec<(String, String, bool, Option<String>)> = Vec::new();
     let mut usage = TokenUsage::default();
     let mut first_token = true;
     let mut char_count: usize = 0;
@@ -353,6 +369,7 @@ async fn collect_stream(
             return StreamResult {
                 text: full_text,
                 tool_calls,
+                eager_results,
                 usage,
                 char_count,
                 interrupted: true,
@@ -397,6 +414,34 @@ async fn collect_stream(
                 });
                 native_think_buf.push_str(&delta);
             }
+            StreamChunk::ToolCallReady(tc) => {
+                // A single tool call finished streaming (Anthropic content_block_stop).
+                // If it's read-only and auto-approved, execute it now while
+                // subsequent tool calls are still being streamed.
+                if !native_think_buf.is_empty() {
+                    sink.emit(EngineEvent::SpinnerStop);
+                    sink.emit(EngineEvent::ThinkingDone);
+                    native_think_buf.clear();
+                }
+                let args: serde_json::Value =
+                    serde_json::from_str(&tc.arguments).unwrap_or_default();
+                let is_read_only = !crate::tools::is_mutating_tool(&tc.function_name);
+                let is_auto_approved = !matches!(
+                    crate::approval::check_tool(&tc.function_name, &args, mode, Some(project_root),),
+                    crate::approval::ToolApproval::NeedsConfirmation
+                        | crate::approval::ToolApproval::Blocked
+                );
+
+                if is_read_only && is_auto_approved && tc.function_name != "InvokeAgent" {
+                    // Execute eagerly — read-only tools are fast (10–50ms),
+                    // the channel buffers incoming chunks while we run.
+                    tracing::debug!("Eager dispatch: {} (id={})", tc.function_name, tc.id);
+                    let r = tools.execute(&tc.function_name, &tc.arguments, None).await;
+                    eager_results.push((tc.id.clone(), r.output, r.success, r.full_output));
+                }
+                // Always add to tool_calls for persistence and normal flow
+                tool_calls.push(tc);
+            }
             StreamChunk::ToolCalls(tcs) => {
                 if !native_think_buf.is_empty() {
                     sink.emit(EngineEvent::SpinnerStop);
@@ -404,7 +449,8 @@ async fn collect_stream(
                     native_think_buf.clear();
                 }
                 sink.emit(EngineEvent::SpinnerStop);
-                tool_calls = tcs;
+                // Append — some tool calls may already be in the list from ToolCallReady
+                tool_calls.extend(tcs);
             }
             StreamChunk::Done(u) => {
                 if !native_think_buf.is_empty() {
@@ -428,6 +474,7 @@ async fn collect_stream(
                 return StreamResult {
                     text: full_text,
                     tool_calls,
+                    eager_results,
                     usage,
                     char_count,
                     interrupted: false,
@@ -446,6 +493,7 @@ async fn collect_stream(
     StreamResult {
         text: full_text,
         tool_calls,
+        eager_results,
         usage,
         char_count,
         interrupted: false,
@@ -665,7 +713,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         };
 
         // Collect the streamed response
-        let stream_result = collect_stream(&mut rx, sink, &cancel).await;
+        let stream_result = collect_stream(&mut rx, sink, &cancel, tools, mode, project_root).await;
 
         if stream_result.interrupted {
             if !stream_result.text.is_empty() {
@@ -805,10 +853,55 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
         made_tool_calls = true;
 
-        // Execute tool calls — parallelize when possible
-        if tool_calls.len() > 1 && can_parallelize(&tool_calls, mode, project_root) {
+        // Record results from eagerly-executed tools (dispatched during streaming)
+        let eager_ids: std::collections::HashSet<String> = stream_result
+            .eager_results
+            .iter()
+            .map(|(id, _, _, _)| id.clone())
+            .collect();
+
+        if !eager_ids.is_empty() {
+            tracing::info!(
+                "{} tool(s) executed eagerly during streaming",
+                eager_ids.len()
+            );
+            for (tc_id, result, success, full_output) in &stream_result.eager_results {
+                // Find the matching ToolCall for metadata
+                if let Some(tc) = tool_calls.iter().find(|tc| tc.id == *tc_id) {
+                    sink.emit(EngineEvent::ToolCallStart {
+                        id: tc_id.clone(),
+                        name: tc.function_name.clone(),
+                        args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
+                        is_sub_agent: false,
+                    });
+                    crate::tool_dispatch::record_tool_result(
+                        tc,
+                        result,
+                        *success,
+                        full_output.as_deref(),
+                        db,
+                        session_id,
+                        tools.caps.tool_result_chars,
+                        project_root,
+                        file_tracker,
+                        sink,
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        // Filter out eagerly-executed tools from the remaining dispatch
+        let remaining_tools: Vec<ToolCall> = tool_calls
+            .iter()
+            .filter(|tc| !eager_ids.contains(&tc.id))
+            .cloned()
+            .collect();
+
+        // Execute remaining tool calls — parallelize when possible
+        if remaining_tools.len() > 1 && can_parallelize(&remaining_tools, mode, project_root) {
             execute_tools_parallel(
-                &tool_calls,
+                &remaining_tools,
                 project_root,
                 config,
                 db,
@@ -822,9 +915,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 &bg_agents,
             )
             .await?;
-        } else if tool_calls.len() > 1 {
+        } else if remaining_tools.len() > 1 {
             execute_tools_split_batch(
-                &tool_calls,
+                &remaining_tools,
                 project_root,
                 config,
                 db,
@@ -840,9 +933,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 &bg_agents,
             )
             .await?;
-        } else {
+        } else if !remaining_tools.is_empty() {
             execute_tools_sequential(
-                &tool_calls,
+                &remaining_tools,
                 project_root,
                 config,
                 db,

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -303,6 +303,8 @@ use super::stream_collector::ChunkParser;
 /// and accumulates tool calls + usage across the stream.
 pub(crate) struct AnthropicChunkParser {
     tool_calls: Vec<(String, String, String)>, // (id, name, args_json)
+    /// Indices of tool calls already emitted via `ToolCallReady`.
+    emitted_tool_indices: std::collections::HashSet<usize>,
     usage: TokenUsage,
     thinking_indices: std::collections::HashSet<usize>,
 }
@@ -311,6 +313,7 @@ impl AnthropicChunkParser {
     pub fn new() -> Self {
         Self {
             tool_calls: Vec::new(),
+            emitted_tool_indices: std::collections::HashSet::new(),
             usage: TokenUsage::default(),
             thinking_indices: std::collections::HashSet::new(),
         }
@@ -394,7 +397,24 @@ impl ChunkParser for AnthropicChunkParser {
                     self.usage.cache_creation_tokens = u.cache_creation_input_tokens;
                 }
             }
-            _ => {} // message_stop, content_block_stop, ping, etc.
+            _ => {
+                // content_block_stop — emit ToolCallReady for completed tool calls
+                if event.event_type == "content_block_stop"
+                    && let Some(idx) = event.index
+                    && idx < self.tool_calls.len()
+                    && !self.tool_calls[idx].0.is_empty()
+                {
+                    let (id, name, args) = &self.tool_calls[idx];
+                    chunks.push(StreamChunk::ToolCallReady(ToolCall {
+                        id: id.clone(),
+                        function_name: name.clone(),
+                        arguments: args.clone(),
+                        thought_signature: None,
+                    }));
+                    self.emitted_tool_indices.insert(idx);
+                }
+                // message_stop, ping, etc. — ignored
+            }
         }
 
         chunks
@@ -403,18 +423,22 @@ impl ChunkParser for AnthropicChunkParser {
     fn finish(&mut self) -> Vec<StreamChunk> {
         let mut chunks = Vec::new();
         if !self.tool_calls.is_empty() {
-            let tcs = self
+            // Only emit tool calls NOT already sent via ToolCallReady
+            let tcs: Vec<_> = self
                 .tool_calls
-                .drain(..)
-                .filter(|(id, _, _)| !id.is_empty())
-                .map(|(id, name, args)| ToolCall {
-                    id,
-                    function_name: name,
-                    arguments: args,
+                .iter()
+                .enumerate()
+                .filter(|(i, (id, _, _))| !id.is_empty() && !self.emitted_tool_indices.contains(i))
+                .map(|(_, (id, name, args))| ToolCall {
+                    id: id.clone(),
+                    function_name: name.clone(),
+                    arguments: args.clone(),
                     thought_signature: None,
                 })
                 .collect();
-            chunks.push(StreamChunk::ToolCalls(tcs));
+            if !tcs.is_empty() {
+                chunks.push(StreamChunk::ToolCalls(tcs));
+            }
         }
         chunks.push(StreamChunk::Done(std::mem::take(&mut self.usage)));
         chunks

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -229,7 +229,19 @@ pub enum StreamChunk {
     TextDelta(String),
     /// A thinking/reasoning delta from native API (Anthropic extended thinking, OpenAI reasoning).
     ThinkingDelta(String),
-    /// A tool call was returned (streaming ends, need full response).
+    /// A single tool call whose arguments finished streaming.
+    ///
+    /// Emitted by providers that support per-block completion events (Anthropic
+    /// `content_block_stop`). Enables eager execution of read-only tools while
+    /// subsequent tool calls are still being streamed.
+    ///
+    /// Providers that don't support per-block events (OpenAI, Gemini) never
+    /// emit this — they only emit `ToolCalls` at stream end.
+    ToolCallReady(ToolCall),
+    /// All tool calls from the response (batch, emitted at stream end).
+    ///
+    /// For Anthropic, this only contains tool calls NOT already emitted via
+    /// `ToolCallReady`. For other providers, this contains all tool calls.
     ToolCalls(Vec<ToolCall>),
     /// Stream finished with usage info.
     Done(TokenUsage),

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -34,7 +34,7 @@ use tokio_util::sync::CancellationToken;
 /// and file lifecycle. Called after every successful tool execution regardless
 /// of execution strategy (parallel, split-batch, or sequential).
 #[allow(clippy::too_many_arguments)]
-async fn record_tool_result(
+pub(crate) async fn record_tool_result(
     tc: &ToolCall,
     result: &str,
     success: bool,


### PR DESCRIPTION
## Summary

Implement streaming tool executor following Claude Code's `StreamingToolExecutor` pattern. Read-only auto-approved tools execute during LLM response streaming, overlapping tool execution with generation time.

Closes #644

### The Pattern (from Claude Code)

```
Before: Stream all → Collect all → Execute all
After:  Stream → Tool ready? Execute now → Continue streaming → Execute remaining
```

### How it works

1. **Anthropic parser** (`content_block_stop`): Each tool call's arguments finish before the next tool call starts streaming. On `content_block_stop`, emit `ToolCallReady(ToolCall)` immediately.

2. **`collect_stream`**: When `ToolCallReady` arrives, check:
   - `is_read_only` (Read, List, Grep, Glob, etc.)
   - `is_auto_approved` (not blocked/needs-confirmation)
   - Not `InvokeAgent` (sub-agents need full approval flow)
   
   If all true → execute inline (~10-50ms). The mpsc channel (capacity 64) buffers incoming chunks while we run.

3. **Inference loop**: Record eager results, skip them during normal dispatch.

### Key scenario

```
Model generates: Read("foo.rs") + Edit("bar.rs", 500 lines of replacement)

Before: wait 3-5s for Edit args to stream → execute Read (30ms) → execute Edit
After:  Read executes during Edit's streaming → execute Edit only (saves 30ms+)
```

The real win is when multiple reads precede a large edit — each read completes while the edit's arguments are still streaming.

### Design decisions

| Decision | Rationale |
|---|---|
| Inline execution (not spawned tasks) | Avoids Send/Sync complexity |
| InvokeAgent excluded | Sub-agents need approval flow |
| Other providers unaffected | Only Anthropic has content_block_stop |
| `finish()` deduplicates | Skips tools already sent via ToolCallReady |
| `record_tool_result` → pub(crate) | Needed by inference.rs for eager results |

### New `StreamChunk` variant

```rust
/// A single tool call whose arguments finished streaming.
/// Emitted by providers with per-block completion events (Anthropic).
ToolCallReady(ToolCall),
```

### Files changed

| File | Change |
|---|---|
| `providers/mod.rs` | Add `ToolCallReady(ToolCall)` variant |
| `providers/anthropic.rs` | Emit on `content_block_stop`, deduplicate in `finish()` |
| `inference.rs` | Handle in `collect_stream`, record + filter in loop |
| `tool_dispatch.rs` | `record_tool_result` → `pub(crate)` |

### Verification

- All 286 tests pass
- Clean clippy (zero warnings)
- Clean fmt
- Other providers (OpenAI, Gemini) completely unaffected — they never emit `ToolCallReady`
