### PR TITLE
test: MockProvider call recording + skip_memory isolation (#769)

### DIFF
--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -11,8 +11,8 @@ use crate::config::ModelSettings;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use tokio::sync::mpsc;
 
 static MOCK_CALL_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -62,11 +62,31 @@ impl MockResponse {
     }
 }
 
+/// Returns the shared global Arc that all `from_env()` providers write to.
+///
+/// Tests call `MockProvider::take_env_calls()` (feature = "test-support") to
+/// inspect what messages the sub-agent provider received without needing a
+/// direct reference to the provider instance.
+fn global_env_calls() -> Arc<Mutex<Vec<Vec<ChatMessage>>>> {
+    static CALLS: OnceLock<Arc<Mutex<Vec<Vec<ChatMessage>>>>> = OnceLock::new();
+    CALLS
+        .get_or_init(|| Arc::new(Mutex::new(Vec::new())))
+        .clone()
+}
+
 /// A mock LLM provider that returns scripted responses.
 ///
-/// Responses are consumed in FIFO order. Panics if exhausted.
+/// Responses are consumed in FIFO order. Graceful fallback to empty text when
+/// the queue is exhausted.
+///
+/// Every `chat()` / `chat_stream()` call records the received messages in
+/// `recorded_calls`. Providers created via `from_env()` additionally write to
+/// a shared global, letting tests inspect sub-agent calls without holding a
+/// direct reference to the provider.
 pub struct MockProvider {
     responses: Mutex<Vec<MockResponse>>,
+    /// Records every messages slice passed to `chat()` / `chat_stream()`.
+    recorded_calls: Arc<Mutex<Vec<Vec<ChatMessage>>>>,
 }
 
 impl MockProvider {
@@ -74,6 +94,7 @@ impl MockProvider {
     pub fn new(responses: Vec<MockResponse>) -> Self {
         Self {
             responses: Mutex::new(responses),
+            recorded_calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -103,16 +124,40 @@ impl MockProvider {
                 }
             })
             .collect();
-        Self::new(responses)
+        Self {
+            responses: Mutex::new(responses),
+            recorded_calls: global_env_calls(),
+        }
     }
 
     fn next_response(&self) -> MockResponse {
         let mut responses = self.responses.lock().unwrap();
         if responses.is_empty() {
-            // Graceful fallback: return empty text (model is "done").
             return MockResponse::Text(String::new());
         }
         responses.remove(0)
+    }
+
+    /// All messages passed to `chat()` / `chat_stream()` on this instance.
+    pub fn recorded_calls(&self) -> Vec<Vec<ChatMessage>> {
+        self.recorded_calls.lock().unwrap().clone()
+    }
+
+    /// All messages received by any `from_env()` provider since the last
+    /// `clear_env_calls()`. Requires the `test-support` feature.
+    ///
+    /// Because `execute_sub_agent` creates providers internally via
+    /// `MockProvider::from_env()`, this is the only way for tests to inspect
+    /// what messages the sub-agent's provider actually received.
+    #[cfg(feature = "test-support")]
+    pub fn take_env_calls() -> Vec<Vec<ChatMessage>> {
+        std::mem::take(&mut *global_env_calls().lock().unwrap())
+    }
+
+    /// Clear the global `from_env()` call recorder.
+    #[cfg(feature = "test-support")]
+    pub fn clear_env_calls() {
+        global_env_calls().lock().unwrap().clear();
     }
 }
 
@@ -120,10 +165,11 @@ impl MockProvider {
 impl LlmProvider for MockProvider {
     async fn chat(
         &self,
-        _messages: &[ChatMessage],
+        messages: &[ChatMessage],
         _tools: &[ToolDefinition],
         _settings: &ModelSettings,
     ) -> Result<LlmResponse> {
+        self.recorded_calls.lock().unwrap().push(messages.to_vec());
         match self.next_response() {
             MockResponse::Text(text) => Ok(LlmResponse {
                 content: Some(text),
@@ -161,10 +207,11 @@ impl LlmProvider for MockProvider {
 
     async fn chat_stream(
         &self,
-        _messages: &[ChatMessage],
+        messages: &[ChatMessage],
         _tools: &[ToolDefinition],
         _settings: &ModelSettings,
     ) -> Result<mpsc::Receiver<StreamChunk>> {
+        self.recorded_calls.lock().unwrap().push(messages.to_vec());
         let response = self.next_response();
 
         // Error responses fail at the call site, not inside the stream.

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -151,3 +151,107 @@ async fn test_sub_agent_cache_hit_skips_llm() {
         "should complete with final response: {last}"
     );
 }
+
+// ── skip_memory isolation (#769) ────────────────────────────────────────────
+
+/// Helper: creates `agents/<name>.json` under `env.root`.
+fn write_agent_config(env: &Env, name: &str, skip_memory: bool) {
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join(format!("{name}.json")),
+        serde_json::json!({
+            "name": name,
+            "system_prompt": "You are a lean test agent.",
+            "skip_memory": skip_memory,
+            "allowed_tools": [],
+            "provider": "mock",
+            "base_url": "http://localhost:0"
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+/// Runs one InvokeAgent call via the outer provider and returns the env-provider
+/// recorded calls (messages the sub-agent's MockProvider received).
+async fn invoke_agent_and_take_calls(
+    env: &Env,
+    agent_name: &str,
+) -> Vec<Vec<koda_core::providers::ChatMessage>> {
+    MockProvider::clear_env_calls();
+    env.insert_user_message(&format!("call {agent_name}")).await;
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({"agent_name": agent_name, "prompt": "go"}),
+        ),
+        MockResponse::Text("done".into()),
+    ]);
+    env.run_inference(&provider).await;
+    MockProvider::take_env_calls()
+}
+
+#[cfg(feature = "test-support")]
+#[tokio::test]
+async fn skip_memory_excludes_project_memory_from_sub_agent() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    // Write a distinctive sentinel to the project memory file.
+    std::fs::write(env.root.join("MEMORY.md"), "SENTINEL_XYZ").unwrap();
+    write_agent_config(&env, "lean-agent", /* skip_memory */ true);
+
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
+    }
+    let calls = invoke_agent_and_take_calls(&env, "lean-agent").await;
+    unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+
+    assert!(
+        !calls.is_empty(),
+        "sub-agent provider should have been called"
+    );
+    let all_content: String = calls
+        .iter()
+        .flatten()
+        .filter_map(|m| m.content.as_deref())
+        .collect();
+    assert!(
+        !all_content.contains("SENTINEL_XYZ"),
+        "skip_memory: true must exclude project memory from sub-agent system prompt; got:\n{all_content}"
+    );
+}
+
+#[cfg(feature = "test-support")]
+#[tokio::test]
+async fn without_skip_memory_project_memory_reaches_sub_agent() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    // Same sentinel — but this agent does NOT skip memory.
+    std::fs::write(env.root.join("MEMORY.md"), "SENTINEL_XYZ").unwrap();
+    write_agent_config(&env, "full-agent", /* skip_memory */ false);
+
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
+    }
+    let calls = invoke_agent_and_take_calls(&env, "full-agent").await;
+    unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+
+    assert!(
+        !calls.is_empty(),
+        "sub-agent provider should have been called"
+    );
+    let all_content: String = calls
+        .iter()
+        .flatten()
+        .filter_map(|m| m.content.as_deref())
+        .collect();
+    assert!(
+        all_content.contains("SENTINEL_XYZ"),
+        "skip_memory: false must include project memory in sub-agent system prompt; got:\n{all_content}"
+    );
+}


### PR DESCRIPTION
Fixes #769.

## What

Adds input recording to `MockProvider` so tests can assert on the exact
messages the sub-agent's LLM provider received — the only way to verify
`skip_memory` isolation without log assertions or production-code changes.

## Key design

| Provider created via | `recorded_calls` Arc | Who can read it |
|---|---|---|
| `MockProvider::new()` | private, per-instance | `provider.recorded_calls()` |
| `MockProvider::from_env()` | shared `OnceLock<Arc<…>>` | `MockProvider::take_env_calls()` |

`execute_sub_agent` creates providers internally through
`MockProvider::from_env()`, so tests have no reference to the instance.
The shared global Arc bridges that gap cleanly — serialised by the
existing `ENV_MUTEX` that already owns all `KODA_MOCK_RESPONSES` access.

Test-specific APIs (`take_env_calls`, `clear_env_calls`) are gated behind
`#[cfg(feature = "test-support")]` so they never compile into production.

## Changes

### `koda-core/src/providers/mock.rs`
- `global_env_calls()` — `OnceLock<Arc<Mutex<Vec<Vec<ChatMessage>>>>>`
- `MockProvider` struct gains `recorded_calls: Arc<Mutex<…>>`
- `new()` initialises with a private Arc; `from_env()` uses the global
- `chat()` and `chat_stream()` record the received messages slice
- `recorded_calls()` — instance accessor (always available)
- `take_env_calls()` / `clear_env_calls()` — `test-support` gated

### `koda-core/tests/e2e_agent_test.rs`
Two new tests (both `#[cfg(feature = "test-support")]`):

**`skip_memory_excludes_project_memory_from_sub_agent`**
Write `SENTINEL_XYZ` to `MEMORY.md`, invoke sub-agent with
`skip_memory: true` → sentinel must NOT appear in any provider message.

**`without_skip_memory_project_memory_reaches_sub_agent`**
Same sentinel, `skip_memory: false` → sentinel MUST appear.
Verifies the normal path is intact and the negative test isn't vacuous.

## Results

```
running 4 tests
test skip_memory_excludes_project_memory_from_sub_agent ... ok
test test_sub_agent_cache_hit_skips_llm                 ... ok
test without_skip_memory_project_memory_reaches_sub_agent ... ok
test test_sub_agent_invocation_e2e                      ... ok

test result: ok. 4 passed; 0 failed
```

Full suite: **847 passed, 0 failed** (the pre-existing flaky
`compact::tests::test_circuit_broken_after_max_failures` passes in
isolation — it's a parallel-state issue unrelated to this PR).