### PR TITLE
fix(ci): use taiki-e/install-action for mdbook in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install mdbook
-        uses: cargo-bins/cargo-binstall@v1
+        uses: taiki-e/install-action@v2
         with:
-          binstall-version: latest
-      - run: cargo binstall mdbook --no-confirm --locked
+          tool: mdbook
 
       - name: Build book
         run: mdbook build docs


### PR DESCRIPTION
The `cargo-bins/cargo-binstall@v1` GitHub Action doesn't exist — first deploy of the docs workflow failed with:

```
Unable to resolve action `cargo-bins/cargo-binstall@v1`, unable to find version `v1`
```

Fix: switch to `taiki-e/install-action@v2` which is already used in `ci.yml` for `cargo-llvm-cov` and has first-class support for `mdbook`.