### PR TITLE
feat: improve type-during-inference queue UX

### DIFF
--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -455,12 +455,19 @@ impl TuiContext {
         if let Some(queued) = self.input_queue.pop_front() {
             let mode = approval::read_mode(&self.shared_mode);
             let icon = match mode {
-                ApprovalMode::Confirm => "🔒",
-                ApprovalMode::Auto => "⚡",
+                ApprovalMode::Confirm => "\u{1f512}",
+                ApprovalMode::Auto => "\u{26a1}",
+            };
+            let remaining = self.input_queue.len();
+            let suffix = if remaining > 0 {
+                format!(" (+{remaining} queued)")
+            } else {
+                String::new()
             };
             self.scroll_buffer.push(Line::from(vec![
                 Span::styled(format!("{icon}> "), Style::default().fg(Color::Cyan)),
                 Span::raw(queued.clone()),
+                Span::styled(suffix, Style::default().fg(Color::DarkGray)),
             ]));
             return Some(queued);
         }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -321,6 +321,7 @@ async fn handle_crossterm_event_inline(
                 key,
                 cancel_token,
                 cmd_tx,
+                scroll_buffer,
                 menu,
                 prompt_mode,
                 pending_approval_id,
@@ -344,6 +345,7 @@ async fn handle_inference_key_inline(
     key: crossterm::event::KeyEvent,
     cancel_token: &tokio_util::sync::CancellationToken,
     cmd_tx: &mpsc::Sender<EngineCommand>,
+    scroll_buffer: &mut ScrollBuffer,
     menu: &mut MenuContent,
     prompt_mode: &mut PromptMode,
     pending_approval_id: &mut Option<String>,
@@ -510,6 +512,15 @@ async fn handle_inference_key_inline(
                 history.push(text.clone());
                 let _ = db.history_push(&text).await;
                 *history_idx = None;
+
+                // Visual echo so the user can see what they queued.
+                let preview = truncate_preview(&text, 80);
+                scroll_buffer.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled("📋 Queued: ", Style::default().fg(Color::Yellow)),
+                    Span::styled(preview, Style::default().fg(Color::DarkGray)),
+                ]));
+
                 input_queue.push_back(text);
             }
         }
@@ -518,6 +529,20 @@ async fn handle_inference_key_inline(
         }
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
             cancel_token.cancel();
+        }
+        // Ctrl+U: clear the input queue without cancelling inference.
+        (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => {
+            if !input_queue.is_empty() {
+                let n = input_queue.len();
+                input_queue.clear();
+                scroll_buffer.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        format!("🚫 Cleared {n} queued message(s)"),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]));
+            }
         }
         (KeyCode::BackTab, _) => {
             approval::cycle_mode(shared_mode);
@@ -534,6 +559,19 @@ async fn handle_inference_key_inline(
             completer.reset();
             textarea.input(Event::Key(key));
         }
+    }
+}
+
+/// Truncate a string to `max_chars`, replacing newlines with ↵ and
+/// appending "…" if it was shortened.
+fn truncate_preview(s: &str, max_chars: usize) -> String {
+    let flat: String = s.chars().map(|c| if c == '\n' { '↵' } else { c }).collect();
+    if flat.len() <= max_chars {
+        flat
+    } else {
+        let mut out: String = flat.chars().take(max_chars.saturating_sub(1)).collect();
+        out.push('…');
+        out
     }
 }
 

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -131,15 +131,19 @@ impl Widget for StatusBar<'_> {
             ));
         }
 
-        // Queue indicator
+        // Queue indicator — show count + Ctrl+U hint
         if self.queue_len > 0 {
             spans.push(Span::styled(
                 "\u{2502}",
                 Style::default().fg(Color::Rgb(60, 60, 60)),
             ));
             spans.push(Span::styled(
-                format!(" {} queued ", self.queue_len),
+                format!(" \u{1f4cb} {} queued ", self.queue_len),
                 Style::default().fg(Color::Yellow),
+            ));
+            spans.push(Span::styled(
+                "^U clear ",
+                Style::default().fg(Color::Rgb(100, 100, 100)),
             ));
         }
 


### PR DESCRIPTION
## Summary

Quality-of-life improvements for the type-during-inference input queue.

## Changes

### 1. Visual echo on queue (`tui_handlers_inference.rs`)

When you press Enter during inference, the scroll buffer now shows:
```
  📋 Queued: your message preview here…
```
- Newlines rendered as ↵ for compact display
- Long messages truncated to 80 chars with …
- Users can now see *what* they queued, not just the count

### 2. Ctrl+U to clear queue (`tui_handlers_inference.rs`)

New hotkey during inference: **Ctrl+U clears all queued messages** without cancelling the current turn.

Useful when you type follow-up questions during inference but change your mind. Previously you'd have to Ctrl+C (which also kills the running turn) or wait for all queued messages to process.

Shows visual feedback:
```
  🚫 Cleared 3 queued message(s)
```

### 3. Better indicators

**Status bar** (`status_bar.rs`):
- Before: `3 queued`
- After: `📋 3 queued ^U clear` — includes keyboard hint

**Dequeue echo** (`tui_context/mod.rs`):
- Before: `⚡> do the thing`
- After: `⚡> do the thing (+2 queued)` — shows remaining count

## Files Changed

| File | Lines |
|------|-------|
| `tui_handlers_inference.rs` | +38 |
| `tui_context/mod.rs` | +9/-2 |
| `widgets/status_bar.rs` | +6/-2 |

## Testing

All 333 tests pass. Pre-push hooks (fmt + clippy + check) clean.