### PR TITLE
fix: pre-release hardening — UTF-8 safety, vision match, export path, quote escapes

### DIFF
--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -31,6 +31,15 @@ use koda_core::tools::{ToolEffect, classify_tool};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Truncate a string to at most `max` characters, appending `…` if truncated.
+/// Safe on multi-byte UTF-8 (never splits a codepoint).
+fn truncate_with_ellipsis(s: &str, max: usize) -> String {
+    match s.char_indices().nth(max) {
+        Some((idx, _)) => format!("{}…", &s[..idx]),
+        None => s.to_string(),
+    }
+}
+
 /// Maximum content lines to include per tool result in the transcript.
 const RESULT_PREVIEW_LINES: usize = 10;
 
@@ -228,8 +237,8 @@ fn tool_detail_summary(name: &str, args_json: &str) -> String {
         }
         "Bash" => {
             let cmd = args["command"].as_str().unwrap_or("");
-            if cmd.len() > 80 {
-                format!("{}…", &cmd[..77])
+            if cmd.chars().count() > 80 {
+                truncate_with_ellipsis(cmd, 77)
             } else {
                 cmd.to_string()
             }
@@ -252,8 +261,8 @@ fn tool_detail_summary(name: &str, args_json: &str) -> String {
             if let Some(obj) = args.as_object() {
                 for (_, v) in obj.iter().take(1) {
                     if let Some(s) = v.as_str() {
-                        return if s.len() > 80 {
-                            format!("{}…", &s[..77])
+                        return if s.chars().count() > 80 {
+                            truncate_with_ellipsis(s, 77)
                         } else {
                             s.to_string()
                         };

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -591,7 +591,20 @@ async fn handle_export(
 
     let path_owned;
     let path: &str = match dest {
-        Some(p) => p,
+        Some(p) => {
+            // Reject paths that escape CWD — absolute paths and ".." traversal.
+            let dest_path = std::path::Path::new(p);
+            if dest_path.is_absolute() || p.contains("..") {
+                tui_output::err_msg(
+                    buffer,
+                    "Export path must be relative to the current directory \
+                     (no absolute paths or \"..\" traversal)."
+                        .into(),
+                );
+                return;
+            }
+            p
+        }
         None => {
             path_owned = export_default_filename(&messages);
             &path_owned
@@ -649,11 +662,8 @@ fn export_default_filename(messages: &[koda_core::persistence::Message]) -> Stri
         .filter(|s| !s.is_empty())
         .map(|s| {
             // Hard cap at 40 chars, respecting char boundaries.
-            if s.len() > 40 {
-                s[..40].trim_end_matches('-').to_string()
-            } else {
-                s
-            }
+            let truncated: String = s.chars().take(40).collect();
+            truncated.trim_end_matches('-').to_string()
         })
         .unwrap_or_default();
 

--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -414,17 +414,44 @@ pub fn strip_quoted_strings(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
-        if c == '\'' || c == '"' {
+        if c == '\'' {
+            // Single quotes: no escape sequences in bash — everything until
+            // the next unescaped single quote is literal content.
             result.push(c);
             let mut found_close = false;
             for inner in chars.by_ref() {
-                if inner == c {
+                if inner == '\'' {
                     result.push(c);
                     found_close = true;
                     break;
                 }
                 result.push(' ');
             }
+            // Unterminated quote — content already replaced with spaces.
+            if !found_close {}
+        } else if c == '"' {
+            // Double quotes: backslash escapes the next character (\" stays
+            // inside the string, \\ is a literal backslash, etc.).
+            result.push(c);
+            let mut found_close = false;
+            while let Some(inner) = chars.next() {
+                if inner == '\\' {
+                    // Escaped character — consume the next char as literal
+                    // content (replaced with spaces, same as unescaped content).
+                    result.push(' '); // the backslash
+                    if chars.next().is_some() {
+                        result.push(' '); // the escaped char
+                    }
+                    continue;
+                }
+                if inner == '"' {
+                    result.push(c);
+                    found_close = true;
+                    break;
+                }
+                result.push(' ');
+            }
+            // Unterminated quote — content already replaced with spaces.
             if !found_close {}
         } else {
             result.push(c);
@@ -562,6 +589,29 @@ mod tests {
                 "should not be Destructive (pattern is inside quotes): {cmd}"
             );
         }
+    }
+
+    #[test]
+    fn test_strip_quoted_handles_backslash_escaped_quotes() {
+        // Escaped double-quote inside double-quoted string stays inside.
+        assert_eq!(
+            strip_quoted_strings(r#"echo "it\"s fine" ; ls"#),
+            r#"echo "          " ; ls"#,
+        );
+        // Backslash-escaped quote should NOT prematurely close the string.
+        // Without the fix, the \" would close the quote and expose "; rm -rf /".
+        let stripped = strip_quoted_strings(r#"echo "safe\" ; rm -rf /""#);
+        assert!(
+            !stripped.contains("rm -rf"),
+            "dangerous command should be hidden inside quotes: {stripped}"
+        );
+        // Single quotes: no backslash handling in bash — '\'' is actually
+        // close-quote + literal-backslash + open-close-empty-quote, so the
+        // text after it (`t stop`) is outside quotes and visible.
+        assert_eq!(
+            strip_quoted_strings(r"echo 'can'\''t stop'"),
+            r"echo '   '\''t stop'",
+        );
     }
 
     #[test]

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -206,8 +206,10 @@ pub fn is_image_rejection_error(err: &anyhow::Error) -> bool {
     let msg = format!("{err:#}").to_lowercase();
     // "image" alone is too broad; require it alongside a support-denial word.
     (msg.contains("image") && (msg.contains("support") || msg.contains("invalid")))
-        || msg.contains("vision")
-        || msg.contains("multimodal")
+        || (msg.contains("vision")
+            && (msg.contains("support") || msg.contains("not") || msg.contains("unavailable")))
+        || (msg.contains("multimodal")
+            && (msg.contains("support") || msg.contains("not") || msg.contains("unavailable")))
 }
 
 #[cfg(test)]
@@ -356,6 +358,13 @@ mod tests {
         // "image" alone without support/invalid context should not match
         assert!(!is_image_rejection_error(&anyhow::anyhow!(
             "failed to load image/png from request body"
+        )));
+        // Bare "vision" or "multimodal" without denial context → no match
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "Invalid API key for vision endpoint"
+        )));
+        assert!(!is_image_rejection_error(&anyhow::anyhow!(
+            "multimodal endpoint rate limit"
         )));
     }
 }


### PR DESCRIPTION
## Pre-release hardening for v0.2.8

Two commits: code fixes + documentation sync.

---

### Commit 1: Code fixes (4 items from cross-agent review)

#### 1. 🚨 UTF-8 byte-index slicing → panic on multi-byte chars
**Files:** `transcript.rs`, `tui_commands.rs`

`&cmd[..77]` and `s[..40]` panic at runtime if byte offset N lands inside a multi-byte codepoint (CJK, emoji, accented characters). Replaced with char-based `truncate_with_ellipsis()` helper and `.chars().take(40)`.

#### 2. ⚠️ `is_image_rejection_error()` — "vision" substring too broad
**File:** `inference_helpers.rs`

Bare `msg.contains("vision")` matched auth errors. Now requires conjunction: `"vision" + ("support" | "not" | "unavailable")`. Added negative tests.

#### 3. ⚠️ `/export` path traversal — no validation on user-supplied dest
**File:** `tui_commands.rs`

`/export ../../etc/crontab` would write to arbitrary paths. Now rejects absolute paths and `..` traversal.

#### 4. ⚠️ `strip_quoted_strings()` — backslash-escape bypass
**File:** `bash_safety.rs`

Escaped quotes (`\"`) inside double-quoted strings now handled correctly. Added 3 test cases.

---

### Commit 2: Documentation sync (7 gaps)

1. **CHANGELOG.md** — [Unreleased] was missing 8 PRs of changes (#803-#817)
2. **CLAUDE.md** — version number 0.2.3 → 0.2.7
3. **CLAUDE.md** — workspace tree missing 6 files (transcript.rs, app.rs, etc.)
4. **CLAUDE.md** — test list missing 7 test files
5. **docs/tools.md** — missing 4 tools from reference (TodoRead, TodoWrite, RecallContext, WebSearch)
6. **docs/attachments.md** — SVG listed under Images (it's text, not vision)
7. **docs/commands.md** — /export path restriction not documented

---

9 files, +159/−20. All 332 tests pass.