### PR TITLE
refactor: consolidate config files into SQLite (#693)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "toml",
  "tracing",
  "url",
  "uuid",
@@ -3181,15 +3180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3872,45 +3862,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
-
-[[package]]
-name = "toml"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
-dependencies = [
- "winnow",
-]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4866,12 +4817,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -120,16 +120,16 @@ async fn main() -> Result<()> {
         match cmd {
             Command::Server { port, stdio } => {
                 if *stdio {
-                    // Load and inject stored API keys (env vars take precedence)
-                    match koda_core::keystore::KeyStore::load() {
-                        Ok(store) => store.inject_into_env(),
-                        Err(e) => tracing::warn!("Failed to load keystore: {e}"),
-                    }
-
                     let project_root = cli.project_root.clone().unwrap_or_else(|| {
                         std::env::current_dir().expect("Failed to get current directory")
                     });
                     let project_root = std::fs::canonicalize(&project_root)?;
+
+                    // Init DB and inject keys (#693)
+                    let db = koda_core::db::Database::init(&koda_core::db::config_dir()?).await?;
+                    if let Err(e) = koda_core::keystore::inject_into_env(&db).await {
+                        tracing::warn!("Failed to load keystore: {e}");
+                    }
 
                     let config = koda_core::config::KodaConfig::load(&project_root, &cli.agent)?;
                     let config = config
@@ -179,10 +179,12 @@ async fn main() -> Result<()> {
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);
 
+    // Initialize database early — keys and settings live here (#693)
+    let db = koda_core::db::Database::init(&koda_core::db::config_dir()?).await?;
+
     // Load and inject stored API keys (env vars take precedence)
-    match koda_core::keystore::KeyStore::load() {
-        Ok(store) => store.inject_into_env(),
-        Err(e) => tracing::warn!("Failed to load keystore: {e}"),
+    if let Err(e) = koda_core::keystore::inject_into_env(&db).await {
+        tracing::warn!("Failed to load keystore: {e}");
     }
 
     // Headless mode: skip onboarding, banner, version check
@@ -196,7 +198,6 @@ async fn main() -> Result<()> {
                 cli.thinking_budget,
                 cli.reasoning_effort,
             );
-        let db = koda_core::db::Database::init(&koda_core::db::config_dir()?).await?;
         let session_id = match cli.session {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,
@@ -230,8 +231,7 @@ async fn main() -> Result<()> {
             cli.reasoning_effort,
         );
 
-    // Initialize database
-    let db = koda_core::db::Database::init(&koda_core::db::config_dir()?).await?;
+    // Initialize database is already done above
 
     // Load or create session
     let session_id = match cli.session {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -75,7 +75,7 @@ pub async fn handle_slash_command(
                         let prov = provider.read().await;
                         config.query_and_apply_capabilities(prov.as_ref()).await;
                     }
-                    crate::tui_wizards::save_provider(config);
+                    crate::tui_wizards::save_provider(config, &session.db).await;
                     tui_output::ok_msg(
                         buffer,
                         format!(
@@ -93,7 +93,7 @@ pub async fn handle_slash_command(
                     let prov = provider.read().await;
                     config.query_and_apply_capabilities(prov.as_ref()).await;
                 }
-                crate::tui_wizards::save_provider(config);
+                crate::tui_wizards::save_provider(config, &session.db).await;
                 tui_output::ok_msg(buffer, format!("Model set to: {model}"));
             }
             SlashAction::Continue

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -176,7 +176,8 @@ impl TuiContext {
             self.textarea.select_all();
             self.textarea.cut();
             self.history.push(text.clone());
-            save_history(&self.history);
+            // Persist to DB (fire-and-forget)
+            let _ = self.session.db.history_push(&text).await;
             self.history_idx = None;
             let mode = approval::read_mode(&self.shared_mode);
             let icon = match mode {
@@ -414,48 +415,6 @@ impl TuiContext {
 }
 
 // ---------------------------------------------------------------------------
-// Command history persistence
-// ---------------------------------------------------------------------------
-
-const MAX_HISTORY: usize = 500;
-fn history_file_path() -> std::path::PathBuf {
-    let config_dir = std::env::var("XDG_CONFIG_HOME")
-        .or_else(|_| std::env::var("HOME").map(|h| format!("{h}/.config")))
-        .or_else(|_| std::env::var("USERPROFILE").map(|h| format!("{h}/.config")))
-        .unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(config_dir)
-        .join("koda")
-        .join("history")
-}
-
-pub(crate) fn load_history() -> Vec<String> {
-    load_history_from(&history_file_path())
-}
-
-fn load_history_from(path: &std::path::Path) -> Vec<String> {
-    match std::fs::read_to_string(path) {
-        Ok(content) => content
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(String::from)
-            .collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
-pub(crate) fn save_history(history: &[String]) {
-    save_history_to(history, &history_file_path());
-}
-
-fn save_history_to(history: &[String], path: &std::path::Path) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let start = history.len().saturating_sub(MAX_HISTORY);
-    let content = history[start..].join("\n");
-    let _ = std::fs::write(path, content);
-}
-
 // ---------------------------------------------------------------------------
 // Pure helper: history index navigation
 // ---------------------------------------------------------------------------
@@ -531,42 +490,27 @@ mod tests {
         assert_eq!(history_down_index(None, 5), None);
     }
 
-    // ── History file persistence ──────────────────────────────
+    // ── History DB persistence ────────────────────────────────
 
-    #[test]
-    fn test_history_round_trip() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("koda").join("history");
+    #[tokio::test]
+    async fn test_history_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = koda_core::db::Database::init(tmp.path()).await.unwrap();
 
-        let input = vec!["hello".into(), "world".into(), "/model gpt-4".into()];
-        save_history_to(&input, &path);
+        db.history_push("hello").await.unwrap();
+        db.history_push("world").await.unwrap();
+        db.history_push("/model gpt-4").await.unwrap();
 
-        let loaded = load_history_from(&path);
-        assert_eq!(loaded, input);
-        assert!(path.exists());
+        let loaded = db.history_load().await.unwrap();
+        assert_eq!(loaded, vec!["hello", "world", "/model gpt-4"]);
     }
 
-    #[test]
-    fn test_history_truncation() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("koda").join("history");
+    #[tokio::test]
+    async fn test_history_empty_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = koda_core::db::Database::init(tmp.path()).await.unwrap();
 
-        let big: Vec<String> = (0..MAX_HISTORY + 100).map(|i| format!("cmd {i}")).collect();
-        save_history_to(&big, &path);
-
-        let loaded = load_history_from(&path);
-        assert_eq!(loaded.len(), MAX_HISTORY);
-        // Should keep the LATEST entries (tail)
-        assert_eq!(loaded[0], format!("cmd {}", 100));
-        assert_eq!(loaded[MAX_HISTORY - 1], format!("cmd {}", MAX_HISTORY + 99));
-    }
-
-    #[test]
-    fn test_load_history_missing_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("nonexistent").join("history");
-
-        let loaded = load_history_from(&path);
+        let loaded = db.history_load().await.unwrap();
         assert!(loaded.is_empty());
     }
 }

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -463,7 +463,7 @@ impl TuiContext {
                                 self.config.model_settings.model = actual_model.clone();
                                 self.config.recalculate_model_derived();
                                 self.query_model_capabilities().await;
-                                crate::tui_wizards::save_provider(&self.config);
+                                crate::tui_wizards::save_provider(&self.config, &self.session.db).await;
                                 self.renderer.model = actual_model.clone();
                                 self.scroll_buffer.push(Line::styled(
                                     format!("  \u{2714} Model: {label} ({actual_model})"),
@@ -476,7 +476,7 @@ impl TuiContext {
                             self.config.model_settings.model = model_id.clone();
                             self.config.recalculate_model_derived();
                             self.query_model_capabilities().await;
-                            crate::tui_wizards::save_provider(&self.config);
+                            crate::tui_wizards::save_provider(&self.config, &self.session.db).await;
                             self.renderer.model = model_id.clone();
                             self.scroll_buffer.push(Line::styled(
                                 format!("  \u{2714} Model set to: {model_id}"),
@@ -552,7 +552,7 @@ impl TuiContext {
                     self.config.model_settings.model = model_id.clone();
                     self.config.recalculate_model_derived();
                     self.query_model_capabilities().await;
-                    crate::tui_wizards::save_provider(&self.config);
+                    crate::tui_wizards::save_provider(&self.config, &self.session.db).await;
                     self.renderer.model = model_id.clone();
                     self.scroll_buffer.push(Line::styled(
                         format!("  \u{2714} Model set to: {model_id} ({ptype})"),
@@ -604,10 +604,7 @@ impl TuiContext {
                     }
                     if !value.is_empty() {
                         koda_core::runtime_env::set(&env_name, &value);
-                        if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
-                            store.set(&env_name, &value);
-                            let _ = store.save();
-                        }
+                        let _ = koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
                         let masked = koda_core::keystore::mask_key(&value);
                         self.scroll_buffer.push(Line::styled(
                             format!("  \u{2714} {env_name} set to {masked}"),
@@ -624,10 +621,7 @@ impl TuiContext {
                         ));
                     } else if !value.is_empty() {
                         koda_core::runtime_env::set(&env_name, &value);
-                        if let Ok(mut store) = koda_core::keystore::KeyStore::load() {
-                            store.set(&env_name, &value);
-                            let _ = store.save();
-                        }
+                        let _ = koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
                         let masked = koda_core::keystore::mask_key(&value);
                         self.scroll_buffer.push(Line::styled(
                             format!("  \u{2714} {env_name} set to {masked}"),
@@ -661,7 +655,7 @@ impl TuiContext {
         self.config.model_settings.model = self.config.model.clone();
         self.config.recalculate_model_derived();
         *self.provider.write().await = koda_core::providers::create_provider(&self.config);
-        crate::tui_wizards::save_provider(&self.config);
+        crate::tui_wizards::save_provider(&self.config, &self.session.db).await;
 
         let prov = self.provider.read().await;
         if let Ok(models) = prov.list_models().await {

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -463,7 +463,8 @@ impl TuiContext {
                                 self.config.model_settings.model = actual_model.clone();
                                 self.config.recalculate_model_derived();
                                 self.query_model_capabilities().await;
-                                crate::tui_wizards::save_provider(&self.config, &self.session.db).await;
+                                crate::tui_wizards::save_provider(&self.config, &self.session.db)
+                                    .await;
                                 self.renderer.model = actual_model.clone();
                                 self.scroll_buffer.push(Line::styled(
                                     format!("  \u{2714} Model: {label} ({actual_model})"),
@@ -604,7 +605,8 @@ impl TuiContext {
                     }
                     if !value.is_empty() {
                         koda_core::runtime_env::set(&env_name, &value);
-                        let _ = koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
+                        let _ =
+                            koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
                         let masked = koda_core::keystore::mask_key(&value);
                         self.scroll_buffer.push(Line::styled(
                             format!("  \u{2714} {env_name} set to {masked}"),
@@ -621,7 +623,8 @@ impl TuiContext {
                         ));
                     } else if !value.is_empty() {
                         koda_core::runtime_env::set(&env_name, &value);
-                        let _ = koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
+                        let _ =
+                            koda_core::keystore::set_key(&self.session.db, &env_name, &value).await;
                         let masked = koda_core::keystore::mask_key(&value);
                         self.scroll_buffer.push(Line::styled(
                             format!("  \u{2714} {env_name} set to {masked}"),

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -9,9 +9,6 @@
 mod events;
 mod menus;
 
-use events::load_history;
-pub(crate) use events::save_history;
-
 use crate::input;
 use crate::scroll_buffer::ScrollBuffer;
 use crate::sink::UiEvent;
@@ -123,9 +120,8 @@ impl TuiContext {
         version_check: tokio::task::JoinHandle<Option<String>>,
         first_run: bool,
     ) -> Result<Self> {
-        // Restore last-used provider
-        let settings = koda_core::approval::Settings::load();
-        if let Some(ref last) = settings.last_provider {
+        // Restore last-used provider from DB (#693)
+        if let Ok(Some(last)) = koda_core::settings::load_last_provider(&db).await {
             let ptype =
                 koda_core::config::ProviderType::from_url_or_name("", Some(&last.provider_type));
             config.provider_type = ptype;
@@ -324,7 +320,7 @@ impl TuiContext {
             silent_compact_deferred: false,
             inference_start: None,
             context_pct: 0,
-            history: load_history(),
+            history: db.history_load().await.unwrap_or_default(),
             history_idx: None,
             completer,
             mouse_selection: None,

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -7,7 +7,7 @@
 use crate::input;
 use crate::scroll_buffer::ScrollBuffer;
 use crate::sink::UiEvent;
-use crate::tui_context::{TuiContext, save_history};
+use crate::tui_context::TuiContext;
 use crate::tui_types::{MenuContent, PromptMode, TuiState};
 use crate::tui_viewport::draw_viewport;
 
@@ -36,6 +36,7 @@ impl TuiContext {
     ) -> anyhow::Result<()> {
         let cli_sink = crate::sink::CliSink::channel(ui_tx.clone());
         let cancel_token = self.session.cancel.clone();
+        let db_handle = self.session.db.clone();
 
         self.tui_state = TuiState::Inferring;
         self.inference_start = Some(std::time::Instant::now());
@@ -105,6 +106,7 @@ impl TuiContext {
                             &mut self.history_idx,
                             &mut self.input_queue,
                             &mut self.paste_blocks,
+                            &db_handle,
                         ).await;
                     }
                     Some(ui_event) = ui_rx.recv() => {
@@ -283,6 +285,7 @@ async fn handle_crossterm_event_inline(
     history_idx: &mut Option<usize>,
     input_queue: &mut std::collections::VecDeque<String>,
     paste_blocks: &mut Vec<input::PasteBlock>,
+    db: &koda_core::db::Database,
 ) {
     use crossterm::event::MouseEventKind;
     match ev {
@@ -327,6 +330,7 @@ async fn handle_crossterm_event_inline(
                 history,
                 history_idx,
                 input_queue,
+                db,
             )
             .await;
         }
@@ -349,6 +353,7 @@ async fn handle_inference_key_inline(
     history: &mut Vec<String>,
     history_idx: &mut Option<usize>,
     input_queue: &mut std::collections::VecDeque<String>,
+    db: &koda_core::db::Database,
 ) {
     // Approval hotkeys
     if let MenuContent::Approval { id, .. } = menu {
@@ -503,7 +508,7 @@ async fn handle_inference_key_inline(
                 textarea.select_all();
                 textarea.cut();
                 history.push(text.clone());
-                save_history(history);
+                let _ = db.history_push(&text).await;
                 *history_idx = None;
                 input_queue.push_back(text);
             }

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -410,13 +410,14 @@ pub(crate) fn handle_memory(
     }
 }
 
-pub(crate) fn save_provider(config: &KodaConfig) {
-    let mut s = koda_core::approval::Settings::load();
-    let _ = s.save_last_provider(
+pub(crate) async fn save_provider(config: &KodaConfig, db: &koda_core::db::Database) {
+    let _ = koda_core::settings::save_last_provider(
+        db,
         &config.provider_type.to_string(),
         &config.base_url,
         &config.model,
-    );
+    )
+    .await;
 }
 
 // ── API key management (/key) ─────────────────────────

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -21,7 +21,6 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "1"
 
 # Logging
 tracing = "0.1"

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -312,8 +312,8 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
 
 // ── Settings persistence ──────────────────────────────────
 
-/// Re-export settings types used by approval persistence.
-pub use crate::settings::{LastProvider, Settings};
+/// Re-export settings types for provider persistence.
+pub use crate::settings::LastProvider;
 
 // ── Tests ─────────────────────────────────────────────────
 

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -391,11 +391,10 @@ impl From<MessageRow> for Message {
 impl Database {
     /// Get a value from the global KV store.
     pub async fn kv_get(&self, key: &str) -> Result<Option<String>> {
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT value FROM kv_store WHERE key = ?")
-                .bind(key)
-                .fetch_optional(&self.pool)
-                .await?;
+        let row: Option<(String,)> = sqlx::query_as("SELECT value FROM kv_store WHERE key = ?")
+            .bind(key)
+            .fetch_optional(&self.pool)
+            .await?;
         Ok(row.map(|(v,)| v))
     }
 

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -15,6 +15,8 @@
 //! - **Sessions** — session metadata, timestamps, model info
 //! - **File ownership** — which files Koda created (for auto-approve Delete)
 //! - **Progress entries** — survive compaction for persistent tracking
+//! - **KV store** — settings (last provider) and API keys (#693)
+//! - **Input history** — REPL command history (#693)
 //!
 //! ## Module layout
 //!
@@ -76,7 +78,14 @@ impl Database {
 
         let db_path = db_dir.join("koda.db");
 
-        Self::open(&db_path).await
+        let db = Self::open(&db_path).await?;
+
+        // Ensure restrictive permissions — DB contains API keys and
+        // conversation history that may include secrets (#693).
+        #[cfg(unix)]
+        Self::set_db_permissions(&db_path);
+
+        Ok(db)
     }
 
     /// Open a database at a specific path (used by tests and init).
@@ -179,7 +188,45 @@ impl Database {
         .execute(pool)
         .await?;
 
+        // Global key-value store (#693): replaces settings.toml and keys.toml.
+        // Keys are namespaced by convention:
+        //   - `setting:*`  — last-used provider, etc.
+        //   - `apikey:*`   — API keys (GEMINI_API_KEY, etc.)
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS kv_store (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .execute(pool)
+        .await?;
+
+        // REPL input history (#693): replaces ~/.config/koda/history.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS input_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                input TEXT NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );",
+        )
+        .execute(pool)
+        .await?;
+
         Ok(())
+    }
+
+    /// Set koda.db file permissions to 0600 (owner-only).
+    ///
+    /// The DB contains API keys and conversation history that may include
+    /// secrets. Restrictive permissions prevent other local users from reading.
+    #[cfg(unix)]
+    fn set_db_permissions(db_path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = std::fs::set_permissions(db_path, perms) {
+            tracing::warn!("Failed to set 0600 on {}: {e}", db_path.display());
+        }
     }
 }
 
@@ -336,5 +383,88 @@ impl From<MessageRow> for Message {
             thinking_tokens: r.thinking_tokens,
             created_at: r.created_at,
         }
+    }
+}
+
+// ── Global KV store (#693) ─────────────────────────────────────────────────────────
+
+impl Database {
+    /// Get a value from the global KV store.
+    pub async fn kv_get(&self, key: &str) -> Result<Option<String>> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT value FROM kv_store WHERE key = ?")
+                .bind(key)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(v,)| v))
+    }
+
+    /// Set a value in the global KV store (upsert).
+    pub async fn kv_set(&self, key: &str, value: &str) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO kv_store (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Delete a key from the global KV store.
+    pub async fn kv_delete(&self, key: &str) -> Result<()> {
+        sqlx::query("DELETE FROM kv_store WHERE key = ?")
+            .bind(key)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Get all KV entries matching a prefix (e.g. `"apikey:"`).
+    pub async fn kv_list_prefix(&self, prefix: &str) -> Result<Vec<(String, String)>> {
+        let pattern = format!("{prefix}%");
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT key, value FROM kv_store WHERE key LIKE ?")
+                .bind(&pattern)
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows)
+    }
+}
+
+// ── Input history (#693) ─────────────────────────────────────────────────────────
+
+/// Maximum number of input history entries to keep.
+const MAX_INPUT_HISTORY: i64 = 500;
+
+impl Database {
+    /// Append an input to the history.
+    pub async fn history_push(&self, input: &str) -> Result<()> {
+        sqlx::query("INSERT INTO input_history (input) VALUES (?)")
+            .bind(input)
+            .execute(&self.pool)
+            .await?;
+
+        // Trim old entries beyond the cap.
+        sqlx::query(
+            "DELETE FROM input_history WHERE id NOT IN (
+                SELECT id FROM input_history ORDER BY id DESC LIMIT ?
+            )",
+        )
+        .bind(MAX_INPUT_HISTORY)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
+    /// Load all history entries, oldest first.
+    pub async fn history_load(&self) -> Result<Vec<String>> {
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT input FROM input_history ORDER BY id ASC")
+                .fetch_all(&self.pool)
+                .await?;
+        Ok(rows.into_iter().map(|(s,)| s).collect())
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -51,7 +51,6 @@ use crate::persistence::Persistence;
 use crate::providers::{
     ChatMessage, ImageData, LlmProvider, StreamChunk, TokenUsage, ToolCall, ToolDefinition,
 };
-use crate::settings::Settings;
 use crate::tool_dispatch::{
     can_parallelize, execute_tools_parallel, execute_tools_sequential, execute_tools_split_batch,
 };
@@ -553,8 +552,6 @@ pub struct InferenceContext<'a> {
     pub pending_images: Option<Vec<ImageData>>,
     /// Current approval mode.
     pub mode: ApprovalMode,
-    /// User settings (may be mutated for auto-compact).
-    pub settings: &'a mut Settings,
     /// Event sink for streaming output to the client.
     pub sink: &'a dyn EngineSink,
     /// Cancellation token for graceful interruption.
@@ -578,7 +575,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         tool_defs,
         pending_images,
         mode,
-        settings,
         sink,
         cancel,
         cmd_rx,
@@ -973,7 +969,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 session_id,
                 tools,
                 mode,
-                settings,
                 sink,
                 cancel.clone(),
                 cmd_rx,
@@ -991,7 +986,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 session_id,
                 tools,
                 mode,
-                settings,
                 sink,
                 cancel.clone(),
                 cmd_rx,

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -1,118 +1,54 @@
-//! Secure API key storage.
+//! Secure API key storage (#693).
 //!
-//! Keys are stored in `~/.config/koda/keys.toml` with
-//! restrictive file permissions (0600). This file is user-level,
-//! never inside a project directory, and never committed to git.
+//! Keys are stored in SQLite via the [`crate::db`] KV store with the
+//! `apikey:` prefix. The database file is created with 0600 permissions.
 //!
 //! ## Supported providers
 //!
 //! Each provider has its own key entry. Use `/key` in the REPL
 //! or the onboarding wizard to manage keys.
 //!
-//! ```toml
-//! [keys]
-//! anthropic = "sk-ant-..."
-//! openai = "sk-..."
-//! gemini = "AIza..."
-//! ```
-//!
 //! Keys are also read from environment variables (e.g., `ANTHROPIC_API_KEY`).
 //! The keystore is checked first, then the environment.
 
-use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::PathBuf;
+use crate::db::Database;
+use anyhow::Result;
 
-const KEYS_FILE: &str = "keys.toml";
+/// KV key prefix for API keys.
+const PREFIX: &str = "apikey:";
 
-/// Stored API keys, keyed by env var name (e.g. "ANTHROPIC_API_KEY").
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct KeyStore {
-    #[serde(default)]
-    /// Map of environment variable name → API key value.
-    pub keys: HashMap<String, String>,
+/// Set an API key in the DB.
+pub async fn set_key(db: &Database, env_name: &str, value: &str) -> Result<()> {
+    let key = format!("{PREFIX}{env_name}");
+    db.kv_set(&key, value).await
 }
 
-impl KeyStore {
-    /// Load keys from disk. Returns empty store if file doesn't exist.
-    pub fn load() -> Result<Self> {
-        let path = Self::keys_path()?;
-        if !path.exists() {
-            return Ok(Self::default());
-        }
-        let content = std::fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
-        let store: Self = toml::from_str(&content)
-            .with_context(|| format!("Failed to parse {}", path.display()))?;
-        Ok(store)
-    }
+/// Get an API key from the DB.
+pub async fn get_key(db: &Database, env_name: &str) -> Result<Option<String>> {
+    let key = format!("{PREFIX}{env_name}");
+    db.kv_get(&key).await
+}
 
-    /// Save keys to disk with restrictive permissions.
-    ///
-    /// On Unix, the file is created with mode 0600 atomically via `OpenOptions`
-    /// to avoid a TOCTOU window where the file is world-readable between
-    /// `write()` and `set_permissions()`.
-    pub fn save(&self) -> Result<()> {
-        let path = Self::keys_path()?;
+/// Remove an API key from the DB.
+pub async fn remove_key(db: &Database, env_name: &str) -> Result<()> {
+    let key = format!("{PREFIX}{env_name}");
+    db.kv_delete(&key).await
+}
 
-        // Ensure config directory exists
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        let content = toml::to_string_pretty(self)?;
-
-        #[cfg(unix)]
-        {
-            use std::io::Write;
-            use std::os::unix::fs::OpenOptionsExt;
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&path)
-                .with_context(|| format!("Failed to create {}", path.display()))?;
-            file.write_all(content.as_bytes())?;
-        }
-
-        #[cfg(not(unix))]
-        {
-            // TODO: Windows ACL — std::fs::write inherits parent directory ACLs,
-            // which typically grants read access to the Users group. API keys are
-            // readable by any local user. Low risk for single-user dev machines,
-            // but if koda ever runs on shared workstations or as a service,
-            // restrict the DACL to the current user SID via SetNamedSecurityInfoW.
-            std::fs::write(&path, &content)?;
-        }
-
-        tracing::info!("Saved keys to {}", path.display());
-        Ok(())
-    }
-
-    /// Set a key by env var name.
-    pub fn set(&mut self, env_name: &str, value: &str) {
-        self.keys.insert(env_name.to_string(), value.to_string());
-    }
-
-    /// Load all stored keys into the runtime environment.
-    /// Only sets vars that aren't already set (env vars and
-    /// previously-set runtime vars take precedence).
-    pub fn inject_into_env(&self) {
-        for (name, value) in &self.keys {
-            if crate::runtime_env::get(name).is_none() {
-                crate::runtime_env::set(name, value);
-                tracing::debug!("Injected stored key: {name}");
-            }
+/// Load all stored keys and inject into the runtime environment.
+///
+/// Only sets vars that aren't already set (env vars and
+/// previously-set runtime vars take precedence).
+pub async fn inject_into_env(db: &Database) -> Result<()> {
+    let entries = db.kv_list_prefix(PREFIX).await?;
+    for (key, value) in entries {
+        let env_name = &key[PREFIX.len()..];
+        if crate::runtime_env::get(env_name).is_none() {
+            crate::runtime_env::set(env_name, &value);
+            tracing::debug!("Injected stored key: {env_name}");
         }
     }
-
-    /// Path to the keys file: ~/.config/koda/keys.toml
-    pub fn keys_path() -> Result<PathBuf> {
-        let config_dir = crate::db::config_dir()?;
-        Ok(config_dir.join(KEYS_FILE))
-    }
+    Ok(())
 }
 
 /// Mask a key for display: shows first 4 and last 4 characters.
@@ -136,32 +72,6 @@ pub fn mask_key(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn test_keystore_roundtrip() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("keys.toml");
-
-        let mut store = KeyStore::default();
-        store.set("OPENAI_API_KEY", "sk-test-123");
-        store.set("ANTHROPIC_API_KEY", "sk-ant-456");
-
-        // Save
-        let content = toml::to_string_pretty(&store).unwrap();
-        std::fs::write(&path, &content).unwrap();
-
-        // Load
-        let loaded: KeyStore = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-        assert_eq!(
-            loaded.keys.get("OPENAI_API_KEY").map(|s| s.as_str()),
-            Some("sk-test-123")
-        );
-        assert_eq!(
-            loaded.keys.get("ANTHROPIC_API_KEY").map(|s| s.as_str()),
-            Some("sk-ant-456")
-        );
-    }
 
     #[test]
     fn test_mask_key() {
@@ -169,12 +79,33 @@ mod tests {
         assert_eq!(mask_key("short"), "****");
     }
 
-    #[test]
-    fn test_remove_key() {
-        let mut store = KeyStore::default();
-        store.set("TEST_KEY", "value");
-        assert!(store.keys.remove("TEST_KEY").is_some());
-        assert!(store.keys.remove("TEST_KEY").is_none());
-        assert_eq!(store.keys.get("TEST_KEY"), None);
+    #[tokio::test]
+    async fn test_keystore_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = Database::init(tmp.path()).await.unwrap();
+
+        set_key(&db, "TEST_KEY", "test-value").await.unwrap();
+        let val = get_key(&db, "TEST_KEY").await.unwrap();
+        assert_eq!(val.as_deref(), Some("test-value"));
+
+        remove_key(&db, "TEST_KEY").await.unwrap();
+        let val = get_key(&db, "TEST_KEY").await.unwrap();
+        assert_eq!(val, None);
+    }
+
+    #[tokio::test]
+    async fn test_inject_skips_existing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = Database::init(tmp.path()).await.unwrap();
+
+        // Set a key that already exists in runtime env
+        let unique = format!("KODA_TEST_{}", std::process::id());
+        crate::runtime_env::set(&unique, "original");
+        set_key(&db, &unique, "overwritten").await.unwrap();
+
+        inject_into_env(&db).await.unwrap();
+
+        // Should keep the original value
+        assert_eq!(crate::runtime_env::get(&unique).as_deref(), Some("original"));
     }
 }

--- a/koda-core/src/keystore.rs
+++ b/koda-core/src/keystore.rs
@@ -106,6 +106,9 @@ mod tests {
         inject_into_env(&db).await.unwrap();
 
         // Should keep the original value
-        assert_eq!(crate::runtime_env::get(&unique).as_deref(), Some("original"));
+        assert_eq!(
+            crate::runtime_env::get(&unique).as_deref(),
+            Some("original")
+        );
     }
 }

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -1,7 +1,7 @@
 //! KodaSession — per-conversation state.
 //!
 //! Holds mutable, per-turn state: database handle, session ID,
-//! provider instance, approval settings, and cancellation token.
+//! provider instance, approval mode, and cancellation token.
 //! Instantiable N times for parallel sub-agents or cowork mode.
 //!
 //! ## Architecture
@@ -30,7 +30,6 @@ use crate::engine::{EngineCommand, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference::InferenceContext;
 use crate::providers::{self, ImageData, LlmProvider};
-use crate::settings::Settings;
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -39,7 +38,7 @@ use tokio_util::sync::CancellationToken;
 
 /// A single conversation session with its own state.
 ///
-/// Each session has its own provider, approval settings, and cancel token.
+/// Each session has its own provider, approval mode, and cancel token.
 /// Multiple sessions can share the same `Arc<KodaAgent>`.
 pub struct KodaSession {
     /// Unique session identifier.
@@ -52,8 +51,6 @@ pub struct KodaSession {
     pub provider: Box<dyn LlmProvider>,
     /// Current approval mode (Auto / Confirm).
     pub mode: ApprovalMode,
-    /// User settings (last provider, preferences).
-    pub settings: Settings,
     /// Cancellation token for graceful shutdown.
     pub cancel: CancellationToken,
     /// File lifecycle tracker — tracks files created by Koda (#465).
@@ -72,7 +69,6 @@ impl KodaSession {
         mode: ApprovalMode,
     ) -> Self {
         let provider = providers::create_provider(config);
-        let settings = Settings::load();
         // Wire db+session into ToolRegistry for RecallContext
         agent.tools.set_session(Arc::new(db.clone()), id.clone());
         let file_tracker = FileTracker::new(&id, db.clone()).await;
@@ -82,7 +78,6 @@ impl KodaSession {
             db,
             provider,
             mode,
-            settings,
             cancel: CancellationToken::new(),
             file_tracker,
             title_set: false,
@@ -91,8 +86,7 @@ impl KodaSession {
 
     /// Run one inference turn: prompt → streaming → tool execution → response.
     ///
-    /// Emits `TurnStart` and `TurnEnd` lifecycle events. The loop-cap prompt
-    /// is handled via `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`
+    /// Emits `TurnStart` and `TurnEnd` lifecycle events. The loop-cap prompt is handled via `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`
     /// through the `cmd_rx` channel.
     pub async fn run_turn(
         &mut self,
@@ -117,7 +111,6 @@ impl KodaSession {
             tool_defs: &self.agent.tool_defs,
             pending_images,
             mode: self.mode,
-            settings: &mut self.settings,
             sink,
             cancel: self.cancel.clone(),
             cmd_rx,

--- a/koda-core/src/settings.rs
+++ b/koda-core/src/settings.rs
@@ -1,27 +1,17 @@
-//! Last-used provider persistence.
+//! Last-used provider persistence (#693).
 //!
 //! Remembers the last provider/model/base-URL so Koda can auto-restore
-//! on next startup. Currently stored in `~/.config/koda/settings.toml`.
-//!
-//! **Note:** This module is slated for removal (#693). The TOML file
-//! should be a row in SQLite, not a separate config file — users should
-//! never edit it manually.
+//! on next startup. Stored in SQLite via the [`crate::db`] KV store.
 //!
 //! This is **not** user configuration — Koda follows "customization over
 //! configuration" (see DESIGN.md). The only persisted state is which
 //! provider the user last chose via `/model`.
 
-use std::path::{Path, PathBuf};
+use crate::db::Database;
+use anyhow::Result;
 
-/// Last-used provider state, restored on startup.
-///
-/// Not user configuration — just session memory.
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct Settings {
-    /// Last-used provider/model, restored on next startup.
-    #[serde(default)]
-    pub last_provider: Option<LastProvider>,
-}
+/// KV key for the last-used provider.
+const KV_KEY: &str = "setting:last_provider";
 
 /// Last-used provider configuration, restored on startup.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -34,51 +24,26 @@ pub struct LastProvider {
     pub model: String,
 }
 
-impl Settings {
-    /// Load from `~/.config/koda/settings.toml`, returning defaults if missing.
-    pub fn load() -> Self {
-        Self::settings_path()
-            .and_then(|path| std::fs::read_to_string(&path).ok())
-            .and_then(|content| toml::from_str(&content).ok())
-            .unwrap_or_default()
+/// Load the last-used provider from the DB. Returns `None` if not set.
+pub async fn load_last_provider(db: &Database) -> Result<Option<LastProvider>> {
+    match db.kv_get(KV_KEY).await? {
+        Some(json) => Ok(serde_json::from_str(&json)?),
+        None => Ok(None),
     }
+}
 
-    /// Save to `~/.config/koda/settings.toml`.
-    pub fn save(&self) -> anyhow::Result<()> {
-        let path = Self::settings_path()
-            .ok_or_else(|| anyhow::anyhow!("Cannot determine config directory"))?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let content = toml::to_string_pretty(self)?;
-        std::fs::write(&path, content)?;
-        Ok(())
-    }
-
-    /// Save the last-used provider/model for restoration on next startup.
-    pub fn save_last_provider(
-        &mut self,
-        provider_type: &str,
-        base_url: &str,
-        model: &str,
-    ) -> anyhow::Result<()> {
-        self.last_provider = Some(LastProvider {
-            provider_type: provider_type.to_string(),
-            base_url: base_url.to_string(),
-            model: model.to_string(),
-        });
-        self.save()
-    }
-
-    fn settings_path() -> Option<PathBuf> {
-        let home = std::env::var("HOME")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .ok()?;
-        Some(
-            Path::new(&home)
-                .join(".config")
-                .join("koda")
-                .join("settings.toml"),
-        )
-    }
+/// Save the last-used provider to the DB.
+pub async fn save_last_provider(
+    db: &Database,
+    provider_type: &str,
+    base_url: &str,
+    model: &str,
+) -> Result<()> {
+    let lp = LastProvider {
+        provider_type: provider_type.to_string(),
+        base_url: base_url.to_string(),
+        model: model.to_string(),
+    };
+    let json = serde_json::to_string(&lp)?;
+    db.kv_set(KV_KEY, &json).await
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -3,7 +3,7 @@
 //! Extracted from `tool_dispatch.rs` — handles `InvokeAgent` execution,
 //! background agent spawning, worktree provisioning, and sub-agent caching.
 
-use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
+use crate::approval::{self, ApprovalMode, ToolApproval};
 use crate::approval_flow::request_approval;
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
@@ -35,7 +35,6 @@ async fn run_bg_agent(
     parent_session: String,
     tx: tokio::sync::oneshot::Sender<Result<String, String>>,
 ) {
-    let mut settings = Settings::default();
     let cancel = CancellationToken::new();
     let (_, mut cmd_rx) = mpsc::channel(1);
     let null_sink = crate::engine::sink::NullSink;
@@ -52,7 +51,6 @@ async fn run_bg_agent(
         &db,
         &sync_arguments,
         ApprovalMode::Auto,
-        &mut settings,
         &null_sink,
         cancel,
         &mut cmd_rx,
@@ -83,7 +81,6 @@ pub(crate) async fn execute_sub_agent(
     db: &Database,
     arguments: &str,
     mode: ApprovalMode,
-    _settings: &mut Settings,
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -27,7 +27,7 @@
 //!   `match` in `ToolRegistry::execute()`, not a `HashMap<String, Box<dyn Tool>>`.
 //!   Rust's exhaustive matching catches missing handlers at compile time.
 
-use crate::approval::{self, ApprovalMode, Settings, ToolApproval};
+use crate::approval::{self, ApprovalMode, ToolApproval};
 use crate::approval_flow::{handle_ask_user, request_approval};
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
@@ -208,14 +208,12 @@ pub(crate) async fn execute_one_tool(
 ) -> (String, String, bool, Option<String>) {
     let (result, success, full_output) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
-        let mut sub_settings = Settings::default();
         match sub_agent_dispatch::execute_sub_agent(
             project_root,
             config,
             db,
             &tc.arguments,
             mode,
-            &mut sub_settings,
             sink,
             cancel.clone(),
             // Sub-agents get a fresh command channel (they auto-approve in all modes)
@@ -331,7 +329,6 @@ pub(crate) async fn execute_tools_split_batch(
     session_id: &str,
     tools: &crate::tools::ToolRegistry,
     mode: ApprovalMode,
-    settings: &mut Settings,
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
@@ -407,7 +404,6 @@ pub(crate) async fn execute_tools_split_batch(
                 session_id,
                 tools,
                 mode,
-                settings,
                 sink,
                 cancel.clone(),
                 cmd_rx,
@@ -430,7 +426,6 @@ pub(crate) async fn execute_tools_split_batch(
             session_id,
             tools,
             mode,
-            settings,
             sink,
             cancel.clone(),
             cmd_rx,
@@ -454,7 +449,6 @@ pub(crate) async fn execute_tools_sequential(
     session_id: &str,
     tools: &crate::tools::ToolRegistry,
     mode: ApprovalMode,
-    _settings: &mut Settings,
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -74,7 +74,6 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
     let sink = TestSink::new();
     let cancel = CancellationToken::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
-    let mut settings = koda_core::approval::Settings::load();
     let mut file_tracker = koda_core::file_tracker::FileTracker::new(&session_id, db.clone()).await;
 
     // Cancel after 100ms — well before SlowProvider's 60s sleep
@@ -97,7 +96,6 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         tool_defs: &tool_defs,
         pending_images: None,
         mode: koda_core::approval::ApprovalMode::Auto,
-        settings: &mut settings,
         sink: &sink,
         cancel,
         cmd_rx: &mut cmd_rx,

--- a/koda-core/tests/e2e_harness/mod.rs
+++ b/koda-core/tests/e2e_harness/mod.rs
@@ -11,7 +11,6 @@ use koda_core::{
     engine::{EngineCommand, EngineEvent, sink::TestSink},
     inference::{self, InferenceContext},
     providers::mock::MockProvider,
-    settings::Settings,
     tools::ToolRegistry,
 };
 use std::path::PathBuf;
@@ -66,7 +65,6 @@ impl Env {
     pub async fn run_inference(&self, provider: &MockProvider) -> Vec<EngineEvent> {
         let sink = TestSink::new();
         let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
-        let mut settings = Settings::load();
         let tool_defs = self.tool_defs();
         let mut file_tracker =
             koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
@@ -82,7 +80,6 @@ impl Env {
             tool_defs: &tool_defs,
             pending_images: None,
             mode: ApprovalMode::Auto,
-            settings: &mut settings,
             sink: &sink,
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -18,7 +18,6 @@ use koda_core::{
         ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
         mock::{MockProvider, MockResponse},
     },
-    settings::Settings,
 };
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -159,7 +158,6 @@ async fn test_provider_error_emits_error_event() {
     let provider = MockProvider::new(vec![MockResponse::Error("Internal server error".into())]);
     let sink = koda_core::engine::sink::TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
-    let mut settings = Settings::load();
     let tool_defs = env.tool_defs();
     let mut file_tracker =
         koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
@@ -175,7 +173,6 @@ async fn test_provider_error_emits_error_event() {
         tool_defs: &tool_defs,
         pending_images: None,
         mode: ApprovalMode::Auto,
-        settings: &mut settings,
         sink: &sink,
         cancel: CancellationToken::new(),
         cmd_rx: &mut cmd_rx,
@@ -262,7 +259,6 @@ async fn test_cancel_during_streaming() {
 
     let sink = koda_core::engine::sink::TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
-    let mut settings = Settings::load();
     let tool_defs = env.tool_defs();
     let cancel = CancellationToken::new();
     let mut file_tracker =
@@ -286,7 +282,6 @@ async fn test_cancel_during_streaming() {
         tool_defs: &tool_defs,
         pending_images: None,
         mode: ApprovalMode::Auto,
-        settings: &mut settings,
         sink: &sink,
         cancel,
         cmd_rx: &mut cmd_rx,

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -11,7 +11,6 @@ use koda_core::{
     engine::{EngineCommand, EngineEvent, sink::TestSink},
     inference::{self, InferenceContext},
     providers::mock::{MockProvider, MockResponse},
-    settings::Settings,
     tools::ToolRegistry,
 };
 use std::path::PathBuf;
@@ -65,7 +64,6 @@ impl Env {
     async fn run(&self, provider: &MockProvider) -> (anyhow::Result<()>, Vec<EngineEvent>) {
         let sink = TestSink::new();
         let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
-        let mut settings = Settings::load();
         let tool_defs = self.tool_defs();
         let mut file_tracker =
             koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
@@ -81,7 +79,6 @@ impl Env {
             tool_defs: &tool_defs,
             pending_images: None,
             mode: ApprovalMode::Auto,
-            settings: &mut settings,
             sink: &sink,
             cancel: CancellationToken::new(),
             cmd_rx: &mut cmd_rx,

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -15,7 +15,6 @@ use koda_core::{
         mock::{MockProvider, MockResponse},
     },
     session::KodaSession,
-    settings::Settings,
     tools::ToolRegistry,
 };
 use std::path::PathBuf;
@@ -90,7 +89,6 @@ impl Env {
             db: self.db.clone(),
             provider,
             mode: ApprovalMode::Auto,
-            settings: Settings::load(),
             cancel: cancel.clone(),
             file_tracker,
             title_set: false,


### PR DESCRIPTION
## Summary

Migrate `settings.toml`, `keys.toml`, and `history` from flat files into SQLite via the existing db module, eliminating 3 config files.

### What changed

| Before | After |
|---|---|
| `settings.toml` (last provider) | `kv_store` table, `setting:` prefix |
| `keys.toml` (API keys, 0600) | `kv_store` table, `apikey:` prefix |
| `history` (REPL input, 500 lines) | `input_history` table |

### Side effects

- **Remove `Settings` struct from inference pipeline** — it was threaded through `InferenceContext`, `tool_dispatch`, and `sub_agent_dispatch` but was **never read or written** during inference. Dead weight removed from 6 function signatures.
- **Remove `toml` dependency from koda-core** — no longer needed.
- **DB initialized earlier in `main.rs`** — so keys can be injected before provider creation.
- **0600 permissions on `koda.db`** — the DB contains API keys and conversation history that may include secrets. This is a security improvement even without the key migration.

### After migration, `~/.config/koda/` is:

```
~/.config/koda/
├── db/koda.db     # everything (0600)
├── logs/          # tracing (human-readable)
├── agents/        # user-authored JSON
├── skills/        # user-authored SKILL.md
└── memory.md      # model + human scratchpad
```

### Breaking change

Users need to delete `~/.config/koda/db/koda.db` (or the whole `db/` directory) on first run after this merge. The old DB schema is not migrated — the new tables are created fresh.

### Stats

- **22 files changed**, 278 insertions(+), 405 deletions(-)
- Net **-127 lines**

Closes #693