### PR TITLE
release: v0.2.4 — fix broken v0.2.3 publish, drop continue-on-error, add dep version gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,36 @@ jobs:
           fi
           echo "✅ Tag v$TAG matches koda-core ($CORE_VER), koda-cli ($CLI_VER), koda-ast ($AST_VER), and koda-email ($EMAIL_VER)"
 
+      - name: Check intra-workspace dependency versions are consistent
+        # Catches stale version pins like `koda-email = { path = "...", version = "0.2.0" }`
+        # when the actual crate is already at 0.2.3 — which causes crates.io publish failures
+        # because the path dep is stripped on publish and the stale constraint is shipped instead.
+        run: |
+          CORE_VER=$(grep '^version' koda-core/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          CLI_VER=$(grep  '^version' koda-cli/Cargo.toml  | head -1 | sed 's/.*"\(.*\)"/\1/')
+          EMAIL_VER=$(grep '^version' koda-email/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          FAILED=0
+
+          # koda-core → koda-email
+          CORE_DEP_EMAIL=$(grep 'koda-email\s*=' koda-core/Cargo.toml | sed 's/.*version\s*=\s*"\([^"]*\)".*/\1/')
+          if [ "$CORE_DEP_EMAIL" != "$EMAIL_VER" ]; then
+            echo "::error::koda-core pins koda-email at $CORE_DEP_EMAIL but koda-email is $EMAIL_VER"
+            FAILED=1
+          fi
+
+          # koda-cli → koda-core
+          CLI_DEP_CORE=$(grep 'koda-core\s*=' koda-cli/Cargo.toml | head -1 | sed 's/.*version\s*=\s*"\([^"]*\)".*/\1/')
+          if [ "$CLI_DEP_CORE" != "$CORE_VER" ]; then
+            echo "::error::koda-cli pins koda-core at $CLI_DEP_CORE but koda-core is $CORE_VER"
+            FAILED=1
+          fi
+
+          if [ $FAILED -eq 1 ]; then
+            echo "Fix the stale version pins above before tagging a release."
+            exit 1
+          fi
+          echo "✅ All intra-workspace dependency version pins are consistent."
+
   # Cross-platform tests before shipping binaries.
   # Depends on verify-version: no point burning 30+ min of cross-platform
   # tests when the tag is wrong and the release is dead anyway.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,60 +148,31 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     environment: crates-io
-    continue-on-error: true
-    # crates.io versions are immutable — publish only after github-release
-    # confirms binaries are good. Runs in parallel with update-homebrew;
-    # the two are independent distribution channels.
+    # crates.io versions are immutable. If this job fails, do NOT paper over
+    # it — bump to the next patch version instead and cut a fresh release.
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       # Publish order follows dependency graph:
       # koda-ast, koda-email (no workspace deps) → koda-core → koda-cli
-      #
-      # Each step is idempotent: "already exists" on crates.io is treated as
-      # success so a re-run after a partial publish doesn't break.
       - name: Publish koda-ast
-        run: |
-          out=$(cargo publish -p koda-ast 2>&1); rc=$?
-          echo "$out"
-          if [ $rc -ne 0 ]; then
-            echo "$out" | grep -q "already exists" || exit $rc
-            echo "koda-ast already published — skipping."
-          fi
+        run: cargo publish -p koda-ast
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish koda-email
-        run: |
-          out=$(cargo publish -p koda-email 2>&1); rc=$?
-          echo "$out"
-          if [ $rc -ne 0 ]; then
-            echo "$out" | grep -q "already exists" || exit $rc
-            echo "koda-email already published — skipping."
-          fi
+        run: cargo publish -p koda-email
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
         run: sleep 60
       - name: Publish koda-core
-        run: |
-          out=$(cargo publish -p koda-core 2>&1); rc=$?
-          echo "$out"
-          if [ $rc -ne 0 ]; then
-            echo "$out" | grep -q "already exists" || exit $rc
-            echo "koda-core already published — skipping."
-          fi
+        run: cargo publish -p koda-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
         run: sleep 60
       - name: Publish koda-cli
-        run: |
-          out=$(cargo publish -p koda-cli 2>&1); rc=$?
-          echo "$out"
-          if [ $rc -ne 0 ]; then
-            echo "$out" | grep -q "already exists" || exit $rc
-            echo "koda-cli already published — skipping."
-          fi
+        run: cargo publish -p koda-cli
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-## [0.2.3] - 2026-04-09
+## [0.2.4] - 2026-04-09
+
+Patch release to correct a broken v0.2.3 crates.io publish.
+
+### Fixed
+- **crates.io publish** — v0.2.3 was only partially published: `koda-ast` and
+  `koda-email` reached the registry but `koda-core` and `koda-cli` did not,
+  leaving the release in an inconsistent state. Root causes:
+  - Stale intra-workspace version pin: `koda-core` declared
+    `koda-email = { version = "0.2.0" }` while the crate was at `0.2.3`.
+    `cargo publish` strips `path` deps and ships only the version constraint,
+    causing an ambiguous resolution against the freshly-indexed crate (#794).
+  - Missing crate metadata (`repository`, `homepage`, `readme`, `keywords`,
+    `categories`, `authors`) on `koda-ast` and `koda-email` (#794).
+  - crates.io index propagation window too short (`sleep 30` → `sleep 60`) (#794).
+- **Release CI hardening** (#795, #796):
+  - `continue-on-error: true` removed from the publish job — a failed publish
+    now correctly fails the release workflow instead of going silently green.
+  - New `verify-version` gate checks that every intra-workspace `version` pin
+    matches the actual crate version, catching stale pins before any build or
+    publish step runs.
+
 
 Skills, tracing, testing, and security hardening release. 42 PRs merged since v0.2.2.
 

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.3" }
+koda-core = { path = "../koda-core", version = "0.2.4" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.3", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.4", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"
@@ -59,7 +59,7 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-email = { path = "../koda-email", version = "0.2.3" }
+koda-email = { path = "../koda-email", version = "0.2.4" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary

Closes out the release #41 saga. Three things in one PR:

### 1. Bump to v0.2.4 (admit v0.2.3 is broken)

`v0.2.3` is permanently in a partial state on crates.io — `koda-ast` and `koda-email` were published, but `koda-core` and `koda-cli` were not. crates.io is immutable, so the right fix is a new clean patch release rather than papering over the inconsistency.

- All four crates bumped `0.2.3` → `0.2.4`
- Intra-workspace pins updated (`koda-core` → `koda-email`, `koda-cli` → `koda-core`)
- CHANGELOG documents v0.2.4 and the root causes of the broken v0.2.3

### 2. Fix publish job honesty (`continue-on-error` removed, idempotent logic reverted)

The `continue-on-error: true` on the publish job allowed a failed crates.io publish to go silently green — the GitHub Release and Homebrew jobs would succeed and nobody would notice until users tried to `cargo add koda-core` and got a resolution error.

- `continue-on-error: true` **removed** — a failed publish must fail the release
- Idempotent bash wrapping from #795 **reverted** — plain `cargo publish`; if it fails, cut a new patch, do not retry the same version

### 3. Intra-workspace dependency version gate

New step in `verify-version` (the first job, everything depends on it) that checks every intra-workspace `version` pin matches the actual crate version. Catches the stale `version = "0.2.0"` class of bug at tag time, before any builds or publishes run.

```
::error::koda-core pins koda-email at 0.2.0 but koda-email is 0.2.3
Fix the stale version pins above before tagging a release.
```

## After merging

1. Yank the broken partial v0.2.3 crates (already done via `cargo yank`)
2. Tag `v0.2.4` to trigger the release workflow
