### PR TITLE
test: verify coverage regression gate (intentional failure)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,9 +44,11 @@ jobs:
         id: ast
         continue-on-error: true
         run: |
+          # TEST ONLY: threshold raised to 99 to verify regression issue creation.
+          # Revert in the next PR.
           cargo llvm-cov \
             --lib -p koda-ast \
-            --fail-under-lines 80 \
+            --fail-under-lines 99 \
             --lcov --output-path lcov-ast.info
 
       - name: koda-email coverage (≥ 70% lines)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -447,6 +447,11 @@ docs-size  (independent)   guards per-chapter byte cap on docs/src/*.md
   gaps, Windows catches platform-specific API errors (e.g. `std::os::unix`).
 - macOS omitted from `check`: POSIX like Linux; caught locally since dev is on macOS.
 
+**Branch ruleset required gates: `Test` and `Docs` only.**
+`Lint` and `Check` are transitively enforced via `test`'s `needs: [lint, check]` —
+adding them as explicit gates would be redundant. `Docs` is required separately
+because it is independent of the `test` chain.
+
 ### Coverage workflow (`coverage.yml`)
 
 Coverage is **not** a PR gate — it runs post-merge on `main` and is informational.


### PR DESCRIPTION
Raises `koda-ast` threshold to 99% — guaranteed to fail — to confirm the post-merge coverage workflow correctly opens a `coverage-regression` issue.

Revert PR follows immediately after merge. Do not leave this merged.