### PR TITLE
fix: loop guard catches read-only and varying-args tool loops (#826)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -603,6 +603,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let mut made_tool_calls = false;
     let mut retried_empty = false;
     let mut loop_detector = LoopDetector::new();
+    let mut consecutive_tool_only: u32 = 0;
     let sub_agent_cache = crate::sub_agent_cache::SubAgentCache::new();
     let bg_agents = crate::bg_agent::new_shared();
     let mut skill_scope = SkillToolScope::new();
@@ -697,7 +698,24 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Apply skill-scoped tool filtering: when a skill with `allowed_tools`
         // is active, only those tools (+ meta-tools) are sent to the LLM.
         let scoped_tool_defs = skill_scope.filter_tool_defs(tool_defs);
-        let active_tool_defs: &[ToolDefinition] = &scoped_tool_defs;
+
+        // If the model has produced N consecutive tool-call-only responses
+        // (tools but no text), suppress tool definitions for this turn to
+        // force it to generate a text response. This prevents local models
+        // from looping infinitely through tool calls (#826).
+        let active_tool_defs: &[ToolDefinition] =
+            if consecutive_tool_only >= crate::loop_guard::TOOL_ONLY_RESPONSE_LIMIT {
+                sink.emit(EngineEvent::Info {
+                    message: format!(
+                        "Model produced {} consecutive tool-only responses — \
+                         suppressing tools for this turn to prompt a text reply.",
+                        consecutive_tool_only,
+                    ),
+                });
+                &[]
+            } else {
+                &scoped_tool_defs
+            };
 
         // Build per-iteration immutable context for helpers
         let turn = TurnState {
@@ -881,6 +899,14 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
         let usage = stream_result.usage;
         let char_count = stream_result.char_count;
+
+        // Track consecutive tool-call-only responses (no text output).
+        // Reset when the model produces any text alongside or instead of tools.
+        if !tool_calls.is_empty() && full_text.trim().is_empty() {
+            consecutive_tool_only += 1;
+        } else {
+            consecutive_tool_only = 0;
+        }
 
         // Empty response after tool use — retry once before giving up.
         if tool_calls.is_empty()

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1176,13 +1176,12 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             }
         }
 
-        // Loop detection: same tool+args repeated REPEAT_THRESHOLD times → stop immediately.
-        if let Some(fp) = loop_detector.record(&tool_calls) {
-            let culprit = fp.split(':').next().unwrap_or("unknown");
-            let n = crate::loop_guard::REPEAT_THRESHOLD;
+        // Loop detection: repeated tool calls or tool-name saturation → stop.
+        if let Some(culprit) = loop_detector.record(&tool_calls) {
+            let tool_name = culprit.split(':').next().unwrap_or(&culprit);
             sink.emit(EngineEvent::Warn {
                 message: format!(
-                    "Loop guard: '{culprit}' was called {n}× with similar arguments — \
+                    "Loop guard: '{tool_name}' called repeatedly — \
                      stopping to avoid wasted tokens. \
                      If the model was making progress, send a follow-up message to continue."
                 ),

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -3,11 +3,22 @@
 //! Tracks recent tool call fingerprints in a sliding window and flags
 //! when the same tool+args combination repeats too many times.
 //!
-//! ## Detection method
+//! ## Detection methods
 //!
-//! Each tool call is fingerprinted as `(tool_name, hash(args))`. The guard
-//! maintains a sliding window of the last N fingerprints. When the same
-//! fingerprint appears more than the threshold, a loop is detected.
+//! Two complementary strategies catch runaway loops:
+//!
+//! 1. **Exact fingerprint** — `(tool_name, hash(args))` repeated
+//!    `REPEAT_THRESHOLD` times in the window → immediate stop.
+//!    Catches: model retrying the same command verbatim.
+//!
+//! 2. **Tool-name saturation** — same *tool name* (any args) appears
+//!    `NAME_SATURATION_THRESHOLD` times in the window → immediate stop.
+//!    Catches: model calling `Bash(ls -la)`, `Bash(ls -l)`, `Bash(ls)`…
+//!    with slightly varying args (#826).
+//!
+//! Both strategies track *all* tools — read-only and mutating alike.
+//! A model that calls `List` or `Grep` 8 times in 20 calls is clearly
+//! stuck, regardless of whether those tools have side-effects.
 //!
 //! ## What happens on detection
 //!
@@ -31,8 +42,13 @@ pub const MAX_ITERATIONS_DEFAULT: u32 = 200;
 /// Hard cap for sub-agent loops.
 pub const MAX_SUB_AGENT_ITERATIONS: usize = 20;
 
-/// How many times the same fingerprint must appear to flag a loop.
+/// How many times the same exact fingerprint (tool+args) must appear to flag a loop.
 pub const REPEAT_THRESHOLD: usize = 3;
+
+/// How many times the same *tool name* (any args) must appear in the
+/// window to flag a saturation loop. Higher than `REPEAT_THRESHOLD`
+/// because it's normal to call the same tool a few times with different args.
+pub const NAME_SATURATION_THRESHOLD: usize = 8;
 
 /// Sliding window size (individual tool calls, not batches).
 const WINDOW_SIZE: usize = 20;
@@ -45,9 +61,11 @@ const DISPLAY_RECENT: usize = 5;
 /// Tracks repeated tool call patterns.
 #[derive(Default)]
 pub struct LoopDetector {
-    /// Sliding window of recent tool fingerprints.
+    /// Sliding window of recent tool fingerprints (tool+args).
     window: VecDeque<String>,
-    /// Ring buffer of the last N tool names (for display only).
+    /// Parallel window of just tool names (for saturation check).
+    name_window: VecDeque<String>,
+    /// Ring buffer of the last N tool names (for display).
     recent: VecDeque<String>,
 }
 
@@ -56,23 +74,26 @@ impl LoopDetector {
     pub fn new() -> Self {
         Self {
             window: VecDeque::new(),
+            name_window: VecDeque::new(),
             recent: VecDeque::new(),
         }
     }
 
     /// Record a batch of tool calls.
-    /// Returns `Some(repeated_fingerprint)` when a loop is detected.
+    /// Returns `Some(culprit_description)` when a loop is detected.
     pub fn record(&mut self, tool_calls: &[ToolCall]) -> Option<String> {
         for tc in tool_calls {
             let fp = fingerprint(&tc.function_name, &tc.arguments);
 
-            // Sliding window for loop detection ONLY tracks mutating tools.
-            // Repeating read-only operations is handled by stale-read optimization.
-            if crate::tools::is_mutating_tool(&tc.function_name) {
-                self.window.push_back(fp);
-                if self.window.len() > WINDOW_SIZE {
-                    self.window.pop_front();
-                }
+            // Track ALL tools — read-only loops are just as wasteful (#826).
+            self.window.push_back(fp);
+            if self.window.len() > WINDOW_SIZE {
+                self.window.pop_front();
+            }
+
+            self.name_window.push_back(tc.function_name.clone());
+            if self.name_window.len() > WINDOW_SIZE {
+                self.name_window.pop_front();
             }
 
             // Ring buffer for display always tracks all tools
@@ -91,14 +112,28 @@ impl LoopDetector {
     }
 
     fn check(&self) -> Option<String> {
-        let mut counts: HashMap<&str, usize> = HashMap::new();
+        // Strategy 1: exact fingerprint repeated REPEAT_THRESHOLD times
+        let mut fp_counts: HashMap<&str, usize> = HashMap::new();
         for fp in &self.window {
-            *counts.entry(fp.as_str()).or_insert(0) += 1;
+            *fp_counts.entry(fp.as_str()).or_insert(0) += 1;
         }
-        counts
-            .into_iter()
-            .find(|(_, n)| *n >= REPEAT_THRESHOLD)
-            .map(|(fp, _)| fp.to_string())
+        if let Some((fp, _)) = fp_counts.iter().find(|(_, n)| **n >= REPEAT_THRESHOLD) {
+            return Some(fp.to_string());
+        }
+
+        // Strategy 2: same tool name saturates the window (#826)
+        let mut name_counts: HashMap<&str, usize> = HashMap::new();
+        for name in &self.name_window {
+            *name_counts.entry(name.as_str()).or_insert(0) += 1;
+        }
+        if let Some((name, count)) = name_counts
+            .iter()
+            .find(|(_, n)| **n >= NAME_SATURATION_THRESHOLD)
+        {
+            return Some(format!("{name} (×{count} with varying args)"));
+        }
+
+        None
     }
 }
 
@@ -178,15 +213,55 @@ mod tests {
     }
 
     #[test]
-    fn ignores_readonly_tools() {
+    fn detects_readonly_tool_loop() {
+        // Read-only tools are now tracked (#826)
         let mut d = LoopDetector::new();
         let tc = call("Read", "{\"path\":\"src/main.rs\"}");
         assert!(d.record(std::slice::from_ref(&tc)).is_none());
         assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        // Even 4 repetitions shouldn't trigger because Read is ignored
-        assert!(d.check().is_none());
+        assert!(
+            d.record(std::slice::from_ref(&tc)).is_some(),
+            "read-only tools should be caught at REPEAT_THRESHOLD"
+        );
+    }
+
+    #[test]
+    fn detects_name_saturation_with_varying_args() {
+        // Same tool name but different args each time (#826)
+        let mut d = LoopDetector::new();
+        for i in 0..NAME_SATURATION_THRESHOLD {
+            let args = format!("{{\"command\":\"ls -variant-{i}\"}}");
+            let result = d.record(&[call("Bash", &args)]);
+            if i < NAME_SATURATION_THRESHOLD - 1 {
+                assert!(result.is_none(), "should not trigger at call {i}");
+            } else {
+                assert!(result.is_some(), "should trigger at call {i}");
+                assert!(
+                    result.unwrap().contains("varying args"),
+                    "should mention varying args"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mixed_tools_no_false_positive() {
+        // Alternating between different tools shouldn't trigger saturation
+        let mut d = LoopDetector::new();
+        for i in 0..20 {
+            let name = if i % 3 == 0 {
+                "Bash"
+            } else if i % 3 == 1 {
+                "Read"
+            } else {
+                "List"
+            };
+            let args = format!("{{\"i\":{i}}}");
+            assert!(
+                d.record(&[call(name, &args)]).is_none(),
+                "mixed tools should not trigger (call {i})"
+            );
+        }
     }
 
     #[test]

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -88,6 +88,10 @@ impl LoopDetector {
     /// Record a batch of tool calls.
     /// Returns `Some(culprit_description)` when a loop is detected.
     pub fn record(&mut self, tool_calls: &[ToolCall]) -> Option<String> {
+        // Collect unique tool names in this batch — parallel calls to the
+        // same tool in one response are intentional, not a loop signal.
+        let mut batch_names: Vec<&str> = Vec::new();
+
         for tc in tool_calls {
             let fp = fingerprint(&tc.function_name, &tc.arguments);
 
@@ -97,9 +101,15 @@ impl LoopDetector {
                 self.window.pop_front();
             }
 
-            self.name_window.push_back(tc.function_name.clone());
-            if self.name_window.len() > WINDOW_SIZE {
-                self.name_window.pop_front();
+            // Deduplicate names per batch: 10 parallel Read calls = 1 entry,
+            // not 10. This prevents false positives when the model reads
+            // many files at once (which we explicitly encourage).
+            if !batch_names.contains(&tc.function_name.as_str()) {
+                batch_names.push(&tc.function_name);
+                self.name_window.push_back(tc.function_name.clone());
+                if self.name_window.len() > WINDOW_SIZE {
+                    self.name_window.pop_front();
+                }
             }
 
             // Ring buffer for display always tracks all tools
@@ -272,6 +282,37 @@ mod tests {
                 d.record(&[call(name, &args)]).is_none(),
                 "mixed tools should not trigger (call {i})"
             );
+        }
+    }
+
+    #[test]
+    fn parallel_reads_in_one_batch_not_a_loop() {
+        // 10 parallel Read calls in a single batch should NOT trigger
+        // saturation — the model is doing what we asked (read many files
+        // at once). Only sequential batches should count.
+        let mut d = LoopDetector::new();
+        let batch: Vec<ToolCall> = (0..10)
+            .map(|i| call("Read", &format!("{{\"path\":\"file{i}.rs\"}}")))
+            .collect();
+        assert!(
+            d.record(&batch).is_none(),
+            "parallel reads in one batch should not trigger saturation"
+        );
+    }
+
+    #[test]
+    fn parallel_reads_across_batches_triggers_saturation() {
+        // But if the model keeps sending Read-only batches across many
+        // iterations, that IS a loop.
+        let mut d = LoopDetector::new();
+        for i in 0..NAME_SATURATION_THRESHOLD {
+            let batch = vec![call("Read", &format!("{{\"path\":\"file{i}.rs\"}}"))];
+            let result = d.record(&batch);
+            if i < NAME_SATURATION_THRESHOLD - 1 {
+                assert!(result.is_none(), "should not trigger at batch {i}");
+            } else {
+                assert!(result.is_some(), "should trigger at batch {i}");
+            }
         }
     }
 

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -53,6 +53,12 @@ pub const NAME_SATURATION_THRESHOLD: usize = 8;
 /// Sliding window size (individual tool calls, not batches).
 const WINDOW_SIZE: usize = 20;
 
+/// After this many consecutive tool-call-only responses (no text), tool
+/// definitions are suppressed for one turn to force a text response.
+/// Prevents models (especially local ones) from entering infinite
+/// tool-call loops without ever producing output (#826).
+pub const TOOL_ONLY_RESPONSE_LIMIT: u32 = 5;
+
 /// How many recent tool names to show in the hard-cap prompt.
 const DISPLAY_RECENT: usize = 5;
 

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -210,11 +210,16 @@ mod tests {
     }
 
     #[test]
-    fn different_args_not_a_loop() {
+    fn different_args_below_saturation_not_a_loop() {
+        // Different args should NOT trigger the exact-fingerprint check.
+        // Stay below NAME_SATURATION_THRESHOLD to avoid the saturation check.
         let mut d = LoopDetector::new();
-        for i in 0..10 {
+        for i in 0..NAME_SATURATION_THRESHOLD - 1 {
             let args = format!("{{\"path\":\"file{i}.rs\"}}");
-            assert!(d.record(&[call("Edit", &args)]).is_none());
+            assert!(
+                d.record(&[call("Edit", &args)]).is_none(),
+                "should not trigger at call {i}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #826 — Gemma 4 local model enters infinite tool-call loop (370+ calls) on a simple `ls` prompt.

## Why it happens

Two layers of failure:

### Layer 1: Root cause — model never stops calling tools

Gemma 4 (via LM Studio's OpenAI-compat layer) enters a mode where every response contains tool calls but **zero text**. The model never \decides\ to stop and summarize results — it just keeps calling tools forever. This is a known weakness of local models whose tool-calling support is synthetic/adapted rather than natively trained.

### Layer 2: Safety net — loop guard had blind spots

Even when the model loops, the loop guard should catch it. But it had two gaps:

| Gap | Why it matters |
|-----|----------------|
| Read-only tools untracked | `List`, `Read`, `Grep`, `Glob` excluded from the sliding window |
| Same tool + varying args | `Bash(ls -la)` vs `Bash(ls -l)` produced different fingerprints |

## Fix (2 commits)

### Commit 1: Improved loop guard (safety net)

Two detection strategies, both now tracking **all** tools:

- **Exact fingerprint** (existing, now universal): same `tool+args` ×3 in window of 20
- **Name saturation** (new): same tool *name* ×8 in window of 20, any args

### Commit 2: Tool suppression (root cause)

Track consecutive iterations where the model produced tool calls but no text. After **5** such iterations (`TOOL_ONLY_RESPONSE_LIMIT`), suppress tool definitions for one turn — the model is forced to produce a text response since no tools are available. Counter resets once text is generated.

This is the key fix: it prevents the infinite loop at the source rather than just catching it after the fact.

## Changes

| File | What |
|------|------|
| `loop_guard.rs` | Removed `is_mutating_tool` filter; added `name_window` + `NAME_SATURATION_THRESHOLD=8`; added `TOOL_ONLY_RESPONSE_LIMIT=5`; 5 new tests |
| `inference.rs` | Added `consecutive_tool_only` counter; suppress tool defs when limit hit; simplified warning message |

## How these interact

```
Iteration 1: Bash(ls -la) → tools only, no text    [counter=1]
Iteration 2: Bash(ls -l)  → tools only, no text    [counter=2]
Iteration 3: Bash(ls)     → tools only, no text    [counter=3]
Iteration 4: List(.)      → tools only, no text    [counter=4]
Iteration 5: Grep(*.rs)   → tools only, no text    [counter=5]
Iteration 6: tools SUPPRESSED → model forced to produce text [counter=0]
```

Without this fix, Gemma 4 would continue to iteration 200+ before the hard cap stopped it.

## Test Coverage

5 new tests in `loop_guard.rs`. All 333 tests pass.