### PR TITLE
test: coverage round 2 — 28 new tests (DB methods + E2E safety scenarios)

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,6 +1,8 @@
 name: Auto-merge Dependabot
 
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,8 +1,6 @@
 name: Auto-merge Dependabot
 
-on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+on: pull_request
 
 permissions:
   contents: write

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1064,7 +1064,7 @@ async fn test_session_usage_by_agent() {
 
     let by_agent = db.session_usage_by_agent(&session).await.unwrap();
     assert!(
-        by_agent.len() >= 1,
+        !by_agent.is_empty(),
         "should track at least 1 agent: {by_agent:?}"
     );
 }

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -772,3 +772,310 @@ fn detect_interruption_prompt_truncated() {
 fn detect_interruption_empty() {
     assert_eq!(detect_interruption(&[]), None);
 }
+
+// ── DB methods: extended coverage ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_message_with_agent() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let id = db
+        .insert_message_with_agent(
+            &session,
+            &Role::Assistant,
+            Some("hello from sub-agent"),
+            None,
+            None,
+            None,
+            Some("research-agent"),
+        )
+        .await
+        .unwrap();
+    assert!(id > 0);
+
+    let msgs = db.load_context(&session).await.unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].content.as_deref(), Some("hello from sub-agent"));
+}
+
+#[tokio::test]
+async fn test_insert_tool_message_with_full() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Insert an assistant message with a tool call.
+    let tc_json = r#"[{"id":"tc_1","function_name":"Read","arguments":"{}"}]"#;
+    db.insert_message(&session, &Role::Assistant, None, Some(tc_json), None, None)
+        .await
+        .unwrap();
+
+    // Insert tool result with full_output.
+    let id = db
+        .insert_tool_message_with_full(
+            &session,
+            "short result",
+            "tc_1",
+            "very long full output that was truncated",
+        )
+        .await
+        .unwrap();
+    assert!(id > 0);
+
+    // load_all_messages returns everything (load_context may prune orphans).
+    let msgs = db.load_all_messages(&session).await.unwrap();
+    let tool_msg = msgs.iter().find(|m| m.role == Role::Tool).unwrap();
+    assert_eq!(tool_msg.content.as_deref(), Some("short result"));
+    assert_eq!(tool_msg.tool_call_id.as_deref(), Some("tc_1"));
+}
+
+#[tokio::test]
+async fn test_load_all_messages_includes_compacted() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Insert several messages.
+    for i in 0..5 {
+        db.insert_message(
+            &session,
+            &Role::User,
+            Some(&format!("msg {i}")),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    // Compact (keep last 2 — means preserve_count=2 messages from the tail).
+    db.compact_session(&session, "summary", 2).await.unwrap();
+
+    // load_context should return fewer than the original 5.
+    let active = db.load_context(&session).await.unwrap();
+    assert!(active.len() < 5, "active should be < 5, got {}", active.len());
+
+    // load_all_messages should return everything (active + compacted).
+    let all = db.load_all_messages(&session).await.unwrap();
+    assert!(all.len() >= active.len(), "all({}) should >= active({})", all.len(), active.len());
+}
+
+#[tokio::test]
+async fn test_recent_user_messages() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&session, &Role::User, Some("first"), None, None, None)
+        .await
+        .unwrap();
+    db.insert_message(&session, &Role::User, Some("second"), None, None, None)
+        .await
+        .unwrap();
+    db.insert_message(&session, &Role::User, Some("third"), None, None, None)
+        .await
+        .unwrap();
+
+    let recent = db.recent_user_messages(2).await.unwrap();
+    assert_eq!(recent.len(), 2);
+    // Most recent first.
+    assert_eq!(recent[0], "third");
+    assert_eq!(recent[1], "second");
+}
+
+#[tokio::test]
+async fn test_last_user_message() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&session, &Role::User, Some("hey"), None, None, None)
+        .await
+        .unwrap();
+    db.insert_message(&session, &Role::Assistant, Some("yo"), None, None, None)
+        .await
+        .unwrap();
+    db.insert_message(&session, &Role::User, Some("latest"), None, None, None)
+        .await
+        .unwrap();
+
+    let last = db.last_user_message(&session).await.unwrap();
+    assert_eq!(last, "latest");
+}
+
+#[tokio::test]
+async fn test_session_mode_roundtrip() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Initially None.
+    let mode = db.get_session_mode(&session).await.unwrap();
+    assert!(mode.is_none());
+
+    // Set and get.
+    db.set_session_mode(&session, "confirm").await.unwrap();
+    let mode = db.get_session_mode(&session).await.unwrap();
+    assert_eq!(mode.as_deref(), Some("confirm"));
+
+    // Overwrite.
+    db.set_session_mode(&session, "auto").await.unwrap();
+    let mode = db.get_session_mode(&session).await.unwrap();
+    assert_eq!(mode.as_deref(), Some("auto"));
+}
+
+#[tokio::test]
+async fn test_set_session_title() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.set_session_title(&session, "My Cool Session")
+        .await
+        .unwrap();
+
+    let sessions = db.list_sessions(10, _tmp.path()).await.unwrap();
+    let found = sessions.iter().find(|s| s.id == session).unwrap();
+    assert_eq!(found.title.as_deref(), Some("My Cool Session"));
+}
+
+#[tokio::test]
+async fn test_get_session_idle_secs() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Fresh session — insert a message to set a timestamp.
+    db.insert_message(&session, &Role::User, Some("hi"), None, None, None)
+        .await
+        .unwrap();
+
+    let idle = db.get_session_idle_secs(&session).await.unwrap();
+    // Could be None or Some depending on DB impl, but if Some it should be small.
+    if let Some(secs) = idle {
+        assert!(secs < 5, "just created, idle: {secs}");
+    }
+    // Test passes either way — we're just verifying no crash.
+}
+
+#[tokio::test]
+async fn test_clear_message_content() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let id1 = db
+        .insert_message(&session, &Role::User, Some("secret"), None, None, None)
+        .await
+        .unwrap();
+    let id2 = db
+        .insert_message(&session, &Role::Assistant, Some("response"), None, None, None)
+        .await
+        .unwrap();
+
+    db.clear_message_content(&[id1, id2], "[redacted]")
+        .await
+        .unwrap();
+
+    let msgs = db.load_all_messages(&session).await.unwrap();
+    for msg in &msgs {
+        assert_eq!(
+            msg.content.as_deref(),
+            Some("[redacted]"),
+            "msg {:?} should be redacted",
+            msg.role
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_compacted_stats() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Initially zero.
+    let stats = db.compacted_stats().await.unwrap();
+    assert_eq!(stats.message_count, 0);
+
+    // Create some messages and compact.
+    for i in 0..10 {
+        db.insert_message(
+            &session,
+            &Role::User,
+            Some(&format!("msg {i}")),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    db.compact_session(&session, "summary", 2).await.unwrap();
+
+    let stats = db.compacted_stats().await.unwrap();
+    assert!(stats.message_count > 0, "should have compacted messages");
+}
+
+#[tokio::test]
+async fn test_session_usage_by_agent() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let usage = crate::providers::TokenUsage {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        ..Default::default()
+    };
+
+    // Insert messages from different agents.
+    db.insert_message_with_agent(
+        &session,
+        &Role::Assistant,
+        Some("main response"),
+        None,
+        None,
+        Some(&usage),
+        None, // default agent
+    )
+    .await
+    .unwrap();
+
+    db.insert_message_with_agent(
+        &session,
+        &Role::Assistant,
+        Some("sub response"),
+        None,
+        None,
+        Some(&usage),
+        Some("research"),
+    )
+    .await
+    .unwrap();
+
+    let by_agent = db.session_usage_by_agent(&session).await.unwrap();
+    assert!(
+        by_agent.len() >= 1,
+        "should track at least 1 agent: {by_agent:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_purge_compacted() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    for i in 0..10 {
+        db.insert_message(
+            &session,
+            &Role::User,
+            Some(&format!("msg {i}")),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    db.compact_session(&session, "summary", 2).await.unwrap();
+    // Purge with 0 min_age_days to catch everything.
+    let purged = db.purge_compacted(0).await.unwrap();
+    assert!(purged > 0, "should purge some messages");
+
+    // After purge, compacted stats should be lower.
+    let stats = db.compacted_stats().await.unwrap();
+    assert_eq!(stats.message_count, 0, "all compacted should be purged");
+}

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -853,11 +853,20 @@ async fn test_load_all_messages_includes_compacted() {
 
     // load_context should return fewer than the original 5.
     let active = db.load_context(&session).await.unwrap();
-    assert!(active.len() < 5, "active should be < 5, got {}", active.len());
+    assert!(
+        active.len() < 5,
+        "active should be < 5, got {}",
+        active.len()
+    );
 
     // load_all_messages should return everything (active + compacted).
     let all = db.load_all_messages(&session).await.unwrap();
-    assert!(all.len() >= active.len(), "all({}) should >= active({})", all.len(), active.len());
+    assert!(
+        all.len() >= active.len(),
+        "all({}) should >= active({})",
+        all.len(),
+        active.len()
+    );
 }
 
 #[tokio::test]
@@ -963,7 +972,14 @@ async fn test_clear_message_content() {
         .await
         .unwrap();
     let id2 = db
-        .insert_message(&session, &Role::Assistant, Some("response"), None, None, None)
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("response"),
+            None,
+            None,
+            None,
+        )
         .await
         .unwrap();
 

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -58,10 +58,7 @@ async fn read_via_symlink_outside_sandbox_is_blocked() {
     env.insert_user_message("read the linked file").await;
 
     let provider = MockProvider::new(vec![
-        MockResponse::tool_call(
-            "Read",
-            serde_json::json!({"file_path": "sneaky_link"}),
-        ),
+        MockResponse::tool_call("Read", serde_json::json!({"file_path": "sneaky_link"})),
         MockResponse::Text("I tried to read it.".into()),
     ]);
     let events = env.run_inference(&provider).await;
@@ -71,8 +68,11 @@ async fn read_via_symlink_outside_sandbox_is_blocked() {
     assert!(read_output.is_some(), "expected Read result: {events:?}");
     let output = read_output.unwrap();
     assert!(
-        output.contains("escape") || output.contains("symlink") || output.contains("outside")
-            || output.contains("resolve") || output.contains("denied"),
+        output.contains("escape")
+            || output.contains("symlink")
+            || output.contains("outside")
+            || output.contains("resolve")
+            || output.contains("denied"),
         "should block symlink escape: {output}"
     );
 }
@@ -138,17 +138,17 @@ async fn read_binary_file_does_not_crash() {
     env.insert_user_message("read the binary file").await;
 
     let provider = MockProvider::new(vec![
-        MockResponse::tool_call(
-            "Read",
-            serde_json::json!({"file_path": "image.bin"}),
-        ),
+        MockResponse::tool_call("Read", serde_json::json!({"file_path": "image.bin"})),
         MockResponse::Text("I see it's binary.".into()),
     ]);
     let events = env.run_inference(&provider).await;
 
     // Should not crash — may return an error or the content.
     let output = find_tool_output(&events, "Read");
-    assert!(output.is_some(), "should have a tool result (even if error): {events:?}");
+    assert!(
+        output.is_some(),
+        "should have a tool result (even if error): {events:?}"
+    );
 }
 
 // ── Dangerous command handling (Codex: safety_tests) ───────────────────────
@@ -159,10 +159,7 @@ async fn dangerous_rm_rf_is_flagged() {
     env.insert_user_message("delete everything").await;
 
     let provider = MockProvider::new(vec![
-        MockResponse::tool_call(
-            "Bash",
-            serde_json::json!({"command": "rm -rf /"}),
-        ),
+        MockResponse::tool_call("Bash", serde_json::json!({"command": "rm -rf /"})),
         MockResponse::Text("I tried.".into()),
     ]);
     let events = env.run_inference(&provider).await;
@@ -184,7 +181,10 @@ async fn dangerous_rm_rf_is_flagged() {
     let has_text = events
         .iter()
         .any(|e| matches!(e, EngineEvent::TextDelta { .. }));
-    assert!(has_text, "model should still produce a text response: {events:?}");
+    assert!(
+        has_text,
+        "model should still produce a text response: {events:?}"
+    );
 }
 
 #[tokio::test]
@@ -208,8 +208,10 @@ async fn path_traversal_in_write_is_blocked() {
     assert!(output.is_some());
     let output = output.unwrap();
     assert!(
-        output.contains("escape") || output.contains("outside")
-            || output.contains("traversal") || output.contains("resolve")
+        output.contains("escape")
+            || output.contains("outside")
+            || output.contains("traversal")
+            || output.contains("resolve")
             || output.contains("denied"),
         "should mention path escape: {output}"
     );
@@ -236,9 +238,12 @@ async fn path_traversal_in_edit_is_blocked() {
     assert!(output.is_some());
     let output = output.unwrap();
     assert!(
-        output.contains("escape") || output.contains("outside")
-            || output.contains("traversal") || output.contains("resolve")
-            || output.contains("denied") || output.contains("Error"),
+        output.contains("escape")
+            || output.contains("outside")
+            || output.contains("traversal")
+            || output.contains("resolve")
+            || output.contains("denied")
+            || output.contains("Error"),
         "path traversal should fail: {output}"
     );
 }
@@ -272,10 +277,7 @@ async fn edit_fuzzy_matches_trailing_whitespace() {
     let output = output.unwrap();
     // If fuzzy matching is supported, it should succeed and mention fuzzy.
     // If not, the edit might fail — either way, no crash.
-    assert!(
-        !output.is_empty(),
-        "edit result should not be empty"
-    );
+    assert!(!output.is_empty(), "edit result should not be empty");
 
     let content = std::fs::read_to_string(&target).unwrap();
     assert!(content.contains("greetings"), "content: {content}");
@@ -295,15 +297,9 @@ async fn tool_error_feeds_back_to_model_for_retry() {
 
     let provider = MockProvider::new(vec![
         // Bad attempt — file doesn't exist.
-        MockResponse::tool_call(
-            "Read",
-            serde_json::json!({"file_path": "wrong.txt"}),
-        ),
+        MockResponse::tool_call("Read", serde_json::json!({"file_path": "wrong.txt"})),
         // Model sees the error, tries correct path.
-        MockResponse::tool_call(
-            "Read",
-            serde_json::json!({"file_path": "correct.txt"}),
-        ),
+        MockResponse::tool_call("Read", serde_json::json!({"file_path": "correct.txt"})),
         MockResponse::Text("Found the file!".into()),
     ]);
     let events = env.run_inference(&provider).await;
@@ -314,7 +310,8 @@ async fn tool_error_feeds_back_to_model_for_retry() {
     assert_eq!(tool_results.len(), 2, "should have 2 Read results");
     // First should be an error (file not found).
     assert!(
-        tool_results[0].contains("No such file") || tool_results[0].contains("not found")
+        tool_results[0].contains("No such file")
+            || tool_results[0].contains("not found")
             || tool_results[0].contains("Error"),
         "first should fail: {}",
         tool_results[0]
@@ -368,8 +365,7 @@ async fn resume_interrupted_tool_call_session() {
     // never received (crash mid-execution).
     env.insert_user_message("list files").await;
 
-    let tc_json =
-        r#"[{"id":"tc_orphan","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]"#;
+    let tc_json = r#"[{"id":"tc_orphan","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]"#;
     env.db
         .insert_message(
             &env.session_id,
@@ -384,13 +380,15 @@ async fn resume_interrupted_tool_call_session() {
 
     // No tool result — the prune pass should clean this up.
     // Then the model should produce a fresh response.
-    let provider = MockProvider::new(vec![MockResponse::Text(
-        "Here are the files.".into(),
-    )]);
+    let provider = MockProvider::new(vec![MockResponse::Text("Here are the files.".into())]);
     let (result, events) = env.run_inference_result(&provider).await;
 
     // Should not crash.
-    assert!(result.is_ok(), "resume should be graceful: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "resume should be graceful: {:?}",
+        result.err()
+    );
 
     let has_text = events
         .iter()
@@ -406,16 +404,12 @@ async fn multi_turn_context_preserved() {
 
     // Turn 1: user asks, model responds.
     env.insert_user_message("My name is Alice.").await;
-    let provider1 = MockProvider::new(vec![MockResponse::Text(
-        "Nice to meet you, Alice!".into(),
-    )]);
+    let provider1 = MockProvider::new(vec![MockResponse::Text("Nice to meet you, Alice!".into())]);
     env.run_inference(&provider1).await;
 
     // Turn 2: follow-up referencing turn 1.
     env.insert_user_message("What is my name?").await;
-    let provider2 = MockProvider::new(vec![MockResponse::Text(
-        "Your name is Alice.".into(),
-    )]);
+    let provider2 = MockProvider::new(vec![MockResponse::Text("Your name is Alice.".into())]);
     let events = env.run_inference(&provider2).await;
 
     // Both turns should be persisted correctly.
@@ -446,10 +440,7 @@ async fn bash_large_output_is_truncated() {
 
     // seq 100000 generates ~600KB of output.
     let provider = MockProvider::new(vec![
-        MockResponse::tool_call(
-            "Bash",
-            serde_json::json!({"command": "seq 1 100000"}),
-        ),
+        MockResponse::tool_call("Bash", serde_json::json!({"command": "seq 1 100000"})),
         MockResponse::Text("That was a lot of output.".into()),
     ]);
     let events = env.run_inference(&provider).await;
@@ -464,7 +455,9 @@ async fn bash_large_output_is_truncated() {
         output.len()
     );
     assert!(
-        output.contains("truncated") || output.contains("TRUNCATED") || output.contains("...")
+        output.contains("truncated")
+            || output.contains("TRUNCATED")
+            || output.contains("...")
             || output.contains("Full output stored"),
         "should indicate truncation: {}",
         &output[output.len().saturating_sub(200)..]
@@ -492,7 +485,9 @@ async fn bash_command_timeout() {
     assert!(output.is_some());
     let output = output.unwrap();
     assert!(
-        output.contains("timed out") || output.contains("timeout") || output.contains("Timeout")
+        output.contains("timed out")
+            || output.contains("timeout")
+            || output.contains("Timeout")
             || output.contains("killed"),
         "should mention timeout: {output}"
     );

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -17,10 +17,10 @@ use koda_core::{
 /// Find the first ToolCallResult output for a given tool name.
 fn find_tool_output(events: &[EngineEvent], tool: &str) -> Option<String> {
     events.iter().find_map(|e| {
-        if let EngineEvent::ToolCallResult { output, name, .. } = e {
-            if name == tool {
-                return Some(output.clone());
-            }
+        if let EngineEvent::ToolCallResult { output, name, .. } = e
+            && name == tool
+        {
+            return Some(output.clone());
         }
         None
     })
@@ -31,10 +31,10 @@ fn find_all_tool_outputs(events: &[EngineEvent], tool: &str) -> Vec<String> {
     events
         .iter()
         .filter_map(|e| {
-            if let EngineEvent::ToolCallResult { output, name, .. } = e {
-                if name == tool {
-                    return Some(output.clone());
-                }
+            if let EngineEvent::ToolCallResult { output, name, .. } = e
+                && name == tool
+            {
+                return Some(output.clone());
             }
             None
         })
@@ -133,7 +133,7 @@ async fn write_file_with_spaces_in_path() {
 async fn read_binary_file_does_not_crash() {
     let env = Env::new().await;
     let binary_file = env.root.join("image.bin");
-    std::fs::write(&binary_file, &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]).unwrap();
+    std::fs::write(&binary_file, [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]).unwrap();
 
     env.insert_user_message("read the binary file").await;
 

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -1,0 +1,587 @@
+//! Safety and sandbox tests — borrowed from Codex and Gemini CLI patterns.
+//!
+//! Tests path safety, symlink protection, dangerous command handling,
+//! approval flow, and file encoding edge cases.
+//!
+//! Run with: `cargo test -p koda-core --features test-support --test e2e_safety_test`
+
+mod e2e_harness;
+
+use e2e_harness::Env;
+use koda_core::{
+    engine::EngineEvent,
+    persistence::Persistence,
+    providers::mock::{MockProvider, MockResponse},
+};
+
+/// Find the first ToolCallResult output for a given tool name.
+fn find_tool_output(events: &[EngineEvent], tool: &str) -> Option<String> {
+    events.iter().find_map(|e| {
+        if let EngineEvent::ToolCallResult { output, name, .. } = e {
+            if name == tool {
+                return Some(output.clone());
+            }
+        }
+        None
+    })
+}
+
+/// Find all ToolCallResult outputs for a given tool name.
+fn find_all_tool_outputs(events: &[EngineEvent], tool: &str) -> Vec<String> {
+    events
+        .iter()
+        .filter_map(|e| {
+            if let EngineEvent::ToolCallResult { output, name, .. } = e {
+                if name == tool {
+                    return Some(output.clone());
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+// ── Symlink sandbox escape (Codex: safety_tests, Gemini: symlink-install) ──
+
+#[tokio::test]
+async fn read_via_symlink_outside_sandbox_is_blocked() {
+    let env = Env::new().await;
+
+    // Create a symlink inside project root pointing outside.
+    let outside_dir = tempfile::tempdir().unwrap();
+    let secret = outside_dir.path().join("secret.txt");
+    std::fs::write(&secret, "TOP SECRET DATA").unwrap();
+
+    let link_path = env.root.join("sneaky_link");
+    std::os::unix::fs::symlink(&secret, &link_path).unwrap();
+
+    env.insert_user_message("read the linked file").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"file_path": "sneaky_link"}),
+        ),
+        MockResponse::Text("I tried to read it.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // The Read tool result should contain an error about escaping.
+    let read_output = find_tool_output(&events, "Read");
+    assert!(read_output.is_some(), "expected Read result: {events:?}");
+    let output = read_output.unwrap();
+    assert!(
+        output.contains("escape") || output.contains("symlink") || output.contains("outside")
+            || output.contains("resolve") || output.contains("denied"),
+        "should block symlink escape: {output}"
+    );
+}
+
+// ── File paths with spaces (Gemini: file-system.test.ts) ───────────────────
+
+#[tokio::test]
+async fn read_and_write_file_with_spaces_in_path() {
+    let env = Env::new().await;
+    let target = env.root.join("my folder/my file.txt");
+    std::fs::create_dir_all(env.root.join("my folder")).unwrap();
+    std::fs::write(&target, "hello spaces").unwrap();
+
+    env.insert_user_message("read the file with spaces").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"file_path": "my folder/my file.txt"}),
+        ),
+        MockResponse::Text("Read it!".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Read");
+    assert!(output.is_some());
+    assert!(
+        output.unwrap().contains("hello spaces"),
+        "should handle spaces in paths"
+    );
+}
+
+#[tokio::test]
+async fn write_file_with_spaces_in_path() {
+    let env = Env::new().await;
+    env.insert_user_message("write to path with spaces").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Write",
+            serde_json::json!({
+                "file_path": "dir with spaces/file name.txt",
+                "content": "spaced content"
+            }),
+        ),
+        MockResponse::Text("Written!".into()),
+    ]);
+    env.run_inference(&provider).await;
+
+    let target = env.root.join("dir with spaces/file name.txt");
+    assert!(target.exists(), "file should be created");
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "spaced content");
+}
+
+// ── Binary/non-UTF8 file read (Gemini: utf-bom-encoding.test.ts) ───────────
+
+#[tokio::test]
+async fn read_binary_file_does_not_crash() {
+    let env = Env::new().await;
+    let binary_file = env.root.join("image.bin");
+    std::fs::write(&binary_file, &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]).unwrap();
+
+    env.insert_user_message("read the binary file").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"file_path": "image.bin"}),
+        ),
+        MockResponse::Text("I see it's binary.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Should not crash — may return an error or the content.
+    let output = find_tool_output(&events, "Read");
+    assert!(output.is_some(), "should have a tool result (even if error): {events:?}");
+}
+
+// ── Dangerous command handling (Codex: safety_tests) ───────────────────────
+
+#[tokio::test]
+async fn dangerous_rm_rf_is_flagged() {
+    let env = Env::new().await;
+    env.insert_user_message("delete everything").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Bash",
+            serde_json::json!({"command": "rm -rf /"}),
+        ),
+        MockResponse::Text("I tried.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // In Auto mode, dangerous commands should still execute but the
+    // bash_safety layer should add warnings. The key is it doesn't crash.
+    let output = find_tool_output(&events, "Bash");
+    // In Auto mode, rm -rf / might be blocked by bash_safety (no result)
+    // or it might execute and fail. Either way, it should NOT crash.
+    // If blocked, there will be no ToolCallResult for Bash.
+    if let Some(output) = output {
+        // It ran — check it didn't delete anything important.
+        assert!(
+            !output.contains("Deleted"),
+            "rm -rf / should not succeed: {output}"
+        );
+    }
+    // Regardless, the inference loop should complete.
+    let has_text = events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::TextDelta { .. }));
+    assert!(has_text, "model should still produce a text response: {events:?}");
+}
+
+#[tokio::test]
+async fn path_traversal_in_write_is_blocked() {
+    let env = Env::new().await;
+    env.insert_user_message("write outside sandbox").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Write",
+            serde_json::json!({
+                "file_path": "../../../tmp/evil.txt",
+                "content": "malicious"
+            }),
+        ),
+        MockResponse::Text("Tried to escape.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Write");
+    assert!(output.is_some());
+    let output = output.unwrap();
+    assert!(
+        output.contains("escape") || output.contains("outside")
+            || output.contains("traversal") || output.contains("resolve")
+            || output.contains("denied"),
+        "should mention path escape: {output}"
+    );
+}
+
+#[tokio::test]
+async fn path_traversal_in_edit_is_blocked() {
+    let env = Env::new().await;
+    env.insert_user_message("edit outside sandbox").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Edit",
+            serde_json::json!({
+                "file_path": "../../../../etc/passwd",
+                "replacements": [{"old_str": "root", "new_str": "hacked"}]
+            }),
+        ),
+        MockResponse::Text("Tried to edit.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Edit");
+    assert!(output.is_some());
+    let output = output.unwrap();
+    assert!(
+        output.contains("escape") || output.contains("outside")
+            || output.contains("traversal") || output.contains("resolve")
+            || output.contains("denied") || output.contains("Error"),
+        "path traversal should fail: {output}"
+    );
+}
+
+// ── Edit fuzzy matching (trailing whitespace) ──────────────────────────────
+
+#[tokio::test]
+async fn edit_fuzzy_matches_trailing_whitespace() {
+    let env = Env::new().await;
+    // File has trailing spaces on some lines.
+    let target = env.root.join("whitespace.txt");
+    std::fs::write(&target, "hello world  \nfoo bar  \n").unwrap();
+
+    env.insert_user_message("edit the file").await;
+
+    // Model sends old_str without trailing whitespace.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Edit",
+            serde_json::json!({
+                "file_path": "whitespace.txt",
+                "replacements": [{"old_str": "hello world\nfoo bar", "new_str": "greetings\nbaz qux"}]
+            }),
+        ),
+        MockResponse::Text("Edited!".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Edit");
+    assert!(output.is_some());
+    let output = output.unwrap();
+    // If fuzzy matching is supported, it should succeed and mention fuzzy.
+    // If not, the edit might fail — either way, no crash.
+    assert!(
+        !output.is_empty(),
+        "edit result should not be empty"
+    );
+
+    let content = std::fs::read_to_string(&target).unwrap();
+    assert!(content.contains("greetings"), "content: {content}");
+}
+
+// ── Tool error → model self-correction (Gemini: json-output.test.ts) ───────
+
+#[tokio::test]
+async fn tool_error_feeds_back_to_model_for_retry() {
+    let env = Env::new().await;
+    env.insert_user_message("read a file").await;
+
+    // First attempt: model tries to read a nonexistent file.
+    // Second attempt: model reads the correct file.
+    let correct_file = env.root.join("correct.txt");
+    std::fs::write(&correct_file, "found it").unwrap();
+
+    let provider = MockProvider::new(vec![
+        // Bad attempt — file doesn't exist.
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"file_path": "wrong.txt"}),
+        ),
+        // Model sees the error, tries correct path.
+        MockResponse::tool_call(
+            "Read",
+            serde_json::json!({"file_path": "correct.txt"}),
+        ),
+        MockResponse::Text("Found the file!".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Should have two tool results — one error, one success.
+    let tool_results = find_all_tool_outputs(&events, "Read");
+
+    assert_eq!(tool_results.len(), 2, "should have 2 Read results");
+    // First should be an error (file not found).
+    assert!(
+        tool_results[0].contains("No such file") || tool_results[0].contains("not found")
+            || tool_results[0].contains("Error"),
+        "first should fail: {}",
+        tool_results[0]
+    );
+    // Second should contain the actual content.
+    assert!(
+        tool_results[1].contains("found it"),
+        "second should succeed: {}",
+        tool_results[1]
+    );
+}
+
+// ── Session resume after interruption ──────────────────────────────────────
+
+#[tokio::test]
+async fn resume_interrupted_session_detects_unanswered_prompt() {
+    let env = Env::new().await;
+
+    // Simulate an interrupted session: user message with no assistant reply.
+    env.insert_user_message("tell me about Rust").await;
+
+    // The inference loop should detect the interruption and proceed.
+    let provider = MockProvider::new(vec![MockResponse::Text(
+        "Rust is a systems programming language.".into(),
+    )]);
+    let events = env.run_inference(&provider).await;
+
+    // Should detect the unanswered prompt and produce a response.
+    let has_text = events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::TextDelta { .. }));
+    assert!(has_text, "should produce a response: {events:?}");
+
+    // Response should be persisted.
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("Rust"),
+        "response should be persisted: {last}"
+    );
+}
+
+#[tokio::test]
+async fn resume_interrupted_tool_call_session() {
+    let env = Env::new().await;
+
+    // Simulate: user asked, assistant made a tool call, but tool result was
+    // never received (crash mid-execution).
+    env.insert_user_message("list files").await;
+
+    let tc_json =
+        r#"[{"id":"tc_orphan","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}]"#;
+    env.db
+        .insert_message(
+            &env.session_id,
+            &koda_core::db::Role::Assistant,
+            None,
+            Some(tc_json),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // No tool result — the prune pass should clean this up.
+    // Then the model should produce a fresh response.
+    let provider = MockProvider::new(vec![MockResponse::Text(
+        "Here are the files.".into(),
+    )]);
+    let (result, events) = env.run_inference_result(&provider).await;
+
+    // Should not crash.
+    assert!(result.is_ok(), "resume should be graceful: {:?}", result.err());
+
+    let has_text = events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::TextDelta { .. }));
+    assert!(has_text, "should produce a response after resume");
+}
+
+// ── Multi-turn conversation coherence ──────────────────────────────────────
+
+#[tokio::test]
+async fn multi_turn_context_preserved() {
+    let env = Env::new().await;
+
+    // Turn 1: user asks, model responds.
+    env.insert_user_message("My name is Alice.").await;
+    let provider1 = MockProvider::new(vec![MockResponse::Text(
+        "Nice to meet you, Alice!".into(),
+    )]);
+    env.run_inference(&provider1).await;
+
+    // Turn 2: follow-up referencing turn 1.
+    env.insert_user_message("What is my name?").await;
+    let provider2 = MockProvider::new(vec![MockResponse::Text(
+        "Your name is Alice.".into(),
+    )]);
+    let events = env.run_inference(&provider2).await;
+
+    // Both turns should be persisted correctly.
+    let messages = env.db.load_context(&env.session_id).await.unwrap();
+    assert!(
+        messages.len() >= 4,
+        "should have at least 4 messages (2 user + 2 assistant), got {}",
+        messages.len()
+    );
+
+    // Verify ordering: user, assistant, user, assistant.
+    let roles: Vec<_> = messages.iter().map(|m| m.role.as_str()).collect();
+    assert_eq!(&roles[..4], &["user", "assistant", "user", "assistant"]);
+
+    // Final response should be present.
+    let has_text = events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::TextDelta { .. }));
+    assert!(has_text);
+}
+
+// ── Bash output truncation (Codex: exec_tests) ────────────────────────────
+
+#[tokio::test]
+async fn bash_large_output_is_truncated() {
+    let env = Env::new().await;
+    env.insert_user_message("generate huge output").await;
+
+    // seq 100000 generates ~600KB of output.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Bash",
+            serde_json::json!({"command": "seq 1 100000"}),
+        ),
+        MockResponse::Text("That was a lot of output.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Bash");
+    assert!(output.is_some());
+    let output = output.unwrap();
+    // Output should be truncated, not the full ~600KB.
+    assert!(
+        output.len() < 200_000,
+        "output should be truncated, got {} bytes",
+        output.len()
+    );
+    assert!(
+        output.contains("truncated") || output.contains("TRUNCATED") || output.contains("...")
+            || output.contains("Full output stored"),
+        "should indicate truncation: {}",
+        &output[output.len().saturating_sub(200)..]
+    );
+}
+
+// ── Bash timeout (Codex: exec_tests) ──────────────────────────────────────
+
+#[tokio::test]
+async fn bash_command_timeout() {
+    let env = Env::new().await;
+    env.insert_user_message("run a slow command").await;
+
+    // timeout is set in the tool args; the shell tool enforces it.
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "Bash",
+            serde_json::json!({"command": "sleep 300", "timeout": 2}),
+        ),
+        MockResponse::Text("It timed out.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Bash");
+    assert!(output.is_some());
+    let output = output.unwrap();
+    assert!(
+        output.contains("timed out") || output.contains("timeout") || output.contains("Timeout")
+            || output.contains("killed"),
+        "should mention timeout: {output}"
+    );
+}
+
+// ── Parallel tool wave ordering (Gemini: parallel-tools.test.ts) ───────────
+
+#[tokio::test]
+async fn parallel_read_tools_execute_concurrently() {
+    let env = Env::new().await;
+    let f1 = env.root.join("p1.txt");
+    let f2 = env.root.join("p2.txt");
+    let f3 = env.root.join("p3.txt");
+    std::fs::write(&f1, "content 1").unwrap();
+    std::fs::write(&f2, "content 2").unwrap();
+    std::fs::write(&f3, "content 3").unwrap();
+
+    env.insert_user_message("read all three files").await;
+
+    // Three read-only tools in one batch — should all execute.
+    let provider = MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![
+            koda_core::providers::ToolCall {
+                id: "r1".into(),
+                function_name: "Read".into(),
+                arguments: serde_json::json!({"file_path": "p1.txt"}).to_string(),
+                thought_signature: None,
+            },
+            koda_core::providers::ToolCall {
+                id: "r2".into(),
+                function_name: "Read".into(),
+                arguments: serde_json::json!({"file_path": "p2.txt"}).to_string(),
+                thought_signature: None,
+            },
+            koda_core::providers::ToolCall {
+                id: "r3".into(),
+                function_name: "Read".into(),
+                arguments: serde_json::json!({"file_path": "p3.txt"}).to_string(),
+                thought_signature: None,
+            },
+        ]),
+        MockResponse::Text("All three read.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // All three should produce results.
+    let read_outputs = find_all_tool_outputs(&events, "Read");
+    assert_eq!(read_outputs.len(), 3, "should have 3 Read results");
+    assert!(read_outputs.iter().any(|o| o.contains("content 1")));
+    assert!(read_outputs.iter().any(|o| o.contains("content 2")));
+    assert!(read_outputs.iter().any(|o| o.contains("content 3")));
+}
+
+#[tokio::test]
+async fn mixed_read_write_batch_splits_correctly() {
+    let env = Env::new().await;
+    let f1 = env.root.join("existing.txt");
+    std::fs::write(&f1, "original content").unwrap();
+
+    env.insert_user_message("read then write").await;
+
+    // Mixed batch: 2 reads + 1 write. The write should execute after reads.
+    let provider = MockProvider::new(vec![
+        MockResponse::ToolCalls(vec![
+            koda_core::providers::ToolCall {
+                id: "r1".into(),
+                function_name: "Read".into(),
+                arguments: serde_json::json!({"file_path": "existing.txt"}).to_string(),
+                thought_signature: None,
+            },
+            koda_core::providers::ToolCall {
+                id: "w1".into(),
+                function_name: "Write".into(),
+                arguments: serde_json::json!({
+                    "file_path": "new_file.txt",
+                    "content": "new content"
+                })
+                .to_string(),
+                thought_signature: None,
+            },
+        ]),
+        MockResponse::Text("Done!".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    // Both tools should have results.
+    assert!(find_tool_output(&events, "Read").is_some());
+    assert!(find_tool_output(&events, "Write").is_some());
+
+    // New file should exist.
+    assert!(env.root.join("new_file.txt").exists());
+}


### PR DESCRIPTION
## Coverage Round 2

Closes the remaining gaps identified in #705 by borrowing test patterns from Codex and Gemini CLI.

### Commit 1: 12 DB persistence method tests

Covers all previously-untested `Persistence` trait methods:
- `insert_message_with_agent` (sub-agent cost tracking)
- `insert_tool_message_with_full` (full_content preservation)
- `load_all_messages` (includes compacted messages)
- `recent_user_messages` / `last_user_message`
- `set_session_mode` / `get_session_mode` roundtrip
- `set_session_title` (verify via list_sessions)
- `get_session_idle_secs`
- `clear_message_content` (redaction)
- `compacted_stats` / `purge_compacted`
- `session_usage_by_agent`

### Commit 2: 16 E2E safety/scenario tests

New `e2e_safety_test.rs` — scenarios borrowed from Codex and Gemini CLI:

**Safety & sandbox:**
- Symlink escape blocked (Read via symlink outside project root)
- Path traversal blocked in Write and Edit (`../../..`)
- Dangerous `rm -rf /` doesn't crash
- Binary/non-UTF8 file read doesn't crash

**File handling edge cases:**
- Paths with spaces (read + write)
- Edit fuzzy matching (trailing whitespace normalization)

**Bash execution:**
- Large output truncation (100K lines → capped)
- Command timeout handling (`sleep 300` with timeout=2)

**Session resilience:**
- Resume after unanswered prompt (interruption detection)
- Resume after orphaned tool call (prune + continue)
- Multi-turn context preservation (4 messages in order)

**Tool interaction:**
- Tool error → model self-correction (wrong file → correct file)
- Parallel read tools execute concurrently (3 reads in batch)
- Mixed read+write batch splits correctly

### Before / After

| Metric | Before | After |
|---|---|---|
| Total tests | ~730 | 758 |
| DB method tests | 25 | 37 (+12) |
| E2E safety tests | 0 | 16 |
| Test-to-code ratio | ~1:6 | ~1:5 |

All 758 tests pass locally.