### PR TITLE
fix: add missing required-features gates for e2e integration tests

### DIFF
--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -85,6 +85,18 @@ name = "e2e_test"
 required-features = ["test-support"]
 
 [[test]]
+name = "e2e_agent_test"
+required-features = ["test-support"]
+
+[[test]]
+name = "e2e_skills_test"
+required-features = ["test-support"]
+
+[[test]]
+name = "e2e_tools_test"
+required-features = ["test-support"]
+
+[[test]]
 name = "cancel_test"
 required-features = ["test-support"]
 


### PR DESCRIPTION
## Summary

Three integration tests that use `TestSink` were missing `required-features = ["test-support"]` in Cargo.toml, causing compilation failures on bare `cargo test -p koda-core`:

```
error[E0432]: unresolved import `koda_core::engine::sink::TestSink`
```

### Root cause

`TestSink` is gated behind `#[cfg(any(test, feature = "test-support"))]`. The `#[cfg(test)]` flag only applies to **unit tests** inside `src/` — integration tests in `tests/` are compiled as separate crates and need the explicit `test-support` feature.

### Fix

Added `[[test]]` entries with `required-features` for the three missing tests:

| Test file | Status |
|---|---|
| `e2e_test` | ✅ already gated |
| `cancel_test` | ✅ already gated |
| `inference_recovery_test` | ✅ already gated |
| `session_test` | ✅ already gated |
| **`e2e_agent_test`** | 🔧 **added** |
| **`e2e_skills_test`** | 🔧 **added** |
| **`e2e_tools_test`** | 🔧 **added** |

### Testing

- `cargo test -p koda-core` now compiles and runs cleanly (647 tests, 0 failures)
- `cargo test -p koda-core --features test-support` still runs the full e2e suite