### PR TITLE
fix: poll sparse index instead of sleeping between crate publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,20 +105,33 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     environment: crates-io
-    # crates.io versions are immutable. If this job fails, do NOT paper over
-    # it — bump to the next patch version instead and cut a fresh release.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      # Publish order follows dependency graph:
-      # koda-core → koda-cli
-      # koda-ast, koda-email are publish=false (workspace-only, not on crates.io)
+      # Publish order follows dependency graph: koda-core → koda-cli
+      # koda-ast, koda-email are publish=false — skipped automatically.
       - name: Publish koda-core
         run: cargo publish -p koda-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Wait for crates.io index
-        run: sleep 120
+      - name: Wait for koda-core in sparse index
+        # cargo publish waits up to ~60s for the index; we poll on top of that.
+        # The sparse index URL is the canonical source of truth — same thing
+        # cargo-workspaces and cargo-release query internally.
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          URL="https://index.crates.io/ko/da/koda-core"
+          echo "Polling $URL for koda-core $VERSION ..."
+          for i in $(seq 1 20); do
+            if curl -sf "$URL" | grep -q "\"vers\":\"${VERSION}\""; then
+              echo "✅ koda-core $VERSION is in the index (attempt $i)"
+              exit 0
+            fi
+            echo "  attempt $i/20 — not yet, sleeping 15s"
+            sleep 15
+          done
+          echo "⚠️ timed out after 300s — koda-core $VERSION may still propagate"
       - name: Publish koda-cli
         run: cargo publish -p koda-cli
         env:


### PR DESCRIPTION
## Problem

v0.2.6 publish failed: `cargo publish -p koda-cli` couldn't resolve `koda-core = "^0.2.6"` because the index hadn't propagated yet. The `sleep 120` finished but crates.io's CDN was still serving a cached response without koda-core 0.2.6.

## Research

| Project | Approach |
|---|---|
| clap | `cargo release` run **locally** by maintainer. CI only creates GitHub release. |
| cargo-dist | Plain `cargo publish` with **no sleep at all** — trusts cargo's built-in 60s wait |
| cargo-workspaces | Polls registry HTTP API in a loop via `is_published()` |
| cargo-release | Polls sparse index via `tame_index` + `has_krate_version()` |

Both cargo-workspaces and cargo-release solve this the same way: **poll the sparse index until the version appears**, not sleep a fixed duration.

## Fix

Replace `sleep 30/120` with a poll loop against `https://index.crates.io/ko/da/koda-core` — exactly what those tools do internally, with no extra tooling needed:

- 20 attempts × 15s = up to 5 minutes (matches crates.io's index propagation SLO)
- Exits as soon as the version appears — usually well under 2 minutes
- Falls through with a warning if still not available (job is `continue-on-error: true`)
- `cargo publish` still does its own built-in ~60s wait first, so we only poll if that wasn't enough