### PR TITLE
fix: graceful degradation for weak models that can't tool-call

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -214,6 +214,26 @@ For example, `/model claude-sonnet` switches instantly to Claude Sonnet
 (resolving the alias to the exact model ID and switching provider if needed).
 `/model <exact-model-id>` works for models not in the alias list.
 
+### Model requirements
+
+Koda requires models with **native function/tool calling** support.
+The model must emit structured `function_call` blocks — not JSON as
+plain text. Models that can't do this will produce errors and a warning:
+
+> *This model appears to struggle with tool calling.
+> Consider switching to a model with native function-call support.*
+
+**Known-good local models** (via LM Studio or Ollama):
+
+| Model | Tool calling | Notes |
+|---|---|---|
+| Qwen 3.x (any size) | ✅ | Recommended for local use |
+| Llama 3.3 70B+ | ✅ | Strong tool calling |
+| DeepSeek V3 | ✅ | |
+| Mistral Small/Large | ✅ | |
+| Phi-4 | ⚠️ | Mostly works, occasional hallucinated tool names |
+| GLM-4 / tiny models | ❌ | Emits JSON as text, not function calls |
+
 ---
 
 ## File References

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -223,16 +223,10 @@ plain text. Models that can't do this will produce errors and a warning:
 > *This model appears to struggle with tool calling.
 > Consider switching to a model with native function-call support.*
 
-**Known-good local models** (via LM Studio or Ollama):
-
-| Model | Tool calling | Notes |
-|---|---|---|
-| Qwen 3.x (any size) | ✅ | Recommended for local use |
-| Llama 3.3 70B+ | ✅ | Strong tool calling |
-| DeepSeek V3 | ✅ | |
-| Mistral Small/Large | ✅ | |
-| Phi-4 | ⚠️ | Mostly works, occasional hallucinated tool names |
-| GLM-4 / tiny models | ❌ | Emits JSON as text, not function calls |
+Most modern instruction-tuned models support tool calling, but some
+smaller or older models do not. If you see the warning above, try a
+different model. Check your model's documentation for function-call
+support.
 
 ---
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -18,7 +18,8 @@ use crate::engine::{EngineCommand, EngineEvent, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
     CONTEXT_WARN_THRESHOLD, PREFLIGHT_COMPACT_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
-    estimate_tokens, is_context_overflow_error, is_rate_limit_error, rate_limit_backoff,
+    estimate_tokens, is_context_overflow_error, is_rate_limit_error, is_server_error,
+    rate_limit_backoff,
 };
 use crate::loop_guard::LoopDetector;
 use crate::persistence::Persistence;
@@ -706,6 +707,17 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                         return Ok(());
                     }
                 }
+            }
+            Err(e) if is_server_error(&e) => {
+                sink.emit(EngineEvent::SpinnerStop);
+                sink.emit(EngineEvent::Warn {
+                    message: format!(
+                        "Provider returned a server error: {e:#}. \
+                         This often means the model can't handle the current \
+                         conversation state. Try a different model or start a new session."
+                    ),
+                });
+                return Ok(());
             }
             Err(e) => {
                 return Err(e).context("LLM inference failed");

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -64,6 +64,20 @@ pub fn assemble_messages(
     messages
 }
 
+/// Detect if an error is a server error (5xx) from the provider.
+///
+/// These are typically transient (LM Studio choking on malformed input,
+/// Ollama OOM, etc.) and should end the turn gracefully rather than crash.
+pub fn is_server_error(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}").to_lowercase();
+    msg.contains("500")
+        || msg.contains("502")
+        || msg.contains("503")
+        || msg.contains("internal server error")
+        || msg.contains("bad gateway")
+        || msg.contains("service unavailable")
+}
+
 /// Detect if an error is a rate limit or overload response from the provider.
 ///
 /// Matches HTTP 429 (Too Many Requests) and Anthropic's HTTP 529 (overloaded),

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -531,7 +531,20 @@ impl ToolRegistry {
                 };
             }
 
-            other => Err(anyhow::anyhow!("Unknown tool: {other}")),
+            other => {
+                // Detect garbled tool names (JSON blobs, very long strings)
+                // — a sign the model can't do structured tool calling.
+                let warning = if other.contains('{') || other.len() > 64 {
+                    format!(
+                        "Unknown tool: {other}. \
+                         This model appears to struggle with tool calling. \
+                         Consider switching to a model with native function-call support."
+                    )
+                } else {
+                    format!("Unknown tool: {other}")
+                };
+                Err(anyhow::anyhow!(warning))
+            }
         };
 
         match result {

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -183,12 +183,23 @@ async fn test_provider_error_emits_error_event() {
     })
     .await;
 
-    assert!(result.is_err(), "expected error from provider failure");
-    let err = result.unwrap_err();
-    let chain = format!("{err:?}");
     assert!(
-        chain.contains("Internal server error"),
-        "error chain should contain provider message, got: {chain}"
+        result.is_ok(),
+        "server errors should end gracefully, not crash"
+    );
+
+    // The warning should be emitted as an event, not as a fatal error
+    let events = sink.events();
+    let has_warn = events.iter().any(|e| {
+        if let EngineEvent::Warn { message } = e {
+            message.contains("server error")
+        } else {
+            false
+        }
+    });
+    assert!(
+        has_warn,
+        "expected a Warn event about server error, got events: {events:?}"
     );
 }
 


### PR DESCRIPTION
Closes #656

## Problem

Weak local models (e.g. `glm-4.6v-flash`) crash koda with a 500 cascade:

1. Model emits garbled tool name (JSON blob instead of `function_call`)
2. Koda sends error `tool_result` back
3. Provider chokes on next request → 500
4. Koda treats 500 as fatal → `✗ Turn failed`

## Fix (2 parts, +57 −7 lines)

### 1. Handle 500s gracefully (`inference.rs` + `inference_helpers.rs`)

New `is_server_error()` detects 5xx responses. Instead of `return Err(...)`, the inference loop now emits a `Warn` event and ends the turn cleanly:

```
⚠️ Provider returned a server error: 500 Internal Server Error.
   This often means the model can't handle the current conversation state.
   Try a different model or start a new session.
```

### 2. Warn on garbled tool names (`tools/mod.rs`)

When the tool name contains `{` or exceeds 64 chars (JSON blob as tool name):

```
Error: Unknown tool: {"detail": false, ...}.
This model appears to struggle with tool calling.
Consider switching to a model with native function-call support.
```

### Design decisions (from #656 discussion)

| Rejected | Why |
|---|---|
| Startup probe | Adds latency for every session, even with good models |
| Parse JSON from tool names | Rat hole — infinite model quirks |
| Fuzzy-match hallucinated names | Security risk (`Delete` ≠ `List`) |
| Chat-only fallback | A worse ChatGPT; defeats the purpose |

### Test update

`test_provider_error_emits_error_event` — updated to assert `Ok(())` + `Warn` event instead of `Err`.

4 files, all tests pass, clean clippy, clean fmt.