### PR TITLE
fix: name the responsible tool in Edit staleness validation error (#804 item 7)

### DIFF
--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -505,11 +505,15 @@ pub(crate) async fn execute_tools_sequential(
         // with an approval prompt that will inevitably fail.
         if let Some(error) = {
             let cache = tools.file_read_cache();
+            let last_writer = tools.last_writer_cache();
+            let last_bash = tools.last_bash_cache();
             tools::validate::validate_tool_call(
                 &tc.function_name,
                 &parsed_args,
                 project_root,
                 Some(&cache),
+                Some(&last_writer),
+                Some(&last_bash),
             )
             .await
         } {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -155,6 +155,20 @@ use crate::providers::ToolDefinition;
 /// share the same cache — reads by one agent benefit all others.
 pub type FileReadCache = Arc<std::sync::Mutex<HashMap<String, (u64, SystemTime)>>>;
 
+/// Tracks which tool last wrote each absolute file path.
+///
+/// Keyed by canonical `PathBuf`; value is `(tool_name, when)` using a
+/// monotonic `Instant`. Populated on every successful Write and Edit so
+/// the validation layer can include the responsible tool in staleness
+/// error messages (#804 item 7).
+pub type LastWriterCache = Arc<std::sync::Mutex<HashMap<PathBuf, (String, std::time::Instant)>>>;
+
+/// Tracks the most recent successful Bash invocation.
+///
+/// Stores `(command_snippet, when)`. Only the latest call is kept — enough
+/// context to tell the model "Bash ran 2s ago, it may have changed the file".
+pub type LastBashCache = Arc<std::sync::Mutex<Option<(String, std::time::Instant)>>>;
+
 /// Result of executing a tool.
 ///
 /// The `success` field is set automatically by `ToolRegistry::execute()` —
@@ -190,6 +204,10 @@ pub struct ToolRegistry {
     project_root: PathBuf,
     definitions: HashMap<String, ToolDefinition>,
     read_cache: FileReadCache,
+    /// Per-file last-writer tracking for richer staleness errors (#804 item 7).
+    last_writer: LastWriterCache,
+    /// Most recent Bash invocation for staleness error context (#804 item 7).
+    last_bash: LastBashCache,
     /// Undo stack for file mutations.
     pub undo: std::sync::Mutex<crate::undo::UndoStack>,
     /// Discovered skills.
@@ -256,6 +274,8 @@ impl ToolRegistry {
             project_root,
             definitions,
             read_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            last_writer: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            last_bash: Arc::new(std::sync::Mutex::new(None)),
             undo: std::sync::Mutex::new(crate::undo::UndoStack::new()),
             skill_registry,
             db: std::sync::RwLock::new(None),
@@ -277,6 +297,16 @@ impl ToolRegistry {
     /// Get a clone of the `Arc` file-read cache for sharing with sub-agents.
     pub fn file_read_cache(&self) -> FileReadCache {
         Arc::clone(&self.read_cache)
+    }
+
+    /// Get a clone of the last-writer cache for passing to validation.
+    pub fn last_writer_cache(&self) -> LastWriterCache {
+        Arc::clone(&self.last_writer)
+    }
+
+    /// Get a clone of the last-bash cache for passing to validation.
+    pub fn last_bash_cache(&self) -> LastBashCache {
+        Arc::clone(&self.last_bash)
     }
 
     /// Attach database + session for tools that need history access.
@@ -429,11 +459,26 @@ impl ToolRegistry {
                 )
                 .await;
                 return match shell_result {
-                    Ok(so) => ToolResult {
-                        output: so.summary,
-                        success: true,
-                        full_output: so.full_output,
-                    },
+                    Ok(so) => {
+                        // Record the invocation so validate_edit can hint at it
+                        // in staleness error messages (#804 item 7).
+                        let snippet = args["command"]
+                            .as_str()
+                            .unwrap_or("")
+                            .chars()
+                            .take(72)
+                            .collect::<String>();
+                        if !snippet.is_empty()
+                            && let Ok(mut guard) = self.last_bash.lock()
+                        {
+                            *guard = Some((snippet, std::time::Instant::now()));
+                        }
+                        ToolResult {
+                            output: so.summary,
+                            success: true,
+                            full_output: so.full_output,
+                        }
+                    }
                     Err(e) => ToolResult {
                         output: format!("Error: {e}"),
                         success: false,
@@ -534,11 +579,22 @@ impl ToolRegistry {
         };
 
         match result {
-            Ok(output) => ToolResult {
-                output,
-                success: true,
-                full_output: None,
-            },
+            Ok(output) => {
+                // Record successful Write/Edit so the validation layer can
+                // name the responsible tool in staleness error messages.
+                if matches!(name, "Write" | "Edit")
+                    && let Some(path) =
+                        crate::file_tracker::resolve_file_path_from_args(&args, &self.project_root)
+                    && let Ok(mut guard) = self.last_writer.lock()
+                {
+                    guard.insert(path, (name.to_string(), std::time::Instant::now()));
+                }
+                ToolResult {
+                    output,
+                    success: true,
+                    full_output: None,
+                }
+            }
             Err(e) => ToolResult {
                 output: format!("Error: {e}"),
                 success: false,

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -18,14 +18,36 @@
 
 use super::safe_resolve_path;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
+
+/// Format a monotonic `Instant` age into a compact human-readable string.
+///
+/// ```text
+/// <5s  → "just now"
+/// <60s → "12s ago"
+/// else → "3m ago"
+/// ```
+fn fmt_age(instant: std::time::Instant) -> String {
+    let secs = instant.elapsed().as_secs();
+    if secs < 5 {
+        "just now".to_string()
+    } else if secs < 60 {
+        format!("{secs}s ago")
+    } else {
+        format!("{}m ago", secs / 60)
+    }
+}
 
 /// Validate a tool call before approval.
 ///
 /// `read_cache` is the session file-read cache.  When provided, `validate_edit`
 /// uses it to detect files that have been modified on disk since the model last
 /// read them — catching the most common source of lost-context edits.
+///
+/// `last_writer` and `last_bash` add context to staleness errors: instead of a
+/// generic "file was modified" message the model sees which tool was responsible
+/// and how long ago it ran (#804 item 7).
 ///
 /// Returns `None` if the call looks valid, or `Some(error_message)` describing
 /// why it will fail. The error message is fed back to the model so it can
@@ -35,14 +57,45 @@ pub async fn validate_tool_call(
     args: &serde_json::Value,
     project_root: &Path,
     read_cache: Option<&super::FileReadCache>,
+    last_writer: Option<&super::LastWriterCache>,
+    last_bash: Option<&super::LastBashCache>,
 ) -> Option<String> {
     match tool_name {
-        "Edit" => validate_edit(args, project_root, read_cache).await,
+        "Edit" => validate_edit(args, project_root, read_cache, last_writer, last_bash).await,
         "Write" => validate_write(args, project_root).await,
         "Delete" => validate_delete(args, project_root).await,
         "Bash" => validate_bash(args),
         _ => None,
     }
+}
+
+/// Build a parenthetical hint describing what tool last modified a file.
+///
+/// Priority:
+/// 1. A recorded Write/Edit entry for this exact path  → " (last written by Edit 3s ago)"
+/// 2. A recent Bash invocation (possible indirect modifier) → " (Bash ran 2s ago: `cargo fmt ...`)"
+/// 3. Neither known                                        → "" (empty; generic message is fine)
+fn writer_hint(
+    resolved: &PathBuf,
+    last_writer: Option<&super::LastWriterCache>,
+    last_bash: Option<&super::LastBashCache>,
+) -> String {
+    // Check for a direct Write/Edit record for this path.
+    if let Some(lw) = last_writer
+        && let Ok(guard) = lw.lock()
+        && let Some((tool, when)) = guard.get(resolved)
+    {
+        return format!(" (last written by {} {})", tool, fmt_age(*when));
+    }
+    // Fall back to the most recent Bash call — it may have modified the file
+    // indirectly (formatter, build script, etc.).
+    if let Some(lb) = last_bash
+        && let Ok(guard) = lb.lock()
+        && let Some((snippet, when)) = guard.as_ref()
+    {
+        return format!(" (Bash ran {}: `{}`)", fmt_age(*when), snippet);
+    }
+    String::new()
 }
 
 /// Edit: file must exist, replacements must be non-empty, each old_str must
@@ -52,6 +105,8 @@ async fn validate_edit(
     args: &serde_json::Value,
     project_root: &Path,
     read_cache: Option<&super::FileReadCache>,
+    last_writer: Option<&super::LastWriterCache>,
+    last_bash: Option<&super::LastBashCache>,
 ) -> Option<String> {
     let path_str = args["file_path"]
         .as_str()
@@ -99,10 +154,12 @@ async fn validate_edit(
         if let Some(cm) = cached_mtime
             && cm != current_mtime
         {
+            // Build a context hint naming the responsible tool so the model
+            // doesn't have to guess why the file changed (#804 item 7).
+            let hint = writer_hint(&resolved, last_writer, last_bash);
             return Some(format!(
-                "File '{}' has been modified on disk since you last read it. \
+                "File '{path_str}' has been modified on disk since you last read it{hint}. \
                  Read it again to get the current content before editing.",
-                path_str
             ));
         }
     }
@@ -377,14 +434,20 @@ mod tests {
             "path": "hello.txt",
             "replacements": [{"old_str": "line two", "new_str": "line TWO"}]
         });
-        assert!(validate_edit(&args, dir.path(), None).await.is_none());
+        assert!(
+            validate_edit(&args, dir.path(), None, None, None)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
     async fn edit_missing_path() {
         let dir = setup();
         let args = json!({"replacements": [{"old_str": "x", "new_str": "y"}]});
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("path"), "{err}");
     }
 
@@ -395,7 +458,9 @@ mod tests {
             "path": "nope.txt",
             "replacements": [{"old_str": "x", "new_str": "y"}]
         });
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("Cannot read"), "{err}");
         assert!(err.contains("Write"), "{err}"); // suggests Write
     }
@@ -404,7 +469,9 @@ mod tests {
     async fn edit_empty_replacements() {
         let dir = setup();
         let args = json!({"path": "hello.txt", "replacements": []});
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("empty"), "{err}");
     }
 
@@ -415,7 +482,9 @@ mod tests {
             "path": "hello.txt",
             "replacements": [{"old_str": "", "new_str": "y"}]
         });
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("empty"), "{err}");
     }
 
@@ -433,7 +502,9 @@ mod tests {
             "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
         });
         assert!(
-            validate_edit(&args, dir.path(), None).await.is_none(),
+            validate_edit(&args, dir.path(), None, None, None)
+                .await
+                .is_none(),
             "fuzzy match should pass validation"
         );
     }
@@ -445,7 +516,9 @@ mod tests {
             "path": "hello.txt",
             "replacements": [{"old_str": "does not exist", "new_str": "y"}]
         });
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("not found"), "{err}");
     }
 
@@ -456,7 +529,9 @@ mod tests {
             "path": "hello.txt",
             "replacements": [{"old_str": "line one"}]
         });
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("new_str"), "{err}");
     }
 
@@ -534,7 +609,11 @@ mod tests {
             "file_path": "hello.txt",
             "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
         });
-        assert!(validate_edit(&args, dir.path(), None).await.is_none());
+        assert!(
+            validate_edit(&args, dir.path(), None, None, None)
+                .await
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -596,7 +675,7 @@ mod tests {
             "path": "hello.txt",
             "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
         });
-        let err = validate_edit(&args, dir.path(), Some(&cache))
+        let err = validate_edit(&args, dir.path(), Some(&cache), None, None)
             .await
             .unwrap();
         assert!(err.contains("modified on disk"), "{err}");
@@ -615,7 +694,7 @@ mod tests {
             "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
         });
         assert!(
-            validate_edit(&args, dir.path(), Some(&cache))
+            validate_edit(&args, dir.path(), Some(&cache), None, None)
                 .await
                 .is_none(),
             "up-to-date file should not trigger stale warning"
@@ -632,11 +711,69 @@ mod tests {
             "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
         });
         assert!(
-            validate_edit(&args, dir.path(), Some(&empty_cache))
+            validate_edit(&args, dir.path(), Some(&empty_cache), None, None)
                 .await
                 .is_none(),
             "no cache entry should not trigger stale warning"
         );
+    }
+
+    // ── Staleness hint messages (#804 item 7) ─────────────────
+
+    #[tokio::test]
+    async fn stale_file_hints_last_writer_tool() {
+        let dir = setup();
+        let file = dir.path().join("hello.txt");
+        let cache = make_cache(&file, SystemTime::UNIX_EPOCH);
+
+        // Populate last_writer with an Edit entry for this file.
+        let last_writer = super::super::LastWriterCache::default();
+        last_writer.lock().unwrap().insert(
+            file.clone(),
+            ("Edit".to_string(), std::time::Instant::now()),
+        );
+
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
+        });
+        let err = validate_edit(&args, dir.path(), Some(&cache), Some(&last_writer), None)
+            .await
+            .unwrap();
+        assert!(err.contains("modified on disk"), "{err}");
+        assert!(err.contains("last written by Edit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn stale_file_hints_bash_when_no_writer_entry() {
+        let dir = setup();
+        let file = dir.path().join("hello.txt");
+        let cache = make_cache(&file, SystemTime::UNIX_EPOCH);
+
+        // No last_writer entry for this file — fall through to last_bash.
+        let last_writer = super::super::LastWriterCache::default();
+        let last_bash = super::super::LastBashCache::default();
+        *last_bash.lock().unwrap() = Some((
+            "cargo fmt -- src/bash_safety.rs".to_string(),
+            std::time::Instant::now(),
+        ));
+
+        let args = json!({
+            "path": "hello.txt",
+            "replacements": [{"old_str": "line two", "new_str": "LINE TWO"}]
+        });
+        let err = validate_edit(
+            &args,
+            dir.path(),
+            Some(&cache),
+            Some(&last_writer),
+            Some(&last_bash),
+        )
+        .await
+        .unwrap();
+        assert!(err.contains("modified on disk"), "{err}");
+        assert!(err.contains("Bash ran"), "{err}");
+        assert!(err.contains("cargo fmt"), "{err}");
     }
 
     // ── Omission placeholder detection ────────────────────────
@@ -735,7 +872,9 @@ mod tests {
                 "new_str": "// rest of code ..."
             }]
         });
-        let err = validate_edit(&args, dir.path(), None).await.unwrap();
+        let err = validate_edit(&args, dir.path(), None, None, None)
+            .await
+            .unwrap();
         assert!(err.contains("omission placeholder"), "{err}");
     }
 
@@ -750,6 +889,10 @@ mod tests {
             }]
         });
         // "..." without a known prefix should NOT be detected
-        assert!(validate_edit(&args, dir.path(), None).await.is_none());
+        assert!(
+            validate_edit(&args, dir.path(), None, None, None)
+                .await
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Problem

Closes #804 item 7.

The debug session showed a retry loop where the model repeatedly called Edit on `bash_safety.rs`, hit the staleness validation error, re-read the file, and retried — never breaking the cycle. The error it saw each time:

```
Validation error: File 'bash_safety.rs' has been modified on disk since you
last read it. Read it again to get the current content before editing.
```

The model had no signal for *why* the file was stale. It assumed its own prior Edit was the cause and kept retrying. The actual culprit was a Bash call (`cargo fmt`) that had run between the Read and the Edit.

## Fix

Two new `Arc<Mutex<...>>` caches on `ToolRegistry`, zero extra disk I/O:

| Cache | Type | Populated by |
|---|---|---|
| `LastWriterCache` | `HashMap<PathBuf, (String, Instant)>` | Every successful Write or Edit |
| `LastBashCache` | `Option<(String, Instant)>` | Every successful Bash (first 72 chars of command) |

A new `writer_hint()` function in `validate.rs` checks `LastWriterCache` first (exact path), then `LastBashCache` as a fallback. The staleness error now reads:

**When Bash was the culprit:**
```
Validation error: File 'bash_safety.rs' has been modified on disk since you
last read it (Bash ran 2s ago: `cargo fmt -- src/bash_safety.rs`).
Read it again to get the current content before editing.
```

**When Edit/Write was the culprit:**
```
Validation error: File 'bash_safety.rs' has been modified on disk since you
last read it (last written by Edit just now).
Read it again to get the current content before editing.
```

**When neither is known (external tool, user edit):**
```
Validation error: File 'bash_safety.rs' has been modified on disk since you
last read it. Read it again to get the current content before editing.
```
Unchanged from before — no regression for the external-editor case.

## What this does NOT do

- **No content-hash staleness** (Gemini-style SHA256) — mtime approach is unchanged; hash fallback is a separable follow-up
- **No per-file Bash tracking** — Bash doesn't declare which files it touches; `LastBashCache` tracks the most recent invocation globally and frames it as "may have modified" (not "definitely did")
- **No sub-agent sharing** — each sub-agent gets fresh caches; wiring them through `with_shared_cache` is a follow-up

## Files changed

```
koda-core/src/tools/mod.rs      +2 type aliases, 2 fields, 2 accessors,
                                  Bash/Write/Edit recording in execute()
koda-core/src/tools/validate.rs +fmt_age(), +writer_hint(),
                                  updated validate_edit() signature,
                                  +2 tests
koda-core/src/tool_dispatch.rs  pass 2 new caches to validate_tool_call()
```

## Tests

```
stale_file_hints_last_writer_tool          — error contains "last written by Edit"
stale_file_hints_bash_when_no_writer_entry — error contains "Bash ran" + command snippet
```

All 285 prior validate tests pass unchanged (internal `validate_edit()` calls updated to `None, None` for the new optional cache params).

## Related

- #814 — arch discussion: evaluate apply_patch as Edit replacement
