### PR TITLE
fix: remove dead auto_compact_threshold config, hard-code 85%

### DIFF
--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -187,12 +187,8 @@ impl TuiContext {
     }
 
     async fn maybe_auto_compact(&mut self) {
-        if self.config.auto_compact_threshold == 0 {
-            return;
-        }
-
         let ctx_pct = self.context_pct as usize;
-        if ctx_pct < self.config.auto_compact_threshold {
+        if ctx_pct < koda_core::inference_helpers::AUTO_COMPACT_THRESHOLD {
             return;
         }
 

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -320,9 +320,6 @@ pub struct AgentConfig {
     /// Override max inference iterations.
     #[serde(default)]
     pub max_iterations: Option<u32>,
-    /// Override auto-compact threshold percentage.
-    #[serde(default)]
-    pub auto_compact_threshold: Option<usize>,
     /// Grant write access (Write/Edit/Delete tools). Default: false.
     /// Sub-agents are read-only by default (principle of least privilege).
     /// Set to `true` for agents that need to create or modify files.
@@ -355,8 +352,6 @@ pub struct KodaConfig {
     pub model_settings: ModelSettings,
     /// Max inference iterations per turn.
     pub max_iterations: u32,
-    /// Context usage percentage (0-100) that triggers auto-compact. 0 = disabled.
-    pub auto_compact_threshold: usize,
 }
 
 impl KodaConfig {
@@ -421,8 +416,6 @@ impl KodaConfig {
 
         let max_iterations = agent.max_iterations.unwrap_or(200);
 
-        let auto_compact_threshold = agent.auto_compact_threshold.unwrap_or(85);
-
         Ok(Self {
             agent_name: agent.name,
             system_prompt: agent.system_prompt,
@@ -435,7 +428,6 @@ impl KodaConfig {
             agents_dir,
             model_settings: settings,
             max_iterations,
-            auto_compact_threshold,
         })
     }
 
@@ -518,7 +510,6 @@ impl KodaConfig {
         self.model_settings.max_context_tokens = new_ctx;
 
         self.max_iterations = 200;
-        self.auto_compact_threshold = 85;
     }
 
     /// Apply capabilities queried from the provider API.
@@ -615,7 +606,6 @@ impl KodaConfig {
             agents_dir: PathBuf::from("agents"),
             model_settings,
             max_iterations: crate::loop_guard::MAX_ITERATIONS_DEFAULT,
-            auto_compact_threshold: 80,
         }
     }
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -17,7 +17,7 @@ use crate::db::{Database, Role};
 use crate::engine::{EngineCommand, EngineEvent, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
-    CONTEXT_WARN_THRESHOLD, PREFLIGHT_COMPACT_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
+    AUTO_COMPACT_THRESHOLD, CONTEXT_WARN_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
     estimate_tokens, is_context_overflow_error, is_rate_limit_error, is_server_error,
     rate_limit_backoff,
 };
@@ -130,7 +130,7 @@ async fn assemble_context(turn: &TurnState<'_>) -> Result<Vec<ChatMessage>> {
     // Warn users when approaching the context limit (headless mode silently
     // drops ContextUsage events, so this Warn is the only signal they get).
     let ctx_pct = crate::context::percentage();
-    if (CONTEXT_WARN_THRESHOLD..PREFLIGHT_COMPACT_THRESHOLD).contains(&ctx_pct) {
+    if (CONTEXT_WARN_THRESHOLD..AUTO_COMPACT_THRESHOLD).contains(&ctx_pct) {
         // Include analysis hints so the user knows *why* context is high.
         let mut warning = format!("Context at {ctx_pct}% — approaching limit.");
         let top = analysis.top_tool_results(2);
@@ -161,7 +161,7 @@ async fn preflight_compact_if_needed(
     messages: Vec<ChatMessage>,
 ) -> Result<Vec<ChatMessage>> {
     let ctx_pct = crate::context::percentage();
-    if ctx_pct < PREFLIGHT_COMPACT_THRESHOLD {
+    if ctx_pct < AUTO_COMPACT_THRESHOLD {
         return Ok(messages);
     }
 

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -3,14 +3,13 @@
 
 use crate::providers::{ChatMessage, ToolCall};
 
-/// Pre-flight context budget threshold (percentage).
-/// If context usage exceeds this before calling the provider, auto-compact first.
-/// Context usage % at which a pre-flight auto-compact fires (engine-side).
-pub const PREFLIGHT_COMPACT_THRESHOLD: usize = 90;
+/// Context usage % at which a pre-flight auto-compact fires.
+/// Matches CC's default (~85%). Hard-coded — no config knob needed.
+pub const AUTO_COMPACT_THRESHOLD: usize = 85;
+
 /// Context usage % at which a user-visible warning is emitted.
-///
-/// Sits below `PREFLIGHT_COMPACT_THRESHOLD` so users see the warning
-/// 1–2 turns before compaction fires automatically.
+/// Sits below `AUTO_COMPACT_THRESHOLD` so users see the warning
+/// 1–2 turns before compaction fires.
 pub const CONTEXT_WARN_THRESHOLD: usize = 80;
 
 /// Characters-per-token ratio for heuristic estimation.


### PR DESCRIPTION
## Problem

`AgentConfig.auto_compact_threshold` was dead code:
- Config field defaulted to 85% but was **never read** by the inference loop
- Inference loop used a hard-coded `PREFLIGHT_COMPACT_THRESHOLD = 90%` instead
- `recalculate_model_derived()` reset it to 85% on model switch (pointless)
- TUI had its own check using the config field (also dead since it never matched)

## Fix

YAGNI — nobody needs to customize this. Hard-code 85% (matching CC) and delete the config field entirely.

- Remove `auto_compact_threshold` from `AgentConfig` and `KodaConfig`
- Remove load/reset/test references
- Replace `PREFLIGHT_COMPACT_THRESHOLD` (90%) with `AUTO_COMPACT_THRESHOLD` (85%)
- TUI `maybe_auto_compact` uses the constant directly

4 files, +10/-25. fmt + clippy clean, all tests pass.

Closes #666