### PR TITLE
fix: gate symlink test on unix (fixes Windows CI)

### DIFF
--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -38,6 +38,7 @@ fn find_all_tool_outputs(events: &[EngineEvent], tool: &str) -> Vec<String> {
 // ── Symlink sandbox escape (Codex: safety_tests, Gemini: symlink-install) ──
 
 #[tokio::test]
+#[cfg(unix)]
 async fn read_via_symlink_outside_sandbox_is_blocked() {
     let env = Env::new().await;
 


### PR DESCRIPTION
One-liner: `#[cfg(unix)]` on `read_via_symlink_outside_sandbox_is_blocked`.

`std::os::unix::fs::symlink` doesn't exist on Windows — this broke the release workflow for v0.2.3.

After merge, re-tag v0.2.3 to include the fix.