### PR TITLE
feat: persist and render thinking blocks in session history (#804 item 4)

### DIFF
--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -117,6 +117,24 @@ fn render_assistant_message(lines: &mut Vec<Line<'static>>, msg: &Message) {
     // Response separator
     lines.push(Line::styled("  \u{2500}\u{2500}\u{2500}", DIM));
 
+    // Thinking block — rendered before text, matching live streaming style:
+    //   💭 Thinking...      ← header
+    //   │ <line>            ← one line per newline in thinking_content
+    if let Some(ref thinking) = msg.thinking_content
+        && !thinking.is_empty()
+    {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled("\u{1f4ad} Thinking", DIM),
+        ]));
+        for line in thinking.lines() {
+            lines.push(Line::from(vec![
+                Span::styled("  \u{2502} ", DIM),
+                Span::styled(line.to_string(), DIM),
+            ]));
+        }
+    }
+
     // Text content (markdown rendered as plain styled text for history)
     if let Some(ref content) = msg.content
         && !content.is_empty()
@@ -287,6 +305,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -112,7 +112,20 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
             Role::Assistant => {
                 out.push_str("## 🤖 Assistant\n\n");
 
-                // Text content first
+                // Thinking block (Claude extended thinking) — before text
+                if let Some(ref thinking) = msg.thinking_content
+                    && !thinking.trim().is_empty()
+                {
+                    out.push_str("> 💭 **Thinking**\n");
+                    for line in thinking.trim().lines() {
+                        out.push_str("> ");
+                        out.push_str(line);
+                        out.push('\n');
+                    }
+                    out.push('\n');
+                }
+
+                // Text content
                 if let Some(ref content) = msg.content {
                     let trimmed = content.trim();
                     if !trimmed.is_empty() {
@@ -271,6 +284,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -742,6 +742,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -438,6 +438,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-core/src/context_analysis.rs
+++ b/koda-core/src/context_analysis.rs
@@ -354,6 +354,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -159,6 +159,7 @@ impl Database {
                 cache_read_tokens INTEGER,
                 cache_creation_tokens INTEGER,
                 thinking_tokens INTEGER,
+                thinking_content TEXT,
                 agent_name TEXT,
                 compacted_at TEXT,
                 completed_at DATETIME,
@@ -298,7 +299,7 @@ impl Database {
         let rows: Vec<MessageRow> = sqlx::query_as(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens, thinking_content,
                     created_at
              FROM messages
              WHERE session_id = ? AND id < ? AND compacted_at IS NULL
@@ -352,6 +353,7 @@ pub(crate) struct MessageRow {
     pub cache_read_tokens: Option<i64>,
     pub cache_creation_tokens: Option<i64>,
     pub thinking_tokens: Option<i64>,
+    pub thinking_content: Option<String>,
     pub created_at: Option<String>,
 }
 
@@ -396,6 +398,7 @@ impl From<MessageRow> for Message {
             cache_read_tokens: r.cache_read_tokens,
             cache_creation_tokens: r.cache_creation_tokens,
             thinking_tokens: r.thinking_tokens,
+            thinking_content: r.thinking_content,
             created_at: r.created_at,
         }
     }

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -268,6 +268,20 @@ impl Persistence for Database {
         Ok(())
     }
 
+    /// Persist the accumulated thinking/reasoning text for an assistant message.
+    ///
+    /// Called after `insert_message` so the INSERT signature stays lean —
+    /// only assistant messages from Claude with extended thinking enabled will
+    /// ever call this. All other callers of `insert_message` are unaffected.
+    async fn update_message_thinking_content(&self, message_id: i64, content: &str) -> Result<()> {
+        sqlx::query("UPDATE messages SET thinking_content = ? WHERE id = ?")
+            .bind(content)
+            .bind(message_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     /// Load active (non-compacted) messages for a session.
     ///
     /// Returns messages in chronological order. Compacted messages
@@ -280,7 +294,7 @@ impl Persistence for Database {
         let mut messages: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens, thinking_content,
                     created_at
              FROM messages
              WHERE session_id = ? AND compacted_at IS NULL
@@ -307,7 +321,7 @@ impl Persistence for Database {
         let rows: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
                     prompt_tokens, completion_tokens,
-                    cache_read_tokens, cache_creation_tokens, thinking_tokens,
+                    cache_read_tokens, cache_creation_tokens, thinking_tokens, thinking_content,
                     created_at
              FROM messages
              WHERE session_id = ?

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -384,6 +384,7 @@ fn test_prune_mismatched_tool_calls_unit() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }
@@ -581,6 +582,7 @@ fn test_prune_null_content_drops_ghost_assistant() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }
@@ -636,6 +638,7 @@ fn test_prune_whitespace_only_drops_blank_assistant() {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }
@@ -719,6 +722,7 @@ fn msg(role: Role, content: &str) -> Message {
         cache_read_tokens: None,
         cache_creation_tokens: None,
         thinking_tokens: None,
+        thinking_content: None,
         created_at: None,
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -89,6 +89,12 @@ struct TurnState<'a> {
 struct StreamResult {
     /// Accumulated text content from the response.
     text: String,
+    /// All thinking/reasoning content produced during the stream, in order.
+    ///
+    /// Empty string when the model produced no thinking blocks (non-Claude
+    /// providers, or Claude with thinking disabled). Persisted to the DB so
+    /// it can be re-rendered on session resume.
+    thinking_content: String,
     /// Tool calls requested by the model.
     tool_calls: Vec<ToolCall>,
     /// Results from tools executed eagerly during streaming.
@@ -370,7 +376,10 @@ async fn collect_stream(
     let mut usage = TokenUsage::default();
     let mut first_token = true;
     let mut char_count: usize = 0;
-    let mut native_think_buf = String::new();
+    // Permanent accumulator — never cleared, flows into StreamResult.
+    let mut thinking_content = String::new();
+    // True while we are inside a thinking block (between ThinkingStart and ThinkingDone).
+    let mut in_thinking_block = false;
     let mut response_banner_shown = false;
     let mut thinking_banner_shown = false;
     let mut interrupted = false;
@@ -394,6 +403,7 @@ async fn collect_stream(
             });
             return StreamResult {
                 text: full_text,
+                thinking_content,
                 tool_calls,
                 eager_results,
                 usage,
@@ -408,10 +418,10 @@ async fn collect_stream(
         match chunk {
             StreamChunk::TextDelta(delta) => {
                 if first_token {
-                    if !native_think_buf.is_empty() {
+                    if in_thinking_block {
                         sink.emit(EngineEvent::SpinnerStop);
                         sink.emit(EngineEvent::ThinkingDone);
-                        native_think_buf.clear();
+                        in_thinking_block = false;
                         thinking_banner_shown = true;
                     }
                     sink.emit(EngineEvent::SpinnerStop);
@@ -435,19 +445,20 @@ async fn collect_stream(
                     sink.emit(EngineEvent::ThinkingStart);
                     thinking_banner_shown = true;
                 }
+                in_thinking_block = true;
                 sink.emit(EngineEvent::ThinkingDelta {
                     text: delta.clone(),
                 });
-                native_think_buf.push_str(&delta);
+                thinking_content.push_str(&delta);
             }
             StreamChunk::ToolCallReady(tc) => {
                 // A single tool call finished streaming (Anthropic content_block_stop).
                 // If it's read-only and auto-approved, execute it now while
                 // subsequent tool calls are still being streamed.
-                if !native_think_buf.is_empty() {
+                if in_thinking_block {
                     sink.emit(EngineEvent::SpinnerStop);
                     sink.emit(EngineEvent::ThinkingDone);
-                    native_think_buf.clear();
+                    in_thinking_block = false;
                 }
                 let args: serde_json::Value =
                     serde_json::from_str(&tc.arguments).unwrap_or_default();
@@ -469,20 +480,20 @@ async fn collect_stream(
                 tool_calls.push(tc);
             }
             StreamChunk::ToolCalls(tcs) => {
-                if !native_think_buf.is_empty() {
+                if in_thinking_block {
                     sink.emit(EngineEvent::SpinnerStop);
                     sink.emit(EngineEvent::ThinkingDone);
-                    native_think_buf.clear();
+                    in_thinking_block = false;
                 }
                 sink.emit(EngineEvent::SpinnerStop);
                 // Append — some tool calls may already be in the list from ToolCallReady
                 tool_calls.extend(tcs);
             }
             StreamChunk::Done(u) => {
-                if !native_think_buf.is_empty() {
+                if in_thinking_block {
                     sink.emit(EngineEvent::SpinnerStop);
                     sink.emit(EngineEvent::ThinkingDone);
-                    native_think_buf.clear();
+                    // `in_thinking_block` not cleared — loop breaks immediately.
                 }
                 usage = u;
                 break;
@@ -499,6 +510,7 @@ async fn collect_stream(
                 });
                 return StreamResult {
                     text: full_text,
+                    thinking_content,
                     tool_calls,
                     eager_results,
                     usage,
@@ -518,6 +530,7 @@ async fn collect_stream(
 
     StreamResult {
         text: full_text,
+        thinking_content,
         tool_calls,
         eager_results,
         usage,
@@ -769,16 +782,27 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let stream_result = collect_stream(&mut rx, sink, &cancel, tools, mode, project_root).await;
 
         if stream_result.interrupted {
-            if !stream_result.text.is_empty() {
-                db.insert_message(
-                    session_id,
-                    &Role::Assistant,
-                    Some(&stream_result.text),
-                    None,
-                    None,
-                    None,
-                )
-                .await?;
+            let has_text = !stream_result.text.is_empty();
+            let has_thinking = !stream_result.thinking_content.is_empty();
+            if has_text || has_thinking {
+                let mid = db
+                    .insert_message(
+                        session_id,
+                        &Role::Assistant,
+                        if has_text {
+                            Some(stream_result.text.as_str())
+                        } else {
+                            None
+                        },
+                        None,
+                        None,
+                        None,
+                    )
+                    .await?;
+                if has_thinking {
+                    db.update_message_thinking_content(mid, &stream_result.thinking_content)
+                        .await?;
+                }
             }
             return Ok(());
         }
@@ -790,6 +814,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
 
         let full_text = stream_result.text;
+        let stream_thinking = stream_result.thinking_content;
         // Normalize tool names from model output to canonical PascalCase (#548).
         // Models (especially local/small ones via OpenAI-compat APIs) may emit
         // lowercase or snake_case names ("list", "read_file"). This runs for all
@@ -868,6 +893,14 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Mark the message as fully delivered. This distinguishes clean
         // completions from interrupted/in-progress turns on session resume.
         db.mark_message_complete(msg_id).await?;
+
+        // Persist thinking content produced by Claude extended thinking.
+        // Only set for assistant messages from models with thinking enabled;
+        // all other providers leave this empty and we skip the UPDATE.
+        if !stream_thinking.is_empty() {
+            db.update_message_thinking_content(msg_id, &stream_thinking)
+                .await?;
+        }
 
         // If no tool calls, we already streamed the response — done
         if tool_calls.is_empty() {
@@ -1243,6 +1276,8 @@ mod tests {
         )
         .await;
 
+        // Thinking content must be captured in the dedicated field.
+        assert_eq!(result.thinking_content, "Let me think...");
         // Thinking deltas should NOT appear in the text output.
         assert_eq!(result.text, "Answer!");
     }

--- a/koda-core/src/microcompact.rs
+++ b/koda-core/src/microcompact.rs
@@ -238,6 +238,7 @@ mod tests {
             cache_read_tokens: None,
             cache_creation_tokens: None,
             thinking_tokens: None,
+            thinking_content: None,
             created_at: None,
         }
     }

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -98,6 +98,11 @@ pub struct Message {
     pub cache_creation_tokens: Option<i64>,
     /// Reasoning/thinking tokens.
     pub thinking_tokens: Option<i64>,
+    /// Full thinking/reasoning text produced by Claude extended thinking.
+    ///
+    /// `None` for non-Claude models, or when thinking was disabled.
+    /// Persisted so the content can be re-rendered on session resume.
+    pub thinking_content: Option<String>,
     /// ISO 8601 creation timestamp.
     pub created_at: Option<String>,
 }
@@ -259,6 +264,12 @@ pub trait Persistence: Send + Sync {
     /// `StreamChunk::Done` — not after user cancellation or a network error.
     /// A `NULL` `completed_at` means the message is in-progress or was interrupted.
     async fn mark_message_complete(&self, message_id: i64) -> Result<()>;
+
+    /// Persist thinking/reasoning text for an assistant message.
+    ///
+    /// Called only for Claude with extended thinking enabled. All other
+    /// providers leave `thinking_content` NULL.
+    async fn update_message_thinking_content(&self, message_id: i64, content: &str) -> Result<()>;
 
     // ── Token usage ──
 


### PR DESCRIPTION
## Summary

Closes item 4 from #804.

Thinking blocks produced by Claude extended thinking (and Gemini thought parts, o1/o3 reasoning, and `<think>` tag models) now survive session boundaries and re-render in history exactly as they appear during live inference.

## Problem

`native_think_buf` in `collect_stream` was cleared after every `ThinkingDone` event and never written to the DB. On session resume, `history_render.rs` had `thinking_tokens: None` hardcoded and no render path for thinking content at all. Thinking blocks existed only in the live stream — gone the moment the turn finished.

## Solution

### Data pipeline
- **`StreamResult`** gains a `thinking_content: String` field — a permanent accumulator, never cleared
- Separate `in_thinking_block: bool` flag drives `ThinkingStart`/`ThinkingDone` event emission without disturbing the accumulator
- After the assistant `INSERT`, a new `update_message_thinking_content(msg_id, &content)` `UPDATE` writes the text to the DB — keeps `insert_message` signature unchanged (zero churn on its 17 call sites)
- Interrupted turns also persist whatever thinking had accumulated before cancellation

### Schema
`thinking_content TEXT` column added to `messages` `CREATE TABLE`. No migration needed (fresh DB).

### Rendering
- **`history_render.rs`**: thinking block rendered before text, matching live gutter style exactly:
  ```
    ───
    💭 Thinking
    │ The approach here is to first check whether...
    │ ...
    the actual response text
  ```
- **`transcript.rs`**: `/export` includes thinking as a Markdown blockquote before the assistant text

## Provider compatibility

All three provider families already funnel through `StreamChunk::ThinkingDelta` — the accumulator catches them all:

| Model family | Source | Notes |
|---|---|---|
| Claude Sonnet/Opus | `stream_collector.rs` native delta | Extended thinking only |
| Gemini 2.5 Pro/Flash | `gemini.rs` `part.thought == true` | Batch-delivered (one chunk) |
| o1 / o3 / o4-mini | `openai_compat.rs` `reasoning_content` | Streamed deltas |
| GPT-4o / 4.5 | — | No-op, `thinking_content` stays empty |
| DeepSeek-R1 / QwQ / local | `stream_tag_filter.rs` tag strip | `<think>`/`<reasoning>` tags |

Models without thinking produce no `ThinkingDelta`s → `thinking_content` is `""` → `if !stream_thinking.is_empty()` guard skips the UPDATE → column stays NULL → render skips the block. Zero UX change for non-thinking models.

## Design decisions

- **Flat rendering** (no collapse): matches the live streaming UX — thinking is always visible inline, no new keybindings needed
- **DB-backed**: unlike Claude Code and Gemini CLI (in-memory only), Koda's SQLite store means thinking survives process restarts
- **UPDATE not INSERT**: `insert_message` signature untouched, 17 call sites unaffected

## Files changed
```
koda-core/src/inference.rs        — StreamResult + collect_stream + persist call
koda-core/src/persistence.rs      — Message struct + Persistence trait
koda-core/src/db/mod.rs           — schema + MessageRow + SELECTs + From impl
koda-core/src/db/queries.rs       — update_message_thinking_content impl
koda-core/src/compact.rs          — Message literal update
koda-core/src/context_analysis.rs — Message literal update
koda-core/src/microcompact.rs     — Message literal update
koda-core/src/db/tests.rs         — Message literal updates
koda-cli/src/history_render.rs    — thinking block renderer + test helper
koda-cli/src/transcript.rs        — /export thinking blockquote
koda-cli/src/tui_commands.rs      — Message literal update
```

## Testing
- Updated `collect_stream_thinking_then_text` to assert `result.thinking_content == "Let me think..."`
- All existing tests pass (`cargo test`)