### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-04
+
+Bug-fix release. All fixes discovered during real-world usage after v0.2.0.
+
+### Fixed
+- **Provider menu label** (#653) — renamed misleading `is_current` marker to
+  `key_set`, removed stale provider marker.
+- **Context window from local provider API** (#655) — `query_and_apply_capabilities`
+  now reads the actual context window from locally-hosted providers (Ollama,
+  LM Studio) instead of falling back to the hardcoded lookup table.
+- **Graceful degradation for weak models** (#657) — models that can’t
+  tool-call no longer crash the inference loop. Falls back to text-only mode
+  with a user-visible warning.
+- **`full_content` in `load_messages_before`** (#659) — the recall context
+  query now includes untruncated tool output, fixing empty results when
+  searching older Bash output.
+- **Time-based microcompact** (#660) — microcompact no longer clears tool
+  results every turn. Now uses message age (5+ minutes) instead of
+  per-turn eviction, preserving recent tool output the model needs.
+
+### Changed
+- **Auto-compact threshold** (#667) — removed dead `auto_compact_threshold`
+  config field (was never read by the inference loop). Hard-coded to 85%
+  matching Claude Code’s behavior. The previous hard-coded constant was 90%.
+
+### Testing
+- All 288 tests pass across 4 crates
+- Clean clippy (zero warnings), clean fmt
+- CI: Ubuntu, macOS, Windows
+
 ## [0.2.0] - 2026-04-04
 
 Major release closing all P0/P1 architecture gaps vs Claude Code v2.1.88.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.0" }
+koda-core = { path = "../koda-core", version = "0.2.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.0", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.1", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## v0.2.1 Release

Bug-fix release. All fixes discovered during real-world usage after v0.2.0.

### Changes since v0.2.0

| PR | Type | Description |
|---|---|---|
| #653 | fix | Provider menu: rename `is_current` → `key_set` |
| #655 | fix | Read context window from local provider API |
| #657 | fix | Graceful degradation for weak models |
| #659 | fix | Include `full_content` in recall queries |
| #660 | fix | Time-based microcompact (stop clearing every turn) |
| #667 | fix | Remove dead `auto_compact_threshold`, hard-code 85% |

### Checklist

- [x] Version bumped in all 4 Cargo.toml files
- [x] `koda-core` dependency version updated in `koda-cli`
- [x] CHANGELOG.md updated with `[0.2.1]` section
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean (zero warnings)
- [x] All 288 tests pass

### After merge

Tag `v0.2.1` on the merge commit → GitHub workflow builds + publishes automatically.