### PR TITLE
chore: remove duplicate CI on main, drop stale docs-size gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]    # PR status checks
-  push:
-    branches: [main]    # Seeds shared-key caches after every merge so the
-                        # next PR gets a warm restore rather than a cold compile
+    branches: [main]
   workflow_call:        # Called by other workflows
 
 permissions:
@@ -88,34 +85,4 @@ jobs:
       - name: Run audit
         run: cargo audit || true  # Advisory-only, don't fail CI
 
-  docs-size:
-    name: Docs Chapter Size
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Check chapter sizes
-        run: |
-          # Guard against individual doc chapters growing unbounded.
-          # Each docs/src/*.md chapter is capped at 8 192 bytes (~2 K tokens).
-          # At this cap, the full embedded blob stays under ~144 KB even if
-          # every chapter simultaneously hits the limit — still acceptable for
-          # an infrequently activated skill.
-          #
-          # SUMMARY.md is the mdBook table of contents and grows naturally as
-          # chapters are added — it is excluded from this gate.
-          #
-          # To raise the cap: bump MAX_BYTES and explain why in the commit
-          # message (e.g. "commands.md now covers sub-commands — 10 KB needed").
-          MAX_BYTES=8192
-          FAILED=0
-          for f in docs/src/*.md; do
-            [ "$(basename "$f")" = "SUMMARY.md" ] && continue
-            size=$(wc -c < "$f")
-            if [ "$size" -gt "$MAX_BYTES" ]; then
-              echo "❌  $f: ${size}B exceeds cap of ${MAX_BYTES}B"
-              FAILED=1
-            else
-              printf "✅  %-45s %5dB\n" "$f" "$size"
-            fi
-          done
-          exit $FAILED
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: lint  # stable across branches & workflow edits
+          shared-key: test-support  # shared with test: same features, same targets
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
@@ -56,8 +56,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test  # OS already baked into rust-cache primary key;
-                            # no cross-contamination between ubuntu and windows
+          shared-key: test-support  # shared with lint: same features, same targets
       - run: cargo test --workspace --features koda-core/test-support
 
   doc:


### PR DESCRIPTION
Three changes, no additions.

**1. Remove CI on main push** — redundant since branch protection requires PR checks to pass before merge. The squash merge commit is the exact tree that passed CI on the PR. Running it again wastes minutes per merge. The 'cache seeding' justification doesn't hold: `Swatinem/rust-cache` saves on PR runs already.

**2. Drop stale docs-size gate** — enforced a per-chapter 8 KB cap to keep the embedded docs blob under 144 KB. `build.rs` was deleted in v0.2.6; docs are no longer embedded. The constraint it was guarding against doesn't exist anymore.

**3. Share cache between lint and test** — both jobs compile `--workspace --all-targets --features koda-core/test-support`. Clippy produces the same `.rlib` artifacts that `cargo test` links against. Separate cache keys meant each job cold-compiled the same thing. Single `shared-key: test-support` → lint warms the cache, test reuses it.