### PR TITLE
fix(tracing): fix zero-bytes log — replace dead filter with EnvFilter

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -192,7 +192,12 @@ pub(crate) async fn run() -> Result<()> {
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
     tracing_subscriber::fmt()
         .with_writer(non_blocking)
-        .with_env_filter("koda_agent=debug")
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                tracing_subscriber::EnvFilter::new("koda_core=info,koda_cli=info")
+            }),
+        )
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .init();
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);


### PR DESCRIPTION
## What

Fixes the log-always-empty bug from #762 (PR 1 of 3).

## Root cause

`koda-cli/src/app.rs` had a hardcoded filter `"koda_agent=debug"`. The target `koda_agent` does not exist anywhere in the codebase — it was never registered. Every `tracing::info!`, `warn!`, `error!` call in `koda_core` and `koda_cli` was silently dropped. Every log file was 0 bytes.

## Fix (6-line diff)

```rust
// before
.with_env_filter("koda_agent=debug")

// after
.with_env_filter(
    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
        tracing_subscriber::EnvFilter::new("koda_core=info,koda_cli=info")
    }),
)
.with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
```

**`EnvFilter::try_from_default_env()`** reads `RUST_LOG` at startup; falls back to `koda_core=info,koda_cli=info` when unset. The targets match the actual crate names so all existing log calls now emit.

**`FmtSpan::CLOSE`** is added here — not strictly required for the bug fix, but it is the global gate for span close events with elapsed time. Without it, the `#[tracing::instrument]` work in PR 3 produces no timing output. Cost: one line.

## No dep changes

`tracing-subscriber` already declares `features = ["env-filter"]` in `koda-cli/Cargo.toml`. `FmtSpan` is in default features.

## Usage after this PR

```bash
# default — info from koda_core and koda_cli
koda "some prompt"
tail -f ~/.config/koda/logs/koda.log  # now has content

# debug — verbose, all targets
RUST_LOG=koda_core=debug,koda_cli=debug koda "some prompt"

# surgical — just inference
RUST_LOG=koda_core::inference=debug koda "some prompt"
```

## Acceptance criteria from #762
- [x] `RUST_LOG=koda_core=debug koda ...` produces non-empty log output
- [x] Default filter is `koda_core=info,koda_cli=info`; `RUST_LOG` overrides it

Part of #762. PRs 2 (per-session log file) and 3 (instrumentation) follow.