### PR TITLE
chore(ci): gate docs chapter size at 8KB per file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,38 @@ jobs:
       - name: Run audit
         run: cargo audit || true  # Advisory-only, don't fail CI
 
+  docs-size:
+    name: Docs Chapter Size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check chapter sizes
+        run: |
+          # Guard against individual doc chapters growing unbounded.
+          # Each docs/src/*.md chapter is capped at 8 192 bytes (~2 K tokens).
+          # At this cap, the full embedded blob stays under ~144 KB even if
+          # every chapter simultaneously hits the limit — still acceptable for
+          # an infrequently activated skill.
+          #
+          # SUMMARY.md is the mdBook table of contents and grows naturally as
+          # chapters are added — it is excluded from this gate.
+          #
+          # To raise the cap: bump MAX_BYTES and explain why in the commit
+          # message (e.g. "commands.md now covers sub-commands — 10 KB needed").
+          MAX_BYTES=8192
+          FAILED=0
+          for f in docs/src/*.md; do
+            [ "$(basename "$f")" = "SUMMARY.md" ] && continue
+            size=$(wc -c < "$f")
+            if [ "$size" -gt "$MAX_BYTES" ]; then
+              echo "❌  $f: ${size}B exceeds cap of ${MAX_BYTES}B"
+              FAILED=1
+            else
+              printf "✅  %-45s %5dB\n" "$f" "$size"
+            fi
+          done
+          exit $FAILED
+
   coverage:
     name: Coverage
     needs: test


### PR DESCRIPTION
## Summary

Adds a `docs-size` CI job that checks each `docs/src/*.md` chapter against an 8 192-byte cap on every PR. Closes #741.

## Design decisions

**Source files, not build artifact.** The original #741 proposed gating the concatenated `koda_docs.md` output from `build.rs`. This PR gates the source `.md` files directly — no build step, no artifact to find, check fires where a contributor would actually make the edit.

**SUMMARY.md excluded.** It is the mdBook table of contents. It grows whenever a chapter is *added*, not when chapters get bloated. Gating it would penalise adding new chapters.

**8 KB cap.** Largest chapter today is `commands.md` at 4 788 B. The cap gives ~67% headroom for legitimate expansion before the gate fires. At the cap, the full embedded blob stays under ~144 KB across all 18 chapters — still negligible for an infrequently activated skill.

**No `needs:` dependency.** The job only needs `checkout` and `wc`. Runs fully in parallel with `lint`/`test`/`audit` — zero added latency to the critical path.

**How to raise the cap.** Bump `MAX_BYTES` in the workflow and explain why in the commit message. The advisory comment in the job says exactly that.

## History

This issue went through significant design exploration before landing here:
- #741 originally proposed gating the concatenated artifact
- #760 proposed a full redesign (dynamic skill content, callable functions, per-chapter `include_str!` constants) — closed as over-engineered after analysis showed 26 KB / $0.02 per call on a rarely-activated skill is not a real problem
- #741 reopened with narrowed scope: gate source files, nothing else