### PR TITLE
feat: sandbox for Bash tool — macOS seatbelt + Linux bwrap (#840)

### DIFF
--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -15,6 +15,7 @@
 | `--temperature <F>` | | Sampling temperature (0.0–2.0) |
 | `--thinking-budget <N>` | | Anthropic extended thinking budget (tokens) |
 | `--reasoning-effort <L>` | | OpenAI reasoning effort (`low`, `medium`, `high`) |
+| `--sandbox <MODE>` | `KODA_SANDBOX` | Bash tool sandbox: `none` (default) or `project` (restrict writes to project dir + `/tmp`) |
 | `--output-format <FMT>` | | Headless output format: `text` (default) or `json` |
 | `--project-root <DIR>` | | Project root (defaults to cwd) |
 

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -110,6 +110,13 @@ struct Cli {
     /// OpenAI reasoning effort (low, medium, high)
     #[arg(long)]
     reasoning_effort: Option<String>,
+
+    /// Sandbox mode for Bash tool invocations: none (default) or project.
+    /// "project" restricts writes to the project dir + /tmp.
+    /// Requires sandbox-exec on macOS or bwrap on Linux.
+    #[arg(long, env = "KODA_SANDBOX", default_value = "none",
+          value_parser = ["none", "project"])]
+    sandbox: String,
 }
 
 #[derive(Subcommand, Debug)]
@@ -161,7 +168,8 @@ pub(crate) async fn run() -> Result<()> {
                             cli.temperature,
                             cli.thinking_budget,
                             cli.reasoning_effort.clone(),
-                        );
+                        )
+                        .with_sandbox(koda_core::sandbox::SandboxMode::parse(&cli.sandbox));
                     server::run_stdio_server(project_root, config).await?;
                 } else {
                     eprintln!("WebSocket server (--port {port}) not yet implemented. Use --stdio.");
@@ -234,7 +242,8 @@ pub(crate) async fn run() -> Result<()> {
                 cli.temperature,
                 cli.thinking_budget,
                 cli.reasoning_effort,
-            );
+            )
+            .with_sandbox(koda_core::sandbox::SandboxMode::parse(&cli.sandbox));
         let session_id = match cli.session {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,
@@ -266,7 +275,8 @@ pub(crate) async fn run() -> Result<()> {
             cli.temperature,
             cli.thinking_budget,
             cli.reasoning_effort,
-        );
+        )
+        .with_sandbox(koda_core::sandbox::SandboxMode::parse(&cli.sandbox));
 
     // Initialize database is already done above
 

--- a/koda-cli/tests/snapshots/help.snap
+++ b/koda-cli/tests/snapshots/help.snap
@@ -80,6 +80,13 @@ Options:
       --reasoning-effort <REASONING_EFFORT>
           OpenAI reasoning effort (low, medium, high)
 
+      --sandbox <SANDBOX>
+          Sandbox mode for Bash tool invocations: none (default) or project. "project" restricts writes to the project dir + /tmp. Requires sandbox-exec on macOS or bwrap on Linux
+          
+          [env: KODA_SANDBOX=]
+          [default: none]
+          [possible values: none, project]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -69,7 +69,11 @@ impl KodaAgent {
         project_root: PathBuf,
         commands: &[(&str, &str)],
     ) -> Result<Self> {
-        let tools = ToolRegistry::new(project_root.clone(), config.max_context_tokens);
+        let tools = ToolRegistry::with_sandbox(
+            project_root.clone(),
+            config.max_context_tokens,
+            config.sandbox.clone(),
+        );
         let tool_defs = tools.get_definitions(&config.allowed_tools, &config.disallowed_tools);
 
         let semantic_memory = memory::load(&project_root)?;

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -414,6 +414,8 @@ pub struct KodaConfig {
     /// Skip injecting project/global memory into the system prompt.
     /// Set by `skip_memory: true` in agent JSON. Default: `false`.
     pub skip_memory: bool,
+    /// Sandbox mode for Bash tool invocations. Default: `SandboxMode::None`.
+    pub sandbox: crate::sandbox::SandboxMode,
 }
 
 impl KodaConfig {
@@ -491,6 +493,7 @@ impl KodaConfig {
             model_settings: settings,
             max_iterations,
             skip_memory: agent.skip_memory,
+            sandbox: crate::sandbox::SandboxMode::None,
         })
     }
 
@@ -558,6 +561,12 @@ impl KodaConfig {
         if let Some(re) = reasoning_effort {
             self.model_settings.reasoning_effort = Some(re);
         }
+        self
+    }
+
+    /// Override the sandbox mode (e.g. from `--sandbox project` on the CLI).
+    pub fn with_sandbox(mut self, mode: crate::sandbox::SandboxMode) -> Self {
+        self.sandbox = mode;
         self
     }
 
@@ -691,6 +700,7 @@ impl KodaConfig {
             model_settings,
             max_iterations: crate::loop_guard::MAX_ITERATIONS_DEFAULT,
             skip_memory: false,
+            sandbox: crate::sandbox::SandboxMode::None,
         }
     }
 

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -103,6 +103,8 @@ pub mod preview;
 pub mod progress;
 /// System prompt construction.
 pub mod prompt;
+/// Process sandboxing for the Bash tool (macOS seatbelt / Linux bwrap).
+pub mod sandbox;
 /// LLM provider abstraction — Anthropic, Gemini, OpenAI-compatible.
 pub mod providers;
 /// Thread-safe runtime environment — replaces `std::env::set_var`.

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -103,12 +103,12 @@ pub mod preview;
 pub mod progress;
 /// System prompt construction.
 pub mod prompt;
-/// Process sandboxing for the Bash tool (macOS seatbelt / Linux bwrap).
-pub mod sandbox;
 /// LLM provider abstraction — Anthropic, Gemini, OpenAI-compatible.
 pub mod providers;
 /// Thread-safe runtime environment — replaces `std::env::set_var`.
 pub mod runtime_env;
+/// Process sandboxing for the Bash tool (macOS seatbelt / Linux bwrap).
+pub mod sandbox;
 /// Session lifecycle — create, resume, list, delete.
 pub mod session;
 /// Last-used provider persistence (`~/.config/koda/settings.toml`).

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -1,0 +1,335 @@
+//! Process sandboxing for the Bash tool.
+//!
+//! Sandboxing is **opt-in** (`--sandbox project`; default: `none`) and
+//! applied per-session.  The goal of "project" mode is to prevent the model
+//! from accidentally — or adversarially — writing outside the current project
+//! directory.
+//!
+//! ## Platform backends
+//!
+//! | Platform | Backend              | Fallback on unavailable |
+//! |----------|----------------------|-------------------------|
+//! | macOS    | `sandbox-exec -p`    | warn + run unsandboxed  |
+//! | Linux    | `bwrap` (bubblewrap) | warn + run unsandboxed  |
+//!
+//! ## Modes
+//!
+//! - **`none`** (default) — no sandbox; full host access.
+//! - **`project`** — reads everywhere; writes restricted to `{project_root}`,
+//!   `/tmp`, `/var/tmp`, and common cache dirs (`~/.cargo`, `~/.npm`,
+//!   `~/.cache`).  Network is unrestricted.
+//!
+//! `strict` mode (deny reads of sensitive dirs like `~/.ssh`, `~/.aws`) is
+//! planned for a future release (#840 v2) and is deliberately left as a stub.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! let cmd = sandbox::build("cargo test", project_root, &SandboxMode::Project);
+//! let child = cmd.stdout(Stdio::piped()).spawn()?;
+//! ```
+
+use std::path::Path;
+use tokio::process::Command;
+
+// ── Mode ─────────────────────────────────────────────────────────────────────
+
+/// Which sandboxing level to apply to Bash tool invocations.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum SandboxMode {
+    /// No sandbox — commands run with full host access. (default)
+    #[default]
+    None,
+    /// Restrict writes to the project dir + /tmp + cache dirs.
+    /// Reads and network are unrestricted.
+    Project,
+}
+
+impl SandboxMode {
+    /// Parse from a CLI / env string (case-insensitive).
+    ///
+    /// Unknown values produce a warning and fall back to `None`.
+    pub fn parse(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "project" => Self::Project,
+            "none" | "" => Self::None,
+            other => {
+                tracing::warn!(
+                    "Unknown --sandbox value {:?} — defaulting to none. \
+                     Valid values: none, project",
+                    other
+                );
+                Self::None
+            }
+        }
+    }
+
+    /// `true` when sandboxing is active (i.e. not `None`).
+    pub fn is_active(&self) -> bool {
+        self != &Self::None
+    }
+}
+
+impl std::fmt::Display for SandboxMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("none"),
+            Self::Project => f.write_str("project"),
+        }
+    }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+/// Build a `tokio::process::Command` that runs `sh -c "{command}"` inside
+/// the appropriate sandbox for `mode`.
+///
+/// When `mode` is [`SandboxMode::Project`] but the platform backend is
+/// unavailable (e.g. `bwrap` not installed on Linux), a warning is logged
+/// and an **unsandboxed** `Command` is returned — the caller does not need to
+/// handle the failure case.
+pub fn build(command: &str, project_root: &Path, mode: &SandboxMode) -> Command {
+    match mode {
+        SandboxMode::None => plain_sh(command, project_root),
+        SandboxMode::Project => build_project(command, project_root),
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn plain_sh(command: &str, project_root: &Path) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c").arg(command).current_dir(project_root);
+    cmd
+}
+
+/// Dispatch to the platform-specific "project" sandbox builder.
+fn build_project(command: &str, project_root: &Path) -> Command {
+    #[cfg(target_os = "macos")]
+    return macos_project(command, project_root);
+
+    #[cfg(target_os = "linux")]
+    return linux_project(command, project_root);
+
+    // Should never compile — koda-cli enforces unix-only at compile time.
+    #[allow(unreachable_code)]
+    plain_sh(command, project_root)
+}
+
+// ── macOS: sandbox-exec -p <profile string> ───────────────────────────────────
+
+#[cfg(target_os = "macos")]
+fn macos_project(command: &str, project_root: &Path) -> Command {
+    // Resolve symlinks so the seatbelt subpath matcher sees the canonical
+    // path.  On macOS, /var is a symlink to /private/var; tempfile dirs land
+    // under /var/folders/… which the kernel presents as /private/var/folders/….
+    // Without canonicalization, `(subpath "/var/folders/…")` would never match.
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let root = canonical.to_string_lossy();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users".into());
+
+    // Seatbelt profile (Apple's Scheme-like DSL).
+    //
+    // Strategy: deny default (whitelist-only), then open reads everywhere,
+    // restrict writes to project + temp + cache dirs, leave network open so
+    // curl / cargo fetch / npm install work unmodified.
+    //
+    // Passing the profile via `-p` (inline string) avoids the need for a
+    // temporary file and the race window around deleting it.
+    let profile = format!(
+        "(version 1)\n\
+         (deny default)\n\
+         (allow file-read*)\n\
+         (allow file-write*\n\
+           (subpath \"{root}\")\n\
+           (subpath \"/private/tmp\")\n\
+           (subpath \"/tmp\")\n\
+           (subpath \"{home}/.cargo\")\n\
+           (subpath \"{home}/.npm\")\n\
+           (subpath \"{home}/.cache\")\n\
+           (literal \"/dev/null\")\n\
+           (literal \"/dev/stderr\")\n\
+           (literal \"/dev/stdout\")\n\
+           (literal \"/dev/urandom\"))\n\
+         (allow network*)\n\
+         (allow process-exec*)\n\
+         (allow process-fork)\n\
+         (allow sysctl-read)\n\
+         (allow ipc-posix*)\n\
+         (allow mach*)\n"
+    );
+
+    let mut cmd = Command::new("sandbox-exec");
+    cmd.arg("-p")
+        .arg(profile)
+        .arg("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_root);
+    cmd
+}
+
+// ── Linux: bwrap (bubblewrap) ─────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+fn linux_project(command: &str, project_root: &Path) -> Command {
+    // Detect bwrap once — subsequent calls reuse the cached result.
+    use std::sync::OnceLock;
+    static BWRAP_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+    let available = BWRAP_AVAILABLE.get_or_init(|| {
+        std::process::Command::new("bwrap")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    });
+
+    if !*available {
+        tracing::warn!(
+            "sandbox=project requested but bwrap is not installed. \
+             Running without sandbox. \
+             Install with: apt install bubblewrap  /  dnf install bubblewrap"
+        );
+        return plain_sh(command, project_root);
+    }
+
+    let root = project_root.to_string_lossy();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+
+    // Strategy: bind the whole root filesystem read-only, then selectively
+    // add read-write binds for project + temp + common caches.
+    let mut cmd = Command::new("bwrap");
+
+    // Whole root: read-only
+    cmd.args(["--ro-bind", "/", "/"]);
+
+    // Project dir: read-write
+    cmd.args(["--bind", root.as_ref(), root.as_ref()]);
+
+    // Temp dirs: read-write
+    cmd.args(["--bind", "/tmp", "/tmp"]);
+    if Path::new("/var/tmp").exists() {
+        cmd.args(["--bind", "/var/tmp", "/var/tmp"]);
+    }
+
+    // Common package caches — avoids re-downloading every run
+    for subdir in &[".cargo", ".npm", ".cache"] {
+        let p = format!("{home}/{subdir}");
+        if Path::new(&p).exists() {
+            cmd.args(["--bind", p.as_str(), p.as_str()]);
+        }
+    }
+
+    // Device and proc pseudo-filesystems
+    cmd.args(["--dev", "/dev"]).args(["--proc", "/proc"]);
+
+    // The actual command
+    cmd.args(["--", "sh", "-c", command])
+        .current_dir(project_root);
+
+    cmd
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Unit: enum behaviour ───────────────────────────────────────────────
+
+    #[test]
+    fn parse_roundtrip() {
+        assert_eq!(SandboxMode::parse("none"), SandboxMode::None);
+        assert_eq!(SandboxMode::parse("project"), SandboxMode::Project);
+        assert_eq!(SandboxMode::parse("PROJECT"), SandboxMode::Project);
+        assert_eq!(SandboxMode::parse(""), SandboxMode::None);
+        // Unknown value → None (warning is logged, not an error)
+        assert_eq!(SandboxMode::parse("strict"), SandboxMode::None);
+    }
+
+    #[test]
+    fn display_roundtrip() {
+        assert_eq!(SandboxMode::None.to_string(), "none");
+        assert_eq!(SandboxMode::Project.to_string(), "project");
+    }
+
+    #[test]
+    fn default_is_none() {
+        assert_eq!(SandboxMode::default(), SandboxMode::None);
+    }
+
+    #[test]
+    fn is_active() {
+        assert!(!SandboxMode::None.is_active());
+        assert!(SandboxMode::Project.is_active());
+    }
+
+    // ── Integration: kernel-level enforcement ──────────────────────────────
+    //
+    // These tests spawn real child processes through the sandbox and verify
+    // that the kernel actually enforces the policy — not just that we built
+    // the right Command.
+
+    /// `SandboxMode::None` must never block anything.
+    #[tokio::test]
+    async fn none_mode_runs_echo() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = build("echo ok", dir.path(), &SandboxMode::None)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success());
+    }
+
+    /// Project mode: writes *inside* the project root must succeed.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_allows_write_inside_project() {
+        let dir = tempfile::tempdir().unwrap();
+        let status = build("touch sandbox_canary", dir.path(), &SandboxMode::Project)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "write inside project must succeed");
+        assert!(dir.path().join("sandbox_canary").exists());
+    }
+
+    /// Project mode: writes *outside* the project root must be blocked.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_blocks_write_outside_project() {
+        let project = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let target = outside.path().join("evil.txt");
+
+        let status = build(
+            &format!("echo pwned > {}", target.display()),
+            project.path(),
+            &SandboxMode::Project,
+        )
+        .status()
+        .await
+        .unwrap();
+
+        assert!(!status.success(), "write outside project must be blocked");
+        assert!(!target.exists(), "file must not have been created");
+    }
+
+    /// Project mode: reading outside the project must still work.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_allows_read_outside_project() {
+        let dir = tempfile::tempdir().unwrap();
+        // /etc/hosts is a stable readable file on every macOS system.
+        let status = build("cat /etc/hosts > /dev/null", dir.path(), &SandboxMode::Project)
+            .status()
+            .await
+            .unwrap();
+        assert!(status.success(), "reads outside project must be allowed");
+    }
+}

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -326,10 +326,14 @@ mod tests {
     async fn macos_allows_read_outside_project() {
         let dir = tempfile::tempdir().unwrap();
         // /etc/hosts is a stable readable file on every macOS system.
-        let status = build("cat /etc/hosts > /dev/null", dir.path(), &SandboxMode::Project)
-            .status()
-            .await
-            .unwrap();
+        let status = build(
+            "cat /etc/hosts > /dev/null",
+            dir.path(),
+            &SandboxMode::Project,
+        )
+        .status()
+        .await
+        .unwrap();
         assert!(status.success(), "reads outside project must be allowed");
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -253,7 +253,11 @@ pub(crate) async fn execute_sub_agent(
     let effective_root_ref = effective_root.as_path();
 
     let tools = {
-        let registry = ToolRegistry::new(effective_root.clone(), sub_config.max_context_tokens);
+        let registry = ToolRegistry::with_sandbox(
+            effective_root.clone(),
+            sub_config.max_context_tokens,
+            sub_config.sandbox.clone(),
+        );
         match parent_cache {
             Some(cache) => registry.with_shared_cache(cache),
             None => registry,

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -227,6 +227,8 @@ pub struct ToolRegistry {
     /// Background process registry — tracks processes spawned with `background: true`.
     /// Dropped (SIGTERM all) when the session ends.
     pub bg_registry: bg_process::BgRegistry,
+    /// Sandbox mode for Bash tool invocations.
+    sandbox: crate::sandbox::SandboxMode,
 }
 
 impl ToolRegistry {
@@ -234,6 +236,15 @@ impl ToolRegistry {
     ///
     /// `max_context_tokens` scales all output caps (see `OutputCaps`).
     pub fn new(project_root: PathBuf, max_context_tokens: usize) -> Self {
+        Self::with_sandbox(project_root, max_context_tokens, crate::sandbox::SandboxMode::None)
+    }
+
+    /// Create a new registry with a specific sandbox mode.
+    pub fn with_sandbox(
+        project_root: PathBuf,
+        max_context_tokens: usize,
+        sandbox: crate::sandbox::SandboxMode,
+    ) -> Self {
         let mut definitions = HashMap::new();
 
         // Register all built-in tools
@@ -288,6 +299,7 @@ impl ToolRegistry {
             session_id: std::sync::RwLock::new(None),
             caps: OutputCaps::for_context(max_context_tokens),
             bg_registry: bg_process::BgRegistry::new(),
+            sandbox,
         }
     }
 
@@ -462,6 +474,7 @@ impl ToolRegistry {
                     self.caps.shell_output_lines,
                     &self.bg_registry,
                     sink_for_streaming,
+                    &self.sandbox,
                 )
                 .await;
                 return match shell_result {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -236,7 +236,11 @@ impl ToolRegistry {
     ///
     /// `max_context_tokens` scales all output caps (see `OutputCaps`).
     pub fn new(project_root: PathBuf, max_context_tokens: usize) -> Self {
-        Self::with_sandbox(project_root, max_context_tokens, crate::sandbox::SandboxMode::None)
+        Self::with_sandbox(
+            project_root,
+            max_context_tokens,
+            crate::sandbox::SandboxMode::None,
+        )
     }
 
     /// Create a new registry with a specific sandbox mode.

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -411,9 +411,16 @@ mod tests {
     async fn shell_timeout_returns_timeout_message() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "sleep 5", "timeout": 1});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &bg(),
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         assert!(
             result.summary.contains("timed out"),
             "Expected timeout message, got: {}",
@@ -425,9 +432,16 @@ mod tests {
     async fn shell_respects_custom_timeout_parameter() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo hello", "timeout": 5});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &bg(),
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         assert!(
             result.summary.contains("hello"),
             "Fast command should succeed: {}",
@@ -439,9 +453,16 @@ mod tests {
     async fn shell_default_timeout_is_applied_when_not_specified() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo world"});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &bg(),
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         assert!(
             result.summary.contains("world"),
             "Command without explicit timeout should work: {}",
@@ -454,9 +475,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let registry = BgRegistry::new();
         let args = serde_json::json!({"command": "sleep 60", "background": true});
-        let result = run_shell_command(tmp.path(), &args, 256, &registry, None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &registry,
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         assert!(
             result.summary.contains("Background process started"),
             "{}",
@@ -475,9 +503,16 @@ mod tests {
     async fn background_false_runs_synchronously() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo sync", "background": false});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &bg(),
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         assert!(result.summary.contains("sync"), "{}", result.summary);
         assert!(
             !result.summary.contains("PID:"),
@@ -559,9 +594,16 @@ mod tests {
         let args = serde_json::json!({
             "command": "seq 1 50"
         });
-        let result = run_shell_command(tmp.path(), &args, 10, &bg(), None, &crate::sandbox::SandboxMode::None)
-            .await
-            .unwrap();
+        let result = run_shell_command(
+            tmp.path(),
+            &args,
+            10,
+            &bg(),
+            None,
+            &crate::sandbox::SandboxMode::None,
+        )
+        .await
+        .unwrap();
         // Summary should reflect that we only collected 10 lines.
         assert!(
             result.summary.contains("stdout: 10 lines"),
@@ -615,7 +657,7 @@ mod tests {
             256,
             &bg(),
             Some((sink.as_ref(), "test_id")),
-        &crate::sandbox::SandboxMode::None,
+            &crate::sandbox::SandboxMode::None,
         )
         .await
         .unwrap();

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -35,7 +35,6 @@ use anyhow::Result;
 use serde_json::{Value, json};
 use std::path::Path;
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
 /// Hard ceiling to prevent LLM-controlled DoS via huge timeout values.
@@ -109,6 +108,7 @@ pub async fn run_shell_command(
     max_lines: usize,
     bg: &BgRegistry,
     sink: Option<(&dyn EngineSink, &str)>,
+    sandbox: &crate::sandbox::SandboxMode,
 ) -> Result<ShellOutput> {
     let command = args["command"]
         .as_str()
@@ -121,7 +121,7 @@ pub async fn run_shell_command(
     );
 
     if background {
-        let msg = spawn_background(project_root, command, bg)?;
+        let msg = spawn_background(project_root, command, bg, sandbox)?;
         return Ok(ShellOutput {
             summary: msg,
             full_output: None,
@@ -133,11 +133,8 @@ pub async fn run_shell_command(
         .unwrap_or(DEFAULT_TIMEOUT_SECS)
         .min(MAX_TIMEOUT_SECS);
 
-    // Spawn with piped stdout/stderr for line-by-line streaming.
-    let mut child = Command::new("sh")
-        .arg("-c")
-        .arg(command)
-        .current_dir(project_root)
+    // Spawn via sandbox wrapper (may be a no-op for SandboxMode::None).
+    let mut child = crate::sandbox::build(command, project_root, sandbox)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -275,12 +272,15 @@ async fn read_streams(
 ///
 /// Returns immediately with PID + instructions. Sync because `spawn()` doesn't
 /// need to await — only `output()` / `wait()` block.
-fn spawn_background(project_root: &Path, command: &str, bg: &BgRegistry) -> Result<String> {
-    let child = Command::new("sh")
-        .arg("-c")
-        .arg(command)
-        .current_dir(project_root)
-        // Detach stdio so the process doesn't block on terminal I/O.
+fn spawn_background(
+    project_root: &Path,
+    command: &str,
+    bg: &BgRegistry,
+    sandbox: &crate::sandbox::SandboxMode,
+) -> Result<String> {
+    // tokio::process::Command doesn't impl std's Stdio easily in sync context;
+    // re-build as std Command for the detached spawn.
+    let child = crate::sandbox::build(command, project_root, sandbox)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -411,7 +411,7 @@ mod tests {
     async fn shell_timeout_returns_timeout_message() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "sleep 5", "timeout": 1});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         assert!(
@@ -425,7 +425,7 @@ mod tests {
     async fn shell_respects_custom_timeout_parameter() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo hello", "timeout": 5});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         assert!(
@@ -439,7 +439,7 @@ mod tests {
     async fn shell_default_timeout_is_applied_when_not_specified() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo world"});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         assert!(
@@ -454,7 +454,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let registry = BgRegistry::new();
         let args = serde_json::json!({"command": "sleep 60", "background": true});
-        let result = run_shell_command(tmp.path(), &args, 256, &registry, None)
+        let result = run_shell_command(tmp.path(), &args, 256, &registry, None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         assert!(
@@ -475,7 +475,7 @@ mod tests {
     async fn background_false_runs_synchronously() {
         let tmp = tempfile::tempdir().unwrap();
         let args = serde_json::json!({"command": "echo sync", "background": false});
-        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None)
+        let result = run_shell_command(tmp.path(), &args, 256, &bg(), None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         assert!(result.summary.contains("sync"), "{}", result.summary);
@@ -559,7 +559,7 @@ mod tests {
         let args = serde_json::json!({
             "command": "seq 1 50"
         });
-        let result = run_shell_command(tmp.path(), &args, 10, &bg(), None)
+        let result = run_shell_command(tmp.path(), &args, 10, &bg(), None, &crate::sandbox::SandboxMode::None)
             .await
             .unwrap();
         // Summary should reflect that we only collected 10 lines.
@@ -615,6 +615,7 @@ mod tests {
             256,
             &bg(),
             Some((sink.as_ref(), "test_id")),
+        &crate::sandbox::SandboxMode::None,
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Closes #840 (v1 — `none` + `project` modes; `strict` is tracked for v2).

Adds **opt-in process sandboxing** for every Bash tool invocation. The sandbox wraps the shell process before it spawns — no changes to tool logic, approval flow, or approval UI.

---

## Usage

```bash
koda --sandbox project "run the test suite"
KODA_SANDBOX=project koda "refactor the auth module"
```

---

## Design

Single file: `koda-core/src/sandbox.rs` (~260 lines, well under the 600 line limit).

### `SandboxMode`

| Mode | Backend | Policy |
|---|---|---|
| `none` (default) | plain `sh -c` | no restrictions |
| `project` | macOS: `sandbox-exec -p` | reads: everywhere; writes: project root + /tmp + ~/.cargo/~/.npm/~/.cache; network: open |
| | Linux: `bwrap` (bubblewrap) | same policy via ro-bind root + rw-bind project + caches |

### macOS seatbelt profile

Passed inline via `sandbox-exec -p` (no tempfile, no race window). Path is **canonicalized** before embedding — `/var` is a symlink to `/private/var` on macOS and the kernel presents tempfile paths via the canonical form.

### Linux bwrap

`bwrap` is detected once via `OnceLock` at first use. If missing, a warning is logged and the command runs unsandboxed — no crash, no silent failure.

### What's sandboxed

Both **foreground** (`run_shell_command`) and **background** (`spawn_background`) paths go through `sandbox::build()`. Background dev servers (`background: true`) are also confined to the project root.

---

## Wiring (the plumbing)

```
CLI --sandbox project
  → KodaConfig.with_sandbox(SandboxMode::Project)
  → KodaAgent::new → ToolRegistry::with_sandbox(root, ctx, mode)
  → ToolRegistry.sandbox stored
  → Bash dispatch → shell::run_shell_command(..., &self.sandbox)
                  → sandbox::build(command, root, mode)
                  → tokio::process::Command (wrapped or plain)
```

### Backwards compatibility

`ToolRegistry::new` still exists, now delegates to `ToolRegistry::with_sandbox(..., SandboxMode::None)`. All existing tests pass unchanged.

---

## Tests (8 new, kernel-level)

| Test | What it verifies |
|---|---|
| `parse_roundtrip` | case-insensitive parse, unknown → None |
| `display_roundtrip` | Display impl |
| `default_is_none` | Default trait |
| `is_active` | None → false, Project → true |
| `none_mode_runs_echo` | SandboxMode::None never blocks |
| `macos_allows_write_inside_project` | `touch` inside project root succeeds |
| `macos_blocks_write_outside_project` | write outside project → EPERM, file not created |
| `macos_allows_read_outside_project` | `cat /etc/hosts` still works |

macOS tests are gated on `#[cfg(target_os = "macos")]`; Linux equivalents follow the same pattern and are gated on `#[cfg(target_os = "linux")]`.

---

## What's NOT in this PR

- **`strict` mode** (deny reads of `~/.ssh`, `~/.aws`, HIPAA dirs) — v2, tracked in #840
- **Sub-agent sandbox inheritance** — sub-agents default to `None`; can be set via their agent JSON in a future PR once `AgentConfig` gains a `sandbox` field