### PR TITLE
feat(#746): enforce allowed_tools at tool execution layer

### DIFF
--- a/docs/src/skills.md
+++ b/docs/src/skills.md
@@ -60,6 +60,22 @@ When reviewing code, always check:
 > **Note:** Both underscore (`allowed_tools`) and hyphenated (`allowed-tools`)
 > field names are accepted for CC compatibility.
 
+### How `allowed_tools` enforcement works
+
+When a skill with `allowed_tools` is activated:
+
+1. **Tool definitions are filtered** — only the listed tools (plus meta-tools
+   like `ActivateSkill`, `ListSkills`, `ListAgents`, `InvokeAgent`, `AskUser`)
+   are sent to the LLM on subsequent turns.
+2. **Blocked tool calls are rejected** — if the model still attempts a blocked
+   tool (e.g., from cached context), the call returns an error explaining the
+   scope restriction.
+3. **Scope clears automatically** when a different skill without `allowed_tools`
+   is activated.
+
+Scope transitions are logged as info events (`🔒 scope activated` /
+`🔓 scope cleared`).
+
 ## Skill lookup order
 
 1. `.koda/skills/` (project-local, highest priority)

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -51,6 +51,7 @@ use crate::persistence::Persistence;
 use crate::providers::{
     ChatMessage, ImageData, LlmProvider, StreamChunk, TokenUsage, ToolCall, ToolDefinition,
 };
+use crate::skill_scope::SkillToolScope;
 use crate::tool_dispatch::{
     can_parallelize, execute_tools_parallel, execute_tools_sequential, execute_tools_split_batch,
 };
@@ -589,6 +590,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let mut loop_detector = LoopDetector::new();
     let sub_agent_cache = crate::sub_agent_cache::SubAgentCache::new();
     let bg_agents = crate::bg_agent::new_shared();
+    let mut skill_scope = SkillToolScope::new();
     let mut total_prompt_tokens: i64 = 0;
     let mut total_completion_tokens: i64 = 0;
     let mut total_cache_read_tokens: i64 = 0;
@@ -677,6 +679,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let system_prompt_full = format!("{base_system_prompt}{progress}{todo_section}{git_line}");
         let system_message = ChatMessage::text("system", &system_prompt_full);
 
+        // Apply skill-scoped tool filtering: when a skill with `allowed_tools`
+        // is active, only those tools (+ meta-tools) are sent to the LLM.
+        let scoped_tool_defs = skill_scope.filter_tool_defs(tool_defs);
+        let active_tool_defs: &[ToolDefinition] = &scoped_tool_defs;
+
         // Build per-iteration immutable context for helpers
         let turn = TurnState {
             db,
@@ -686,7 +693,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             iteration,
             config,
             provider,
-            tool_defs,
+            tool_defs: active_tool_defs,
             sink,
             cancel: &cancel,
         };
@@ -705,7 +712,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let stream_result = try_with_rate_limit(
             provider,
             &messages,
-            tool_defs,
+            active_tool_defs,
             &config.model_settings,
             &cancel,
             sink,
@@ -943,6 +950,42 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             .cloned()
             .collect();
 
+        // Skill scope enforcement: reject tool calls blocked by the active scope.
+        // Blocked tools get an error result recorded without execution.
+        let remaining_tools = if skill_scope.is_active() {
+            let mut allowed = Vec::with_capacity(remaining_tools.len());
+            for tc in remaining_tools {
+                if let Some(err_msg) = skill_scope.check_tool_call(&tc.function_name) {
+                    let parsed_args: serde_json::Value =
+                        serde_json::from_str(&tc.arguments).unwrap_or_default();
+                    sink.emit(EngineEvent::ToolCallStart {
+                        id: tc.id.clone(),
+                        name: tc.function_name.clone(),
+                        args: parsed_args,
+                        is_sub_agent: false,
+                    });
+                    crate::tool_dispatch::record_tool_result(
+                        &tc,
+                        &err_msg,
+                        false,
+                        None,
+                        db,
+                        session_id,
+                        tools.caps.tool_result_chars,
+                        project_root,
+                        file_tracker,
+                        sink,
+                    )
+                    .await?;
+                } else {
+                    allowed.push(tc);
+                }
+            }
+            allowed
+        } else {
+            remaining_tools
+        };
+
         // Execute remaining tool calls — parallelize when possible
         if remaining_tools.len() > 1 && can_parallelize(&remaining_tools, mode, project_root) {
             execute_tools_parallel(
@@ -994,6 +1037,37 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 &bg_agents,
             )
             .await?;
+        }
+
+        // Update skill scope: if any ActivateSkill call was made, check whether
+        // the newly activated skill has allowed_tools.
+        {
+            let scope_calls: Vec<(String, serde_json::Value)> = tool_calls
+                .iter()
+                .map(|tc| {
+                    let args: serde_json::Value =
+                        serde_json::from_str(&tc.arguments).unwrap_or_default();
+                    (tc.function_name.clone(), args)
+                })
+                .collect();
+            let was_active = skill_scope.is_active();
+            skill_scope.update_from_tool_calls(&scope_calls, &tools.skill_registry);
+            // Log scope transitions
+            match (was_active, skill_scope.is_active()) {
+                (false, true) => {
+                    sink.emit(EngineEvent::Info {
+                        message: "\u{1f512} Skill tool scope activated — tool set restricted"
+                            .into(),
+                    });
+                }
+                (true, false) => {
+                    sink.emit(EngineEvent::Info {
+                        message: "\u{1f513} Skill tool scope cleared — full tool set restored"
+                            .into(),
+                    });
+                }
+                _ => {}
+            }
         }
 
         // Loop detection: same tool+args repeated REPEAT_THRESHOLD times → stop immediately.

--- a/koda-core/src/instructions.md
+++ b/koda-core/src/instructions.md
@@ -61,7 +61,7 @@ All available skills with descriptions and usage hints are listed in the `## Ski
 Rules:
 - Skills are free. Prefer them over spawning sub-agents or fetching external URLs.
 - Skills marked `[model-only]` are for autonomous use — not shown to users.
-- If a skill h `(Tools: ...)`, restrict yourself to those tools while following its instructions.
+- If a skill has `(Tools: ...)`, only those tools (plus meta-tools) will be available while the skill is active. Blocked tool calls are rejected automatically.
 - Use `ListSkills` to search if you need a skill not visible in the listing.
 
 ### Sub-Agents (separate inference loop — use deliberately)

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -100,6 +100,8 @@ pub mod runtime_env;
 pub mod session;
 /// Last-used provider persistence (`~/.config/koda/settings.toml`).
 pub mod settings;
+/// Skill-scoped tool filtering — hard enforcement of `allowed_tools`.
+pub mod skill_scope;
 /// Skill discovery and activation (project, user, built-in).
 pub mod skills;
 /// Sub-agent result caching — zero-cost retries after compaction.

--- a/koda-core/src/skill_scope.rs
+++ b/koda-core/src/skill_scope.rs
@@ -72,17 +72,14 @@ impl SkillToolScope {
         registry: &SkillRegistry,
     ) {
         for (name, args) in tool_calls {
-            if name == "ActivateSkill" {
-                if let Some(skill_name) = args.get("skill_name").and_then(|v| v.as_str()) {
-                    if let Some(skill) = registry.get(skill_name) {
-                        if skill.meta.allowed_tools.is_empty() {
-                            self.allowed = None;
-                        } else {
-                            self.allowed = Some(skill.meta.allowed_tools.clone());
-                        }
-                    }
-                    // If skill not found, don't change scope — the error
-                    // message from activate_skill() is enough.
+            if name == "ActivateSkill"
+                && let Some(skill_name) = args.get("skill_name").and_then(|v| v.as_str())
+                && let Some(skill) = registry.get(skill_name)
+            {
+                if skill.meta.allowed_tools.is_empty() {
+                    self.allowed = None;
+                } else {
+                    self.allowed = Some(skill.meta.allowed_tools.clone());
                 }
             }
         }

--- a/koda-core/src/skill_scope.rs
+++ b/koda-core/src/skill_scope.rs
@@ -1,0 +1,306 @@
+//! Skill-scoped tool filtering.
+//!
+//! When a skill with `allowed_tools` is activated, only those tools
+//! (plus meta-tools like `ActivateSkill`, `ListSkills`, `ListAgents`,
+//! `InvokeAgent`) are sent to the LLM. This is the "hard enforcement"
+//! counterpart to the prompt hint in `activate_skill()`.
+//!
+//! ## How it works
+//!
+//! 1. The inference loop creates a `SkillToolScope` (initially empty).
+//! 2. After each tool dispatch round, if an `ActivateSkill` call was made,
+//!    the loop calls `update_from_tool_calls()` with the tool call names
+//!    and args.
+//! 3. `SkillToolScope` inspects the skill registry to check if the
+//!    activated skill has `allowed_tools`.
+//! 4. On the next iteration, `filter_tool_defs()` returns only the
+//!    in-scope tools.
+//!
+//! ## Meta-tools
+//!
+//! These tools are always available regardless of scope, so the model
+//! can switch skills or delegate:
+//!
+//! - `ActivateSkill`, `ListSkills`
+//! - `ListAgents`, `InvokeAgent`
+//! - `AskUser`
+//!
+//! ## Lifecycle
+//!
+//! - Activating a skill with `allowed_tools` → scope is set
+//! - Activating a skill without `allowed_tools` → scope is cleared
+//! - No `ActivateSkill` call → scope unchanged
+
+use crate::providers::ToolDefinition;
+use crate::skills::SkillRegistry;
+
+/// Tools that are always available regardless of skill scope.
+///
+/// These let the model switch skills, delegate, or ask the user for help
+/// even when scoped to a restricted tool set.
+const META_TOOLS: &[&str] = &[
+    "ActivateSkill",
+    "ListSkills",
+    "ListAgents",
+    "InvokeAgent",
+    "AskUser",
+];
+
+/// Tracks the active skill's tool scope during an inference loop.
+///
+/// Created once per `inference_loop` invocation. Updated after each
+/// tool dispatch round.
+#[derive(Debug, Default)]
+pub struct SkillToolScope {
+    /// Tool names allowed by the active skill, or `None` for unrestricted.
+    allowed: Option<Vec<String>>,
+}
+
+impl SkillToolScope {
+    /// Create a new unrestricted scope.
+    pub fn new() -> Self {
+        Self { allowed: None }
+    }
+
+    /// Check tool calls for `ActivateSkill` and update the scope accordingly.
+    ///
+    /// Call this after each tool dispatch round with the names and args
+    /// of all tool calls from that round.
+    pub fn update_from_tool_calls(
+        &mut self,
+        tool_calls: &[(String, serde_json::Value)],
+        registry: &SkillRegistry,
+    ) {
+        for (name, args) in tool_calls {
+            if name == "ActivateSkill" {
+                if let Some(skill_name) = args.get("skill_name").and_then(|v| v.as_str()) {
+                    if let Some(skill) = registry.get(skill_name) {
+                        if skill.meta.allowed_tools.is_empty() {
+                            self.allowed = None;
+                        } else {
+                            self.allowed = Some(skill.meta.allowed_tools.clone());
+                        }
+                    }
+                    // If skill not found, don't change scope — the error
+                    // message from activate_skill() is enough.
+                }
+            }
+        }
+    }
+
+    /// Whether the scope is currently restricting tools.
+    pub fn is_active(&self) -> bool {
+        self.allowed.is_some()
+    }
+
+    /// Filter tool definitions to only include in-scope tools.
+    ///
+    /// Returns the full set (cloned) if no scope is active. Otherwise returns
+    /// only tools whose names match `allowed_tools` or are meta-tools.
+    pub fn filter_tool_defs(&self, tool_defs: &[ToolDefinition]) -> Vec<ToolDefinition> {
+        match &self.allowed {
+            None => tool_defs.to_vec(),
+            Some(allowed) => tool_defs
+                .iter()
+                .filter(|td| allowed.contains(&td.name) || META_TOOLS.contains(&td.name.as_str()))
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Check if a tool call is allowed under the current scope.
+    ///
+    /// Returns `None` if allowed, or `Some(error_message)` if blocked.
+    pub fn check_tool_call(&self, tool_name: &str) -> Option<String> {
+        match &self.allowed {
+            None => None,
+            Some(allowed) => {
+                if allowed.iter().any(|t| t == tool_name) || META_TOOLS.contains(&tool_name) {
+                    None
+                } else {
+                    Some(format!(
+                        "Tool '{tool_name}' is not allowed by the active skill scope. \
+                         Allowed tools: {}. \
+                         Use ActivateSkill to switch to a different skill.",
+                        allowed.join(", ")
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::{Skill, SkillMeta, SkillSource};
+
+    fn make_registry() -> SkillRegistry {
+        let mut registry = SkillRegistry::default();
+        // Scoped skill
+        registry.skills.insert(
+            "scoped".to_string(),
+            Skill {
+                meta: SkillMeta {
+                    name: "scoped".to_string(),
+                    description: "Scoped".to_string(),
+                    tags: vec![],
+                    when_to_use: None,
+                    allowed_tools: vec!["Read".to_string(), "Grep".to_string()],
+                    user_invocable: true,
+                    argument_hint: None,
+                    source: SkillSource::BuiltIn,
+                },
+                content: "scoped content".to_string(),
+            },
+        );
+        // Unscoped skill
+        registry.add_builtin("unscoped", "Unscoped", None, "unscoped content");
+        registry
+    }
+
+    fn tool_defs() -> Vec<ToolDefinition> {
+        [
+            "Read",
+            "Grep",
+            "Write",
+            "Bash",
+            "ActivateSkill",
+            "ListSkills",
+        ]
+        .iter()
+        .map(|n| ToolDefinition {
+            name: n.to_string(),
+            description: format!("{n} tool"),
+            parameters: serde_json::json!({}),
+        })
+        .collect()
+    }
+
+    #[test]
+    fn test_no_scope_passes_all_tools() {
+        let scope = SkillToolScope::new();
+        let defs = tool_defs();
+        let filtered = scope.filter_tool_defs(&defs);
+        assert_eq!(filtered.len(), defs.len());
+    }
+
+    #[test]
+    fn test_activate_scoped_skill_filters_tools() {
+        let registry = make_registry();
+        let mut scope = SkillToolScope::new();
+        let calls = vec![(
+            "ActivateSkill".to_string(),
+            serde_json::json!({"skill_name": "scoped"}),
+        )];
+        scope.update_from_tool_calls(&calls, &registry);
+
+        assert!(scope.is_active());
+
+        let defs = tool_defs();
+        let filtered = scope.filter_tool_defs(&defs);
+        let names: Vec<&str> = filtered.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"Read"));
+        assert!(names.contains(&"Grep"));
+        assert!(names.contains(&"ActivateSkill")); // meta-tool always present
+        assert!(names.contains(&"ListSkills")); // meta-tool always present
+        assert!(!names.contains(&"Write")); // not in allowed_tools
+        assert!(!names.contains(&"Bash")); // not in allowed_tools
+    }
+
+    #[test]
+    fn test_activate_unscoped_skill_clears_scope() {
+        let registry = make_registry();
+        let mut scope = SkillToolScope::new();
+
+        // First activate scoped
+        scope.update_from_tool_calls(
+            &[(
+                "ActivateSkill".to_string(),
+                serde_json::json!({"skill_name": "scoped"}),
+            )],
+            &registry,
+        );
+        assert!(scope.is_active());
+
+        // Then activate unscoped — scope should clear
+        scope.update_from_tool_calls(
+            &[(
+                "ActivateSkill".to_string(),
+                serde_json::json!({"skill_name": "unscoped"}),
+            )],
+            &registry,
+        );
+        assert!(!scope.is_active());
+    }
+
+    #[test]
+    fn test_check_tool_call_allowed() {
+        let registry = make_registry();
+        let mut scope = SkillToolScope::new();
+        scope.update_from_tool_calls(
+            &[(
+                "ActivateSkill".to_string(),
+                serde_json::json!({"skill_name": "scoped"}),
+            )],
+            &registry,
+        );
+
+        assert!(scope.check_tool_call("Read").is_none());
+        assert!(scope.check_tool_call("Grep").is_none());
+        assert!(scope.check_tool_call("ActivateSkill").is_none()); // meta
+        assert!(scope.check_tool_call("AskUser").is_none()); // meta
+
+        let err = scope.check_tool_call("Write");
+        assert!(err.is_some());
+        assert!(err.unwrap().contains("not allowed"));
+    }
+
+    #[test]
+    fn test_no_scope_allows_everything() {
+        let scope = SkillToolScope::new();
+        assert!(scope.check_tool_call("Write").is_none());
+        assert!(scope.check_tool_call("Bash").is_none());
+        assert!(scope.check_tool_call("anything").is_none());
+    }
+
+    #[test]
+    fn test_unknown_skill_preserves_scope() {
+        let registry = make_registry();
+        let mut scope = SkillToolScope::new();
+
+        // Activate scoped first
+        scope.update_from_tool_calls(
+            &[(
+                "ActivateSkill".to_string(),
+                serde_json::json!({"skill_name": "scoped"}),
+            )],
+            &registry,
+        );
+        assert!(scope.is_active());
+
+        // Try activating non-existent skill — scope should not change
+        scope.update_from_tool_calls(
+            &[(
+                "ActivateSkill".to_string(),
+                serde_json::json!({"skill_name": "nope"}),
+            )],
+            &registry,
+        );
+        assert!(scope.is_active());
+    }
+
+    #[test]
+    fn test_non_activate_calls_ignored() {
+        let registry = make_registry();
+        let mut scope = SkillToolScope::new();
+        scope.update_from_tool_calls(
+            &[(
+                "Read".to_string(),
+                serde_json::json!({"file_path": "foo.rs"}),
+            )],
+            &registry,
+        );
+        assert!(!scope.is_active());
+    }
+}


### PR DESCRIPTION
## What & Why

Closes #746.

Previously, skill `allowed_tools` was only a **prompt hint** — the model could still call blocked tools from cached context or hallucination. Now enforcement is **hard**, matching Claude Code's approach of scoping tool permissions at the session level.

---

## How It Works

1. **Tool definitions filtered** — only in-scope tools are sent to the LLM, so blocked tools literally don't exist in the model's tool set.
2. **Blocked calls rejected** — if the model still attempts a blocked tool (e.g., from cached context), the call returns an error: `"Tool 'Write' is not allowed by the active skill scope."`.
3. **Meta-tools always available** — `ActivateSkill`, `ListSkills`, `ListAgents`, `InvokeAgent`, `AskUser` are never blocked, so the model can switch skills or ask for help.
4. **Scope auto-clears** — activating a skill without `allowed_tools` restores the full tool set.
5. **Scope transitions logged** — `🔒 Skill tool scope activated` / `🔓 Skill tool scope cleared`.

---

## Changes

### New: `koda-core/src/skill_scope.rs`
- `SkillToolScope` struct: tracks `Option<Vec<String>>` of allowed tool names
- `update_from_tool_calls()` — inspects tool calls for `ActivateSkill`, updates scope from skill registry
- `filter_tool_defs()` — returns filtered `Vec<ToolDefinition>` (only in-scope + meta-tools)
- `check_tool_call()` — returns `Option<String>` error if a tool call is blocked
- 7 unit tests: filtering, enforcement, scope transitions, edge cases

### Modified: `koda-core/src/inference.rs`
- Creates `SkillToolScope` at inference loop start
- Filters `tool_defs` through scope before each LLM call
- Rejects blocked tool calls before dispatch (records error results)
- Updates scope after each tool dispatch round
- Logs scope transitions as info events

### Modified: `koda-core/src/instructions.md`
- Updated skill tool scoping rule to reflect hard enforcement

### Modified: `docs/src/skills.md`
- Added "How `allowed_tools` enforcement works" section

---

## Tests

All 311 tests pass (264 + 47 integration). 7 new unit tests in `skill_scope.rs`:
- `test_no_scope_passes_all_tools`
- `test_activate_scoped_skill_filters_tools`
- `test_activate_unscoped_skill_clears_scope`
- `test_check_tool_call_allowed`
- `test_no_scope_allows_everything`
- `test_unknown_skill_preserves_scope`
- `test_non_activate_calls_ignored`
