### PR TITLE
ci: merge lint+check into test job — one container, one compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  lint:
-    name: Lint
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,37 +27,16 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-support  # shared with test: same features, same targets
+          shared-key: test-support
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings
-
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: check  # stable across branches & workflow edits → primary key always hits
-      - name: cargo check (all targets, no features)
-        # Catches cfg-gated items invisible behind feature flags AND
-        # platform-specific compile errors (e.g. std::os::unix on Windows).
+      - name: Check (no features)
+        # Catches cfg-gated items invisible behind feature flags.
         run: cargo check --workspace --all-targets
-
-  test:
-    name: Test
-    needs: [lint, check]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: test-support  # shared with lint: same features, same targets
-      - run: cargo test --workspace --features koda-core/test-support
+      - name: Test
+        run: cargo test --workspace --features koda-core/test-support
 
   doc:
     name: Docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -455,25 +455,22 @@ an immutable version number; it does not need to wait for Homebrew.
 ### CI job DAG (`ci.yml`)
 
 ```
-lint  ──┬──► test          lint = fmt + clippy (Linux only — no value on Windows)
-check ─┘                   check = cargo check --all-targets, no features
-                           matrix: [ubuntu-latest, windows-latest], fail-fast: false
-doc        (independent)   catches broken rustdoc regardless of lint
-audit      (independent)   reads Cargo.lock against advisories — orthogonal to code quality
-docs-size  (independent)   guards per-chapter byte cap on docs/src/*.md
+test (fmt → clippy → check → test)   single container, compile once
+doc        (independent)              catches broken rustdoc regardless of test
+audit      (independent)              reads Cargo.lock against advisories — orthogonal to code quality
 ```
 
-- `test` gates on **both** `lint` and `check` — the expensive job never runs if cheap ones fail.
-- `doc`, `audit`, `docs-size` run unconditionally in parallel — they provide independent signals
-  and are fast enough that cancelling them on lint failure would lose information, not save time.
-- `check` uses `fail-fast: false` so both platforms always report — Ubuntu catches cfg-gated
-  gaps, Windows catches platform-specific API errors (e.g. `std::os::unix`).
-- macOS omitted from `check`: POSIX like Linux; caught locally since dev is on macOS.
+- `test` runs all checks sequentially in one container: `cargo fmt --check` → `cargo clippy`
+  → `cargo check --all-targets` (no features, catches cfg-gated gaps) → `cargo test`.
+  A failure in any step aborts the rest — fast-fail is preserved within the job.
+- One container = one compile chain = no redundant recompilation across separate runners.
+  The pre-push hook mirrors this sequence locally, so CI is a clean-environment confirmation
+  rather than a first-discovery gate.
+- `doc`, `audit` run unconditionally in parallel — independent signals, fast enough that
+  cancelling them on test failure would lose information, not save time.
 
 **Branch ruleset required gates: `Test` and `Docs` only.**
-`Lint` and `Check` are transitively enforced via `test`'s `needs: [lint, check]` —
-adding them as explicit gates would be redundant. `Docs` is required separately
-because it is independent of the `test` chain.
+`Docs` is required separately because it is independent of the `test` job.
 
 ### Coverage workflow (`coverage.yml`)
 


### PR DESCRIPTION
Fixes #836.

## What

Collapses the three separate `lint`, `check`, and `test` CI jobs into a single `test` job that runs sequentially in one container:

```
cargo fmt --check → cargo clippy → cargo check (no features) → cargo test
```

`doc` and `audit` are unchanged — they stay as independent parallel jobs.

## Why

The pre-push hook ([`.githooks/pre-push`](.githooks/pre-push)) already runs `fmt`, `clippy`, and `cargo check` before any push reaches CI. The separate `lint` and `check` jobs were re-confirming the same work on Linux at the cost of:

- Two extra runner spin-ups per PR
- 3× redundant recompilation (one per job)
- A shared cache key hack between `lint` and `test` trying to paper over the cost

Pure-Rust code that compiles on macOS essentially never fails on Linux in the absence of platform-specific APIs. CI is now a clean-environment confirmation, not a first-discovery gate.

**Fast-fail is preserved** — a `fmt` or `clippy` failure still aborts before tests run, just within a single job instead of across separate runners.

## CLAUDE.md

Updated the CI DAG comment to match the new structure. Also removed the Windows matrix reference — Windows support was intentionally dropped, not a gap to fill.

## Checklist

- [x] `ci.yml`: `lint` + `check` + `test` merged into single `test` job
- [x] `CLAUDE.md`: CI DAG updated, Windows matrix mention removed
- [x] Branch ruleset gates unchanged (`Test` and `Docs`) — job name `test` preserved