### PR TITLE
fix: deduplicate UTC date formatting — use time v0.3 (#818)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,6 +1812,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "tempfile",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -56,6 +56,10 @@ tracing-appender = "0.2"
 # Error handling
 anyhow = "1"
 
+# Date/time — already a transitive dep via ratatui; declared directly so
+# callers aren't silently depending on an undeclared transitive.
+time = "0.3"
+
 # Base64 encoding (for image input)
 base64 = "0.22"
 agent-client-protocol-schema = { version = "0.11", features = ["unstable_session_model", "unstable_session_list", "unstable"] }

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -45,6 +45,7 @@ pub(crate) mod tui_render;
 pub(crate) mod tui_types;
 pub(crate) mod tui_viewport;
 pub(crate) mod tui_wizards;
+pub(crate) mod util;
 pub(crate) mod widgets;
 pub(crate) mod wrap_input;
 pub(crate) mod wrap_util;

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -29,7 +29,6 @@
 use koda_core::persistence::{Message, Role};
 use koda_core::tools::{ToolEffect, classify_tool};
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Truncate a string to at most `max` characters, appending `…` if truncated.
 /// Safe on multi-byte UTF-8 (never splits a codepoint).
@@ -43,38 +42,17 @@ fn truncate_with_ellipsis(s: &str, max: usize) -> String {
 /// Maximum content lines to include per tool result in the transcript.
 const RESULT_PREVIEW_LINES: usize = 10;
 
-/// Format a Unix timestamp as `YYYY-MM-DD HH:MM` (UTC).
-///
-/// Uses pure stdlib — no chrono dep needed.
+/// Format the current UTC time as `YYYY-MM-DD HH:MM UTC` for the transcript header.
 fn format_utc_now() -> String {
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
-    // Simple manual UTC decomposition (no DST, no timezone tables).
-    let mins_total = secs / 60;
-    let hours_total = mins_total / 60;
-    let days_total = hours_total / 24;
-    let min = mins_total % 60;
-    let hour = hours_total % 24;
-    // Gregorian calendar approximation for year/month/day.
-    let (year, month, day) = gregorian_from_days(days_total as u32);
-    format!("{year:04}-{month:02}-{day:02} {hour:02}:{min:02} UTC")
-}
-
-/// Convert days-since-epoch to (year, month, day) in the proleptic Gregorian calendar.
-fn gregorian_from_days(mut z: u32) -> (u32, u32, u32) {
-    z += 719_468;
-    let era = z / 146_097;
-    let doe = z % 146_097;
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    (y, m, d)
+    let dt = crate::util::utc_now();
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02} UTC",
+        dt.year(),
+        dt.month() as u8,
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+    )
 }
 
 /// Generate a Markdown transcript from a slice of session messages.

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -627,16 +627,16 @@ async fn handle_export(
 /// Format: `koda-YYYYMMDD-HHMMSS-<slug>.md`  (slug from first user prompt, max 40 chars).
 /// Falls back to `koda-YYYYMMDD-HHMMSS.md` when no user message exists.
 fn export_default_filename(messages: &[koda_core::persistence::Message]) -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    // Manual UTC decomposition — no chrono dep needed.
-    let (y, mo, d, h, mi, s) = decompose_utc(secs);
-    let ts = format!("{y:04}{mo:02}{d:02}-{h:02}{mi:02}{s:02}");
+    let dt = crate::util::utc_now();
+    let ts = format!(
+        "{:04}{:02}{:02}-{:02}{:02}{:02}",
+        dt.year(),
+        dt.month() as u8,
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second(),
+    );
 
     let slug: String = messages
         .iter()
@@ -672,65 +672,6 @@ fn export_default_filename(messages: &[koda_core::persistence::Message]) -> Stri
     } else {
         format!("koda-{ts}-{slug}.md")
     }
-}
-
-/// Decompose a Unix timestamp (seconds) into (year, month, day, hour, min, sec) UTC.
-/// No external crates required — just enough calendar math for a filename.
-fn decompose_utc(mut secs: u64) -> (u64, u64, u64, u64, u64, u64) {
-    let s = secs % 60;
-    secs /= 60;
-    let mi = secs % 60;
-    secs /= 60;
-    let h = secs % 24;
-    secs /= 24; // days since epoch
-
-    // Gregorian calendar: 400-year cycle = 146097 days.
-    let (mut y, mut days) = (1970u64, secs);
-    loop {
-        let leap = if y % 400 == 0 {
-            true
-        } else if y % 100 == 0 {
-            false
-        } else {
-            y % 4 == 0
-        };
-        let dy = if leap { 366 } else { 365 };
-        if days < dy {
-            break;
-        }
-        days -= dy;
-        y += 1;
-    }
-    let leap = if y % 400 == 0 {
-        true
-    } else if y % 100 == 0 {
-        false
-    } else {
-        y % 4 == 0
-    };
-    let month_days: [u64; 12] = [
-        31,
-        if leap { 29 } else { 28 },
-        31,
-        30,
-        31,
-        30,
-        31,
-        31,
-        30,
-        31,
-        30,
-        31,
-    ];
-    let mut mo = 1u64;
-    for &md in &month_days {
-        if days < md {
-            break;
-        }
-        days -= md;
-        mo += 1;
-    }
-    (y, mo, days + 1, h, mi, s)
 }
 
 #[cfg(test)]

--- a/koda-cli/src/util.rs
+++ b/koda-cli/src/util.rs
@@ -1,0 +1,36 @@
+//! Shared utilities for `koda-cli`.
+//!
+//! Centralises the one piece of logic that was previously duplicated:
+//! getting the current UTC time. Both callers then format the components
+//! they need with a plain `format!()` — no magic, no hidden coupling.
+//!
+//! ## Why `time` and not hand-rolled math?
+//!
+//! The previous implementations in `transcript.rs` (Hinnant O(1) with a
+//! `u32` that overflows in 2106) and `tui_commands.rs` (year-walk O(year)
+//! with `u64`) were independently written, disagreed on types, and neither
+//! was going to be kept in sync with the other (#818).
+//!
+//! `time v0.3` is already a transitive dependency (via `ratatui`) so
+//! declaring it directly adds zero new weight to the binary.
+
+use time::OffsetDateTime;
+
+/// Return the current instant in UTC.
+///
+/// Callers format the components they need:
+///
+/// ```ignore
+/// let dt = utc_now();
+/// // transcript header:  "2026-04-11 14:30 UTC"
+/// format!("{:04}-{:02}-{:02} {:02}:{:02} UTC",
+///     dt.year(), dt.month() as u8, dt.day(), dt.hour(), dt.minute())
+///
+/// // export filename:    "20260411-143022"
+/// format!("{:04}{:02}{:02}-{:02}{:02}{:02}",
+///     dt.year(), dt.month() as u8, dt.day(),
+///     dt.hour(), dt.minute(), dt.second())
+/// ```
+pub(crate) fn utc_now() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}


### PR DESCRIPTION
## Problem

Two independent UTC→date implementations in `koda-cli`:

| | `transcript.rs` | `tui_commands.rs` |
|---|---|---|
| Algorithm | Hinnant O(1) | Year-walk O(year) |
| Integer type | `u32` 💀 overflows 2106 | `u64` ✅ |
| Output | `2026-04-11 14:30 UTC` | `20260411-143022` |

A bug fix in one would never propagate to the other. The `u32` overflow was already waiting to happen.

## Fix

Extract `crate::util::utc_now() -> OffsetDateTime` backed by `time v0.3`.

`time v0.3.47` is **already a transitive dep** via `ratatui` — declaring it directly in `koda-cli/Cargo.toml` adds zero new weight to the binary. Callers format the components they need with a plain `format!()`.

## Changes

- **`koda-cli/src/util.rs`** (new) — `pub(crate) fn utc_now() -> OffsetDateTime`
- **`koda-cli/src/transcript.rs`** — delete `format_utc_now()` + `gregorian_from_days()`, use util
- **`koda-cli/src/tui_commands.rs`** — delete `decompose_utc()`, use util
- **`koda-cli/Cargo.toml`** — declare `time = "0.3"` as a direct dep

## Net impact

```
6 files changed, 62 insertions(+), 101 deletions(-)
```

0 hand-rolled calendar math remaining.

Closes #818.