### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-04-05
+
+Documentation, safety, and architecture release. 17 PRs merged since v0.2.1.
+
+### Added
+- **CLI reference in docs.rs** (#703) — full flag table with env vars
+  (`KODA_MODEL`, `KODA_PROVIDER`, `KODA_BASE_URL`) and subcommand docs.
+- **Privacy statement** (#703) — explicit zero-telemetry guarantee in
+  crate-level docs.
+- **Guide agent** (#691) — built-in `/agent guide` for answering questions
+  about Koda's features.
+- **Registry-driven `/help`** (#684) — `/help` output generated from the
+  slash command registry (single source of truth).
+- **Tool descriptions with behavioral guidance** (#686) — enriched tool
+  descriptions tell the model *when* and *how* to use each tool.
+- **Capabilities generated from code** (#685) — tool capability list
+  auto-generated from `ToolDef` structs, replacing static markdown.
+- **Doc examples on public APIs** (#689) — `cargo test` now exercises
+  doc examples for key types.
+
+### Changed
+- **All 29 koda-cli modules now `pub`** (#702) — docs.rs renders the full
+  user manual. docs.rs is the single source of truth for documentation.
+- **Config consolidated into SQLite** (#698) — API keys, settings, and
+  last-used provider moved from dotfiles to `~/.config/koda/db/koda.db`.
+  Eliminates 3 config files.
+- **Parameter name alignment** (#688) — `Grep` and `Glob` tools renamed
+  `path` parameter to `file_path` for consistency with Read/Write/Edit.
+- **CONTRIBUTING.md merged into CLAUDE.md** (#687) — single contributor
+  reference file.
+- **README trimmed** (#690, #699) — removed duplicated content, fixed
+  outdated claims, kept it scannable.
+- **Module docs enriched** (#694, #696) — every module has `//!` docs;
+  thin pages expanded with usage examples and cross-references.
+
+### Fixed
+- **Destructive commands rejected in headless mode** (#701) — `rm -rf`,
+  `sudo`, `git push --force` etc. are now rejected outright when no human
+  is present to approve. Previously auto-approved in headless.
+- **`ToolEffect` propagated through approval flow** (#701) — approval
+  sinks receive the classified effect so they can make policy decisions
+  without re-classifying.
+- **`blocking_send` panic in tokio runtime** (#701) — replaced with
+  `try_send` to avoid panic when called from async context.
+
 ## [0.2.1] - 2026-04-04
 
 Bug-fix release. All fixes discovered during real-world usage after v0.2.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.1" }
+koda-core = { path = "../koda-core", version = "0.2.2" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.1", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.2", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.2.2

Bump all crate versions to 0.2.2. After merge, tag with `v0.2.2` to trigger the release workflow.

### What's in this release (17 PRs since v0.2.1)

#### Added
- CLI reference in docs.rs — full flag table with env vars (#703)
- Privacy statement — explicit zero-telemetry guarantee (#703)
- Guide agent — built-in `/agent guide` (#691)
- Registry-driven `/help` (#684)
- Tool descriptions with behavioral guidance (#686)
- Capabilities generated from code (#685)
- Doc examples on public APIs (#689)

#### Changed
- All 29 koda-cli modules now `pub` — docs.rs renders full user manual (#702)
- Config consolidated into SQLite — eliminates 3 config files (#698)
- Parameter name alignment: `path` → `file_path` (#688)
- CONTRIBUTING.md merged into CLAUDE.md (#687)
- README trimmed (#690, #699)
- Module docs enriched (#694, #696)

#### Fixed
- **Destructive commands rejected in headless mode** (#701)
- `ToolEffect` propagated through approval flow (#701)
- `blocking_send` panic in tokio runtime (#701)

### Post-merge steps

```bash
git tag v0.2.2
git push origin v0.2.2
```

The release workflow will:
1. Verify tag matches crate versions
2. Run cross-platform tests
3. Build binaries (linux x86/arm, macOS x86/arm, Windows)
4. Publish to crates.io
5. Create GitHub release with binaries
6. Update Homebrew tap