### PR TITLE
feat(tracing): instrument execute_one_tool, execute_sub_agent, inference_loop

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -564,6 +564,7 @@ pub struct InferenceContext<'a> {
 }
 
 /// Run the inference loop: send messages, stream responses, dispatch tool calls.
+#[tracing::instrument(skip_all, fields(session_id = %ctx.session_id, agent = %ctx.config.agent_name))]
 pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let InferenceContext {
         project_root,

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -76,6 +76,7 @@ async fn run_bg_agent(
 ///
 /// Results are cached in `sub_agent_cache` keyed by `(agent_name, prompt_hash)`.
 /// On cache hit, returns immediately without any LLM calls.
+#[tracing::instrument(skip_all, fields(agent_name, cached = false))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_sub_agent(
     project_root: &Path,
@@ -93,6 +94,7 @@ pub(crate) async fn execute_sub_agent(
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"].as_str().unwrap_or("task");
+    tracing::Span::current().record("agent_name", agent_name);
     let prompt = args["prompt"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
@@ -144,6 +146,7 @@ pub(crate) async fn execute_sub_agent(
         sink.emit(EngineEvent::Info {
             message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
         });
+        tracing::Span::current().record("cached", true);
         return Ok(cached);
     }
 

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -192,6 +192,7 @@ pub(crate) fn can_parallelize(
 }
 
 /// Execute a single tool call, returning (tool_call_id, result_output, success).
+#[tracing::instrument(skip_all, fields(tool = %tc.function_name))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_one_tool(
     tc: &ToolCall,


### PR DESCRIPTION
## What

PR 3 of 3 for #762. Stacked on #764 (per-session log file). Closes #762.

Instruments the three zero-coverage execution paths using `#[tracing::instrument]`. With `FmtSpan::CLOSE` from PR 1, each span automatically emits a structured close event with elapsed time — no manual timing, no scattered `debug!` calls.

## The 5-line diff

```rust
// tool_dispatch.rs — every tool call, completely dark before this
#[tracing::instrument(skip_all, fields(tool = %tc.function_name))]
pub(crate) async fn execute_one_tool(…)

// sub_agent_dispatch.rs — agent spawn/return, one warn! before this
#[tracing::instrument(skip_all, fields(agent_name, cached = false))]
pub(crate) async fn execute_sub_agent(…) {
    let agent_name = args["agent_name"].as_str().unwrap_or("task");
    tracing::Span::current().record("agent_name", agent_name);  // ← set after parse
    …
    tracing::Span::current().record("cached", true);  // ← set on cache hit
    return Ok(cached);

// inference.rs — main loop, dark on the happy path before this
#[tracing::instrument(skip_all, fields(session_id = %ctx.session_id, agent = %ctx.config.agent_name))]
pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()>
```

## What you'll see in the log

```
2026-04-08T15:31:04.120Z  INFO koda_core::inference: close, session_id="abc-123", agent="task", time.busy=4.231s, time.idle=12ms
2026-04-08T15:31:04.080Z DEBUG koda_core::tool_dispatch: close, tool="Read", time.busy=3ms, time.idle=0ns
2026-04-08T15:31:04.090Z DEBUG koda_core::tool_dispatch: close, tool="Write", time.busy=1ms, time.idle=0ns
2026-04-08T15:31:04.100Z  INFO koda_core::sub_agent_dispatch: close, agent_name="plan", cached=false, time.busy=2.1s, time.idle=8ms
```

## Why `#[tracing::instrument]` over scattered `debug!`

A `debug!` approach requires: manually start a timer at entry, format the args as strings, log at exit, compute and log the duration — at every single callsite. `#[tracing::instrument]` does all of this declaratively. The fields reference actual function parameters so they survive refactoring. The timing comes from the subscriber, not the code.

## `agent_name` deferred recording

`execute_sub_agent` parses `agent_name` from a JSON string inside the body — it isn't available as a parameter. Tracing supports this via `Span::current().record("agent_name", value)` after the field is computed. The span is declared with `fields(agent_name)` (placeholder) and populated on the first line after the parse.

## Spans are hierarchical

Tool call spans nest inside `inference_loop` spans. Sub-agent spans nest inside `execute_one_tool` spans (since sub-agents are invoked via the `InvokeAgent` tool). The nesting is visible in any span-aware log viewer.

## Acceptance criteria from #762
- [x] A tool call appears in the log with name and duration
- [x] A sub-agent dispatch appears in the log with agent name, cache status, and duration
- [x] An inference loop span appears in the log with session ID, agent, and total duration