### PR TITLE
fix: include full_content in load_messages_before query

### DIFF
--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -216,7 +216,7 @@ impl Database {
         limit: i64,
     ) -> Result<Vec<Message>> {
         let rows: Vec<MessageRow> = sqlx::query_as(
-            "SELECT id, session_id, role, content, tool_calls, tool_call_id,
+            "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
                     cache_read_tokens, cache_creation_tokens, thinking_tokens
              FROM messages


### PR DESCRIPTION
The `load_messages_before` function was missing the `full_content` column in its SELECT statement, while both `load_context` and `load_all_messages` include it. This caused `full_content` to be silently set to None for paginated messages during virtual scroll pagination.

Fixes #658