### PR TITLE
fix: surface actionable warning when model rejects image input (#804 item 6)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -43,8 +43,8 @@ use crate::engine::{EngineCommand, EngineEvent, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
     AUTO_COMPACT_THRESHOLD, CONTEXT_WARN_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
-    estimate_tokens, is_context_overflow_error, is_rate_limit_error, is_server_error,
-    rate_limit_backoff,
+    estimate_tokens, is_context_overflow_error, is_image_rejection_error, is_rate_limit_error,
+    is_server_error, rate_limit_backoff,
 };
 use crate::loop_guard::LoopDetector;
 use crate::persistence::Persistence;
@@ -718,6 +718,13 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Pre-flight budget check: if context is critically high, compact first
         let messages = preflight_compact_if_needed(&turn, messages).await?;
 
+        // Track whether this turn carried image attachments so we can surface
+        // a targeted warning if the provider rejects them.
+        let had_images = turn
+            .pending_images
+            .map(|imgs| !imgs.is_empty())
+            .unwrap_or(false);
+
         // Stream the response (with rate limit retry)
         sink.emit(EngineEvent::SpinnerStart {
             message: "Thinking...".into(),
@@ -769,6 +776,18 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                         "Provider returned a server error: {e:#}. \
                          This often means the model can't handle the current \
                          conversation state. Try a different model or start a new session."
+                    ),
+                });
+                return Ok(());
+            }
+            Err(e) if had_images && is_image_rejection_error(&e) => {
+                sink.emit(EngineEvent::SpinnerStop);
+                sink.emit(EngineEvent::Warn {
+                    message: format!(
+                        "⚠ This model rejected the image attachment — \
+                         it likely does not support vision input. \
+                         Switch to a vision-capable model such as \
+                         claude-sonnet, gemini-flash, or gpt-4o. ({e})"
                     ),
                 });
                 return Ok(());

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -184,6 +184,32 @@ pub fn is_context_overflow_error(err: &anyhow::Error) -> bool {
         || (msg.contains("413") && msg.contains("too large"))
 }
 
+/// Detect if an error is a provider rejection of image / vision input.
+///
+/// Fires when the model or API endpoint does not support multimodal input and
+/// returns an explicit error rather than silently ignoring the image bytes.
+/// Matches the documented rejection messages from OpenAI-compat servers
+/// (LM Studio, Ollama), the OpenAI API, and Gemini.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::is_image_rejection_error;
+///
+/// assert!(is_image_rejection_error(&anyhow::anyhow!("This model does not support image input")));
+/// assert!(is_image_rejection_error(&anyhow::anyhow!("Invalid image. The model does not support vision input.")));
+/// assert!(is_image_rejection_error(&anyhow::anyhow!("multimodal content is not supported")));
+/// assert!(!is_image_rejection_error(&anyhow::anyhow!("rate limit exceeded")));
+/// assert!(!is_image_rejection_error(&anyhow::anyhow!("prompt is too long")));
+/// ```
+pub fn is_image_rejection_error(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}").to_lowercase();
+    // "image" alone is too broad; require it alongside a support-denial word.
+    (msg.contains("image") && (msg.contains("support") || msg.contains("invalid")))
+        || msg.contains("vision")
+        || msg.contains("multimodal")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,5 +320,42 @@ mod tests {
     fn test_is_not_server_error_for_auth() {
         let err = anyhow::anyhow!("401 Unauthorized");
         assert!(!is_server_error(&err));
+    }
+
+    #[test]
+    fn test_is_image_rejection_error_matches() {
+        // LM Studio / Ollama
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "LLM API returned 400: This model does not support image input"
+        )));
+        // OpenAI
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "Invalid image. The model does not support vision input."
+        )));
+        // Generic multimodal rejection
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "multimodal content is not supported by this endpoint"
+        )));
+        // Case-insensitive
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "Vision capability not available"
+        )));
+    }
+
+    #[test]
+    fn test_is_image_rejection_error_no_false_positives() {
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "rate limit exceeded"
+        )));
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "prompt is too long"
+        )));
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "502 bad gateway"
+        )));
+        // "image" alone without support/invalid context should not match
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "failed to load image/png from request body"
+        )));
     }
 }


### PR DESCRIPTION
## Problem

Closes item 6 from #804.

When a non-vision model received an image attachment it either silently ignored the bytes (qwen3.5 in the debug session — the model called `tesseract` as a workaround) or returned a provider 400 that surfaced as a generic hard crash. Either way the user got no indication their image was not processed.

## Fix

Two files, no new structs, no capability registry.

### `inference_helpers.rs` — `is_image_rejection_error()`

New predicate alongside the existing `is_server_error` / `is_rate_limit_error` / `is_context_overflow_error` family. Matches documented rejection messages from all three provider families:

| Provider | Example error body |
|---|---|
| LM Studio / Ollama | `This model does not support image input` |
| OpenAI API | `Invalid image. The model does not support vision input.` |
| Generic | `multimodal content is not supported by this endpoint` |

Pattern: `("image" AND ("support" OR "invalid")) OR "vision" OR "multimodal"` — requires co-occurrence to avoid false positives on incidental `image/png` strings in unrelated error bodies.

### `inference.rs` — new match arm

```rust
Err(e) if had_images && is_image_rejection_error(&e) => {
    sink.emit(EngineEvent::Warn {
        message: "⚠ This model rejected the image attachment — it likely does \
                  not support vision input. Switch to a vision-capable model \
                  such as claude-sonnet, gemini-flash, or gpt-4o.",
    });
}
```

`had_images` is derived from `turn.pending_images` before the stream spawn — only fires on turns where images were actually attached. The arm sits after `is_server_error` (5xx) and before the hard `Err(e)` fallback.

## What this deliberately does NOT do

- **No static capability registry** — YAGNI; ~150-entry Aider-style list is a maintenance burden and produces false positives for unlisted local models
- **No pre-flight model probe** — over-engineering
- **Silent degradation** (model ignores the image, returns no error) is out of scope; that path requires a capability registry which was explicitly rejected

## Files changed

```
koda-core/src/inference_helpers.rs  — is_image_rejection_error() + 8 unit tests
koda-core/src/inference.rs          — had_images tracking + new match arm
```

## Tests

- 4 positive assertions: LM Studio body, OpenAI body, multimodal generic, case-insensitive
- 4 negative assertions: rate limit, context overflow, 502, bare `image/png` (no false positive)
