### PR TITLE
feat(tracing): per-process log file + 'latest' symlink

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -185,11 +185,24 @@ pub(crate) async fn run() -> Result<()> {
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
     let project_root = std::fs::canonicalize(&project_root)?;
 
-    // Initialize logging to file (invisible to user)
+    // Initialize logging to a per-process file (invisible to user).
+    //
+    // Each koda invocation gets its own log file named koda-<PID>.log.
+    // A 'latest' symlink is updated to point to it so users can always
+    // tail the current session without knowing the filename:
+    //   tail -f ~/.config/koda/logs/latest
     let log_dir = koda_core::db::config_dir()?.join("logs");
     std::fs::create_dir_all(&log_dir)?;
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "koda.log");
+    let log_filename = format!("koda-{}.log", std::process::id());
+    let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    // Best-effort symlink — silently skip on non-unix or permission errors.
+    #[cfg(unix)]
+    {
+        let latest = log_dir.join("latest");
+        let _ = std::fs::remove_file(&latest);
+        let _ = std::os::unix::fs::symlink(log_dir.join(&log_filename), &latest);
+    }
     tracing_subscriber::fmt()
         .with_writer(non_blocking)
         .with_env_filter(

--- a/koda-core/skills/debug/SKILL.md
+++ b/koda-core/skills/debug/SKILL.md
@@ -20,24 +20,20 @@ If no issue was described, read the config, logs, and environment and summarise 
 
 ## Step 1: Session Log
 
-Koda writes a rolling daily log to `~/.config/koda/logs/`. Read the most recent file:
+Koda writes a per-process log to `~/.config/koda/logs/`. A `latest` symlink always points to the current session's file:
 
 ```bash
-# Find the latest log file
-ls -t ~/.config/koda/logs/ | head -5
+# Tail the current session log
+tail -50 ~/.config/koda/logs/latest 2>/dev/null || echo "(no log file found)"
 
-# Tail the last 50 lines (logs may be sparse until issue #758 lands)
-tail -50 ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null \
-  || tail -50 ~/.config/koda/logs/$(ls -t ~/.config/koda/logs/ | head -1) 2>/dev/null \
-  || echo "(no log file found)"
+# List recent log files
+ls -lt ~/.config/koda/logs/ | head -10
 ```
 
 Search for errors and warnings:
 ```bash
-grep -E "ERROR|WARN" ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null | tail -20
+grep -E "ERROR|WARN" ~/.config/koda/logs/latest 2>/dev/null | tail -20
 ```
-
-Note: logs are currently sparse — instrumentation is being improved in issue #758. If the log is empty, proceed to the steps below.
 
 ## Step 2: Environment and API Keys
 


### PR DESCRIPTION
## What

PR 2 of 3 for #762. Stacked on #763 (the filter fix).

Replaces `rolling::daily` with a per-process log file and a `latest` symlink — borrowing the UX from CC's `~/.claude/debug/latest` pattern.

## Before

```
~/.config/koda/logs/koda.log.2026-04-08   ← all runs on the same day share one file
```
No way to isolate a specific session. To find today's log you had to know today's date.

## After

```
~/.config/koda/logs/koda-<PID>.log        ← one file per koda invocation
~/.config/koda/logs/latest                ← symlink, always points to the current run
```

`tail -f ~/.config/koda/logs/latest` just works, every time, regardless of what the PID was.

## Design choices

**PID as identifier.** The session ID from the DB is created after log init — it isn't available at the point where the file appender is constructed. PID is always available from stdlib (`std::process::id()`), adds no deps, and is unique enough in practice. The `latest` symlink handles the "I don't know the filename" case.

**`rolling::never`.** `tracing_appender::rolling::never(dir, filename)` creates a single file with no rotation — exactly what we want. Already in `tracing-appender 0.2.x` which is declared.

**Symlink is `#[cfg(unix)]` and best-effort.** On non-unix or permission-restricted dirs, koda still runs and logs to the per-process file; only the symlink is skipped. No `?` propagation — a symlink failure is never fatal.

## Files changed

- `koda-cli/src/app.rs` — appender construction + symlink
- `koda-core/skills/debug/SKILL.md` — Step 1 updated from date-suffix fallback dance to `latest`

## Acceptance criteria from #762
- [x] Each koda invocation writes to its own log file
- [x] `latest` symlink is updated on each run
- [x] `debug` skill updated to reference `latest`

Part of #762. PR 3 (instrumentation) follows.