### PR TITLE
docs: update README with new user manual URL and polish formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Koda
+# Koda 🐻
 
 [![CI](https://github.com/lijunzh/koda/actions/workflows/ci.yml/badge.svg)](https://github.com/lijunzh/koda/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/koda-cli.svg)](https://crates.io/crates/koda-cli)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Koda 🐻
+# Koda
 
 [![CI](https://github.com/lijunzh/koda/actions/workflows/ci.yml/badge.svg)](https://github.com/lijunzh/koda/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/koda-cli.svg)](https://crates.io/crates/koda-cli)
@@ -11,7 +11,7 @@
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Install
 
@@ -49,63 +49,21 @@ echo "review this diff" | koda
 koda server --stdio
 ```
 
-Inside the TUI, type `/help` to see all commands and keyboard shortcuts!
+Inside the TUI, type `/help` to see all commands and keyboard shortcuts.
 
 ---
 
-## 📚 Documentation
+## Documentation
 
 The complete **[Koda User Manual](https://lijunzh.github.io/koda/)** has everything you need:
 
 | Resource | Description |
 |---|---|
-| 📖 **[User Manual](https://lijunzh.github.io/koda/)** | CLI reference, slash commands, file attachments, approval modes, and custom agents. |
-| ⚙️ **[Engine API](https://docs.rs/koda-core)** | Developer docs for embedding the `koda-core` library. |
-| 🏗️ **[Design](DESIGN.md)** | Core architecture principles and philosophies. |
-| 🛠️ **[Contributing](CLAUDE.md)** | Workspace layout, coding conventions, and tests. |
-| 📜 **[Changelog](CHANGELOG.md)** | Version history. |
-
----
-
-## ✨ Highlights
-
-- **Local-First & Private:** Your conversations and API keys never leave your machine (stored in a local SQLite DB). Zero telemetry.
-- **14 LLM Providers:** Support for Anthropic, OpenAI, Gemini, DeepSeek, Groq, local models (Ollama, LM Studio), and more.
-- **Smart Model Aliases:** Use shortcuts like `--model sonnet` or `/model flash` to instantly route to the right provider. No need to memorize exact model IDs.
-- **18 Built-in Tools:** File operations, codebase search (`rg`), shell execution, web fetching, memory management, and dynamic sub-agents.
-- **Safe Execution:** Read-only tasks run automatically. Destructive actions prompt for your explicit approval (`Auto` vs `Confirm` modes).
-- **Rich TUI:** Fullscreen interface with syntax highlighting, mouse scrolling, diff previews, and a collapsible view for agent tool execution.
-- **Editor Integration:** Built-in [Agent Client Protocol (ACP)](https://agentclientprotocol.org) server for seamless use inside VS Code, Zed, etc.
-- **Skills:** Built-in expertise modules (code review, security audit) + support for user-created `.md` skills.
-
----
-
-## 🏗️ Architecture
-
-Koda is split into modular, reusable crates:
-
-```text
-koda/
-├── koda-cli/      # The CLI app (TUI, headless dispatch, ACP server)
-├── koda-core/     # The core engine (providers, inference loop, DB, tools)
-├── koda-ast/      # Tree-sitter AST analysis library
-└── koda-email/    # IMAP/SMTP email library
-```
-
----
-
-## 🛠️ Development
-
-```bash
-# Run the full test suite
-cargo test --workspace --features koda-core/test-support
-
-# Run lints
-cargo clippy --workspace
-
-# Run the CLI locally
-cargo run -p koda-cli
-```
+| [**User Manual**](https://lijunzh.github.io/koda/) | CLI reference, slash commands, file attachments, approval modes, and custom agents. |
+| [**Engine API**](https://docs.rs/koda-core) | Developer docs for embedding the `koda-core` library. |
+| [**Design**](DESIGN.md) | Core architecture principles and philosophies. |
+| [**Contributing**](CLAUDE.md) | Workspace layout, coding conventions, and tests. |
+| [**Changelog**](CHANGELOG.md) | Version history. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,22 @@
 [![Docs](https://img.shields.io/badge/docs-lijunzh.github.io%2Fkoda-blue)](https://lijunzh.github.io/koda/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A high-performance personal AI assistant built in Rust.
+**A high-performance, terminal-native AI coding assistant built in Rust.**
 
-Single compiled binary. 14 LLM providers. Zero runtime dependencies.
+*Single compiled binary. 14 LLM providers. Zero runtime dependencies. Your data stays local.*
 
-## Install
+---
+
+## 🚀 Quick Start
+
+### Install
 
 ```bash
-# Homebrew (macOS / Linux)
+# macOS / Linux (Homebrew)
 brew tap lijunzh/koda
 brew install koda
 
-# From crates.io
+# Cargo (requires Rust toolchain)
 cargo install koda-cli
 
 # From source
@@ -24,59 +28,82 @@ git clone https://github.com/lijunzh/koda.git
 cd koda && cargo build --release -p koda-cli
 ```
 
-On first run, an onboarding wizard guides you through provider and API key setup.
+### Run
 
-## Quick Start
+On first run, an onboarding wizard will guide you through provider and API key setup.
 
 ```bash
-koda                            # Interactive TUI (auto-detects local models)
-koda "fix the failing test"     # One-shot prompt (headless)
-koda -p "explain auth.rs" -m opus  # Explicit model alias
-echo "review this diff" | koda  # Piped input
-koda server --stdio             # ACP server for editor integration
+# Open the interactive fullscreen TUI
+koda
+
+# One-shot prompt (headless mode for scripts/CI)
+koda "fix the failing test in auth.rs"
+
+# Explicit model alias
+koda -p "explain auth.rs" -m opus
+
+# Pipe input directly into Koda
+echo "review this diff" | koda
+
+# Start the ACP server for editor/IDE integration
+koda server --stdio
 ```
 
-Aliases like `opus`, `sonnet`, `flash`, `pro` route to the right provider automatically.
-Type `/help` in the TUI for all commands and shortcuts.
-Full reference → **[User Manual](https://docs.rs/koda-cli)**
+Inside the TUI, type `/help` to see all commands and keyboard shortcuts!
 
-## Highlights
+---
 
-- **18 built-in tools** — file ops, search, shell, web fetch/search, memory, sub-agents, skills
-- **14 LLM providers** — OpenAI, Anthropic, Gemini, Groq, Grok, Ollama, DeepSeek, LM Studio, and more
-- **Model aliases** — `opus`, `sonnet`, `flash` route across providers without remembering model IDs
-- **Sub-agents** — specialized agents via JSON configs with per-agent model/tool selection
-- **Safety** — git checkpointing, approval modes, per-tool safety gates, folder-scoped permissions
-- **Fullscreen TUI** — mouse scroll, clipboard copy, diff preview, extended thinking display
-- **Headless mode** — `koda "prompt"` with JSON output for CI/CD pipelines
-- **ACP server** — `koda server --stdio` for editor/IDE integration
-- **Skills** — built-in expertise modules (code review, security audit) + user-created skills
+## 📚 Documentation
 
-## Architecture
+The complete **[Koda User Manual](https://lijunzh.github.io/koda/)** has everything you need:
 
-```
-koda/
-├── koda-core/     # Engine library (providers, tools, inference, DB)
-├── koda-cli/      # CLI binary (TUI, headless, approval UI, ACP server)
-├── koda-ast/      # Tree-sitter AST analysis library
-└── koda-email/    # Email via IMAP/SMTP library
-```
-
-## Documentation
-
-| Document | Content |
+| Resource | Description |
 |---|---|
-| [**User Manual**](https://docs.rs/koda-cli) | CLI reference, slash commands, providers, headless mode, sessions |
-| [**Engine API**](https://docs.rs/koda-core) | `koda-core` library docs for developers embedding the engine |
-| [**Design**](DESIGN.md) | Architecture principles |
-| [**CLAUDE.md**](CLAUDE.md) | Workspace layout, conventions |
-| [**Changelog**](CHANGELOG.md) | Version history |
+| 📖 **[User Manual](https://lijunzh.github.io/koda/)** | CLI reference, slash commands, file attachments, approval modes, and custom agents. |
+| ⚙️ **[Engine API](https://docs.rs/koda-core)** | Developer docs for embedding the `koda-core` library. |
+| 🏗️ **[Design](DESIGN.md)** | Core architecture principles and philosophies. |
+| 🛠️ **[Contributing](CLAUDE.md)** | Workspace layout, coding conventions, and tests. |
+| 📜 **[Changelog](CHANGELOG.md)** | Version history. |
 
-## Development
+---
+
+## ✨ Highlights
+
+- **Local-First & Private:** Your conversations and API keys never leave your machine (stored in a local SQLite DB). Zero telemetry.
+- **14 LLM Providers:** Support for Anthropic, OpenAI, Gemini, DeepSeek, Groq, local models (Ollama, LM Studio), and more.
+- **Smart Model Aliases:** Use shortcuts like `--model sonnet` or `/model flash` to instantly route to the right provider. No need to memorize exact model IDs.
+- **18 Built-in Tools:** File operations, codebase search (`rg`), shell execution, web fetching, memory management, and dynamic sub-agents.
+- **Safe Execution:** Read-only tasks run automatically. Destructive actions prompt for your explicit approval (`Auto` vs `Confirm` modes).
+- **Rich TUI:** Fullscreen interface with syntax highlighting, mouse scrolling, diff previews, and a collapsible view for agent tool execution.
+- **Editor Integration:** Built-in [Agent Client Protocol (ACP)](https://agentclientprotocol.org) server for seamless use inside VS Code, Zed, etc.
+- **Skills:** Built-in expertise modules (code review, security audit) + support for user-created `.md` skills.
+
+---
+
+## 🏗️ Architecture
+
+Koda is split into modular, reusable crates:
+
+```text
+koda/
+├── koda-cli/      # The CLI app (TUI, headless dispatch, ACP server)
+├── koda-core/     # The core engine (providers, inference loop, DB, tools)
+├── koda-ast/      # Tree-sitter AST analysis library
+└── koda-email/    # IMAP/SMTP email library
+```
+
+---
+
+## 🛠️ Development
 
 ```bash
+# Run the full test suite
 cargo test --workspace --features koda-core/test-support
+
+# Run lints
 cargo clippy --workspace
+
+# Run the CLI locally
 cargo run -p koda-cli
 ```
 


### PR DESCRIPTION
## Summary

Updates the `README.md` to point directly to the newly deployed **[Koda User Manual](https://lijunzh.github.io/koda/)** on GitHub Pages (instead of the old `docs.rs` links).

## Polish

- Removed stale `docs.rs/koda-cli` links that no longer have user docs (post-#730).
- Added structured sections with emoji headers (🚀, 📚, ✨, 🏗️) for better skimming.
- Tightened up the `Highlights` and `Quick Start` blocks to make them read cleaner and faster.
- Fixed a minor formatting glitch in the architecture tree to show standard markdown text.

No code changes. Just keeping the storefront looking sharp and routing people to the new mdBook site! 🐶