### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 > **Lineage:** This project continues from [`koda-agent`](https://github.com/lijunzh/koda-agent) (archived at v0.1.5).
 > Versions v0.1.0–v0.1.5 of `koda-agent` are documented in that repository's CHANGELOG.
 
+## [0.2.9] - 2026-04-11
+
+### Added
+- **Bash safety: token-level classification (shlex + `DangerCheck` enum)** —
+  Replaces substring matching with POSIX shell tokenisation via the `shlex`
+  crate. `grep "cargo publish" .` and `grep $'cargo publish' .` are now
+  correctly `ReadOnly` instead of falsely `Destructive`. Private items
+  (`rm`, `sudo`, `git push -f`, `gh pr merge`, …) are expressed as a typed
+  `DangerCheck` enum instead of a flat `&[&str]` list, eliminating the whole
+  class of quoted-argument false positives (#807, #823, #841).
+- **Edit staleness guard** — `edit_file` now computes a SHA-256 of the
+  file content on every full read and rejects a subsequent edit if the file
+  has changed on disk since the model last read it (external bash tool, the
+  user, another agent). Implements the Gemini CLI strategy (#814, #839).
+- **Edit multi-match line numbers** — when `old_str` matches more than once,
+  the error now lists the exact line numbers so the model can tighten its
+  snippet in one shot instead of guessing (#814, #839).
+- **Clipboard: OSC 52 fallback for SSH and tmux** — `/copy` and Ctrl+Y now
+  work over SSH and inside tmux sessions via OSC 52 terminal escape sequences
+  and `tmux load-buffer -w`. Detects SSH via `SSH_CONNECTION` (not `SSH_TTY`,
+  which persists in tmux panes after local reattach) (#837).
+- **Type-during-inference queue UX** — keystrokes typed while the model is
+  streaming are queued and replayed immediately when the response completes;
+  the status bar shows pending queue depth (#828).
+
+### Changed
+- **Loop detection: Gemini CLI model (feedback injection)** — replaces the
+  old windowed-fingerprint hard stop with a two-phase approach: first
+  detection injects a "take a step back" system message to nudge the model;
+  second detection (model ignored the feedback) hard-stops. Threshold raised
+  to 5 consecutive identical calls (matches Gemini CLI's
+  `TOOL_CALL_LOOP_THRESHOLD`) (#826, #829, #831, #832).
+- **Per-turn tool call deduplication and cap removed** — frontier models
+  legitimately emit 30+ parallel tool calls in a single response. Dedup and
+  the 20-call cap suppressed valid parallel work. Repeated patterns across
+  turns are now the loop guard's responsibility (#831, #832).
+- **SSE parser: accept `data:` without trailing space** — the SSE spec
+  (RFC) makes the space optional; Gemma 4 and some self-hosted models omit
+  it. Fixes frozen inference on affected endpoints (#823, #824).
+- **UTC date formatting centralised** — three copies of manual Gregorian
+  calendar math replaced with a single `util::utc_now()` backed by the
+  `time` v0.3 crate already in the dependency tree (#818, #833).
+
+### Fixed
+- **Ctrl+C aborts background HTTP reader** — `SseCollector` now exposes a
+  `JoinHandle`; on cancellation the handle is `abort()`ed immediately so the
+  TCP connection closes and single-slot servers (LM Studio, vLLM) can accept
+  the next request without waiting for the timeout (#825, #827).
+- **Duplicate comment removed** — copy-paste artifact in `inference.rs`
+  ("Network drop: warning already emitted" appeared twice on consecutive
+  lines).
+
+### Internal / CI
+- Lint + check merged into the test job — one container, one compile; no
+  duplicate build time (#838).
+- Test coverage expanded: thinking block persistence, `fmt_age`, tokenizer
+  edge cases (CJK paths, trailing backslash, consecutive spaces), image
+  rejection heuristics, loop guard repeat count and tool name (#834, #835).
+- Behavioral bash-safety tests moved to `koda-core/tests/bash_safety_test.rs`
+  (external contract); 20 behavioral + 11 internal = 31 tests (#841).
+
 ## [0.2.8] - 2026-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.8" }
+koda-core = { path = "../koda-core", version = "0.2.9" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -73,6 +73,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.8", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.9", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -836,7 +836,6 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         }
 
         // Network drop: warning already emitted by collect_stream.
-        // Network drop: warning already emitted by collect_stream.
         // Discard the partial response — storing it would corrupt the session.
         if stream_result.network_error.is_some() {
             sse_handle.abort();


### PR DESCRIPTION
## Release v0.2.9

### Pre-release checklist

- [x] `cargo clippy` clean (0 warnings, 0 errors)
- [x] `RUSTDOCFLAGS=-Dwarnings cargo doc` clean
- [x] 856 lib tests passing
- [x] 31 bash-safety tests passing (20 behavioral + 11 internal)
- [x] Version bumped in `koda-core/Cargo.toml`, `koda-cli/Cargo.toml`, and both `koda-core` dep pins in `koda-cli`
- [x] `Cargo.lock` updated
- [x] CHANGELOG.md entry written
- [x] Duplicate comment in `inference.rs` fixed (copy-paste artifact, lines 838–839)
- [x] CI green on PR branch

---

## What's in this release

### Added
- **Bash safety: shlex token-level classification** — `grep "cargo publish" .` no longer false-positives as Destructive. New typed `DangerCheck` enum replaces flat substring list. Closes #807 (#841)
- **Edit staleness guard** — SHA-256 detects external file changes between read and edit (#814, #839)
- **Edit multi-match line numbers** — ambiguous `old_str` reports exact line numbers (#814, #839)
- **Clipboard: OSC 52 fallback** — `/copy` works over SSH and in tmux (#837)
- **Type-during-inference queue** — keystrokes buffered during streaming, replayed on completion (#828)

### Changed
- **Loop detection: Gemini CLI model** — feedback injection on first detection, hard stop on second; threshold 5 consecutive identical calls (#829, #831, #832)
- **Per-turn dedup/cap removed** — frontier models emit 30+ parallel calls legitimately; loop guard handles cross-turn patterns (#831, #832)
- **SSE `data:` without space** — fixes Gemma 4 + some self-hosted endpoints (#823, #824)
- **UTC formatting centralised** — `util::utc_now()` backed by `time` v0.3 (#818, #833)

### Fixed
- **Ctrl+C aborts HTTP reader** — `SseCollector.handle.abort()` closes TCP immediately, unblocks single-slot servers like LM Studio (#825, #827)
- **Duplicate comment** in `inference.rs` ("Network drop" appeared twice consecutively)

### CI
- Lint + check merged into test job (#838)
- Test coverage: thinking blocks, tokenizer edge cases, image rejection, loop guard (#834, #835)
- Bash-safety behavioral tests extracted to external test file (#841)

---

## Code review notes

| Area | Finding |
|---|---|
| `file_tools.rs:468` `unwrap()` | Safe — inside `match ranges.len() { 1 => }` arm; length structurally guaranteed |
| SHA-256 cache key | `read_file` uses `{:?}` on `None` → `"None"`; matches `edit_file`'s `"{}:None:None"` literal ✓ |
| `SseCollector` abort | Called on both Ctrl+C interrupt and network drop paths ✓ |
| OSC 52 gate | `SSH_CONNECTION` (not `SSH_TTY`) — correct; `SSH_TTY` persists in tmux panes after local reattach ✓ |
| Dedup/cap removal | Deliberate design decision, well-documented in `tool_normalize.rs` and `loop_guard.rs` ✓ |