### PR TITLE
test: 13 tests for approval_flow.rs — closes #705

### DIFF
--- a/koda-core/src/approval_flow.rs
+++ b/koda-core/src/approval_flow.rs
@@ -90,3 +90,468 @@ pub(crate) async fn request_approval(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::sink::TestSink;
+    use crate::tools::ToolEffect;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    // ── handle_ask_user ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ask_user_returns_answer() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({"question": "Pick one?", "options": ["a", "b"]});
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        // Wait for AskUserRequest to be emitted, then reply with matching id.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let id = sink
+            .events()
+            .into_iter()
+            .find_map(|e| {
+                if let EngineEvent::AskUserRequest { id, .. } = e {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .expect("AskUserRequest not emitted");
+
+        cmd_tx
+            .send(EngineCommand::AskUserResponse {
+                id,
+                answer: "b".into(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(task.await.unwrap(), Some("b".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_user_emits_request_event_with_question_and_options() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({
+            "question": "Continue?",
+            "options": ["yes", "no"]
+        });
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let _task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let events = sink.events();
+        let req = events.iter().find_map(|e| {
+            if let EngineEvent::AskUserRequest {
+                question, options, ..
+            } = e
+            {
+                Some((question.clone(), options.clone()))
+            } else {
+                None
+            }
+        });
+        let (q, opts) = req.expect("no AskUserRequest emitted");
+        assert_eq!(q, "Continue?");
+        assert_eq!(opts, vec!["yes", "no"]);
+
+        drop(cmd_tx);
+    }
+
+    #[tokio::test]
+    async fn ask_user_ignores_response_with_wrong_id() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({"question": "Q?", "options": []});
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let id = sink
+            .events()
+            .into_iter()
+            .find_map(|e| {
+                if let EngineEvent::AskUserRequest { id, .. } = e {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        // Wrong id first — should be ignored.
+        cmd_tx
+            .send(EngineCommand::AskUserResponse {
+                id: "wrong-id".into(),
+                answer: "nope".into(),
+            })
+            .await
+            .unwrap();
+
+        // Correct id — should be accepted.
+        cmd_tx
+            .send(EngineCommand::AskUserResponse {
+                id,
+                answer: "correct".into(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(task.await.unwrap(), Some("correct".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_user_returns_none_on_interrupt() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({"question": "Q?", "options": []});
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cmd_tx.send(EngineCommand::Interrupt).await.unwrap();
+        assert_eq!(task.await.unwrap(), None);
+        assert!(cancel.is_cancelled(), "interrupt should cancel the token");
+    }
+
+    #[tokio::test]
+    async fn ask_user_returns_none_when_channel_closes() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({"question": "Q?", "options": []});
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        drop(cmd_tx);
+        assert_eq!(task.await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn ask_user_returns_none_on_cancellation() {
+        let sink = Arc::new(TestSink::new());
+        let (_cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+        let args = serde_json::json!({"question": "Q?", "options": []});
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            handle_ask_user(&*sink2, &mut rx, &cancel2, &args).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.cancel();
+        assert_eq!(task.await.unwrap(), None);
+    }
+
+    // ── request_approval ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn request_approval_returns_approve() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Write",
+                "overwrite main.rs",
+                None,
+                ToolEffect::LocalMutation,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let id = sink
+            .events()
+            .into_iter()
+            .find_map(|e| {
+                if let EngineEvent::ApprovalRequest { id, .. } = e {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .expect("ApprovalRequest not emitted");
+
+        cmd_tx
+            .send(EngineCommand::ApprovalResponse {
+                id,
+                decision: ApprovalDecision::Approve,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Approve));
+    }
+
+    #[tokio::test]
+    async fn request_approval_returns_reject() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Bash",
+                "rm -rf .",
+                None,
+                ToolEffect::Destructive,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let id = sink
+            .events()
+            .into_iter()
+            .find_map(|e| {
+                if let EngineEvent::ApprovalRequest { id, .. } = e {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        cmd_tx
+            .send(EngineCommand::ApprovalResponse {
+                id,
+                decision: ApprovalDecision::Reject,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Reject));
+    }
+
+    #[tokio::test]
+    async fn request_approval_emits_event_with_tool_name_and_detail() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let _task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Edit",
+                "replace line 42",
+                None,
+                ToolEffect::LocalMutation,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let events = sink.events();
+        let req = events.iter().find_map(|e| {
+            if let EngineEvent::ApprovalRequest {
+                tool_name, detail, ..
+            } = e
+            {
+                Some((tool_name.clone(), detail.clone()))
+            } else {
+                None
+            }
+        });
+        let (tool, detail) = req.expect("no ApprovalRequest emitted");
+        assert_eq!(tool, "Edit");
+        assert_eq!(detail, "replace line 42");
+
+        drop(cmd_tx);
+    }
+
+    #[tokio::test]
+    async fn request_approval_ignores_response_with_wrong_id() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Write",
+                "detail",
+                None,
+                ToolEffect::LocalMutation,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let id = sink
+            .events()
+            .into_iter()
+            .find_map(|e| {
+                if let EngineEvent::ApprovalRequest { id, .. } = e {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+
+        // Wrong id ignored.
+        cmd_tx
+            .send(EngineCommand::ApprovalResponse {
+                id: "wrong".into(),
+                decision: ApprovalDecision::Reject,
+            })
+            .await
+            .unwrap();
+
+        // Correct id accepted.
+        cmd_tx
+            .send(EngineCommand::ApprovalResponse {
+                id,
+                decision: ApprovalDecision::Approve,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Approve));
+    }
+
+    #[tokio::test]
+    async fn request_approval_returns_none_on_interrupt() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Bash",
+                "detail",
+                None,
+                ToolEffect::Destructive,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cmd_tx.send(EngineCommand::Interrupt).await.unwrap();
+        assert_eq!(task.await.unwrap(), None);
+        assert!(cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn request_approval_returns_none_when_channel_closes() {
+        let sink = Arc::new(TestSink::new());
+        let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Write",
+                "detail",
+                None,
+                ToolEffect::LocalMutation,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        drop(cmd_tx);
+        assert_eq!(task.await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn request_approval_returns_none_on_cancellation() {
+        let sink = Arc::new(TestSink::new());
+        let (_cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
+        let cancel = CancellationToken::new();
+
+        let sink2 = Arc::clone(&sink);
+        let cancel2 = cancel.clone();
+        let task = tokio::spawn(async move {
+            let mut rx = cmd_rx;
+            request_approval(
+                &*sink2,
+                &mut rx,
+                &cancel2,
+                "Write",
+                "detail",
+                None,
+                ToolEffect::LocalMutation,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.cancel();
+        assert_eq!(task.await.unwrap(), None);
+    }
+}


### PR DESCRIPTION
Part of #705 — closes the last **P0** gap (`approval_flow.rs`). P1/P2/P3 coverage continues in future PRs.

Last untested P0 module: `approval_flow.rs` — the async request/response dance for tool approvals and `AskUser`.

### Tests added (13)

**`handle_ask_user`** (6):
- Returns the answer on matching `AskUserResponse`
- Emits `AskUserRequest` with correct question and options
- Ignores responses with wrong id, keeps waiting for the right one
- Returns `None` on `Interrupt` (and cancels the token)
- Returns `None` when channel closes
- Returns `None` on `CancellationToken`

**`request_approval`** (7):
- Returns `Approve` on matching `ApprovalResponse`
- Returns `Reject` decision
- Emits `ApprovalRequest` with correct `tool_name` and `detail`
- Ignores responses with wrong id, keeps waiting for the right one
- Returns `None` on `Interrupt` (and cancels the token)
- Returns `None` when channel closes
- Returns `None` on `CancellationToken`

### #705 scorecard after this PR

| Metric | Start | Now |
|---|---|---|
| Test lines | ~4K | ~5.8K |
| Ratio (src:test) | 1:9 | ~1:4.5 |
| Total tests | ~600 | 771 |
| P0 gaps | several | **0** |