### PR TITLE
docs: make all koda-cli modules pub for docs.rs (#695)

### DIFF
--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -1,34 +1,190 @@
-//! Koda CLI — TUI, headless mode, and ACP server.
+//! # Koda CLI
 //!
-//! This crate provides the user-facing interfaces for the Koda AI assistant.
-//! The engine lives in [`koda_core`] — this crate handles presentation.
+//! User-facing interfaces for the [Koda](https://github.com/lijunzh/koda)
+//! personal AI assistant. The engine lives in [`koda_core`] — this crate
+//! handles presentation.
 //!
 //! ## Entry points
 //!
-//! - **TUI** (default) — fullscreen ratatui terminal with streaming markdown,
-//!   syntax highlighting, slash commands, and mouse selection
-//! - **Headless** (`koda -p "..."`) — run a single prompt, print output, exit
-//! - **ACP server** (`koda server --stdio`) — JSON-RPC over stdin/stdout for
-//!   editor integrations (Zed, VS Code)
+//! | Mode | Invocation | Module |
+//! |------|-----------|--------|
+//! | **TUI** (default) | `koda` | [`tui_app`] |
+//! | **Headless** | `koda "prompt"` or `koda -p "..."` | [`headless`] |
+//! | **ACP server** | `koda server --stdio` | [`server`], [`acp_adapter`] |
+//!
+//! ## Quick start
+//!
+//! ```bash
+//! # Interactive REPL (auto-detects local models)
+//! koda
+//!
+//! # One-shot with positional prompt
+//! koda "fix the failing test"
+//!
+//! # Explicit model alias
+//! koda -p "explain auth.rs" -m opus
+//!
+//! # Piped input
+//! echo "review this diff" | koda
+//!
+//! # ACP server for editor integration
+//! koda server --stdio
+//! ```
 //!
 //! ## Slash commands
 //!
+//! Type these in the REPL input. Tab-completion is supported.
+//!
 //! | Command | Description |
 //! |---------|-------------|
-//! | `/help` | Show available commands |
-//! | `/model <name>` | Switch model (aliases supported) |
-//! | `/provider` | Pick provider interactively |
+//! | `/help` | Show available commands and keybindings |
+//! | `/model <name>` | Switch model — aliases like `opus`, `sonnet`, `flash` |
+//! | `/provider` | Browse all models from a provider |
 //! | `/compact` | Summarize old context to free tokens |
-//! | `/diff` | Show uncommitted changes |
-//! | `/undo` | Revert last file mutation |
-//! | `/sessions` | List / resume sessions |
-//! | `/memory` | View/edit CLAUDE.md |
-//! | `/skills` | List/activate skills |
-//! | `/agent` | List sub-agents |
+//! | `/diff` | Show uncommitted changes (review or commit) |
+//! | `/undo` | Revert last turn's file mutations |
+//! | `/sessions` | List, resume, or delete past sessions |
+//! | `/memory` | View/edit project and global memory files |
+//! | `/skills` | List available skills (search with query) |
+//! | `/agent <name>` | Switch to a sub-agent |
 //! | `/key` | Manage API keys |
-//! | `/expand` | Replay last tool output |
-//! | `/verbose` | Toggle debug output |
-//! | `/exit` | Quit |
+//! | `/expand` | Replay last tool output (full, untruncated) |
+//! | `/verbose` | Toggle full tool output |
+//! | `/purge <days>` | Delete archived history older than N days |
+//! | `/exit` | Quit the session |
+//!
+//! ## Keybindings
+//!
+//! ### Input mode
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | `Enter` | Send message |
+//! | `Alt+Enter` | Insert newline (multi-line input) |
+//! | `Tab` | Autocomplete slash commands and `@file` paths |
+//! | `Shift+Tab` | Toggle approval mode (auto ↔ confirm) |
+//! | `Esc` | Cancel current inference |
+//! | `Ctrl+C` | Cancel current inference |
+//! | `Up/Down` | Scroll through input history |
+//! | Mouse scroll | Scroll conversation history |
+//!
+//! ### Approval prompt (y/n/a/f)
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | `y` | Approve this action |
+//! | `n` | Reject this action |
+//! | `a` | Approve and switch to auto mode |
+//! | `f` | Reject with typed feedback |
+//! | `Esc` | Reject |
+//!
+//! ## Approval modes
+//!
+//! Koda has two approval modes, toggled with `Shift+Tab`:
+//!
+//! - **Auto** — approve all non-destructive actions automatically.
+//!   Destructive commands (`rm`, `sudo`, `git push --force`, etc.) still
+//!   require confirmation.
+//! - **Confirm** — every write/mutation requires explicit `y` before
+//!   executing. Read-only tools (Read, Grep, Glob) are always auto-approved.
+//!
+//! In headless mode (`koda "prompt"`), destructive actions are **rejected**
+//! outright — there's no human to approve them.
+//!
+//! ## Memory
+//!
+//! Koda reads memory files that persist across sessions:
+//!
+//! - **Project memory** — `MEMORY.md` (or `CLAUDE.md`, `AGENTS.md`) in the
+//!   project root. Injected into every system prompt for this project.
+//! - **Global memory** — `~/.config/koda/memory.md`. Injected into every
+//!   system prompt across all projects.
+//!
+//! Use `/memory` to view and edit, or the `MemoryWrite` tool to append facts
+//! during a conversation.
+//!
+//! ## Custom agents
+//!
+//! Place JSON files in `.koda/agents/` (project) or `~/.config/koda/agents/`
+//! (global):
+//!
+//! ```json
+//! {
+//!   "name": "testgen",
+//!   "system_prompt": "You are a test generation specialist.",
+//!   "model": "gemini-2.5-flash",
+//!   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+//! }
+//! ```
+//!
+//! The model dispatches to sub-agents via the `InvokeAgent` tool. Each agent
+//! runs in its own session with its own model, tools, and system prompt.
+//!
+//! ## Skills
+//!
+//! Skills are reusable expertise modules (markdown files with structured
+//! instructions). Built-in skills include code review and security audit.
+//!
+//! - List skills: `/skills` or the `ListSkills` tool
+//! - Activate a skill: `/skills <query>` or the `ActivateSkill` tool
+//! - Create custom skills: place `.md` files in `.koda/skills/` or
+//!   `~/.config/koda/skills/`
+//!
+//! ## Providers and model aliases
+//!
+//! Koda supports 14 LLM providers. Model aliases route across providers
+//! without remembering full model IDs:
+//!
+//! | Alias | Provider | Model |
+//! |-------|----------|-------|
+//! | `gemini-flash-lite` | Gemini | gemini-flash-lite-latest |
+//! | `gemini-flash` | Gemini | gemini-flash-latest |
+//! | `gemini-pro` | Gemini | gemini-pro-latest |
+//! | `claude-haiku` | Anthropic | claude-haiku-4-5 |
+//! | `claude-sonnet` | Anthropic | claude-sonnet-4-6 |
+//! | `claude-opus` | Anthropic | claude-opus-4-6 |
+//!
+//! Local providers (LM Studio, Ollama, vLLM) are auto-detected on first run
+//! and require no API key.
+//!
+//! ## Configuration
+//!
+//! Everything lives in `~/.config/koda/`:
+//!
+//! | Path | Content |
+//! |------|---------|
+//! | `db/koda.db` | SQLite — sessions, messages, settings, API keys, history |
+//! | `logs/` | Tracing logs (human-readable) |
+//! | `agents/` | Global custom agent JSON files |
+//! | `skills/` | Global custom skill markdown files |
+//! | `memory.md` | Global memory (injected into all system prompts) |
 
 pub mod acp_adapter;
+pub mod ansi_parse;
+pub mod completer;
+pub mod diff_render;
+pub mod headless;
+pub mod highlight;
+pub mod history_render;
+pub mod input;
+pub mod md_render;
+pub mod mouse_select;
+pub mod onboarding;
 pub mod repl;
+pub mod scroll_buffer;
+pub mod server;
+pub mod sink;
+pub mod startup;
+pub mod tool_history;
+pub mod tui_app;
+pub mod tui_commands;
+pub mod tui_context;
+pub mod tui_handlers_inference;
+pub mod tui_output;
+pub mod tui_render;
+pub mod tui_types;
+pub mod tui_viewport;
+pub mod tui_wizards;
+pub mod widgets;
+pub mod wrap_input;
+pub mod wrap_util;

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -1,35 +1,9 @@
-//! Koda 🐻 - A high-performance AI coding agent built in Rust.
+//! Koda 🐻 - A high-performance personal AI assistant built in Rust.
 //!
 //! CLI entry point. The binary is named `koda` for ergonomics.
+//! See [`koda_cli`] for the full user manual.
 
-mod ansi_parse;
-mod completer;
-mod diff_render;
-mod headless;
-mod highlight;
-mod history_render;
-mod input;
-mod md_render;
-mod mouse_select;
-mod onboarding;
-mod repl;
-mod scroll_buffer;
-mod server;
-mod sink;
-mod startup;
-mod tool_history;
-mod tui_app;
-mod tui_commands;
-mod tui_context;
-mod tui_handlers_inference;
-mod tui_output;
-mod tui_render;
-mod tui_types;
-mod tui_viewport;
-mod tui_wizards;
-mod widgets;
-mod wrap_input;
-mod wrap_util;
+use koda_cli::*;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};

--- a/koda-cli/src/md_render.rs
+++ b/koda-cli/src/md_render.rs
@@ -32,6 +32,12 @@ pub struct MarkdownRenderer {
     highlighter: Option<CodeHighlighter>,
 }
 
+impl Default for MarkdownRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MarkdownRenderer {
     pub fn new() -> Self {
         Self {

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -3,10 +3,10 @@
 //! Reads newline-delimited JSON from stdin, writes JSON-RPC messages to stdout.
 //! Implements the ACP lifecycle: Initialize → Authenticate → NewSession → Prompt → Cancel.
 
+use crate::acp_adapter::{self, AcpOutgoing, PendingApproval};
 use acp::Side;
 use agent_client_protocol_schema as acp;
 use anyhow::Result;
-use koda_cli::acp_adapter::{self, AcpOutgoing, PendingApproval};
 use koda_core::agent::KodaAgent;
 use koda_core::approval::ApprovalMode;
 use koda_core::config::KodaConfig;

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -9,7 +9,7 @@ use koda_core::engine::{EngineEvent, EngineSink};
 // ── UiEvent ───────────────────────────────────────────────
 
 /// Events forwarded from `CliSink` to the main event loop.
-pub(crate) enum UiEvent {
+pub enum UiEvent {
     Engine(EngineEvent),
 }
 

--- a/koda-cli/src/tool_history.rs
+++ b/koda-cli/src/tool_history.rs
@@ -18,6 +18,12 @@ pub struct ToolOutputHistory {
     entries: Vec<ToolOutputRecord>,
 }
 
+impl Default for ToolOutputHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ToolOutputHistory {
     pub fn new() -> Self {
         Self {
@@ -46,6 +52,10 @@ impl ToolOutputHistory {
 
     pub fn len(&self) -> usize {
         self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 

--- a/koda-cli/src/tui_app.rs
+++ b/koda-cli/src/tui_app.rs
@@ -1,6 +1,6 @@
 //! TUI main event loop.
 //!
-//! Thin entry point that creates a [`TuiContext`] and runs the event loop.
+//! Thin entry point that creates a `TuiContext` and runs the event loop.
 //! All handler logic lives in `tui_context.rs` and its sub-modules.
 //!
 //! Supporting modules:

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -44,6 +44,12 @@ pub struct TuiRenderer {
     streaming_tool_ids: std::collections::HashSet<String>,
 }
 
+impl Default for TuiRenderer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TuiRenderer {
     pub fn new() -> Self {
         Self {

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -36,7 +36,7 @@ pub(crate) enum TuiState {
 
 /// What's currently shown in the `menu_area` below the status bar.
 /// Only one menu can be active at a time.
-pub(crate) enum MenuContent {
+pub enum MenuContent {
     /// Nothing — menu_area is empty.
     None,
     /// Slash command dropdown (auto-appears on `/`).

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -1,3 +1,5 @@
+//! TUI widgets — dropdown menus, status bar, and interactive selectors.
+
 pub mod dropdown;
 pub mod file_menu;
 pub mod model_menu;


### PR DESCRIPTION
## Summary

Move 28 private `mod` declarations from `main.rs` to `pub mod` in `lib.rs` so docs.rs renders the full user manual. **docs.rs is the single source of truth** — no separate `docs/` directory needed.

### Why docs.rs instead of a `docs/` folder?

A separate docs directory creates a second source of truth that drifts from the code. The `//!` module docs in the source code *are* the documentation. docs.rs auto-generates and hosts them for free. A guide agent can fetch any page via `WebFetch`.

### What's in lib.rs now

The `lib.rs` `//!` docs serve as the **user manual home page**, covering:

- Quick start examples (5 common invocations)
- All 15 slash commands with descriptions
- All keybindings (input mode + approval prompt)
- Approval modes (auto vs confirm) with behavior details
- Memory system (project MEMORY.md + global ~/.config/koda/memory.md)
- Custom agents (JSON config schema + file placement)
- Skills system (built-in + custom, discovery + activation)
- Provider/model alias table (6 aliases across 2 providers)
- Configuration file layout (~/.config/koda/ structure)

### Other changes

- `UiEvent` and `MenuContent` promoted from `pub(crate)` to `pub` (required by pub module visibility rules)
- Fix `koda_cli::` → `crate::` in server.rs (lib crate resolution)
- Fix broken doc link to private `TuiContext`
- Add `//!` docs to `widgets/mod.rs` (only module missing them)

### Verification

```
$ cargo doc -p koda-cli --no-deps  # 0 warnings, 29 modules rendered
$ cargo doc -p koda-core --no-deps # 0 warnings
$ cargo test                        # 12/12 pass
```

Closes #695