### PR TITLE
fix: time-based microcompact — stop clearing tool results every turn

### DIFF
--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -249,6 +249,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -402,6 +402,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 

--- a/koda-core/src/context_analysis.rs
+++ b/koda-core/src/context_analysis.rs
@@ -339,6 +339,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -45,6 +45,11 @@ pub fn config_dir() -> Result<std::path::PathBuf> {
 }
 
 impl Database {
+    /// Access the underlying connection pool (for tests and raw queries).
+    pub fn pool(&self) -> &SqlitePool {
+        &self.pool
+    }
+
     /// Initialize the database, run migrations, and enable WAL mode.
     ///
     /// `koda_config_dir` is the koda configuration directory (e.g. `~/.config/koda`).
@@ -218,7 +223,8 @@ impl Database {
         let rows: Vec<MessageRow> = sqlx::query_as(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    created_at
              FROM messages
              WHERE session_id = ? AND id < ? AND compacted_at IS NULL
              ORDER BY id DESC
@@ -234,6 +240,23 @@ impl Database {
         let mut messages: Vec<Message> = rows.into_iter().map(|r| r.into()).collect();
         messages.reverse();
         Ok(messages)
+    }
+
+    /// Seconds since the last assistant message in this session.
+    ///
+    /// Returns `None` if there are no (non-compacted) assistant messages.
+    /// Used by microcompact to decide whether the idle gap threshold is met.
+    pub async fn seconds_since_last_assistant(&self, session_id: &str) -> Result<Option<i64>> {
+        let row: Option<(i64,)> = sqlx::query_as(
+            "SELECT CAST((julianday('now') - julianday(created_at)) * 86400 AS INTEGER) \
+             FROM messages \
+             WHERE session_id = ? AND role = 'assistant' AND compacted_at IS NULL \
+             ORDER BY id DESC LIMIT 1",
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(secs,)| secs))
     }
 }
 
@@ -254,6 +277,7 @@ pub(crate) struct MessageRow {
     pub cache_read_tokens: Option<i64>,
     pub cache_creation_tokens: Option<i64>,
     pub thinking_tokens: Option<i64>,
+    pub created_at: Option<String>,
 }
 
 /// Session metadata for listing.
@@ -297,6 +321,7 @@ impl From<MessageRow> for Message {
             cache_read_tokens: r.cache_read_tokens,
             cache_creation_tokens: r.cache_creation_tokens,
             thinking_tokens: r.thinking_tokens,
+            created_at: r.created_at,
         }
     }
 }

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -278,7 +278,8 @@ impl Persistence for Database {
         let mut messages: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    created_at
              FROM messages
              WHERE session_id = ? AND compacted_at IS NULL
              ORDER BY id ASC",
@@ -304,7 +305,8 @@ impl Persistence for Database {
         let rows: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    created_at
              FROM messages
              WHERE session_id = ?
              ORDER BY id ASC",

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -380,6 +380,7 @@ fn test_prune_mismatched_tool_calls_unit() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 
@@ -576,6 +577,7 @@ fn test_prune_null_content_drops_ghost_assistant() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 
@@ -630,6 +632,7 @@ fn test_prune_whitespace_only_drops_blank_assistant() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 
@@ -712,6 +715,7 @@ fn msg(role: Role, content: &str) -> Message {
         cache_read_tokens: None,
         cache_creation_tokens: None,
         thinking_tokens: None,
+        created_at: None,
     }
 }
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -578,6 +578,18 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     // Pre-build the base system message (avoids re-cloning 4-8KB per iteration)
     let base_system_prompt = system_prompt.to_string();
 
+    // Microcompact: clear old tool results before the first LLM call.
+    // Time-based trigger — only fires when the idle gap since the last
+    // assistant message exceeds the threshold (not during active tool use).
+    if let Ok(Some(mc)) = crate::microcompact::microcompact_session(db, session_id).await {
+        sink.emit(EngineEvent::Info {
+            message: format!(
+                "\u{1f9f9} Microcompact: cleared {} old tool results (~{} tokens)",
+                mc.cleared, mc.tokens_saved,
+            ),
+        });
+    }
+
     loop {
         // Inject completed background agent results as user messages
         for bg_result in bg_agents.drain_completed() {
@@ -975,17 +987,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 ),
             });
             break Ok(());
-        }
-
-        // Microcompact: clear old tool results to keep context lean.
-        // Cheap (no LLM call), idempotent, runs every turn.
-        if let Ok(Some(mc)) = crate::microcompact::microcompact_session(db, session_id).await {
-            sink.emit(EngineEvent::Info {
-                message: format!(
-                    "\u{1f9f9} Microcompact: cleared {} old tool results (~{} tokens)",
-                    mc.cleared, mc.tokens_saved,
-                ),
-            });
         }
 
         iteration += 1;

--- a/koda-core/src/microcompact.rs
+++ b/koda-core/src/microcompact.rs
@@ -3,8 +3,10 @@
 //! Replaces old tool result content with a stub (`[Old tool result content cleared]`)
 //! directly in the database. No LLM call, no API cost — just a SQL UPDATE.
 //!
-//! This keeps context lean between full compactions. A session with 20 file reads
-//! only keeps the N most recent results; older ones become stubs.
+//! **Time-based trigger**: only fires when the gap since the last assistant
+//! message exceeds a threshold (default 5 minutes). This prevents aggressive
+//! clearing during active tool use and matches Claude Code's pattern where
+//! microcompact only runs when the prompt cache has gone cold.
 //!
 //! Inspired by Claude Code's `microCompact.ts`.
 
@@ -37,7 +39,19 @@ const COMPACTABLE_TOOLS: &[&str] = &[
 ];
 
 /// Number of most-recent compactable tool results to keep intact.
-const KEEP_RECENT: usize = 6;
+///
+/// Claude Code uses 5 with a 60-minute gap threshold. We match their
+/// keep-recent count.
+const KEEP_RECENT: usize = 5;
+
+/// Minimum idle gap (in seconds) since the last assistant message before
+/// microcompact fires. During active tool use the model needs those results;
+/// clearing them mid-turn is wasteful and confusing.
+///
+/// 5 minutes = user went for coffee, came back, sent a new message.
+/// Claude Code uses 60 minutes (tied to Anthropic's prompt cache TTL).
+/// We use a shorter gap because koda has no server-side cache to protect.
+const GAP_THRESHOLD_SECS: i64 = 300;
 
 /// Minimum token size for a tool result to be worth clearing.
 /// Don't bother clearing tiny results — the overhead of the stub is comparable.
@@ -54,13 +68,22 @@ pub struct MicrocompactResult {
 
 /// Run microcompact on a session — clear old compactable tool results.
 ///
-/// This is cheap (no LLM call) and idempotent. Safe to run every turn.
-///
-/// Returns `None` if nothing was cleared (already clean or too few results).
+/// Only fires when the gap since the last assistant message exceeds
+/// `GAP_THRESHOLD_SECS`. Returns `None` if the trigger doesn't fire
+/// or nothing was cleared.
 pub async fn microcompact_session(
     db: &Database,
     session_id: &str,
 ) -> Result<Option<MicrocompactResult>> {
+    // Check the time-based trigger first — skip the heavy scan if idle gap
+    // hasn't been reached.
+    let gap = db.seconds_since_last_assistant(session_id).await?;
+    match gap {
+        None => return Ok(None), // No assistant messages yet.
+        Some(s) if s < GAP_THRESHOLD_SECS => return Ok(None),
+        _ => {} // Gap exceeded — proceed.
+    }
+
     let history = db.load_context(session_id).await?;
     if history.len() < KEEP_RECENT + 2 {
         return Ok(None);
@@ -215,6 +238,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            created_at: None,
         }
     }
 
@@ -286,7 +310,8 @@ mod tests {
         assert!(diagnosis(&messages).is_none());
     }
 
-    /// Integration test: verifies microcompact clears old results in a real SQLite DB.
+    /// Integration test: verifies microcompact clears old results in a real SQLite DB,
+    /// but only when the time-based trigger fires (last assistant msg is old enough).
     #[tokio::test]
     async fn test_microcompact_session_integration() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -301,11 +326,9 @@ mod tests {
             let tc_id = format!("tc_{i}");
             let tc_json =
                 format!(r#"[{{"id":"{tc_id}","function_name":"Read","arguments":"{{}}"}}]"#);
-            // Assistant with tool_calls
             db.insert_message(&session, &Role::Assistant, None, Some(&tc_json), None, None)
                 .await
                 .unwrap();
-            // Tool result
             db.insert_message(
                 &session,
                 &Role::Tool,
@@ -318,9 +341,25 @@ mod tests {
             .unwrap();
         }
 
-        // Run microcompact
+        // Should NOT trigger — last assistant message is fresh (just inserted).
         let result = microcompact_session(&db, &session).await.unwrap();
-        assert!(result.is_some());
+        assert!(result.is_none(), "should not trigger for fresh messages");
+
+        // Backdate the last assistant message so the time-based trigger fires.
+        sqlx::query(
+            "UPDATE messages SET created_at = datetime('now', '-10 minutes') \
+             WHERE session_id = ? AND role = 'assistant' \
+             AND id = (SELECT MAX(id) FROM messages WHERE session_id = ? AND role = 'assistant')",
+        )
+        .bind(&session)
+        .bind(&session)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        // NOW it should trigger.
+        let result = microcompact_session(&db, &session).await.unwrap();
+        assert!(result.is_some(), "should trigger after gap threshold");
         let mc = result.unwrap();
         assert_eq!(mc.cleared, 3); // 3 oldest should be cleared
         assert!(mc.tokens_saved > 0);

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -89,6 +89,8 @@ pub struct Message {
     pub cache_creation_tokens: Option<i64>,
     /// Reasoning/thinking tokens.
     pub thinking_tokens: Option<i64>,
+    /// ISO 8601 creation timestamp.
+    pub created_at: Option<String>,
 }
 
 /// Detected interruption state for a resumed session.


### PR DESCRIPTION
Closes #658 (includes the full_content fix from #659)

## Problem

Microcompact fired after every tool call once there were 7+ compactable results (`KEEP_RECENT=6`). A typical coding session hit this after just 3 turns:

```
Read file → Read file → Run test → Grep → Read → Build → Run test
                                                          ↑ microcompact fires here
                                                            and every tool call after
```

This aggressively cleared tool results the model still needed during active use.

## Fix: copy Claude Code's time-based pattern

Claude Code's `microCompact.ts` only fires microcompact when the idle gap since the last assistant message exceeds a threshold (60 min for Anthropic, tied to their prompt cache TTL). During active tool use, nothing is cleared.

### Before → After

| Aspect | Before | After |
|---|---|---|
| **When** | Every tool iteration | Once per user turn, before inference |
| **Trigger** | `compactable.len() > 6` | Idle gap > 5 minutes |
| **KEEP_RECENT** | 6 | 5 (matches Claude Code) |
| **Active use** | Clears results mid-turn | No clearing |

### Why 5 minutes (not 60)?

Claude Code uses 60 minutes because it's tied to Anthropic's server-side prompt cache TTL. Koda has no server-side cache to protect, so we use a shorter gap — long enough that the user has clearly stepped away, short enough that stale context gets cleaned up on return.

## Changes

| File | Change |
|---|---|
| `microcompact.rs` | Time-based trigger via DB gap query, remove per-turn firing |
| `inference.rs` | Move microcompact from tool loop to pre-inference (once per turn) |
| `db/mod.rs` | Add `seconds_since_last_assistant()`, `pool()` accessor, `created_at` in queries, fix `full_content` in `load_messages_before` (#658) |
| `db/queries.rs` | Add `created_at` to SELECT queries |
| `persistence.rs` | Add `created_at` field to `Message` struct |
| Test constructors | Add `created_at: None` to all Message constructors |

9 files, +102 −26 lines. All tests pass, clean clippy, clean fmt.