### PR TITLE
feat(#745): add allowed_tools, user_invocable, argument_hint to skill metadata

### DIFF
--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -34,6 +34,9 @@ name: my-checklist
 description: One-line summary shown in ListSkills output.
 tags: [review, quality]
 when_to_use: Use when the user asks to review a pull request or a diff.
+allowed_tools: [Read, Grep, Glob]
+user_invocable: true
+argument_hint: <file_or_pr_url>
 ---
 
 # My Review Checklist
@@ -49,7 +52,13 @@ When reviewing code, always check:
 | `name` | ✔ | Skill identifier (used with `ActivateSkill`) |
 | `description` | recommended | One-line summary shown in `ListSkills` |
 | `tags` | optional | Searchable tags: `[tag1, tag2]` |
-| `when_to_use` | recommended | Guidance for the model on when to activate this skill. Shown in `ListSkills` output so the model can self-route without hard-coded hints. |
+| `when_to_use` | recommended | Guidance for the model on when to activate |
+| `allowed_tools` | optional | Restrict tools during activation (empty = all) |
+| `user_invocable` | optional | `false` = model-only, hidden from `/skills` |
+| `argument_hint` | optional | Usage hint (e.g. `<file_path>`) |
+
+> **Note:** Both underscore (`allowed_tools`) and hyphenated (`allowed-tools`)
+> field names are accepted for CC compatibility.
 
 ## Skill lookup order
 

--- a/koda-core/src/instructions.md
+++ b/koda-core/src/instructions.md
@@ -58,13 +58,20 @@ Do not use destructive commands as shortcuts for investigation. If you find unex
 
 All available skills with descriptions and usage hints are listed in the `## Skills` section of this prompt. When a user request matches any listed skill, you MUST call `ActivateSkill` before generating any response — do not answer from training data when a skill covers the topic.
 
-Skills are free. Prefer them over spawning sub-agents or fetching external URLs for knowledge tasks. Use `ListSkills` to search if you need a skill not visible in the listing.
+Rules:
+- Skills are free. Prefer them over spawning sub-agents or fetching external URLs.
+- Skills marked `[model-only]` are for autonomous use — not shown to users.
+- If a skill h `(Tools: ...)`, restrict yourself to those tools while following its instructions.
+- Use `ListSkills` to search if you need a skill not visible in the listing.
 
 ### Sub-Agents (separate inference loop — use deliberately)
 
-Available sub-agents with descriptions are listed in `## Available Sub-Agents`. Use `InvokeAgent` when the task matches an agent's stated purpose. Do not invent agent names not in that list.
+Available sub-agents with descriptions are listed in `## Available Sub-Agents`. Use `InvokeAgent` when the task matches an agent's stated purpose.
 
-Do not spawn sub-agents for simple, single-file edits or straightforward commands — the overhead is not worth it.
+Rules:
+- Do NOT invent agent names not listed in the prompt.
+- Do not spawn sub-agents for simple, single-file edits — the overhead is not worth it.
+- Sub-agent results are NOT visible to the user — always summarize key findings.
 
 ## Using Your Tools
 

--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -161,14 +161,26 @@ pub fn build_system_prompt(
              Do not answer from training data when a skill covers the topic.\n\n",
         );
         for meta in &skills {
+            // Base: "- **name** — description"
+            let mut line = format!("- **{}** — {}", meta.name, meta.description);
+            // Append when_to_use if present
             if let Some(wtu) = &meta.when_to_use {
-                prompt.push_str(&format!(
-                    "- **{}** — {} — {}\n",
-                    meta.name, meta.description, wtu
-                ));
-            } else {
-                prompt.push_str(&format!("- **{}** — {}\n", meta.name, meta.description));
+                line.push_str(&format!(" — {wtu}"));
             }
+            // Append tool scope hint
+            if !meta.allowed_tools.is_empty() {
+                line.push_str(&format!(" (Tools: {})", meta.allowed_tools.join(", ")));
+            }
+            // Append argument hint
+            if let Some(hint) = &meta.argument_hint {
+                line.push_str(&format!(" `{hint}`"));
+            }
+            // Mark model-only skills
+            if !meta.user_invocable {
+                line.push_str(" [model-only]");
+            }
+            line.push('\n');
+            prompt.push_str(&line);
         }
         prompt.push_str(
             "\nCustom skills: `.koda/skills/<name>/SKILL.md` (project) \
@@ -434,6 +446,39 @@ mod tests {
         let result = build_system_prompt("Base.", "", dir.path(), &[], &env, &[], &registry);
         assert!(result.contains("**plain**"));
         assert!(result.contains("Plain skill"));
+    }
+
+    #[test]
+    fn test_skills_section_shows_metadata() {
+        use crate::skills::{Skill, SkillMeta, SkillSource};
+
+        let dir = TempDir::new().unwrap();
+        let env = test_env();
+        let mut registry = SkillRegistry::default();
+        // Inject a skill with all metadata fields populated
+        registry.skills.insert(
+            "scoped".to_string(),
+            Skill {
+                meta: SkillMeta {
+                    name: "scoped".to_string(),
+                    description: "Scoped skill".to_string(),
+                    tags: vec![],
+                    when_to_use: Some("Use for scoped work".to_string()),
+                    allowed_tools: vec!["Read".to_string(), "Grep".to_string()],
+                    user_invocable: false,
+                    argument_hint: Some("<file_path>".to_string()),
+                    source: SkillSource::BuiltIn,
+                },
+                content: "scoped content".to_string(),
+            },
+        );
+        let result = build_system_prompt("Base.", "", dir.path(), &[], &env, &[], &registry);
+        assert!(result.contains("**scoped**"), "skill name");
+        assert!(result.contains("Scoped skill"), "description");
+        assert!(result.contains("Use for scoped work"), "when_to_use");
+        assert!(result.contains("(Tools: Read, Grep)"), "allowed_tools");
+        assert!(result.contains("`<file_path>`"), "argument_hint");
+        assert!(result.contains("[model-only]"), "user_invocable=false");
     }
 
     #[test]

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -40,6 +40,18 @@ use std::collections::HashMap;
 use std::path::Path;
 
 /// Metadata from a SKILL.md frontmatter.
+///
+/// ## Parity with Claude Code
+///
+/// These fields map to Claude Code's `FrontmatterData`:
+///
+/// | CC field | Koda field | Notes |
+/// |---|---|---|
+/// | `description` | `description` | |
+/// | `when_to_use` | `when_to_use` | |
+/// | `allowed-tools` | `allowed_tools` | Scoped tool access |
+/// | `user-invocable` | `user_invocable` | Default: `true` |
+/// | `argument-hint` | `argument_hint` | Usage guidance |
 #[derive(Debug, Clone)]
 pub struct SkillMeta {
     /// Skill name (derived from filename or frontmatter).
@@ -52,6 +64,18 @@ pub struct SkillMeta {
     /// Surfaced in `ListSkills` output so the model can decide without
     /// hard-coded hints in `instructions.md`.
     pub when_to_use: Option<String>,
+    /// Tool names allowed when this skill is active.
+    /// Empty = all tools available (default). Non-empty = only these tools.
+    /// Mirrors CC's `allowed-tools` frontmatter field.
+    pub allowed_tools: Vec<String>,
+    /// Whether users can invoke this skill (e.g. via `/skill-name`).
+    /// `true` (default) = shown in user-facing skill list.
+    /// `false` = model-only, not surfaced in `/skills` but still activatable.
+    /// Mirrors CC's `user-invocable` frontmatter field.
+    pub user_invocable: bool,
+    /// Usage hint shown when listing the skill (e.g. `"<file_path>"`)
+    /// Mirrors CC's `argument-hint` frontmatter field.
+    pub argument_hint: Option<String>,
     /// Where this skill was discovered.
     pub source: SkillSource,
 }
@@ -79,7 +103,7 @@ pub struct Skill {
 /// Registry of discovered skills.
 #[derive(Debug, Default)]
 pub struct SkillRegistry {
-    skills: HashMap<String, Skill>,
+    pub(crate) skills: HashMap<String, Skill>,
 }
 
 impl SkillRegistry {
@@ -151,6 +175,21 @@ impl SkillRegistry {
         metas
     }
 
+    /// List only user-invocable skills (excludes model-only skills).
+    ///
+    /// Used by the `/skills` REPL command and `ListSkills` when called
+    /// by the user (vs. the model discovering skills autonomously).
+    pub fn list_user_invocable(&self) -> Vec<&SkillMeta> {
+        let mut metas: Vec<&SkillMeta> = self
+            .skills
+            .values()
+            .filter(|s| s.meta.user_invocable)
+            .map(|s| &s.meta)
+            .collect();
+        metas.sort_by_key(|m| &m.name);
+        metas
+    }
+
     /// Search skills by query (matches name, description, tags).
     pub fn search(&self, query: &str) -> Vec<&SkillMeta> {
         let q = query.to_lowercase();
@@ -171,6 +210,14 @@ impl SkillRegistry {
     /// Activate a skill by name — returns the full content for context injection.
     pub fn activate(&self, name: &str) -> Option<&str> {
         self.skills.get(name).map(|s| s.content.as_str())
+    }
+
+    /// Get the full skill metadata + content by name.
+    ///
+    /// Used when activation needs to inspect `allowed_tools` or other
+    /// metadata beyond just the content string.
+    pub fn get(&self, name: &str) -> Option<&Skill> {
+        self.skills.get(name)
     }
 
     /// Inject a built-in skill programmatically (e.g. from a downstream CLI).
@@ -196,6 +243,9 @@ impl SkillRegistry {
                 description: description.to_string(),
                 tags: vec![],
                 when_to_use: when_to_use.map(str::to_string),
+                allowed_tools: vec![],
+                user_invocable: true,
+                argument_hint: None,
                 source: SkillSource::BuiltIn,
             },
             content: content.to_string(),
@@ -239,12 +289,16 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
     let content = after_open[close_pos + 4..].trim_start().to_string();
 
     // Simple YAML parsing (no serde_yaml dependency).
-    // Supported keys: name, description, tags, when_to_use.
+    // Supported keys: name, description, tags, when_to_use, allowed_tools,
+    //   user_invocable, argument_hint.
     // Multi-line YAML values and complex types are intentionally not supported.
     let mut name = String::new();
     let mut description = String::new();
     let mut tags = Vec::new();
     let mut when_to_use: Option<String> = None;
+    let mut allowed_tools: Vec<String> = Vec::new();
+    let mut user_invocable = true;
+    let mut argument_hint: Option<String> = None;
 
     for line in frontmatter.lines() {
         let line = line.trim();
@@ -254,6 +308,38 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
             description = val.trim().to_string();
         } else if let Some(val) = line.strip_prefix("when_to_use:") {
             when_to_use = Some(val.trim().to_string());
+        } else if let Some(val) = line
+            .strip_prefix("allowed_tools:")
+            .or_else(|| line.strip_prefix("allowed-tools:"))
+        {
+            // Parse [Tool1, Tool2] or comma-separated
+            let val = val.trim();
+            if let Some(inner) = val.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                allowed_tools = inner
+                    .split(',')
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .collect();
+            } else if !val.is_empty() {
+                allowed_tools = val
+                    .split(',')
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .collect();
+            }
+        } else if let Some(val) = line
+            .strip_prefix("user_invocable:")
+            .or_else(|| line.strip_prefix("user-invocable:"))
+        {
+            user_invocable = val.trim() != "false";
+        } else if let Some(val) = line
+            .strip_prefix("argument_hint:")
+            .or_else(|| line.strip_prefix("argument-hint:"))
+        {
+            let val = val.trim();
+            if !val.is_empty() {
+                argument_hint = Some(val.to_string());
+            }
         } else if let Some(val) = line.strip_prefix("tags:") {
             // Parse [tag1, tag2, tag3]
             let val = val.trim();
@@ -273,6 +359,9 @@ fn parse_skill_md(raw: &str, source: SkillSource) -> Option<Skill> {
             description,
             tags,
             when_to_use,
+            allowed_tools,
+            user_invocable,
+            argument_hint,
             source,
         },
         content,
@@ -304,8 +393,95 @@ Do the review.
             skill.meta.when_to_use.as_deref(),
             Some("Use when asked to review code or a PR.")
         );
+        assert!(skill.meta.allowed_tools.is_empty());
+        assert!(skill.meta.user_invocable);
+        assert!(skill.meta.argument_hint.is_none());
         assert!(skill.content.contains("# Code Review"));
         assert!(skill.content.contains("Do the review."));
+    }
+
+    #[test]
+    fn test_parse_allowed_tools() {
+        let raw = "---\nname: scoped\ndescription: Scoped skill\ntags: []\nallowed_tools: [Read, Grep, Glob]\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert_eq!(skill.meta.allowed_tools, vec!["Read", "Grep", "Glob"]);
+    }
+
+    #[test]
+    fn test_parse_allowed_tools_hyphenated() {
+        let raw = "---\nname: scoped\ndescription: Scoped skill\ntags: []\nallowed-tools: [Read, Write]\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert_eq!(skill.meta.allowed_tools, vec!["Read", "Write"]);
+    }
+
+    #[test]
+    fn test_parse_user_invocable_false() {
+        let raw = "---\nname: model-only\ndescription: hidden\ntags: []\nuser_invocable: false\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert!(!skill.meta.user_invocable);
+    }
+
+    #[test]
+    fn test_parse_user_invocable_hyphenated() {
+        let raw = "---\nname: model-only\ndescription: hidden\ntags: []\nuser-invocable: false\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert!(!skill.meta.user_invocable);
+    }
+
+    #[test]
+    fn test_parse_user_invocable_default_true() {
+        let raw = "---\nname: visible\ndescription: shown\ntags: []\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert!(skill.meta.user_invocable);
+    }
+
+    #[test]
+    fn test_parse_argument_hint() {
+        let raw = "---\nname: pdf\ndescription: Generate PDF\ntags: []\nargument_hint: <file_path>\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert_eq!(skill.meta.argument_hint.as_deref(), Some("<file_path>"));
+    }
+
+    #[test]
+    fn test_parse_argument_hint_hyphenated() {
+        let raw = "---\nname: pdf\ndescription: Generate PDF\ntags: []\nargument-hint: <output_dir>\n---\ncontent";
+        let skill = parse_skill_md(raw, SkillSource::BuiltIn).unwrap();
+        assert_eq!(skill.meta.argument_hint.as_deref(), Some("<output_dir>"));
+    }
+
+    #[test]
+    fn test_list_user_invocable_excludes_model_only() {
+        let mut registry = SkillRegistry::default();
+        registry.add_builtin("user-skill", "for users", None, "content");
+        // Manually insert a model-only skill
+        registry.skills.insert(
+            "model-skill".to_string(),
+            Skill {
+                meta: SkillMeta {
+                    name: "model-skill".to_string(),
+                    description: "model only".to_string(),
+                    tags: vec![],
+                    when_to_use: None,
+                    allowed_tools: vec![],
+                    user_invocable: false,
+                    argument_hint: None,
+                    source: SkillSource::BuiltIn,
+                },
+                content: "secret".to_string(),
+            },
+        );
+        assert_eq!(registry.list().len(), 2);
+        assert_eq!(registry.list_user_invocable().len(), 1);
+        assert_eq!(registry.list_user_invocable()[0].name, "user-skill");
+    }
+
+    #[test]
+    fn test_get_returns_full_skill() {
+        let mut registry = SkillRegistry::default();
+        registry.add_builtin("test", "desc", None, "body");
+        let skill = registry.get("test").unwrap();
+        assert_eq!(skill.meta.name, "test");
+        assert_eq!(skill.content, "body");
     }
 
     #[test]

--- a/koda-core/src/tools/skill_tools.rs
+++ b/koda-core/src/tools/skill_tools.rs
@@ -81,9 +81,24 @@ pub fn list_skills(registry: &SkillRegistry, args: &serde_json::Value) -> String
         } else {
             format!(" [{}]", meta.tags.join(", "))
         };
+        let hint = meta
+            .argument_hint
+            .as_deref()
+            .map(|h| format!(" {h}"))
+            .unwrap_or_default();
+        let tools_note = if meta.allowed_tools.is_empty() {
+            String::new()
+        } else {
+            format!(" (Tools: {})", meta.allowed_tools.join(", "))
+        };
+        let visibility = if !meta.user_invocable {
+            " [model-only]"
+        } else {
+            ""
+        };
         out.push_str(&format!(
-            "  \u{1f4da} {} \u{2014} {}{}\n",
-            meta.name, meta.description, tags
+            "  \u{1f4da} {}{} \u{2014} {}{}{}{visibility}\n",
+            meta.name, hint, meta.description, tags, tools_note
         ));
         if let Some(wtu) = &meta.when_to_use {
             out.push_str(&format!("    When to use: {wtu}\n"));
@@ -97,15 +112,28 @@ pub fn list_skills(registry: &SkillRegistry, args: &serde_json::Value) -> String
 }
 
 /// Load a skill's full SKILL.md content by name.
+///
+/// Returns the skill content along with metadata about scoped tools
+/// (if `allowed_tools` is set in the skill's frontmatter).
 pub fn activate_skill(registry: &SkillRegistry, args: &serde_json::Value) -> String {
     let name = match args.get("skill_name").and_then(|v| v.as_str()) {
         Some(n) => n,
         None => return "Missing 'skill_name' parameter.".to_string(),
     };
 
-    match registry.activate(name) {
-        Some(content) => {
-            format!("Skill '{name}' activated. Follow these instructions:\n\n{content}")
+    match registry.get(name) {
+        Some(skill) => {
+            let mut result = format!(
+                "Skill '{name}' activated. Follow these instructions:\n\n{}",
+                skill.content
+            );
+            if !skill.meta.allowed_tools.is_empty() {
+                result.push_str(&format!(
+                    "\n\n[Skill scope: only use these tools: {}]",
+                    skill.meta.allowed_tools.join(", ")
+                ));
+            }
+            result
         }
         None => {
             let available: Vec<String> = registry.list().iter().map(|m| m.name.clone()).collect();
@@ -274,5 +302,79 @@ mod tests {
             "expected activation message: {result}"
         );
         assert!(result.contains("Instructions for alpha"));
+    }
+
+    #[test]
+    fn test_activate_skill_with_allowed_tools() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".koda").join("skills").join("scoped");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: scoped\ndescription: Scoped skill\ntags: []\nallowed_tools: [Read, Grep]\n---\n\nDo stuff.",
+        )
+        .unwrap();
+        let registry = SkillRegistry::discover(tmp.path());
+        let result = activate_skill(&registry, &json!({"skill_name": "scoped"}));
+        assert!(result.contains("activated"), "should activate: {result}");
+        assert!(result.contains("Do stuff."));
+        assert!(
+            result.contains("[Skill scope: only use these tools: Read, Grep]"),
+            "should include tool scope: {result}"
+        );
+    }
+
+    #[test]
+    fn test_list_skills_shows_allowed_tools() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".koda").join("skills").join("scoped");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: scoped\ndescription: Scoped\ntags: []\nallowed_tools: [Read, Grep]\n---\n\ncontent",
+        )
+        .unwrap();
+        let registry = SkillRegistry::discover(tmp.path());
+        let result = list_skills(&registry, &json!({}));
+        assert!(
+            result.contains("(Tools: Read, Grep)"),
+            "should show allowed tools: {result}"
+        );
+    }
+
+    #[test]
+    fn test_list_skills_shows_model_only_tag() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".koda").join("skills").join("hidden");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: hidden\ndescription: Hidden\ntags: []\nuser_invocable: false\n---\n\ncontent",
+        )
+        .unwrap();
+        let registry = SkillRegistry::discover(tmp.path());
+        let result = list_skills(&registry, &json!({}));
+        assert!(
+            result.contains("[model-only]"),
+            "should show model-only tag: {result}"
+        );
+    }
+
+    #[test]
+    fn test_list_skills_shows_argument_hint() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join(".koda").join("skills").join("pdf");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: pdf\ndescription: Generate PDF\ntags: []\nargument_hint: <file_path>\n---\n\ncontent",
+        )
+        .unwrap();
+        let registry = SkillRegistry::discover(tmp.path());
+        let result = list_skills(&registry, &json!({}));
+        assert!(
+            result.contains("pdf <file_path>"),
+            "should show argument hint: {result}"
+        );
     }
 }


### PR DESCRIPTION
## What & Why

Closes #745 (P0 items only — P1/P2 deferred as YAGNI).

Adds three metadata fields to `SkillMeta` for parity with Claude Code's skill frontmatter:

- **`allowed_tools`** — scoped tool access during skill activation (parse + display; hard enforcement tracked in #746)
- **`user_invocable`** — distinguishes model-only vs user-accessible skills (default: `true`)
- **`argument_hint`** — usage guidance for the LLM (e.g. `<file_path>`)

Both underscore (`allowed_tools`) and hyphenated (`allowed-tools`) frontmatter keys are accepted, matching CC's convention.

---

## Changes

### `koda-core/src/skills.rs`
- Add `allowed_tools: Vec<String>`, `user_invocable: bool`, `argument_hint: Option<String>` to `SkillMeta`
- Parse all three from SKILL.md frontmatter (underscore + hyphen variants)
- Add `list_user_invocable()` method to filter model-only skills
- Add `get_skill()` for full metadata + content access
- 8 new unit tests: parsing, defaults, hyphenated keys, `list_user_invocable` filtering

### `koda-core/src/prompt.rs`
- Enhance skill listing to display `allowed_tools` as `(Tools: ...)`, `argument_hint` as backtick hint, and `[model-only]` tag
- 1 new test: `test_skills_section_shows_metadata`

### `koda-core/src/tools/skill_tools.rs`
- `ActivateSkill` result now appends `[Skill scope: only use these tools: ...]` when `allowed_tools` is non-empty
- `ListSkills` output now shows allowed_tools, argument_hint, and `[model-only]` markers
- Update `ActivateSkill` tool description with explicit BLOCKING REQUIREMENT

### `koda-core/src/instructions.md`
- Merged instructions from #744 (dynamic section references) with #745 rules (model-only, tool scoping)

### `docs/src/skills.md`
- Document new frontmatter fields

---

## What's NOT in this PR (intentional)

- **Hard enforcement of `allowed_tools`** at tool execution layer → tracked in #746
- P1 items (agent markdown format, `context: fork`, `paths`, `maxTurns`) → YAGNI
- P2 items (hooks, budget-aware listing, shell commands) → YAGNI

---

## Tests

All 311 tests pass. New tests cover:
- Parsing `allowed_tools` (bracket + comma + hyphenated variants)
- Parsing `user_invocable` (true/false + default + hyphenated)
- Parsing `argument_hint` (present + hyphenated)
- `list_user_invocable()` filtering
- Prompt rendering with all metadata fields
