### PR TITLE
test: improve coverage for thinking blocks, fmt_age, tokenizer, image rejection

### DIFF
--- a/koda-cli/src/input.rs
+++ b/koda-cli/src/input.rs
@@ -663,6 +663,29 @@ mod tests {
         assert!(tokenize_shell_aware("   ").is_empty());
     }
 
+    #[test]
+    fn test_tokenize_unicode_cjk_path() {
+        // CJK characters in paths must be preserved verbatim — they're
+        // regular characters to the tokenizer, no escaping needed.
+        let tokens = tokenize_shell_aware("read /home/用户/文件.rs please");
+        assert_eq!(tokens, vec!["read", "/home/用户/文件.rs", "please"]);
+    }
+
+    #[test]
+    fn test_tokenize_trailing_backslash() {
+        // A trailing backslash (incomplete escape) should not panic and
+        // should be kept as-is so unescape_path can handle it downstream.
+        let tokens = tokenize_shell_aware("fix bad\\");
+        assert_eq!(tokens, vec!["fix", "bad\\"]);
+    }
+
+    #[test]
+    fn test_tokenize_multiple_consecutive_spaces() {
+        // Multiple spaces between tokens must not produce empty tokens.
+        let tokens = tokenize_shell_aware("fix  the  bug");
+        assert_eq!(tokens, vec!["fix", "the", "bug"]);
+    }
+
     // ── unescape_path tests ─────────────────────────────────
 
     #[test]

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -349,4 +349,24 @@ mod tests {
         assert!(!out.contains("line1"));
         assert!(out.contains("3 line(s) of output"));
     }
+
+    #[test]
+    fn thinking_content_renders_as_blockquote() {
+        // thinking_content is Claude's chain-of-thought — it is intentionally
+        // included in the exported transcript as a blockquote so the user can
+        // review the model's reasoning (#819).
+        let mut msg = make_msg(Role::Assistant, "The answer is 42.");
+        msg.thinking_content = Some("Let me think step by step: 6 x 7 = 42.".into());
+
+        let out = render(&[msg], None);
+        assert!(out.contains("The answer is 42."), "response text must appear");
+        assert!(
+            out.contains("Thinking"),
+            "thinking block header must appear in transcript"
+        );
+        assert!(
+            out.contains("Let me think step by step"),
+            "thinking content must appear in transcript"
+        );
+    }
 }

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -359,7 +359,10 @@ mod tests {
         msg.thinking_content = Some("Let me think step by step: 6 x 7 = 42.".into());
 
         let out = render(&[msg], None);
-        assert!(out.contains("The answer is 42."), "response text must appear");
+        assert!(
+            out.contains("The answer is 42."),
+            "response text must appear"
+        );
         assert!(
             out.contains("Thinking"),
             "thinking block header must appear in transcript"

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1222,9 +1222,16 @@ async fn thinking_content_persists_and_is_loaded_in_context() {
     let (db, _tmp) = setup().await;
     let session = db.create_session("default", _tmp.path()).await.unwrap();
 
-    db.insert_message(&session, &Role::User, Some("what is 2+2?"), None, None, None)
-        .await
-        .unwrap();
+    db.insert_message(
+        &session,
+        &Role::User,
+        Some("what is 2+2?"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     let assistant_id = db
         .insert_message(

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1167,3 +1167,87 @@ async fn test_kv_list_prefix() {
     assert!(keys.contains(&"cfg:bar"));
     assert!(!keys.contains(&"other:baz"));
 }
+
+// ── thinking_content (#819) ────────────────────────────────────────────
+
+#[tokio::test]
+async fn thinking_content_round_trip() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let id = db
+        .insert_message(&session, &Role::Assistant, Some("answer"), None, None, None)
+        .await
+        .unwrap();
+
+    db.update_message_thinking_content(id, "I should think carefully about this…")
+        .await
+        .unwrap();
+
+    let msgs = db.load_context(&session).await.unwrap();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(
+        msgs[0].thinking_content.as_deref(),
+        Some("I should think carefully about this…"),
+        "thinking_content should survive a round-trip through the DB"
+    );
+}
+
+#[tokio::test]
+async fn thinking_content_null_by_default() {
+    // Messages for non-Claude models should have NULL thinking_content.
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&session, &Role::User, Some("hello"), None, None, None)
+        .await
+        .unwrap();
+    db.insert_message(&session, &Role::Assistant, Some("hi"), None, None, None)
+        .await
+        .unwrap();
+
+    let msgs = db.load_context(&session).await.unwrap();
+    for msg in &msgs {
+        assert!(
+            msg.thinking_content.is_none(),
+            "thinking_content should be None when never written (role: {:?})",
+            msg.role
+        );
+    }
+}
+
+#[tokio::test]
+async fn thinking_content_persists_and_is_loaded_in_context() {
+    // Simulates session resume: write thinking content, then re-load context.
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&session, &Role::User, Some("what is 2+2?"), None, None, None)
+        .await
+        .unwrap();
+
+    let assistant_id = db
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("It is 4."),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    db.update_message_thinking_content(assistant_id, "2+2=4 trivially")
+        .await
+        .unwrap();
+
+    // Reload context (as session resume would).
+    let msgs = db.load_context(&session).await.unwrap();
+    let assistant = msgs.iter().find(|m| m.role == Role::Assistant).unwrap();
+    assert_eq!(
+        assistant.thinking_content.as_deref(),
+        Some("2+2=4 trivially"),
+        "thinking_content must survive context reload (session resume path)"
+    );
+}

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -342,6 +342,14 @@ mod tests {
         assert!(is_image_rejection_error(&anyhow::anyhow!(
             "Vision capability not available"
         )));
+        // Anthropic — model does not support vision (#819)
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "400 Bad Request: Images are not supported for this model"
+        )));
+        // Anthropic — invalid image data (base64 corruption, wrong format)
+        assert!(is_image_rejection_error(&anyhow::anyhow!(
+            "400 Bad Request: Invalid image: unable to decode image data"
+        )));
     }
 
     #[test]

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -21,15 +21,15 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-/// Format a monotonic `Instant` age into a compact human-readable string.
+/// Format a duration into a compact human-readable age string.
 ///
 /// ```text
 /// <5s  → "just now"
 /// <60s → "12s ago"
 /// else → "3m ago"
 /// ```
-fn fmt_age(instant: std::time::Instant) -> String {
-    let secs = instant.elapsed().as_secs();
+fn fmt_age(age: std::time::Duration) -> String {
+    let secs = age.as_secs();
     if secs < 5 {
         "just now".to_string()
     } else if secs < 60 {
@@ -85,7 +85,7 @@ fn writer_hint(
         && let Ok(guard) = lw.lock()
         && let Some((tool, when)) = guard.get(resolved)
     {
-        return format!(" (last written by {} {})", tool, fmt_age(*when));
+        return format!(" (last written by {} {})", tool, fmt_age(when.elapsed()));
     }
     // Fall back to the most recent Bash call — it may have modified the file
     // indirectly (formatter, build script, etc.).
@@ -93,7 +93,7 @@ fn writer_hint(
         && let Ok(guard) = lb.lock()
         && let Some((snippet, when)) = guard.as_ref()
     {
-        return format!(" (Bash ran {}: `{}`)", fmt_age(*when), snippet);
+        return format!(" (Bash ran {}: `{}`)", fmt_age(when.elapsed()), snippet);
     }
     String::new()
 }
@@ -894,5 +894,38 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    // ── fmt_age boundary values (#819) ───────────────────────
+
+    #[test]
+    fn fmt_age_under_5s_is_just_now() {
+        assert_eq!(fmt_age(std::time::Duration::from_secs(0)), "just now");
+        assert_eq!(fmt_age(std::time::Duration::from_secs(4)), "just now");
+    }
+
+    #[test]
+    fn fmt_age_exactly_5s() {
+        // Boundary: 5s is the first value that produces "Xs ago".
+        assert_eq!(fmt_age(std::time::Duration::from_secs(5)), "5s ago");
+    }
+
+    #[test]
+    fn fmt_age_under_60s() {
+        assert_eq!(fmt_age(std::time::Duration::from_secs(30)), "30s ago");
+        assert_eq!(fmt_age(std::time::Duration::from_secs(59)), "59s ago");
+    }
+
+    #[test]
+    fn fmt_age_exactly_60s() {
+        // Boundary: 60s is the first value that produces "Xm ago".
+        assert_eq!(fmt_age(std::time::Duration::from_secs(60)), "1m ago");
+    }
+
+    #[test]
+    fn fmt_age_minutes() {
+        assert_eq!(fmt_age(std::time::Duration::from_secs(90)), "1m ago");
+        assert_eq!(fmt_age(std::time::Duration::from_secs(120)), "2m ago");
+        assert_eq!(fmt_age(std::time::Duration::from_secs(3600)), "60m ago");
     }
 }


### PR DESCRIPTION
## Summary

Closes #819.

QA identified these coverage gaps during v0.2.8 pre-release review. This PR adds tests across five files with zero production code changes — except one clean refactor that was *required* to make a function testable.

---

### What's new

#### `koda-core/src/db/tests.rs` — thinking blocks (DB)
- **round-trip**: insert → `update_message_thinking_content` → `load_context` → assert value survives
- **null-by-default**: messages with no thinking call should have `None` (non-Claude models)
- **session-resume**: same round-trip via `load_context` (mirrors the session-resume code path)

#### `koda-core/src/tools/validate.rs` — `fmt_age` boundary values
- **Refactor**: `fmt_age(Instant)` → `fmt_age(Duration)` so tests don't need to sleep. Both call sites updated (`when.elapsed()`). Pure behaviour-preserving change.
- **Boundary tests**: 0s, 4s ("just now"), exactly 5s, 30s, 59s, exactly 60s, 90s, 120s, 3600s

#### `koda-cli/src/input.rs` — tokenizer edge cases
- Unicode/CJK paths: `/home/用户/文件.rs` must not be mangled
- Trailing backslash: must not panic, kept as-is for `unescape_path` downstream
- Multiple consecutive spaces: must produce no empty tokens

#### `koda-cli/src/transcript.rs` — thinking content rendering
- Verifies `thinking_content` renders as a `> 💭 **Thinking**` blockquote (intended behaviour)
- Notably: first draft asserted the field should be *hidden* — the test caught that the design intentionally shows it

#### `koda-core/src/inference_helpers.rs` — Anthropic image rejection
- Two Anthropic-specific formats added to the existing test: model-does-not-support-images and invalid-image-data

---

289 tests, 0 failures. fmt ✓ clippy ✓ check ✓