### PR TITLE
fix: remove inaccurate provider descriptions, derive from type

### DIFF
--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -136,21 +136,24 @@ pub async fn handle_command(
 }
 
 /// Available providers for the interactive picker.
-pub const PROVIDERS: &[(&str, &str, &str)] = &[
-    ("lmstudio", "LM Studio", "Local, no API key"),
-    ("ollama", "Ollama", "Local, no API key"),
-    ("openai", "OpenAI", ""),
-    ("anthropic", "Anthropic", ""),
-    ("deepseek", "DeepSeek", ""),
-    ("gemini", "Google Gemini", ""),
-    ("groq", "Groq", "Fast inference"),
-    ("grok", "Grok (xAI)", ""),
-    ("mistral", "Mistral", ""),
-    ("minimax", "MiniMax", ""),
-    ("openrouter", "OpenRouter", "Meta-provider"),
-    ("together", "Together", ""),
-    ("fireworks", "Fireworks", "Fast inference"),
-    ("vllm", "vLLM", "Local, no API key"),
+///
+/// Tuple: (internal_key, display_name). Descriptions like "Local, no API key"
+/// are derived from `ProviderType::requires_api_key()` at render time.
+pub const PROVIDERS: &[(&str, &str)] = &[
+    ("lmstudio", "LM Studio"),
+    ("ollama", "Ollama"),
+    ("openai", "OpenAI"),
+    ("anthropic", "Anthropic"),
+    ("deepseek", "DeepSeek"),
+    ("gemini", "Google Gemini"),
+    ("groq", "Groq"),
+    ("grok", "Grok (xAI)"),
+    ("mistral", "Mistral"),
+    ("minimax", "MiniMax"),
+    ("openrouter", "OpenRouter"),
+    ("together", "Together"),
+    ("fireworks", "Fireworks"),
+    ("vllm", "vLLM"),
 ];
 
 /// Get the full git diff (unstaged + staged), capped for context window safety.

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -87,15 +87,15 @@ impl TuiContext {
         let providers = crate::repl::PROVIDERS;
         let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
             .iter()
-            .map(
-                |(key, name, desc)| crate::widgets::provider_menu::ProviderItem {
+            .map(|(key, name)| {
+                let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
+                crate::widgets::provider_menu::ProviderItem {
                     key,
                     name,
-                    description: desc,
-                    is_current: koda_core::config::ProviderType::from_url_or_name("", Some(key))
-                        == self.config.provider_type,
-                },
-            )
+                    local: !ptype.requires_api_key(),
+                    is_current: ptype == self.config.provider_type,
+                }
+            })
             .collect();
         let mut dd =
             crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a provider");
@@ -114,17 +114,17 @@ impl TuiContext {
         let providers = crate::repl::PROVIDERS;
         let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
             .iter()
-            .filter(|&&(name, _, _)| {
+            .filter(|&&(name, _)| {
                 let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(name));
                 ptype.requires_api_key()
             })
-            .map(|&(key, name, desc)| {
+            .map(|&(key, name)| {
                 let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
                 let has_key = koda_core::runtime_env::is_set(ptype.env_key_name());
                 crate::widgets::provider_menu::ProviderItem {
                     key,
                     name,
-                    description: desc,
+                    local: false,
                     is_current: has_key, // repurpose: green = key is set
                 }
             })

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -230,14 +230,15 @@ impl TuiContext {
             let providers = crate::repl::PROVIDERS;
             let items: Vec<crate::widgets::provider_menu::ProviderItem> = providers
                 .iter()
-                .map(
-                    |(key, name, desc)| crate::widgets::provider_menu::ProviderItem {
+                .map(|(key, name)| {
+                    let ptype = koda_core::config::ProviderType::from_url_or_name("", Some(key));
+                    crate::widgets::provider_menu::ProviderItem {
                         key,
                         name,
-                        description: desc,
+                        local: !ptype.requires_api_key(),
                         is_current: false,
-                    },
-                )
+                    }
+                })
                 .collect();
             menu = MenuContent::Provider(crate::widgets::dropdown::DropdownState::new(
                 items,

--- a/koda-cli/src/widgets/provider_menu.rs
+++ b/koda-cli/src/widgets/provider_menu.rs
@@ -12,8 +12,8 @@ pub struct ProviderItem {
     pub key: &'static str,
     /// Display name (e.g. "Anthropic", "OpenAI").
     pub name: &'static str,
-    /// Short description (e.g. "Claude Sonnet, Opus").
-    pub description: &'static str,
+    /// Whether this is a local provider (no API key needed).
+    pub local: bool,
     /// Whether this is the currently active provider.
     pub is_current: bool,
 }
@@ -23,9 +23,16 @@ impl DropdownItem for ProviderItem {
         self.name
     }
     fn description(&self) -> String {
-        let mut desc = self.description.to_string();
+        let mut desc = if self.local {
+            "Local, no API key".to_string()
+        } else {
+            String::new()
+        };
         if self.is_current {
-            desc.push_str(" \u{25c0} current");
+            if !desc.is_empty() {
+                desc.push(' ');
+            }
+            desc.push_str("\u{25c0} current");
         }
         desc
     }
@@ -33,7 +40,7 @@ impl DropdownItem for ProviderItem {
         let f = filter.to_lowercase();
         self.name.to_lowercase().contains(&f)
             || self.key.to_lowercase().contains(&f)
-            || self.description.to_lowercase().contains(&f)
+            || (self.local && "local".contains(&f))
     }
 }
 
@@ -46,23 +53,34 @@ mod tests {
         let item = ProviderItem {
             key: "anthropic",
             name: "Anthropic",
-            description: "Claude Sonnet, Opus",
+            local: false,
             is_current: true,
         };
         assert!(item.description().contains('\u{25c0}'));
     }
 
     #[test]
-    fn filter_matches_key_name_desc() {
+    fn local_shows_description() {
         let item = ProviderItem {
-            key: "anthropic",
-            name: "Anthropic",
-            description: "Claude Sonnet, Opus",
+            key: "ollama",
+            name: "Ollama",
+            local: true,
             is_current: false,
         };
-        assert!(item.matches_filter("anth"));
-        assert!(item.matches_filter("Claude"));
-        assert!(item.matches_filter("opus"));
+        assert!(item.description().contains("Local, no API key"));
+    }
+
+    #[test]
+    fn filter_matches_key_name_local() {
+        let item = ProviderItem {
+            key: "lmstudio",
+            name: "LM Studio",
+            local: true,
+            is_current: false,
+        };
+        assert!(item.matches_filter("lm"));
+        assert!(item.matches_filter("Studio"));
+        assert!(item.matches_filter("local"));
         assert!(!item.matches_filter("gemini"));
     }
 }

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -30,7 +30,7 @@ pub enum ProviderType {
     LMStudio,
     /// Google Gemini API.
     Gemini,
-    /// Groq (fast inference, OpenAI-compatible).
+    /// Groq (OpenAI-compatible).
     Groq,
     /// Grok / xAI API.
     Grok,


### PR DESCRIPTION
Closes #649

Remove hardcoded 'Fast inference' (Groq, Fireworks) and 'Meta-provider' (OpenRouter) descriptions. The only useful description ('Local, no API key') is now derived from `ProviderType::requires_api_key()` instead of stored as a static string.

### Before
```rust
pub const PROVIDERS: &[(&str, &str, &str)] = &[
    ("groq", "Groq", "Fast inference"),      // inaccurate
    ("openrouter", "OpenRouter", "Meta-provider"), // jargon-y
    ("ollama", "Ollama", "Local, no API key"),  // useful but duplicated
    ("openai", "OpenAI", ""),                   // 11 of these
];
```

### After
```rust
pub const PROVIDERS: &[(&str, &str)] = &[
    ("groq", "Groq"),
    ("openrouter", "OpenRouter"),
    ("ollama", "Ollama"),       // 'Local, no API key' derived from requires_api_key()
    ("openai", "OpenAI"),
];
```

### Why DRYer
- `ProviderItem.local: bool` replaces `description: &'static str`
- `description()` method derives the text from the bool
- `matches_filter("local")` still works for finding local providers
- Impossible for descriptions to drift from actual provider capabilities

All tests pass, clean clippy, clean fmt.