### PR TITLE
fix: improve loop detection warning message (#804 item 8)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1169,10 +1169,12 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Loop detection: same tool+args repeated REPEAT_THRESHOLD times → stop immediately.
         if let Some(fp) = loop_detector.record(&tool_calls) {
             let culprit = fp.split(':').next().unwrap_or("unknown");
+            let n = crate::loop_guard::REPEAT_THRESHOLD;
             sink.emit(EngineEvent::Warn {
                 message: format!(
-                    "Loop detected: '{culprit}' is repeating with identical arguments. \
-                     Stopping to avoid wasted work. Rephrase the task or check for ambiguity."
+                    "Loop guard: '{culprit}' was called {n}× with similar arguments — \
+                     stopping to avoid wasted tokens. \
+                     If the model was making progress, send a follow-up message to continue."
                 ),
             });
             break Ok(());

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -11,8 +11,9 @@
 //!
 //! ## What happens on detection
 //!
-//! - **Soft limit** (repeated tool calls): injects a system message telling
-//!   the model it's looping, asking it to try a different approach
+//! - **Soft limit** (repeated tool calls): emits a `Warn` event naming the
+//!   culprit tool and repeat count; the turn ends and the user can send a
+//!   follow-up message to continue
 //! - **Hard limit** (iteration cap): prompts the user interactively to
 //!   continue or stop — falls back to stop in headless environments
 //!
@@ -31,7 +32,7 @@ pub const MAX_ITERATIONS_DEFAULT: u32 = 200;
 pub const MAX_SUB_AGENT_ITERATIONS: usize = 20;
 
 /// How many times the same fingerprint must appear to flag a loop.
-const REPEAT_THRESHOLD: usize = 3;
+pub const REPEAT_THRESHOLD: usize = 3;
 
 /// Sliding window size (individual tool calls, not batches).
 const WINDOW_SIZE: usize = 20;

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -193,10 +193,9 @@ async fn loop_detection_stops_repeated_tool_calls() {
     let events = env.run_inference(&provider).await;
 
     // Should detect the loop and emit a warning.
-    let has_loop_warn = events.iter().any(|e| {
-        matches!(e, EngineEvent::Warn { message } if message.contains("Loop detected")
-            || message.contains("repeating"))
-    });
+    let has_loop_warn = events
+        .iter()
+        .any(|e| matches!(e, EngineEvent::Warn { message } if message.contains("Loop guard")));
     assert!(has_loop_warn, "expected loop detection warning: {events:?}");
 }
 


### PR DESCRIPTION
## Problem

Closes #804 item 8.

The loop detection warning had three compounding problems:

```
⚠ Loop detected: 'TodoWrite' is repeating with identical arguments.
  Stopping to avoid wasted work. Rephrase the task or check for ambiguity.
```

1. **"identical arguments"** — wrong after #806. The fingerprint is content-aware (hashes the full args, not just the first 200 chars). The args were similar, not byte-for-byte identical.
2. **"Rephrase the task or check for ambiguity"** — actively wrong advice in the debug session case where the model was correctly checking off todo items. Telling it to rephrase would make things worse.
3. **No recovery path** — the turn ends silently. Users had no idea they could just send a follow-up message to continue.

## Fix

```
⚠ Loop guard: 'TodoWrite' was called 3× with similar arguments —
  stopping to avoid wasted tokens. If the model was making progress,
  send a follow-up message to continue.
```

- Accurate: "similar" not "identical", "Loop guard" not "Loop detected"
- Includes the repeat count (`REPEAT_THRESHOLD`, now `pub`)
- Actionable: tells the user exactly what to do to recover

## Files changed

```
koda-core/src/loop_guard.rs            REPEAT_THRESHOLD: const → pub const
                                        module doc updated
koda-core/src/inference.rs             rewritten Warn message
koda-core/tests/inference_edge_test.rs assertion updated to 'Loop guard'
```

3 files, 11 insertions, 9 deletions.