### PR TITLE
feat(skills): add simplify, debug, remember bundled skills

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# .githooks/pre-push — mirrors the Lint CI job locally.
+#
+# Runs before every `git push`. Skip with `git push --no-verify` if you
+# need to push a WIP branch and let CI catch issues instead.
+#
+# One-time setup (per clone):
+#   git config core.hooksPath .githooks
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+fail() { echo -e "${RED}✗${NC} $*"; }
+info() { echo -e "${YELLOW}→${NC} $*"; }
+
+info "Running pre-push checks (skip with --no-verify)..."
+echo
+
+# --- Format ------------------------------------------------------------------
+info "cargo fmt"
+if cargo fmt --all --check; then
+    ok "fmt clean"
+else
+    fail "fmt: run 'cargo fmt --all' to fix"
+    exit 1
+fi
+
+# --- Clippy ------------------------------------------------------------------
+info "cargo clippy"
+if cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings 2>&1; then
+    ok "clippy clean"
+else
+    fail "clippy: fix the warnings above"
+    exit 1
+fi
+
+echo
+ok "All checks passed — pushing."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -32,10 +32,22 @@ fi
 
 # --- Clippy ------------------------------------------------------------------
 info "cargo clippy"
-if cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings 2>&1; then
+if cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings; then
     ok "clippy clean"
 else
     fail "clippy: fix the warnings above"
+    exit 1
+fi
+
+# --- Check (no features) -----------------------------------------------------
+# Compiles every target without optional features to catch cfg-gated items
+# that are invisible when a feature flag is active. Mirrors CI exactly.
+# (This is what caught the missing required-features stanza in #737.)
+info "cargo check (no features)"
+if cargo check --workspace --all-targets; then
+    ok "check clean"
+else
+    fail "check: fix the errors above"
     exit 1
 fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,18 @@ cargo build
 cargo test --workspace --features koda-core/test-support
 ```
 
+## Local checks (one-time setup)
+
+Activate the pre-push hook to catch `fmt` and `clippy` failures before they
+hit CI:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook mirrors the Lint CI job exactly. Skip it for a WIP push with
+`git push --no-verify`.
+
 ## Reporting Issues
 
 The easiest contribution is

--- a/koda-core/skills/debug/SKILL.md
+++ b/koda-core/skills/debug/SKILL.md
@@ -16,9 +16,30 @@ Help the user diagnose an issue they're encountering with koda. Work through the
 
 The user's issue: {{args}}
 
-If no issue was described, read the config and environment and summarise anything that looks wrong.
+If no issue was described, read the config, logs, and environment and summarise anything that looks wrong.
 
-## Step 1: Environment and API Keys
+## Step 1: Session Log
+
+Koda writes a rolling daily log to `~/.config/koda/logs/`. Read the most recent file:
+
+```bash
+# Find the latest log file
+ls -t ~/.config/koda/logs/ | head -5
+
+# Tail the last 50 lines (logs may be sparse until issue #758 lands)
+tail -50 ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null \
+  || tail -50 ~/.config/koda/logs/$(ls -t ~/.config/koda/logs/ | head -1) 2>/dev/null \
+  || echo "(no log file found)"
+```
+
+Search for errors and warnings:
+```bash
+grep -E "ERROR|WARN" ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null | tail -20
+```
+
+Note: logs are currently sparse — instrumentation is being improved in issue #758. If the log is empty, proceed to the steps below.
+
+## Step 2: Environment and API Keys
 
 Check which provider is configured and whether its key is present:
 
@@ -32,7 +53,7 @@ Common issues:
 - Key set but for wrong provider → check `~/.config/koda/settings.toml` for the active provider
 - Custom base URL pointing to unreachable endpoint
 
-## Step 2: Settings File
+## Step 3: Settings File
 
 Read the koda settings file:
 
@@ -45,7 +66,7 @@ Check for:
 - `model` — does it exist on that provider?
 - `base_url` — is it reachable?
 
-## Step 3: Agent and Skill Config
+## Step 4: Agent and Skill Config
 
 List any user-level agent or skill overrides:
 
@@ -56,7 +77,7 @@ ls ~/.config/koda/skills/ 2>/dev/null && echo "---skills above---" || echo "(no 
 
 If custom agents exist, read any that seem relevant to the issue.
 
-## Step 4: API Connectivity Test
+## Step 5: API Connectivity Test
 
 Test raw connectivity to the configured provider endpoint. Use the base URL from settings.toml or the provider default:
 
@@ -78,7 +99,7 @@ Expected: HTTP 200. Common failures:
 - 403 → key exists but no access to model
 - 000 or connection refused → network issue, wrong base URL, VPN required
 
-## Step 5: Memory Files
+## Step 6: Memory Files
 
 Check whether memory files exist and are well-formed:
 
@@ -90,10 +111,12 @@ wc -l ./CLAUDE.md 2>/dev/null || echo "(no CLAUDE.md)"
 
 Large memory files (>500 lines) can cause context overflow. If suspiciously large, read the first 50 lines.
 
-## Step 6: Summarise Findings
+## Step 7: Summarise Findings
 
 After running all steps, provide:
 
 1. **Root cause** (if found) — be specific
 2. **Fix** — exact command or change needed
-3. **If unresolved** — what additional information to collect (e.g., run koda with `RUST_LOG=debug koda ...` and share the output)
+3. **If unresolved** — what additional information to collect:
+   - Run koda with `RUST_LOG=koda_core=debug,koda_cli=debug koda ...` and share the resulting log file
+   - Or set `RUST_LOG=debug` for maximum verbosity (very noisy)

--- a/koda-core/skills/debug/SKILL.md
+++ b/koda-core/skills/debug/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: debug
+description: Diagnose koda issues — checks provider config, API connectivity, settings, and environment.
+tags: [debug, diagnostics, troubleshooting, config]
+when_to_use: Use when koda is misbehaving — wrong provider, API errors, tools not working, unexpected behaviour. Describe the issue and this skill will guide a systematic diagnosis.
+argument_hint: [issue description, e.g. "API calls are failing with 401"]
+allowed_tools: [Read, Grep, Glob, List, Bash]
+user_invocable: true
+---
+
+# Debug: Diagnose Koda Issues
+
+Help the user diagnose an issue they're encountering with koda. Work through the checklist below, run each command, and report findings. Do not skip steps — a step that passes is still useful information.
+
+## Issue Description
+
+The user's issue: {{args}}
+
+If no issue was described, read the config and environment and summarise anything that looks wrong.
+
+## Step 1: Environment and API Keys
+
+Check which provider is configured and whether its key is present:
+
+```bash
+# Show relevant env vars (mask actual key values)
+env | grep -E "KODA|OPENAI|ANTHROPIC|GEMINI|GROQ|MISTRAL|DEEPSEEK|FIREWORKS|TOGETHER|API_KEY|API_BASE" | sed 's/=.*/=<set>/'
+```
+
+Common issues:
+- Key env var not set → `export OPENAI_API_KEY=...` (or whichever provider)
+- Key set but for wrong provider → check `~/.config/koda/settings.toml` for the active provider
+- Custom base URL pointing to unreachable endpoint
+
+## Step 2: Settings File
+
+Read the koda settings file:
+
+```bash
+cat ~/.config/koda/settings.toml 2>/dev/null || echo "(no settings.toml found — using defaults)"
+```
+
+Check for:
+- `provider` — is it what the user expects?
+- `model` — does it exist on that provider?
+- `base_url` — is it reachable?
+
+## Step 3: Agent and Skill Config
+
+List any user-level agent or skill overrides:
+
+```bash
+ls ~/.config/koda/agents/ 2>/dev/null && echo "---agents above---" || echo "(no user agents)"
+ls ~/.config/koda/skills/ 2>/dev/null && echo "---skills above---" || echo "(no user skills)"
+```
+
+If custom agents exist, read any that seem relevant to the issue.
+
+## Step 4: API Connectivity Test
+
+Test raw connectivity to the configured provider endpoint. Use the base URL from settings.toml or the provider default:
+
+```bash
+# OpenAI-compatible (OpenAI, Groq, Fireworks, local LM Studio, etc.)
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  https://api.openai.com/v1/models 2>&1 | head -5
+
+# Anthropic
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  https://api.anthropic.com/v1/models 2>&1
+```
+
+Expected: HTTP 200. Common failures:
+- 401 → wrong or missing API key
+- 403 → key exists but no access to model
+- 000 or connection refused → network issue, wrong base URL, VPN required
+
+## Step 5: Memory Files
+
+Check whether memory files exist and are well-formed:
+
+```bash
+wc -l ~/.config/koda/memory.md 2>/dev/null || echo "(no global memory)"
+wc -l ./MEMORY.md 2>/dev/null || echo "(no project memory)"
+wc -l ./CLAUDE.md 2>/dev/null || echo "(no CLAUDE.md)"
+```
+
+Large memory files (>500 lines) can cause context overflow. If suspiciously large, read the first 50 lines.
+
+## Step 6: Summarise Findings
+
+After running all steps, provide:
+
+1. **Root cause** (if found) — be specific
+2. **Fix** — exact command or change needed
+3. **If unresolved** — what additional information to collect (e.g., run koda with `RUST_LOG=debug koda ...` and share the output)

--- a/koda-core/skills/remember/SKILL.md
+++ b/koda-core/skills/remember/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: remember
+description: Review auto-memory entries and propose promotions, cleanups, and deduplication across all memory layers.
+tags: [memory, review, cleanup, organisation]
+when_to_use: Use when you want to review, organise, or promote auto-memory entries. Also useful for cleaning up outdated or conflicting entries across MEMORY.md, global memory, and auto-memory.
+allowed_tools: [Read, Write, Edit, Bash, MemoryRead, MemoryWrite]
+user_invocable: true
+---
+
+# Memory Review
+
+## Goal
+
+Review koda's memory landscape and produce a clear report of proposed changes, grouped by action type. Do **NOT** apply changes — present proposals for user approval first.
+
+## Step 1: Gather All Memory Layers
+
+Read every active memory layer:
+
+1. **Auto-memory** — already in your system prompt context; review it there
+2. **Project memory** — read whichever file exists at the project root (first match wins):
+   - `MEMORY.md` — koda native
+   - `CLAUDE.md` — Claude Code compat
+   - `AGENTS.md` — Codex compat
+3. **Global memory** — read `~/.config/koda/memory.md`
+
+```bash
+# Check which project memory file is active
+ls MEMORY.md CLAUDE.md AGENTS.md 2>/dev/null | head -1
+```
+
+**Success criteria**: you have the contents of all three layers and can compare them.
+
+## Step 2: Classify Each Auto-Memory Entry
+
+For each substantive entry in auto-memory, determine the best destination:
+
+| Destination | What belongs there | Examples |
+|---|---|---|
+| **MEMORY.md** (project) | Project conventions and instructions that all contributors working with koda in this repo should follow | "use `cargo nextest` not `cargo test`", "API routes use kebab-case", "always run `cargo clippy` before committing" |
+| **Global memory** (`~/.config/koda/memory.md`) | Personal preferences specific to this user, not tied to any one project | "I prefer concise responses", "always explain trade-offs", "don't auto-commit", "run tests before committing" |
+| **Stay in auto-memory** | Working notes, temporary context, or entries that don't clearly fit elsewhere | Session-specific observations, uncertain patterns, one-off notes |
+
+**Important distinctions:**
+- `MEMORY.md` and global memory contain instructions for koda, not preferences for external tools (editor theme, IDE keybindings, shell aliases don't belong in either)
+- Workflow practices (PR conventions, merge strategy, branch naming) are ambiguous — ask the user whether they're personal or project-wide
+- When unsure, ask rather than guess
+
+**Success criteria**: every entry has a proposed destination, or is flagged as ambiguous.
+
+## Step 3: Identify Cleanup Opportunities
+
+Scan across all layers for:
+
+- **Duplicates**: auto-memory entries already captured in `MEMORY.md` or global memory → propose removing from auto-memory
+- **Outdated**: entries in `MEMORY.md` or global memory contradicted by newer auto-memory entries → propose updating the older layer
+- **Conflicts**: contradictions between any two layers → propose resolution, noting which is more recent
+- **Bloat**: very long auto-memory entries that could be summarised without losing meaning
+
+**Success criteria**: all cross-layer issues identified.
+
+## Step 4: Present the Report
+
+Output a structured report grouped by action type:
+
+1. **Promotions** — entries to move, with destination and rationale
+2. **Cleanup** — duplicates, outdated entries, conflicts to resolve
+3. **Ambiguous** — entries where you need the user's input before acting
+4. **No action needed** — brief note on entries that should stay put
+
+If auto-memory is empty, say so and offer to review `MEMORY.md` and global memory for stale content.
+
+## Rules
+
+- Present **ALL** proposals before making any changes
+- Do **NOT** modify files without explicit user approval for each change
+- Do **NOT** create new memory files unless the user confirms they want one
+- Ask about ambiguous entries — do not guess

--- a/koda-core/skills/simplify/SKILL.md
+++ b/koda-core/skills/simplify/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: simplify
+description: Review changed code for reuse, quality, and efficiency — then fix any issues found.
+tags: [review, quality, refactor, cleanup]
+when_to_use: Use after finishing an implementation to catch duplication, hacky patterns, and inefficiencies before committing. Runs three parallel review agents then applies fixes.
+argument_hint: [optional focus area, e.g. "focus on error handling"]
+user_invocable: true
+---
+
+# Simplify: Code Review and Cleanup
+
+Review all changed files for reuse, quality, and efficiency. Fix any issues found.
+
+## Phase 1: Identify Changes
+
+Run `git diff` (or `git diff HEAD` if there are staged changes) to see what changed. If there are no git changes, review the most recently modified files that the user mentioned or that you edited earlier in this conversation.
+
+## Phase 2: Launch Three Review Agents in Parallel
+
+Use `InvokeAgent` to launch all three agents concurrently in a **single message**. Pass each agent the full diff so it has complete context.
+
+### Agent 1: Code Reuse Review
+
+For each change:
+
+1. **Search for existing utilities and helpers** that could replace newly written code. Look for similar patterns elsewhere in the codebase — utility directories, shared modules, and files adjacent to the changed ones.
+2. **Flag any new function that duplicates existing functionality.** Suggest the existing function to use instead.
+3. **Flag any inline logic that could use an existing utility** — hand-rolled string manipulation, manual path handling, custom environment checks, ad-hoc type guards, and similar patterns are common candidates.
+
+### Agent 2: Code Quality Review
+
+Review the same changes for hacky patterns:
+
+1. **Redundant state**: state that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls
+2. **Parameter sprawl**: adding new parameters to a function instead of generalizing or restructuring existing ones
+3. **Copy-paste with slight variation**: near-duplicate code blocks that should be unified with a shared abstraction
+4. **Leaky abstractions**: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+5. **Stringly-typed code**: using raw strings where constants, enums, or typed wrappers already exist in the codebase
+6. **Unnecessary structural nesting**: wrapper types, layers, or modules that add no value — check if inner element properties already provide the needed behaviour
+7. **Unnecessary comments**: comments that narrate WHAT the code does (well-named identifiers do that), reference the task/caller, or describe the change — delete them; keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds)
+
+### Agent 3: Efficiency Review
+
+Review the same changes for efficiency:
+
+1. **Unnecessary work**: redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns
+2. **Missed concurrency**: independent operations run sequentially when they could run in parallel with `InvokeAgent` or parallel tool calls
+3. **Hot-path bloat**: new blocking work added to startup or per-request hot paths
+4. **Recurring no-op updates**: state updates inside polling loops or event handlers that fire unconditionally — add change-detection so downstream consumers aren't notified when nothing changed
+5. **Unnecessary existence checks**: pre-checking file/resource existence before operating (TOCTOU anti-pattern) — operate directly and handle the error instead
+6. **Memory**: unbounded data structures, missing cleanup, leaked resources
+7. **Overly broad operations**: reading entire files when only a portion is needed, loading all records when filtering for one
+
+## Phase 3: Fix Issues
+
+Wait for all three agents to complete. Aggregate their findings and fix each issue directly in the code. If a finding is a false positive or not worth addressing, note it and move on — do not argue with it, just skip it.
+
+When done, briefly summarise what was fixed (or confirm the code was already clean).

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -138,6 +138,18 @@ impl SkillRegistry {
                 "security-audit",
                 include_str!("../skills/security-audit/SKILL.md"),
             ),
+            (
+                "simplify",
+                include_str!("../skills/simplify/SKILL.md"),
+            ),
+            (
+                "debug",
+                include_str!("../skills/debug/SKILL.md"),
+            ),
+            (
+                "remember",
+                include_str!("../skills/remember/SKILL.md"),
+            ),
         ];
 
         for (name, content) in builtins {
@@ -509,6 +521,9 @@ Do the review.
         assert!(registry.len() >= 2);
         assert!(registry.activate("code-review").is_some());
         assert!(registry.activate("security-audit").is_some());
+        assert!(registry.activate("simplify").is_some());
+        assert!(registry.activate("debug").is_some());
+        assert!(registry.activate("remember").is_some());
     }
 
     #[test]
@@ -517,8 +532,9 @@ Do the review.
         registry.load_builtin();
 
         let results = registry.search("review");
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].name, "code-review");
+        // code-review, simplify, and remember all contain "review" in their metadata
+        assert!(results.len() >= 1);
+        assert!(results.iter().any(|s| s.name == "code-review"));
 
         let results = registry.search("security");
         assert_eq!(results.len(), 1);
@@ -571,9 +587,14 @@ Do the review.
         registry.load_builtin();
 
         let list = registry.list();
-        assert!(list.len() >= 2);
-        assert_eq!(list[0].name, "code-review");
-        assert_eq!(list[1].name, "security-audit");
+        let names: Vec<&str> = list.iter().map(|s| s.name.as_str()).collect();
+        // Sorted alphabetically: code-review, debug, remember, security-audit, simplify
+        assert!(list.len() >= 5);
+        assert_eq!(names[0], "code-review");
+        assert_eq!(names[1], "debug");
+        assert_eq!(names[2], "remember");
+        assert_eq!(names[3], "security-audit");
+        assert_eq!(names[4], "simplify");
     }
 
     #[test]

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -524,7 +524,7 @@ Do the review.
 
         let results = registry.search("review");
         // code-review, simplify, and remember all contain "review" in their metadata
-        assert!(results.len() >= 1);
+        assert!(!results.is_empty());
         assert!(results.iter().any(|s| s.name == "code-review"));
 
         let results = registry.search("security");

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -138,18 +138,9 @@ impl SkillRegistry {
                 "security-audit",
                 include_str!("../skills/security-audit/SKILL.md"),
             ),
-            (
-                "simplify",
-                include_str!("../skills/simplify/SKILL.md"),
-            ),
-            (
-                "debug",
-                include_str!("../skills/debug/SKILL.md"),
-            ),
-            (
-                "remember",
-                include_str!("../skills/remember/SKILL.md"),
-            ),
+            ("simplify", include_str!("../skills/simplify/SKILL.md")),
+            ("debug", include_str!("../skills/debug/SKILL.md")),
+            ("remember", include_str!("../skills/remember/SKILL.md")),
         ];
 
         for (name, content) in builtins {


### PR DESCRIPTION
Closes #753

## Summary

Adds the three P0 bundled skills from #753. All embedded at compile time via `include_str!`, registered through the existing skill infrastructure — zero new Rust infrastructure needed.

---

## New skills

### `simplify` — Code review and cleanup

Three-phase workflow adapted from CC's `simplify.ts`:
1. `git diff` to identify what changed
2. Launch **three InvokeAgent calls in parallel** (reuse / quality / efficiency)
3. Aggregate findings and fix in place

Reuse agent finds duplicated logic. Quality agent catches redundant state, parameter sprawl, copy-paste blocks, leaky abstractions, stringly-typed code, and unnecessary comments. Efficiency agent finds redundant work, missed concurrency, hot-path bloat, and memory leaks.

### `debug` — Diagnose koda issues

Koda-native. Seven-step diagnosis:
1. **Session log** — reads `~/.config/koda/logs/koda.log.YYYY-MM-DD` (koda's actual rolling log file), grep for ERROR/WARN. Note: logs are currently sparse due to a broken filter — tracked in #758. Includes `RUST_LOG` workaround.
2. Env var check — API keys, provider config (masked)
3. `~/.config/koda/settings.toml` inspection
4. User agent/skill override inventory
5. Raw API connectivity test via `curl`
6. Memory file sanity check
7. Root-cause summary with fix or escalation path

`allowed_tools: [Read, Grep, Glob, List, Bash]` — read-only.

### `remember` — Memory review and promotion

Adapted from CC's `remember.ts`, mapped to koda's three memory layers:
- **Auto-memory** — already in the system prompt context
- **Project memory** — `MEMORY.md` / `CLAUDE.md` / `AGENTS.md` at project root
- **Global memory** — `~/.config/koda/memory.md`

Classifies each auto-memory entry, detects duplicates/conflicts/outdated entries, presents a structured report (Promotions / Cleanup / Ambiguous / No action). **Applies nothing without explicit user approval.**

`allowed_tools: [Read, Write, Edit, Bash, MemoryRead, MemoryWrite]`

---

## `skills.rs` changes

- `load_builtin()`: embed all three new skills via `include_str!`
- `test_builtin_skills_load`: assert all 5 builtins activate
- `test_list_sorted`: assert correct alphabetical order
- `test_search("review")`: relaxed from exact-count to contains-assert

---

## Related issues created during review

- #758 — fix tracing filter + add instrumentation (debug skill will get richer once this lands)
- #759 — use `tracing-test` to assert log output in integration tests (prereq: #758)

---

## What's NOT in this PR (per #753 discussion)

- `review` agent — dropped (DRY violation with `code-review` skill)
- `verify` skill — dropped (verify agent is adversarially stronger)
- `update-config` skill — dropped (YAGNI)
- `skillify` — tracked in #755
- `koda-guide` — tracked in #756

---

## Testing

- `cargo build` — clean ✅
- `cargo test -p koda-core` — 34/34 skills tests pass ✅
