### PR TITLE
feat(tracing): instrument execute_one_tool, execute_sub_agent, inference_loop

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -564,6 +564,7 @@ pub struct InferenceContext<'a> {
 }
 
 /// Run the inference loop: send messages, stream responses, dispatch tool calls.
+#[tracing::instrument(skip_all, fields(session_id = %ctx.session_id, agent = %ctx.config.agent_name))]
 pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let InferenceContext {
         project_root,

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -76,6 +76,7 @@ async fn run_bg_agent(
 ///
 /// Results are cached in `sub_agent_cache` keyed by `(agent_name, prompt_hash)`.
 /// On cache hit, returns immediately without any LLM calls.
+#[tracing::instrument(skip_all, fields(agent_name, cached = false))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_sub_agent(
     project_root: &Path,
@@ -93,6 +94,7 @@ pub(crate) async fn execute_sub_agent(
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"].as_str().unwrap_or("task");
+    tracing::Span::current().record("agent_name", agent_name);
     let prompt = args["prompt"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
@@ -144,6 +146,7 @@ pub(crate) async fn execute_sub_agent(
         sink.emit(EngineEvent::Info {
             message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
         });
+        tracing::Span::current().record("cached", true);
         return Ok(cached);
     }
 

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -192,6 +192,7 @@ pub(crate) fn can_parallelize(
 }
 
 /// Execute a single tool call, returning (tool_call_id, result_output, success).
+#[tracing::instrument(skip_all, fields(tool = %tc.function_name))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_one_tool(
     tc: &ToolCall,


### PR DESCRIPTION
Final PR for #762. Rebased clean off main after #767 merged.

5 lines, 3 files, no new deps. Full stack (PR1+PR2+PR3) already passed CI on #767.

- `execute_one_tool`: `#[tracing::instrument(skip_all, fields(tool = %tc.function_name))]`
- `execute_sub_agent`: `fields(agent_name, cached = false)` + `Span::current().record()` after JSON parse and on cache hit
- `inference_loop`: `fields(session_id = %ctx.session_id, agent = %ctx.config.agent_name)`

With `FmtSpan::CLOSE` from PR1, each span emits a structured close event with elapsed time — zero manual timing code.

Closes #762.