### PR TITLE
fix(ci): add shared-key to rust-cache in check job — fix cold compile on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check  # stable across branches & workflow edits → primary key always hits
       - name: cargo check (all targets, no features)
         # Catches cfg-gated items invisible behind feature flags AND
         # platform-specific compile errors (e.g. std::os::unix on Windows).


### PR DESCRIPTION
## Problem

Windows `Check` was taking 4+ minutes on every PR even with a warm cache.

Root cause: without `shared-key`, `rust-cache@v2` keys on the job definition hash. Any edit to `ci.yml` changes that hash → primary key miss → restore-key fallback → only `~/.cargo/registry` restored, not `target/` → full recompile every run.

**Evidence:**
```
Check (windows-latest) #929:  8s restore + 251s compile + 36s save  ← cold
Check (windows-latest) #930:  3s restore + 190s compile + 28s save  ← cold again
```
A real cache hit would be 30-60s restore, ~20s compile, near-zero save.

## Fix

```yaml
- uses: Swatinem/rust-cache@v2
  with:
    shared-key: check  # stable across branches & workflow edits
```

Primary key becomes `os + "check" + toolchain + Cargo.lock` — unaffected by workflow file changes. Windows check should drop from ~200s to ~20-30s after first warm run.