### PR TITLE
refactor: rename settings.rs → last_provider.rs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ koda/
 │   │   ├── prompt.rs       # System prompt construction
 │   │   ├── runtime_env.rs  # Thread-safe runtime env for API keys
 │   │   ├── session.rs      # KodaSession (per-conversation: DB, provider, settings)
-│   │   ├── settings.rs     # Runtime settings (approval mode, etc.)
+│   │   ├── last_provider.rs # Last-used provider recall (SQLite KV, not a config file)
 │   │   ├── skills.rs       # Skill discovery and activation
 │   │   ├── skill_scope.rs  # Skill-scoped tool allow/deny enforcement
 │   │   ├── sub_agent_cache.rs # Sub-agent provider/model config cache

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -224,7 +224,7 @@ pub(crate) async fn run() -> Result<()> {
 
     tracing::info!("Koda starting. Project root: {:?}", project_root);
 
-    // Initialize database early — keys and settings live here (#693)
+    // Initialize database early — keys and last-provider recall live here (#693)
     let db = koda_core::db::Database::init(&koda_core::db::config_dir()?).await?;
 
     // Load and inject stored API keys (env vars take precedence)

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -121,7 +121,7 @@ impl TuiContext {
         first_run: bool,
     ) -> Result<Self> {
         // Restore last-used provider from DB (#693)
-        if let Ok(Some(last)) = koda_core::settings::load_last_provider(&db).await {
+        if let Ok(Some(last)) = koda_core::last_provider::load_last_provider(&db).await {
             let ptype =
                 koda_core::config::ProviderType::from_url_or_name("", Some(&last.provider_type));
             config.provider_type = ptype;

--- a/koda-cli/src/tui_wizards.rs
+++ b/koda-cli/src/tui_wizards.rs
@@ -411,7 +411,7 @@ pub(crate) fn handle_memory(
 }
 
 pub(crate) async fn save_provider(config: &KodaConfig, db: &koda_core::db::Database) {
-    let _ = koda_core::settings::save_last_provider(
+    let _ = koda_core::last_provider::save_last_provider(
         db,
         &config.provider_type.to_string(),
         &config.base_url,

--- a/koda-core/src/approval.rs
+++ b/koda-core/src/approval.rs
@@ -311,7 +311,7 @@ fn is_outside_project(tool_name: &str, args: &serde_json::Value, project_root: &
 // ── Settings persistence ──────────────────────────────────
 
 /// Re-export settings types for provider persistence.
-pub use crate::settings::LastProvider;
+pub use crate::last_provider::LastProvider;
 
 // ── Tests ─────────────────────────────────────────────────
 

--- a/koda-core/src/last_provider.rs
+++ b/koda-core/src/last_provider.rs
@@ -1,11 +1,14 @@
-//! Last-used provider persistence (#693).
+//! Last-used provider recall (#693).
 //!
 //! Remembers the last provider/model/base-URL so Koda can auto-restore
 //! on next startup. Stored in SQLite via the [`crate::db`] KV store.
 //!
 //! This is **not** user configuration — Koda follows "customization over
-//! configuration" (see DESIGN.md). The only persisted state is which
+//! configuration" (see DESIGN.md §P1). The only persisted state is which
 //! provider the user last chose via `/model`.
+//!
+//! Renamed from `settings.rs` to avoid implying a user-editable config
+//! surface — koda has none.
 
 use crate::db::Database;
 use anyhow::Result;

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -83,6 +83,8 @@ pub mod inference;
 pub mod inference_helpers;
 /// Credential storage — `keys.toml` with env var fallback.
 pub mod keystore;
+/// Last-used provider recall (stored in SQLite KV store, not a config file).
+pub mod last_provider;
 /// Loop detection — catches runaway repeated tool calls.
 pub mod loop_guard;
 /// Project memory — `MEMORY.md` / `CLAUDE.md` read/write.
@@ -111,8 +113,6 @@ pub mod runtime_env;
 pub mod sandbox;
 /// Session lifecycle — create, resume, list, delete.
 pub mod session;
-/// Last-used provider persistence (`~/.config/koda/settings.toml`).
-pub mod settings;
 /// Skill-scoped tool filtering — hard enforcement of `allowed_tools`.
 pub mod skill_scope;
 /// Skill discovery and activation (project, user, built-in).

--- a/koda-email/README.md
+++ b/koda-email/README.md
@@ -44,7 +44,7 @@ Add to `.mcp.json` (use env var references — don't hardcode credentials):
 > **⚠️ Security:** Never hardcode email credentials in `.mcp.json` — if that
 > file is committed to a repo, your inbox is exposed. Set `EMAIL_USER` and
 > `EMAIL_PASS` as environment variables or use koda's built-in keystore
-> (`/provider` wizard stores credentials encrypted at `~/.config/koda/keys`).
+> (`/key` wizard stores credentials in the SQLite KV store at `~/.config/koda/db/koda.db`, file mode 0600).
 
 ## MCP tools exposed
 


### PR DESCRIPTION
## What

Renames `settings.rs` → `last_provider.rs`. No behavior change.

## Why

`settings.rs` implied koda has a user-editable config surface. It doesn't — DESIGN.md §P1 says "customization over configuration." The module only persists which provider/model the user last chose via `/model`. The new name says exactly what it does.

Discovered during the sandbox parity review (#844): we audited what's actually stored in `~/.config/koda/db/koda.db` and confirmed there are exactly **zero** user config entries — only operational state (sessions, messages, history) and credentials (API keys). The `setting:last_provider` KV entry is UX recall, not configuration.

## Changes (8 files, pure rename)

| File | Change |
|---|---|
| `koda-core/src/settings.rs` → `last_provider.rs` | Renamed + updated module doc |
| `koda-core/src/lib.rs` | `pub mod last_provider` + fixed stale "settings.toml" doc |
| `koda-core/src/approval.rs` | `use crate::last_provider::LastProvider` |
| `koda-cli/src/tui_context/mod.rs` | `koda_core::last_provider::load_last_provider` |
| `koda-cli/src/tui_wizards.rs` | `koda_core::last_provider::save_last_provider` |
| `koda-cli/src/app.rs` | Fixed stale comment ("keys and settings" → "keys and last-provider recall") |
| `CLAUDE.md` | Fixed tree listing (was "Runtime settings") |
| `koda-email/README.md` | Fixed stale claim ("encrypted at ~/.config/koda/keys" → SQLite KV store, 0600) |

## Tests

All existing tests pass — the module's 3 unit tests now run under `last_provider::tests`.
