### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-04-08
+
+Skills, tracing, testing, and security hardening release. 42 PRs merged since v0.2.2.
+
+### Added
+- **Built-in skills** (#736, #757) — `simplify`, `debug`, `remember` bundled
+  skills; offline docs embedded as a skill (guide agent deleted).
+- **Skill metadata** (#742, #747) — `when_to_use`, `allowed_tools`,
+  `user_invocable`, `argument_hint` fields on `SkillMeta`; surfaced in
+  `ListSkills` output.
+- **Dynamic system prompt injection** (#744) — skill + agent listings
+  injected into the system prompt at inference time (not config load).
+- **`allowed_tools` enforcement** (#751) — tool allow-lists enforced at
+  the execution layer, not just prompt level.
+- **Per-process log files** (#767) — each koda process writes to
+  `~/.koda/logs/<pid>.log` with a `latest` symlink.
+- **`#[tracing::instrument]`** (#763, #768) — structured spans on
+  `inference_loop`, `execute_one_tool`, and `execute_sub_agent`.
+- **Golden-file replay** (#776) — `RecordingProvider` / `ReplayProvider`
+  in `koda-test-utils` for deterministic conversation replay.
+- **`koda-test-utils` crate** (#772, #774) — dedicated test utility crate
+  with `Env`, `EnvBuilder`, `insta` snapshot support, and golden-file
+  harness.
+- **MockProvider call recording** (#770) — `recorded_calls()` and
+  `take_env_calls()` for inspecting sub-agent provider traffic.
+- **mdBook user manual** (#730) — full user manual at docs site, with
+  chapter size gate in CI (#761).
+- **Edit placeholder detection** (#708) — rejects `// ... rest of code`
+  omission placeholders in `Edit` tool `new_str`.
+
+### Fixed
+- **Tracing zero-bytes bug** (#763) — replaced dead `tracing_subscriber`
+  filter with `EnvFilter` + `FmtSpan::CLOSE`.
+- **Fork bomb classification** (#775) — `:(){ :|:& };:` and variants now
+  classified as `Destructive`.
+- **Shell output caps** (#710) — enforce collection caps and bump DB
+  storage to 2 MB.
+- **Agent parity** (#754) — deeper sub-agent prompts, `skip_memory`,
+  `allowed_tools` propagation.
+
+### Changed
+- **CI coverage gate** raised from 70% → 80% for koda-core + koda-ast (#722).
+- **CI consolidation** (#726) — optimized lint/test job dependencies.
+- **`pub(crate)` visibility** (#729) — all koda-cli modules scoped to
+  crate-internal.
+- **Dependency updates** — tokio 1.51.1, fastrand 2.4.1,
+  ratatui-textarea 0.9.0, similar 2→3, plus ~30 transitive bumps.
+
+### Testing
+- **350+ new tests** across 7 PRs (#709, #711, #712, #714, #718, #720,
+  #722, #725, #727) — approval flow, inference loop, DB methods, file
+  tools, E2E safety, email module.
+- **`insta` snapshot testing** (#774) — snapshot assertions for event
+  sequences and config serialization.
+- **`EnvBuilder` pattern** (#774) — fluent test setup replacing
+  imperative boilerplate.
+
 ## [0.2.2] - 2026-04-05
 
 Documentation, safety, and architecture release. 17 PRs merged since v0.2.1.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "imap",
@@ -3858,9 +3858,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A high-performance AI coding agent built in Rust"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.2" }
+koda-core = { path = "../koda-core", version = "0.2.3" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.2", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.3", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Release v0.2.3

**42 PRs** merged since v0.2.2. Bumps all crate versions `0.2.2 → 0.2.3`.

### Highlights

| Category | Changes |
|---|---|
| 🧠 Skills | `simplify`, `debug`, `remember` built-in; metadata fields |
| 🔧 Tracing | Per-process logs, `#[instrument]` spans, EnvFilter fix |
| 🛡️ Security | Fork bomb detection, `allowed_tools` enforcement |
| 🧪 Testing | 350+ new tests, `koda-test-utils` crate, golden-file replay |
| 📚 Docs | mdBook user manual, docs CI size gate |
| 📦 Deps | tokio 1.51.1, fastrand 2.4.1, ratatui-textarea 0.9.0 |

### Checklist
- [x] Version bumps (koda-core, koda-cli, koda-ast, koda-email)
- [x] Cargo.lock updated (`cargo update`)
- [x] CHANGELOG.md updated
- [x] All tests pass locally (1,300+)
- [x] `cargo doc --workspace` clean with `-Dwarnings`
- [x] Pre-push hooks pass (fmt, clippy, check)

### Post-merge
Tag `v0.2.3` on the merge commit → release workflow handles the rest.