### PR TITLE
refactor: feature-gate MockProvider + extract koda-test-utils crate (#771)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "glob",
  "ignore",
  "koda-email",
+ "koda-test-utils",
  "path-clean",
  "regex",
  "reqwest",
@@ -1825,6 +1826,18 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "koda-test-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "koda-core",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["koda-core", "koda-cli", "koda-ast", "koda-email"]
+members = ["koda-core", "koda-cli", "koda-ast", "koda-email", "koda-test-utils"]
 resolver = "3"
 default-members = ["koda-cli"]
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -71,6 +71,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 test-support = []
 
 [dev-dependencies]
+koda-test-utils = { path = "../koda-test-utils" }
 tempfile = "3"
 tokio = { version = "1", features = ["full", "test-util"] }
 regex = "1"

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -70,6 +70,7 @@ pub enum ProviderType {
     /// vLLM (local, OpenAI-compatible).
     Vllm,
     /// Mock provider for testing (reads KODA_MOCK_RESPONSES env var).
+    #[cfg(any(test, feature = "test-support"))]
     Mock,
 }
 
@@ -175,6 +176,7 @@ impl ProviderType {
                 env_key: "KODA_API_KEY",
                 api_key: false,
             },
+            #[cfg(any(test, feature = "test-support"))]
             Self::Mock => ProviderMeta {
                 name: "mock",
                 url: "http://localhost:0",
@@ -219,6 +221,7 @@ impl ProviderType {
                 "together" => Self::Together,
                 "fireworks" => Self::Fireworks,
                 "vllm" => Self::Vllm,
+                #[cfg(any(test, feature = "test-support"))]
                 "mock" => Self::Mock,
                 _ => Self::OpenAI,
             };

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -45,6 +45,7 @@ pub mod stream_collector;
 pub mod stream_tag_filter;
 
 /// Mock provider for deterministic testing.
+#[cfg(any(test, feature = "test-support"))]
 pub mod mock;
 
 use anyhow::Result;
@@ -348,6 +349,7 @@ pub fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider> {
             });
             Box::new(gemini::GeminiProvider::new(key, Some(&config.base_url)))
         }
+        #[cfg(any(test, feature = "test-support"))]
         ProviderType::Mock => Box::new(mock::MockProvider::from_env()),
         _ => Box::new(openai_compat::OpenAiCompatProvider::new(
             &config.base_url,

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -11,11 +11,12 @@ use koda_core::persistence::Persistence;
 use koda_core::{
     config::{KodaConfig, ProviderType},
     db::{Database, Role},
-    engine::{EngineCommand, EngineEvent, sink::TestSink},
+    engine::{EngineCommand, EngineEvent},
     inference::{self, InferenceContext},
-    providers::{ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition},
+    providers::{LlmResponse, ModelInfo, StreamChunk},
     tools::ToolRegistry,
 };
+use koda_test_utils::{ChatMessage, LlmProvider, TestSink, ToolDefinition};
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::sync::mpsc;

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -1,13 +1,7 @@
 //! E2E tests: sub-agent invocation and caching.
 
-mod e2e_harness;
-
-use e2e_harness::{ENV_MUTEX, Env};
-use koda_core::{
-    engine::EngineEvent,
-    persistence::Persistence,
-    providers::mock::{MockProvider, MockResponse},
-};
+use koda_core::{engine::EngineEvent, persistence::Persistence};
+use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
 
 #[tokio::test]
 async fn test_sub_agent_invocation_e2e() {

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -5,14 +5,8 @@
 //!
 //! Run with: `cargo test -p koda-core --features test-support --test e2e_safety_test`
 
-mod e2e_harness;
-
-use e2e_harness::Env;
-use koda_core::{
-    engine::EngineEvent,
-    persistence::Persistence,
-    providers::mock::{MockProvider, MockResponse},
-};
+use koda_core::{engine::EngineEvent, persistence::Persistence};
+use koda_test_utils::{Env, MockProvider, MockResponse};
 
 /// Find the first ToolCallResult output for a given tool name.
 fn find_tool_output(events: &[EngineEvent], tool: &str) -> Option<String> {

--- a/koda-core/tests/e2e_skills_test.rs
+++ b/koda-core/tests/e2e_skills_test.rs
@@ -1,18 +1,7 @@
 //! E2E tests: skills, compaction, and file ownership.
 
-mod e2e_harness;
-
-use e2e_harness::Env;
-use koda_core::{
-    compact,
-    db::Role,
-    engine::EngineEvent,
-    persistence::Persistence,
-    providers::{
-        LlmProvider,
-        mock::{MockProvider, MockResponse},
-    },
-};
+use koda_core::{compact, db::Role, engine::EngineEvent, persistence::Persistence};
+use koda_test_utils::{Env, LlmProvider, MockProvider, MockResponse};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -3,22 +3,17 @@
 //! Mock provider → inference loop → real tools → DB persistence.
 //! All file operations happen in isolated temp directories.
 
-mod e2e_harness;
-
 use anyhow::Result;
 use async_trait::async_trait;
-use e2e_harness::Env;
 use koda_core::{
     approval::ApprovalMode,
     config::ModelSettings,
     engine::{EngineCommand, EngineEvent},
     inference::{self, InferenceContext},
     persistence::Persistence,
-    providers::{
-        ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
-        mock::{MockProvider, MockResponse},
-    },
+    providers::{LlmResponse, ModelInfo, StreamChunk},
 };
+use koda_test_utils::{ChatMessage, Env, LlmProvider, MockProvider, MockResponse, ToolDefinition};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 

--- a/koda-core/tests/e2e_tools_test.rs
+++ b/koda-core/tests/e2e_tools_test.rs
@@ -3,13 +3,8 @@
 //! Covers tools that are only unit-tested elsewhere, plus v0.1.14
 //! regression tests for post-edit AST verification (#467/#504).
 
-mod e2e_harness;
-
-use e2e_harness::Env;
-use koda_core::{
-    engine::EngineEvent,
-    providers::mock::{MockProvider, MockResponse},
-};
+use koda_core::engine::EngineEvent;
+use koda_test_utils::{Env, MockProvider, MockResponse};
 
 // ── Glob ─────────────────────────────────────────────────────
 

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -6,14 +6,8 @@
 //!
 //! Run with: `cargo test -p koda-core --features test-support --test inference_edge_test`
 
-mod e2e_harness;
-
-use e2e_harness::Env;
-use koda_core::{
-    engine::EngineEvent,
-    persistence::Persistence,
-    providers::mock::{MockProvider, MockResponse},
-};
+use koda_core::{engine::EngineEvent, persistence::Persistence};
+use koda_test_utils::{Env, MockProvider, MockResponse};
 use tokio_util::sync::CancellationToken;
 
 // ── Rate limit retry ─────────────────────────────────────────

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -8,11 +8,11 @@ use koda_core::{
     approval::ApprovalMode,
     config::{KodaConfig, ProviderType},
     db::{Database, Role},
-    engine::{EngineCommand, EngineEvent, sink::TestSink},
+    engine::{EngineCommand, EngineEvent},
     inference::{self, InferenceContext},
-    providers::mock::{MockProvider, MockResponse},
     tools::ToolRegistry,
 };
+use koda_test_utils::{MockProvider, MockResponse, TestSink};
 use std::path::PathBuf;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -9,13 +9,13 @@ use koda_core::{
     approval::ApprovalMode,
     config::{KodaConfig, ProviderType},
     db::{Database, Persistence, Role},
-    engine::{EngineCommand, EngineEvent, event::TurnEndReason, sink::TestSink},
-    providers::{
-        ChatMessage, LlmProvider, LlmResponse, ModelInfo, StreamChunk, ToolDefinition,
-        mock::{MockProvider, MockResponse},
-    },
+    engine::{EngineCommand, EngineEvent, event::TurnEndReason},
+    providers::{LlmResponse, ModelInfo, StreamChunk},
     session::KodaSession,
     tools::ToolRegistry,
+};
+use koda_test_utils::{
+    ChatMessage, LlmProvider, MockProvider, MockResponse, TestSink, ToolDefinition,
 };
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/koda-test-utils/Cargo.toml
+++ b/koda-test-utils/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "koda-test-utils"
+version = "0.1.0"
+edition = "2024"
+description = "Test utilities for koda — mock providers, test sinks, and E2E harness"
+license = "MIT"
+publish = false
+
+[lib]
+name = "koda_test_utils"
+path = "src/lib.rs"
+
+[dependencies]
+koda-core = { path = "../koda-core", features = ["test-support"] }
+tokio = { version = "1", features = ["full", "test-util"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tempfile = "3"
+anyhow = "1"
+serde_json = "1"

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -1,7 +1,7 @@
-//! Shared test harness for E2E tests.
+//! Shared test environment for E2E tests.
 //!
-//! Provides `Env` — an isolated test environment with temp dir, DB,
-//! session, config, and tool registry.  Every E2E test file imports this.
+//! Provides [`Env`] — an isolated test environment with temp dir, DB,
+//! session, config, and tool registry.
 
 use koda_core::persistence::Persistence;
 use koda_core::{
@@ -18,22 +18,31 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 /// Mutex to serialize tests that share process-global env vars
-/// (KODA_MOCK_RESPONSES). `#[tokio::test]` runs tests concurrently
+/// (KODA_MOCK_RESPONSES).  `#[tokio::test]` runs tests concurrently
 /// within the same process, so unsynchronized set_var/remove_var
 /// on the same env var is a data race.
-#[allow(dead_code)] // Only used by e2e_agent_test, but compiled into every test binary.
 pub static ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+/// An isolated test environment with temp dir, DB, session, config,
+/// and tool registry.
 pub struct Env {
+    /// The temporary directory backing this environment.
+    /// Kept alive for the lifetime of `Env`.
     pub _tmp: tempfile::TempDir,
+    /// Path to the project root (inside `_tmp`).
     pub root: PathBuf,
+    /// SQLite database for this test.
     pub db: Database,
+    /// The test session ID.
     pub session_id: String,
+    /// Koda configuration for this test.
     pub config: KodaConfig,
+    /// Tool registry scoped to the test root.
     pub tools: ToolRegistry,
 }
 
 impl Env {
+    /// Create a fresh, isolated test environment.
     pub async fn new() -> Self {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().to_path_buf();
@@ -51,10 +60,12 @@ impl Env {
         }
     }
 
+    /// Get tool definitions (no disabled/allowed filters).
     pub fn tool_defs(&self) -> Vec<koda_core::providers::ToolDefinition> {
         self.tools.get_definitions(&[], &[])
     }
 
+    /// Insert a user message into the test session.
     pub async fn insert_user_message(&self, text: &str) {
         self.db
             .insert_message(&self.session_id, &Role::User, Some(text), None, None, None)
@@ -75,7 +86,6 @@ impl Env {
     }
 
     /// Run inference and return Result + events (for testing error paths).
-    #[allow(dead_code)] // Used by inference_edge_test, not all test binaries.
     pub async fn run_inference_result(
         &self,
         provider: &dyn LlmProvider,
@@ -85,7 +95,6 @@ impl Env {
     }
 
     /// Run inference with a cancellation token.
-    #[allow(dead_code)] // Used by inference_edge_test, not all test binaries.
     pub async fn run_inference_cancellable(
         &self,
         provider: &dyn LlmProvider,

--- a/koda-test-utils/src/lib.rs
+++ b/koda-test-utils/src/lib.rs
@@ -1,0 +1,35 @@
+//! Test utilities for koda — mock providers, test sinks, and E2E harness.
+//!
+//! This crate is intentionally **not published** and exists only to support
+//! `koda-core` integration tests and downstream test binaries.  It depends on
+//! `koda-core` with the `test-support` feature enabled, so all cfg-gated test
+//! APIs are available.
+//!
+//! # Quick start
+//!
+//! ```rust,ignore
+//! use koda_test_utils::{Env, MockProvider, MockResponse};
+//!
+//! #[tokio::test]
+//! async fn my_test() {
+//!     let env = Env::new().await;
+//!     env.insert_user_message("hello").await;
+//!     let provider = MockProvider::new(vec![MockResponse::Text("hi".into())]);
+//!     let events = env.run_inference(&provider).await;
+//!     // assert on events…
+//! }
+//! ```
+
+mod env;
+
+// ── Re-exports from koda-core (test-support gated) ─────────────────────────
+
+pub use koda_core::config::{KodaConfig, ProviderType};
+pub use koda_core::engine::EngineEvent;
+pub use koda_core::engine::sink::TestSink;
+pub use koda_core::providers::mock::{MockProvider, MockResponse};
+pub use koda_core::providers::{ChatMessage, LlmProvider, ToolDefinition};
+
+// ── This crate's own utilities ─────────────────────────────────────────────
+
+pub use env::{ENV_MUTEX, Env};


### PR DESCRIPTION
## What

Two commits that complete **P0** of the testing infrastructure epic (#771):

### Commit 1: Feature-gate `MockProvider` + `ProviderType::Mock`

`ProviderType::Mock` and the entire `mock.rs` module (637 lines) were compiled into every production binary despite being purely test infrastructure. This was a test concern leaking into production code — the `Mock` variant existed solely because `execute_sub_agent` calls `create_provider()` internally, and tests needed sub-agents to use mock providers.

**Fix:** Gate all Mock-related code behind `#[cfg(any(test, feature = "test-support"))]`:
- `ProviderType::Mock` enum variant + its `ProviderMeta` arm
- `"mock"` name alias in `from_url_or_name()`
- `pub mod mock` in `providers/mod.rs`
- `create_provider()` dispatch arm

Production binary no longer contains any mock infrastructure. Tests compile with `cfg(test)` or `--features test-support` as before.

**Files:** `config.rs`, `providers/mod.rs` (+5 lines)

### Commit 2: Extract `koda-test-utils` crate

Create a dedicated workspace crate that centralises all test infrastructure, following the patterns from Codex (`core_test_support`, 5,630 LOC) and Gemini CLI (`test-utils` pkg, 1,588 LOC).

**What moved:**
- `Env` harness: `tests/e2e_harness/mod.rs` → `koda-test-utils/src/env.rs` (with doc comments)
- `ENV_MUTEX`: same move
- Re-exports: `MockProvider`, `MockResponse`, `TestSink`, `ChatMessage`, `LlmProvider`, `ToolDefinition`, `EngineEvent`, `KodaConfig`, `ProviderType`

**Migration:** All 9 integration test files updated to import from `koda_test_utils`. Old `tests/e2e_harness/` deleted.

**Before:**
```rust
mod e2e_harness;
use e2e_harness::{ENV_MUTEX, Env};
use koda_core::providers::mock::{MockProvider, MockResponse};
use koda_core::engine::EngineEvent;
```

**After:**
```rust
use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
use koda_core::engine::EngineEvent;
```

## Test results

- All 977 tests pass (847 unit + 130 integration)
- Production build (`cargo check -p koda-cli`) clean — no mock code compiled
- Pre-push hooks (fmt + clippy + check) all green

## What is NOT in this PR

- P1: `insta` snapshot testing
- P1: Builder pattern for `TestEnv`
- P2: Companion test files
- P2: Golden-file recording provider
- P3: `wiremock` HTTP-level tests

Those are tracked in #771 and will be separate PRs.

Closes P0 of #771.