### PR TITLE
feat(ux): tool-type-aware output styling + /copy transcript export (#804 issue 3)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -17,6 +17,11 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
         "Summarize conversation to reclaim context",
         None,
     ),
+    (
+        "/copy",
+        "Copy session transcript to clipboard (or /copy file.md to save)",
+        Some("[file.md]"),
+    ),
     ("/diff", "Show git diff (review, commit)", None),
     ("/exit", "Quit the session", None),
     ("/expand", "Show full output of last tool call", None),

--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -5,13 +5,16 @@
 //! Keeps the history view compact — tool results are summarized, not
 //! replayed in full.
 
+use std::collections::HashMap;
+
 use koda_core::persistence::{Message, Role};
+use koda_core::tools::{ToolEffect, classify_tool};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
 
-use crate::tui_output::{BOLD, DIM};
+use crate::tui_output::{BOLD, DIM, READ_CONTENT, TOOL_PREFIX, WRITE_CONTENT};
 
 /// Maximum lines of tool output to show inline in history replay.
 const TOOL_OUTPUT_PREVIEW_LINES: usize = 3;
@@ -20,9 +23,29 @@ const TOOL_OUTPUT_PREVIEW_LINES: usize = 3;
 ///
 /// Renders user messages with a `❯` prompt, assistant text with a `───`
 /// separator, tool calls as `● ToolName detail`, and tool results as
-/// abbreviated summaries.
+/// abbreviated summaries. Tool result styling is differentiated by tool type:
+/// read-only tools (Read, Grep, List…) render their content in a readable
+/// light color; mutating tools (Bash, Write, Edit…) stay dim.
 pub fn render_history_messages(messages: &[Message]) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Build a tool_call_id → tool_name map so tool result messages can
+    // look up which tool produced them and pick the right content style.
+    let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
+    for msg in messages {
+        if msg.role == Role::Assistant
+            && let Some(ref tc_json) = msg.tool_calls
+            && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
+        {
+            for call in calls {
+                if let (Some(id), Some(name)) =
+                    (call["id"].as_str(), call["function"]["name"].as_str())
+                {
+                    tool_id_to_name.insert(id.to_string(), name.to_string());
+                }
+            }
+        }
+    }
 
     for msg in messages {
         match msg.role {
@@ -36,7 +59,13 @@ pub fn render_history_messages(messages: &[Message]) -> Vec<Line<'static>> {
                 render_assistant_message(&mut lines, msg);
             }
             Role::Tool => {
-                render_tool_result(&mut lines, msg);
+                let tool_name = msg
+                    .tool_call_id
+                    .as_deref()
+                    .and_then(|id| tool_id_to_name.get(id))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+                render_tool_result(&mut lines, msg, tool_name);
             }
         }
     }
@@ -131,13 +160,22 @@ fn render_tool_call_headers(lines: &mut Vec<Line<'static>>, tc_json: &str) {
 }
 
 /// Render a tool result message (abbreviated).
-fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message) {
+///
+/// Content style is determined by the tool type:
+/// - Read-only tools (Read, Grep, List, Glob…) → `READ_CONTENT` (legible light gray)
+/// - Mutating tools (Bash, Write, Edit…)        → `WRITE_CONTENT` (dim, less important)
+fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message, tool_name: &str) {
     let content = msg.content.as_deref().unwrap_or("");
     let total_lines = content.lines().count();
 
+    let content_style = match classify_tool(tool_name) {
+        ToolEffect::ReadOnly => READ_CONTENT,
+        _ => WRITE_CONTENT,
+    };
+
     if total_lines == 0 {
         lines.push(Line::from(vec![
-            Span::styled("  \u{2514} ", DIM),
+            Span::styled("  \u{2514} ", TOOL_PREFIX),
             Span::styled("(empty)", DIM),
         ]));
         return;
@@ -147,21 +185,21 @@ fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message) {
         // Short output — show in full
         for line in content.lines() {
             lines.push(Line::from(vec![
-                Span::styled("  \u{2502} ", DIM),
-                Span::raw(line.to_string()),
+                Span::styled("  \u{2502} ", TOOL_PREFIX),
+                Span::styled(line.to_string(), content_style),
             ]));
         }
     } else {
         // Long output — show preview + count
         for line in content.lines().take(TOOL_OUTPUT_PREVIEW_LINES) {
             lines.push(Line::from(vec![
-                Span::styled("  \u{2502} ", DIM),
-                Span::raw(line.to_string()),
+                Span::styled("  \u{2502} ", TOOL_PREFIX),
+                Span::styled(line.to_string(), content_style),
             ]));
         }
         let hidden = total_lines - TOOL_OUTPUT_PREVIEW_LINES;
         lines.push(Line::from(vec![
-            Span::styled("  \u{2514} ", DIM),
+            Span::styled("  \u{2514} ", TOOL_PREFIX),
             Span::styled(format!("... {hidden} more line(s)"), DIM),
         ]));
     }

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -35,6 +35,7 @@ pub(crate) mod server;
 pub(crate) mod sink;
 pub(crate) mod startup;
 pub(crate) mod tool_history;
+pub(crate) mod transcript;
 pub(crate) mod tui_app;
 pub(crate) mod tui_commands;
 pub(crate) mod tui_context;

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -70,6 +70,11 @@ pub enum ReplAction {
     Handled,
     /// Input was not a slash command — treat as a chat message.
     NotACommand,
+    /// `/copy [<file.md>]` — export the conversation transcript.
+    ///
+    /// Without an argument: copy to clipboard.
+    /// With a filename: save to that file as Markdown.
+    Copy(Option<String>),
 }
 
 /// Parse and handle a slash command. Returns the action for the main loop.
@@ -156,6 +161,8 @@ pub async fn handle_command(
         "/skills" => ReplAction::ListSkills(arg.map(|s| s.to_string())),
 
         "/key" | "/keys" => ReplAction::ManageKeys,
+
+        "/copy" => ReplAction::Copy(arg.map(|s| s.to_string())),
 
         _ => ReplAction::NotACommand,
     }

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -1,0 +1,351 @@
+//! Conversation transcript generator.
+//!
+//! Converts a session's `Message` slice into a human-readable Markdown
+//! document suitable for clipboard copy or file export.
+//!
+//! ## Format
+//!
+//! ```text
+//! # Koda Session — 2026-04-10 10:32
+//!
+//! ## User
+//! What does this function do?
+//!
+//! ## Assistant
+//! The function `foo()` does …
+//!
+//! ### 🔍 Read `src/main.rs`
+//! > (3 lines shown)
+//! > fn main() { … }
+//!
+//! ### ✏️ Edit `src/main.rs`
+//! > Applied 1 change
+//! ```
+//!
+//! Tool results are summarised (not dumped verbatim) to keep the export
+//! concise. The `full_content` field is intentionally ignored \u2014 if users
+//! want raw output they can re-run the tool.
+
+use koda_core::persistence::{Message, Role};
+use koda_core::tools::{ToolEffect, classify_tool};
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Maximum content lines to include per tool result in the transcript.
+const RESULT_PREVIEW_LINES: usize = 10;
+
+/// Format a Unix timestamp as `YYYY-MM-DD HH:MM` (UTC).
+///
+/// Uses pure stdlib — no chrono dep needed.
+fn format_utc_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    // Simple manual UTC decomposition (no DST, no timezone tables).
+    let mins_total = secs / 60;
+    let hours_total = mins_total / 60;
+    let days_total = hours_total / 24;
+    let min = mins_total % 60;
+    let hour = hours_total % 24;
+    // Gregorian calendar approximation for year/month/day.
+    let (year, month, day) = gregorian_from_days(days_total as u32);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{min:02} UTC")
+}
+
+/// Convert days-since-epoch to (year, month, day) in the proleptic Gregorian calendar.
+fn gregorian_from_days(mut z: u32) -> (u32, u32, u32) {
+    z += 719_468;
+    let era = z / 146_097;
+    let doe = z % 146_097;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+/// Generate a Markdown transcript from a slice of session messages.
+///
+/// Returns the transcript as a `String`. The caller is responsible for
+/// writing it to the clipboard or a file.
+pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
+    let mut out = String::with_capacity(4096);
+
+    // Header
+    let title = session_title.unwrap_or("Koda Session");
+    let now = format_utc_now();
+    out.push_str(&format!("# {title} — {now}\n\n"));
+
+    // Build tool_call_id → tool_name mapping for result correlation
+    let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
+    for msg in messages {
+        if msg.role == Role::Assistant
+            && let Some(ref tc_json) = msg.tool_calls
+            && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
+        {
+            for call in calls {
+                if let (Some(id), Some(name)) =
+                    (call["id"].as_str(), call["function"]["name"].as_str())
+                {
+                    tool_id_to_name.insert(id.to_string(), name.to_string());
+                }
+            }
+        }
+    }
+
+    for msg in messages {
+        match msg.role {
+            Role::System => {} // Skip — internal plumbing
+
+            Role::User => {
+                out.push_str("---\n\n## \u{1f9d1} User\n\n");
+                if let Some(ref content) = msg.content {
+                    out.push_str(content.trim());
+                    out.push_str("\n\n");
+                }
+            }
+
+            Role::Assistant => {
+                out.push_str("## 🤖 Assistant\n\n");
+
+                // Text content first
+                if let Some(ref content) = msg.content {
+                    let trimmed = content.trim();
+                    if !trimmed.is_empty() {
+                        out.push_str(trimmed);
+                        out.push_str("\n\n");
+                    }
+                }
+
+                // Tool call headers
+                if let Some(ref tc_json) = msg.tool_calls
+                    && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
+                {
+                    for call in &calls {
+                        let name = call["function"]["name"].as_str().unwrap_or("Tool");
+                        let args_json = call["function"]["arguments"].as_str().unwrap_or("{}");
+                        let detail = tool_detail_summary(name, args_json);
+                        let icon = tool_icon(name);
+                        out.push_str(&format!("### {icon} **{name}**"));
+                        if !detail.is_empty() {
+                            out.push_str(&format!(" `{detail}`"));
+                        }
+                        out.push('\n');
+                    }
+                    out.push('\n');
+                }
+            }
+
+            Role::Tool => {
+                let tool_name = msg
+                    .tool_call_id
+                    .as_deref()
+                    .and_then(|id| tool_id_to_name.get(id))
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+
+                let content = msg.content.as_deref().unwrap_or("").trim();
+                let total_lines = content.lines().count();
+
+                if !content.is_empty() {
+                    let effect = classify_tool(tool_name);
+                    // Only surface read-only tool output \u2014 write/bash output
+                    // is usually noise (diffs, compiler output). Still summarise it.
+                    match effect {
+                        ToolEffect::ReadOnly => {
+                            out.push_str("**Output:**\n\n```\n");
+                            let preview_lines: Vec<&str> =
+                                content.lines().take(RESULT_PREVIEW_LINES).collect();
+                            out.push_str(&preview_lines.join("\n"));
+                            if total_lines > RESULT_PREVIEW_LINES {
+                                out.push_str(&format!(
+                                    "\n… ({} more lines)",
+                                    total_lines - RESULT_PREVIEW_LINES
+                                ));
+                            }
+                            out.push_str("\n```\n\n");
+                        }
+                        _ => {
+                            // Mutating tools: just note how many lines of output
+                            if total_lines > 0 {
+                                out.push_str(&format!(
+                                    "> _{total_lines} line(s) of output — run tool to see full result_\n\n"
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    out
+}
+
+/// Human-readable icon for each tool type.
+fn tool_icon(name: &str) -> &'static str {
+    match name {
+        "Read" => "📄",
+        "Write" => "✏️",
+        "Edit" => "✏️",
+        "Delete" => "🗑️",
+        "Bash" => "💻",
+        "Grep" => "🔍",
+        "List" | "Glob" => "📁",
+        "WebFetch" => "🌐",
+        "TodoWrite" | "TodoRead" => "📋",
+        "MemoryWrite" | "MemoryRead" => "🧠",
+        "InvokeAgent" => "🤖",
+        "AskUser" => "💬",
+        _ => "🔧",
+    }
+}
+
+/// One-line summary of a tool call's arguments (mirrors `history_render`).
+fn tool_detail_summary(name: &str, args_json: &str) -> String {
+    let args: serde_json::Value =
+        serde_json::from_str(args_json).unwrap_or(serde_json::Value::Null);
+    match name {
+        "Read" | "Write" | "Edit" | "Delete" => {
+            args["file_path"].as_str().unwrap_or("").to_string()
+        }
+        "Bash" => {
+            let cmd = args["command"].as_str().unwrap_or("");
+            if cmd.len() > 80 {
+                format!("{}…", &cmd[..77])
+            } else {
+                cmd.to_string()
+            }
+        }
+        "Grep" => {
+            let pat = args["search_string"]
+                .as_str()
+                .or_else(|| args["pattern"].as_str())
+                .unwrap_or("");
+            let dir = args["directory"].as_str().unwrap_or(".");
+            format!("{pat} in {dir}")
+        }
+        "List" | "Glob" => args["directory"]
+            .as_str()
+            .or_else(|| args["path"].as_str())
+            .unwrap_or(".")
+            .to_string(),
+        "WebFetch" => args["url"].as_str().unwrap_or("").to_string(),
+        _ => {
+            if let Some(obj) = args.as_object() {
+                for (_, v) in obj.iter().take(1) {
+                    if let Some(s) = v.as_str() {
+                        return if s.len() > 80 {
+                            format!("{}…", &s[..77])
+                        } else {
+                            s.to_string()
+                        };
+                    }
+                }
+            }
+            String::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use koda_core::persistence::Message;
+
+    fn make_msg(role: Role, content: &str) -> Message {
+        Message {
+            id: 0,
+            session_id: "test".into(),
+            role,
+            content: Some(content.into()),
+            full_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: None,
+            created_at: None,
+        }
+    }
+
+    #[test]
+    fn empty_messages_produces_header_only() {
+        let out = render(&[], Some("Test Session"));
+        assert!(out.contains("# Test Session"));
+        assert!(!out.contains("## 🧑 User"));
+    }
+
+    #[test]
+    fn user_message_renders_correctly() {
+        let msgs = vec![make_msg(Role::User, "hello koda")];
+        let out = render(&msgs, None);
+        assert!(out.contains("## 🧑 User"));
+        assert!(out.contains("hello koda"));
+    }
+
+    #[test]
+    fn assistant_message_renders_correctly() {
+        let msgs = vec![make_msg(Role::Assistant, "I can help!")];
+        let out = render(&msgs, None);
+        assert!(out.contains("## 🤖 Assistant"));
+        assert!(out.contains("I can help!"));
+    }
+
+    #[test]
+    fn system_messages_skipped() {
+        let msgs = vec![
+            make_msg(Role::System, "secret prompt"),
+            make_msg(Role::User, "hi"),
+        ];
+        let out = render(&msgs, None);
+        assert!(!out.contains("secret prompt"));
+    }
+
+    #[test]
+    fn tool_read_result_shown_as_code_block() {
+        let mut result_msg = make_msg(Role::Tool, "fn main() {}\n");
+        result_msg.tool_call_id = Some("call_1".into());
+
+        let mut assistant_msg = make_msg(Role::Assistant, "");
+        assistant_msg.tool_calls = Some(
+            serde_json::json!([{
+                "id": "call_1",
+                "function": { "name": "Read", "arguments": r#"{"file_path":"src/main.rs"}"# }
+            }])
+            .to_string(),
+        );
+
+        let msgs = vec![assistant_msg, result_msg];
+        let out = render(&msgs, None);
+        assert!(out.contains("```"));
+        assert!(out.contains("fn main()"));
+    }
+
+    #[test]
+    fn bash_result_shows_summary_not_content() {
+        let mut result_msg = make_msg(Role::Tool, "line1\nline2\nline3");
+        result_msg.tool_call_id = Some("call_2".into());
+
+        let mut assistant_msg = make_msg(Role::Assistant, "");
+        assistant_msg.tool_calls = Some(
+            serde_json::json!([{
+                "id": "call_2",
+                "function": { "name": "Bash", "arguments": r#"{"command":"ls"}"# }
+            }])
+            .to_string(),
+        );
+
+        let msgs = vec![assistant_msg, result_msg];
+        let out = render(&msgs, None);
+        // Bash is mutating → summarised, not shown verbatim
+        assert!(!out.contains("line1"));
+        assert!(out.contains("3 line(s) of output"));
+    }
+}

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -13,6 +13,9 @@ use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_output;
 use crate::tui_render::TuiRenderer;
 use koda_core::persistence::Persistence;
+// For /copy transcript export:
+use crate::mouse_select::copy_to_clipboard;
+use crate::transcript;
 
 use koda_core::agent::KodaAgent;
 use koda_core::approval;
@@ -171,6 +174,10 @@ pub async fn handle_slash_command(
         ReplAction::ManageKeys => {
             crate::tui_wizards::handle_keys(buffer);
             SlashAction::OpenKeyMenu
+        }
+        ReplAction::Copy(ref dest) => {
+            handle_copy(buffer, session, dest.as_deref()).await;
+            SlashAction::Continue
         }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
@@ -467,6 +474,71 @@ fn handle_expand(buffer: &mut ScrollBuffer, renderer: &TuiRenderer, n: usize) {
                         "No tool output #{n}. Have {total} recorded (use /expand 1\u{2013}{total})."
                     ),
                 );
+            }
+        }
+    }
+}
+
+// ── /copy ────────────────────────────────────────────────
+
+/// Export the session transcript to clipboard or a Markdown file.
+///
+/// - `dest = None`        → copy to system clipboard
+/// - `dest = Some(path)`  → write Markdown to that file path
+///
+/// Uses `transcript::render` to produce a structured Markdown document
+/// from all session messages (system messages excluded).
+async fn handle_copy(
+    buffer: &mut ScrollBuffer,
+    session: &koda_core::session::KodaSession,
+    dest: Option<&str>,
+) {
+    // Fetch all messages — `load_all_messages` includes compacted history.
+    let messages = match session.db.load_all_messages(&session.id).await {
+        Ok(msgs) => msgs,
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Could not load messages: {e}"));
+            return;
+        }
+    };
+
+    // Try to get the session title for a nicer header.
+    let title_storage;
+    let session_title: Option<&str> = match session
+        .db
+        .list_sessions(200, std::path::Path::new("/"))
+        .await
+    {
+        Ok(sessions) => {
+            title_storage = sessions
+                .into_iter()
+                .find(|s| s.id == session.id)
+                .and_then(|s| s.title);
+            title_storage.as_deref()
+        }
+        Err(_) => None,
+    };
+
+    let md = transcript::render(&messages, session_title);
+
+    match dest {
+        None => {
+            // Clipboard copy via arboard (same fn used by mouse-select).
+            match copy_to_clipboard(&md) {
+                Ok(msg) => tui_output::ok_msg(buffer, format!("Transcript {msg}")),
+                Err(e) => tui_output::err_msg(buffer, e),
+            }
+        }
+        Some(path) => {
+            // File export.
+            match std::fs::write(path, &md) {
+                Ok(()) => {
+                    let lines = md.lines().count();
+                    tui_output::ok_msg(buffer, format!("Saved {lines} lines → {path}"));
+                }
+                Err(e) => {
+                    tui_output::err_msg(buffer, format!("Could not write {path}: {e}"));
+                }
             }
         }
     }

--- a/koda-cli/src/tui_output.rs
+++ b/koda-cli/src/tui_output.rs
@@ -29,6 +29,21 @@ pub const MAGENTA: Style = Style::new().fg(Color::Magenta);
 pub const ORANGE: Style = Style::new().fg(Color::Rgb(255, 165, 0));
 pub const AMBER: Style = Style::new().fg(Color::Rgb(255, 191, 0));
 
+/// Structural glyphs (│ └ ●) — always dim regardless of tool type.
+pub const TOOL_PREFIX: Style = Style::new().fg(Color::DarkGray);
+
+/// Content from read-only tools (Read, Grep, List, Glob …).
+///
+/// Slightly off-white — readable without comassistant prose.
+/// This is the main fix for #804 issue #3: read output was previously
+/// indistinguishable from muted/dim decorative text.
+pub const READ_CONTENT: Style = Style::new().fg(Color::Rgb(198, 200, 209)); // cool light gray
+
+/// Content from mutating tools (Bash stdout, Write/Edit diffs, etc.).
+///
+/// Kept dim — users rarely need to follow this verbatim.
+pub const WRITE_CONTENT: Style = Style::new().fg(Color::DarkGray);
+
 // Warm palette — earthy tones for koda's bear identity.
 pub const WARM_TITLE: Style = Style::new()
     .fg(Color::Rgb(229, 192, 123)) // soft gold #e5c07b

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -37,9 +37,13 @@
 
 use crate::ansi_parse::parse_ansi_spans;
 use crate::scroll_buffer::ScrollBuffer;
-use crate::tui_output::{self, AMBER, BOLD, CYAN, DIM, MAGENTA, ORANGE, RED, YELLOW};
+use crate::tui_output::{
+    self, AMBER, BOLD, CYAN, DIM, MAGENTA, ORANGE, READ_CONTENT, RED, TOOL_PREFIX, WRITE_CONTENT,
+    YELLOW,
+};
 use crate::widgets::status_bar::TurnStats;
 use koda_core::engine::EngineEvent;
+use koda_core::tools::{ToolEffect, classify_tool};
 use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
@@ -195,15 +199,28 @@ impl TuiRenderer {
                 line,
                 is_stderr,
             } => {
-                self.streaming_tool_ids.insert(id);
-                let (prefix, style) = if is_stderr {
+                self.streaming_tool_ids.insert(id.clone());
+                // Determine content style from the tool type: read-only tools
+                // (Read, Grep, List…) get a legible off-white; mutating tools
+                // (Bash, Write, Edit…) stay dim — fixing #804 issue #3.
+                let tool_name = self
+                    .pending_tool_args
+                    .get(&id)
+                    .map(|(n, _)| n.as_str())
+                    .unwrap_or("");
+                let (prefix, content_style) = if is_stderr {
                     ("  \u{2502}e ", RED)
+                } else if matches!(classify_tool(tool_name), ToolEffect::ReadOnly) {
+                    ("  \u{2502} ", READ_CONTENT)
                 } else {
-                    ("  \u{2502} ", DIM)
+                    ("  \u{2502} ", WRITE_CONTENT)
                 };
                 tui_output::emit_line(
                     buffer,
-                    Line::from(vec![Span::styled(prefix, DIM), Span::styled(line, style)]),
+                    Line::from(vec![
+                        Span::styled(prefix, TOOL_PREFIX),
+                        Span::styled(line, content_style),
+                    ]),
                 );
             }
             EngineEvent::ToolCallResult { id, name, output } => {


### PR DESCRIPTION
## What

Two connected UX improvements from the `#804` audit:

### 1. Tool-type-aware output styling (fixes #804 issue #3)

Previously all tool output was rendered in `DarkGray` (`DIM`) regardless of tool type — making Read/Grep/List content hard to follow since it blended with decorative glyphs.

**Changes in `tui_output.rs`:**
- `READ_CONTENT` — cool light gray `rgb(198, 200, 209)`: used for content from read-only tools (Read, Grep, List, Glob, MemoryRead, TodoRead…)
- `WRITE_CONTENT` — `DarkGray` (same as before): kept for mutating tools (Bash, Write, Edit, Delete…)
- `TOOL_PREFIX` — `DarkGray`: structural glyphs (`│`, `└`, `●`) always dim regardless of tool type — they're decoration, not content

**Changes in `tui_render.rs`** (live streaming path):
- `ToolOutputLine` now dispatches on `classify_tool(tool_name)` to pick `READ_CONTENT` vs `WRITE_CONTENT` for the `│` content lines

**Changes in `history_render.rs`** (session resume):
- `render_tool_result()` already had the right intent (`content_style` based on `classify_tool`) but was referencing wrong constants — now uses `READ_CONTENT` / `WRITE_CONTENT`

### 2. `/copy` — session transcript export

New command that renders the current session as structured Markdown and either:
- Copies to clipboard: `/copy`  
- Writes to a file: `/copy path/to/output.md`

**New `transcript.rs` module:**
- Skips system messages (internal plumbing)
- User messages: rendered as `## 🧑 User` with content
- Assistant messages: text + tool call headers (`### 🔍 Read`, `### ⚡ Bash`, etc.)
- Tool results: read-only tools show up to 10 lines in a fenced code block; mutating tools summarised as `N line(s) of output` (rarely useful verbatim)
- Session title from DB if available; UTC timestamp header

**Changes in `tui_commands.rs`:**
- `ReplAction::Copy` handles `/copy [file]`
- Clipboard path reuses the existing `arboard` dep (no new deps)
- File path writes UTF-8 Markdown directly

**Changes in `completer.rs`:**
- `/copy` added to `SLASH_COMMANDS` with `[file.md]` arg hint for tab-completion

## Why

- Read tool output is what users most want to follow (it's the code/content the model is examining). It should be legible, not washed out.
- Bash/Write/Edit output is implementation noise — keeping it dim reduces visual clutter.
- `/copy` fills the gap of "how do I share this conversation?" without leaving the TUI.

## Testing

- 6 new unit tests in `transcript.rs` covering user/assistant/tool rendering, read vs write truncation, and the `/copy file` code path
- All 20 existing `history_render` tests continue to pass
- `cargo clippy` + `cargo fmt` clean

## Checklist

- [x] `cargo fmt --all` clean
- [x] `cargo clippy` clean (collapsed nested `if` chains per clippy suggestion)
- [x] Existing tests pass
- [x] New tests added for `transcript.rs`
- [x] No new dependencies
