### PR TITLE
fix: abort SSE reader + clear input queue on Ctrl+C (#825)

### DIFF
--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -163,6 +163,21 @@ impl TuiContext {
     // ── Post-turn cleanup ──────────────────────────────────────
 
     async fn post_turn_cleanup(&mut self, ui_rx: &mut mpsc::UnboundedReceiver<UiEvent>) {
+        // If the turn was cancelled, clear the input queue so queued
+        // messages don't immediately start a new turn that may block
+        // on a single-slot local server (LM Studio, ollama) (#825).
+        if self.session.cancel.is_cancelled() && !self.input_queue.is_empty() {
+            let n = self.input_queue.len();
+            self.input_queue.clear();
+            self.scroll_buffer.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    format!("\u{1f6ab} Cleared {n} queued message(s)"),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
+
         self.tui_state = TuiState::Idle;
         self.inference_start = None;
         self.session.cancel = tokio_util::sync::CancellationToken::new();

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -50,6 +50,7 @@ use crate::loop_guard::LoopDetector;
 use crate::persistence::Persistence;
 use crate::providers::{
     ChatMessage, ImageData, LlmProvider, StreamChunk, TokenUsage, ToolCall, ToolDefinition,
+    stream_collector::SseCollector,
 };
 use crate::skill_scope::SkillToolScope;
 use crate::tool_dispatch::{
@@ -265,7 +266,7 @@ async fn try_with_rate_limit(
     model_settings: &crate::config::ModelSettings,
     cancel: &CancellationToken,
     sink: &dyn EngineSink,
-) -> Result<Option<mpsc::Receiver<StreamChunk>>> {
+) -> Result<Option<SseCollector>> {
     let mut last_err = None;
     for attempt in 0..RATE_LIMIT_MAX_RETRIES {
         let result = tokio::select! {
@@ -273,7 +274,7 @@ async fn try_with_rate_limit(
             _ = cancel.cancelled() => return Ok(None),
         };
         match result {
-            Ok(rx) => return Ok(Some(rx)),
+            Ok(collector) => return Ok(Some(collector)),
             Err(e) if is_rate_limit_error(&e) && attempt + 1 < RATE_LIMIT_MAX_RETRIES => {
                 let delay = rate_limit_backoff(attempt);
                 sink.emit(EngineEvent::SpinnerStop);
@@ -305,7 +306,7 @@ async fn try_with_rate_limit(
 async fn try_overflow_recovery(
     turn: &TurnState<'_>,
     original_err: anyhow::Error,
-) -> Result<Option<(mpsc::Receiver<StreamChunk>, Vec<ChatMessage>)>> {
+) -> Result<Option<(SseCollector, Vec<ChatMessage>)>> {
     turn.sink.emit(EngineEvent::SpinnerStop);
     turn.sink.emit(EngineEvent::Warn {
         message: "\u{26a0}\u{fe0f} Provider rejected request (context overflow). \
@@ -342,13 +343,13 @@ async fn try_overflow_recovery(
     turn.sink.emit(EngineEvent::SpinnerStart {
         message: "Retrying...".into(),
     });
-    let rx = tokio::select! {
+    let collector = tokio::select! {
         result = turn.provider.chat_stream(&messages, turn.tool_defs, &turn.config.model_settings) => {
             result.context("LLM inference failed after compaction retry")?
         }
         _ = turn.cancel.cancelled() => return Ok(None),
     };
-    Ok(Some((rx, messages)))
+    Ok(Some((collector, messages)))
 }
 
 /// Collect a streamed LLM response, executing read-only tools eagerly.
@@ -741,8 +742,8 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         .await;
 
         // Handle cancellation during rate limit retries
-        let stream_result = match stream_result {
-            Ok(Some(rx)) => Ok(rx),
+        let stream_result: Result<SseCollector> = match stream_result {
+            Ok(Some(c)) => Ok(c),
             Ok(None) => {
                 sink.emit(EngineEvent::SpinnerStop);
                 sink.emit(EngineEvent::Warn {
@@ -755,8 +756,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
         // Graceful recovery: if the provider returns a context-overflow error,
         // compact and retry once before giving up.
-        let mut rx = match stream_result {
-            Ok(rx) => rx,
+        let SseCollector {
+            mut rx,
+            handle: sse_handle,
+        } = match stream_result {
+            Ok(c) => c,
             Err(e) if is_context_overflow_error(&e) => {
                 match try_overflow_recovery(&turn, e).await? {
                     Some((rx, _updated)) => rx,
@@ -801,6 +805,10 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let stream_result = collect_stream(&mut rx, sink, &cancel, tools, mode, project_root).await;
 
         if stream_result.interrupted {
+            // Kill the background HTTP reader immediately so the TCP
+            // connection closes and LM Studio (or any single-slot
+            // local server) can accept the next request (#825).
+            sse_handle.abort();
             let has_text = !stream_result.text.is_empty();
             let has_thinking = !stream_result.thinking_content.is_empty();
             if has_text || has_thinking {
@@ -827,8 +835,10 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
 
         // Network drop: warning already emitted by collect_stream.
+        // Network drop: warning already emitted by collect_stream.
         // Discard the partial response — storing it would corrupt the session.
         if stream_result.network_error.is_some() {
+            sse_handle.abort();
             return Ok(());
         }
 

--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -631,7 +631,7 @@ impl LlmProvider for AnthropicProvider {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
-    ) -> Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+    ) -> Result<super::stream_collector::SseCollector> {
         let (api_model, extended_ctx) = resolve_model(&settings.model);
         let system = messages
             .iter()
@@ -694,12 +694,12 @@ impl LlmProvider for AnthropicProvider {
             anyhow::bail!("Anthropic API returned {status}: {body}");
         }
 
-        let rx = super::stream_collector::spawn_sse_collector(
+        let collector = super::stream_collector::spawn_sse_collector(
             resp,
             Box::new(AnthropicChunkParser::new()),
         );
 
-        Ok(rx)
+        Ok(collector)
     }
 }
 

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -529,7 +529,7 @@ impl LlmProvider for GeminiProvider {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
-    ) -> Result<tokio::sync::mpsc::Receiver<StreamChunk>> {
+    ) -> Result<super::stream_collector::SseCollector> {
         let model = &settings.model;
         let (contents, system_instruction) = self.convert_messages(messages);
         let api_tools = Self::build_tools(tools);
@@ -558,10 +558,10 @@ impl LlmProvider for GeminiProvider {
             anyhow::bail!("Gemini API returned {status}: {body}");
         }
 
-        let rx =
+        let collector =
             super::stream_collector::spawn_sse_collector(resp, Box::new(GeminiChunkParser::new()));
 
-        Ok(rx)
+        Ok(collector)
     }
 }
 

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -211,7 +211,7 @@ impl LlmProvider for MockProvider {
         messages: &[ChatMessage],
         _tools: &[ToolDefinition],
         _settings: &ModelSettings,
-    ) -> Result<mpsc::Receiver<StreamChunk>> {
+    ) -> Result<super::stream_collector::SseCollector> {
         self.recorded_calls.lock().unwrap().push(messages.to_vec());
         let response = self.next_response();
 
@@ -231,7 +231,7 @@ impl LlmProvider for MockProvider {
 
         let (tx, rx) = mpsc::channel(32);
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             match response {
                 MockResponse::Text(text) => {
                     // Stream in small chunks to simulate real streaming.
@@ -302,7 +302,7 @@ impl LlmProvider for MockProvider {
             }
         });
 
-        Ok(rx)
+        Ok(super::stream_collector::SseCollector { rx, handle })
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
@@ -327,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn test_text_response() {
         let provider = MockProvider::new(vec![MockResponse::Text("hello".into())]);
-        let rx = provider
+        let collector = provider
             .chat_stream(
                 &[],
                 &[],
@@ -336,7 +336,7 @@ mod tests {
             .await
             .unwrap();
 
-        let chunks: Vec<_> = collect_chunks(rx).await;
+        let chunks: Vec<_> = collect_chunks(collector).await;
         assert!(
             chunks
                 .iter()
@@ -351,7 +351,7 @@ mod tests {
             "Bash",
             serde_json::json!({"command": "echo hi"}),
         )]);
-        let rx = provider
+        let collector = provider
             .chat_stream(
                 &[],
                 &[],
@@ -360,7 +360,7 @@ mod tests {
             .await
             .unwrap();
 
-        let chunks: Vec<_> = collect_chunks(rx).await;
+        let chunks: Vec<_> = collect_chunks(collector).await;
         assert!(
             chunks
                 .iter()
@@ -382,7 +382,10 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("boom"));
     }
 
-    async fn collect_chunks(mut rx: mpsc::Receiver<StreamChunk>) -> Vec<StreamChunk> {
+    async fn collect_chunks(
+        collector: crate::providers::stream_collector::SseCollector,
+    ) -> Vec<StreamChunk> {
+        let mut rx = collector.rx;
         let mut chunks = Vec::new();
         while let Some(chunk) = rx.recv().await {
             chunks.push(chunk);
@@ -584,8 +587,8 @@ mod tests {
     async fn test_stream_text_max_tokens() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::TextMaxTokens("hi there".into())]);
-        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
-        let chunks = collect_chunks(rx).await;
+        let collector = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(collector).await;
         // Should end with Done with stop_reason = "max_tokens"
         let done = chunks
             .iter()
@@ -602,8 +605,8 @@ mod tests {
             arguments: "{}".into(),
             thought_signature: None,
         }])]);
-        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
-        let chunks = collect_chunks(rx).await;
+        let collector = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(collector).await;
         // Should have a ToolCallReady chunk
         assert!(
             chunks
@@ -620,8 +623,8 @@ mod tests {
             partial_text: "partial output".into(),
             error: "connection dropped".into(),
         }]);
-        let rx = provider.chat_stream(&[], &[], &settings).await.unwrap();
-        let chunks = collect_chunks(rx).await;
+        let collector = provider.chat_stream(&[], &[], &settings).await.unwrap();
+        let chunks = collect_chunks(collector).await;
         assert!(
             chunks
                 .iter()

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -300,13 +300,14 @@ pub trait LlmProvider: Send + Sync {
     ) -> Result<LlmResponse>;
 
     /// Send a streaming chat completion request.
-    /// Returns a channel receiver that yields chunks as they arrive.
+    /// Returns an [`stream_collector::SseCollector`] with the chunk receiver and a task handle
+    /// that can be aborted to immediately kill the HTTP read (#825).
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
-    ) -> Result<tokio::sync::mpsc::Receiver<StreamChunk>>;
+    ) -> Result<stream_collector::SseCollector>;
 
     /// List available models from the provider.
     async fn list_models(&self) -> Result<Vec<ModelInfo>>;

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -10,7 +10,6 @@ use super::{
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
 
 /// Client for OpenAI-compatible APIs.
 pub struct OpenAiCompatProvider {
@@ -463,7 +462,7 @@ impl LlmProvider for OpenAiCompatProvider {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         settings: &crate::config::ModelSettings,
-    ) -> Result<mpsc::Receiver<StreamChunk>> {
+    ) -> Result<super::stream_collector::SseCollector> {
         let request = Self::build_request(messages, tools, &settings.model, Some(true), settings);
 
         let mut req = self
@@ -486,10 +485,10 @@ impl LlmProvider for OpenAiCompatProvider {
             anyhow::bail!("LLM API returned {status}: {body}");
         }
 
-        let rx =
+        let collector =
             super::stream_collector::spawn_sse_collector(resp, Box::new(OpenAiChunkParser::new()));
 
-        Ok(rx)
+        Ok(collector)
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -29,6 +29,19 @@ pub trait ChunkParser: Send + 'static {
     fn finish(&mut self) -> Vec<StreamChunk>;
 }
 
+/// Result of [`spawn_sse_collector`]: the chunk receiver and a handle
+/// that can be [`abort`](tokio::task::JoinHandle::abort)ed to kill the
+/// background HTTP read when the caller no longer needs the stream
+/// (e.g. user pressed Ctrl+C).
+#[derive(Debug)]
+pub struct SseCollector {
+    /// Channel receiver yielding parsed [`StreamChunk`]s.
+    pub rx: mpsc::Receiver<StreamChunk>,
+    /// Task handle for the background HTTP reader — call `.abort()`
+    /// to immediately close the TCP connection on cancellation.
+    pub handle: tokio::task::JoinHandle<()>,
+}
+
 /// Spawn a task that reads an SSE byte stream, parses chunks via the given
 /// [`ChunkParser`], and sends [`StreamChunk`]s to the returned receiver.
 ///
@@ -38,13 +51,16 @@ pub trait ChunkParser: Send + 'static {
 /// - `data: ` prefix stripping (non-data lines are ignored)
 /// - `[DONE]` sentinel (standard SSE terminator used by OpenAI)
 /// - Graceful finalization when the stream closes without `[DONE]`
+///
+/// Call [`SseCollector::handle`]`.abort()` to immediately kill the
+/// background reader and close the HTTP connection (#825).
 pub fn spawn_sse_collector(
     response: reqwest::Response,
     parser: Box<dyn ChunkParser>,
-) -> mpsc::Receiver<StreamChunk> {
+) -> SseCollector {
     let (tx, rx) = mpsc::channel(64);
-    tokio::spawn(drive_sse_stream(response, parser, tx));
-    rx
+    let handle = tokio::spawn(drive_sse_stream(response, parser, tx));
+    SseCollector { rx, handle }
 }
 
 /// Inner driver: read SSE lines from a byte stream and dispatch to the parser.

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -13,7 +13,7 @@ use koda_core::{
     db::{Database, Role},
     engine::{EngineCommand, EngineEvent},
     inference::{self, InferenceContext},
-    providers::{LlmResponse, ModelInfo, StreamChunk},
+    providers::{LlmResponse, ModelInfo},
     tools::ToolRegistry,
 };
 use koda_test_utils::{ChatMessage, LlmProvider, TestSink, ToolDefinition};
@@ -42,7 +42,7 @@ impl LlmProvider for SlowProvider {
         _messages: &[ChatMessage],
         _tools: &[ToolDefinition],
         _settings: &koda_core::config::ModelSettings,
-    ) -> Result<mpsc::Receiver<StreamChunk>> {
+    ) -> Result<koda_core::providers::stream_collector::SseCollector> {
         // Simulate a model that hangs on the initial HTTP request
         tokio::time::sleep(Duration::from_secs(60)).await;
         unreachable!("should be cancelled before this returns")

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -11,7 +11,7 @@ use koda_core::{
     engine::{EngineCommand, EngineEvent},
     inference::{self, InferenceContext},
     persistence::Persistence,
-    providers::{LlmResponse, ModelInfo, StreamChunk},
+    providers::{LlmResponse, ModelInfo},
 };
 use koda_test_utils::{ChatMessage, Env, LlmProvider, MockProvider, MockResponse, ToolDefinition};
 use tokio::sync::mpsc;
@@ -240,7 +240,7 @@ async fn test_cancel_during_streaming() {
             _: &[ChatMessage],
             _: &[ToolDefinition],
             _: &ModelSettings,
-        ) -> Result<mpsc::Receiver<StreamChunk>> {
+        ) -> Result<koda_core::providers::stream_collector::SseCollector> {
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
             unreachable!()
         }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -9,7 +9,7 @@ use koda_core::{
     approval::ApprovalMode,
     engine::{EngineCommand, EngineEvent, event::TurnEndReason},
     persistence::Persistence,
-    providers::{LlmResponse, ModelInfo, StreamChunk},
+    providers::{LlmResponse, ModelInfo},
     session::KodaSession,
     tools::ToolRegistry,
 };
@@ -155,7 +155,7 @@ async fn session_cancellation_produces_turn_end_cancelled() {
             _: &[ChatMessage],
             _: &[ToolDefinition],
             _: &koda_core::config::ModelSettings,
-        ) -> Result<mpsc::Receiver<StreamChunk>> {
+        ) -> Result<koda_core::providers::stream_collector::SseCollector> {
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
             unreachable!()
         }

--- a/koda-test-utils/src/golden.rs
+++ b/koda-test-utils/src/golden.rs
@@ -144,14 +144,16 @@ impl<P: LlmProvider> LlmProvider for RecordingProvider<P> {
         messages: &[ChatMessage],
         tools: &[ToolDefinition],
         settings: &ModelSettings,
-    ) -> Result<mpsc::Receiver<StreamChunk>> {
+    ) -> Result<koda_core::providers::stream_collector::SseCollector> {
         let result = self.inner.chat_stream(messages, tools, settings).await;
         match result {
-            Ok(mut rx) => {
+            Ok(collector) => {
+                let mut rx = collector.rx;
+                let _old_handle = collector.handle;
                 // Collect the full stream, record it, then re-emit via a new channel.
                 let (tx, new_rx) = mpsc::channel(256);
                 let responses = self.responses.clone();
-                tokio::spawn(async move {
+                let handle = tokio::spawn(async move {
                     let mut text = String::new();
                     let mut tool_calls = Vec::new();
                     let mut had_network_error = false;
@@ -188,7 +190,7 @@ impl<P: LlmProvider> LlmProvider for RecordingProvider<P> {
                     responses.lock().unwrap().push(mock);
                 });
 
-                Ok(new_rx)
+                Ok(koda_core::providers::stream_collector::SseCollector { rx: new_rx, handle })
             }
             Err(e) => {
                 let msg = format!("{e:#}");


### PR DESCRIPTION
## Summary

Fixes #825 — Ctrl+C during skill inference leaves Koda stuck in inferencing loop.

## Root Cause

Three issues combined into a deadlock:

1. **SSE background reader not aborted** — `drive_sse_stream` spawned task kept reading the old HTTP stream after `collect_stream` returned on cancellation. The TCP connection stayed open, starving LM Studio's single slot.

2. **Input queue not cleared on cancel** — queued follow-up messages immediately dispatched a new inference turn after the cancelled turn's cleanup, but the new `chat_stream()` HTTP request blocked because LM Studio was still draining the old connection.

3. **No way to abort the background task** — `spawn_sse_collector` returned only `mpsc::Receiver<StreamChunk>`, with no handle to kill the spawned task.

## Changes

### `stream_collector.rs`
- New `SseCollector { rx, handle }` struct — exposes the `JoinHandle` for the background HTTP reader
- `spawn_sse_collector()` now returns `SseCollector` instead of bare `Receiver`
- Added `#[derive(Debug)]` for test ergonomics

### `inference.rs`
- Destructures `SseCollector { mut rx, handle: sse_handle }` from provider result
- Calls `sse_handle.abort()` on interruption and network error to kill the background reader immediately
- Updated `try_with_rate_limit` and `try_overflow_recovery` return types

### `providers/mod.rs`
- `LlmProvider::chat_stream()` trait method now returns `SseCollector`

### `tui_handlers_inference.rs`
- `post_turn_cleanup()` clears `input_queue` when the turn was cancelled, with a visible "🚫 Cleared N queued message(s)" notification

### All providers + test utilities
- Anthropic, Gemini, OpenAI-compat, MockProvider, and golden `RecordingProvider` updated to return `SseCollector`
- `cancel_test.rs`, `session_test.rs`, `e2e_test.rs` updated

## Testing

All 333 tests pass. Pre-push hooks (fmt + clippy + check) clean.