### PR TITLE
feat(tracing): per-process log file + 'latest' symlink

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -185,11 +185,24 @@ pub(crate) async fn run() -> Result<()> {
         .unwrap_or_else(|| std::env::current_dir().expect("Failed to get current directory"));
     let project_root = std::fs::canonicalize(&project_root)?;
 
-    // Initialize logging to file (invisible to user)
+    // Initialize logging to a per-process file (invisible to user).
+    //
+    // Each koda invocation gets its own log file named koda-<PID>.log.
+    // A 'latest' symlink is updated to point to it so users can always
+    // tail the current session without knowing the filename:
+    //   tail -f ~/.config/koda/logs/latest
     let log_dir = koda_core::db::config_dir()?.join("logs");
     std::fs::create_dir_all(&log_dir)?;
-    let file_appender = tracing_appender::rolling::daily(&log_dir, "koda.log");
+    let log_filename = format!("koda-{}.log", std::process::id());
+    let file_appender = tracing_appender::rolling::never(&log_dir, &log_filename);
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+    // Best-effort symlink — silently skip on non-unix or permission errors.
+    #[cfg(unix)]
+    {
+        let latest = log_dir.join("latest");
+        let _ = std::fs::remove_file(&latest);
+        let _ = std::os::unix::fs::symlink(log_dir.join(&log_filename), &latest);
+    }
     tracing_subscriber::fmt()
         .with_writer(non_blocking)
         .with_env_filter(

--- a/koda-core/skills/debug/SKILL.md
+++ b/koda-core/skills/debug/SKILL.md
@@ -20,24 +20,20 @@ If no issue was described, read the config, logs, and environment and summarise 
 
 ## Step 1: Session Log
 
-Koda writes a rolling daily log to `~/.config/koda/logs/`. Read the most recent file:
+Koda writes a per-process log to `~/.config/koda/logs/`. A `latest` symlink always points to the current session's file:
 
 ```bash
-# Find the latest log file
-ls -t ~/.config/koda/logs/ | head -5
+# Tail the current session log
+tail -50 ~/.config/koda/logs/latest 2>/dev/null || echo "(no log file found)"
 
-# Tail the last 50 lines (logs may be sparse until issue #758 lands)
-tail -50 ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null \
-  || tail -50 ~/.config/koda/logs/$(ls -t ~/.config/koda/logs/ | head -1) 2>/dev/null \
-  || echo "(no log file found)"
+# List recent log files
+ls -lt ~/.config/koda/logs/ | head -10
 ```
 
 Search for errors and warnings:
 ```bash
-grep -E "ERROR|WARN" ~/.config/koda/logs/koda.log.$(date +%Y-%m-%d) 2>/dev/null | tail -20
+grep -E "ERROR|WARN" ~/.config/koda/logs/latest 2>/dev/null | tail -20
 ```
-
-Note: logs are currently sparse — instrumentation is being improved in issue #758. If the log is empty, proceed to the steps below.
 
 ## Step 2: Environment and API Keys
 


### PR DESCRIPTION
Replaces the auto-closed #764 after rebase onto squash-merged main.

Replaces `rolling::daily` with a per-process log file and a `latest` symlink — borrowing the UX from CC's `~/.claude/debug/latest` pattern.

**Before:** `~/.config/koda/logs/koda.log.2026-04-08` — all runs on the same day share one file.

**After:** `~/.config/koda/logs/koda-<PID>.log` per invocation + `latest` symlink. `tail -f ~/.config/koda/logs/latest` always follows the current session.

Symlink is `#[cfg(unix)]` and best-effort. Debug skill Step 1 updated.

Part of #762, PR 2 of 3.