### PR TITLE
fix(coverage): restore koda-ast threshold to 80% (clean fix)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,11 +44,9 @@ jobs:
         id: ast
         continue-on-error: true
         run: |
-          # TEST ONLY: threshold raised to 99 to verify regression issue creation.
-          # Revert in the next PR.
           cargo llvm-cov \
             --lib -p koda-ast \
-            --fail-under-lines 99 \
+            --fail-under-lines 80 \
             --lcov --output-path lcov-ast.info
 
       - name: koda-email coverage (≥ 70% lines)


### PR DESCRIPTION
Third attempt — previous PRs squash-merged to zero diff because the fix branches descended from a commit where `coverage.yml` was already 80%. This branch is a clean `git checkout origin/main` with one targeted edit. Diff is unambiguous.