### PR TITLE
test: 99 new tests, bump CI gate 70% → 80% (koda-core + koda-ast)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings
 
   coverage:
-    name: Coverage (koda-core ≥ 70% lines)
+    name: Coverage (koda-core ≥ 80%, koda-ast ≥ 80%)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,19 +79,25 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
-      - name: Run coverage
+      - name: koda-core coverage (≥ 80% lines)
         run: |
           cargo llvm-cov \
             --lib -p koda-core \
             --features koda-core/test-support \
-            --fail-under-lines 70 \
-            --lcov --output-path lcov.info
-      - name: Upload lcov report
+            --fail-under-lines 80 \
+            --lcov --output-path lcov-core.info
+      - name: koda-ast coverage (≥ 80% lines)
+        run: |
+          cargo llvm-cov \
+            --lib -p koda-ast \
+            --fail-under-lines 80 \
+            --lcov --output-path lcov-ast.info
+      - name: Upload lcov reports
         uses: actions/upload-artifact@v4
         if: always()   # Upload even on failure so you can inspect regressions
         with:
-          name: lcov-report
-          path: lcov.info
+          name: lcov-reports
+          path: lcov-*.info
           retention-days: 7
 
   audit:

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -696,4 +696,49 @@ mod tests {
         assert!(!result.ends_with('\n'));
         assert_eq!(result, "Clean content");
     }
+
+    // ── circuit breaker ───────────────────────────────────────────────────
+    // Note: CONSECUTIVE_FAILURES is a process-global AtomicU32. Each test
+    // resets it first so concurrent tests don't cross-contaminate.
+
+    #[test]
+    fn test_circuit_not_broken_after_reset() {
+        reset_compact_failures();
+        assert!(!is_compact_circuit_broken());
+    }
+
+    #[test]
+    fn test_circuit_broken_after_max_failures() {
+        reset_compact_failures();
+        // MAX_CONSECUTIVE_FAILURES = 3
+        record_compact_failure();
+        record_compact_failure();
+        let tripped = record_compact_failure();
+        assert!(tripped, "third failure should trip the circuit");
+        assert!(is_compact_circuit_broken());
+        reset_compact_failures(); // clean up
+    }
+
+    #[test]
+    fn test_reset_clears_broken_circuit() {
+        // Trip the circuit
+        reset_compact_failures();
+        record_compact_failure();
+        record_compact_failure();
+        record_compact_failure();
+        assert!(is_compact_circuit_broken());
+        // Reset heals it
+        reset_compact_failures();
+        assert!(!is_compact_circuit_broken());
+    }
+
+    #[test]
+    fn test_record_failure_not_tripped_below_threshold() {
+        reset_compact_failures();
+        let first = record_compact_failure();
+        let second = record_compact_failure();
+        assert!(!first, "first failure should not trip circuit");
+        assert!(!second, "second failure should not trip circuit");
+        reset_compact_failures(); // clean up
+    }
 }

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -941,4 +941,195 @@ mod tests {
         assert_eq!(config.model, "gpt-4o");
         assert_eq!(config.max_context_tokens, 128_000);
     }
+
+    // ── URL-based provider detection (remaining providers) ─────────────────
+
+    #[test]
+    fn test_provider_from_url_ollama() {
+        assert_eq!(
+            ProviderType::from_url_or_name("http://localhost:11434/api", None),
+            ProviderType::Ollama
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_vllm() {
+        assert_eq!(
+            ProviderType::from_url_or_name("http://localhost:8000/v1", None),
+            ProviderType::Vllm
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_gemini() {
+        assert_eq!(
+            ProviderType::from_url_or_name(
+                "https://generativelanguage.googleapis.com/v1beta",
+                None
+            ),
+            ProviderType::Gemini
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_groq() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.groq.com/openai/v1", None),
+            ProviderType::Groq
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_grok() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.x.ai/v1", None),
+            ProviderType::Grok
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_deepseek() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.deepseek.com/v1", None),
+            ProviderType::DeepSeek
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_mistral() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.mistral.ai/v1", None),
+            ProviderType::Mistral
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_openrouter() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://openrouter.ai/api/v1", None),
+            ProviderType::OpenRouter
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_together() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.together.xyz/v1", None),
+            ProviderType::Together
+        );
+    }
+
+    #[test]
+    fn test_provider_from_url_fireworks() {
+        assert_eq!(
+            ProviderType::from_url_or_name("https://api.fireworks.ai/inference/v1", None),
+            ProviderType::Fireworks
+        );
+    }
+
+    // ── Name alias coverage (remaining aliases) ─────────────────────────
+
+    #[test]
+    fn test_provider_name_aliases_extended() {
+        let cases = [
+            ("ollama", ProviderType::Ollama),
+            ("deepseek", ProviderType::DeepSeek),
+            ("mistral", ProviderType::Mistral),
+            ("minimax", ProviderType::MiniMax),
+            ("openrouter", ProviderType::OpenRouter),
+            ("together", ProviderType::Together),
+            ("fireworks", ProviderType::Fireworks),
+            ("vllm", ProviderType::Vllm),
+            ("groq", ProviderType::Groq),
+            ("mock", ProviderType::Mock),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(
+                ProviderType::from_url_or_name("", Some(name)),
+                expected,
+                "alias '{name}' failed"
+            );
+        }
+    }
+
+    // ── requires_api_key ───────────────────────────────────────────────
+
+    #[test]
+    fn test_requires_api_key_local_providers() {
+        // Local providers don't require an API key
+        assert!(!ProviderType::LMStudio.requires_api_key());
+        assert!(!ProviderType::Ollama.requires_api_key());
+        assert!(!ProviderType::Mock.requires_api_key());
+        assert!(!ProviderType::Vllm.requires_api_key());
+    }
+
+    #[test]
+    fn test_requires_api_key_cloud_providers() {
+        assert!(ProviderType::Anthropic.requires_api_key());
+        assert!(ProviderType::OpenAI.requires_api_key());
+        assert!(ProviderType::Gemini.requires_api_key());
+        assert!(ProviderType::Groq.requires_api_key());
+        assert!(ProviderType::Grok.requires_api_key());
+    }
+
+    // ── ModelSettings::defaults_for ─────────────────────────────────────
+
+    #[test]
+    fn test_model_settings_defaults_anthropic_has_max_tokens() {
+        let s = ModelSettings::defaults_for("claude-opus-4-5", &ProviderType::Anthropic);
+        assert_eq!(s.max_tokens, Some(16384));
+        assert_eq!(s.model, "claude-opus-4-5");
+        assert!(s.temperature.is_none());
+    }
+
+    #[test]
+    fn test_model_settings_defaults_openai_no_max_tokens() {
+        let s = ModelSettings::defaults_for("gpt-4o", &ProviderType::OpenAI);
+        assert!(s.max_tokens.is_none(), "OpenAI should use provider default");
+        assert_eq!(s.model, "gpt-4o");
+    }
+
+    // ── with_model_overrides ──────────────────────────────────────────
+
+    #[test]
+    fn test_with_model_overrides_all_fields() {
+        let config = KodaConfig::default_for_testing(ProviderType::Anthropic).with_model_overrides(
+            Some(8192),         // max_tokens
+            Some(0.7),          // temperature
+            Some(2000),         // thinking_budget
+            Some("low".into()), // reasoning_effort
+        );
+        assert_eq!(config.model_settings.max_tokens, Some(8192));
+        assert_eq!(config.model_settings.temperature, Some(0.7));
+        assert_eq!(config.model_settings.thinking_budget, Some(2000));
+        assert_eq!(
+            config.model_settings.reasoning_effort,
+            Some("low".to_string())
+        );
+    }
+
+    #[test]
+    fn test_with_model_overrides_none_changes_nothing() {
+        let original = KodaConfig::default_for_testing(ProviderType::OpenAI);
+        let original_tokens = original.model_settings.max_tokens;
+        let config = original.with_model_overrides(None, None, None, None);
+        assert_eq!(config.model_settings.max_tokens, original_tokens);
+        assert!(config.model_settings.temperature.is_none());
+    }
+
+    // ── builtin_agents ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_builtin_agents_is_not_empty() {
+        let agents = KodaConfig::builtin_agents();
+        assert!(!agents.is_empty(), "builtin_agents should not be empty");
+    }
+
+    #[test]
+    fn test_builtin_agents_contains_core_agents() {
+        let agents = KodaConfig::builtin_agents();
+        let names: Vec<&str> = agents.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(names.contains(&"task"), "should have 'task' agent");
+        assert!(names.contains(&"explore"), "should have 'explore' agent");
+    }
 }

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1095,3 +1095,67 @@ async fn test_purge_compacted() {
     let stats = db.compacted_stats().await.unwrap();
     assert_eq!(stats.message_count, 0, "all compacted should be purged");
 }
+
+// ── config_dir ─────────────────────────────────────────────────────────
+
+/// Serialize tests that mutate XDG_CONFIG_HOME.
+static XDG_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn test_config_dir_with_xdg() {
+    let _guard = XDG_MUTEX.lock().unwrap();
+    // SAFETY: serialized via XDG_MUTEX
+    unsafe { std::env::set_var("XDG_CONFIG_HOME", "/tmp/test_xdg_config") };
+    let dir = super::config_dir().unwrap();
+    unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    // Always ends with "koda"
+    assert!(dir.ends_with("koda"), "got: {dir:?}");
+    assert!(
+        dir.to_string_lossy().contains("test_xdg_config"),
+        "should use XDG_CONFIG_HOME: {dir:?}"
+    );
+}
+
+#[test]
+fn test_config_dir_with_home() {
+    let _guard = XDG_MUTEX.lock().unwrap();
+    unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    let dir = super::config_dir().unwrap();
+    // Should end with koda regardless of base path
+    assert!(dir.ends_with("koda"), "got: {dir:?}");
+}
+
+// ── kv store ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_kv_set_get_delete() {
+    let (db, _tmp) = setup().await;
+    // Initially absent
+    assert!(db.kv_get("my_key").await.unwrap().is_none());
+    // Set
+    db.kv_set("my_key", "hello").await.unwrap();
+    assert_eq!(db.kv_get("my_key").await.unwrap().as_deref(), Some("hello"));
+    // Overwrite
+    db.kv_set("my_key", "updated").await.unwrap();
+    assert_eq!(
+        db.kv_get("my_key").await.unwrap().as_deref(),
+        Some("updated")
+    );
+    // Delete
+    db.kv_delete("my_key").await.unwrap();
+    assert!(db.kv_get("my_key").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn test_kv_list_prefix() {
+    let (db, _tmp) = setup().await;
+    db.kv_set("cfg:foo", "1").await.unwrap();
+    db.kv_set("cfg:bar", "2").await.unwrap();
+    db.kv_set("other:baz", "3").await.unwrap();
+    let items = db.kv_list_prefix("cfg:").await.unwrap();
+    assert_eq!(items.len(), 2);
+    let keys: Vec<&str> = items.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(keys.contains(&"cfg:foo"));
+    assert!(keys.contains(&"cfg:bar"));
+    assert!(!keys.contains(&"other:baz"));
+}

--- a/koda-core/src/progress.rs
+++ b/koda-core/src/progress.rs
@@ -175,4 +175,191 @@ mod tests {
         assert!(extract_delete_progress("Deleted src/old.rs").is_some());
         assert!(extract_delete_progress("File not found").is_none());
     }
+
+    // ── content / format assertions ───────────────────────────────────────
+
+    #[test]
+    fn test_write_progress_content_includes_first_line() {
+        let result = extract_write_progress("Created file: src/main.rs").unwrap();
+        assert!(
+            result.contains("Created file: src/main.rs"),
+            "got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_delete_progress_removed_keyword() {
+        // "removed" is an alternative trigger word
+        assert!(extract_delete_progress("5 files removed successfully").is_some());
+    }
+
+    #[test]
+    fn test_delete_progress_content_includes_first_line() {
+        let result = extract_delete_progress("Deleted src/old.rs").unwrap();
+        assert!(result.contains("Deleted src/old.rs"), "got: {result}");
+    }
+
+    #[test]
+    fn test_edit_progress_long_line_is_truncated() {
+        let long = "Applied replacements to ".to_string() + &"x".repeat(100);
+        let result = extract_edit_progress(&long).unwrap();
+        // Should be capped at 80 chars + "..."
+        assert!(
+            result.contains("..."),
+            "long line should be truncated: {result}"
+        );
+    }
+
+    #[test]
+    fn test_edit_progress_short_line_not_truncated() {
+        let result = extract_edit_progress("Applied 3 replacements to src/lib.rs").unwrap();
+        assert!(
+            !result.contains("..."),
+            "short line should not be truncated: {result}"
+        );
+    }
+
+    // ── extract_bash_progress edge cases ─────────────────────────────────
+
+    #[test]
+    fn test_bash_progress_background_process() {
+        let result = extract_bash_progress(
+            "Background process started\n  Command: cargo watch -x test\n  PID: 1234",
+        )
+        .unwrap();
+        assert!(
+            result.contains("cargo watch"),
+            "should include command: {result}"
+        );
+        assert!(result.contains("Started background"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_build_cargo_finish() {
+        // cargo build output typically contains "Finished" and "target"
+        let result =
+            extract_bash_progress("   Finished `release` profile [optimized] target(s)").unwrap();
+        assert!(result.contains("Build succeeded"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_build_succeeded_literal() {
+        let result = extract_bash_progress("build succeeded").unwrap();
+        assert!(result.contains("Build succeeded"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_build_failed() {
+        let result =
+            extract_bash_progress("error: could not compile `myapp` due to 3 errors").unwrap();
+        assert!(result.contains("Build failed"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_tests_passed_text() {
+        // Some test runners emit "tests passed" not "test result: ok"
+        let result = extract_bash_progress("All 42 tests passed").unwrap();
+        assert!(result.contains("Tests passed"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_tests_failed_text() {
+        let result = extract_bash_progress("3 tests failed").unwrap();
+        assert!(result.contains("Tests failed"), "got: {result}");
+    }
+
+    #[test]
+    fn test_bash_progress_background_long_command_truncated() {
+        let long_cmd = "x".repeat(80);
+        let output = format!("Background process started\n  Command: {long_cmd}\n");
+        let result = extract_bash_progress(&output).unwrap();
+        assert!(
+            result.contains("..."),
+            "long command should be truncated: {result}"
+        );
+    }
+
+    // ── async / DB-backed tests ──────────────────────────────────────────
+
+    async fn test_db() -> (Database, tempfile::TempDir, String) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Database::open(&dir.path().join("progress_test.db"))
+            .await
+            .unwrap();
+        let sid = db.create_session("koda", dir.path()).await.unwrap();
+        (db, dir, sid)
+    }
+
+    #[tokio::test]
+    async fn test_get_progress_summary_empty() {
+        let (db, _dir, sid) = test_db().await;
+        let result = get_progress_summary(&db, &sid).await;
+        assert!(result.is_none(), "empty session should return None");
+    }
+
+    #[tokio::test]
+    async fn test_track_progress_write_tool() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(&db, &sid, "Write", "", "Created file: src/main.rs").await;
+        let summary = get_progress_summary(&db, &sid).await.unwrap();
+        assert!(summary.contains("src/main.rs"), "got: {summary}");
+        assert!(summary.contains("Session Progress"), "got: {summary}");
+    }
+
+    #[tokio::test]
+    async fn test_track_progress_edit_tool() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(
+            &db,
+            &sid,
+            "Edit",
+            "",
+            "Applied 2 replacements to src/lib.rs",
+        )
+        .await;
+        let summary = get_progress_summary(&db, &sid).await.unwrap();
+        assert!(summary.contains("lib.rs"), "got: {summary}");
+    }
+
+    #[tokio::test]
+    async fn test_track_progress_bash_tool() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(
+            &db,
+            &sid,
+            "Bash",
+            "",
+            "test result: ok. 10 passed; 0 failed",
+        )
+        .await;
+        let summary = get_progress_summary(&db, &sid).await.unwrap();
+        assert!(summary.contains("Tests passed"), "got: {summary}");
+    }
+
+    #[tokio::test]
+    async fn test_track_progress_delete_tool() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(&db, &sid, "Delete", "", "Deleted src/old.rs").await;
+        let summary = get_progress_summary(&db, &sid).await.unwrap();
+        assert!(summary.contains("Deleted"), "got: {summary}");
+    }
+
+    #[tokio::test]
+    async fn test_track_progress_unknown_tool_no_entry() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(&db, &sid, "UnknownTool", "", "some result").await;
+        // Unknown tool → no entry tracked
+        let summary = get_progress_summary(&db, &sid).await;
+        assert!(summary.is_none(), "unknown tool should not create progress");
+    }
+
+    #[tokio::test]
+    async fn test_progress_accumulates_multiple_entries() {
+        let (db, _dir, sid) = test_db().await;
+        track_progress(&db, &sid, "Write", "", "Created file: a.rs").await;
+        track_progress(&db, &sid, "Write", "", "Created file: b.rs").await;
+        let summary = get_progress_summary(&db, &sid).await.unwrap();
+        assert!(summary.contains("a.rs"), "got: {summary}");
+        assert!(summary.contains("b.rs"), "got: {summary}");
+    }
 }

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -273,6 +273,9 @@ impl LlmProvider for MockProvider {
 mod tests {
     use super::*;
 
+    /// Serialize env-var mutations across parallel tests.
+    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[tokio::test]
     async fn test_text_response() {
         let provider = MockProvider::new(vec![MockResponse::Text("hello".into())]);
@@ -337,5 +340,251 @@ mod tests {
             chunks.push(chunk);
         }
         chunks
+    }
+
+    // ── MockResponse::tool_call builder ─────────────────────────────────
+
+    #[test]
+    fn test_tool_call_builder() {
+        let tc = MockResponse::tool_call("Read", serde_json::json!({"file_path": "foo.rs"}));
+        match tc {
+            MockResponse::ToolCalls(calls) => {
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].function_name, "Read");
+                let args: serde_json::Value = serde_json::from_str(&calls[0].arguments).unwrap();
+                assert_eq!(args["file_path"], "foo.rs");
+            }
+            other => panic!("expected ToolCalls, got {other:?}"),
+        }
+    }
+
+    // ── from_env ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_from_env_no_var_gives_empty_provider() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: serialized via ENV_MUTEX
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::Text(t) if t.is_empty()));
+    }
+
+    #[test]
+    fn test_from_env_with_text_response() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "hello from env"}]"#);
+        }
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::Text(t) if t == "hello from env"));
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    }
+
+    #[test]
+    fn test_from_env_with_tool_call() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var(
+                "KODA_MOCK_RESPONSES",
+                r#"[{"tool": "Bash", "args": {"command": "ls"}}]"#,
+            );
+        }
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::ToolCalls(calls) if calls[0].function_name == "Bash"));
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    }
+
+    #[test]
+    fn test_from_env_with_error() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"error": "boom"}]"#);
+        }
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::Error(e) if e == "boom"));
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    }
+
+    #[test]
+    fn test_from_env_with_rate_limit() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"rate_limit": true}]"#);
+        }
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::RateLimit));
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    }
+
+    #[test]
+    fn test_from_env_with_context_overflow() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"context_overflow": true}]"#);
+        }
+        let provider = MockProvider::from_env();
+        let next = provider.next_response();
+        assert!(matches!(next, MockResponse::ContextOverflow));
+        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    }
+
+    // ── provider metadata ─────────────────────────────────────────────
+
+    #[test]
+    fn test_provider_name() {
+        let p = MockProvider::new(vec![]);
+        assert_eq!(p.provider_name(), "mock");
+    }
+
+    #[tokio::test]
+    async fn test_list_models_returns_mock_model() {
+        let p = MockProvider::new(vec![]);
+        let models = p.list_models().await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "mock-model");
+    }
+
+    // ── non-streaming chat ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_chat_text_response() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::Text("hi there".into())]);
+        let resp = provider.chat(&[], &[], &settings).await.unwrap();
+        assert_eq!(resp.content.as_deref(), Some("hi there"));
+        assert!(resp.tool_calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_chat_empty_queue_returns_empty_text() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![]);
+        let resp = provider.chat(&[], &[], &settings).await.unwrap();
+        assert_eq!(resp.content.as_deref(), Some(""));
+    }
+
+    #[tokio::test]
+    async fn test_chat_rate_limit_is_error() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::RateLimit]);
+        let result = provider.chat(&[], &[], &settings).await;
+        assert!(result.is_err());
+        // Error message: "LLM API returned 429: Too Many Requests"
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("429") || msg.to_lowercase().contains("too many"),
+            "unexpected rate-limit msg: {msg}"
+        );
+    }
+
+    // ── remaining chat() variants ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_chat_tool_calls_response() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::tool_call(
+            "Bash",
+            serde_json::json!({"command": "ls"}),
+        )]);
+        let resp = provider.chat(&[], &[], &settings).await.unwrap();
+        assert!(resp.content.is_none());
+        assert_eq!(resp.tool_calls.len(), 1);
+        assert_eq!(resp.tool_calls[0].function_name, "Bash");
+    }
+
+    #[tokio::test]
+    async fn test_chat_text_max_tokens_stop_reason() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider =
+            MockProvider::new(vec![MockResponse::TextMaxTokens("truncated text".into())]);
+        let resp = provider.chat(&[], &[], &settings).await.unwrap();
+        assert_eq!(resp.content.as_deref(), Some("truncated text"));
+        assert_eq!(resp.usage.stop_reason, "max_tokens");
+    }
+
+    #[tokio::test]
+    async fn test_chat_context_overflow_is_error() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::ContextOverflow]);
+        let result = provider.chat(&[], &[], &settings).await;
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("too long"),
+            "should mention context length"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chat_network_error() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::NetworkError {
+            partial_text: "partial...".into(),
+            error: "connection reset".into(),
+        }]);
+        let result = provider.chat(&[], &[], &settings).await;
+        assert!(result.is_err());
+    }
+
+    // ── chat_stream() remaining variants ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_stream_text_max_tokens() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::TextMaxTokens("hi there".into())]);
+        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(rx).await;
+        // Should end with Done with stop_reason = "max_tokens"
+        let done = chunks
+            .iter()
+            .find(|c| matches!(c, StreamChunk::Done(u) if u.stop_reason == "max_tokens"));
+        assert!(done.is_some(), "should emit max_tokens Done chunk");
+    }
+
+    #[tokio::test]
+    async fn test_stream_tool_calls_eager() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::ToolCallsEager(vec![ToolCall {
+            id: "tc1".into(),
+            function_name: "Read".into(),
+            arguments: "{}".into(),
+            thought_signature: None,
+        }])]);
+        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(rx).await;
+        // Should have a ToolCallReady chunk
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, StreamChunk::ToolCallReady(tc) if tc.function_name == "Read")),
+            "expected ToolCallReady chunk"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stream_network_error() {
+        let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
+        let provider = MockProvider::new(vec![MockResponse::NetworkError {
+            partial_text: "partial output".into(),
+            error: "connection dropped".into(),
+        }]);
+        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(rx).await;
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, StreamChunk::TextDelta(s) if s == "partial output")),
+            "should emit partial text"
+        );
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, StreamChunk::NetworkError(_))),
+            "should emit NetworkError chunk"
+        );
     }
 }

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -344,3 +344,94 @@ pub fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider> {
         )),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── is_localhost_url ────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_localhost_url_localhost() {
+        assert!(is_localhost_url("http://localhost:1234/v1"));
+        assert!(is_localhost_url("HTTP://LOCALHOST:11434/api"));
+    }
+
+    #[test]
+    fn test_is_localhost_url_127() {
+        assert!(is_localhost_url("http://127.0.0.1:8000/v1"));
+    }
+
+    #[test]
+    fn test_is_localhost_url_ipv6() {
+        assert!(is_localhost_url("http://[::1]:1234/v1"));
+    }
+
+    #[test]
+    fn test_is_localhost_url_remote() {
+        assert!(!is_localhost_url("https://api.openai.com/v1"));
+        assert!(!is_localhost_url("https://api.anthropic.com/v1"));
+    }
+
+    // ── redact_url_credentials ─────────────────────────────────────────
+
+    #[test]
+    fn test_redact_with_credentials() {
+        let result = redact_url_credentials("http://user:secret@proxy.corp.com:8080");
+        assert!(
+            !result.contains("secret"),
+            "credentials should be redacted: {result}"
+        );
+        assert!(
+            result.contains("***:***"),
+            "should have redacted placeholder: {result}"
+        );
+        assert!(
+            result.contains("proxy.corp.com"),
+            "host should be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn test_redact_without_credentials() {
+        let url = "https://proxy.corp.com:8080";
+        assert_eq!(redact_url_credentials(url), url);
+    }
+
+    #[test]
+    fn test_redact_empty_url() {
+        assert_eq!(redact_url_credentials(""), "");
+    }
+
+    // ── ChatMessage::text ─────────────────────────────────────────────
+
+    #[test]
+    fn test_chat_message_text_builder() {
+        let msg = ChatMessage::text("user", "hello world");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.as_deref(), Some("hello world"));
+        assert!(msg.tool_calls.is_none());
+        assert!(msg.tool_call_id.is_none());
+        assert!(msg.images.is_none());
+    }
+
+    #[test]
+    fn test_chat_message_text_assistant() {
+        let msg = ChatMessage::text("assistant", "I can help with that.");
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content.as_deref(), Some("I can help with that."));
+    }
+
+    // ── TokenUsage defaults ────────────────────────────────────────────
+
+    #[test]
+    fn test_token_usage_default() {
+        let usage = TokenUsage::default();
+        assert_eq!(usage.prompt_tokens, 0);
+        assert_eq!(usage.completion_tokens, 0);
+        assert!(
+            usage.stop_reason.is_empty(),
+            "default stop_reason should be empty"
+        );
+    }
+}

--- a/koda-core/src/tools/recall.rs
+++ b/koda-core/src/tools/recall.rs
@@ -149,6 +149,8 @@ fn extract_snippet(text: &str, query: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence::{Persistence, Role};
+    use serde_json::json;
 
     #[test]
     fn test_definition() {
@@ -219,5 +221,96 @@ mod tests {
         let lower_q = "error";
         let snippet = extract_snippet(text, lower_q, 200);
         assert!(snippet.contains("Error"));
+    }
+
+    // ── recall_context integration tests (requires DB) ─────────────────────
+
+    async fn test_db() -> (Database, tempfile::TempDir, String) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Database::open(&dir.path().join("recall_test.db"))
+            .await
+            .unwrap();
+        let sid = db.create_session("koda", dir.path()).await.unwrap();
+        (db, dir, sid)
+    }
+
+    #[tokio::test]
+    async fn test_recall_no_query_or_turn() {
+        let (db, _dir, sid) = test_db().await;
+        let result = recall_context(&db, &sid, &json!({})).await;
+        assert!(
+            result.contains("Provide"),
+            "should ask for query or turn: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recall_empty_history() {
+        let (db, _dir, sid) = test_db().await;
+        let result = recall_context(&db, &sid, &json!({"turn": 1})).await;
+        assert!(result.contains("No conversation history"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_turn_hit() {
+        let (db, _dir, sid) = test_db().await;
+        db.insert_message(&sid, &Role::User, Some("hello world"), None, None, None)
+            .await
+            .unwrap();
+        let result = recall_context(&db, &sid, &json!({"turn": 1})).await;
+        assert!(result.contains("hello world"), "got: {result}");
+        assert!(result.contains("Turn 1"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_turn_out_of_bounds() {
+        let (db, _dir, sid) = test_db().await;
+        db.insert_message(&sid, &Role::User, Some("msg1"), None, None, None)
+            .await
+            .unwrap();
+        let result = recall_context(&db, &sid, &json!({"turn": 99})).await;
+        assert!(result.contains("does not exist"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_query_match() {
+        let (db, _dir, sid) = test_db().await;
+        db.insert_message(
+            &sid,
+            &Role::Assistant,
+            Some("The error was a null pointer exception"),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let result = recall_context(&db, &sid, &json!({"query": "null pointer"})).await;
+        assert!(result.contains("null pointer"), "got: {result}");
+        assert!(result.contains("Found"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_query_no_match() {
+        let (db, _dir, sid) = test_db().await;
+        db.insert_message(&sid, &Role::User, Some("hello world"), None, None, None)
+            .await
+            .unwrap();
+        let result = recall_context(&db, &sid, &json!({"query": "xyzzy"})).await;
+        assert!(result.contains("No matches"), "got: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_recall_by_turn_long_content_truncated() {
+        let (db, _dir, sid) = test_db().await;
+        let long_msg = "z".repeat(3000);
+        db.insert_message(&sid, &Role::User, Some(&long_msg), None, None, None)
+            .await
+            .unwrap();
+        let result = recall_context(&db, &sid, &json!({"turn": 1})).await;
+        assert!(
+            result.contains("[truncated"),
+            "long message should be truncated: {result}"
+        );
     }
 }

--- a/koda-core/src/tools/web_search.rs
+++ b/koda-core/src/tools/web_search.rs
@@ -359,4 +359,86 @@ mod tests {
         let result = web_search(&json!({"query": "   "})).await;
         assert!(result.is_err());
     }
+
+    // ── definitions schema pin ─────────────────────────────────────────
+
+    #[test]
+    fn definitions_returns_one_tool() {
+        let defs = definitions();
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].name, "WebSearch");
+    }
+
+    #[test]
+    fn definitions_query_is_required() {
+        let defs = definitions();
+        let required: Vec<&str> = defs[0].parameters["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(required.contains(&"query"));
+        // num_results is optional
+        assert!(!required.contains(&"num_results"));
+    }
+
+    // ── percent_decode edge cases ────────────────────────────────────
+
+    #[test]
+    fn percent_decode_slash_and_colon() {
+        assert_eq!(percent_decode("%2F"), "/");
+        assert_eq!(percent_decode("%3A"), ":");
+        assert_eq!(percent_decode("%26"), "&");
+        assert_eq!(percent_decode("%3D"), "=");
+    }
+
+    #[test]
+    fn percent_decode_plus_becomes_space() {
+        assert_eq!(percent_decode("hello+world"), "hello world");
+    }
+
+    #[test]
+    fn percent_decode_combined() {
+        // "hello%20world" → "hello world"
+        assert_eq!(percent_decode("hello%20world"), "hello world");
+    }
+
+    #[test]
+    fn percent_decode_truncated_escape_passthrough() {
+        // "%" at end with nothing after is passed through as-is
+        assert_eq!(percent_decode("%"), "%");
+        assert_eq!(percent_decode("%2"), "%2");
+    }
+
+    // ── strip_inline edge cases ──────────────────────────────────────
+
+    #[test]
+    fn strip_inline_plain_text_unchanged() {
+        assert_eq!(strip_inline("hello world"), "hello world");
+    }
+
+    #[test]
+    fn strip_inline_empty_string() {
+        assert_eq!(strip_inline(""), "");
+    }
+
+    #[test]
+    fn strip_inline_nested_tags() {
+        assert_eq!(strip_inline("<b><i>bold italic</i></b>"), "bold italic");
+    }
+
+    // ── parse_results edge cases ─────────────────────────────────────
+
+    #[test]
+    fn parse_empty_html_returns_no_results() {
+        let results = parse_results("", 10);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn parse_zero_max_returns_no_results() {
+        let results = parse_results(FIXTURE, 0);
+        assert!(results.is_empty());
+    }
 }

--- a/koda-core/src/version.rs
+++ b/koda-core/src/version.rs
@@ -91,4 +91,44 @@ mod tests {
     fn test_is_newer_same_version() {
         assert!(!is_newer("0.1.0", "0.1.0"));
     }
+
+    #[test]
+    fn test_is_newer_single_component() {
+        assert!(is_newer("2", "1"));
+        assert!(!is_newer("1", "2"));
+    }
+
+    #[test]
+    fn test_is_newer_patch_only() {
+        assert!(is_newer("0.1.10", "0.1.9"));
+        assert!(!is_newer("0.1.9", "0.1.10"));
+    }
+
+    #[test]
+    fn test_crate_name() {
+        assert_eq!(crate_name(), "koda-cli");
+    }
+
+    #[test]
+    fn test_update_available_same_version_returns_none() {
+        let current = env!("CARGO_PKG_VERSION");
+        // Same version → no update
+        assert!(update_available(current).is_none());
+    }
+
+    #[test]
+    fn test_update_available_older_version_returns_none() {
+        // "0.0.1" is almost certainly older than any real build
+        assert!(update_available("0.0.1").is_none());
+    }
+
+    #[test]
+    fn test_update_available_future_version_returns_some() {
+        // "999.0.0" is always newer than any real build
+        let result = update_available("999.0.0");
+        assert!(result.is_some());
+        let (current, latest) = result.unwrap();
+        assert_eq!(latest, "999.0.0");
+        assert_eq!(current, env!("CARGO_PKG_VERSION"));
+    }
 }


### PR DESCRIPTION
## Summary

99 new unit tests across 9 files, bringing `koda-core` line coverage from **80.56% → 82.93%** (well above the new 80% gate). The CI coverage job now also gates `koda-ast` at 80%.

## Coverage changes

| File | Before | After |
|---|---|---|
| `progress.rs` | ~45% | **99.59%** |
| `providers/mock.rs` | ~89% | **~99%** |
| `providers/mod.rs` | 0% | **new** |
| `version.rs` | ~43% | **71%** |
| `config.rs` | — | **new** |
| `compact.rs` | — | **new** |
| `tools/recall.rs` | — | **new (DB-backed)** |
| `tools/web_search.rs` | — | **new** |
| `db/tests.rs` | — | **new (kv store + config_dir)** |

## CI gate changes (`.github/workflows/ci.yml`)

| Crate | Old gate | New gate | Current |
|---|---|---|---|
| `koda-core` | ≥ 70% | **≥ 80%** | 82.93% ✅ |
| `koda-ast` | none | **≥ 80%** | 85.01% ✅ |
| `koda-email` | none | none (intentional) | 33.66% ⚠️ |

`koda-email` is intentionally left ungated — it sits at 33.66% and would fail immediately. Tracked as follow-up work.

## Test count

701 → **800** passing (`cargo test -p koda-core --lib`)