### PR TITLE
fix(release): make crates.io publish steps idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,24 +127,51 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # Publish order follows dependency graph:
       # koda-ast, koda-email (no workspace deps) → koda-core → koda-cli
+      #
+      # Each step is idempotent: "already exists" on crates.io is treated as
+      # success so a re-run after a partial publish doesn't break.
       - name: Publish koda-ast
-        run: cargo publish -p koda-ast
+        run: |
+          out=$(cargo publish -p koda-ast 2>&1); rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ]; then
+            echo "$out" | grep -q "already exists" || exit $rc
+            echo "koda-ast already published — skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish koda-email
-        run: cargo publish -p koda-email
+        run: |
+          out=$(cargo publish -p koda-email 2>&1); rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ]; then
+            echo "$out" | grep -q "already exists" || exit $rc
+            echo "koda-email already published — skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
         run: sleep 60
       - name: Publish koda-core
-        run: cargo publish -p koda-core
+        run: |
+          out=$(cargo publish -p koda-core 2>&1); rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ]; then
+            echo "$out" | grep -q "already exists" || exit $rc
+            echo "koda-core already published — skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
         run: sleep 60
       - name: Publish koda-cli
-        run: cargo publish -p koda-cli
+        run: |
+          out=$(cargo publish -p koda-cli 2>&1); rc=$?
+          echo "$out"
+          if [ $rc -ne 0 ]; then
+            echo "$out" | grep -q "already exists" || exit $rc
+            echo "koda-cli already published — skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Problem

The publish job in the current re-run (triggered by retagging after #794) is failing because `koda-ast@0.2.3` and `koda-email@0.2.3` were already successfully published during the original failed release #41. crates.io is immutable so re-publishing the same version is an error — but the workflow just hard-fails on it, never reaching `koda-core` and `koda-cli` which were **not** published.

## Fix

Wrap each `cargo publish` step to distinguish between a real error and an "already exists" non-error:

```bash
out=$(cargo publish -p koda-ast 2>&1); rc=$?
echo "$out"
if [ $rc -ne 0 ]; then
  echo "$out" | grep -q "already exists" || exit $rc
  echo "koda-ast already published — skipping."
fi
```

This makes every publish step idempotent: safe to re-run after any partial failure.

## After merging

Same retag dance — delete + recreate `v0.2.3` on the new `main` tip to trigger a clean run that will skip the already-published crates and successfully publish `koda-core` and `koda-cli`.
