### PR TITLE
docs: sync documentation with v0.2.8 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **Thinking block persistence** — Claude's `💭 Thinking…` blocks are now
+  persisted to the database and rendered on session resume / in transcripts.
+  Previously only streamed live and lost on exit (#812).
+- **Tool-type-aware output styling** — read-only tool outputs (Read, Grep,
+  Glob) render in dim text; mutating tools (Write, Edit, Bash) render in
+  bold. Makes scan-reading conversation history much easier (#809).
+- **Image rejection warning** — when a model/endpoint doesn't support vision
+  input, Koda surfaces an actionable warning ("switch to a vision-capable
+  model") instead of silently failing or showing a cryptic API error (#813).
+- **Edit staleness last-writer context** — when a stale-file edit fails,
+  the error now names the tool that last modified the file and how long ago,
+  so the model can self-correct (#815).
+
 ### Changed
 - **`/copy` repurposed — copies last assistant response to clipboard** — `/copy`
   now copies the Nth-most-recent assistant text response to the system clipboard
@@ -17,7 +31,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`/export [file.md]` — full transcript export** — renamed from the old `/copy`.
   Without an argument, auto-generates a timestamped filename from the first user
   prompt (`koda-YYYYMMDD-HHMMSS-<slug>.md`) and writes to the current directory.
-  Explicit path still supported: `/export notes/session.md`.
+  Explicit path still supported: `/export notes/session.md`. Only relative paths
+  accepted (absolute paths and `..` traversal are rejected).
+- **Loop detection message** — reworded from misleading "identical arguments —
+  rephrase the task" to actionable "called 3× with similar arguments — send a
+  follow-up message to continue" (#816).
+
+### Fixed
+- **Image paths with spaces** — macOS drag-and-drop paths with backslash-escaped
+  spaces (e.g. `Screenshot\ 2026-04-09\ at\ 4.37.01\ PM.png`) are now correctly
+  tokenized instead of splitting on spaces (#805).
+- **TodoWrite loop detection** — content-aware dedup prevents the model from
+  re-emitting identical todo lists that trigger false loop detection. Checkbox
+  display upgraded from Unicode circles to `[ ]`/`[→]`/`[x]` (#806).
+- **Quoted strings in bash safety check** — patterns like `grep "rm -rf" logs/`
+  no longer false-positive as destructive. `strip_quoted_strings()` now also
+  handles backslash-escaped quotes inside double-quoted strings (#803, #817).
+- **UTF-8 panics in transcript/export** — byte-index slicing (`&s[..77]`) that
+  panicked on multi-byte characters (CJK, emoji) replaced with char-safe
+  truncation (#817).
+- **`is_image_rejection_error` false positives** — bare "vision" substring
+  match tightened to require conjunction with support-denial words, preventing
+  auth errors from being misclassified (#817).
+- **`/export` path traversal** — user-supplied paths are now validated; absolute
+  paths and `..` traversal are rejected (#817).
 
 ### Removed
 - **`Ctrl+Y` (copy last code block) and `Ctrl+U` (copy last response)** — both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ koda/
 │   │   ├── session.rs      # KodaSession (per-conversation: DB, provider, settings)
 │   │   ├── settings.rs     # Runtime settings (approval mode, etc.)
 │   │   ├── skills.rs       # Skill discovery and activation
+│   │   ├── skill_scope.rs  # Skill-scoped tool allow/deny enforcement
 │   │   ├── sub_agent_cache.rs # Sub-agent provider/model config cache
 │   │   ├── tool_dispatch.rs# Tool dispatch — routes tool calls to the registry
 │   │   ├── tool_normalize.rs # Tool name normalization (snake_case → PascalCase)
@@ -164,6 +165,8 @@ koda/
 │   │   ├── main.rs         # CLI entry point (clap)
 │   │   ├── lib.rs          # Crate root (exports acp_adapter)
 │   │   ├── tui_app.rs      # Main TUI event loop (ratatui Viewport::Fullscreen)
+│   │   ├── app.rs          # App struct: aggregated TUI state + lifecycle
+│   │   ├── builtin_skills.rs # Built-in skill definitions (URL index)
 │   │   ├── tui_context/    # TUI shared mutable state (split into submodules)
 │   │   │   ├── mod.rs      # TuiContext struct, event loop, command dispatch
 │   │   │   ├── events.rs   # Key/mouse handling, clipboard, history persistence
@@ -186,12 +189,15 @@ koda/
 │   │   ├── startup.rs      # Startup banner rendering
 │   │   ├── repl.rs         # Slash command parsing + provider/model lists
 │   │   ├── input.rs        # @file reference processing + image loading
+│   │   ├── transcript.rs   # Session transcript renderer (Markdown export)
 │   │   ├── headless.rs     # Single-prompt headless mode
 │   │   ├── sink.rs         # CliSink (unbounded channel forwarding for TUI)
 │   │   ├── server.rs       # ACP server over stdio JSON-RPC
 │   │   ├── acp_adapter.rs  # ACP protocol adapter
 │   │   ├── onboarding.rs   # First-run wizard (provider + API key setup)
 │   │   └── tool_history.rs # Tool output history for /expand
+│   │   ├── wrap_input.rs   # Input wrapping and paste detection
+│   │   └── wrap_util.rs    # Visual line-width utilities
 │   │   └── widgets/        # TUI widgets
 │   │       ├── mod.rs      # Widget module root
 │   │       ├── dropdown.rs # Generic dropdown widget
@@ -324,11 +330,17 @@ from production builds to keep `koda-core`'s public API clean.
 - `tests/new_tools_test.rs` — glob, tool naming
 - `tests/guarantee_matrix_test.rs` — approval mode × tool effect matrix
 - `tests/inference_recovery_test.rs` — rate-limit retry, context overflow
+- `tests/inference_edge_test.rs` — loop detection, empty tool calls
+- `tests/e2e_safety_test.rs` — approval gates, bash safety classification
 - `tests/session_test.rs` — session lifecycle, TurnStart/TurnEnd events
 - `tests/purge_test.rs` — /purge feature (compacted stats, age filter)
 - `tests/perf_test.rs` — DB, grep, markdown throughput
 - `tests/capabilities_test.rs` — capabilities.md freshness
 - `tests/tool_wiring_test.rs` — every tool routable + approval-handled
+- `tests/tool_normalize_test.rs` — snake_case → PascalCase normalization
+- `tests/golden_test.rs` — snapshot / golden file tests
+- `tests/snapshot_test.rs` — tool definition schema snapshots
+- `tests/token_audit.rs` — token estimation accuracy checks
 
 #### koda-cli
 
@@ -339,6 +351,7 @@ from production builds to keep `koda-core`'s public API clean.
 - `tests/cli_test.rs` — binary subprocess invocation
 - `tests/regression_test.rs` — REPL dispatch, input processing
 - `tests/server_test.rs` — ACP server integration (JSON-RPC lifecycle)
+- `tests/skill_agent_e2e_test.rs` — skill activation + agent switching E2E
 
 **Smoke tests** (MockProvider, CI-safe):
 - `tests/smoke_test.rs` — headless mode: text responses, tool use, session resume, `--resume` flag
@@ -415,7 +428,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.3)
+10. Sync version with workspace (currently 0.2.7)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/docs/src/attachments.md
+++ b/docs/src/attachments.md
@@ -20,11 +20,14 @@ For vision-capable models (Claude, Gemini, GPT-4o), attach images directly:
 
 ```text
 > what does @screenshot.png show?
-> explain the architecture in @diagram.svg
+> explain the architecture in @diagram.png
 ```
 
 Supported formats: PNG, JPEG, GIF, WEBP. Images are base64-encoded and
 sent inline to the model API.
+
+Non-image files (SVG, PDF, etc.) attached via `@` are sent as text content,
+not as vision input.
 
 ## Large pastes
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -158,8 +158,11 @@ Exports the full session transcript as a Markdown document.
 
 ```text
 /export                    ← auto-named file in the current directory
-/export notes/session.md   ← write to a specific path
+/export notes/session.md   ← write to a specific relative path
 ```
+
+Paths must be relative to the current directory. Absolute paths and `..`
+traversal are rejected.
 
 When no path is given, the filename is derived from the first user message
 and the current UTC time:

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -14,8 +14,13 @@ Bash commands require confirmation.
 | `Grep` | Read-only | Search for patterns across files (ripgrep) |
 | `Glob` | Read-only | List files matching a glob pattern |
 | `WebFetch` | Read-only | Fetch a URL and return its text content |
+| `WebSearch` | Read-only | Search the web via DuckDuckGo |
 | `Think` | Internal | Extended reasoning step (no side effects) |
+| `MemoryRead` | Read-only | Read from project or global memory |
 | `MemoryWrite` | Mutating | Append a fact to a memory file |
+| `TodoRead` | Read-only | Read the session task list |
+| `TodoWrite` | Mutating | Update the session task list |
+| `RecallContext` | Read-only | Search session history for past context |
 | `ListSkills` | Read-only | List available skills |
 | `ActivateSkill` | Internal | Load a skill's instructions into context |
 | `InvokeAgent` | Varies | Delegate a task to a named sub-agent |
@@ -26,9 +31,9 @@ Bash commands require confirmation.
 
 | Category | Tools | Auto mode | Confirm mode |
 |----------|-------|-----------|--------------|
-| Read-only | Read, Grep, Glob, ListFiles, WebFetch | ✅ Auto | ✅ Auto |
+| Read-only | Read, Grep, Glob, ListFiles, WebFetch, WebSearch, TodoRead, RecallContext | ✅ Auto | ✅ Auto |
 | Internal | Think, ActivateSkill | ✅ Auto | ✅ Auto |
-| Safe writes | Write, Edit, Delete, MemoryWrite | ✅ Auto | ⏸ Prompt |
+| Safe writes | Write, Edit, Delete, MemoryWrite, TodoWrite | ✅ Auto | ⏸ Prompt |
 | Agent calls | InvokeAgent | ✅ Auto | ⏸ Prompt |
 | User interaction | AskUser | ⏸ Prompt | ⏸ Prompt |
 | Destructive shell | `rm -rf`, `sudo`, `git push --force`, … | ⏸ Prompt | ⏸ Prompt |


### PR DESCRIPTION
## Documentation sync for v0.2.8 release

Cherry-picked from the docs commit that missed #817's merge window.

### 7 gaps found and fixed

1. **CHANGELOG.md** — `[Unreleased]` only had 3 entries; added all v0.2.8 changes across Added/Changed/Fixed/Removed sections (#803–#817)
2. **CLAUDE.md** — version number `0.2.3` → `0.2.7`
3. **CLAUDE.md** — workspace tree missing 6 source files (`transcript.rs`, `app.rs`, `builtin_skills.rs`, `wrap_input.rs`, `wrap_util.rs`, `skill_scope.rs`)
4. **CLAUDE.md** — test list missing 7 test files (`inference_edge_test`, `e2e_safety_test`, `golden_test`, `snapshot_test`, `token_audit`, `tool_normalize_test`, `skill_agent_e2e_test`)
5. **docs/tools.md** — missing 4 tools from reference table + approval matrix (`TodoRead`, `TodoWrite`, `RecallContext`, `WebSearch`)
6. **docs/attachments.md** — SVG listed as image attachment (it's text, not vision input). Changed example to PNG + added clarifying note
7. **docs/commands.md** — `/export` path restriction (relative-only, no `..`) not documented

5 files, +67/−6. No code changes.