### PR TITLE
fix: reject destructive commands in headless mode (#700)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -472,6 +472,7 @@ mod tests {
                 tool_name: "Bash".into(),
                 detail: "cmd".into(),
                 preview: None,
+                effect: koda_core::tools::ToolEffect::LocalMutation,
             },
             EngineEvent::AskUserRequest {
                 id: "b".into(),

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -128,23 +128,39 @@ impl HeadlessSink {
 impl EngineSink for HeadlessSink {
     fn emit(&self, event: EngineEvent) {
         match event {
-            // ── Auto-approve (headless = yolo) ──────────────────
-            EngineEvent::ApprovalRequest { id, .. } => {
-                let _ = self.cmd_tx.blocking_send(EngineCommand::ApprovalResponse {
-                    id,
-                    decision: ApprovalDecision::Approve,
-                });
+            // ── Approve non-destructive, reject destructive ────
+            EngineEvent::ApprovalRequest {
+                id,
+                effect,
+                tool_name,
+                detail,
+                ..
+            } => {
+                if effect == koda_core::tools::ToolEffect::Destructive {
+                    eprintln!(
+                        "\x1b[31m  ✗ Rejected destructive action: {tool_name} — {detail}\x1b[0m"
+                    );
+                    let _ = self.cmd_tx.try_send(EngineCommand::ApprovalResponse {
+                        id,
+                        decision: ApprovalDecision::Reject,
+                    });
+                } else {
+                    let _ = self.cmd_tx.try_send(EngineCommand::ApprovalResponse {
+                        id,
+                        decision: ApprovalDecision::Approve,
+                    });
+                }
             }
             EngineEvent::AskUserRequest { id, question, .. } => {
                 // Headless: no user present, print the question and skip.
                 eprintln!("[koda] AskUser (no interactive session): {question}");
-                let _ = self.cmd_tx.blocking_send(EngineCommand::AskUserResponse {
+                let _ = self.cmd_tx.try_send(EngineCommand::AskUserResponse {
                     id,
                     answer: String::new(),
                 });
             }
             EngineEvent::LoopCapReached { .. } => {
-                let _ = self.cmd_tx.blocking_send(EngineCommand::LoopDecision {
+                let _ = self.cmd_tx.try_send(EngineCommand::LoopDecision {
                     action: koda_core::loop_guard::LoopContinuation::Continue200,
                 });
             }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -565,6 +565,7 @@ fn handle_inference_ui_inline(
             tool_name,
             detail,
             preview,
+            ..
         }) => {
             if preview.is_some() {
                 renderer.preview_shown = true;

--- a/koda-cli/tests/smoke_test.rs
+++ b/koda-cli/tests/smoke_test.rs
@@ -65,6 +65,29 @@ fn mock_text_response_returns_json() {
     );
 }
 
+// ── Headless safety: destructive commands rejected (#700) ────
+
+#[test]
+fn mock_destructive_bash_rejected_in_headless() {
+    // Model tries to run `rm -rf /` — headless should reject it.
+    // The mock response asks for a Bash tool call with a destructive command.
+    let responses = r#"[
+        {"tool":"Bash","args":{"command":"rm -rf /tmp/nonexistent_test_dir"}},
+        {"text":"I tried to delete but it was rejected."}
+    ]"#;
+
+    let (_stdout, stderr, success) = run_mock("delete everything", responses);
+    assert!(
+        success,
+        "Process should succeed (model recovers).\nstderr: {stderr}"
+    );
+    // The rejection message should appear on stderr
+    assert!(
+        stderr.contains("Rejected destructive action"),
+        "Expected rejection message on stderr.\nstderr: {stderr}"
+    );
+}
+
 #[test]
 fn mock_empty_responses_succeeds() {
     let (stdout, stderr, success) = run_mock("say hi", "[]");

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -195,7 +195,7 @@ pub fn check_tool_with_tracker(
     file_tracker: Option<&FileTracker>,
 ) -> ToolApproval {
     // Classify the tool's effect
-    let effect = resolve_effect(tool_name, args);
+    let effect = resolve_tool_effect(tool_name, args);
 
     // Read-only tools always auto-approve in every mode
     if effect == ToolEffect::ReadOnly {
@@ -250,7 +250,7 @@ pub fn check_tool_with_tracker(
 ///
 /// For Bash, refines the generic `LocalMutation` classification by
 /// parsing the actual command string.
-fn resolve_effect(tool_name: &str, args: &serde_json::Value) -> ToolEffect {
+pub fn resolve_tool_effect(tool_name: &str, args: &serde_json::Value) -> ToolEffect {
     let base = crate::tools::classify_tool(tool_name);
 
     if tool_name == "Bash" {

--- a/koda-core/src/approval_flow.rs
+++ b/koda-core/src/approval_flow.rs
@@ -62,6 +62,7 @@ pub(crate) async fn request_approval(
     tool_name: &str,
     detail: &str,
     preview: Option<crate::preview::DiffPreview>,
+    effect: crate::tools::ToolEffect,
 ) -> Option<ApprovalDecision> {
     let approval_id = uuid::Uuid::new_v4().to_string();
     sink.emit(EngineEvent::ApprovalRequest {
@@ -69,6 +70,7 @@ pub(crate) async fn request_approval(
         tool_name: tool_name.to_string(),
         detail: detail.to_string(),
         preview,
+        effect,
     });
 
     loop {

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -117,6 +117,8 @@ pub enum EngineEvent {
         detail: String,
         /// Structured diff preview (rendered by the client).
         preview: Option<crate::preview::DiffPreview>,
+        /// The classified effect that triggered confirmation.
+        effect: crate::tools::ToolEffect,
     },
 
     /// The model needs a clarifying answer from the user before proceeding.
@@ -476,6 +478,7 @@ mod tests {
             tool_name: "Bash".into(),
             detail: "rm -rf node_modules".into(),
             preview: None,
+            effect: crate::tools::ToolEffect::Destructive,
         };
         let json = serde_json::to_string(&event).unwrap();
         let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -353,6 +353,8 @@ pub(crate) async fn execute_sub_agent(
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
                     let diff_preview =
                         preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
+                    let effect =
+                        crate::approval::resolve_tool_effect(&tc.function_name, &parsed_args);
                     match request_approval(
                         sink,
                         cmd_rx,
@@ -360,6 +362,7 @@ pub(crate) async fn execute_sub_agent(
                         &tc.function_name,
                         &detail,
                         diff_preview,
+                        effect,
                     )
                     .await
                     {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -566,6 +566,7 @@ pub(crate) async fn execute_tools_sequential(
                 let detail = tools::describe_action(&tc.function_name, &parsed_args);
                 let diff_preview =
                     preview::compute(&tc.function_name, &parsed_args, project_root).await;
+                let effect = crate::approval::resolve_tool_effect(&tc.function_name, &parsed_args);
 
                 match request_approval(
                     sink,
@@ -574,6 +575,7 @@ pub(crate) async fn execute_tools_sequential(
                     &tc.function_name,
                     &detail,
                     diff_preview,
+                    effect,
                 )
                 .await
                 {


### PR DESCRIPTION
## Summary

Headless mode was blindly auto-approving **every** tool call, including destructive ones like `rm -rf`, `sudo`, `git push --force`.

### Root cause

The bash safety classifier and approval matrix worked correctly:

```
classify_bash("rm -rf /") → Destructive
check_tool(Auto, Destructive) → NeedsConfirmation
Engine emits ApprovalRequest
HeadlessSink: Approve ← 🚨 bug was here
```

`HeadlessSink` had a comment `// headless = yolo` and unconditionally approved everything.

### Fix

1. **Add `effect: ToolEffect` to `ApprovalRequest`** — the engine now tells sinks exactly what severity triggered confirmation, so they don't need to re-classify
2. **HeadlessSink rejects `Destructive`, approves everything else** — the model handles rejection gracefully (describes what it would do instead)
3. **Fix pre-existing `blocking_send` panic** — `HeadlessSink` used `blocking_send` inside a tokio runtime which panics. Switched to `try_send`. This was a latent bug that only manifested when approval requests were triggered (which never happened before because no test exercised this path)
4. **Smoke test** — new test sends a mock `rm -rf` command and verifies the rejection message appears on stderr

### What's now rejected in headless

Any command classified as `Destructive` by `classify_bash_command`:
- `rm`, `rmdir`
- `sudo`, `su`
- `dd`, `mkfs`, `fdisk`
- `chmod`, `chown`
- `curl | sh`, `eval`
- `git push --force`, `git reset --hard`, `git clean`
- `kill`, `reboot`, `shutdown`
- `npm publish`, `cargo publish`

Non-destructive mutations (`Write`, `Edit`, `cargo build`, `git commit`, etc.) are still auto-approved in headless.

Closes #700