### PR TITLE
docs(core): add doc examples to key public APIs (#682)

### DIFF
--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -25,6 +25,16 @@ use std::sync::atomic::{AtomicU8, Ordering};
 // ── Approval Mode ─────────────────────────────────────────
 
 /// The two approval modes.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::approval::ApprovalMode;
+///
+/// let mode = ApprovalMode::Auto;
+/// assert_eq!(mode.as_str(), "auto");
+/// assert_eq!(mode.next(), ApprovalMode::Confirm);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ApprovalMode {

--- a/koda-core/src/model_alias.rs
+++ b/koda-core/src/model_alias.rs
@@ -66,6 +66,16 @@ static ALIASES: &[ModelAlias] = &[
 ///
 /// Returns `None` if `name` is not a known alias (treat as literal model ID).
 /// For `"local"`, returns a sentinel — caller must auto-detect via LMStudio API.
+///
+/// ```
+/// use koda_core::model_alias::resolve;
+/// use koda_core::config::ProviderType;
+///
+/// let r = resolve("gemini-flash").unwrap();
+/// assert_eq!(r.provider, ProviderType::Gemini);
+///
+/// assert!(resolve("not-an-alias").is_none());
+/// ```
 pub fn resolve(name: &str) -> Option<ResolvedAlias> {
     if name == LOCAL_ALIAS {
         return Some(ResolvedAlias {

--- a/koda-core/src/output_caps.rs
+++ b/koda-core/src/output_caps.rs
@@ -58,6 +58,18 @@ impl OutputCaps {
     const BASE_GLOB_RESULTS: usize = 200;
 
     /// Compute caps scaled to the given context window size (in tokens).
+    ///
+    /// ```
+    /// use koda_core::output_caps::OutputCaps;
+    ///
+    /// // 100K context = 1× (baseline)
+    /// let caps = OutputCaps::for_context(100_000);
+    /// assert_eq!(caps.grep_matches, 100);
+    ///
+    /// // 200K context = 2×
+    /// let caps = OutputCaps::for_context(200_000);
+    /// assert_eq!(caps.grep_matches, 200);
+    /// ```
     pub fn for_context(max_context_tokens: usize) -> Self {
         let factor = (max_context_tokens as f64 / BASELINE).clamp(1.0, MAX_SCALE);
 

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -154,6 +154,15 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
 ///
 /// Returns the canonical name if a mapping exists, otherwise returns
 /// the input unchanged (so the dispatcher can surface a proper error).
+///
+/// ```
+/// use koda_core::tool_normalize::normalize_tool_name;
+///
+/// assert_eq!(normalize_tool_name("list_files"), "List");
+/// assert_eq!(normalize_tool_name("Read"), "Read");
+/// assert_eq!(normalize_tool_name("run_command"), "Bash");
+/// assert_eq!(normalize_tool_name("unknown_tool"), "unknown_tool");
+/// ```
 pub fn normalize_tool_name(name: &str) -> String {
     // Single O(1) lookup: lowercase the input and check the alias map.
     // Canonical names are self-mapped (e.g. "list" → "List"), so this

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -7,6 +7,16 @@
 ///
 /// Two-axis model: what does the tool touch (local vs. remote)
 /// and how severe are its effects (read vs. mutate vs. destroy)?
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::tools::{ToolEffect, classify_tool};
+///
+/// assert_eq!(classify_tool("Read"), ToolEffect::ReadOnly);
+/// assert_eq!(classify_tool("Write"), ToolEffect::LocalMutation);
+/// assert_eq!(classify_tool("Delete"), ToolEffect::Destructive);
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum ToolEffect {
@@ -25,6 +35,8 @@ pub enum ToolEffect {
 /// For `Bash`, this returns the *default* classification (`LocalMutation`);
 /// the actual effect depends on the command string and must be refined
 /// via [`crate::bash_safety::classify_bash_command`].
+///
+/// Unknown tools default to `LocalMutation` (conservative — always asks).
 pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
@@ -58,6 +70,14 @@ pub fn classify_tool(name: &str) -> ToolEffect {
 ///
 /// Convenience wrapper over [`classify_tool`] for call sites that only
 /// need a bool (e.g., loop guard).
+///
+/// ```
+/// use koda_core::tools::is_mutating_tool;
+///
+/// assert!(!is_mutating_tool("Read"));
+/// assert!(is_mutating_tool("Write"));
+/// assert!(is_mutating_tool("Delete"));
+/// ```
 pub fn is_mutating_tool(name: &str) -> bool {
     !matches!(classify_tool(name), ToolEffect::ReadOnly)
 }
@@ -131,6 +151,17 @@ use crate::providers::ToolDefinition;
 pub type FileReadCache = Arc<std::sync::Mutex<HashMap<String, (u64, SystemTime)>>>;
 
 /// Result of executing a tool.
+///
+/// The `success` field is set automatically by `ToolRegistry::execute()` —
+/// `Ok(…)` → `true`, `Err(…)` → `false`. Individual tool functions just
+/// return `Result<String>`.
+///
+/// ```
+/// use koda_core::tools::ToolResult;
+///
+/// let ok = ToolResult { output: "done".into(), success: true, full_output: None };
+/// assert!(ok.success);
+/// ```
 #[derive(Debug, Clone)]
 pub struct ToolResult {
     /// The tool's output string (model-facing; may be a summary for Bash).
@@ -563,7 +594,26 @@ impl ToolRegistry {
 }
 
 /// Validate and resolve a path, preventing directory traversal.
-/// Works for both existing and non-existing files (no canonicalize!).
+///
+/// Works for both existing and non-existing files (no `canonicalize!`).
+/// Relative paths are joined to `project_root`; absolute paths must
+/// still be within `project_root`.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::tools::safe_resolve_path;
+/// use std::path::Path;
+///
+/// let root = Path::new("/home/user/project");
+///
+/// // Relative paths resolve within project
+/// let p = safe_resolve_path(root, "src/main.rs").unwrap();
+/// assert_eq!(p, Path::new("/home/user/project/src/main.rs"));
+///
+/// // Traversal is blocked
+/// assert!(safe_resolve_path(root, "../../etc/passwd").is_err());
+/// ```
 pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf> {
     let requested_path = Path::new(requested);
 


### PR DESCRIPTION
## Summary

Add runnable `cargo test --doc` examples to the highest-value public APIs in `koda-core`. Doc test count: **7 → 15** (all passing).

### APIs with new examples

| Module | Item | Example covers |
|---|---|---|
| `tools/mod.rs` | `ToolEffect`, `classify_tool` | Effect classification |
| `tools/mod.rs` | `is_mutating_tool` | Mutation detection |
| `tools/mod.rs` | `safe_resolve_path` | Path security + traversal |
| `tools/mod.rs` | `ToolResult` | Construction |
| `approval.rs` | `ApprovalMode` | Toggle + serialization |
| `tool_normalize.rs` | `normalize_tool_name` | Snake_case → PascalCase |
| `model_alias.rs` | `resolve` | Alias resolution |
| `output_caps.rs` | `OutputCaps::for_context` | Context scaling |

### Already done (verified)

- `#![warn(missing_docs)]` is already enabled and clean
- All public items already have doc comments
- This PR adds the 'with runnable examples' requirement

## Phase 2 of #680

Closes #682