### PR TITLE
release: v0.2.8 — UX hardening, /copy + /export, thinking blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 > **Lineage:** This project continues from [`koda-agent`](https://github.com/lijunzh/koda-agent) (archived at v0.1.5).
 > Versions v0.1.0–v0.1.5 of `koda-agent` are documented in that repository's CHANGELOG.
 
-## [Unreleased]
+## [0.2.8] - 2026-04-11
 
 ### Added
 - **Thinking block persistence** — Claude's `💭 Thinking…` blocks are now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,7 +428,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.7)
+10. Sync version with workspace (currently 0.2.8)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.6"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.6"
+version = "0.2.8"
 edition = "2024"
 publish = false # workspace-only; not published to crates.io
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.7" }
+koda-core = { path = "../koda-core", version = "0.2.8" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -69,6 +69,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.7", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.8", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.6"
+version = "0.2.8"
 edition = "2024"
 publish = false # standalone MCP server; not published to crates.io
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"


### PR DESCRIPTION
## Release v0.2.8

Version bump: `0.2.7` → `0.2.8` across all four crates.

### Version changes
| File | Change |
|---|---|
| `koda-core/Cargo.toml` | `0.2.7` → `0.2.8` |
| `koda-cli/Cargo.toml` | `0.2.7` → `0.2.8` (+ dep on koda-core) |
| `koda-ast/Cargo.toml` | `0.2.6` → `0.2.8` |
| `koda-email/Cargo.toml` | `0.2.6` → `0.2.8` |
| `CHANGELOG.md` | `[Unreleased]` → `[0.2.8] - 2026-04-11` |
| `CLAUDE.md` | version ref `0.2.7` → `0.2.8` |

### What's in the release (11 PRs)

**Added:**
- Thinking block persistence + rendering on session resume (#812)
- Tool-type-aware output styling — dim reads, bold writes (#809)
- Image rejection warning with actionable model-switch hint (#813)
- Edit staleness last-writer context (#815)

**Changed:**
- `/copy` repurposed — copies last assistant response to clipboard (#810)
- `/export [file.md]` — full transcript export, relative paths only (#810, #817)
- Loop detection message rewrite — actionable recovery path (#816)

**Fixed:**
- Image paths with macOS drag-and-drop spaces (#805)
- TodoWrite loop detection — content-aware dedup (#806)
- Bash safety: quoted string + backslash-escape handling (#803, #817)
- UTF-8 safe truncation — no panics on CJK/emoji (#817)
- `is_image_rejection_error` false-positive tightening (#817)
- `/export` path traversal prevention (#817)

**Removed:**
- `Ctrl+Y` / `Ctrl+U` keybindings (#810)

### After merge

Tag `v0.2.8` on main to trigger `release.yml`:
```bash
git tag v0.2.8
git push origin v0.2.8
```