### PR TITLE
docs: refresh all documentation for v0.2.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ koda/
 │   │   ├── approval.rs     # Approval modes + tool confirmation gates
 │   │   ├── bash_path_lint.rs # Heuristic path-escape detection for bash commands
 │   │   ├── bash_safety.rs  # Bash command safety classification
+│   │   ├── bg_agent.rs     # Background sub-agent registry
 │   │   ├── compact.rs      # Session compaction (summarize old messages)
 │   │   ├── config.rs       # Agent/provider config + provider metadata
 │   │   ├── context.rs      # Context window token tracking
@@ -101,6 +102,8 @@ koda/
 │   │   ├── keystore.rs     # Secure API key storage (~/.config/koda/keys.toml, 0600)
 │   │   ├── loop_guard.rs   # Loop detection + iteration hard-cap
 │   │   ├── memory.rs       # Semantic memory (global + project tiers → system prompt)
+│   │   ├── microcompact.rs # Lightweight tool result aging between full compactions
+│   │   ├── model_alias.rs  # Curated model aliases (e.g. "sonnet" → exact model ID)
 │   │   ├── model_context.rs# Model → context window size lookup table (fallback)
 │   │   ├── output_caps.rs  # Output cap scaling based on context window size
 │   │   ├── persistence.rs  # Persistence trait — the database contract
@@ -113,10 +116,14 @@ koda/
 │   │   ├── skills.rs       # Skill discovery and activation
 │   │   ├── sub_agent_cache.rs # Sub-agent provider/model config cache
 │   │   ├── tool_dispatch.rs# Tool dispatch — routes tool calls to the registry
+│   │   ├── tool_normalize.rs # Tool name normalization (snake_case → PascalCase)
+│   │   ├── approval_flow.rs# Approval logic extracted from tool dispatch
+│   │   ├── sub_agent_dispatch.rs # Sub-agent invocation dispatch
+│   │   ├── context_analysis.rs # Per-tool token breakdown + duplicate detection
 │   │   ├── truncate.rs     # Token-safe output truncation
 │   │   ├── undo.rs         # Undo stack for file mutations
 │   │   ├── version.rs      # Background version checker (queries crates.io)
-│   │   ├── file_tracker.rs # File lifecycle tracker — auto-approve cleanup of Koda-created files
+│   │   ├── worktree.rs     # Git worktree isolation for sub-agents
 │   │   ├── engine/         # EngineEvent, EngineCommand, EngineSink trait
 │   │   │   ├── mod.rs      # Module root + re-exports
 │   │   │   ├── event.rs    # EngineEvent + EngineCommand protocol types
@@ -132,14 +139,20 @@ koda/
 │   │   └── tools/          # Built-in tools
 │   │       ├── mod.rs      # ToolRegistry, ToolEffect, tool definitions
 │   │       ├── agent.rs    # Sub-agent invocation tool
+│   │       ├── ask_user.rs # AskUser tool (explicit user clarification)
+│   │       ├── bg_process.rs # Background process registry + spawning
 │   │       ├── file_tools.rs # Read, Write, Edit, Delete
+│   │       ├── fuzzy.rs    # Fuzzy old_str matching for Edit
 │   │       ├── glob_tool.rs# Glob file search
 │   │       ├── grep.rs     # Ripgrep-based text search
 │   │       ├── memory.rs   # MemoryRead, MemoryWrite
 │   │       ├── recall.rs   # RecallContext (session history)
 │   │       ├── shell.rs    # Bash command execution
 │   │       ├── skill_tools.rs # ListSkills, ActivateSkill
-│   │       └── web_fetch.rs# WebFetch (URL content retrieval)
+│   │       ├── todo.rs     # TodoRead, TodoWrite
+│   │       ├── validate.rs # Pre-flight input validation
+│   │       ├── web_fetch.rs# WebFetch (URL content retrieval)
+│   │       └── web_search.rs # WebSearch (DuckDuckGo)
 │   └── tests/              # Engine integration tests
 ├── koda-cli/               # CLI binary
 │   ├── src/
@@ -397,6 +410,6 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.1.10)
+10. Sync version with workspace (currently 0.2.1)
 11. Update this file (CLAUDE.md)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ echo "explain this" | koda        # Piped input
 - **Git integration** — `/diff` review, commit message generation
 - **Headless mode** — `koda -p "prompt"` with JSON output for CI/CD
 - **Persistent memory** — project (`MEMORY.md`) and global (`~/.config/koda/memory.md`)
-- **Cost tracking** — per-turn and per-session cost estimation including thinking tokens
 - **Skills** — built-in expertise modules (code review, security audit) + user-created skills for repeatable analysis
 
 ### 📚 Skills
@@ -121,7 +120,6 @@ Koda connects to your email via IMAP/SMTP through the built-in koda-email integr
 | `/help` | Command palette (select & execute) |
 | `/agent` | List available sub-agents |
 | `/compact` | Summarize conversation to reclaim context |
-| `/cost` | Show token usage for this session |
 | `/diff` | Show/review uncommitted changes |
 | `/key` | Manage API keys |
 | `/memory` | View/save project & global memory |
@@ -188,14 +186,9 @@ Sub-agents can run on different models for cost optimization. The default agent 
 
 Koda auto-detects your model's context window and manages it:
 
-| Model | Context | Auto-compact at |
-|-------|---------|----------------|
-| Claude Opus/Sonnet | 200K tokens | 90% |
-| Gemini 2.5 | 1M tokens | 80% |
-| GPT-4o | 128K tokens | 90% |
-| Local models | 4K–128K | 70% |
-
-Use `/compact` manually, or let auto-compact handle it. The `/cost` command shows token usage and estimated cost.
+Auto-compact fires at **85%** of the model's context window (matching
+Claude Code's default). Use `/compact` manually, or let auto-compact
+handle it. The status bar shows token usage in real time.
 
 ## Documentation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -73,7 +73,7 @@ refuses rather than silently discarding unsummarized messages.
 
 ### Auto-compaction
 
-Koda automatically compacts when context usage exceeds ~85-90% of the
+Koda automatically compacts when context usage exceeds **85%** of the
 model's context window. This happens transparently before sending the
 next request to the LLM.
 
@@ -298,7 +298,6 @@ Create a JSON file in `agents/` (project-local) or `~/.config/koda/agents/`
 - `model`, `provider`, `base_url` — override the parent session's LLM
 - `max_tokens`, `temperature`, `thinking_budget`, `reasoning_effort` — model tuning
 - `max_iterations` — hard cap on tool-call loops
-- `auto_compact_threshold` — context % at which auto-compaction triggers
 
 **Search order**: project `agents/` → user `~/.config/koda/agents/` → built-in.
 First match wins.

--- a/koda-ast/README.md
+++ b/koda-ast/README.md
@@ -18,10 +18,12 @@ code using embedded tree-sitter parsers. Communicates via the
 
 Additional languages require adding tree-sitter grammars to this crate — see [#298](https://github.com/lijunzh/koda/issues/298).
 
-## Auto-provisioning
+## Built-in integration
 
-Koda auto-installs and connects this server when AST analysis is needed.
-No manual setup required — just ask koda to analyze code structure.
+koda-ast is compiled into Koda as a direct library call — no setup needed.
+Just ask koda to analyze code structure and it works out of the box.
+
+The standalone MCP server binary is also available for use in other editors.
 
 ## Manual setup
 

--- a/koda-core/README.md
+++ b/koda-core/README.md
@@ -12,7 +12,6 @@ Pure logic with zero terminal dependencies — communicates exclusively through
 - **Per-tool approval** — two modes (Auto/Confirm) with effect-based safety classification
 - **Inference loop** — streaming tool-use loop with parallel execution
 - **SQLite persistence** — sessions, messages, compaction
-- **MCP client** — connects to external MCP servers for extensibility
 
 **Rust edition:** 2024
 

--- a/koda-email/README.md
+++ b/koda-email/README.md
@@ -6,12 +6,14 @@ Read, search, and send email via IMAP/SMTP. Works with any email provider
 (Gmail, Outlook, FastMail, self-hosted). Communicates via the
 [Model Context Protocol](https://modelcontextprotocol.io) over stdio.
 
-## Auto-provisioning
+## Built-in integration
 
-Koda auto-installs and connects this server when email access is needed.
-Just ask — "check my email" — and koda handles the rest.
+koda-email is compiled into Koda as a direct library call — no setup needed.
+Just ask “check my email” and koda handles the rest.
 
-On first use, you'll be prompted for IMAP/SMTP credentials.
+On first use, you’ll be prompted for IMAP/SMTP credentials.
+
+The standalone MCP server binary is also available for use in other editors.
 
 ## Manual setup
 


### PR DESCRIPTION
## Audit

Thorough review of all documentation files against the actual codebase at v0.2.1.

### Issues fixed

| File | Issue | Fix |
|---|---|---|
| README.md | `/cost` command listed | Removed (deleted v0.1.9) |
| README.md | "Cost tracking" feature | Removed |
| README.md | Per-tier auto-compact table | → single 85% statement |
| koda-core/README.md | "MCP client" bullet | Removed (deleted v0.1.10) |
| user-guide.md | `auto_compact_threshold` config | Removed (just deleted in #667) |
| user-guide.md | "~85-90%" auto-compact | → 85% |
| koda-ast/README.md | "Auto-provisioning" | → "Built-in integration" |
| koda-email/README.md | "Auto-provisioning" | → "Built-in integration" |
| CLAUDE.md | "currently 0.1.10" | → 0.2.1 |
| CLAUDE.md | Duplicate `file_tracker.rs` | Removed duplicate |
| CLAUDE.md | Architecture tree | +12 missing v0.2.0 files |

6 files, +31/-23. All tests pass.