### PR TITLE
docs: merge CONTRIBUTING.md into CLAUDE.md (#678)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Koda is a personal AI assistant built in Rust (edition 2024) — not a product,
 not a platform. See [docs/design.md](docs/design.md) for principles (P1: Personal,
 P2: Simple enough to own alone, P3: Build for the world six months from now).
 
+**Development philosophy:** Make it work, make it right, make it fast — in that
+order. Ship working code first, refactor to clean design second, optimize for
+performance only when measured.
+
 Four-crate workspace:
 - `koda-core` (library) — pure engine with zero terminal deps
 - `koda-cli` (binary `koda`) — CLI frontend with ratatui TUI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,7 @@
 # Contributing to Koda
 
-Koda is a personal AI assistant built in Rust. Contributions are welcome.
-
-## Development Philosophy
-
-Make it work, make it right, make it fast — in that order. Ship working code
-first, refactor to clean design second, optimize for performance only when
-measured. This applies to architecture too — don't design for scale that
-doesn't exist yet.
+All contributor guidance lives in [CLAUDE.md](CLAUDE.md) — the single source of
+truth for project structure, conventions, build commands, and documentation rules.
 
 ## Quick Start
 
@@ -17,53 +11,6 @@ cd koda
 cargo build
 cargo test --workspace --features koda-core/test-support
 ```
-
-## Project Structure
-
-Four-crate workspace:
-
-| Crate | Role |
-|-------|------|
-| `koda-core` | Engine library (zero terminal deps) |
-| `koda-cli` | CLI binary + TUI |
-| `koda-ast` | Tree-sitter AST analysis |
-| `koda-email` | Email via IMAP/SMTP |
-
-See [docs/design.md](docs/design.md) for principles and architecture.
-See [CLAUDE.md](CLAUDE.md) for workspace layout and developer reference.
-
-## Development Commands
-
-```bash
-cargo test --workspace --features koda-core/test-support  # All tests
-cargo fmt --all --check                                    # Format check
-cargo clippy --workspace -- -D warnings                    # Lint
-cargo doc --workspace --no-deps                            # Build docs
-```
-
-## Documentation Rules
-
-- User-facing feature added/changed → update root README + relevant crate README
-- Tool added/changed in koda-ast/koda-email → update the crate README
-- Architecture or design decision → add to the appropriate section in `docs/design.md`
-- New crate → must ship with a README.md
-- Internal refactors don't require doc updates unless they change crate
-  boundaries or public APIs
-
-## On Release
-
-- Move CHANGELOG.md `[Unreleased]` to versioned section
-- Bump version in all 4 crate Cargo.toml files
-- Verify README quick-start examples still work
-
-## Conventions
-
-- Error handling: `anyhow::Result<T>` with `.context()`
-- All I/O is async (`tokio`)
-- Tool names: PascalCase; module names: snake_case
-- `koda-core` has zero terminal deps (no crossterm, no ratatui)
-- Cohesion over line count: don't split a file just because it's long.
-  Split when pieces have genuinely independent responsibilities.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

Single source of truth: all contributor guidance now lives in CLAUDE.md. CONTRIBUTING.md is reduced to a pointer with quick-start and issue-reporting links.

### Why keep CONTRIBUTING.md at all?

GitHub shows a "contributing guide" link on new PRs when CONTRIBUTING.md exists. Deleting it removes that affordance. A slim pointer file gives drive-by contributors the quick-start they need while directing them to the real docs.

### What moved

| Content | Before | After |
|---|---|---|
| Dev philosophy | CONTRIBUTING.md only | CLAUDE.md |
| Quick start | Both (duplicated) | CLAUDE.md (pointer in CONTRIBUTING.md) |
| Project structure | Both (duplicated) | CLAUDE.md |
| Dev commands | Both (duplicated) | CLAUDE.md |
| Doc rules | Both (duplicated) | CLAUDE.md |
| Conventions | Both (duplicated) | CLAUDE.md |
| Release checklist | Both (duplicated) | CLAUDE.md |

Net: **-55 lines** of duplication removed.

## Phase 2 of #680 (documentation architecture overhaul)
- No deps — can merge independently

Closes #678