### PR TITLE
release: v0.2.7 — fix crates.io publish pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-04-10
+
+CI-only release. No functional changes to koda-core or koda-cli.
+
+### Fixed
+- **crates.io publish pipeline** — `cargo publish -p koda-cli` was failing
+  on slow crates.io index days because a fixed `sleep` wasn't enough for
+  koda-core to appear in the sparse index before koda-cli tried to resolve
+  it as a dependency. Replaced the sleep with a poll loop that queries
+  `https://index.crates.io/ko/da/koda-core` directly — the same mechanism
+  used internally by cargo-workspaces and cargo-release — and exits as soon
+  as the version appears (up to 5 min, matching crates.io's propagation SLO).
+  koda-cli has not been successfully published to crates.io since v0.2.2;
+  this release establishes a clean, verified baseline.
+
 ## [0.2.6] - 2026-04-09
 
 Patch release to fix the v0.2.5 `koda-cli` crates.io publish failure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.6" }
+koda-core = { path = "../koda-core", version = "0.2.7" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.6", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.7", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"


### PR DESCRIPTION
CI-only release. No functional changes.

## Why

`koda-cli` has not been successfully published to crates.io since **v0.2.2**. Every release from v0.2.3→v0.2.6 failed at the publish step due to the same root cause.

## Root cause (now actually fixed)

`cargo publish -p koda-cli` resolves `koda-core` from the **crates.io sparse index**. On a slow index day, the fixed `sleep` finished but the CDN was still serving a stale response — koda-core wasn't visible yet, so koda-cli's dependency resolution failed.

## Fix (#799)

Poll `https://index.crates.io/ko/da/koda-core` directly until the version appears (20 × 15s = up to 5 min). This is exactly what cargo-workspaces and cargo-release do internally. No external tooling needed.

## What's in this PR

| File | Change |
|---|---|
| `koda-core/Cargo.toml` | 0.2.6 → 0.2.7 |
| `koda-cli/Cargo.toml` | 0.2.6 → 0.2.7, pin updated |
| `Cargo.lock` | regenerated |
| `CHANGELOG.md` | v0.2.7 entry |