### PR TITLE
fix(release): correct koda-email dep version, add missing crate metadata, extend index wait

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,13 +136,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
-        run: sleep 30
+        run: sleep 60
       - name: Publish koda-core
         run: cargo publish -p koda-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
-        run: sleep 30
+        run: sleep 60
       - name: Publish koda-cli
         run: cargo publish -p koda-cli
         env:

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.2.3"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"
+repository = "https://github.com/lijunzh/koda"
+homepage = "https://github.com/lijunzh/koda"
+readme = "README.md"
+keywords = ["ast", "tree-sitter", "mcp", "ai", "coding-agent"]
+categories = ["development-tools", "command-line-utilities"]
+authors = ["Lijun Zhu"]
 
 [[bin]]
 name = "koda-ast"

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -59,7 +59,7 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-email = { path = "../koda-email", version = "0.2.0" }
+koda-email = { path = "../koda-email", version = "0.2.3" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.2.3"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"
+repository = "https://github.com/lijunzh/koda"
+homepage = "https://github.com/lijunzh/koda"
+readme = "README.md"
+keywords = ["email", "imap", "smtp", "mcp", "ai"]
+categories = ["email", "command-line-utilities"]
+authors = ["Lijun Zhu"]
 
 [[bin]]
 name = "koda-email"


### PR DESCRIPTION
## Problem

Release #41 failed at the crates.io publish step. Three root causes identified:

### 1. Stale version pin in `koda-core` (primary culprit)
`koda-core/Cargo.toml` declared `koda-email = { version = "0.2.0" }` while the crate is at `0.2.3`. When cargo publishes `koda-core` it strips the `path` dep and ships only the version constraint. Resolving `^0.2.0` against a freshly-indexed `0.2.3` entry that hasn't propagated yet is a race condition that loses.

### 2. Missing crate metadata on `koda-ast` and `koda-email`
Both crates were missing `repository`, `homepage`, `readme`, `keywords`, `categories`, and `authors` — all fields present in `koda-core` and `koda-cli`. Inconsistent and can cause crates.io to reject a publish.

### 3. Index propagation window too tight
`sleep 30` between publish steps is too optimistic. crates.io sparse-index propagation realistically takes 30–90 s; bumped to `sleep 60`.

## Changes
- `koda-core/Cargo.toml`: `koda-email` version `0.2.0` → `0.2.3`
- `koda-ast/Cargo.toml`: added `repository`, `homepage`, `readme`, `keywords`, `categories`, `authors`
- `koda-email/Cargo.toml`: same as above
- `.github/workflows/release.yml`: `sleep 30` → `sleep 60` (both index waits)

## Post-merge retag steps

Since crates.io is immutable and the publish failed, the same version `v0.2.3` can be re-published once these fixes land. After merging this PR:

```bash
# Delete the old tag locally and on origin
git tag -d v0.2.3
git push origin :refs/tags/v0.2.3

# Retag on the merged commit and push to trigger the release workflow
git checkout main && git pull
git tag v0.2.3
git push origin v0.2.3
```

The release workflow will re-run, re-creating the GitHub Release (softprops/action-gh-release updates existing releases), pushing a fresh Homebrew formula commit, and publishing all four crates to crates.io in the correct order.