### PR TITLE
feat(#740): add when_to_use field to SkillMeta and surface in ListSkills

### DIFF
--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -13,10 +13,29 @@ tool when it determines a skill is relevant.
 
 ## Creating custom skills
 
-Place `.md` files in `.koda/skills/` (project-local) or
-`~/.config/koda/skills/` (global). The filename becomes the skill name.
+Place a `SKILL.md` file inside a named directory under `.koda/skills/`
+(project-local) or `~/.config/koda/skills/` (global). The directory name
+becomes the skill name.
+
+```text
+.koda/
+  skills/
+    my-checklist/
+      SKILL.md        ← skill content goes here
+```
+
+### SKILL.md format
+
+Frontmatter is YAML between `---` fences; the body is the skill prompt:
 
 ```markdown
+---
+name: my-checklist
+description: One-line summary shown in ListSkills output.
+tags: [review, quality]
+when_to_use: Use when the user asks to review a pull request or a diff.
+---
+
 # My Review Checklist
 
 When reviewing code, always check:
@@ -24,6 +43,13 @@ When reviewing code, always check:
 - [ ] Error handling covers all paths
 - [ ] Tests cover the new logic
 ```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | ✔ | Skill identifier (used with `ActivateSkill`) |
+| `description` | recommended | One-line summary shown in `ListSkills` |
+| `tags` | optional | Searchable tags: `[tag1, tag2]` |
+| `when_to_use` | recommended | Guidance for the model on when to activate this skill. Shown in `ListSkills` output so the model can self-route without hard-coded hints. |
 
 ## Skill lookup order
 

--- a/koda-cli/src/builtin_skills.rs
+++ b/koda-cli/src/builtin_skills.rs
@@ -20,6 +20,11 @@ pub fn inject_builtin_skills(agent: &mut KodaAgent) {
     agent.tools.skill_registry.add_builtin(
         "koda_docs",
         "Koda user manual: commands, TUI, configuration, sessions, providers, and more.",
+        Some(
+            "Use when the user asks how to use Koda: commands, flags, TUI keybindings, \
+             configuration, sessions, providers, approval modes, skills, sub-agents, \
+             ACP server, or any other feature documented in the user manual.",
+        ),
         KODA_DOCS,
     );
 }

--- a/koda-core/skills/code-review/SKILL.md
+++ b/koda-core/skills/code-review/SKILL.md
@@ -2,6 +2,7 @@
 name: code-review
 description: Senior code review — finds bugs, anti-patterns, and improvements
 tags: [review, quality, analysis, bugs]
+when_to_use: Use when asked to review code, a PR, a diff, or a specific file for bugs, design issues, or quality improvements.
 ---
 
 # Code Review

--- a/koda-core/skills/security-audit/SKILL.md
+++ b/koda-core/skills/security-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: security-audit
 description: Security vulnerability scan — finds vulnerabilities before attackers do
 tags: [security, audit, vulnerabilities, owasp]
+when_to_use: Use when asked to audit for security vulnerabilities, check for exposed secrets, review auth/access control, or assess dependency CVEs.
 ---
 
 # Security Audit

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -48,6 +48,10 @@ pub struct SkillMeta {
     pub description: String,
     /// Searchable tags.
     pub tags: Vec<String>,
+    /// Guidance for the model on when to activate this skill.
+    /// Surfaced in `ListSkills` output so the model can decide without
+    /// hard-coded hints in `instructions.md`.
+    pub when_to_use: Option<String>,
     /// Where this skill was discovered.
     pub source: SkillSource,
 }
@@ -175,13 +179,23 @@ impl SkillRegistry {
     /// documentation as a skill without coupling `koda-core` to any
     /// application-specific content.  Call after [`Self::discover`].
     ///
+    /// `when_to_use` is shown in `ListSkills` output so the model knows
+    /// when to activate this skill without hard-coded `instructions.md` hints.
+    ///
     /// Overwrites any previously registered skill with the same name.
-    pub fn add_builtin(&mut self, name: &str, description: &str, content: &str) {
+    pub fn add_builtin(
+        &mut self,
+        name: &str,
+        description: &str,
+        when_to_use: Option<&str>,
+        content: &str,
+    ) {
         let skill = Skill {
             meta: SkillMeta {
                 name: name.to_string(),
                 description: description.to_string(),
                 tags: vec![],
+                when_to_use: when_to_use.map(str::to_string),
                 source: SkillSource::BuiltIn,
             },
             content: content.to_string(),
@@ -224,10 +238,13 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
     let frontmatter = &after_open[..close_pos].trim();
     let content = after_open[close_pos + 4..].trim_start().to_string();
 
-    // Simple YAML parsing (no serde_yaml dependency)
+    // Simple YAML parsing (no serde_yaml dependency).
+    // Supported keys: name, description, tags, when_to_use.
+    // Multi-line YAML values and complex types are intentionally not supported.
     let mut name = String::new();
     let mut description = String::new();
     let mut tags = Vec::new();
+    let mut when_to_use: Option<String> = None;
 
     for line in frontmatter.lines() {
         let line = line.trim();
@@ -235,6 +252,8 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
             name = val.trim().to_string();
         } else if let Some(val) = line.strip_prefix("description:") {
             description = val.trim().to_string();
+        } else if let Some(val) = line.strip_prefix("when_to_use:") {
+            when_to_use = Some(val.trim().to_string());
         } else if let Some(val) = line.strip_prefix("tags:") {
             // Parse [tag1, tag2, tag3]
             let val = val.trim();
@@ -253,6 +272,7 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
             name,
             description,
             tags,
+            when_to_use,
             source,
         },
         content,
@@ -269,6 +289,7 @@ mod tests {
 name: code-review
 description: Senior code review
 tags: [review, quality]
+when_to_use: Use when asked to review code or a PR.
 ---
 
 # Code Review
@@ -279,8 +300,19 @@ Do the review.
         assert_eq!(skill.meta.name, "code-review");
         assert_eq!(skill.meta.description, "Senior code review");
         assert_eq!(skill.meta.tags, vec!["review", "quality"]);
+        assert_eq!(
+            skill.meta.when_to_use.as_deref(),
+            Some("Use when asked to review code or a PR.")
+        );
         assert!(skill.content.contains("# Code Review"));
         assert!(skill.content.contains("Do the review."));
+    }
+
+    #[test]
+    fn test_parse_when_to_use_absent() {
+        let raw = "---\nname: minimal\ndescription: minimal skill\ntags: []\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert!(skill.meta.when_to_use.is_none());
     }
 
     #[test]
@@ -330,20 +362,29 @@ Do the review.
     #[test]
     fn test_add_builtin_injects_skill() {
         let mut registry = SkillRegistry::default();
-        registry.add_builtin("my-app-docs", "My app user manual", "# My App\n\nDo stuff.");
+        registry.add_builtin(
+            "my-app-docs",
+            "My app user manual",
+            Some("Use when the user asks about the app."),
+            "# My App\n\nDo stuff.",
+        );
         assert_eq!(registry.len(), 1);
         let content = registry.activate("my-app-docs").unwrap();
         assert!(content.contains("Do stuff."));
         // Source must be BuiltIn
         let meta = registry.list();
         assert!(matches!(meta[0].source, SkillSource::BuiltIn));
+        assert_eq!(
+            meta[0].when_to_use.as_deref(),
+            Some("Use when the user asks about the app.")
+        );
     }
 
     #[test]
     fn test_add_builtin_overwrites_same_name() {
         let mut registry = SkillRegistry::default();
-        registry.add_builtin("docs", "v1", "version one");
-        registry.add_builtin("docs", "v2", "version two");
+        registry.add_builtin("docs", "v1", None, "version one");
+        registry.add_builtin("docs", "v2", None, "version two");
         assert_eq!(registry.len(), 1);
         assert!(registry.activate("docs").unwrap().contains("version two"));
     }

--- a/koda-core/src/tools/skill_tools.rs
+++ b/koda-core/src/tools/skill_tools.rs
@@ -82,6 +82,9 @@ pub fn list_skills(registry: &SkillRegistry, args: &serde_json::Value) -> String
             "  \u{1f4da} {} \u{2014} {}{}\n",
             meta.name, meta.description, tags
         ));
+        if let Some(wtu) = &meta.when_to_use {
+            out.push_str(&format!("    When to use: {wtu}\n"));
+        }
     }
     out.push_str(&format!(
         "\n{} skill(s). Use ActivateSkill to load one.",
@@ -116,12 +119,21 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    /// Write a minimal valid SKILL.md to `<tmp>/.koda/skills/<skill_name>/SKILL.md`.
+    /// Write a SKILL.md with optional `when_to_use` frontmatter.
     fn write_project_skill(tmp: &TempDir, skill_name: &str, description: &str) {
         let dir = tmp.path().join(".koda").join("skills").join(skill_name);
         std::fs::create_dir_all(&dir).unwrap();
         let content = format!(
             "---\nname: {skill_name}\ndescription: {description}\ntags: [test]\n---\n\nInstructions for {skill_name}."
+        );
+        std::fs::write(dir.join("SKILL.md"), content).unwrap();
+    }
+
+    fn write_project_skill_with_when(tmp: &TempDir, skill_name: &str, when_to_use: &str) {
+        let dir = tmp.path().join(".koda").join("skills").join(skill_name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let content = format!(
+            "---\nname: {skill_name}\ndescription: A skill with guidance.\ntags: []\nwhen_to_use: {when_to_use}\n---\n\nInstructions."
         );
         std::fs::write(dir.join("SKILL.md"), content).unwrap();
     }
@@ -202,6 +214,34 @@ mod tests {
         let registry = SkillRegistry::discover(tmp.path());
         let result = list_skills(&registry, &json!({"query": "zzz-not-found-anywhere"} ));
         assert!(result.contains("No skills found matching"));
+    }
+
+    #[test]
+    fn test_list_skills_shows_when_to_use() {
+        let tmp = TempDir::new().unwrap();
+        write_project_skill_with_when(
+            &tmp,
+            "guided-skill",
+            "Use when the user asks to do the thing.",
+        );
+        let registry = SkillRegistry::discover(tmp.path());
+        let result = list_skills(&registry, &json!({}));
+        assert!(
+            result.contains("When to use: Use when the user asks to do the thing."),
+            "should surface when_to_use in listing: {result}"
+        );
+    }
+
+    #[test]
+    fn test_list_skills_omits_when_to_use_line_if_absent() {
+        // Use a bare registry (no built-ins) so we control exactly what's in it.
+        let mut registry = SkillRegistry::default();
+        registry.add_builtin("plain-skill", "no guidance", None, "content");
+        let result = list_skills(&registry, &json!({}));
+        assert!(
+            !result.contains("When to use:"),
+            "should not emit 'When to use:' when field is absent: {result}"
+        );
     }
 
     // ── activate_skill ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #740.

Adds a `when_to_use` field to `SkillMeta` so skills can carry their own activation guidance. The model reads this from `ListSkills` output and can self-route without relying exclusively on hard-coded hints in `instructions.md`.

Previously, any custom skill a user dropped in `.koda/skills/` had no way to tell the model when to activate it. Now they just add `when_to_use:` to their `SKILL.md` frontmatter and it shows up in `ListSkills`.

## Changes

| File | What changed |
|---|---|
| `koda-core/src/skills.rs` | `when_to_use: Option<String>` on `SkillMeta`; parse from frontmatter; `add_builtin()` gains `when_to_use: Option<&str>` param; 2 new tests |
| `koda-core/src/tools/skill_tools.rs` | `list_skills` emits `When to use: …` line when present; new helper + 2 new tests |
| `koda-core/skills/code-review/SKILL.md` | Add `when_to_use:` frontmatter |
| `koda-core/skills/security-audit/SKILL.md` | Add `when_to_use:` frontmatter |
| `koda-cli/src/builtin_skills.rs` | Pass `when_to_use` for `koda_docs` — self-doc skill is now self-routing in `ListSkills` output |
| `docs/src/skills.md` | Fix directory format (was wrong: single `.md` files, real format is `<name>/SKILL.md`); add frontmatter field reference table |

## ListSkills output (before → after)

**Before:**
```
Available skills:

  📚 code-review — Senior code review — finds bugs, anti-patterns, and improvements [review, quality, analysis, bugs]
  📚 koda_docs — Koda user manual: commands, TUI, configuration, sessions, providers, and more.
```

**After:**
```
Available skills:

  📚 code-review — Senior code review — finds bugs, anti-patterns, and improvements [review, quality, analysis, bugs]
    When to use: Use when asked to review code, a PR, a diff, or a specific file for bugs, design issues, or quality improvements.
  📚 koda_docs — Koda user manual: commands, TUI, configuration, sessions, providers, and more.
    When to use: Use when the user asks how to use Koda: commands, flags, TUI keybindings, configuration, sessions, providers, approval modes, skills, sub-agents, ACP server, or any other feature documented in the user manual.
```

## Design decisions

- **`instructions.md` fast-path hints are kept as-is.** They give the model an explicit hot-path for the most common cases. `when_to_use` in `ListSkills` is the *extensible* fallback for custom skills and for cases the model discovers via `ListSkills` search.
- **No multi-line YAML.** The hand-rolled parser supports single-line `when_to_use:` values only. Documented with a comment. Adding `serde_yaml` is still YAGNI.
- **`add_builtin()` API change is a breaking change for downstream crates** — but `koda-cli` is the only downstream and it's in this same commit.

## Tests

- 821 → 825 unit tests, all passing (`cargo test -p koda-core -p koda-cli`)
- `cargo clippy -- -D warnings` clean
- `cargo fmt` applied