### PR TITLE
fix(provider-menu): rename is_current → key_set, remove stale marker

### DIFF
--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -93,19 +93,11 @@ impl TuiContext {
                     key,
                     name,
                     local: !ptype.requires_api_key(),
-                    is_current: ptype == self.config.provider_type,
+                    key_set: false,
                 }
             })
             .collect();
-        let mut dd =
-            crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a provider");
-        if let Some(idx) = dd.filtered.iter().position(|p| p.is_current) {
-            dd.selected = idx;
-            let max_vis = crate::widgets::dropdown::MAX_VISIBLE;
-            if idx >= max_vis {
-                dd.scroll_offset = idx + 1 - max_vis;
-            }
-        }
+        let dd = crate::widgets::dropdown::DropdownState::new(items, "\u{1f43b} Select a provider");
         self.menu = MenuContent::Provider(dd);
     }
 
@@ -125,7 +117,7 @@ impl TuiContext {
                     key,
                     name,
                     local: false,
-                    is_current: has_key, // repurpose: green = key is set
+                    key_set: has_key,
                 }
             })
             .collect();

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -236,7 +236,7 @@ impl TuiContext {
                         key,
                         name,
                         local: !ptype.requires_api_key(),
-                        is_current: false,
+                        key_set: false,
                     }
                 })
                 .collect();

--- a/koda-cli/src/widgets/provider_menu.rs
+++ b/koda-cli/src/widgets/provider_menu.rs
@@ -1,7 +1,6 @@
 //! Provider picker dropdown — thin wrapper around the generic dropdown.
 //!
-//! Appears when the user types `/provider` with no args.
-//! After selection, the provider setup flow continues with API key input.
+//! Used by both `/provider` (onboarding/model-list) and `/key` (API key mgmt).
 
 use super::dropdown::DropdownItem;
 
@@ -14,8 +13,9 @@ pub struct ProviderItem {
     pub name: &'static str,
     /// Whether this is a local provider (no API key needed).
     pub local: bool,
-    /// Whether this is the currently active provider.
-    pub is_current: bool,
+    /// Whether an API key is configured for this provider.
+    /// Only meaningful in the `/key` picker — always `false` in `/provider`.
+    pub key_set: bool,
 }
 
 impl DropdownItem for ProviderItem {
@@ -28,11 +28,11 @@ impl DropdownItem for ProviderItem {
         } else {
             String::new()
         };
-        if self.is_current {
+        if self.key_set {
             if !desc.is_empty() {
                 desc.push(' ');
             }
-            desc.push_str("\u{25c0} current");
+            desc.push('\u{2705}');
         }
         desc
     }
@@ -49,14 +49,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn current_shows_marker() {
+    fn key_set_shows_checkmark() {
         let item = ProviderItem {
             key: "anthropic",
             name: "Anthropic",
             local: false,
-            is_current: true,
+            key_set: true,
         };
-        assert!(item.description().contains('\u{25c0}'));
+        assert!(item.description().contains('\u{2705}'));
+    }
+
+    #[test]
+    fn no_key_no_marker() {
+        let item = ProviderItem {
+            key: "openai",
+            name: "OpenAI",
+            local: false,
+            key_set: false,
+        };
+        assert!(item.description().is_empty());
     }
 
     #[test]
@@ -65,7 +76,7 @@ mod tests {
             key: "ollama",
             name: "Ollama",
             local: true,
-            is_current: false,
+            key_set: false,
         };
         assert!(item.description().contains("Local, no API key"));
     }
@@ -76,7 +87,7 @@ mod tests {
             key: "lmstudio",
             name: "LM Studio",
             local: true,
-            is_current: false,
+            key_set: false,
         };
         assert!(item.matches_filter("lm"));
         assert!(item.matches_filter("Studio"));


### PR DESCRIPTION
Closes #652

## Problem

`ProviderItem.is_current` was overloaded:
- In `/provider`: compared against `config.provider_type`, but that's stale — the active model determines the provider implicitly
- In `/key`: repurposed to mean "has API key configured" (with a misleading `// repurpose` comment)

The `◀ current` marker in the provider picker was meaningless and could spuriously match multiple providers.

## Fix

| Before | After |
|---|---|
| `is_current: bool` | `key_set: bool` |
| `◀ current` marker in both pickers | ✅ checkmark in `/key` only |
| Pre-scroll to "current" in `/provider` | No pre-scroll (no current concept) |

### Changes
- **`provider_menu.rs`**: rename field, update label `◀ current` → `✅`, update tests
- **`menus.rs`**: `open_provider_picker` sets `key_set: false`, removes pre-scroll; `open_key_picker` sets `key_set: has_key`
- **`mod.rs`**: startup provider picker sets `key_set: false`

3 files changed, 26 insertions, 22 deletions. All tests pass.