### PR TITLE
refactor(tools): align Grep/Glob param name to file_path (#592)

### DIFF
--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -26,7 +26,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "type": "string",
                     "description": "Glob pattern (e.g. '**/*.rs', 'src/**/mod.rs', '*.toml')"
                 },
-                "path": {
+                "file_path": {
                     "type": "string",
                     "description": "Base directory for the search (default: project root)"
                 }
@@ -41,7 +41,10 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
     let pattern = args["pattern"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?;
-    let path_str = args["path"].as_str().unwrap_or(".");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or(".");
     let base = safe_resolve_path(project_root, path_str)?;
 
     // Build full pattern relative to base directory

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -27,7 +27,7 @@ pub fn definitions() -> Vec<ToolDefinition> {
                     "type": "string",
                     "description": "The text pattern to search for (plain text or regex)"
                 },
-                "path": {
+                "file_path": {
                     "type": "string",
                     "description": "Directory to search in (default: project root)"
                 },
@@ -47,7 +47,10 @@ pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Resu
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?
         .to_string();
-    let path_str = args["path"].as_str().unwrap_or(".");
+    let path_str = args["file_path"]
+        .as_str()
+        .or_else(|| args["path"].as_str())
+        .unwrap_or(".");
     let case_insensitive = args["case_insensitive"].as_bool().unwrap_or(false);
 
     let search_root = safe_resolve_path(project_root, path_str)?;


### PR DESCRIPTION
## Summary

Rename `path` → `file_path` in Grep and Glob tool definitions for consistency with all other file tools (Read, Write, Edit, Delete, List).

### Backwards compatibility

Both tools accept `path` as a fallback via `.or_else(|| args["path"])` — in-flight conversations won't break.

### Before / After

| Tool | Before | After |
|---|---|---|
| Grep | `path` | `file_path` (accepts `path` fallback) |
| Glob | `path` | `file_path` (accepts `path` fallback) |
| Read/Write/Edit/Delete/List | `file_path` | `file_path` (unchanged) |

Partial close of #592 (parameter name alignment item).