### PR TITLE
fix(release): crates.io publish last + document branch gate rationale

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,13 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    needs: build
+    needs: github-release
     runs-on: ubuntu-latest
     environment: crates-io
     continue-on-error: true
+    # crates.io versions are immutable — publish only after github-release
+    # confirms binaries are good. Runs in parallel with update-homebrew;
+    # the two are independent distribution channels.
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -163,7 +166,7 @@ jobs:
 
   github-release:
     name: GitHub Release
-    needs: build  # Only depends on build, not publish
+    needs: build  # fans out to update-homebrew and publish in parallel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,11 @@ docs-size  (independent)   guards per-chapter byte cap on docs/src/*.md
   gaps, Windows catches platform-specific API errors (e.g. `std::os::unix`).
 - macOS omitted from `check`: POSIX like Linux; caught locally since dev is on macOS.
 
+**Branch ruleset required gates: `Test` and `Docs` only.**
+`Lint` and `Check` are transitively enforced via `test`'s `needs: [lint, check]` —
+adding them as explicit gates would be redundant. `Docs` is required separately
+because it is independent of the `test` chain.
+
 ### Coverage workflow (`coverage.yml`)
 
 Coverage is **not** a PR gate — it runs post-merge on `main` and is informational.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,6 +427,16 @@ Four workflows live in `.github/workflows/`:
 | `ci.yml` | Pull requests to `main` | Gate PRs — lint, cross-platform check, test, doc, audit |
 | `coverage.yml` | Push to `main` | Post-merge coverage tracking with auto issue creation |
 | `release.yml` | Tag `v*` | Version verify, cross-platform test + build, publish, Homebrew |
+
+Release job chain:
+```
+verify-version → test → build → github-release ─┬→ update-homebrew
+                                                 └→ publish (crates.io)
+```
+crates.io and Homebrew are independent distribution channels — both fan
+out from `github-release` in parallel. Publishing to crates.io only after
+`github-release` ensures binaries are confirmed good before committing to
+an immutable version number; it does not need to wait for Homebrew.
 | `docs.yml` | Push to `main` (docs/ changes) | Build + deploy mdBook to GitHub Pages |
 
 ### CI job DAG (`ci.yml`)


### PR DESCRIPTION
Two related CI correctness fixes.

### crates.io publish order
crates.io versions are **immutable** — once published the same version number can never be re-published (only yanked). Currently `publish` runs in parallel with `github-release`, meaning crates.io can succeed before we know GitHub release + Homebrew are working.

New release chain — fully sequential:
```
verify-version → test → build → github-release → update-homebrew → publish
```

If anything upstream fails, the release can be retagged and retried without being stuck on an already-published crates.io version.

### Branch required gates (closes #780)
Documents in CLAUDE.md why required gates are `Test` + `Docs` only:
- `Lint` is transitively enforced via `test`'s `needs: [lint, check]`
- `Check` is transitively enforced the same way
- Requiring them explicitly as gates is redundant — the DAG does it