### PR TITLE
docs: audit pass — fix dupes, enrich thin pages, add docs strategy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,6 +274,39 @@ calls to potentially different providers.
 
 ---
 
+## Documentation
+
+### docs.rs as the Documentation Site (P1, P2)
+
+Koda uses `cargo doc` / docs.rs as its documentation site. There is no
+separate docs website to build, host, or maintain.
+
+Claude Code hosts a separate docs site at `code.claude.com/docs` and ships
+a `claude_code_docs_map.md` index file that the guide agent fetches at
+runtime to answer user questions. This requires a docs build pipeline,
+hosting infrastructure, and a separate content workflow.
+
+Koda takes a different approach: both `koda-core` (engine library) and
+`koda-cli` (TUI, slash commands, REPL) expose their modules as `pub mod`
+so that `cargo doc` renders them. The guide agent fetches these pages the
+same way CC's guide agent fetches `code.claude.com` — but the content
+comes from rustdoc, not a custom site.
+
+This means:
+
+- **Module-level `//!` docs are user-facing documentation**, not just
+  developer notes. They should explain *what the feature does and how to
+  use it*, not just implementation details.
+- **koda-cli modules must be `pub`** even though they have no external
+  consumers. This is a deliberate visibility trade for documentation
+  coverage — the guide agent needs to read slash command docs, TUI
+  keybindings, and onboarding flow.
+- **Zero infrastructure.** `cargo doc --open` works offline. docs.rs
+  publishes automatically on `cargo publish`. No CI pipeline for docs.
+- **Single source of truth.** Docs live next to code, never drift.
+
+---
+
 ## Interaction
 
 ### No `.koda.md` — Use `CLAUDE.md` (P1, P2)

--- a/koda-core/src/bash_path_lint.rs
+++ b/koda-core/src/bash_path_lint.rs
@@ -1,7 +1,26 @@
-//! Bash path lint: detect commands that escape the project root.
+//! Bash path lint — detect commands that escape the project root.
 //!
-//! Heuristic analysis — catches common accidental escapes, not adversarial inputs.
-//! Dynamic targets (`cd $VAR`, `cd $(cmd)`) are intentionally ignored.
+//! Heuristic analysis that catches common accidental path escapes.
+//! Not designed for adversarial inputs — that's a kernel sandbox concern.
+//!
+//! ## What it catches
+//!
+//! - Absolute paths outside the project (e.g., `cat /etc/passwd`)
+//! - Relative escapes (e.g., `cd ../../../`)
+//! - Home directory access (e.g., `rm ~/.bashrc`)
+//!
+//! ## What it allows
+//!
+//! - Temp directories (`/tmp`, `$TMPDIR`)
+//! - Device files (`/dev/null`, `/dev/stdout`)
+//! - Paths inside the project root
+//!
+//! ## What it intentionally ignores
+//!
+//! - Dynamic targets (`cd $VAR`, `cd $(cmd)`) — can't statically resolve
+//! - Quoted strings (commit messages, echo) — stripped before analysis
+//!
+//! See [`crate::bash_safety`] for the complementary command classification.
 
 use path_clean::PathClean;
 use std::path::{Path, PathBuf};

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -202,8 +202,6 @@ const DANGEROUS_PATTERNS: &[&str] = &[
 
 // ── Classification ───────────────────────────────────────────
 
-/// Classify a bash command's effect.
-///
 /// Classify a bash command by its side-effect severity.
 ///
 /// Returns the *most dangerous* effect found across all pipeline/chain

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -3,6 +3,19 @@
 //! Tracks sub-agents spawned with `background: true` in `InvokeAgent`.
 //! The inference loop drains completed results and injects them as
 //! user-role messages so the model sees them on the next iteration.
+//!
+//! ## Lifecycle
+//!
+//! 1. **Spawn**: `InvokeAgent { background: true }` creates a tokio task
+//! 2. **Track**: the task handle + metadata are stored in `BgAgentRegistry`
+//! 3. **Poll**: before each inference call, the loop calls `drain_completed()`
+//! 4. **Inject**: completed results are appended as user messages
+//! 5. **Cleanup**: on session end, all pending tasks are cancelled
+//!
+//! ## Thread safety
+//!
+//! The registry is wrapped in `Arc<Mutex<>>` and shared between the main
+//! inference loop and the background task spawner.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/koda-core/src/context_analysis.rs
+++ b/koda-core/src/context_analysis.rs
@@ -1,7 +1,22 @@
 //! Context analysis — per-tool token breakdown and duplicate detection.
 //!
 //! Analyzes conversation history to identify where tokens are being spent.
-//! Used by compaction decisions, `/usage` reporting, and microcompact (future).
+//! Used by compaction decisions, `/usage` reporting, and microcompact.
+//!
+//! ## What it reports
+//!
+//! - **Per-tool token counts** — how many tokens each tool's results consume
+//!   (Read, Grep, Bash, etc.)
+//! - **Duplicate file reads** — files read multiple times (wasted context)
+//! - **Human vs assistant split** — how much of the context is user messages
+//!   vs model responses
+//! - **Attachment sizes** — images and files pasted into the conversation
+//!
+//! ## How it's used
+//!
+//! - **Auto-compact**: triggers compaction when total tokens exceed threshold
+//! - **`/usage` command**: shows the token breakdown to the user
+//! - **Microcompact**: identifies old tool results safe to clear
 //!
 //! Inspired by Claude Code's `contextAnalysis.ts`.
 

--- a/koda-core/src/git.rs
+++ b/koda-core/src/git.rs
@@ -1,9 +1,29 @@
 //! Git integration for context injection.
 //!
-//! - `git_context()`: compact git info for the system prompt
+//! Provides a compact snapshot of the current git state for injection into
+//! the system prompt. This gives the model awareness of:
 //!
-//! File-level undo is handled by `undo.rs` (in-memory snapshots),
-//! not git. See DESIGN.md for rationale.
+//! - **Current branch** — so it knows where it's working
+//! - **Staged changes** — diff stat showing what's ready to commit
+//! - **Unstaged changes** — diff stat showing what's modified but not staged
+//! - **Recent commits** — last N commit subjects for historical context
+//!
+//! ## What this module does NOT do
+//!
+//! - **File-level undo** — handled by [`crate::undo`] (in-memory snapshots)
+//! - **Git operations** — commits, pushes, etc. are done via the Bash tool
+//! - **Worktree management** — handled by [`crate::worktree`]
+//!
+//! ## Output format
+//!
+//! ```text
+//! [Git: branch=main
+//!  Staged: 2 files changed, 15 insertions(+), 3 deletions(-)
+//!  Unstaged: 1 file changed, 4 insertions(+)
+//!  Recent: fix: align arrows | docs: enrich modules | feat: add AskUser]
+//! ```
+//!
+//! Diff stats are truncated at 2KB to avoid bloating the system prompt.
 
 use std::path::Path;
 use std::process::Command;

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -96,7 +96,6 @@ impl KeyStore {
         self.keys.insert(env_name.to_string(), value.to_string());
     }
 
-    /// Load all stored keys into the process environment.
     /// Load all stored keys into the runtime environment.
     /// Only sets vars that aren't already set (env vars and
     /// previously-set runtime vars take precedence).

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -46,9 +46,9 @@ pub mod approval;
 pub(crate) mod approval_flow;
 /// Heuristic path-escape detection for bash commands.
 pub mod bash_path_lint;
-/// Bash command safety classification (destructive, mutating, read-only).
+/// Bash command safety classification — ReadOnly, LocalMutation, Destructive.
 pub mod bash_safety;
-/// Background sub-agent registry — tracks agents spawned with `background: true`.
+/// Background sub-agent registry — tracks and drains async agent results.
 pub mod bg_agent;
 /// Context compaction — summarise old messages to reclaim token budget.
 pub mod compact;
@@ -64,15 +64,15 @@ pub mod db;
 pub mod engine;
 /// File lifecycle tracker — tracks files created by Koda per session (#465).
 pub mod file_tracker;
-/// Git helpers — status, diff, blame, log.
+/// Git context injection — branch, staged/unstaged diffs, recent commits.
 pub mod git;
 /// The main inference loop — send messages, stream responses, dispatch tools.
 pub mod inference;
 /// Shared helpers used by the inference loop.
 pub mod inference_helpers;
-/// Credential storage (OS keychain via `keyring`).
+/// Credential storage — `keys.toml` with env var fallback.
 pub mod keystore;
-/// Guardrail against runaway tool-call loops.
+/// Loop detection — catches runaway repeated tool calls.
 pub mod loop_guard;
 /// Project memory — `MEMORY.md` / `CLAUDE.md` read/write.
 pub mod memory;
@@ -94,15 +94,15 @@ pub mod progress;
 pub mod prompt;
 /// LLM provider abstraction — Anthropic, Gemini, OpenAI-compatible.
 pub mod providers;
-/// Environment variable access (mockable for tests).
+/// Thread-safe runtime environment — replaces `std::env::set_var`.
 pub mod runtime_env;
 /// Session lifecycle — create, resume, list, delete.
 pub mod session;
-/// User settings persistence (`~/.config/koda/settings.json`).
+/// Last-used provider persistence (`~/.config/koda/settings.toml`).
 pub mod settings;
 /// Skill discovery and activation (project, user, built-in).
 pub mod skills;
-/// Cache for sub-agent provider/model config across invocations.
+/// Sub-agent result caching — zero-cost retries after compaction.
 pub mod sub_agent_cache;
 /// Sub-agent invocation and lifecycle management.
 pub(crate) mod sub_agent_dispatch;

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -1,9 +1,25 @@
-//! Loop detection and hard-cap user prompt for the inference loop.
+//! Loop detection and hard-cap for the inference loop.
 //!
 //! Tracks recent tool call fingerprints in a sliding window and flags
 //! when the same tool+args combination repeats too many times.
-//! When the hard iteration cap is hit, prompts the user interactively
-//! to continue or stop — falling back to stop in headless environments.
+//!
+//! ## Detection method
+//!
+//! Each tool call is fingerprinted as `(tool_name, hash(args))`. The guard
+//! maintains a sliding window of the last N fingerprints. When the same
+//! fingerprint appears more than the threshold, a loop is detected.
+//!
+//! ## What happens on detection
+//!
+//! - **Soft limit** (repeated tool calls): injects a system message telling
+//!   the model it's looping, asking it to try a different approach
+//! - **Hard limit** (iteration cap): prompts the user interactively to
+//!   continue or stop — falls back to stop in headless environments
+//!
+//! ## Why this matters
+//!
+//! Without loop detection, a confused model can burn thousands of tokens
+//! retrying the same failing edit or grep. The guard is the safety net.
 
 use crate::providers::ToolCall;
 use std::collections::{HashMap, VecDeque};

--- a/koda-core/src/settings.rs
+++ b/koda-core/src/settings.rs
@@ -1,20 +1,21 @@
-//! User settings persistence.
+//! Last-used provider persistence.
 //!
-//! Stores and loads user preferences from `~/.config/koda/settings.toml`.
+//! Remembers the last provider/model/base-URL so Koda can auto-restore
+//! on next startup. Currently stored in `~/.config/koda/settings.toml`.
 //!
-//! ## Stored settings
+//! **Note:** This module is slated for removal (#693). The TOML file
+//! should be a row in SQLite, not a separate config file — users should
+//! never edit it manually.
 //!
-//! - **`provider`** — Default LLM provider
-//! - **`model`** — Default model identifier
-//! - **`base_url`** — Custom API base URL (for LM Studio, self-hosted, etc.)
-//! - **`max_tokens`** — Default max output tokens
-//! - **`temperature`** — Default temperature
-//!
-//! Settings are overridden by CLI flags, which are overridden by agent JSON configs.
+//! This is **not** user configuration — Koda follows "customization over
+//! configuration" (see DESIGN.md). The only persisted state is which
+//! provider the user last chose via `/model`.
 
 use std::path::{Path, PathBuf};
 
-/// User settings stored in `~/.config/koda/settings.toml`.
+/// Last-used provider state, restored on startup.
+///
+/// Not user configuration — just session memory.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct Settings {
     /// Last-used provider/model, restored on next startup.

--- a/koda-core/src/sub_agent_cache.rs
+++ b/koda-core/src/sub_agent_cache.rs
@@ -4,8 +4,17 @@
 //! session. On cache hit, returns the previous response immediately —
 //! zero-cost retries for compaction-triggered re-planning.
 //!
+//! ## Why this exists
+//!
+//! After compaction, the model sometimes re-issues the same sub-agent
+//! call (it forgot it already ran). Without caching, this burns tokens
+//! and time re-running identical work. The cache makes this free.
+//!
+//! ## Invalidation
+//!
 //! Cache entries are invalidated when files are mutated (piggybacks on
-//! `FileReadCache` mtime tracking via a generation counter).
+//! `FileReadCache` mtime tracking via a generation counter). This ensures
+//! stale results aren't served after the codebase changes.
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -3,8 +3,23 @@
 //! Routes tool calls from the inference loop to execution, handling
 //! approval flow, parallelization, and result recording.
 //!
-//! Sub-agent invocation lives in `sub_agent_dispatch.rs`.
-//! Approval request/response lives in `approval_flow.rs`.
+//! ## Dispatch flow
+//!
+//! ```text
+//! Model emits tool calls
+//!   → Classify each call's effect (ReadOnly / LocalMutation / Destructive)
+//!   → Split into read-only batch + mutation batch
+//!   → Read-only tools: execute in parallel (tokio::join)
+//!   → Mutation tools: execute sequentially with approval
+//!   → Record results in DB + inject into conversation
+//! ```
+//!
+//! ## Related modules
+//!
+//! - [`crate::tools`] — tool definitions and `ToolRegistry::execute()`
+//! - [`crate::approval`] — approval mode and effect classification
+//! - `sub_agent_dispatch.rs` — `InvokeAgent` handling (needs provider access)
+//! - `approval_flow.rs` — interactive approval UI flow
 //!
 //! ## Design (DESIGN.md)
 //!

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -3,8 +3,21 @@
 //! Tracks processes spawned by `Bash { background: true }` so they can be
 //! listed, and so they are cleaned up (SIGTERM) when the session ends.
 //!
-//! Each `ToolRegistry` owns one `BgRegistry`.  All background processes for
-//! the session are keyed by PID.
+//! ## Usage
+//!
+//! ```text
+//! Model calls: Bash { command: "npm run dev", background: true }
+//!   → Process spawned, PID recorded in BgRegistry
+//!   → Tool returns immediately: "Started PID 12345"
+//!   → Model continues with other work
+//!   → On session end: all tracked PIDs receive SIGTERM
+//! ```
+//!
+//! ## Design
+//!
+//! Each `ToolRegistry` owns one `BgRegistry`. All background processes for
+//! the session are keyed by PID. The registry is `Mutex`-protected since
+//! the spawning thread and the cleanup path may differ.
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/koda-core/src/tools/recall.rs
+++ b/koda-core/src/tools/recall.rs
@@ -1,7 +1,18 @@
 //! RecallContext — on-demand conversation history retrieval.
 //!
-//! Strong-tier only. Allows the model to page in older conversation
-//! context that was dropped from the sliding window.
+//! Allows the model to page in older conversation context that was dropped
+//! from the sliding window after compaction or microcompact.
+//!
+//! ## When it's used
+//!
+//! After compaction summarizes old messages, the model may need specific
+//! details (e.g., the exact error message from an earlier test run). Rather
+//! than re-running the command, it can recall the original tool result.
+//!
+//! ## Availability
+//!
+//! Strong-tier models only — cheaper models don't benefit enough from
+//! the extra context to justify the cost.
 
 use crate::db::Database;
 use crate::persistence::Persistence;

--- a/koda-core/src/tools/skill_tools.rs
+++ b/koda-core/src/tools/skill_tools.rs
@@ -1,7 +1,19 @@
 //! Skill activation tools for the LLM.
 //!
 //! Provides `ActivateSkill` and `ListSkills` tools that let the LLM
-//! inject expertise into its context by loading SKILL.md files.
+//! inject expertise into its context by loading `SKILL.md` files.
+//!
+//! ## ActivateSkill
+//!
+//! - **`skill_name`** (required) — name of the skill to load
+//! - Injects the skill's instructions into the conversation
+//! - Zero LLM cost (prompt injection, no extra inference call)
+//!
+//! ## ListSkills
+//!
+//! - No parameters — returns all available skills with descriptions
+//!
+//! See [`crate::skills`] for skill discovery, file format, and built-in skills.
 
 use crate::providers::ToolDefinition;
 use crate::skills::SkillRegistry;

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -2,6 +2,18 @@
 //!
 //! Runs **before** the approval prompt so we never ask the user to approve
 //! an operation that will inevitably fail. Cheap checks only — no mutations.
+//!
+//! ## What it validates
+//!
+//! - **Write**: target path resolves within project root
+//! - **Write (overwrite)**: file exists and `overwrite: true` is set
+//! - **Edit**: file exists, `old_str` is found, `old_str` is unique
+//!   (unless `replace_all: true`)
+//! - **Delete**: file exists
+//! - **Bash**: command is non-empty
+//!
+//! Validation errors are returned as tool results (not panics), so the
+//! model sees the error and can self-correct.
 
 use super::safe_resolve_path;
 use std::path::Path;

--- a/koda-core/src/truncate.rs
+++ b/koda-core/src/truncate.rs
@@ -4,6 +4,23 @@
 //! and the last N lines (tail) with a separator indicating how many lines
 //! were hidden. This keeps the UI scannable while preserving the most
 //! important parts (beginning for context, end for results).
+//!
+//! ## Example output
+//!
+//! ```text
+//! line 1
+//! line 2
+//! ... (248 lines hidden) ...
+//! line 299
+//! line 300
+//! ```
+//!
+//! ## Design rationale
+//!
+//! - **Head**: shows the start of output (file headers, command echoes, first errors)
+//! - **Tail**: shows the end (final results, exit codes, summary lines)
+//! - This mirrors how developers read logs: scan the top, then jump to the bottom
+//! - The hidden line count lets the model request specific sections if needed
 
 /// Default threshold: truncate if output exceeds this many lines.
 pub const TRUNCATE_THRESHOLD: usize = 50;


### PR DESCRIPTION
## What

Doc audit for koda-core module-level docs. Fixes issues found during systematic review of all `//!` pages.

### Duplications fixed
- `bash_safety`: remove stuttering description (lines 205-207)
- `keystore`: remove near-duplicate function doc

### Thin pages enriched (15 modules)
`git`, `truncate`, `context_analysis`, `bg_agent`, `sub_agent_cache`, `loop_guard`, `bash_path_lint`, `tool_dispatch`, `tools/bg_process`, `tools/recall`, `tools/validate`, `tools/skill_tools`, `settings`

Each got examples, flow diagrams, or "what it does vs doesn't" sections so the guide agent and contributors get useful context, not just one-liners.

### lib.rs one-liners updated
8 modules updated to match enriched docs.

### settings.rs corrected
The doc listed `max_tokens`, `temperature`, etc. as stored settings — the struct only stores `last_provider`. Fixed docs, flagged #693 for migrating the TOML file into SQLite.

### DESIGN.md: Documentation strategy
Added section explaining why we use docs.rs as our docs site (vs CC's separate `code.claude.com/docs`). Key points:
- Module `//!` docs are user-facing documentation
- koda-cli modules will be made `pub` for docs.rs visibility (separate PR)
- Zero infrastructure — `cargo doc` just works
- Single source of truth — docs live next to code

### Issues filed
- #693: migrate `settings.toml` → SQLite

## Testing
- `cargo clippy`: zero warnings
- `cargo test -p koda-core --lib`: 561 passed
- `cargo test --doc -p koda-core`: 15 passed
- `cargo doc`: zero warnings