### PR TITLE
chore: dependabot grouping + commit-message prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,24 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
     labels:
       - dependencies
       - rust
+    groups:
+      rust-minor-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci(deps)"
     labels:
       - dependencies
       - ci

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,6 +1,8 @@
 name: Auto-merge Dependabot
 
-on: pull_request
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write


### PR DESCRIPTION
Closes #713 (items 1 and 4 — items 2-3 skipped per YAGNI).

### Changes

**`auto-merge-dependabot.yml`**
- `pull_request` → `pull_request_target` — dependabot PRs get a read-only `GITHUB_TOKEN` under `pull_request`, so `gh pr merge` silently 403s. `pull_request_target` runs in the base-branch context and grants a write token. Safe here: we never check out PR code, just call `gh pr merge`.

**`dependabot.yml`**
- Groups minor+patch Cargo bumps into one PR (`rust-minor-patch`), reducing noise and CI runs
- Adds commit-message prefixes: `chore(deps)` for Cargo, `ci(deps)` for Actions