### PR TITLE
docs+tests: comprehensive coverage review and gap fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/lijunzh/koda/actions/workflows/ci.yml/badge.svg)](https://github.com/lijunzh/koda/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/koda-cli.svg)](https://crates.io/crates/koda-cli)
-[![docs.rs](https://docs.rs/koda-core/badge.svg)](https://docs.rs/koda-core)
+[![docs.rs](https://docs.rs/koda-cli/badge.svg)](https://docs.rs/koda-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A high-performance personal AI assistant built in Rust.
@@ -88,7 +88,8 @@ Place in `.koda/agents/` (project) or `~/.config/koda/agents/` (global).
 
 | Document | Content |
 |---|---|
-| [**API Reference**](https://docs.rs/koda-core) | Auto-generated from code |
+| [**User Manual**](https://docs.rs/koda-cli) | CLI reference, slash commands, providers, headless mode, sessions |
+| [**Engine API**](https://docs.rs/koda-core) | `koda-core` library docs for developers embedding the engine |
 | [**Design**](DESIGN.md) | Architecture principles |
 | [**CLAUDE.md**](CLAUDE.md) | Workspace layout, conventions |
 | [**Changelog**](CHANGELOG.md) | Version history |

--- a/README.md
+++ b/README.md
@@ -29,25 +29,16 @@ On first run, an onboarding wizard guides you through provider and API key setup
 ## Quick Start
 
 ```bash
-koda                                # Interactive REPL (auto-detects local models)
-koda "fix the failing test"         # One-shot with positional prompt
-koda -p "explain auth.rs" -m opus   # Explicit model alias
-echo "review this diff" | koda      # Piped input
-koda server --stdio                 # ACP server for editor integration
+koda                            # Interactive TUI (auto-detects local models)
+koda "fix the failing test"     # One-shot prompt (headless)
+koda -p "explain auth.rs" -m opus  # Explicit model alias
+echo "review this diff" | koda  # Piped input
+koda server --stdio             # ACP server for editor integration
 ```
 
-Model aliases route to the right provider automatically:
-
-| Alias | Provider | Model |
-|---|---|---|
-| `flash-lite` | Gemini | gemini-2.0-flash-lite |
-| `flash` | Gemini | gemini-2.5-flash |
-| `pro` | Gemini | gemini-2.5-pro |
-| `haiku` | Anthropic | claude-3-5-haiku |
-| `sonnet` | Anthropic | claude-sonnet-4 |
-| `opus` | Anthropic | claude-opus-4 |
-
-Type `/help` in the REPL for all commands and shortcuts.
+Aliases like `opus`, `sonnet`, `flash`, `pro` route to the right provider automatically.
+Type `/help` in the TUI for all commands and shortcuts.
+Full reference → **[User Manual](https://docs.rs/koda-cli)**
 
 ## Highlights
 
@@ -66,23 +57,10 @@ Type `/help` in the REPL for all commands and shortcuts.
 ```
 koda/
 ├── koda-core/     # Engine library (providers, tools, inference, DB)
-├── koda-cli/      # CLI binary (REPL, TUI, approval UI, ACP server)
+├── koda-cli/      # CLI binary (TUI, headless, approval UI, ACP server)
 ├── koda-ast/      # Tree-sitter AST analysis library
 └── koda-email/    # Email via IMAP/SMTP library
 ```
-
-## Custom Agents
-
-```json
-{
-  "name": "testgen",
-  "system_prompt": "You are a test generation specialist.",
-  "model": "gemini-2.5-flash",
-  "allowed_tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-}
-```
-
-Place in `.koda/agents/` (project) or `~/.config/koda/agents/` (global).
 
 ## Documentation
 

--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -35,6 +35,23 @@ pub enum AcpOutgoing {
 }
 
 /// Maps a Koda tool name to the ACP `ToolKind` enum.
+///
+/// # Examples
+///
+/// ```
+/// use agent_client_protocol_schema::ToolKind;
+/// use koda_cli::acp_adapter::map_tool_kind;
+///
+/// assert_eq!(map_tool_kind("Read"),    ToolKind::Read);
+/// assert_eq!(map_tool_kind("Write"),   ToolKind::Edit);
+/// assert_eq!(map_tool_kind("Bash"),    ToolKind::Execute);
+/// assert_eq!(map_tool_kind("Grep"),    ToolKind::Search);
+/// assert_eq!(map_tool_kind("Delete"),  ToolKind::Delete);
+/// assert_eq!(map_tool_kind("WebFetch"),ToolKind::Fetch);
+/// assert_eq!(map_tool_kind("Think"),   ToolKind::Think);
+/// // Unknown tools fall back to Other
+/// assert_eq!(map_tool_kind("InvokeAgent"), ToolKind::Other);
+/// ```
 pub fn map_tool_kind(name: &str) -> acp::ToolKind {
     match name {
         "Read" => acp::ToolKind::Read,

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -182,6 +182,27 @@ impl InputCompleter {
 ///
 /// An `@` counts as a file reference if it's preceded by whitespace
 /// or is at the start of the input (not an email address).
+///
+/// # Examples
+///
+/// ```
+/// use koda_cli::completer::find_last_at_token;
+///
+/// // Leading @ at position 0
+/// assert_eq!(find_last_at_token("@file.rs"), Some(0));
+///
+/// // @ after a space
+/// assert_eq!(find_last_at_token("explain @src/main.rs"), Some(8));
+///
+/// // Email address — no space before @, so it is NOT treated as a file ref
+/// assert_eq!(find_last_at_token("user@example.com"), None);
+///
+/// // Returns the LAST @ in multi-@ input
+/// assert_eq!(find_last_at_token("@a @b"), Some(3));
+///
+/// // No @ at all
+/// assert_eq!(find_last_at_token("just a normal prompt"), None);
+/// ```
 pub fn find_last_at_token(text: &str) -> Option<usize> {
     for (i, c) in text.char_indices().rev() {
         if c == '@' && (i == 0 || matches!(text.as_bytes()[i - 1], b' ' | b'\n')) {

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -131,4 +131,49 @@ mod tests {
         let result = h.highlight_line("let x = 42;");
         assert!(result.contains("\x1b["));
     }
+
+    #[test]
+    fn test_highlight_spans_rust() {
+        let mut h = CodeHighlighter::new("rust");
+        let spans = h.highlight_spans("fn main() {}");
+        assert!(!spans.is_empty(), "should produce at least one span");
+        // Spans should contain the full text
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("fn"));
+        assert!(text.contains("main"));
+    }
+
+    #[test]
+    fn test_highlight_spans_unknown_lang_passthrough() {
+        let mut h = CodeHighlighter::new("notalang");
+        let spans = h.highlight_spans("hello world");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content.as_ref(), "hello world");
+    }
+
+    #[test]
+    fn test_pre_highlight_produces_per_line_spans() {
+        let content = "fn main() {}\nlet x = 42;\n";
+        let lines = pre_highlight(content, "rs");
+        assert_eq!(lines.len(), 2, "should produce one Vec<Span> per line");
+        for line_spans in &lines {
+            assert!(!line_spans.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_pre_highlight_empty_content() {
+        let lines = pre_highlight("", "rs");
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn test_stateful_multiline_string() {
+        // Highlighting should carry state across lines
+        let mut h = CodeHighlighter::new("rust");
+        let _line1 = h.highlight_spans("let s = \"");
+        let line2 = h.highlight_spans("hello\"");
+        // line2 should still produce spans (stateful parsing)
+        assert!(!line2.is_empty());
+    }
 }

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -2,6 +2,28 @@
 //!
 //! Provides terminal-colored syntax highlighting for code in
 //! fenced markdown code blocks. Uses the same engine as `bat`.
+//!
+//! ## Architecture
+//!
+//! | Type | Role |
+//! |------|------|
+//! | [`CodeHighlighter`] | Stateful per-file highlighter — carries parse state across lines |
+//! | [`pre_highlight`] | Convenience: highlight all lines of a file in one call |
+//!
+//! ## Stateful vs. stateless
+//!
+//! Syntax highlighting is **stateful**: a multiline string that starts on
+//! line 3 affects how line 4 is colored. `CodeHighlighter` preserves this
+//! state across `highlight_spans()` calls. Always call lines in order.
+//!
+//! ## Language lookup
+//!
+//! Languages are found by name token (`"rust"`, `"python"`) or by file
+//! extension (`"rs"`, `"py"`). Unknown languages fall back to unstyled
+//! passthrough — no panic.
+//!
+//! Syntaxes and themes are loaded once at first use via [`once_cell::sync::Lazy`].
+//! Theme: `base16-ocean.dark` (matches popular terminal palettes).
 
 use once_cell::sync::Lazy;
 use syntect::easy::HighlightLines;
@@ -89,6 +111,28 @@ impl CodeHighlighter {
 /// Maintains syntect parse state across lines for correct multiline
 /// string / comment / heredoc highlighting. Used by the diff renderer
 /// to look up pre-computed highlights by line number.
+///
+/// Returns one `Vec<Span>` per **source line** (trailing newlines stripped).
+/// Empty input returns an empty vec.
+///
+/// # Example
+///
+/// ```
+/// use koda_cli::highlight::pre_highlight;
+///
+/// // Two Rust lines → two span vecs
+/// let lines = pre_highlight("fn main() {}\nlet x = 42;", "rs");
+/// assert_eq!(lines.len(), 2);
+/// // Each vec contains at least one span
+/// for span_vec in &lines {
+///     assert!(!span_vec.is_empty());
+/// }
+///
+/// // Unknown extension falls back to a single unstyled span per line
+/// let plain = pre_highlight("hello\nworld", "xyz_unknown");
+/// assert_eq!(plain.len(), 2);
+/// assert_eq!(plain[0][0].content.as_ref(), "hello");
+/// ```
 pub fn pre_highlight(content: &str, ext: &str) -> Vec<Vec<ratatui::text::Span<'static>>> {
     let mut hl = CodeHighlighter::new(ext);
     content

--- a/koda-cli/src/input.rs
+++ b/koda-cli/src/input.rs
@@ -221,6 +221,38 @@ pub fn process_input(input: &str, project_root: &Path) -> ProcessedInput {
 
 /// Format file contexts into a string suitable for injection into the user
 /// message sent to the LLM.
+///
+/// Returns `None` when `files` is empty. Each file is wrapped in an XML
+/// `<file path="...">` tag and joined with a double newline.
+/// Contents exceeding 40 000 bytes are truncated with a note.
+///
+/// # Examples
+///
+/// ```
+/// use koda_cli::input::{FileContext, format_context_files};
+///
+/// // Empty list → None
+/// assert!(format_context_files(&[]).is_none());
+///
+/// // Single file → XML-tagged content
+/// let files = vec![FileContext {
+///     path: "src/main.rs".into(),
+///     content: "fn main() {}".into(),
+/// }];
+/// let out = format_context_files(&files).unwrap();
+/// assert!(out.contains("<file path=\"src/main.rs\">"));
+/// assert!(out.contains("fn main() {}"));
+/// assert!(out.contains("</file>"));
+///
+/// // Multiple files are joined with a blank line
+/// let two = vec![
+///     FileContext { path: "a.rs".into(), content: "// a".into() },
+///     FileContext { path: "b.rs".into(), content: "// b".into() },
+/// ];
+/// let out2 = format_context_files(&two).unwrap();
+/// assert!(out2.contains("a.rs"));
+/// assert!(out2.contains("b.rs"));
+/// ```
 pub fn format_context_files(files: &[FileContext]) -> Option<String> {
     if files.is_empty() {
         return None;
@@ -262,6 +294,28 @@ const PASTE_BLOCK_MAX_CHARS: usize = 40_000;
 ///
 /// Each block is wrapped in `<reference type="pasted" chars="N">...</reference>`
 /// so the model can distinguish pasted reference material from direct instructions.
+///
+/// Returns `None` when `blocks` is empty. Content exceeding 40 000 chars is
+/// truncated with a note.
+///
+/// # Examples
+///
+/// ```
+/// use koda_cli::input::{PasteBlock, format_paste_blocks};
+///
+/// // Empty list → None
+/// assert!(format_paste_blocks(&[]).is_none());
+///
+/// // Single block → tagged output
+/// let blocks = vec![PasteBlock {
+///     content: "SELECT 1;".into(),
+///     char_count: 9,
+/// }];
+/// let out = format_paste_blocks(&blocks).unwrap();
+/// assert!(out.contains("<reference type=\"pasted\" chars=\"9\">"));
+/// assert!(out.contains("SELECT 1;"));
+/// assert!(out.contains("</reference>"));
+/// ```
 pub fn format_paste_blocks(blocks: &[PasteBlock]) -> Option<String> {
     if blocks.is_empty() {
         return None;

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -82,7 +82,7 @@
 //!
 //! ## Keybindings
 //!
-//! ### Input mode
+//! ### Input
 //!
 //! | Key | Action |
 //! |-----|--------|
@@ -90,12 +90,31 @@
 //! | `Alt+Enter` | Insert newline (multi-line input) |
 //! | `Tab` | Autocomplete slash commands and `@file` paths |
 //! | `Shift+Tab` | Toggle approval mode (auto ↔ confirm) |
+//! | `↑ / ↓` | Cycle through input history |
+//! | `Ctrl+R` | Reverse history search |
+//!
+//! ### Navigation
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | `PgUp / PgDn` | Scroll history one page up / down |
+//! | `Home` | Jump to top of history |
+//! | `End` | Jump to bottom (latest output) |
+//! | Mouse scroll | Scroll conversation history |
+//! | `Ctrl+Y` | Copy last code block to clipboard |
+//! | `Ctrl+U` | Copy last assistant response to clipboard |
+//!
+//! ### Session control
+//!
+//! | Key | Action |
+//! |-----|--------|
 //! | `Esc` | Cancel current inference |
 //! | `Ctrl+C` | Cancel current inference |
-//! | `Up/Down` | Scroll through input history |
-//! | Mouse scroll | Scroll conversation history |
+//! | `Ctrl+D` | Quit koda |
 //!
-//! ### Approval prompt (y/n/a/f)
+//! ### Approval prompt
+//!
+//! These keys appear when the agent asks to execute a tool:
 //!
 //! | Key | Action |
 //! |-----|--------|
@@ -156,6 +175,42 @@
 //! - Activate a skill: `/skills <query>` or the `ActivateSkill` tool
 //! - Create custom skills: place `.md` files in `.koda/skills/` or
 //!   `~/.config/koda/skills/`
+//!
+//! ## Configuration precedence
+//!
+//! When multiple sources specify the model, provider, or API key, the
+//! **highest-priority source wins**:
+//!
+//! ```text
+//! 1. CLI flags          --model, --provider, --base-url
+//!        ↓ (override)
+//! 2. Env vars           KODA_MODEL, KODA_PROVIDER, KODA_BASE_URL
+//!        ↓ (set if not already in env)
+//! 3. Keystore / DB      saved by /model, /provider, /key (injected at startup)
+//!        ↓ (fallback)
+//! 4. Built-in defaults  Claude Sonnet via Anthropic
+//! ```
+//!
+//! API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, …)
+//! follow the same chain. Keys saved with `/key` are stored in the local
+//! SQLite keystore and injected into the process environment at startup —
+//! but a key already in the shell environment takes precedence.
+//!
+//! **CI / scripting:** the interactive `/key`, `/model`, `/provider`
+//! wizards are great for local setup, but in automation always prefer
+//! env vars or CLI flags — they work without a terminal and compose
+//! cleanly with `direnv`, Docker, and GitHub Actions secrets.
+//!
+//! ```bash
+//! # Override model for one call without touching saved config
+//! koda "review auth.rs" --model o3
+//!
+//! # Per-project model via direnv (.envrc)
+//! export KODA_MODEL=gemini-2.5-pro
+//!
+//! # CI pipeline
+//! ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_KEY }} koda -p "check types"
+//! ```
 //!
 //! ## Providers and model aliases
 //!

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -1,16 +1,36 @@
-//! # Koda CLI
+//! # Koda — User Manual
 //!
-//! User-facing interfaces for the [Koda](https://github.com/lijunzh/koda)
-//! personal AI assistant. The engine lives in [`koda_core`] — this crate
-//! handles presentation.
+//! Koda is a terminal-native AI coding agent. It runs locally, keeps all
+//! data on your machine, and connects to any LLM provider you choose.
 //!
-//! ## Entry points
+//! This page is the **complete reference**. Use Ctrl+F to jump to any topic.
 //!
-//! | Mode | Invocation | Module |
-//! |------|-----------|--------|
-//! | **TUI** (default) | `koda` | [`tui_app`] |
-//! | **Headless** | `koda "prompt"` or `koda -p "..."` | [`headless`] |
-//! | **ACP server** | `koda server --stdio` | [`server`], [`acp_adapter`] |
+//! ## Modes at a glance
+//!
+//! | Mode | How to invoke | Best for |
+//! |------|--------------|----------|
+//! | **Interactive TUI** | `koda` (no args) | Long sessions, iterative coding |
+//! | **Headless** | `koda "prompt"` or `echo … \| koda` | Scripts, CI, one-shot tasks |
+//! | **ACP server** | `koda server --stdio` | Editor plugins (VS Code, Zed, …) |
+//!
+//! ---
+//!
+//! ## Quick start
+//!
+//! ```bash
+//! # 1. Open the interactive TUI
+//! koda
+//!
+//! # 2. Ask something at the prompt
+//! #    > explain why the auth tests are failing
+//!
+//! # 3. Type /help inside for keybindings and commands
+//! ```
+//!
+//! First run triggers onboarding: Koda looks for a running local model
+//! (LM Studio, Ollama) and falls back to prompting for a cloud API key.
+//!
+//! ---
 //!
 //! ## CLI reference
 //!
@@ -20,8 +40,8 @@
 //! |------|---------|-------------|
 //! | `-p`, `--prompt <PROMPT>` | | Run a single prompt and exit (headless). Use `"-"` for stdin |
 //! | `<PROMPT>` (positional) | | Same as `-p` — `koda "fix the bug"` works |
-//! | `-a`, `--agent <NAME>` | | Agent to use (matches JSON in `agents/`, default: `default`) |
-//! | `-s`, `--resume <ID>` | | Resume a previous session by ID |
+//! | `-a`, `--agent <NAME>` | | Agent definition to use (JSON in `agents/`, default: `default`) |
+//! | `-s`, `--resume <ID>` | | Resume a previous session by ID prefix |
 //! | `--model <NAME>` | `KODA_MODEL` | Model name or alias (e.g. `claude-sonnet`, `gemini-flash`) |
 //! | `--provider <NAME>` | `KODA_PROVIDER` | LLM provider (`anthropic`, `gemini`, `openai`, `ollama`, …) |
 //! | `--base-url <URL>` | `KODA_BASE_URL` | Override the provider's API base URL |
@@ -37,48 +57,307 @@
 //! | Command | Description |
 //! |---------|-------------|
 //! | `koda server --stdio` | Start ACP server over stdin/stdout (for editors) |
-//! | `koda server --port <N>` | Start ACP server on TCP port (default: 9999) |
+//! | `koda server --port <N>` | WebSocket ACP server on port N (not yet implemented) |
 //!
-//! ## Quick start
+//! ---
+//!
+//! ## Headless mode
+//!
+//! Headless mode runs a single prompt, prints the answer, and exits.
+//! No TUI — the assistant's reply streams to stdout; tool status goes to stderr.
 //!
 //! ```bash
-//! # Interactive REPL (auto-detects local models)
-//! koda
+//! # Positional prompt (shortest form)
+//! koda "what does this codebase do?"
 //!
-//! # One-shot with positional prompt
-//! koda "fix the failing test"
+//! # Explicit -p flag
+//! koda -p "fix the failing tests"
 //!
-//! # Explicit model alias
-//! koda -p "explain auth.rs" -m opus
+//! # Read prompt from stdin (use "-" literally)
+//! koda -p - < my_question.txt
 //!
-//! # Piped input
-//! echo "review this diff" | koda
+//! # Pipe into koda — stdin is auto-detected when not a TTY
+//! git diff HEAD~1 | koda
+//! cat error.log | koda
+//! echo "review auth.rs" | koda
 //!
-//! # ACP server for editor integration
-//! koda server --stdio
+//! # With a model override
+//! koda "explain this" --model gemini-flash
+//!
+//! # Capture just the assistant reply (tool status stays on stderr)
+//! koda "list exported functions in lib.rs" > functions.txt
 //! ```
+//!
+//! ### Exit codes
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | `0` | Turn completed successfully |
+//! | `1` | Error (API failure, bad config, …) |
+//!
+//! ### Approval in headless mode
+//!
+//! There is no human to approve tool calls. Koda automatically:
+//!
+//! - **Approves** read-only tools: Read, Grep, Glob, WebFetch
+//! - **Approves** safe write tools: Write, Edit (files only)
+//! - **Rejects** destructive Bash commands (`rm -rf`, `git push --force`, …)
+//! - **Skips** AskUser questions (prints to stderr, continues with empty answer)
+//!
+//! Rejected actions are printed to stderr. The turn still completes with
+//! exit code 0 unless the API itself errors.
+//!
+//! ### Output formats
+//!
+//! `--output-format text` (default) — streams the assistant's reply to stdout
+//! exactly as typed. Tool call summaries go to stderr.
+//!
+//! `--output-format json` — emits a single JSON object after the turn ends:
+//!
+//! ```json
+//! {
+//!   "success": true,
+//!   "response": "The exported functions are …",
+//!   "session_id": "a3f8bc12-…",
+//!   "model": "claude-sonnet-4-6"
+//! }
+//! ```
+//!
+//! ### File attachment in headless mode
+//!
+//! The `@file` syntax works in headless mode too:
+//!
+//! ```bash
+//! koda "review @src/auth.rs and @tests/auth_test.rs"
+//! ```
+//!
+//! ### Resuming a session in headless mode
+//!
+//! ```bash
+//! # Note the session ID shown in the TUI status bar, then continue from a script
+//! koda -s a3f8bc "run the failing tests and fix them"
+//! ```
+//!
+//! ---
+//!
+//! ## Interactive mode (TUI)
+//!
+//! Run `koda` with no arguments to open the full-screen TUI.
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────────────────┐
+//! │  [conversation history — scrollable with PgUp/PgDn]                     │
+//! │                                                                          │
+//! │  ⚡ Bash   cargo test                                                    │
+//! │  │ running 42 tests …                                                   │
+//! │  ✓ Bash (exit 0)                                                         │
+//! │                                                                          │
+//! │  All tests pass! Here's what I changed in `auth.rs` …                   │
+//! ├────────────── claude-sonnet · auto · 34% · 8s ───────────────────────────┤
+//! │  > _                                                                     │
+//! └──────────────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! The status bar shows: **model** · **approval mode** · **context %** · **elapsed**
+//!
+//! ---
+//!
+//! ## File and image attachment
+//!
+//! Type `@` anywhere in your message to attach files as context:
+//!
+//! ```text
+//! > explain @src/auth.rs
+//! > compare @old_impl.rs and @new_impl.rs
+//! > what's wrong with @error.log
+//! ```
+//!
+//! As you type after `@`, a fuzzy file picker appears. Press `Tab` to cycle
+//! through matches or select with `Enter`. The file's full contents are
+//! injected into the message before it's sent to the model.
+//!
+//! ### Images
+//!
+//! For vision-capable models (Claude, Gemini, GPT-4o), attach images directly:
+//!
+//! ```text
+//! > what does @screenshot.png show?
+//! > explain the architecture in @diagram.svg
+//! ```
+//!
+//! Supported formats: PNG, JPEG, GIF, WEBP. Images are base64-encoded and
+//! sent inline to the model API.
+//!
+//! ### Large pastes
+//!
+//! Pasting more than ~500 characters into the input is automatically wrapped
+//! in a reference block to keep prompts clean:
+//!
+//! ```text
+//! > [pasted 1,234 chars — attached as reference]
+//! > what's the bug in this code?
+//! ```
+//!
+//! The paste is still sent to the model; it just doesn't clutter the display.
+//!
+//! ---
 //!
 //! ## Slash commands
 //!
-//! Type these in the REPL input. Tab-completion is supported.
+//! Type in the TUI input. Tab-completion is available for all commands.
 //!
-//! | Command | Description |
-//! |---------|-------------|
-//! | `/help` | Show available commands and keybindings |
-//! | `/model <name>` | Switch model — aliases like `opus`, `sonnet`, `flash` |
-//! | `/provider` | Browse all models from a provider |
-//! | `/compact` | Summarize old context to free tokens |
-//! | `/diff` | Show uncommitted changes (review or commit) |
-//! | `/undo` | Revert last turn's file mutations |
-//! | `/sessions` | List, resume, or delete past sessions |
-//! | `/memory` | View/edit project and global memory files |
-//! | `/skills` | List available skills (search with query) |
-//! | `/agent <name>` | Switch to a sub-agent |
-//! | `/key` | Manage API keys |
-//! | `/expand` | Replay last tool output (full, untruncated) |
-//! | `/verbose` | Toggle full tool output |
-//! | `/purge <days>` | Delete archived history older than N days |
-//! | `/exit` | Quit the session |
+//! ### `/help`
+//!
+//! Shows the quick-reference keybinding card inside the TUI.
+//! This docs page is the full reference; `/help` is the in-session reminder.
+//!
+//! ### `/model [<alias-or-id>]`
+//!
+//! Without an argument: opens an interactive picker listing all model aliases
+//! and any locally running models detected via LM Studio or Ollama.
+//!
+//! With an argument: switches immediately.
+//!
+//! ```text
+//! /model gemini-flash        ← switch by alias
+//! /model claude-opus         ← switch by alias
+//! /model local               ← auto-detect from LM Studio
+//! /model gpt-4o              ← literal model ID (no alias needed)
+//! /model llama3.2            ← any model name your provider understands
+//! ```
+//!
+//! The new model is persisted to the keystore and used for all future
+//! sessions until changed again. See [**Providers and model aliases**](#providers-and-model-aliases).
+//!
+//! ### `/provider [<name>]`
+//!
+//! Without an argument: opens a two-step picker — choose provider, then
+//! browse and pick one of its available models.
+//!
+//! With an argument: jumps straight to that provider's model list.
+//!
+//! ```text
+//! /provider                  ← open the picker
+//! /provider anthropic        ← go straight to Anthropic models
+//! /provider ollama           ← browse locally running Ollama models
+//! ```
+//!
+//! ### `/key`
+//!
+//! Opens the API key manager. Select a provider, then type or paste your key.
+//! Keys are stored in the local SQLite keystore (file mode 0600) and injected
+//! as environment variables at every startup.
+//!
+//! Shell env vars always win over stored keys — so `export ANTHROPIC_API_KEY=…`
+//! in your shell or `.envrc` is always a clean override.
+//!
+//! ### `/compact`
+//!
+//! Summarises old conversation history to free context tokens. Koda
+//! auto-compacts when the context window hits **85%** full, but you can
+//! trigger it manually at any time:
+//!
+//! - All but the **last 4 messages** are summarised by the model
+//! - The summary replaces the old messages in the DB
+//! - The compressed session continues normally
+//! - Use `/purge` later to clean up the archived messages
+//!
+//! ### `/purge [<age>]`
+//!
+//! Deletes compacted (archived) message history. Does not touch the live messages
+//! in your current session.
+//!
+//! ```text
+//! /purge        ← delete all archived messages (prompts for confirmation)
+//! /purge 90d    ← only messages archived more than 90 days ago
+//! /purge 30d    ← only messages archived more than 30 days ago
+//! ```
+//!
+//! Requires `y` to confirm. Deleted messages are gone permanently.
+//!
+//! ### `/undo`
+//!
+//! Reverts all file mutations from the **previous inference turn** — Write,
+//! Edit, and Delete tool calls. One `/undo` per turn; call again to go back
+//! another turn. Bash commands (e.g. `cargo build`) are **not** undoable.
+//!
+//! ```text
+//! # Koda wrote bad code in the last turn
+//! /undo    ← all file changes from that turn are reverted
+//! /undo    ← undo the turn before that
+//! ```
+//!
+//! ### `/diff`
+//!
+//! Shows a summary of uncommitted `git diff` in the project root. Then offers:
+//!
+//! - **Review** — sends the diff to the model for code review comments
+//! - **Commit** — asks the model to write a conventional commit message and
+//!   runs `git commit -m "…"`
+//!
+//! ### `/sessions [<sub-command>]`
+//!
+//! ```text
+//! /sessions              ← open the session picker (shows last 100 sessions)
+//! /sessions resume abc   ← resume the session whose ID starts with "abc"
+//! /sessions delete abc   ← permanently delete that session
+//! ```
+//!
+//! Session IDs are UUIDs; you only need 6–8 characters to be unambiguous.
+//! On resume, Koda shows an away-summary: idle time, message count, token
+//! usage, and a banner if the previous turn was interrupted mid-inference.
+//!
+//! ### `/memory [save]`
+//!
+//! ```text
+//! /memory        ← show the paths to project and global memory files
+//! /memory save   ← ask the model to summarise the session and append to MEMORY.md
+//! ```
+//!
+//! See [**Memory**](#memory) for the full memory system.
+//!
+//! ### `/skills [<query>]`
+//!
+//! ```text
+//! /skills              ← list all built-in and custom skills
+//! /skills security     ← filter by name or description
+//! ```
+//!
+//! ### `/agent <name>`
+//!
+//! Switches to a named sub-agent for the current session. The agent's
+//! system prompt, model, and allowed tools replace the current defaults.
+//!
+//! ```text
+//! /agent testgen     ← use the "testgen" agent definition
+//! ```
+//!
+//! ### `/expand [<n>]`
+//!
+//! Shows the full, untruncated output of a recent tool call. Useful when Koda
+//! collapsed a long `cargo build` or `grep` result during streaming.
+//!
+//! ```text
+//! /expand      ← show full output of the most recent tool call
+//! /expand 3    ← show full output of the 3rd most recent tool call
+//! ```
+//!
+//! ### `/verbose [on|off]`
+//!
+//! Toggles verbose tool output. By default Koda collapses long outputs
+//! during streaming. Verbose mode shows every line in real time.
+//!
+//! ```text
+//! /verbose      ← toggle
+//! /verbose on   ← enable explicitly
+//! /verbose off  ← disable explicitly
+//! ```
+//!
+//! ### `/exit`
+//!
+//! Quit Koda. Equivalent to `Ctrl+D`.
+//!
+//! ---
 //!
 //! ## Keybindings
 //!
@@ -120,61 +399,164 @@
 //! |-----|--------|
 //! | `y` | Approve this action |
 //! | `n` | Reject this action |
-//! | `a` | Approve and switch to auto mode |
-//! | `f` | Reject with typed feedback |
-//! | `Esc` | Reject |
+//! | `a` | Approve and switch to auto mode (no more confirmations this session) |
+//! | `f` | Reject and type written feedback explaining why |
+//! | `Esc` | Reject (same as `n`) |
+//!
+//! ---
 //!
 //! ## Approval modes
 //!
-//! Koda has two approval modes, toggled with `Shift+Tab`:
+//! Koda has two approval modes, toggled with `Shift+Tab` (current mode shown
+//! in the status bar):
 //!
-//! - **Auto** — approve all non-destructive actions automatically.
-//!   Destructive commands (`rm`, `sudo`, `git push --force`, etc.) still
-//!   require confirmation.
-//! - **Confirm** — every write/mutation requires explicit `y` before
-//!   executing. Read-only tools (Read, Grep, Glob) are always auto-approved.
+//! **Auto** — safe tools run without confirmation. Destructive shell commands
+//! (`rm -rf`, `sudo`, `git push --force`, etc.) still require explicit `y`.
+//! Read-only tools (Read, Grep, Glob, WebFetch) are always auto-approved.
 //!
-//! In headless mode (`koda "prompt"`), destructive actions are **rejected**
-//! outright — there's no human to approve them.
+//! **Confirm** — every write or mutation requires explicit `y` before executing.
+//! Read-only tools are still auto-approved.
+//!
+//! The mode is **persisted per session** — if you approve with `a` (auto),
+//! that session remembers it even after resuming.
+//!
+//! In headless mode, there is no human to prompt. Destructive Bash commands
+//! are silently rejected; all other tools proceed automatically.
+//!
+//! ---
+//!
+//! ## Session management
+//!
+//! Koda stores every conversation in a local SQLite database, organised by
+//! project root. Each session gets a UUID that you can use to resume it.
+//!
+//! ```bash
+//! # List and pick a session interactively
+//! /sessions
+//!
+//! # Resume by ID prefix from the TUI
+//! /sessions resume a3f8bc
+//!
+//! # Resume from the command line (headless or interactive)
+//! koda -s a3f8bc
+//! koda -s a3f8bc "continue where we left off"
+//!
+//! # Delete a session permanently
+//! /sessions delete a3f8bc
+//! ```
+//!
+//! **Away summary** — when you resume a session that was idle, Koda shows:
+//! - How long you were away
+//! - Message and tool-call counts
+//! - Total tokens used
+//! - A banner if the previous turn was interrupted mid-inference
+//!
+//! **Session title** — Koda auto-generates a short title after the first
+//! exchange. The title is shown in `/sessions` and the status bar.
+//!
+//! ---
+//!
+//! ## Context management
+//!
+//! Every provider has a context window limit (measured in tokens). The status
+//! bar shows current usage as a percentage (e.g. `34%`).
+//!
+//! ### Auto-compact
+//!
+//! When usage reaches **85%**, Koda automatically compacts the session:
+//!
+//! 1. All but the last 4 messages are summarised by the model
+//! 2. The summary is stored in the DB (recoverable with `/purge`)
+//! 3. A status line appears: `🐻 Context at 85% — auto-compacting…`
+//!
+//! Auto-compact is skipped if there are pending tool calls (it waits for the
+//! turn to finish cleanly).
+//!
+//! ### Manual compact
+//!
+//! Run `/compact` at any time to compact early, e.g. before starting a large
+//! refactor so you have the full context window available.
+//!
+//! ### Purging archived history
+//!
+//! `/compact` keeps summaries in the DB. Use `/purge` to delete them:
+//!
+//! ```text
+//! /purge        ← prompt and delete all archived messages
+//! /purge 90d    ← delete only archived messages older than 90 days
+//! ```
+//!
+//! ---
 //!
 //! ## Memory
 //!
-//! Koda reads memory files that persist across sessions:
+//! Memory files persist facts and preferences across sessions.
 //!
-//! - **Project memory** — `MEMORY.md` (or `CLAUDE.md`, `AGENTS.md`) in the
-//!   project root. Injected into every system prompt for this project.
-//! - **Global memory** — `~/.config/koda/memory.md`. Injected into every
-//!   system prompt across all projects.
+//! **Project memory** — `MEMORY.md` in the project root (Koda also reads
+//! `CLAUDE.md` and `AGENTS.md` for compatibility). Injected into every
+//! system prompt for that project.
 //!
-//! Use `/memory` to view and edit, or the `MemoryWrite` tool to append facts
-//! during a conversation.
+//! **Global memory** — `~/.config/koda/memory.md`. Injected into every
+//! system prompt across all projects.
 //!
-//! ## Custom agents
-//!
-//! Place JSON files in `.koda/agents/` (project) or `~/.config/koda/agents/`
-//! (global):
-//!
-//! ```json
-//! {
-//!   "name": "testgen",
-//!   "system_prompt": "You are a test generation specialist.",
-//!   "model": "gemini-2.5-flash",
-//!   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
-//! }
+//! ```text
+//! /memory        ← show the paths to both memory files
+//! /memory save   ← ask the model to summarise and append to MEMORY.md
 //! ```
 //!
-//! The model dispatches to sub-agents via the `InvokeAgent` tool. Each agent
-//! runs in its own session with its own model, tools, and system prompt.
+//! The `MemoryWrite` tool lets the model append facts to memory directly
+//! during a conversation:
 //!
-//! ## Skills
+//! ```text
+//! > Remember that we use tabs not spaces in this project
+//! ```
+//! (Koda will call `MemoryWrite` automatically when you ask it to remember.)
 //!
-//! Skills are reusable expertise modules (markdown files with structured
-//! instructions). Built-in skills include code review and security audit.
+//! ---
 //!
-//! - List skills: `/skills` or the `ListSkills` tool
-//! - Activate a skill: `/skills <query>` or the `ActivateSkill` tool
-//! - Create custom skills: place `.md` files in `.koda/skills/` or
-//!   `~/.config/koda/skills/`
+//! ## Providers and model aliases
+//!
+//! ### All supported providers
+//!
+//! | Provider name | `--provider` value | API key env var | Default model | Needs key |
+//! |---|---|---|---|---|
+//! | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | claude-sonnet-4-6 | ✓ |
+//! | OpenAI | `openai` | `OPENAI_API_KEY` | gpt-4o | ✓ |
+//! | Google Gemini | `gemini` | `GEMINI_API_KEY` | gemini-flash-latest | ✓ |
+//! | Groq | `groq` | `GROQ_API_KEY` | llama-3.3-70b-versatile | ✓ |
+//! | Grok / xAI | `grok` | `XAI_API_KEY` | grok-3 | ✓ |
+//! | DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | deepseek-chat | ✓ |
+//! | Mistral | `mistral` | `MISTRAL_API_KEY` | mistral-large-latest | ✓ |
+//! | MiniMax | `minimax` | `MINIMAX_API_KEY` | minimax-text-01 | ✓ |
+//! | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | anthropic/claude-3.5-sonnet | ✓ |
+//! | Together AI | `together` | `TOGETHER_API_KEY` | Llama-3.3-70B-Instruct-Turbo | ✓ |
+//! | Fireworks AI | `fireworks` | `FIREWORKS_API_KEY` | llama-v3p3-70b-instruct | ✓ |
+//! | LM Studio | `lm-studio` | — | auto-detect | ✗ |
+//! | Ollama | `ollama` | — | auto-detect | ✗ |
+//! | vLLM | `vllm` | — | auto-detect | ✗ |
+//!
+//! Local providers (LM Studio, Ollama, vLLM) are auto-detected on first run
+//! and require no API key. The model is discovered from the running server.
+//!
+//! ### Model aliases
+//!
+//! Aliases let you switch models without memorising exact IDs. They're shown
+//! in the `/model` picker and accepted by `--model` and `/model`.
+//!
+//! | Alias | Provider | Exact model ID |
+//! |-------|----------|----------------|
+//! | `gemini-flash-lite` | Gemini | `gemini-flash-lite-latest` |
+//! | `gemini-flash` | Gemini | `gemini-flash-latest` |
+//! | `gemini-pro` | Gemini | `gemini-pro-latest` |
+//! | `claude-haiku` | Anthropic | `claude-haiku-4-5-20251001` |
+//! | `claude-sonnet` | Anthropic | `claude-sonnet-4-6` |
+//! | `claude-opus` | Anthropic | `claude-opus-4-6` |
+//! | `local` | LM Studio | auto-detect at runtime |
+//!
+//! You can also use **any literal model ID** your provider supports — aliases
+//! are just shortcuts. `koda --model gpt-4o-mini` or `/model o3` both work.
+//!
+//! ---
 //!
 //! ## Configuration precedence
 //!
@@ -182,75 +564,181 @@
 //! **highest-priority source wins**:
 //!
 //! ```text
-//! 1. CLI flags          --model, --provider, --base-url
-//!        ↓ (override)
-//! 2. Env vars           KODA_MODEL, KODA_PROVIDER, KODA_BASE_URL
-//!        ↓ (set if not already in env)
+//! 1. CLI flags          --model, --provider, --base-url        (highest)
+//!        ↓
+//! 2. Shell env vars     KODA_MODEL, KODA_PROVIDER, KODA_BASE_URL
+//!        ↓
 //! 3. Keystore / DB      saved by /model, /provider, /key (injected at startup)
-//!        ↓ (fallback)
-//! 4. Built-in defaults  Claude Sonnet via Anthropic
+//!        ↓
+//! 4. Built-in defaults  Claude Sonnet via Anthropic              (lowest)
 //! ```
 //!
 //! API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, …)
-//! follow the same chain. Keys saved with `/key` are stored in the local
-//! SQLite keystore and injected into the process environment at startup —
-//! but a key already in the shell environment takes precedence.
-//!
-//! **CI / scripting:** the interactive `/key`, `/model`, `/provider`
-//! wizards are great for local setup, but in automation always prefer
-//! env vars or CLI flags — they work without a terminal and compose
-//! cleanly with `direnv`, Docker, and GitHub Actions secrets.
+//! follow the same chain. Keys saved with `/key` are injected at startup —
+//! but a key already in the shell environment takes precedence and is never
+//! overwritten.
 //!
 //! ```bash
-//! # Override model for one call without touching saved config
+//! # Per-call override (doesn't change saved config)
 //! koda "review auth.rs" --model o3
 //!
-//! # Per-project model via direnv (.envrc)
+//! # Per-project via direnv (.envrc)
 //! export KODA_MODEL=gemini-2.5-pro
 //!
-//! # CI pipeline
+//! # CI / GitHub Actions
 //! ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_KEY }} koda -p "check types"
 //! ```
 //!
-//! ## Providers and model aliases
+//! ---
 //!
-//! Koda supports 14 LLM providers. Model aliases route across providers
-//! without remembering full model IDs:
+//! ## Custom agents
 //!
-//! | Alias | Provider | Model |
-//! |-------|----------|-------|
-//! | `gemini-flash-lite` | Gemini | gemini-flash-lite-latest |
-//! | `gemini-flash` | Gemini | gemini-flash-latest |
-//! | `gemini-pro` | Gemini | gemini-pro-latest |
-//! | `claude-haiku` | Anthropic | claude-haiku-4-5 |
-//! | `claude-sonnet` | Anthropic | claude-sonnet-4-6 |
-//! | `claude-opus` | Anthropic | claude-opus-4-6 |
+//! Place JSON files in `.koda/agents/` (project-local) or
+//! `~/.config/koda/agents/` (global):
 //!
-//! Local providers (LM Studio, Ollama, vLLM) are auto-detected on first run
-//! and require no API key.
+//! ```json
+//! {
+//!   "name": "testgen",
+//!   "system_prompt": "You are a test generation specialist. When asked to write tests, always use the project's existing test patterns.",
+//!   "model": "gemini-2.5-flash",
+//!   "allowed_tools": ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+//! }
+//! ```
 //!
-//! ## Configuration
+//! | Field | Required | Description |
+//! |-------|----------|-------------|
+//! | `name` | ✓ | Identifier used with `/agent <name>` and `InvokeAgent` |
+//! | `system_prompt` | ✓ | The agent's persona and instructions |
+//! | `model` | | Model alias or ID (defaults to current saved model) |
+//! | `allowed_tools` | | Subset of tools the agent can call (defaults to all) |
+//!
+//! The main model dispatches to sub-agents via the `InvokeAgent` tool. Each
+//! sub-agent runs in its own worktree with its own model, tools, and session.
+//!
+//! ---
+//!
+//! ## Skills
+//!
+//! Skills are reusable expertise modules — markdown files loaded into the
+//! system prompt on demand. Built-in skills include code review and security
+//! audit.
+//!
+//! ```text
+//! /skills                  ← list all available skills
+//! /skills security         ← filter by name or description
+//! ```
+//!
+//! The model can also activate skills automatically via the `ActivateSkill`
+//! tool when it determines a skill is relevant.
+//!
+//! ### Creating custom skills
+//!
+//! Place `.md` files in `.koda/skills/` (project-local) or
+//! `~/.config/koda/skills/` (global). The filename becomes the skill name.
+//!
+//! ```markdown
+//! # My Review Checklist
+//!
+//! When reviewing code, always check:
+//! - [ ] No hardcoded secrets
+//! - [ ] Error handling covers all paths
+//! - [ ] Tests cover the new logic
+//! ```
+//!
+//! ---
+//!
+//! ## Tools reference
+//!
+//! Koda exposes these tools to the model. In **Confirm** approval mode you'll
+//! be prompted before each mutating call. In **Auto** mode, only destructive
+//! Bash commands require confirmation.
+//!
+//! | Tool | Effect | Description |
+//! |------|--------|-------------|
+//! | `Read` | Read-only | Read a file (with optional line range) |
+//! | `Write` | Mutating | Create or overwrite a file |
+//! | `Edit` | Mutating | Targeted text replacement within a file |
+//! | `Delete` | Mutating | Delete a file or directory |
+//! | `Bash` | Varies | Run a shell command |
+//! | `Grep` | Read-only | Search for patterns across files (ripgrep) |
+//! | `Glob` | Read-only | List files matching a glob pattern |
+//! | `WebFetch` | Read-only | Fetch a URL and return its text content |
+//! | `Think` | Internal | Extended reasoning step (no side effects) |
+//! | `MemoryWrite` | Mutating | Append a fact to a memory file |
+//! | `ListSkills` | Read-only | List available skills |
+//! | `ActivateSkill` | Internal | Load a skill's instructions into context |
+//! | `InvokeAgent` | Varies | Delegate a task to a named sub-agent |
+//! | `ListFiles` | Read-only | List directory contents |
+//! | `AskUser` | Interactive | Ask the user a clarifying question |
+//!
+//! ---
+//!
+//! ## ACP server (editor integration)
+//!
+//! Koda implements the [Agent Client Protocol](https://agentclientprotocol.org)
+//! over stdio JSON-RPC 2.0. This lets editors connect to Koda as a local agent
+//! without network setup.
+//!
+//! ```bash
+//! # Start the server (editors launch this automatically)
+//! koda server --stdio
+//! ```
+//!
+//! The protocol lifecycle:
+//!
+//! ```text
+//! Editor → initialize           (negotiate protocol version)
+//! Koda   ← InitializeResponse
+//!
+//! Editor → session/new          (create a session)
+//! Koda   ← NewSessionResponse   (returns session_id)
+//!
+//! Editor → session/prompt       (send a user message)
+//! Koda   ← [stream of session/update events]
+//! Koda   ← PromptResponse       (turn complete)
+//!
+//! Editor → Cancel               (optional — aborts the running turn)
+//! ```
+//!
+//! Each line on stdin/stdout is a complete, self-contained JSON-RPC object.
+//! For VS Code, Zed, and other editors, see your editor's extension docs for
+//! how to configure a local ACP agent.
+//!
+//! ---
+//!
+//! ## Configuration files
 //!
 //! Everything lives in `~/.config/koda/`:
 //!
 //! | Path | Content |
 //! |------|---------|
-//! | `db/koda.db` | SQLite — sessions, messages, settings, API keys, history |
-//! | `logs/` | Tracing logs (human-readable) |
-//! | `agents/` | Global custom agent JSON files |
+//! | `db/koda.db` | SQLite — sessions, messages, settings, API keys, input history |
+//! | `logs/koda.log` | Rolling daily tracing log (not shown in the TUI) |
+//! | `agents/` | Global custom agent JSON definitions |
 //! | `skills/` | Global custom skill markdown files |
 //! | `memory.md` | Global memory (injected into all system prompts) |
+//!
+//! Project-level overrides live in `.koda/` at your project root and take
+//! priority over global config:
+//!
+//! | Path | Content |
+//! |------|---------|
+//! | `.koda/agents/` | Project-specific agent definitions |
+//! | `.koda/skills/` | Project-specific skills |
+//! | `MEMORY.md` | Project memory (also checks `CLAUDE.md`, `AGENTS.md`) |
+//!
+//! ---
 //!
 //! ## Privacy and data
 //!
 //! Koda has **zero telemetry**. No usage data, crash reports, or analytics
-//! are collected or transmitted. All data stays local:
+//! are collected or transmitted anywhere.
 //!
-//! - Conversations are stored in your local SQLite database
+//! - Conversations are stored **only** in your local SQLite database
 //! - API keys are stored locally in the same database (file mode 0600)
-//! - The only network traffic is your LLM API calls to the provider you choose
-//! - No phone-home, no update checks to third-party servers (version checks
-//!   query crates.io only)
+//! - The only network traffic is your LLM API calls to the provider you chose
+//! - Version checks query crates.io only (no Koda-specific server)
+//! - You can audit every byte sent to the model by reading the DB directly
 
 pub mod acp_adapter;
 pub mod ansi_parse;

--- a/koda-cli/src/main.rs
+++ b/koda-cli/src/main.rs
@@ -10,9 +10,49 @@ use clap::{Parser, Subcommand};
 use koda_core::persistence::Persistence;
 use std::path::PathBuf;
 
-/// Koda 🐻 - Your AI coding bear.
+const LONG_ABOUT: &str = "Koda runs in two modes:
+
+  INTERACTIVE   Run `koda` (no arguments) to open the full TUI.
+                Type your question and press Enter.
+                Type /help inside for keybindings and all commands.
+
+  HEADLESS      Pass a prompt to get a single answer and exit.
+                Great for scripts, pipes, and CI pipelines.
+                  koda \"explain this codebase\"
+                  git diff | koda
+                  koda -p - < prompt.txt
+
+Configuration precedence (highest wins):
+  1. CLI flags     --model, --provider, --base-url
+  2. Env vars      KODA_MODEL, KODA_PROVIDER, KODA_BASE_URL
+  3. Saved config  set interactively with /model, /provider, /key
+  4. Built-in defaults
+
+API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, …)
+follow the same order. Keys saved with /key are loaded from the
+local keystore at startup and injected as env vars — shell env
+vars always win over stored keys.";
+
+const AFTER_HELP: &str = "Examples:
+  koda                                # interactive TUI (type /help inside)
+  koda \"explain this codebase\"       # one-shot question, then exit
+  koda -p \"fix the failing tests\"    # same, explicit flag form
+  koda -p -                           # read prompt from stdin
+  git diff | koda                     # pipe diff as the prompt
+  koda \"refactor\" --model o3         # one-shot with a specific model
+  KODA_MODEL=gemini-flash koda \"...\" # env-var model override
+  koda server --stdio                 # ACP stdio server for editor plugins
+  koda -s abc123 \"continue\"          # resume a saved session";
+
+/// Koda 🐻 - A high-performance AI coding agent built in Rust
 #[derive(Parser, Debug)]
-#[command(name = "koda", version, about)]
+#[command(
+    name = "koda",
+    version,
+    about,
+    long_about = LONG_ABOUT,
+    after_help = AFTER_HELP,
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -51,7 +91,7 @@ struct Cli {
     #[arg(long, env = "KODA_MODEL")]
     model: Option<String>,
 
-    /// LLM provider (openai, anthropic, lmstudio, gemini, groq, grok)
+    /// LLM provider (openai, anthropic, lmstudio, gemini, groq, grok, ollama)
     #[arg(long, env = "KODA_PROVIDER")]
     provider: Option<String>,
 
@@ -74,14 +114,19 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Start ACP server for external clients
+    /// Start an ACP (Agent Client Protocol) server for editor/client integrations
     Server {
+        /// WebSocket port (not yet implemented — use --stdio instead)
         #[arg(long, default_value = "9999")]
         port: u16,
+        /// Use stdin/stdout JSON-RPC transport (required for VS Code, Zed, etc.)
+        ///
+        /// Reads newline-delimited JSON-RPC 2.0 from stdin and writes to stdout.
+        /// This is the standard ACP transport for local agent integrations.
         #[arg(long)]
         stdio: bool,
     },
-    /// Connect CLI to a running server
+    /// Connect to a running Koda server (not yet implemented)
     Connect { url: String },
 }
 

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -12,40 +12,63 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// Action to take after processing a REPL command.
+///
+/// Returned by [`handle_command`] and translated into UI-specific
+/// behavior by the TUI event loop (`tui_app.rs`) or the headless runner.
+/// Variants with no data are signals; variants with data carry parsed arguments.
 pub enum ReplAction {
+    /// `/exit` — terminate the session.
     Quit,
+    /// `/model <name>` — switch to a specific model or alias.
     SwitchModel(String),
+    /// `/model` (no arg) — open the interactive model picker.
     PickModel,
+    /// `/provider <name>` — configure a specific provider.
     SetupProvider(ProviderType, String), // (provider_type, base_url)
+    /// `/provider` (no arg) — open the interactive provider picker.
     PickProvider,
+    /// `/help` — show the help panel.
     ShowHelp,
+    /// `/sessions` (no arg) — open the session list picker.
     ListSessions,
+    /// `/sessions resume <id>` or `/sessions <id>` — resume a session.
     ResumeSession(String),
+    /// `/sessions delete <id>` — delete a session.
     DeleteSession(String),
-    /// Inject text as if the user typed it (used by /diff review, /diff commit)
+    /// Inject text as if the user typed it.
+    ///
+    /// Used by `/diff review` and `/diff commit` to inject a pre-built prompt.
     InjectPrompt(String),
-    /// Compact the conversation by summarizing history
+    /// `/compact` — summarise conversation history to free context tokens.
     Compact,
-    /// Purge compacted messages (optional age filter like "90d")
+    /// `/purge [<age>]` — delete archived messages older than `age`.
+    ///
+    /// Age is a string like `"90d"`, `"30d"`, etc. `None` means "all".
     Purge(Option<String>),
-    /// Expand Nth most recent tool output (1 = last)
+    /// `/expand [<n>]` — show the full output of the Nth-most-recent tool call.
+    ///
+    /// `n` defaults to 1 (most recent). Output is replayed untruncated.
     Expand(usize),
-    /// Toggle verbose tool output (None = toggle, Some = set)
+    /// `/verbose [on|off]` — toggle or set verbose tool output.
+    ///
+    /// `None` = toggle; `Some(true/false)` = set explicitly.
     Verbose(Option<bool>),
-    /// List available sub-agents
+    /// `/agent` — open the sub-agent picker.
     ListAgents,
-    /// Show git diff summary
+    /// `/diff` (no sub-command) — show the pending git diff summary.
     ShowDiff,
-    /// Memory management command
+    /// `/memory [save|<text>]` — view/append memory files.
     MemoryCommand(Option<String>),
-    /// Undo last turn's file mutations
+    /// `/undo` — revert file mutations from the last turn.
     Undo,
-    /// List available skills (optional search query)
+    /// `/skills [<query>]` — list available skills, optionally filtered.
     ListSkills(Option<String>),
-    /// Manage API keys
+    /// `/key` — open the API key manager.
     ManageKeys,
+    /// Command was handled internally (UI action already taken).
     #[allow(dead_code)]
     Handled,
+    /// Input was not a slash command — treat as a chat message.
     NotACommand,
 }
 

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -1,7 +1,41 @@
 //! ACP server over stdio JSON-RPC.
 //!
 //! Reads newline-delimited JSON from stdin, writes JSON-RPC messages to stdout.
-//! Implements the ACP lifecycle: Initialize → Authenticate → NewSession → Prompt → Cancel.
+//! Implements the [ACP (Agent Client Protocol)](https://agentclientprotocol.org)
+//! lifecycle over stdio:
+//!
+//! ```text
+//! Client → koda server --stdio
+//!
+//! → initialize         (negotiate protocol version)
+//! ← InitializeResponse
+//!
+//! → authenticate       (no-op for local agent, always succeeds)
+//! ← AuthenticateResponse
+//!
+//! → session/new        (create a session, returns session_id)
+//! ← NewSessionResponse
+//!
+//! → session/prompt     (send a user message; blocks until turn complete)
+//! ← [stream of session/update notifications]
+//! ← PromptResponse
+//!
+//! → Cancel notification (optional — cancels the running turn)
+//! ```
+//!
+//! ## Transport
+//!
+//! Messages are **newline-delimited JSON-RPC 2.0**. Each line is a complete,
+//! independent JSON object. The server reads from stdin line-by-line and
+//! writes to stdout via a background task to avoid blocking the read loop.
+//!
+//! ## Approval flow
+//!
+//! When the engine needs to execute a destructive tool, it emits an
+//! `ApprovalRequest` event. The server translates this into an outgoing
+//! `session/request_permission` JSON-RPC *request* to the client. The client
+//! sends back a `result` with `outcome: { selected: { option_id: "approve" } }`
+//! or `"reject"`. The mapping is handled by [`crate::acp_adapter`].
 
 use crate::acp_adapter::{self, AcpOutgoing, PendingApproval};
 use acp::Side;

--- a/koda-cli/src/sink.rs
+++ b/koda-cli/src/sink.rs
@@ -44,3 +44,26 @@ impl EngineSink for CliSink {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_forwards_to_channel() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = CliSink::channel(tx);
+        sink.emit(EngineEvent::SpinnerStop);
+        let msg = rx.try_recv().expect("should receive event");
+        assert!(matches!(msg, UiEvent::Engine(EngineEvent::SpinnerStop)));
+    }
+
+    #[test]
+    fn emit_does_not_panic_on_closed_channel() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let sink = CliSink::channel(tx);
+        drop(rx); // close the receiver
+        // Should not panic — just logs a warning
+        sink.emit(EngineEvent::SpinnerStop);
+    }
+}

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -346,14 +346,14 @@ fn show_help(buffer: &mut ScrollBuffer) {
     tui_output::emit_line(buffer, Line::styled("  Input", BOLD));
     tui_output::blank(buffer);
     let input_keys: &[(&str, &str)] = &[
-        ("Enter",       "Send message"),
-        ("Alt+Enter",   "Insert newline (multi-line input)"),
-        ("@file.rs",    "Attach file context to your message"),
-        ("@image.png",  "Attach image (vision-capable models)"),
-        ("↑ / ↓",      "Cycle through input history"),
-        ("Ctrl+R",      "Reverse history search"),
-        ("Tab",         "Autocomplete @file path or /command"),
-        ("Shift+Tab",   "Cycle approval mode (auto ↔ confirm)"),
+        ("Enter", "Send message"),
+        ("Alt+Enter", "Insert newline (multi-line input)"),
+        ("@file.rs", "Attach file context to your message"),
+        ("@image.png", "Attach image (vision-capable models)"),
+        ("↑ / ↓", "Cycle through input history"),
+        ("Ctrl+R", "Reverse history search"),
+        ("Tab", "Autocomplete @file path or /command"),
+        ("Shift+Tab", "Cycle approval mode (auto ↔ confirm)"),
     ];
     for (key, desc) in input_keys {
         tui_output::emit_line(
@@ -370,12 +370,12 @@ fn show_help(buffer: &mut ScrollBuffer) {
     tui_output::emit_line(buffer, Line::styled("  Navigation", BOLD));
     tui_output::blank(buffer);
     let nav_keys: &[(&str, &str)] = &[
-        ("PgUp / PgDn",    "Scroll history up / down one page"),
-        ("Home",           "Jump to top of history"),
-        ("End",            "Jump to bottom (latest output)"),
-        ("Mouse scroll",   "Scroll history"),
-        ("Ctrl+Y",         "Copy last code block to clipboard"),
-        ("Ctrl+U",         "Copy last assistant response to clipboard"),
+        ("PgUp / PgDn", "Scroll history up / down one page"),
+        ("Home", "Jump to top of history"),
+        ("End", "Jump to bottom (latest output)"),
+        ("Mouse scroll", "Scroll history"),
+        ("Ctrl+Y", "Copy last code block to clipboard"),
+        ("Ctrl+U", "Copy last assistant response to clipboard"),
     ];
     for (key, desc) in nav_keys {
         tui_output::emit_line(
@@ -393,7 +393,7 @@ fn show_help(buffer: &mut ScrollBuffer) {
     tui_output::blank(buffer);
     let session_keys: &[(&str, &str)] = &[
         ("Esc / Ctrl+C", "Cancel running inference"),
-        ("Ctrl+D",       "Quit koda"),
+        ("Ctrl+D", "Quit koda"),
     ];
     for (key, desc) in session_keys {
         tui_output::emit_line(
@@ -416,10 +416,10 @@ fn show_help(buffer: &mut ScrollBuffer) {
     );
     tui_output::blank(buffer);
     let approval_keys: &[(&str, &str)] = &[
-        ("y",   "Approve this tool call"),
-        ("n",   "Reject this tool call"),
-        ("a",   "Approve and switch to auto mode (no more prompts)"),
-        ("f",   "Reject and provide written feedback"),
+        ("y", "Approve this tool call"),
+        ("n", "Reject this tool call"),
+        ("a", "Approve and switch to auto mode (no more prompts)"),
+        ("f", "Reject and provide written feedback"),
         ("Esc", "Reject (same as n)"),
     ];
     for (key, desc) in approval_keys {

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -305,20 +305,28 @@ async fn handle_resume_session(
 ///
 /// Single source of truth: `completer::SLASH_COMMANDS` drives both
 /// Tab completion and this help screen.
+///
+/// Sections:
+/// 1. Commands — slash commands from the registry
+/// 2. Input — text entry and file attachment
+/// 3. Navigation — scroll and history search
+/// 4. Session control — cancel, quit, clipboard
+/// 5. Approval — keys shown when the engine requests tool approval
 fn show_help(buffer: &mut ScrollBuffer) {
     use crate::completer::SLASH_COMMANDS;
 
-    tui_output::blank(buffer);
-    tui_output::emit_line(buffer, Line::styled("  Koda — Commands", BOLD));
-    tui_output::blank(buffer);
-
-    // Compute column width from longest command name
+    // Column width: longest command label (cmd + arg_hint) + padding
     let max_cmd_len = SLASH_COMMANDS
         .iter()
-        .map(|(cmd, _, _)| cmd.len())
+        .map(|(cmd, _, hint)| cmd.len() + hint.map(|h| h.len() + 1).unwrap_or(0))
         .max()
         .unwrap_or(10);
+    let col = max_cmd_len.max(16) + 4; // at least 20 chars wide
 
+    // ── Commands ───────────────────────────────────────────────
+    tui_output::blank(buffer);
+    tui_output::emit_line(buffer, Line::styled("  Commands", BOLD));
+    tui_output::blank(buffer);
     for &(cmd, desc, arg_hint) in SLASH_COMMANDS {
         let label = match arg_hint {
             Some(hint) => format!("{cmd} {hint}"),
@@ -327,27 +335,99 @@ fn show_help(buffer: &mut ScrollBuffer) {
         tui_output::emit_line(
             buffer,
             Line::from(vec![
-                Span::styled(format!("  {label:<width$}", width = max_cmd_len + 12), CYAN),
+                Span::styled(format!("  {label:<col$}"), CYAN),
                 Span::styled(desc, DIM),
             ]),
         );
     }
 
+    // ── Input ──────────────────────────────────────────────────
     tui_output::blank(buffer);
-    tui_output::emit_line(buffer, Line::styled("  Shortcuts", BOLD));
+    tui_output::emit_line(buffer, Line::styled("  Input", BOLD));
     tui_output::blank(buffer);
-    let shortcuts = [
-        ("Shift+Tab", "Cycle approval mode (auto/confirm)"),
-        ("Alt+Enter", "Insert newline (multi-line input)"),
-        ("@file.rs", "Attach file context"),
-        ("@image.png", "Attach image (multi-modal)"),
+    let input_keys: &[(&str, &str)] = &[
+        ("Enter",       "Send message"),
+        ("Alt+Enter",   "Insert newline (multi-line input)"),
+        ("@file.rs",    "Attach file context to your message"),
+        ("@image.png",  "Attach image (vision-capable models)"),
+        ("↑ / ↓",      "Cycle through input history"),
+        ("Ctrl+R",      "Reverse history search"),
+        ("Tab",         "Autocomplete @file path or /command"),
+        ("Shift+Tab",   "Cycle approval mode (auto ↔ confirm)"),
     ];
-    for (key, desc) in shortcuts {
+    for (key, desc) in input_keys {
         tui_output::emit_line(
             buffer,
             Line::from(vec![
-                Span::styled(format!("  {key:<width$}", width = max_cmd_len + 12), CYAN),
-                Span::styled(desc, DIM),
+                Span::styled(format!("  {key:<col$}"), CYAN),
+                Span::styled(*desc, DIM),
+            ]),
+        );
+    }
+
+    // ── Navigation ─────────────────────────────────────────────
+    tui_output::blank(buffer);
+    tui_output::emit_line(buffer, Line::styled("  Navigation", BOLD));
+    tui_output::blank(buffer);
+    let nav_keys: &[(&str, &str)] = &[
+        ("PgUp / PgDn",    "Scroll history up / down one page"),
+        ("Home",           "Jump to top of history"),
+        ("End",            "Jump to bottom (latest output)"),
+        ("Mouse scroll",   "Scroll history"),
+        ("Ctrl+Y",         "Copy last code block to clipboard"),
+        ("Ctrl+U",         "Copy last assistant response to clipboard"),
+    ];
+    for (key, desc) in nav_keys {
+        tui_output::emit_line(
+            buffer,
+            Line::from(vec![
+                Span::styled(format!("  {key:<col$}"), CYAN),
+                Span::styled(*desc, DIM),
+            ]),
+        );
+    }
+
+    // ── Session control ────────────────────────────────────────
+    tui_output::blank(buffer);
+    tui_output::emit_line(buffer, Line::styled("  Session control", BOLD));
+    tui_output::blank(buffer);
+    let session_keys: &[(&str, &str)] = &[
+        ("Esc / Ctrl+C", "Cancel running inference"),
+        ("Ctrl+D",       "Quit koda"),
+    ];
+    for (key, desc) in session_keys {
+        tui_output::emit_line(
+            buffer,
+            Line::from(vec![
+                Span::styled(format!("  {key:<col$}"), CYAN),
+                Span::styled(*desc, DIM),
+            ]),
+        );
+    }
+
+    // ── Approval (shown when a tool needs confirmation) ────────
+    tui_output::blank(buffer);
+    tui_output::emit_line(
+        buffer,
+        Line::from(vec![
+            Span::styled("  Approval ", BOLD),
+            Span::styled("(when the agent asks to run a tool)", DIM),
+        ]),
+    );
+    tui_output::blank(buffer);
+    let approval_keys: &[(&str, &str)] = &[
+        ("y",   "Approve this tool call"),
+        ("n",   "Reject this tool call"),
+        ("a",   "Approve and switch to auto mode (no more prompts)"),
+        ("f",   "Reject and provide written feedback"),
+        ("Esc", "Reject (same as n)"),
+    ];
+    for (key, desc) in approval_keys {
+        tui_output::emit_line(
+            buffer,
+            Line::from(vec![
+                Span::styled(format!("  {key:<col$}"), CYAN),
+                Span::styled(*desc, DIM),
             ]),
         );
     }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -2,6 +2,38 @@
 //!
 //! All output is rendered as `ratatui::text::Line` / `Span` and written
 //! above the viewport via `insert_before()`. No ANSI strings.
+//!
+//! ## Pipeline
+//!
+//! ```text
+//! EngineEvent (from koda_core)
+//!     ↓
+//! TuiRenderer::render_to_buffer()
+//!     ↓  assembles styled Line<'static> values
+//! ScrollBuffer::push()            ← render cache (VecDeque)
+//!     ↓
+//! tui_app  →  Paragraph::new(buffer.all_lines()).scroll()
+//!     ↓
+//! ratatui Terminal::draw()
+//! ```
+//!
+//! ## Streaming text
+//!
+//! `TextDelta` events accumulate in `text_buf`. Complete lines (split at `\n`)
+//! are flushed through the markdown renderer ([`crate::md_render`]) immediately
+//! so the user sees progressive output. The partial tail is flushed on `TextDone`.
+//!
+//! ## Tool output
+//!
+//! `ToolOutputLine` events stream output in real time during long-running
+//! tool calls (e.g. `cargo build`). When `ToolCallResult` arrives, if output
+//! was already streamed the renderer just shows a compact exit-line summary
+//! rather than duplicating all output.
+//!
+//! ## Verbose mode
+//!
+//! Set `TuiRenderer::verbose = true` to suppress the
+//! [`koda_core::truncate`]-based collapsing. Every output line is shown.
 
 use crate::ansi_parse::parse_ansi_spans;
 use crate::scroll_buffer::ScrollBuffer;

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -2,6 +2,16 @@
 //!
 //! Extracted from `tui_app.rs` to keep type definitions separate
 //! from the event loop logic. See #209.
+//!
+//! ## Key types
+//!
+//! | Type | Role |
+//! |------|------|
+//! | [`TuiState`] | Idle vs. actively inferring |
+//! | [`MenuContent`] | What is shown in the menu area below the status bar |
+//! | [`PromptMode`] | Normal chat vs. wizard text entry |
+//! | [`ProviderWizard`] | Multi-step provider setup state machine |
+//! | `Term` | Type alias for the ratatui terminal backed by crossterm |
 
 use ratatui::{Terminal, backend::CrosstermBackend};
 
@@ -35,11 +45,14 @@ pub(crate) enum TuiState {
 }
 
 /// What's currently shown in the `menu_area` below the status bar.
-/// Only one menu can be active at a time.
+///
+/// Only one menu can be active at a time. The TUI switches between
+/// variants in response to slash commands, `@` completions, and
+/// engine events (approval requests, loop cap, etc.).
 pub enum MenuContent {
-    /// Nothing — menu_area is empty.
+    /// Nothing — menu_area is empty (normal chat state).
     None,
-    /// Slash command dropdown (auto-appears on `/`).
+    /// Slash command dropdown (auto-appears when the user types `/`).
     Slash(SlashDropdown),
     /// Model picker dropdown (`/model` with no args).
     Model(ModelDropdown),
@@ -51,33 +64,34 @@ pub enum MenuContent {
     Key(ProviderDropdown),
     /// Session picker dropdown (`/sessions` with no args).
     Session(SessionDropdown),
-    /// File picker dropdown (auto-appears on `@`).
+    /// File picker dropdown (auto-appears when the user types `@`).
     File {
         dropdown: FileDropdown,
-        /// Text before the `@` token (to reconstruct the full input).
+        /// Text before the `@` token (to reconstruct the full input on selection).
         prefix: String,
     },
-    /// Wizard trail — completed steps shown dimmed during multi-step flow.
+    /// Wizard trail — completed steps shown dimmed during a multi-step flow.
     WizardTrail(Vec<(String, String)>),
-    /// Approval hotkey bar — shown during inference when engine requests approval.
+    /// Approval hotkey bar — shown during inference when the engine requests
+    /// a tool approval (`y`/`n`/`a`/`f`).
     Approval {
         id: String,
         tool_name: String,
         detail: String,
     },
-    /// AskUser input bar — model is asking a clarifying question.
+    /// AskUser input bar — the model is asking a clarifying question.
     AskUser {
         id: String,
         question: String,
         options: Vec<String>,
     },
-    /// Loop cap hotkey bar — continue or stop after iteration limit.
+    /// Loop cap hotkey bar — continue or stop after the iteration limit is hit.
     LoopCap,
     /// Purge confirmation bar — \[y\] confirm / \[n\] cancel.
     PurgeConfirm { min_age_days: u32, detail: String },
     /// Ctrl+R reverse history search overlay.
     HistorySearch {
-        /// Current search query.
+        /// Current search query (updated on each keystroke).
         query: String,
         /// Matching history entries, newest first (pre-computed on each keystroke).
         matches: Vec<String>,

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -7,10 +7,10 @@
 //!
 //! | Type | Role |
 //! |------|------|
-//! | [`TuiState`] | Idle vs. actively inferring |
+//! | `TuiState` | Idle vs. actively inferring |
 //! | [`MenuContent`] | What is shown in the menu area below the status bar |
-//! | [`PromptMode`] | Normal chat vs. wizard text entry |
-//! | [`ProviderWizard`] | Multi-step provider setup state machine |
+//! | `PromptMode` | Normal chat vs. wizard text entry |
+//! | `ProviderWizard` | Multi-step provider setup state machine |
 //! | `Term` | Type alias for the ratatui terminal backed by crossterm |
 
 use ratatui::{Terminal, backend::CrosstermBackend};

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -1,4 +1,8 @@
 //! TUI widgets — dropdown menus, status bar, and interactive selectors.
+//!
+//! Each widget module owns its data model (`*Item` structs) and rendering
+//! logic (`build_*_lines` functions). The generic [`dropdown::DropdownState`]
+//! provides shared navigation (up/down/scroll/filter) so menus stay DRY.
 
 pub mod dropdown;
 pub mod file_menu;

--- a/koda-cli/src/wrap_util.rs
+++ b/koda-cli/src/wrap_util.rs
@@ -15,6 +15,26 @@ use unicode_width::UnicodeWidthChar;
 /// the current row, it breaks *before* the word.
 ///
 /// For words longer than the terminal width, force-breaks mid-word.
+///
+/// # Examples
+///
+/// ```
+/// use koda_cli::wrap_util::visual_line_count;
+///
+/// // Short line — fits in one row
+/// assert_eq!(visual_line_count("hello world", 80), 1);
+///
+/// // Empty string counts as one row (the cursor still occupies a cell)
+/// assert_eq!(visual_line_count("", 80), 1);
+///
+/// // 160 identical chars at width 80 = 2 rows
+/// assert_eq!(visual_line_count(&"x".repeat(160), 80), 2);
+///
+/// // Word-wrap: the second word is wrapped to the next row
+/// // because 75 + 1 + 75 = 151 > 80
+/// let s = format!("{} {}", "a".repeat(75), "b".repeat(75));
+/// assert_eq!(visual_line_count(&s, 80), 2);
+/// ```
 pub fn visual_line_count(text: &str, width: usize) -> usize {
     if text.is_empty() {
         return 1;

--- a/koda-core/src/approval_flow.rs
+++ b/koda-core/src/approval_flow.rs
@@ -1,7 +1,9 @@
 //! Approval flow and user interaction during tool execution.
 //!
 //! Extracted from `tool_dispatch.rs` — handles the async request/response
-//! dance for tool approvals and the `AskUser` tool.
+//! dance for tool approvals and the `AskUser` tool. Both functions emit
+//! an event via [`EngineSink`] and `select!` on the command channel,
+//! respecting cancellation tokens for graceful shutdown.
 
 use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
 

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -300,6 +300,19 @@ fn build_summary_prompt(conversation_text: &str) -> String {
 /// The analysis block improves summary quality (model "thinks" before writing)
 /// but has no informational value once the summary is written. Stripping it
 /// saves tokens in the ongoing context.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::compact::strip_analysis_block;
+///
+/// let input = "<analysis>\nthinking...\n</analysis>\n\n<summary>\nThe result.\n</summary>";
+/// let result = strip_analysis_block(input);
+/// assert_eq!(result, "The result.");
+///
+/// // Plain text without tags passes through unchanged:
+/// assert_eq!(strip_analysis_block("just text"), "just text");
+/// ```
 pub fn strip_analysis_block(summary: &str) -> String {
     // Remove <analysis>...</analysis> including the tags
     let stripped = if let Some(start) = summary.find("<analysis>") {

--- a/koda-core/src/context.rs
+++ b/koda-core/src/context.rs
@@ -24,6 +24,8 @@ pub fn get() -> (usize, usize) {
 }
 
 /// Get context usage as a percentage (0-100).
+///
+/// Returns 0 when max is zero (no division-by-zero panic).
 pub fn percentage() -> usize {
     let (used, max) = get();
     if max == 0 {
@@ -32,7 +34,9 @@ pub fn percentage() -> usize {
     (used * 100) / max
 }
 
-/// Format context usage for the footer: "4.1k/128k (3%)"
+/// Format context usage for the footer: "4.1k/128k (3%)".
+///
+/// Returns an empty string when max is zero.
 pub fn format_footer() -> String {
     let (used, max) = get();
     if max == 0 {

--- a/koda-core/src/context.rs
+++ b/koda-core/src/context.rs
@@ -2,6 +2,7 @@
 //!
 //! Tracks the current context usage (tokens used / max tokens) so the
 //! prompt and footer can display it. Updated after each inference turn.
+//! Uses `AtomicUsize` for lock-free reads from the TUI render thread.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -91,5 +92,27 @@ mod tests {
         // When max is zero, format_footer returns empty
         update(0, 0);
         assert_eq!(format_footer(), "");
+    }
+
+    #[test]
+    fn test_update_get_roundtrip() {
+        update(10_000, 128_000);
+        let (used, max) = get();
+        assert_eq!(used, 10_000);
+        assert_eq!(max, 128_000);
+    }
+
+    #[test]
+    fn test_percentage_full() {
+        update(128_000, 128_000);
+        assert_eq!(percentage(), 100);
+    }
+
+    #[test]
+    fn test_format_k_boundary() {
+        assert_eq!(format_k(999), "999");
+        assert_eq!(format_k(1_000), "1.0k");
+        assert_eq!(format_k(9_999), "10.0k");
+        assert_eq!(format_k(10_000), "10k");
     }
 }

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -1,7 +1,9 @@
 //! `Persistence` trait implementation for `Database`.
 //!
 //! All SQL queries that fulfill the `Persistence` contract live here,
-//! along with the `prune_mismatched_tool_calls` helper.
+//! along with message sanitisation helpers that run on every `load_context`
+//! call: orphan tool-call pruning, null-content cleanup, and whitespace-only
+//! message removal.
 
 use anyhow::Result;
 use std::path::Path;

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1,4 +1,8 @@
 //! Tests for the SQLite persistence layer.
+//!
+//! Covers the `Persistence` trait methods on `Database`, message pruning
+//! helpers (`prune_mismatched_tool_calls`, `prune_null_content_messages`,
+//! `prune_whitespace_only_messages`), and interrupted turn detection.
 
 use super::queries::prune_mismatched_tool_calls;
 use super::queries::{

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -37,6 +37,20 @@ pub const SYSTEM_PROMPT_OVERHEAD: usize = 100;
 /// Estimate token count for a set of messages.
 ///
 /// Uses a calibrated heuristic: `chars / CHARS_PER_TOKEN + PER_MESSAGE_OVERHEAD`.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::estimate_tokens;
+/// use koda_core::providers::ChatMessage;
+///
+/// let messages = vec![
+///     ChatMessage::text("system", "You are helpful."),
+///     ChatMessage::text("user", "Hello world"),
+/// ];
+/// let tokens = estimate_tokens(&messages);
+/// assert!(tokens > 20 && tokens < 40);
+/// ```
 pub fn estimate_tokens(messages: &[ChatMessage]) -> usize {
     messages
         .iter()
@@ -77,6 +91,16 @@ pub fn assemble_messages(
 ///
 /// These are typically transient (LM Studio choking on malformed input,
 /// Ollama OOM, etc.) and should end the turn gracefully rather than crash.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::is_server_error;
+///
+/// assert!(is_server_error(&anyhow::anyhow!("HTTP 500 from provider")));
+/// assert!(is_server_error(&anyhow::anyhow!("bad gateway")));
+/// assert!(!is_server_error(&anyhow::anyhow!("401 Unauthorized")));
+/// ```
 pub fn is_server_error(err: &anyhow::Error) -> bool {
     let msg = format!("{err:#}").to_lowercase();
     msg.contains("500")
@@ -91,6 +115,16 @@ pub fn is_server_error(err: &anyhow::Error) -> bool {
 ///
 /// Matches HTTP 429 (Too Many Requests) and Anthropic's HTTP 529 (overloaded),
 /// plus common text patterns across providers.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::is_rate_limit_error;
+///
+/// assert!(is_rate_limit_error(&anyhow::anyhow!("429 Too Many Requests")));
+/// assert!(is_rate_limit_error(&anyhow::anyhow!("quota exceeded")));
+/// assert!(!is_rate_limit_error(&anyhow::anyhow!("prompt is too long")));
+/// ```
 pub fn is_rate_limit_error(err: &anyhow::Error) -> bool {
     let msg = format!("{err:#}").to_lowercase();
     msg.contains("429")
@@ -129,6 +163,16 @@ pub fn rate_limit_backoff(attempt: u32) -> std::time::Duration {
 /// - Anthropic: "prompt is too long", "input is too long"
 /// - OpenAI: "maximum context length exceeded", "context_length_exceeded"
 /// - Generic: HTTP 400/413 with size-related messages
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::is_context_overflow_error;
+///
+/// assert!(is_context_overflow_error(&anyhow::anyhow!("prompt is too long")));
+/// assert!(is_context_overflow_error(&anyhow::anyhow!("context_length_exceeded")));
+/// assert!(!is_context_overflow_error(&anyhow::anyhow!("rate limit exceeded")));
+/// ```
 pub fn is_context_overflow_error(err: &anyhow::Error) -> bool {
     let msg = format!("{err:#}").to_lowercase();
     msg.contains("too long")

--- a/koda-core/src/model_context.rs
+++ b/koda-core/src/model_context.rs
@@ -19,6 +19,19 @@ const MIN_CONTEXT: usize = 4_096;
 /// Matches known models by prefix/pattern. Returns the full context window
 /// in tokens. The caller should apply a usage budget (e.g., 95%) to leave
 /// room for the response.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::model_context::context_window_for_model;
+///
+/// assert_eq!(context_window_for_model("claude-sonnet-4-6"), 200_000);
+/// assert_eq!(context_window_for_model("gpt-4o"), 128_000);
+/// assert_eq!(context_window_for_model("gemini-2.5-pro"), 1_048_576);
+///
+/// // Unknown models get a conservative default:
+/// assert_eq!(context_window_for_model("mystery-model"), 128_000);
+/// ```
 pub fn context_window_for_model(model: &str) -> usize {
     let m = model.to_lowercase();
 

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -32,6 +32,15 @@ pub enum Role {
 
 impl Role {
     /// String representation for database storage.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use koda_core::persistence::Role;
+    ///
+    /// assert_eq!(Role::User.as_str(), "user");
+    /// assert_eq!(Role::Assistant.as_str(), "assistant");
+    /// ```
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::System => "system",

--- a/koda-core/src/preview.rs
+++ b/koda-core/src/preview.rs
@@ -496,4 +496,69 @@ mod tests {
             other => panic!("expected UnifiedDiff, got {other:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn test_delete_dir() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("subdir");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::write(dir.join("file.txt"), "content").unwrap();
+
+        let args = json!({ "path": dir.to_str().unwrap(), "recursive": true });
+        let preview = compute("Delete", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::DeleteDir(d) => assert!(d.recursive),
+            other => panic!("expected DeleteDir, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_dir_non_recursive() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("emptydir");
+        std::fs::create_dir(&dir).unwrap();
+
+        let args = json!({ "path": dir.to_str().unwrap() });
+        let preview = compute("Delete", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::DeleteDir(d) => assert!(!d.recursive),
+            other => panic!("expected DeleteDir, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_path() {
+        let tmp = TempDir::new().unwrap();
+        let args = json!({ "path": "nonexistent_file.rs" });
+        let preview = compute("Delete", &args, tmp.path()).await.unwrap();
+        assert!(matches!(preview, DiffPreview::PathNotFound));
+    }
+
+    #[tokio::test]
+    async fn test_write_new_file_truncates_long_content() {
+        let tmp = TempDir::new().unwrap();
+        // Create content with more lines than MAX_WRITE_NEW_LINES (60)
+        let content: String = (1..=100).map(|i| format!("line {i}\n")).collect();
+        let args = json!({ "path": "big_new_file.rs", "content": content });
+
+        let preview = compute("Write", &args, tmp.path()).await.unwrap();
+        match preview {
+            DiffPreview::WriteNew(w) => {
+                assert_eq!(w.line_count, 100);
+                assert_eq!(w.first_lines.len(), 60);
+                assert!(w.truncated);
+            }
+            other => panic!("expected WriteNew, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_build_unified_diff_truncates_large_diffs() {
+        // Produce a diff with more than MAX_DIFF_LINES (120) changed lines
+        let old: String = (1..=200).map(|i| format!("old line {i}\n")).collect();
+        let new: String = (1..=200).map(|i| format!("new line {i}\n")).collect();
+
+        let diff = build_unified_diff("test.txt", &old, &new);
+        assert!(diff.truncated, "large diff should be truncated");
+    }
 }

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -123,6 +123,17 @@ pub struct ChatMessage {
 
 impl ChatMessage {
     /// Create a simple text message (convenience for the common case).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use koda_core::providers::ChatMessage;
+    ///
+    /// let msg = ChatMessage::text("user", "Hello!");
+    /// assert_eq!(msg.role, "user");
+    /// assert_eq!(msg.content.as_deref(), Some("Hello!"));
+    /// assert!(msg.tool_calls.is_none());
+    /// ```
     pub fn text(role: &str, content: &str) -> Self {
         Self {
             role: role.to_string(),

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -2,6 +2,8 @@
 //!
 //! Extracted from `tool_dispatch.rs` — handles `InvokeAgent` execution,
 //! background agent spawning, worktree provisioning, and sub-agent caching.
+//! Each sub-agent gets its own session, provider, and (optionally) worktree
+//! for isolation. Results are cached by `(agent_name, prompt_hash)`.
 
 use crate::approval::{self, ApprovalMode, ToolApproval};
 use crate::approval_flow::request_approval;

--- a/koda-core/src/tools/fuzzy.rs
+++ b/koda-core/src/tools/fuzzy.rs
@@ -18,6 +18,21 @@ use std::ops::Range;
 ///
 /// Never called when `haystack.contains(needle)` — exact matching is always
 /// tried first so this is the fallback path only.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::tools::fuzzy::fuzzy_match_ranges;
+///
+/// // File has trailing spaces that the model's edit stripped:
+/// let file = "fn foo() {\n    let x = 1;   \n}\n";
+/// let needle = "    let x = 1;";
+/// let matches = fuzzy_match_ranges(needle, file);
+/// assert_eq!(matches.len(), 1);
+///
+/// // No match at all:
+/// assert!(fuzzy_match_ranges("not here", file).is_empty());
+/// ```
 pub fn fuzzy_match_ranges(needle: &str, haystack: &str) -> Vec<Range<usize>> {
     // Strip trailing whitespace from every needle line.
     let norm_needle: Vec<&str> = needle.lines().map(str::trim_end).collect();

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -150,4 +150,31 @@ mod tests {
         assert!(result.contains("mod.rs"));
         assert!(!result.contains("main.rs")); // Not in src/tools
     }
+
+    #[tokio::test]
+    async fn test_glob_capped_results() {
+        let tmp = setup();
+        // Cap at 2 results — there are 3 .rs files
+        let args = json!({ "pattern": "**/*.rs" });
+        let result = glob_search(tmp.path(), &args, 2).await.unwrap();
+        assert!(result.contains("Capped"), "should show cap message: {result}");
+    }
+
+    #[tokio::test]
+    async fn test_glob_missing_pattern_errors() {
+        let tmp = setup();
+        let args = json!({});
+        let result = glob_search(tmp.path(), &args, 200).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("pattern"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_specific_filename() {
+        let tmp = setup();
+        let args = json!({ "pattern": "**/mod.rs" });
+        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        assert!(result.contains("mod.rs"));
+        assert!(!result.contains("main.rs"));
+    }
 }

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -157,7 +157,10 @@ mod tests {
         // Cap at 2 results — there are 3 .rs files
         let args = json!({ "pattern": "**/*.rs" });
         let result = glob_search(tmp.path(), &args, 2).await.unwrap();
-        assert!(result.contains("Capped"), "should show cap message: {result}");
+        assert!(
+            result.contains("Capped"),
+            "should show cap message: {result}"
+        );
     }
 
     #[tokio::test]

--- a/koda-core/src/undo.rs
+++ b/koda-core/src/undo.rs
@@ -120,11 +120,37 @@ impl UndoStack {
 }
 
 /// Check if a tool name is a file-mutating tool that should be snapshotted.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::undo::is_mutating_tool;
+///
+/// assert!(is_mutating_tool("Write"));
+/// assert!(is_mutating_tool("Edit"));
+/// assert!(is_mutating_tool("Delete"));
+/// assert!(!is_mutating_tool("Read"));
+/// assert!(!is_mutating_tool("Grep"));
+/// ```
 pub fn is_mutating_tool(name: &str) -> bool {
     matches!(name, "Write" | "Edit" | "Delete" | "Overwrite")
 }
 
 /// Extract the target file path from tool arguments.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::undo::extract_file_path;
+///
+/// let args = serde_json::json!({"file_path": "src/main.rs"});
+/// assert_eq!(extract_file_path("Write", &args), Some("src/main.rs".into()));
+/// assert_eq!(extract_file_path("Read", &args), None);
+///
+/// // Also accepts "path" as an alias:
+/// let args = serde_json::json!({"path": "lib.rs"});
+/// assert_eq!(extract_file_path("Edit", &args), Some("lib.rs".into()));
+/// ```
 pub fn extract_file_path(name: &str, args: &serde_json::Value) -> Option<String> {
     match name {
         "Write" | "Edit" | "Delete" | "Overwrite" => args


### PR DESCRIPTION
## Summary

docs.rs is now the **primary end-user manual** for Koda, not just a developer reference.
Three-pronged overhaul: tests, module docs, and all three help channels.

---

## docs.rs / lib.rs — comprehensive user manual (3.8× expansion)

**Before:** ~200-line overview (entry points, flags, slash command table, brief keybindings)

**After:** 740-line structured reference with 18 named sections, Ctrl+F-searchable

### New sections

| Section | What's documented |
|---|---|
| **Headless mode** | Exit codes, approval behavior, JSON output schema, stdin piping, `@file` in scripts, session resumption |
| **Interactive mode** | TUI layout diagram with status bar label explanation |
| **File and image attachment** | `@` syntax, Tab fuzzy picker, image formats, paste-block threshold |
| **Slash commands** (per-command `###` headings) | Every command with full description, all sub-commands, and code examples |
| **Session management** | UUID prefix matching, `-s` flag, away-summary on resume, interrupted-turn banner |
| **Context management** | 85% auto-compact threshold, 4-message preserve window, `/purge` lifecycle |
| **Providers table** | All 14 providers: `--provider` value, API key env var, default model, needs-key column |
| **Model aliases table** | All 7 aliases including `local`, with exact model IDs |
| **Tools reference** | All 15 tools with effect level (read-only / mutating / internal) |
| **ACP server** | Protocol lifecycle diagram, stdio transport, editor integration guidance |

### Sections meaningfully expanded

| Section | Improvement |
|---|---|
| Approval modes | Added "persisted per session" note; clarified headless auto-reject |
| Memory | Added `MemoryWrite` tool example |
| Custom agents | Added field reference table; sub-agent worktree note |
| Skills | Added custom skill creation with markdown example |
| Configuration files | Added `.koda/` project-level paths alongside `~/.config/koda/` |

---

## Help channel architecture

| Audience | Channel | What it covers |
|---|---|---|
| End-users (scripts/CI) | `koda --help` | Modes, all flags, config precedence, 9 usage examples |
| End-users (interactive) | `/help` in TUI | 5 sections, 22 keybindings (was 4) |
| All users (deep reference) | docs.rs | Complete scrollable manual — the single source of truth |

### `koda --help` improvements
- `long_about`: two-mode explanation + config precedence chain + API key semantics
- `after_help`: 9 concrete examples covering every invocation style
- `koda server --help`: `--stdio` now fully described as ACP JSON-RPC transport

### `/help` improvements
- 5 sections vs 1: Commands / Input / Navigation / Session control / Approval
- 22 keybindings documented (was 4) — all were implemented, none were visible

### Env vars answer
Still needed. `/key`, `/model`, `/provider` write to the keystore DB. `KODA_*` env vars are the CI/scripting/direnv escape hatch. Both co-exist cleanly via the precedence chain: `CLI flags > shell env vars > keystore > defaults`.

---

## koda-cli doc-tests: 0 → 6

| Function | Examples |
|---|---|
| `wrap_util::visual_line_count` | 1-row, empty, 2-row wrap, word-wrap |
| `completer::find_last_at_token` | leading `@`, spaced `@`, email passthrough, last-of-multiple |
| `input::format_context_files` | empty→None, XML tagging, multi-file join |
| `input::format_paste_blocks` | empty→None, tagged output |
| `highlight::pre_highlight` | per-line spans, unknown-lang passthrough |
| `acp_adapter::map_tool_kind` | 8 tool mappings + Other fallback |

---

## koda-core — 20 new unit tests + 11 doc-tests

| File | Added | Gap filled |
|---|---|---|
| `sink.rs` | +2 | Channel forwarding, closed-channel safety |
| `highlight.rs` | +6 | `highlight_spans`, stateful multiline, empty input |
| `context.rs` | +3 | `update`/`get` roundtrip, 100%, `format_k` boundaries |
| `preview.rs` | +5 | Delete dir, nonexistent path, content/diff truncation |
| `glob_tool.rs` | +4 | Cap message, missing pattern, specific filename |

---

## Validation

```
cargo test --workspace       →  1,338 tests, 0 failures
cargo test --doc --workspace →  32 doc-tests, 0 failures
cargo doc --no-deps          →  0 warnings, 0 errors
```
