### PR TITLE
fix: upgrade similar 2→3 + CI --features fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --workspace --all-targets
+      - run: cargo check --workspace --all-targets --features koda-core/test-support
 
   fmt:
     name: Format
@@ -45,7 +45,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,9 +3273,12 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "26d0b06eba54f0ca0770f970a3e89823e766ca638dd940f8469fa0fa50c75396"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -35,7 +35,7 @@ path-clean = "1"
 regex = "1"
 
 # Diff computation
-similar = "2"
+similar = "3"
 
 # File globbing
 glob = "0.3"

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -200,7 +200,6 @@ fn build_unified_diff(path: &str, old_content: &str, new_content: &str) -> Unifi
                     new_line,
                 });
             }
-
         }
 
         total_lines += hunk_lines.len();

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -171,9 +171,6 @@ fn build_unified_diff(path: &str, old_content: &str, new_content: &str) -> Unifi
                 first = false;
             }
 
-            let old_lines = diff.old_slices();
-            let new_lines = diff.new_slices();
-
             for change in diff.iter_changes(op) {
                 let content = change.value().trim_end_matches('\n').to_string();
                 let (tag, old_line, new_line) = match change.tag() {
@@ -204,8 +201,6 @@ fn build_unified_diff(path: &str, old_content: &str, new_content: &str) -> Unifi
                 });
             }
 
-            // Suppress unused-variable warnings — we use iter_changes instead.
-            let _ = (old_lines, new_lines);
         }
 
         total_lines += hunk_lines.len();


### PR DESCRIPTION
Supersedes and closes #717.

## Why not just merge dependabot's PR?

Dependabot's `Cargo.lock` was generated from an older snapshot — it silently **downgraded** tokio (1.51→1.50), libc, mio, socket2, and tree-sitter-rust. Merging it would have regressed those deps. This PR keeps everything else at current versions and only moves `similar`.

## Changes

### `similar` 2 → 3 (`koda-core/Cargo.toml` + `Cargo.lock`)
- Bumps to 3.0.0

### `koda-core/src/preview.rs`
- Removes two dead calls to `old_slices()`/`new_slices()` — both were immediately discarded with `let _ = (...)`. Those methods were removed in similar 3.0.0.

### `.github/workflows/ci.yml`
- Adds `--features koda-core/test-support` to the **check** and **clippy** CI steps
- The **test** step already had the flag; without it `--all-targets` fails to compile integration tests that import `TestSink` (gated behind that feature)
- This was a pre-existing silent failure on every CI run against the integration tests