### PR TITLE
fix: revert local model workarounds + adopt Gemini CLI loop detection (#831)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -114,6 +114,17 @@ limitations — they'll be obsolete before they're stable.
   workarounds for individual models' non-conforming behavior. If a model
   emits malformed output, the fix belongs upstream. See
   [#831](https://github.com/lijunzh/koda/issues/831) for rationale
+- **Don't over-compensate for weak models.** If a model emits 66 identical
+  tool calls, the answer is "use a better model," not a dedup layer that
+  silently papers over the problem. Safety mechanisms should match what
+  frontier agents actually ship — not what we imagine might go wrong.
+  A code review of Claude Code (zero loop detection), Codex (zero), and
+  Gemini CLI (consecutive-call detection + feedback injection) informed
+  our approach: consecutive identical calls → feedback injection → hard
+  stop only if the model ignores feedback. No windowed fingerprinting,
+  no tool-name saturation, no tool-only suppression, no per-turn caps.
+  See [#823](https://github.com/lijunzh/koda/issues/823) for the full
+  analysis
 - **Expand the surface.** Email, calendar, knowledge management — these
   are bets on where AI will be, not where it is
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -107,6 +107,13 @@ limitations — they'll be obsolete before they're stable.
   limitations are tomorrow's non-issues
 - **Don't scaffold around weakness.** Model tiers, capability probes, and
   verbose fallback prompts are building for today. Delete them
+- **Frontier models, standard APIs.** Koda targets frontier-class models
+  (Claude, GPT-4o, Gemini, o3/o4-mini) via their standard APIs. We do not
+  invest engineering effort in workarounds for small local models or
+  non-conforming API servers. If a local server diverges from the OpenAI
+  API spec, the fix belongs in the server, not in koda. Local model quirks
+  are temporary — frontier model capabilities compound. See
+  [#831](https://github.com/lijunzh/koda/issues/831) for rationale
 - **Expand the surface.** Email, calendar, knowledge management — these
   are bets on where AI will be, not where it is
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,11 +108,11 @@ limitations — they'll be obsolete before they're stable.
 - **Don't scaffold around weakness.** Model tiers, capability probes, and
   verbose fallback prompts are building for today. Delete them
 - **Frontier models, standard APIs.** Koda targets frontier-class models
-  (Claude, GPT-4o, Gemini, o3/o4-mini) via their standard APIs. We do not
-  invest engineering effort in workarounds for small local models or
-  non-conforming API servers. If a local server diverges from the OpenAI
-  API spec, the fix belongs in the server, not in koda. Local model quirks
-  are temporary — frontier model capabilities compound. See
+  via their standard APIs — whether cloud-hosted (Claude, GPT-4o, Gemini)
+  or locally served (Qwen, DeepSeek, Llama via LM Studio/Ollama/vLLM).
+  We support the OpenAI-compatible API spec faithfully but do not add
+  workarounds for individual models' non-conforming behavior. If a model
+  emits malformed output, the fix belongs upstream. See
   [#831](https://github.com/lijunzh/koda/issues/831) for rationale
 - **Expand the surface.** Email, calendar, knowledge management — these
   are bets on where AI will be, not where it is

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -156,19 +156,6 @@ impl TuiRenderer {
                         ]),
                     );
                 }
-                // Flush partial line if the buffer is getting long (prevents
-                // the UI from appearing frozen when models like Gemma 4 emit
-                // long thinking stretches without newlines — issue #823).
-                if self.think_buf.len() > 120 {
-                    let partial = std::mem::take(&mut self.think_buf);
-                    tui_output::emit_line(
-                        buffer,
-                        Line::from(vec![
-                            Span::styled("  \u{2502} ", DIM),
-                            Span::styled(partial, DIM),
-                        ]),
-                    );
-                }
             }
             EngineEvent::ThinkingDone => {
                 if !self.think_buf.is_empty() {

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -46,7 +46,7 @@ use crate::inference_helpers::{
     estimate_tokens, is_context_overflow_error, is_image_rejection_error, is_rate_limit_error,
     is_server_error, rate_limit_backoff,
 };
-use crate::loop_guard::LoopDetector;
+use crate::loop_guard::{LoopAction, LoopDetector};
 use crate::persistence::Persistence;
 use crate::providers::{
     ChatMessage, ImageData, LlmProvider, StreamChunk, TokenUsage, ToolCall, ToolDefinition,
@@ -603,7 +603,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let mut made_tool_calls = false;
     let mut retried_empty = false;
     let mut loop_detector = LoopDetector::new();
-    let mut consecutive_tool_only: u32 = 0;
     let sub_agent_cache = crate::sub_agent_cache::SubAgentCache::new();
     let bg_agents = crate::bg_agent::new_shared();
     let mut skill_scope = SkillToolScope::new();
@@ -699,23 +698,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // is active, only those tools (+ meta-tools) are sent to the LLM.
         let scoped_tool_defs = skill_scope.filter_tool_defs(tool_defs);
 
-        // If the model has produced N consecutive tool-call-only responses
-        // (tools but no text), suppress tool definitions for this turn to
-        // force it to generate a text response. This prevents models
-        // from looping infinitely through tool calls (#826).
-        let active_tool_defs: &[ToolDefinition] =
-            if consecutive_tool_only >= crate::loop_guard::TOOL_ONLY_RESPONSE_LIMIT {
-                sink.emit(EngineEvent::Info {
-                    message: format!(
-                        "Model produced {} consecutive tool-only responses — \
-                         suppressing tools for this turn to prompt a text reply.",
-                        consecutive_tool_only,
-                    ),
-                });
-                &[]
-            } else {
-                &scoped_tool_defs
-            };
+        let active_tool_defs: &[ToolDefinition] = &scoped_tool_defs;
 
         // Build per-iteration immutable context for helpers
         let turn = TurnState {
@@ -868,33 +851,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // HashMap lookup — and must happen here (not in providers) so dispatch,
         // approval, loop guard, undo, and persistence all see consistent
         // canonical names.
-        let dedup = crate::tool_normalize::normalize_tool_calls(stream_result.tool_calls);
-        let tool_calls = dedup.calls;
-
-        // Log deduplication / capping so it's visible in traces.
-        if !dedup.duplicate_ids.is_empty() {
-            let n = dedup.duplicate_ids.len();
-            tracing::warn!(
-                duplicates = n,
-                "Deduplicated {n} identical tool calls in single response"
-            );
-            sink.emit(EngineEvent::Warn {
-                message: format!(
-                    "Model emitted {n} duplicate tool call(s) — deduplicated to {} unique.",
-                    tool_calls.len(),
-                ),
-            });
-        }
+        let tool_calls = crate::tool_normalize::normalize_tool_calls(stream_result.tool_calls);
         let usage = stream_result.usage;
         let char_count = stream_result.char_count;
-
-        // Track consecutive tool-call-only responses (no text output).
-        // Reset when the model produces any text alongside or instead of tools.
-        if !tool_calls.is_empty() && full_text.trim().is_empty() {
-            consecutive_tool_only += 1;
-        } else {
-            consecutive_tool_only = 0;
-        }
 
         // Empty response after tool use — retry once before giving up.
         if tool_calls.is_empty()
@@ -1144,21 +1103,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             .await?;
         }
 
-        // Record synthetic results for deduplicated tool calls.
-        // The model expects one tool result per ID it emitted, even for
-        // duplicates we didn't execute.
-        for dup_id in &dedup.duplicate_ids {
-            db.insert_message(
-                session_id,
-                &Role::Tool,
-                Some("Duplicate tool call — result already returned for an identical call."),
-                None,
-                Some(dup_id),
-                None,
-            )
-            .await?;
-        }
-
         // Update skill scope: if any ActivateSkill call was made, check whether
         // the newly activated skill has allowed_tools.
         {
@@ -1190,17 +1134,45 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             }
         }
 
-        // Loop detection: repeated tool calls or tool-name saturation → stop.
-        if let Some(culprit) = loop_detector.record(&tool_calls) {
-            let tool_name = culprit.split(':').next().unwrap_or(&culprit);
-            sink.emit(EngineEvent::Warn {
-                message: format!(
-                    "Loop guard: '{tool_name}' called repeatedly — \
-                     stopping to avoid wasted tokens. \
-                     If the model was making progress, send a follow-up message to continue."
-                ),
-            });
-            break Ok(());
+        // Loop detection: consecutive identical tool calls → feedback or stop.
+        // Modeled after Gemini CLI: first detection injects a nudge message,
+        // second detection (model ignored feedback) hard-stops.
+        match loop_detector.record(&tool_calls) {
+            LoopAction::Ok => {}
+            LoopAction::InjectFeedback(detail) => {
+                tracing::warn!(%detail, "Loop detected — injecting feedback");
+                sink.emit(EngineEvent::Warn {
+                    message: format!(
+                        "Loop detected: {detail}. Injecting feedback to nudge the model."
+                    ),
+                });
+                // Inject a system-style user message to redirect the model.
+                db.insert_message(
+                    session_id,
+                    &Role::User,
+                    Some(&format!(
+                        "System: Potential loop detected — {detail}. \
+                         Please take a step back and confirm you're making forward progress. \
+                         If not, analyze your previous actions and try a different approach. \
+                         Avoid repeating the same tool calls without new results."
+                    )),
+                    None,
+                    None,
+                    None,
+                )
+                .await?;
+                loop_detector.clear_after_feedback();
+                // Continue the loop — give the model a chance to recover
+            }
+            LoopAction::HardStop(detail) => {
+                sink.emit(EngineEvent::Warn {
+                    message: format!(
+                        "Loop guard: {detail} — model ignored feedback, stopping. \
+                         Send a follow-up message to continue."
+                    ),
+                });
+                break Ok(());
+            }
         }
 
         iteration += 1;

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -885,18 +885,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 ),
             });
         }
-        if dedup.capped {
-            tracing::warn!(
-                kept = tool_calls.len(),
-                "Tool calls capped at per-turn limit"
-            );
-            sink.emit(EngineEvent::Warn {
-                message: format!(
-                    "Model requested too many tool calls — capped at {}.",
-                    tool_calls.len(),
-                ),
-            });
-        }
         let usage = stream_result.usage;
         let char_count = stream_result.char_count;
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -701,7 +701,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
         // If the model has produced N consecutive tool-call-only responses
         // (tools but no text), suppress tool definitions for this turn to
-        // force it to generate a text response. This prevents local models
+        // force it to generate a text response. This prevents models
         // from looping infinitely through tool calls (#826).
         let active_tool_defs: &[ToolDefinition] =
             if consecutive_tool_only >= crate::loop_guard::TOOL_ONLY_RESPONSE_LIMIT {
@@ -824,8 +824,8 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
         if stream_result.interrupted {
             // Kill the background HTTP reader immediately so the TCP
-            // connection closes and LM Studio (or any single-slot
-            // local server) can accept the next request (#825).
+            // connection closes and the server (LM Studio, vLLM, or any single-slot
+            // server) can accept the next request (#825).
             sse_handle.abort();
             let has_text = !stream_result.text.is_empty();
             let has_thinking = !stream_result.thinking_content.is_empty();
@@ -863,11 +863,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         let full_text = stream_result.text;
         let stream_thinking = stream_result.thinking_content;
         // Normalize tool names from model output to canonical PascalCase (#548).
-        // Models (especially local/small ones via OpenAI-compat APIs) may emit
-        // lowercase or snake_case names ("list", "read_file"). This runs for all
-        // providers — the canonical fast-path is a single HashMap lookup — and
-        // must happen here (not in providers) so dispatch, approval, loop guard,
-        // undo, and persistence all see consistent canonical names.
+        // Models may emit lowercase or snake_case names ("list", "read_file").
+        // This runs for all providers — the canonical fast-path is a single
+        // HashMap lookup — and must happen here (not in providers) so dispatch,
+        // approval, loop guard, undo, and persistence all see consistent
+        // canonical names.
         let dedup = crate::tool_normalize::normalize_tool_calls(stream_result.tool_calls);
         let tool_calls = dedup.calls;
 

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -1,40 +1,35 @@
-//! Loop detection and hard-cap for the inference loop.
+//! Loop detection for the inference loop.
 //!
-//! Tracks recent tool call fingerprints in a sliding window and flags
-//! when the same tool+args combination repeats too many times.
+//! Modeled after Gemini CLI's approach: simple consecutive-identical-call
+//! detection + feedback injection instead of hard stops. No windowed
+//! fingerprinting, no name saturation heuristics, no tool-only suppression.
 //!
-//! ## Detection methods
+//! ## Design philosophy
 //!
-//! Two complementary strategies catch runaway loops:
+//! Claude Code and Codex have **zero** loop detection — they trust the model.
+//! Gemini CLI has the only thoughtful approach: detect consecutive identical
+//! tool calls (same name + args), then inject a "take a step back" feedback
+//! message to nudge the model out of the loop. Hard-stop only on the 2nd
+//! detection (model ignored the feedback).
 //!
-//! 1. **Exact fingerprint** — `(tool_name, hash(args))` repeated
-//!    `REPEAT_THRESHOLD` times in the window → immediate stop.
-//!    Catches: model retrying the same command verbatim.
+//! ## What we DON'T do (and why)
 //!
-//! 2. **Tool-name saturation** — same *tool name* (any args) appears
-//!    `NAME_SATURATION_THRESHOLD` times in the window → immediate stop.
-//!    Catches: model calling `Bash(ls -la)`, `Bash(ls -l)`, `Bash(ls)`…
-//!    with slightly varying args (#826).
+//! - **No windowed fingerprint tracking** — nobody else does this.
+//! - **No tool-name saturation** — editing 12 files in a refactoring is normal.
+//! - **No tool-only response suppression** — efficient models work silently.
+//! - **No per-turn tool call cap** — frontier models emit 30+ parallel calls.
+//! - **No deduplication** — if a model emits 66 identical calls, the user
+//!   should see that and switch models, not have us silently paper over it.
 //!
-//! Both strategies track *all* tools — read-only and mutating alike.
-//! A model that calls `List` or `Grep` 8 times in 20 calls is clearly
-//! stuck, regardless of whether those tools have side-effects.
+//! ## What we DO
 //!
-//! ## What happens on detection
-//!
-//! - **Soft limit** (repeated tool calls): emits a `Warn` event naming the
-//!   culprit tool and repeat count; the turn ends and the user can send a
-//!   follow-up message to continue
-//! - **Hard limit** (iteration cap): prompts the user interactively to
-//!   continue or stop — falls back to stop in headless environments
-//!
-//! ## Why this matters
-//!
-//! Without loop detection, a confused model can burn thousands of tokens
-//! retrying the same failing edit or grep. The guard is the safety net.
+//! 1. **Consecutive identical calls** — same `(tool, args)` called
+//!    `CONSECUTIVE_REPEAT_THRESHOLD` times in a row → inject feedback.
+//! 2. **Hard iteration cap** — absolute ceiling on loop iterations.
+//!    User can extend interactively.
 
 use crate::providers::ToolCall;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 
 /// Default hard cap for the main inference loop.
 pub const MAX_ITERATIONS_DEFAULT: u32 = 200;
@@ -42,77 +37,82 @@ pub const MAX_ITERATIONS_DEFAULT: u32 = 200;
 /// Hard cap for sub-agent loops.
 pub const MAX_SUB_AGENT_ITERATIONS: usize = 20;
 
-/// How many times the same exact fingerprint (tool+args) must appear to flag a loop.
-pub const REPEAT_THRESHOLD: usize = 3;
-
-/// How many times the same *tool name* (any args) must appear in the
-/// window to flag a saturation loop. Higher than `REPEAT_THRESHOLD`
-/// because it's normal to call the same tool a few times with different args.
-pub const NAME_SATURATION_THRESHOLD: usize = 8;
-
-/// Sliding window size (individual tool calls, not batches).
-const WINDOW_SIZE: usize = 20;
-
-/// After this many consecutive tool-call-only responses (no text), tool
-/// definitions are suppressed for one turn to force a text response.
-/// Prevents models from entering infinite tool-call loops without ever
-/// producing output (#826).
-pub const TOOL_ONLY_RESPONSE_LIMIT: u32 = 5;
+/// How many **consecutive** identical tool calls (same name + args) trigger
+/// loop detection. "Consecutive" means the same fingerprint appears this
+/// many times with no other tool call in between.
+///
+/// Set to 5 to match Gemini CLI's `TOOL_CALL_LOOP_THRESHOLD`.
+/// A normal "read → edit → test" cycle never triggers this because each
+/// step is a different tool call.
+const CONSECUTIVE_REPEAT_THRESHOLD: usize = 5;
 
 /// How many recent tool names to show in the hard-cap prompt.
 const DISPLAY_RECENT: usize = 5;
 
 // ── Loop detection ────────────────────────────────────────────────
 
-/// Tracks repeated tool call patterns.
-#[derive(Default)]
+/// What to do when a loop is detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoopAction {
+    /// No loop detected — continue normally.
+    Ok,
+    /// First detection — inject feedback message to nudge the model.
+    /// Contains a descriptive message for the feedback injection.
+    InjectFeedback(String),
+    /// Second detection — model ignored feedback, hard stop.
+    HardStop(String),
+}
+
+/// Tracks consecutive identical tool calls.
+///
+/// Detection is simple: if the last N tool calls all have the same
+/// fingerprint (tool name + args), that's a loop. On first detection,
+/// the caller injects a feedback message. On second detection (model
+/// ignored the feedback), the caller hard-stops.
 pub struct LoopDetector {
-    /// Sliding window of recent tool fingerprints (tool+args).
-    window: VecDeque<String>,
-    /// Parallel window of just tool names (for saturation check).
-    name_window: VecDeque<String>,
-    /// Ring buffer of the last N tool names (for display).
+    /// The fingerprint of the last tool call.
+    last_fingerprint: Option<String>,
+    /// How many consecutive times we've seen `last_fingerprint`.
+    consecutive_count: usize,
+    /// How many times we've detected a loop in this session.
+    detection_count: u32,
+    /// Ring buffer of recent tool names (for display in hard-cap prompt).
     recent: VecDeque<String>,
+}
+
+impl Default for LoopDetector {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LoopDetector {
     /// Create a new loop detector with empty history.
     pub fn new() -> Self {
         Self {
-            window: VecDeque::new(),
-            name_window: VecDeque::new(),
+            last_fingerprint: None,
+            consecutive_count: 0,
+            detection_count: 0,
             recent: VecDeque::new(),
         }
     }
 
-    /// Record a batch of tool calls.
-    /// Returns `Some(culprit_description)` when a loop is detected.
-    pub fn record(&mut self, tool_calls: &[ToolCall]) -> Option<String> {
-        // Collect unique tool names in this batch — parallel calls to the
-        // same tool in one response are intentional, not a loop signal.
-        let mut batch_names: Vec<&str> = Vec::new();
-
+    /// Record a batch of tool calls and check for loops.
+    ///
+    /// Returns a [`LoopAction`] indicating what the caller should do.
+    pub fn record(&mut self, tool_calls: &[ToolCall]) -> LoopAction {
         for tc in tool_calls {
             let fp = fingerprint(&tc.function_name, &tc.arguments);
 
-            // Track ALL tools — read-only loops are just as wasteful (#826).
-            self.window.push_back(fp);
-            if self.window.len() > WINDOW_SIZE {
-                self.window.pop_front();
+            // Update consecutive counter
+            if self.last_fingerprint.as_ref() == Some(&fp) {
+                self.consecutive_count += 1;
+            } else {
+                self.last_fingerprint = Some(fp);
+                self.consecutive_count = 1;
             }
 
-            // Deduplicate names per batch: 10 parallel Read calls = 1 entry,
-            // not 10. This prevents false positives when the model reads
-            // many files at once (which we explicitly encourage).
-            if !batch_names.contains(&tc.function_name.as_str()) {
-                batch_names.push(&tc.function_name);
-                self.name_window.push_back(tc.function_name.clone());
-                if self.name_window.len() > WINDOW_SIZE {
-                    self.name_window.pop_front();
-                }
-            }
-
-            // Ring buffer for display always tracks all tools
+            // Update display ring buffer
             self.recent.push_back(tc.function_name.clone());
             if self.recent.len() > DISPLAY_RECENT {
                 self.recent.pop_front();
@@ -122,34 +122,39 @@ impl LoopDetector {
         self.check()
     }
 
+    /// Clear the detection state after feedback injection so the model
+    /// gets a fresh chance. Increments `detection_count` so the next
+    /// trigger will be a hard stop.
+    pub fn clear_after_feedback(&mut self) {
+        self.detection_count += 1;
+        self.last_fingerprint = None;
+        self.consecutive_count = 0;
+    }
+
     /// Recent tool names (most recent last), for display in the hard-cap prompt.
     pub fn recent_names(&self) -> Vec<String> {
         self.recent.iter().cloned().collect()
     }
 
-    fn check(&self) -> Option<String> {
-        // Strategy 1: exact fingerprint repeated REPEAT_THRESHOLD times
-        let mut fp_counts: HashMap<&str, usize> = HashMap::new();
-        for fp in &self.window {
-            *fp_counts.entry(fp.as_str()).or_insert(0) += 1;
-        }
-        if let Some((fp, _)) = fp_counts.iter().find(|(_, n)| **n >= REPEAT_THRESHOLD) {
-            return Some(fp.to_string());
+    fn check(&self) -> LoopAction {
+        if self.consecutive_count < CONSECUTIVE_REPEAT_THRESHOLD {
+            return LoopAction::Ok;
         }
 
-        // Strategy 2: same tool name saturates the window (#826)
-        let mut name_counts: HashMap<&str, usize> = HashMap::new();
-        for name in &self.name_window {
-            *name_counts.entry(name.as_str()).or_insert(0) += 1;
-        }
-        if let Some((name, count)) = name_counts
-            .iter()
-            .find(|(_, n)| **n >= NAME_SATURATION_THRESHOLD)
-        {
-            return Some(format!("{name} (×{count} with varying args)"));
-        }
+        let fp = self.last_fingerprint.as_deref().unwrap_or("unknown");
+        let tool_name = fp.split(':').next().unwrap_or(fp);
+        let detail = format!(
+            "'{tool_name}' called {n} times consecutively with identical arguments",
+            n = self.consecutive_count,
+        );
 
-        None
+        if self.detection_count == 0 {
+            // First detection — inject feedback
+            LoopAction::InjectFeedback(detail)
+        } else {
+            // Already injected feedback before — hard stop
+            LoopAction::HardStop(detail)
+        }
     }
 }
 
@@ -161,8 +166,6 @@ fn fingerprint(name: &str, args: &str) -> String {
 
 // ── Hard-cap prompt ───────────────────────────────────────────────
 
-/// Prompt the user when the hard iteration cap is hit.
-///
 /// Options for continuing after hitting the hard cap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -204,115 +207,126 @@ mod tests {
     #[test]
     fn no_loop_on_unique_calls() {
         let mut d = LoopDetector::new();
-        assert!(d.record(&[call("Edit", "{\"path\":\"a.rs\"}")]).is_none());
-        assert!(d.record(&[call("Edit", "{\"path\":\"b.rs\"}")]).is_none());
-        assert!(d.record(&[call("Bash", "{\"cmd\":\"ls\"}")]).is_none());
-    }
-
-    #[test]
-    fn detects_repeated_identical_call() {
-        let mut d = LoopDetector::new();
-        let tc = call("Edit", "{\"path\":\"src/main.rs\"}");
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        // Third repetition should trigger
-        assert!(d.record(std::slice::from_ref(&tc)).is_some());
-    }
-
-    #[test]
-    fn different_args_below_saturation_not_a_loop() {
-        // Different args should NOT trigger the exact-fingerprint check.
-        // Stay below NAME_SATURATION_THRESHOLD to avoid the saturation check.
-        let mut d = LoopDetector::new();
-        for i in 0..NAME_SATURATION_THRESHOLD - 1 {
-            let args = format!("{{\"path\":\"file{i}.rs\"}}");
-            assert!(
-                d.record(&[call("Edit", &args)]).is_none(),
-                "should not trigger at call {i}"
-            );
-        }
-    }
-
-    #[test]
-    fn detects_readonly_tool_loop() {
-        // Read-only tools are now tracked (#826)
-        let mut d = LoopDetector::new();
-        let tc = call("Read", "{\"path\":\"src/main.rs\"}");
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        assert!(d.record(std::slice::from_ref(&tc)).is_none());
-        assert!(
-            d.record(std::slice::from_ref(&tc)).is_some(),
-            "read-only tools should be caught at REPEAT_THRESHOLD"
+        assert_eq!(
+            d.record(&[call("Edit", "{\"path\":\"a.rs\"}")]),
+            LoopAction::Ok
+        );
+        assert_eq!(
+            d.record(&[call("Edit", "{\"path\":\"b.rs\"}")]),
+            LoopAction::Ok
+        );
+        assert_eq!(
+            d.record(&[call("Bash", "{\"cmd\":\"ls\"}")]),
+            LoopAction::Ok
         );
     }
 
     #[test]
-    fn detects_name_saturation_with_varying_args() {
-        // Same tool name but different args each time (#826)
+    fn detects_consecutive_identical_calls() {
         let mut d = LoopDetector::new();
-        for i in 0..NAME_SATURATION_THRESHOLD {
-            let args = format!("{{\"command\":\"ls -variant-{i}\"}}");
-            let result = d.record(&[call("Bash", &args)]);
-            if i < NAME_SATURATION_THRESHOLD - 1 {
-                assert!(result.is_none(), "should not trigger at call {i}");
-            } else {
-                assert!(result.is_some(), "should trigger at call {i}");
-                assert!(
-                    result.unwrap().contains("varying args"),
-                    "should mention varying args"
-                );
-            }
+        let tc = call("Edit", "{\"path\":\"src/main.rs\"}");
+        for _ in 0..CONSECUTIVE_REPEAT_THRESHOLD - 1 {
+            assert_eq!(d.record(std::slice::from_ref(&tc)), LoopAction::Ok);
         }
+        // Should trigger feedback on threshold
+        assert!(matches!(
+            d.record(std::slice::from_ref(&tc)),
+            LoopAction::InjectFeedback(_)
+        ));
     }
 
     #[test]
-    fn mixed_tools_no_false_positive() {
-        // Alternating between different tools shouldn't trigger saturation
+    fn different_tool_resets_consecutive_count() {
         let mut d = LoopDetector::new();
-        for i in 0..20 {
-            let name = if i % 3 == 0 {
-                "Bash"
-            } else if i % 3 == 1 {
-                "Read"
-            } else {
-                "List"
-            };
-            let args = format!("{{\"i\":{i}}}");
-            assert!(
-                d.record(&[call(name, &args)]).is_none(),
-                "mixed tools should not trigger (call {i})"
+        let tc = call("Edit", "{\"path\":\"src/main.rs\"}");
+        // Almost at threshold
+        for _ in 0..CONSECUTIVE_REPEAT_THRESHOLD - 2 {
+            assert_eq!(d.record(std::slice::from_ref(&tc)), LoopAction::Ok);
+        }
+        // Different tool resets the count
+        assert_eq!(
+            d.record(&[call("Bash", "{\"cmd\":\"test\"}")]),
+            LoopAction::Ok
+        );
+        // Back to same tool — starts from 1 again
+        for _ in 0..CONSECUTIVE_REPEAT_THRESHOLD - 1 {
+            assert_eq!(d.record(std::slice::from_ref(&tc)), LoopAction::Ok);
+        }
+        assert!(matches!(
+            d.record(std::slice::from_ref(&tc)),
+            LoopAction::InjectFeedback(_)
+        ));
+    }
+
+    #[test]
+    fn read_edit_test_cycle_never_triggers() {
+        // The most common coding workflow should NEVER trigger.
+        let mut d = LoopDetector::new();
+        let test_cmd = "{\"command\":\"cargo test\"}";
+        let read_args = "{\"path\":\"src/lib.rs\"}";
+
+        for cycle in 0..20 {
+            assert_eq!(
+                d.record(&[call("Read", read_args)]),
+                LoopAction::Ok,
+                "read should not trigger at cycle {cycle}"
+            );
+            let edit_args = format!("{{\"path\":\"src/lib.rs\",\"old\":\"v{cycle}\"}}");
+            assert_eq!(
+                d.record(&[call("Edit", &edit_args)]),
+                LoopAction::Ok,
+                "edit should not trigger at cycle {cycle}"
+            );
+            assert_eq!(
+                d.record(&[call("Bash", test_cmd)]),
+                LoopAction::Ok,
+                "test should not trigger at cycle {cycle}"
             );
         }
     }
 
     #[test]
-    fn parallel_reads_in_one_batch_not_a_loop() {
-        // 10 parallel Read calls in a single batch should NOT trigger
-        // saturation — the model is doing what we asked (read many files
-        // at once). Only sequential batches should count.
+    fn feedback_then_hard_stop() {
+        let mut d = LoopDetector::new();
+        let tc = call("Read", "{\"path\":\"stuck.rs\"}");
+
+        // First detection → feedback
+        for _ in 0..CONSECUTIVE_REPEAT_THRESHOLD {
+            d.record(std::slice::from_ref(&tc));
+        }
+        // The last record returned InjectFeedback — now simulate the
+        // caller clearing state and the model looping again
+        d.detection_count = 1; // feedback was injected
+        d.clear_after_feedback();
+
+        // Second detection → hard stop
+        for _ in 0..CONSECUTIVE_REPEAT_THRESHOLD {
+            d.record(std::slice::from_ref(&tc));
+        }
+        assert!(matches!(d.check(), LoopAction::HardStop(_)));
+    }
+
+    #[test]
+    fn parallel_calls_same_tool_not_a_loop() {
+        // 10 parallel Read calls with DIFFERENT args in one batch — not a loop
         let mut d = LoopDetector::new();
         let batch: Vec<ToolCall> = (0..10)
             .map(|i| call("Read", &format!("{{\"path\":\"file{i}.rs\"}}")))
             .collect();
-        assert!(
-            d.record(&batch).is_none(),
-            "parallel reads in one batch should not trigger saturation"
-        );
+        assert_eq!(d.record(&batch), LoopAction::Ok);
     }
 
     #[test]
-    fn parallel_reads_across_batches_triggers_saturation() {
-        // But if the model keeps sending Read-only batches across many
-        // iterations, that IS a loop.
+    fn same_tool_different_args_not_consecutive() {
+        // Same tool name but different args each time — not consecutive
         let mut d = LoopDetector::new();
-        for i in 0..NAME_SATURATION_THRESHOLD {
-            let batch = vec![call("Read", &format!("{{\"path\":\"file{i}.rs\"}}"))];
-            let result = d.record(&batch);
-            if i < NAME_SATURATION_THRESHOLD - 1 {
-                assert!(result.is_none(), "should not trigger at batch {i}");
-            } else {
-                assert!(result.is_some(), "should trigger at batch {i}");
-            }
+        for i in 0..20 {
+            let args = format!("{{\"command\":\"ls -variant-{i}\"}}");
+            assert_eq!(
+                d.record(&[call("Bash", &args)]),
+                LoopAction::Ok,
+                "different args should not trigger at call {i}"
+            );
         }
     }
 
@@ -327,13 +341,5 @@ mod tests {
         assert_eq!(names.len(), 5);
         assert_eq!(names[0], "Tool3");
         assert_eq!(names[4], "Tool7");
-    }
-
-    #[test]
-    fn fingerprint_truncates_long_args() {
-        let long_args = "x".repeat(500);
-        let fp = fingerprint("Bash", &long_args);
-        // name + ":" + 200 chars
-        assert_eq!(fp.len(), "Bash:".len() + 200);
     }
 }

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -55,8 +55,8 @@ const WINDOW_SIZE: usize = 20;
 
 /// After this many consecutive tool-call-only responses (no text), tool
 /// definitions are suppressed for one turn to force a text response.
-/// Prevents models (especially local ones) from entering infinite
-/// tool-call loops without ever producing output (#826).
+/// Prevents models from entering infinite tool-call loops without ever
+/// producing output (#826).
 pub const TOOL_ONLY_RESPONSE_LIMIT: u32 = 5;
 
 /// How many recent tool names to show in the hard-cap prompt.

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -153,12 +153,6 @@ struct StreamDelta {
     /// Reasoning content from o1/o3/o4-mini models.
     #[serde(default)]
     reasoning_content: Option<String>,
-    /// Thinking content from Gemma 4 and other models via LM Studio.
-    #[serde(default)]
-    thinking_content: Option<String>,
-    /// Alternative thinking field used by some local model servers.
-    #[serde(default)]
-    thought_content: Option<String>,
     tool_calls: Option<Vec<StreamToolCall>>,
 }
 
@@ -230,17 +224,11 @@ impl ChunkParser for OpenAiChunkParser {
                 };
             }
 
-            // Reasoning / thinking content (o1/o3/o4-mini, Gemma 4, etc.)
-            // Models and local servers may use different field names.
-            let thinking = choice
-                .delta
-                .reasoning_content
-                .as_deref()
-                .or(choice.delta.thinking_content.as_deref())
-                .or(choice.delta.thought_content.as_deref())
-                .unwrap_or_default();
-            if !thinking.is_empty() {
-                chunks.push(StreamChunk::ThinkingDelta(thinking.to_string()));
+            // Reasoning content (o1/o3/o4-mini)
+            if let Some(reasoning) = &choice.delta.reasoning_content
+                && !reasoning.is_empty()
+            {
+                chunks.push(StreamChunk::ThinkingDelta(reasoning.clone()));
             }
 
             // Text delta — run through <think> tag filter

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -102,12 +102,7 @@ async fn drive_sse_stream(
             let line = buffer[..line_end].trim().to_string();
             buffer.drain(..=line_end);
 
-            // SSE spec: "data: payload" or "data:payload" (space is optional)
-            let data = if let Some(d) = line.strip_prefix("data: ") {
-                d
-            } else if let Some(d) = line.strip_prefix("data:") {
-                d
-            } else {
+            let Some(data) = line.strip_prefix("data: ") else {
                 continue;
             };
 
@@ -175,12 +170,7 @@ mod tests {
 
         for line in sse_text.lines() {
             let trimmed = line.trim();
-            // Mirror the real SSE parser: accept both `data: ` and `data:`
-            let data = if let Some(d) = trimmed.strip_prefix("data: ") {
-                d
-            } else if let Some(d) = trimmed.strip_prefix("data:") {
-                d
-            } else {
+            let Some(data) = trimmed.strip_prefix("data: ") else {
                 continue;
             };
             if data.trim() == "[DONE]" {
@@ -221,28 +211,6 @@ mod tests {
 
         assert_eq!(chunks.len(), 2); // 1 delta + Done
         assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "payload"));
-    }
-
-    /// SSE spec allows `data:` without a trailing space (issue #823).
-    #[tokio::test]
-    async fn test_data_without_space_parsed() {
-        let sse = "data:hello\ndata:world\n";
-        let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
-
-        assert_eq!(chunks.len(), 3); // 2 deltas + Done
-        assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "hello"));
-        assert!(matches!(&chunks[1], StreamChunk::TextDelta(t) if t == "world"));
-    }
-
-    /// Mixed `data: ` and `data:` lines should both be parsed.
-    #[tokio::test]
-    async fn test_data_mixed_space_variants() {
-        let sse = "data: with-space\ndata:no-space\n";
-        let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
-
-        assert_eq!(chunks.len(), 3);
-        assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "with-space"));
-        assert!(matches!(&chunks[1], StreamChunk::TextDelta(t) if t == "no-space"));
     }
 
     // ── Anthropic parser fixture tests ────────────────────────────
@@ -456,38 +424,5 @@ data: [DONE]
             }
             other => panic!("Expected Done, got {:?}", other),
         }
-    }
-
-    /// Gemma 4 via LM Studio may use `thinking_content` field (issue #823).
-    #[tokio::test]
-    async fn test_openai_thinking_content_field() {
-        let sse = r#"data: {"choices":[{"delta":{"thinking_content":"Gemma thinking..."},"finish_reason":null}],"usage":null}
-data: {"choices":[{"delta":{"content":"Answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}
-data: [DONE]
-"#;
-        let chunks = drive_parser(Box::new(OpenAiChunkParser::new()), sse).await;
-
-        assert!(matches!(&chunks[0], StreamChunk::ThinkingDelta(t) if t == "Gemma thinking..."));
-        // "Answer" is short enough to be held back by the tag filter until flush
-        let text: String = chunks
-            .iter()
-            .filter_map(|c| match c {
-                StreamChunk::TextDelta(t) => Some(t.as_str()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(text, "Answer");
-    }
-
-    /// Some servers use `thought_content` instead of `reasoning_content`.
-    #[tokio::test]
-    async fn test_openai_thought_content_field() {
-        let sse = r#"data: {"choices":[{"delta":{"thought_content":"deep thoughts"},"finish_reason":null}],"usage":null}
-data: {"choices":[{"delta":{"content":"Done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}
-data: [DONE]
-"#;
-        let chunks = drive_parser(Box::new(OpenAiChunkParser::new()), sse).await;
-
-        assert!(matches!(&chunks[0], StreamChunk::ThinkingDelta(t) if t == "deep thoughts"));
     }
 }

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -102,7 +102,12 @@ async fn drive_sse_stream(
             let line = buffer[..line_end].trim().to_string();
             buffer.drain(..=line_end);
 
-            let Some(data) = line.strip_prefix("data: ") else {
+            // SSE spec: space after colon is optional ("data: x" and "data:x" are equivalent)
+            let data = if let Some(d) = line.strip_prefix("data: ") {
+                d
+            } else if let Some(d) = line.strip_prefix("data:") {
+                d
+            } else {
                 continue;
             };
 
@@ -170,7 +175,12 @@ mod tests {
 
         for line in sse_text.lines() {
             let trimmed = line.trim();
-            let Some(data) = trimmed.strip_prefix("data: ") else {
+            // Mirror the real SSE parser: accept both `data: ` and `data:`
+            let data = if let Some(d) = trimmed.strip_prefix("data: ") {
+                d
+            } else if let Some(d) = trimmed.strip_prefix("data:") {
+                d
+            } else {
                 continue;
             };
             if data.trim() == "[DONE]" {
@@ -211,6 +221,28 @@ mod tests {
 
         assert_eq!(chunks.len(), 2); // 1 delta + Done
         assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "payload"));
+    }
+
+    /// SSE spec allows `data:` without a trailing space.
+    #[tokio::test]
+    async fn test_data_without_space_parsed() {
+        let sse = "data:hello\ndata:world\n";
+        let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
+
+        assert_eq!(chunks.len(), 3); // 2 deltas + Done
+        assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "hello"));
+        assert!(matches!(&chunks[1], StreamChunk::TextDelta(t) if t == "world"));
+    }
+
+    /// Mixed `data: ` and `data:` lines should both be parsed.
+    #[tokio::test]
+    async fn test_data_mixed_space_variants() {
+        let sse = "data: with-space\ndata:no-space\n";
+        let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
+
+        assert_eq!(chunks.len(), 3);
+        assert!(matches!(&chunks[0], StreamChunk::TextDelta(t) if t == "with-space"));
+        assert!(matches!(&chunks[1], StreamChunk::TextDelta(t) if t == "no-space"));
     }
 
     // ── Anthropic parser fixture tests ────────────────────────────

--- a/koda-core/src/providers/stream_tag_filter.rs
+++ b/koda-core/src/providers/stream_tag_filter.rs
@@ -1,8 +1,9 @@
 //! Streaming tag filter for LLM responses.
 //!
-//! Models served via OpenAI-compatible endpoints may emit XML tags and special
-//! tokens directly in their text output instead of using structured APIs.
-//! This filter intercepts them at the **provider layer**:
+//! Models using OpenAI-compatible endpoints (DeepSeek, Qwen, Llama, etc.)
+//! may emit XML tags and special tokens directly in their text output
+//! instead of using structured API fields. This filter intercepts them
+//! at the **provider layer**:
 //!
 //! - **Thinking tags** (`<think>`, `<thinking>`, `<reasoning>`, `<reflection>`)
 //!   → converted to `ThinkingDelta` chunks

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -1,10 +1,10 @@
 //! Tool name normalization — maps model-emitted variants to canonical PascalCase.
 //!
-//! Models (especially smaller/local ones via OpenAI-compatible APIs) sometimes
-//! emit tool names in lowercase (`list`, `read`) or snake_case (`list_files`,
-//! `read_file`) instead of the canonical PascalCase (`List`, `Read`). This
-//! module provides a single normalization point at the API boundary so all
-//! downstream code (dispatch, approval, loop guard, undo) sees canonical names.
+//! Models sometimes emit tool names in lowercase (`list`, `read`) or
+//! snake_case (`list_files`, `read_file`) instead of the canonical PascalCase
+//! (`List`, `Read`). This module provides a single normalization point at the
+//! API boundary so all downstream code (dispatch, approval, loop guard, undo)
+//! sees canonical names.
 //!
 //! ## Design
 //!
@@ -173,9 +173,8 @@ pub fn normalize_tool_name(name: &str) -> String {
 /// Called once after `collect_stream()` returns, before dispatch/approval.
 /// Maximum tool calls per single model response.
 ///
-/// A safety cap to prevent runaway models (especially local ones) from
-/// issuing hundreds of tool calls in a single turn.  The cap applies
-/// *after* deduplication.
+/// A safety cap to prevent runaway models from issuing hundreds of tool
+/// calls in a single turn.  The cap applies *after* deduplication.
 pub const MAX_TOOL_CALLS_PER_TURN: usize = 20;
 
 /// Normalize + deduplicate + cap tool calls from a single model response.
@@ -411,7 +410,7 @@ mod tests {
 
     #[test]
     fn dedup_66_identical_list_calls() {
-        // Reproduces #773: Gemma 4 emitting 66 identical List calls
+        // Models may emit many identical tool calls in a single response (#773)
         let calls: Vec<ToolCall> = (0..66)
             .map(|i| tc(&format!("call_{i}"), "list", "{\"path\":\".\"}"))
             .collect();

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -168,24 +168,18 @@ pub fn normalize_tool_name(name: &str) -> String {
     name.to_string()
 }
 
-/// Normalize all tool calls in a batch.
-///
-/// Called once after `collect_stream()` returns, before dispatch/approval.
-/// Maximum tool calls per single model response.
-///
-/// A safety cap to prevent runaway models from issuing hundreds of tool
-/// calls in a single turn.  The cap applies *after* deduplication.
-pub const MAX_TOOL_CALLS_PER_TURN: usize = 20;
-
-/// Normalize + deduplicate + cap tool calls from a single model response.
+/// Normalize + deduplicate tool calls from a single model response.
 ///
 /// 1. **Normalize** — map model-emitted names to canonical PascalCase.
 /// 2. **Deduplicate** — collapse identical `(name, args)` pairs.  The
 ///    first occurrence's ID is kept; duplicate IDs are returned in
 ///    `DeduplicatedToolCalls::duplicate_ids` so the caller can record
 ///    a synthetic tool result for each (the model expects one per ID).
-/// 3. **Cap** — truncate to [`MAX_TOOL_CALLS_PER_TURN`] to prevent
-///    runaway models from issuing hundreds of calls.
+///
+/// No per-turn cap is applied — frontier models legitimately emit 20+
+/// parallel tool calls (e.g. reading many files at once). Runaway loops
+/// are caught by the loop guard (`REPEAT_THRESHOLD`, `NAME_SATURATION_THRESHOLD`)
+/// and the hard iteration cap (`MAX_ITERATIONS_DEFAULT`).
 pub fn normalize_tool_calls(tool_calls: Vec<ToolCall>) -> DeduplicatedToolCalls {
     use std::collections::HashSet;
 
@@ -204,29 +198,21 @@ pub fn normalize_tool_calls(tool_calls: Vec<ToolCall>) -> DeduplicatedToolCalls 
         }
     }
 
-    let capped = unique.len() > MAX_TOOL_CALLS_PER_TURN;
-    if capped {
-        unique.truncate(MAX_TOOL_CALLS_PER_TURN);
-    }
-
     DeduplicatedToolCalls {
         calls: unique,
         duplicate_ids,
-        capped,
     }
 }
 
 /// Result of [`normalize_tool_calls`]: unique calls + metadata about duplicates.
 #[derive(Debug)]
 pub struct DeduplicatedToolCalls {
-    /// Unique, normalized tool calls (max [`MAX_TOOL_CALLS_PER_TURN`]).
+    /// Unique, normalized tool calls.
     pub calls: Vec<ToolCall>,
     /// IDs of tool calls that were duplicates of an earlier call in the
     /// same response.  The caller should record a synthetic tool result
     /// for each (e.g. "Duplicate call — result already returned.").
     pub duplicate_ids: Vec<String>,
-    /// `true` if the list was truncated to the per-turn cap.
-    pub capped: bool,
 }
 
 #[cfg(test)]
@@ -394,7 +380,6 @@ mod tests {
         assert_eq!(result.calls.len(), 1);
         assert_eq!(result.calls[0].id, "1");
         assert_eq!(result.duplicate_ids, vec!["2", "3"]);
-        assert!(!result.capped);
     }
 
     #[test]
@@ -421,7 +406,9 @@ mod tests {
     }
 
     #[test]
-    fn cap_limits_tool_calls() {
+    fn many_unique_calls_not_capped() {
+        // Frontier models legitimately emit 30+ parallel tool calls.
+        // Dedup should pass them all through without truncation.
         let calls: Vec<ToolCall> = (0..30)
             .map(|i| {
                 tc(
@@ -432,9 +419,12 @@ mod tests {
             })
             .collect();
         let result = normalize_tool_calls(calls);
-        assert_eq!(result.calls.len(), MAX_TOOL_CALLS_PER_TURN);
-        assert!(result.capped);
-        assert!(result.duplicate_ids.is_empty()); // all unique, just capped
+        assert_eq!(
+            result.calls.len(),
+            30,
+            "all unique calls should pass through"
+        );
+        assert!(result.duplicate_ids.is_empty());
     }
 
     fn tc(id: &str, name: &str, args: &str) -> ToolCall {

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -168,51 +168,19 @@ pub fn normalize_tool_name(name: &str) -> String {
     name.to_string()
 }
 
-/// Normalize + deduplicate tool calls from a single model response.
+/// Normalize all tool calls in a batch.
 ///
-/// 1. **Normalize** — map model-emitted names to canonical PascalCase.
-/// 2. **Deduplicate** — collapse identical `(name, args)` pairs.  The
-///    first occurrence's ID is kept; duplicate IDs are returned in
-///    `DeduplicatedToolCalls::duplicate_ids` so the caller can record
-///    a synthetic tool result for each (the model expects one per ID).
-///
-/// No per-turn cap is applied — frontier models legitimately emit 20+
-/// parallel tool calls (e.g. reading many files at once). Runaway loops
-/// are caught by the loop guard (`REPEAT_THRESHOLD`, `NAME_SATURATION_THRESHOLD`)
-/// and the hard iteration cap (`MAX_ITERATIONS_DEFAULT`).
-pub fn normalize_tool_calls(tool_calls: Vec<ToolCall>) -> DeduplicatedToolCalls {
-    use std::collections::HashSet;
-
-    let mut seen: HashSet<(String, String)> = HashSet::new();
-    let mut unique = Vec::new();
-    let mut duplicate_ids = Vec::new();
-
-    for mut tc in tool_calls {
+/// Maps model-emitted names to canonical PascalCase. No deduplication,
+/// no per-turn cap — frontier models legitimately emit 30+ parallel
+/// calls (e.g. reading many files at once). If a model emits duplicate
+/// calls, the user should see that and switch models, not have us
+/// silently paper over it. Loops are caught by the consecutive-call
+/// detector in `loop_guard.rs`.
+pub fn normalize_tool_calls(mut tool_calls: Vec<ToolCall>) -> Vec<ToolCall> {
+    for tc in &mut tool_calls {
         tc.function_name = normalize_tool_name(&tc.function_name);
-        let key = (tc.function_name.clone(), tc.arguments.clone());
-        if seen.contains(&key) {
-            duplicate_ids.push(tc.id);
-        } else {
-            seen.insert(key);
-            unique.push(tc);
-        }
     }
-
-    DeduplicatedToolCalls {
-        calls: unique,
-        duplicate_ids,
-    }
-}
-
-/// Result of [`normalize_tool_calls`]: unique calls + metadata about duplicates.
-#[derive(Debug)]
-pub struct DeduplicatedToolCalls {
-    /// Unique, normalized tool calls.
-    pub calls: Vec<ToolCall>,
-    /// IDs of tool calls that were duplicates of an earlier call in the
-    /// same response.  The caller should record a synthetic tool result
-    /// for each (e.g. "Duplicate call — result already returned.").
-    pub duplicate_ids: Vec<String>,
+    tool_calls
 }
 
 #[cfg(test)]
@@ -341,15 +309,16 @@ mod tests {
             },
             ToolCall {
                 id: "3".into(),
-                function_name: "Read".into(), // already canonical
+                function_name: "Read".into(),
                 arguments: r#"{"path":"y"}"#.into(),
                 thought_signature: None,
             },
         ];
         let normalized = normalize_tool_calls(calls);
-        assert_eq!(normalized.calls[0].function_name, "List");
-        assert_eq!(normalized.calls[1].function_name, "Read");
-        assert_eq!(normalized.calls[2].function_name, "Read");
+        assert_eq!(normalized[0].function_name, "List");
+        assert_eq!(normalized[1].function_name, "Read");
+        assert_eq!(normalized[2].function_name, "Read");
+        assert_eq!(normalized.len(), 3); // no dedup
     }
 
     // ── Every canonical name has a lowercase alias ──────────────
@@ -363,76 +332,6 @@ mod tests {
                 name,
                 "Missing lowercase alias for '{name}'"
             );
-        }
-    }
-
-    // ── Deduplication ───────────────────────────────────────────
-
-    #[test]
-    fn dedup_collapses_identical_calls() {
-        let args = "{\"path\":\".\"}";
-        let calls = vec![
-            tc("1", "List", args),
-            tc("2", "List", args),
-            tc("3", "List", args),
-        ];
-        let result = normalize_tool_calls(calls);
-        assert_eq!(result.calls.len(), 1);
-        assert_eq!(result.calls[0].id, "1");
-        assert_eq!(result.duplicate_ids, vec!["2", "3"]);
-    }
-
-    #[test]
-    fn dedup_keeps_different_args() {
-        let calls = vec![
-            tc("1", "Read", "{\"path\":\"a.rs\"}"),
-            tc("2", "Read", "{\"path\":\"b.rs\"}"),
-        ];
-        let result = normalize_tool_calls(calls);
-        assert_eq!(result.calls.len(), 2);
-        assert!(result.duplicate_ids.is_empty());
-    }
-
-    #[test]
-    fn dedup_66_identical_list_calls() {
-        // Models may emit many identical tool calls in a single response (#773)
-        let calls: Vec<ToolCall> = (0..66)
-            .map(|i| tc(&format!("call_{i}"), "list", "{\"path\":\".\"}"))
-            .collect();
-        let result = normalize_tool_calls(calls);
-        assert_eq!(result.calls.len(), 1, "should collapse 66 → 1");
-        assert_eq!(result.duplicate_ids.len(), 65);
-        assert_eq!(result.calls[0].function_name, "List"); // also normalized
-    }
-
-    #[test]
-    fn many_unique_calls_not_capped() {
-        // Frontier models legitimately emit 30+ parallel tool calls.
-        // Dedup should pass them all through without truncation.
-        let calls: Vec<ToolCall> = (0..30)
-            .map(|i| {
-                tc(
-                    &format!("call_{i}"),
-                    "Read",
-                    &format!("{{\"path\":\"file_{i}.rs\"}}"),
-                )
-            })
-            .collect();
-        let result = normalize_tool_calls(calls);
-        assert_eq!(
-            result.calls.len(),
-            30,
-            "all unique calls should pass through"
-        );
-        assert!(result.duplicate_ids.is_empty());
-    }
-
-    fn tc(id: &str, name: &str, args: &str) -> ToolCall {
-        ToolCall {
-            id: id.into(),
-            function_name: name.into(),
-            arguments: args.into(),
-            thought_signature: None,
         }
     }
 

--- a/koda-core/tests/golden_test.rs
+++ b/koda-core/tests/golden_test.rs
@@ -8,34 +8,36 @@
 use koda_core::engine::EngineEvent;
 use koda_test_utils::{Env, golden};
 
-/// Regression test for #773: Gemma 4 emitting 10 identical List calls
-/// in a single response.  The dedup layer should collapse them to 1.
+/// Regression test for #773 → #823: Gemma 4 emitting 10 identical List calls
+/// in a single response. With dedup removed (#823), all calls execute.
+/// If a model is broken enough to emit duplicates, the user should see it
+/// and switch models rather than us silently papering over it.
 #[tokio::test]
-async fn gemma4_duplicate_list_calls_are_deduped() {
+async fn gemma4_duplicate_list_calls_all_execute() {
     let provider = golden::replay("tests/fixtures/gemma4_duplicate_list.golden.json");
     let env = Env::new().await;
     env.insert_user_message("ls").await;
 
     let events = env.run_inference(&provider).await;
 
-    // Should see a warn about deduplication
+    // No dedup warning should appear
     let dedup_warn = events.iter().any(|e| {
         matches!(
             e,
             EngineEvent::Warn { message } if message.contains("duplicate")
         )
     });
-    assert!(dedup_warn, "expected dedup warning in events: {events:?}");
+    assert!(!dedup_warn, "should NOT see dedup warning: {events:?}");
 
-    // Should only execute List ONCE, not 10 times
+    // All 10 List calls should execute (no dedup)
     let list_calls: Vec<_> = events
         .iter()
         .filter(|e| matches!(e, EngineEvent::ToolCallStart { name, .. } if name == "List"))
         .collect();
     assert_eq!(
         list_calls.len(),
-        1,
-        "expected 1 List call after dedup, got {}: {list_calls:?}",
+        10,
+        "expected 10 List calls (no dedup), got {}: {list_calls:?}",
         list_calls.len(),
     );
 }

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -171,32 +171,52 @@ async fn max_tokens_continues_loop() {
 // ── Loop detection ───────────────────────────────────────────
 
 #[tokio::test]
-async fn loop_detection_stops_repeated_tool_calls() {
+async fn loop_detection_injects_feedback_then_stops() {
     let env = Env::new().await;
     env.insert_user_message("keep trying").await;
 
-    // Produce the same tool call repeatedly. The loop detector should fire
-    // after REPEAT_THRESHOLD (3) identical mutating tool calls.
-    // Each MockResponse is consumed by a separate chat_stream call.
-    // After tool execution, the loop re-enters and calls chat_stream again.
+    // Produce the same tool call repeatedly. The loop detector fires after
+    // 5 consecutive identical calls (matching Gemini CLI's threshold).
+    // First detection: injects feedback and continues.
+    // Second detection: hard stops.
+    // Need 10 repeated calls: 5 to trigger feedback + 5 more to hard stop.
     let repeated_call =
         MockResponse::tool_call("Bash", serde_json::json!({"command": "echo stuck"}));
     let provider = MockProvider::new(vec![
-        repeated_call.clone(), // iteration 0: tool call → execute → loop
-        repeated_call.clone(), // iteration 1: tool call → execute → loop
-        repeated_call.clone(), // iteration 2: tool call → loop detector fires
-        // Fallback in case detection doesn't fire at exactly 3:
-        repeated_call.clone(),
-        repeated_call.clone(),
+        repeated_call.clone(), // 1st consecutive
+        repeated_call.clone(), // 2nd
+        repeated_call.clone(), // 3rd
+        repeated_call.clone(), // 4th
+        repeated_call.clone(), // 5th → InjectFeedback, clear, continue
+        repeated_call.clone(), // 1st consecutive (reset)
+        repeated_call.clone(), // 2nd
+        repeated_call.clone(), // 3rd
+        repeated_call.clone(), // 4th
+        repeated_call.clone(), // 5th → HardStop
         MockResponse::Text("unreachable".into()),
     ]);
     let events = env.run_inference(&provider).await;
 
-    // Should detect the loop and emit a warning.
-    let has_loop_warn = events
-        .iter()
-        .any(|e| matches!(e, EngineEvent::Warn { message } if message.contains("Loop guard")));
-    assert!(has_loop_warn, "expected loop detection warning: {events:?}");
+    // Should see the feedback injection warning first
+    let has_feedback = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Warn { message } if message.contains("Loop detected")
+        )
+    });
+    assert!(
+        has_feedback,
+        "expected feedback injection warning: {events:?}"
+    );
+
+    // Should see the hard stop warning second
+    let has_hard_stop = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Warn { message } if message.contains("Loop guard")
+        )
+    });
+    assert!(has_hard_stop, "expected hard stop warning: {events:?}");
 }
 
 // ── Eager tool execution (ToolCallReady) ─────────────────────


### PR DESCRIPTION
## Summary

Reverts Gemma 4-specific workarounds from #823 and replaces our over-engineered loop detection with Gemini CLI's approach, informed by a code review of Claude Code, Codex, and Gemini CLI.

Closes #831.
Closes #830 — the answer to "is 5 the right threshold for tool suppression?" is: the entire mechanism violates P3, so we deleted it.

## Key findings from competitor analysis

| Agent | Loop detection | Dedup | Per-turn cap | Tool-only suppression |
|---|---|---|---|---|
| **Claude Code** | ❌ None | ❌ | ❌ | ❌ |
| **Codex** | ❌ None | ❌ | ❌ | ❌ |
| **Gemini CLI** | ✅ Consecutive (5x) + LLM judge | ❌ | ❌ | ❌ |
| **Koda (before)** | Windowed fingerprint + saturation | ✅ | ✅ (20) | ✅ (5 turns) |
| **Koda (after)** | ✅ Consecutive (5x) + feedback | ❌ | ❌ | ❌ |

## Changes

### Gemma 4 revert
- Remove `thinking_content` / `thought_content` fields from OpenAI-compat `StreamDelta`
- Remove partial-line thinking flush in TUI renderer
- Remove Gemma 4-specific tests in stream_collector
- Add design principle to DESIGN.md: standard APIs only, no per-model workarounds

### Loop detection refactor (Gemini CLI approach)

**Removed** — artificial safety mechanisms no other agent has:
- Tool call deduplication (was papering over Gemma 4 emitting 66 identical calls)
- Windowed fingerprint tracking (`REPEAT_THRESHOLD` in a sliding window)
- Tool-name saturation detection (`NAME_SATURATION_THRESHOLD`)
- Consecutive tool-only response suppression (`TOOL_ONLY_RESPONSE_LIMIT`) — closes #830
- Per-turn tool call cap (`MAX_TOOL_CALLS_PER_TURN = 20`)

**Added** — Gemini CLI's approach:
- Simple consecutive-identical-call detection (same tool+args 5x in a row)
- **Feedback injection** on first detection — injects "take a step back" message, continues
- **Hard stop** only on second detection — model ignored feedback
- Hard iteration cap (200) as absolute ceiling

### SSE spec + comment cleanup
- Restore `data:` (no space) SSE parsing — spec says space is optional
- Fix "local model" framing in comments across 6 files
- Document anti-over-compensation principle in DESIGN.md under P3

## What still works

| Feature | Status |
|---|---|
| LM Studio / Ollama / vLLM via OpenAI-compat API | ✅ |
| Context window auto-detect (LM Studio + Ollama) | ✅ |
| `<think>` tag filter (DeepSeek, Qwen) | ✅ |
| Tool name normalization (snake_case → PascalCase) | ✅ |
| Hard iteration cap (200) | ✅ |
| Consecutive loop detection + feedback injection | ✅ (new) |

## Net impact

- **-500+ lines** removed across the branch
- Simpler, more maintainable loop detection
- No more silent dedup hiding model quality issues
- Feedback injection gives models a chance to recover (vs hard stop)