### PR TITLE
fix: classify fork bombs as Destructive

### DIFF
--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -198,6 +198,9 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     "gh release delete",
     "gh api",
     "gh auth ",
+    // Fork bombs and recursive function definitions
+    "(){",
+    "() {",
 ];
 
 // ── Classification ───────────────────────────────────────────

--- a/koda-core/tests/snapshots/snapshot_test__bash_safety_classifications.snap
+++ b/koda-core/tests/snapshots/snapshot_test__bash_safety_classifications.snap
@@ -55,7 +55,7 @@ expression: results
 - - dd if=/dev/zero of=/dev/sda
   - Destructive
 - - ":(){ :|:& };:"
-  - LocalMutation
+  - Destructive
 - - git push --force
   - Destructive
 - - shutdown -h now


### PR DESCRIPTION
The classic bash fork bomb `:(){ :|:& };:` was classified as `LocalMutation` instead of `Destructive` because no `DANGEROUS_PATTERNS` entry matched it.

**Fix:** Add `(){` and `() {` to `DANGEROUS_PATTERNS`. Any inline function definition with immediate execution is a potential fork bomb or arbitrary code execution vector.

**Found by:** the `insta` snapshot test added in #774 — the snapshot showed `LocalMutation` for the fork bomb, which was obviously wrong.

**Impact:** 2 files, +4/-1 lines. Snapshot updated to reflect the correct classification.

This is a nice proof that snapshot testing pays for itself on day one. 🐶