### PR TITLE
feat(tools): enrich tool descriptions with behavioral guidance (#683)

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -131,7 +131,8 @@ pub fn definitions() -> Vec<ToolDefinition> {
                 and skips common noise (node_modules, __pycache__, .git). \
                 Use with recursive=false (default) to explore project structure one level \
                 at a time. Use with recursive=true for a full tree view. \
-                For finding files by pattern (e.g. all *.rs files), prefer Glob instead.".to_string(),
+                For finding files by pattern (e.g. all *.rs files), prefer Glob instead."
+                .to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -14,8 +14,10 @@ pub fn definitions() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
             name: "Read".to_string(),
-            description: "Read the contents of a file. For large files, use start_line and \
-                num_lines to read specific portions instead of the whole file."
+            description: "Read the contents of a file. The output includes line numbers. \
+                For large files (>500 lines), use start_line and num_lines to read specific \
+                portions instead of the whole file. ALWAYS read a file before editing it — \
+                never guess at file contents. Re-read after editing to verify changes."
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -125,7 +127,11 @@ pub fn definitions() -> Vec<ToolDefinition> {
         },
         ToolDefinition {
             name: "List".to_string(),
-            description: "List files and directories. Respects .gitignore.".to_string(),
+            description: "List files and directories in a given path. Respects .gitignore \
+                and skips common noise (node_modules, __pycache__, .git). \
+                Use with recursive=false (default) to explore project structure one level \
+                at a time. Use with recursive=true for a full tree view. \
+                For finding files by pattern (e.g. all *.rs files), prefer Glob instead.".to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -13,7 +13,11 @@ use std::path::Path;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "Glob".to_string(),
-        description: "Find files by glob pattern (e.g. '**/*.rs'). Returns relative paths."
+        description: "Find files by glob pattern. Returns relative paths, respects .gitignore. \
+            Use '**/*.rs' for recursive matching, 'src/**/mod.rs' for specific names, \
+            '*.toml' for current-directory-only. \
+            Prefer this over List when you know the filename pattern you want. \
+            Prefer Grep when you need to search file contents, not names."
             .to_string(),
         parameters: json!({
             "type": "object",

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -14,8 +14,11 @@ use std::path::Path;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "Grep".to_string(),
-        description: "Recursively search for text across files (respects .gitignore). \
-            Capped at 100 matches."
+        description: "Recursively search for text patterns across files (respects .gitignore). \
+            Returns matching file paths with line numbers and content. \
+            Use plain text for exact matches or regex for complex patterns. \
+            Set case_insensitive=true for case-agnostic search. \
+            Prefer this over Bash + rg/grep. Results are capped at 100 matches."
             .to_string(),
         parameters: json!({
             "type": "object",

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -17,7 +17,8 @@ pub fn definitions() -> Vec<ToolDefinition> {
         description: "Fetch content from a URL. HTML is stripped to readable text by default; \
             set raw=true for raw HTML. Only use URLs from tool results or user input — \
             never guess or generate URLs from memory. \
-            For documentation lookup, prefer reading local files first.".to_string(),
+            For documentation lookup, prefer reading local files first."
+            .to_string(),
         parameters: json!({
             "type": "object",
             "properties": {

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -14,7 +14,10 @@ const DEFAULT_TIMEOUT_SECS: u64 = 15;
 pub fn definitions() -> Vec<ToolDefinition> {
     vec![ToolDefinition {
         name: "WebFetch".to_string(),
-        description: "Fetch content from a URL (HTML stripped to text).".to_string(),
+        description: "Fetch content from a URL. HTML is stripped to readable text by default; \
+            set raw=true for raw HTML. Only use URLs from tool results or user input — \
+            never guess or generate URLs from memory. \
+            For documentation lookup, prefer reading local files first.".to_string(),
         parameters: json!({
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary

Upgrade tool descriptions from bare one-liners to CC-style behavioral instructions. The model now receives 'when to use' and 'when NOT to use' guidance directly in each tool definition.

### Before → After

| Tool | Before | After |
|---|---|---|
| Read | "Read the contents of a file" | + line numbers, read-before-edit rule |
| List | "List files and directories" | + recursive guidance, Glob vs List |
| Grep | "Recursively search... Capped at 100" | + regex/case flags, prefer over Bash |
| Glob | "Find files by glob pattern" | + syntax examples, when vs List/Grep |
| WebFetch | "Fetch content from a URL" | + URL provenance rule, raw mode |

### Why this matters

CC's BashTool description alone is 369 lines of behavioral instructions. Our descriptions were functional but bare — the model had to infer usage patterns from `instructions.md` alone. Now each tool carries its own 'when to use / when not to use' context, which gives models (especially weaker ones) much better tool selection behavior.

## Phase 1 of #680 (documentation architecture overhaul)
- CC Layer 2: per-tool behavioral instructions
- No deps — parallel with #674 and #677

Closes #683