### PR TITLE
fix(bash): strip quoted strings before dangerous-pattern check (#802)

### DIFF
--- a/koda-core/src/bash_path_lint.rs
+++ b/koda-core/src/bash_path_lint.rs
@@ -159,7 +159,6 @@ enum CdTarget {
     Path(String),
 }
 
-
 /// Extract the target of a `cd` command from a segment.
 fn extract_cd_target(segment: &str) -> Option<CdTarget> {
     let seg = segment.trim();

--- a/koda-core/src/bash_path_lint.rs
+++ b/koda-core/src/bash_path_lint.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 
 use crate::bash_safety::split_command_segments;
 use crate::bash_safety::strip_env_vars;
+use crate::bash_safety::strip_quoted_strings;
 
 /// Whether `resolved` is a path that is safe to access outside the project root.
 ///
@@ -158,40 +159,6 @@ enum CdTarget {
     Path(String),
 }
 
-/// Replace content inside matched single/double quotes with spaces.
-///
-/// This prevents paths embedded in commit messages, echo strings, and
-/// heredoc bodies from being falsely flagged as path escapes (#562).
-///
-/// ```text
-/// git commit -m "allow /tmp and /dev/*"  →  git commit -m "                    "
-/// echo 'fixed /etc/hosts'               →  echo '                '
-/// ```
-fn strip_quoted_strings(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\'' || c == '"' {
-            result.push(c); // keep the opening quote
-            // Replace everything until the matching close quote with spaces
-            let mut found_close = false;
-            for inner in chars.by_ref() {
-                if inner == c {
-                    result.push(c); // keep the closing quote
-                    found_close = true;
-                    break;
-                }
-                result.push(' ');
-            }
-            if !found_close {
-                // Unterminated quote — already replaced content, just continue
-            }
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
 
 /// Extract the target of a `cd` command from a segment.
 fn extract_cd_target(segment: &str) -> Option<CdTarget> {

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -232,8 +232,11 @@ pub fn classify_bash_command(command: &str) -> ToolEffect {
     }
 
     // Layer 1: dangerous patterns → Destructive
+    // Strip quoted strings first so patterns inside grep arguments, commit
+    // messages, etc. are not falsely flagged (#802).
+    let unquoted = strip_quoted_strings(trimmed);
     for pat in DANGEROUS_PATTERNS {
-        if trimmed.contains(pat) {
+        if unquoted.contains(pat) {
             return ToolEffect::Destructive;
         }
     }
@@ -398,6 +401,38 @@ pub fn split_command_segments(command: &str) -> Vec<&str> {
     segments
 }
 
+/// Replace content inside single and double quotes with spaces.
+///
+/// Prevents patterns inside quoted strings (e.g. grep arguments, commit
+/// messages) from being mistakenly matched as dangerous commands.
+///
+/// ```text
+/// grep -A30 "cargo publish -p koda"  →  grep -A30 "                    "
+/// git commit -m 'fix: rm old file'   →  git commit -m '                '
+/// ```
+pub fn strip_quoted_strings(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\'' || c == '"' {
+            result.push(c);
+            let mut found_close = false;
+            for inner in chars.by_ref() {
+                if inner == c {
+                    result.push(c);
+                    found_close = true;
+                    break;
+                }
+                result.push(' ');
+            }
+            if !found_close {}
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
 /// Strip leading environment variable assignments (e.g., `FOO=bar command`).
 ///
 /// # Examples
@@ -506,6 +541,25 @@ mod tests {
                 classify_bash_command(cmd),
                 ToolEffect::ReadOnly,
                 "expected ReadOnly: {cmd}"
+            );
+        }
+    }
+
+    /// Dangerous patterns inside quoted grep/log arguments must not trigger (#802).
+    #[test]
+    fn test_quoted_dangerous_pattern_not_flagged() {
+        for cmd in [
+            // Exact command from issue #802
+            r#"cd /Users/lijun/repo/koda && gh run view 24209573810 --log | grep -A30 "cargo publish -p koda-cli" | tail -20"#,
+            // Other false-positive patterns
+            r#"grep -r "npm publish" ."#,
+            r#"grep "rm -rf" logs/"#,
+            r#"grep "cargo publish" Makefile"#,
+        ] {
+            assert_ne!(
+                classify_bash_command(cmd),
+                ToolEffect::Destructive,
+                "should not be Destructive (pattern is inside quotes): {cmd}"
             );
         }
     }


### PR DESCRIPTION
## Problem

Commands containing dangerous keywords inside **quoted grep arguments** were incorrectly classified as `Destructive` and prompted for approval even in auto mode.

Reproducer (exact command from #802):
```
cd /Users/lijun/repo/koda && gh run view 24209573810 --log | grep -A30 "cargo publish -p koda-cli" | tail -20
```

The substring `cargo publish` is in `DANGEROUS_PATTERNS`, so `trimmed.contains(pat)` fired even though it only appears inside a quoted grep argument—never executed.

Other affected patterns: `grep -r "npm publish" .`, `grep "rm -rf" logs/`, `git log --grep="sudo apt"`.

## Root Cause

Layer 1 of `classify_bash_command` (`bash_safety.rs`) matched dangerous patterns against the raw command string without first stripping quoted substrings.

## Fix

Strip quoted strings before checking `DANGEROUS_PATTERNS`—the same technique already used by `bash_path_lint.rs` for path-escape detection.

Move `strip_quoted_strings()` from the private scope of `bash_path_lint.rs` to `bash_safety.rs` as a `pub fn` so both modules share one implementation.

## Changes

- `koda-core/src/bash_safety.rs`: add `pub fn strip_quoted_strings()`; use it in `classify_bash_command` layer 1; add regression test `test_quoted_dangerous_pattern_not_flagged`
- `koda-core/src/bash_path_lint.rs`: remove private duplicate; import from `bash_safety`

## Tests

New regression test covers the exact command from the issue plus `npm publish`, `rm -rf`, and `cargo publish` inside quoted grep args. All existing tests continue to pass.