### PR TITLE
release: v0.2.5 — fix koda-cli crates.io publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,13 +164,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
-        run: sleep 60
+        run: sleep 120
       - name: Publish koda-core
         run: cargo publish -p koda-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Wait for crates.io index
-        run: sleep 60
+        run: sleep 120
       - name: Publish koda-cli
         run: cargo publish -p koda-cli
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-04-09
+
+Patch release to fix the v0.2.4 crates.io publish failure for `koda-cli`.
+
+### Fixed
+- **`koda-cli` readme path** — `readme = "../README.md"` pointed outside the
+  package boundary, causing `cargo publish` to warn/fail. Changed to
+  `readme = "README.md"` (the crate's own README) (#797).
+- **`koda-core` missing crate metadata** — added `homepage`, `readme`,
+  `keywords`, and `categories` fields that were present on `koda-ast` and
+  `koda-email` but missing from `koda-core`, risking crates.io rejection (#797).
+- **crates.io index propagation** — doubled the inter-publish sleep from 60 s
+  to 120 s to give the sparse index enough time to reflect newly published
+  dependencies before downstream crates attempt to resolve them (#797).
+
 ## [0.2.4] - 2026-04-09
 
 Patch release to correct a broken v0.2.3 crates.io publish.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "imap",

--- a/README.md
+++ b/README.md
@@ -53,17 +53,24 @@ Inside the TUI, type `/help` to see all commands and keyboard shortcuts.
 
 ---
 
-## Documentation
+## Workspace Crates
 
-The complete **[Koda User Manual](https://lijunzh.github.io/koda/)** has everything you need:
+| Crate | Description |
+|---|---|
+| [**koda-cli**](koda-cli/) | Terminal frontend (TUI + headless + ACP server) |
+| [**koda-core**](koda-core/) | Engine library — providers, tools, inference loop |
+| [**koda-ast**](koda-ast/) | MCP server for tree-sitter AST analysis |
+| [**koda-email**](koda-email/) | MCP server for IMAP/SMTP email integration |
+
+## Documentation
 
 | Resource | Description |
 |---|---|
-| [**User Manual**](https://lijunzh.github.io/koda/) | CLI reference, slash commands, file attachments, approval modes, and custom agents. |
-| [**Engine API**](https://docs.rs/koda-core) | Developer docs for embedding the `koda-core` library. |
-| [**Design**](DESIGN.md) | Core architecture principles and philosophies. |
-| [**Contributing**](CLAUDE.md) | Workspace layout, coding conventions, and tests. |
-| [**Changelog**](CHANGELOG.md) | Version history. |
+| [**User Manual**](https://lijunzh.github.io/koda/) | CLI reference, slash commands, approval modes, and custom agents |
+| [**Engine API**](https://docs.rs/koda-core) | Developer docs for embedding `koda-core` |
+| [**Design**](DESIGN.md) | Architecture principles and philosophies |
+| [**Contributing**](CLAUDE.md) | Workspace layout, coding conventions, and tests |
+| [**Changelog**](CHANGELOG.md) | Version history |
 
 ## License
 

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"
 license = "MIT"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "koda-cli"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
 repository = "https://github.com/lijunzh/koda"
 homepage = "https://github.com/lijunzh/koda"
-readme = "../README.md"
+readme = "README.md"
 keywords = ["ai", "coding-agent", "llm", "cli", "unix"]
 categories = ["command-line-utilities", "development-tools"]
 authors = ["Lijun Zhu"]
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.4" }
+koda-core = { path = "../koda-core", version = "0.2.5" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.4", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.5", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/README.md
+++ b/koda-cli/README.md
@@ -32,7 +32,7 @@ Cycle with `Shift+Tab`:
 | **Auto** | Local mutations auto-approved, destructive ops need confirmation |
 | **Confirm** | Every non-read action requires confirmation |
 
-See the [README](https://github.com/lijunzh/koda) for full documentation.
+See the [User Manual](https://lijunzh.github.io/koda/) for full documentation.
 
 ## License
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "koda-core"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"
 repository = "https://github.com/lijunzh/koda"
+homepage = "https://github.com/lijunzh/koda"
+readme = "README.md"
+keywords = ["ai", "coding-agent", "llm", "engine", "unix"]
+categories = ["development-tools"]
 authors = ["Lijun Zhu"]
 
 [lib]
@@ -59,7 +63,7 @@ futures-util = "0.3"
 anyhow = "1"
 
 # First-party workspace libraries (direct calls)
-koda-email = { path = "../koda-email", version = "0.2.4" }
+koda-email = { path = "../koda-email", version = "0.2.5" }
 
 # Async trait support
 async-trait = "0.1"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"
 license = "MIT"


### PR DESCRIPTION
## Summary

Patch release to fix the **root causes** of the v0.2.4 crates.io publish failure for `koda-cli`.

## Root Causes Fixed

| # | Issue | Fix |
|---|-------|-----|
| 1 | `koda-cli/Cargo.toml` had `readme = "../README.md"` — outside package boundary | Changed to `readme = "README.md"` (crate-local) |
| 2 | `koda-core/Cargo.toml` missing `homepage`, `readme`, `keywords`, `categories` | Added metadata (matching koda-ast/koda-email) |
| 3 | 60 s crates.io index wait too short for sparse index propagation | Doubled to 120 s |

## Changes

- **7 files**, **+33 / −14 lines** — pure metadata + CI timing fix, zero logic changes
- All 4 publishable crates bumped `0.2.4` → `0.2.5`
- Intra-workspace dep pins verified consistent
- `cargo check --workspace` ✅ | `cargo fmt` ✅ | `cargo clippy` ✅

## Release Checklist

- [x] Version bump: koda-cli, koda-core, koda-ast, koda-email
- [x] Intra-workspace dep versions consistent
- [x] CHANGELOG.md updated
- [x] `cargo check --workspace` passes
- [x] Pre-push hooks pass (fmt, clippy, check)

After merge: tag `v0.2.5` on `main` to trigger the release workflow.