### PR TITLE
fix: read context window from local provider API, not lookup table

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -65,6 +65,10 @@ pub async fn handle_slash_command(
                     config.model_settings.model = config.model.clone();
                     config.recalculate_model_derived();
                     *provider.write().await = koda_core::providers::create_provider(config);
+                    {
+                        let prov = provider.read().await;
+                        config.query_and_apply_capabilities(prov.as_ref()).await;
+                    }
                     crate::tui_wizards::save_provider(config);
                     tui_output::ok_msg(
                         buffer,

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -462,6 +462,7 @@ impl TuiContext {
                                 self.config.model = actual_model.clone();
                                 self.config.model_settings.model = actual_model.clone();
                                 self.config.recalculate_model_derived();
+                                self.query_model_capabilities().await;
                                 crate::tui_wizards::save_provider(&self.config);
                                 self.renderer.model = actual_model.clone();
                                 self.scroll_buffer.push(Line::styled(
@@ -474,6 +475,7 @@ impl TuiContext {
                             self.config.model = model_id.clone();
                             self.config.model_settings.model = model_id.clone();
                             self.config.recalculate_model_derived();
+                            self.query_model_capabilities().await;
                             crate::tui_wizards::save_provider(&self.config);
                             self.renderer.model = model_id.clone();
                             self.scroll_buffer.push(Line::styled(
@@ -549,6 +551,7 @@ impl TuiContext {
                     self.config.model = model_id.clone();
                     self.config.model_settings.model = model_id.clone();
                     self.config.recalculate_model_derived();
+                    self.query_model_capabilities().await;
                     crate::tui_wizards::save_provider(&self.config);
                     self.renderer.model = model_id.clone();
                     self.scroll_buffer.push(Line::styled(
@@ -681,6 +684,18 @@ impl TuiContext {
             ),
             Style::default().fg(Color::Green),
         ));
+    }
+
+    /// Query the provider API for context window and apply it.
+    ///
+    /// Called after `recalculate_model_derived()` on model switch so local
+    /// providers (LM Studio, Ollama) report their actual configured context
+    /// window instead of using the lookup table.
+    async fn query_model_capabilities(&mut self) {
+        let prov = self.provider.read().await;
+        self.config
+            .query_and_apply_capabilities(prov.as_ref())
+            .await;
     }
 }
 

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -503,25 +503,34 @@ impl LlmProvider for OpenAiCompatProvider {
     }
 
     async fn model_capabilities(&self, model: &str) -> Result<super::ModelCapabilities> {
-        // Try LM Studio / Ollama extended endpoint first (/api/v0/models)
-        // which returns max_context_length per model.
         let base = self.base_url.trim_end_matches("/v1");
-        if let Ok(caps) = self.query_local_capabilities(base, model).await
+
+        // LM Studio: GET /api/v0/models → data[].max_context_length
+        // Only one model is loaded at a time, so just take the first entry.
+        if let Ok(caps) = self.query_lmstudio_capabilities(base).await
             && caps.context_window.is_some()
         {
             return Ok(caps);
         }
+
+        // Ollama: POST /api/show → model_info.general.context_length
+        if let Ok(caps) = self.query_ollama_capabilities(base, model).await
+            && caps.context_window.is_some()
+        {
+            return Ok(caps);
+        }
+
         Ok(super::ModelCapabilities::default())
     }
 }
 
 impl OpenAiCompatProvider {
-    /// Query LM Studio / Ollama extended model info for context window.
-    async fn query_local_capabilities(
-        &self,
-        base: &str,
-        model: &str,
-    ) -> Result<super::ModelCapabilities> {
+    /// Query LM Studio for the loaded model's context window.
+    ///
+    /// LM Studio serves one model at a time. The user configures the context
+    /// window in LM Studio's UI, so the API-reported value is the source of
+    /// truth — not a lookup table.
+    async fn query_lmstudio_capabilities(&self, base: &str) -> Result<super::ModelCapabilities> {
         let resp = self
             .client
             .get(format!("{base}/api/v0/models"))
@@ -533,22 +542,54 @@ impl OpenAiCompatProvider {
         }
 
         let body: serde_json::Value = resp.json().await?;
-        let models = body["data"].as_array();
 
-        if let Some(models) = models {
-            for m in models {
-                let id = m["id"].as_str().unwrap_or_default();
-                if id == model {
-                    let ctx = m["max_context_length"].as_u64().map(|v| v as usize);
-                    return Ok(super::ModelCapabilities {
-                        context_window: ctx,
-                        max_output_tokens: None,
-                    });
-                }
+        // Take the first loaded model — no ID matching needed.
+        if let Some(model) = body["data"].as_array().and_then(|a| a.first()) {
+            let ctx = model["max_context_length"].as_u64().map(|v| v as usize);
+            if let Some(c) = ctx {
+                tracing::info!("LM Studio reports context window: {c} tokens");
             }
+            return Ok(super::ModelCapabilities {
+                context_window: ctx,
+                max_output_tokens: None,
+            });
         }
 
         Ok(super::ModelCapabilities::default())
+    }
+
+    /// Query Ollama for model context window via `/api/show`.
+    async fn query_ollama_capabilities(
+        &self,
+        base: &str,
+        model: &str,
+    ) -> Result<super::ModelCapabilities> {
+        let resp = self
+            .client
+            .post(format!("{base}/api/show"))
+            .json(&serde_json::json!({ "name": model }))
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Ok(super::ModelCapabilities::default());
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+
+        // Ollama reports context length in model_info.general.context_length
+        let ctx = body["model_info"]["general.context_length"]
+            .as_u64()
+            .map(|v| v as usize);
+
+        if let Some(ctx) = ctx {
+            tracing::info!("Ollama reports context window: {ctx} tokens");
+        }
+
+        Ok(super::ModelCapabilities {
+            context_window: ctx,
+            max_output_tokens: None,
+        })
     }
 }
 /// Convert OpenAI usage response to our TokenUsage, extracting reasoning_tokens.


### PR DESCRIPTION
Closes #654

## Problem

LM Studio users configure context window in the UI (e.g. 262K for qwen3.5-122b), but koda used a hardcoded lookup table that returned **32K** for qwen3.5 models. This caused:
- Premature compaction after ~12 tool calls
- 4 microcompact cycles
- Empty model responses on synthesis

The existing API query (`/api/v0/models`) tried to match model IDs exactly, which failed when LM Studio reported a slightly different ID string.

## Root Insight

LM Studio serves **one model at a time**. There's no need to match IDs — just read the context window from whatever model is loaded. The user-configured value in LM Studio is the source of truth, not a lookup table.

## Fix (3 parts)

### 1. `query_lmstudio_capabilities` — no ID matching
```rust
// Before: loop through models, exact ID match
for m in models { if id == model { ... } }

// After: take the first (only) loaded model
if let Some(model) = body["data"].as_array().and_then(|a| a.first()) {
    let ctx = model["max_context_length"].as_u64();
}
```

### 2. `query_ollama_capabilities` — new
```rust
POST /api/show {"name": model}
→ body["model_info"]["general.context_length"]
```

### 3. All model-switch paths query the API
Before: 3 of 5 model-switch code paths called `recalculate_model_derived()` without following up with `query_and_apply_capabilities()`, silently clobbering API values with lookup table values.

Now all paths call `query_model_capabilities()` after `recalculate_model_derived()`.

## Files Changed

| File | Change |
|---|---|
| `openai_compat.rs` | Replace `query_local_capabilities` with `query_lmstudio_capabilities` + `query_ollama_capabilities` |
| `menus.rs` | Add `query_model_capabilities()` helper; call it on all model-switch paths |
| `tui_commands.rs` | Call `query_and_apply_capabilities` on alias model switch |

3 files, +80 −20 lines. All tests pass, clean clippy, clean fmt.