### PR TITLE
sandbox: sub-agent inherits parent sandbox, never weaker (#845)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -57,6 +57,32 @@ pub enum SandboxMode {
 }
 
 impl SandboxMode {
+    /// Return a numeric strictness level for comparison.
+    ///
+    /// Higher = stricter.  Used by `stricter()` to enforce the
+    /// "never weaken" invariant when inheriting from a parent.
+    fn level(&self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::Project => 1,
+            Self::Strict => 2,
+        }
+    }
+
+    /// Return whichever of `self` and `other` is stricter.
+    ///
+    /// Used by sub-agent dispatch to enforce the invariant that a child
+    /// agent can never run with a weaker sandbox than its parent — the same
+    /// pattern as Codex's `apply_spawn_agent_runtime_overrides()` which
+    /// copies the parent's runtime `sandbox_policy` onto the child config.
+    pub fn stricter(&self, other: &Self) -> Self {
+        if self.level() >= other.level() {
+            self.clone()
+        } else {
+            other.clone()
+        }
+    }
+
     /// Parse from a CLI / env string (case-insensitive).
     ///
     /// Unknown values produce a warning and fall back to `None`.
@@ -474,6 +500,22 @@ mod tests {
     use super::*;
 
     // ── Unit: enum behaviour ───────────────────────────────────────────────
+
+    #[test]
+    fn stricter_returns_higher_level() {
+        use SandboxMode::*;
+        // Same mode → returns self
+        assert_eq!(None.stricter(&None), None);
+        assert_eq!(Project.stricter(&Project), Project);
+        assert_eq!(Strict.stricter(&Strict), Strict);
+        // Different modes → returns the stricter one
+        assert_eq!(None.stricter(&Project), Project);
+        assert_eq!(Project.stricter(&None), Project);
+        assert_eq!(None.stricter(&Strict), Strict);
+        assert_eq!(Strict.stricter(&None), Strict);
+        assert_eq!(Project.stricter(&Strict), Strict);
+        assert_eq!(Strict.stricter(&Project), Strict);
+    }
 
     #[test]
     fn parse_roundtrip() {

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -195,6 +195,21 @@ pub(crate) async fn execute_sub_agent(
         // else: agent opted into its own provider — use its resolved config
         // as-is. The agent JSON is responsible for any model it needs.
 
+        // Inherit sandbox: child can never be weaker than parent (#845).
+        // Same pattern as Codex's `apply_spawn_agent_runtime_overrides()`
+        // which copies the parent's runtime sandbox_policy onto the child.
+        let child_sandbox = cfg.sandbox.clone();
+        cfg.sandbox = parent_config.sandbox.stricter(&cfg.sandbox);
+        if cfg.sandbox != child_sandbox {
+            tracing::info!(
+                agent = agent_name,
+                parent = %parent_config.sandbox,
+                child = %child_sandbox,
+                effective = %cfg.sandbox,
+                "sub-agent sandbox escalated to match parent",
+            );
+        }
+
         cfg
     };
 


### PR DESCRIPTION
## Summary

Sub-agents loaded from agent JSON now inherit the parent's sandbox mode using a **"never weaken"** rule — the child always gets the stricter of the two. Same pattern as Codex's `apply_spawn_agent_runtime_overrides()`.

**Before**: parent runs with `--sandbox strict`, but `task.json` has no `sandbox` field → task agent runs **unsandboxed**.

**After**: task agent inherits `strict` from parent. If the agent JSON explicitly sets `sandbox: "project"` but parent is `strict`, the child still gets `strict`.

## Changes (57 lines, 2 files)

### `koda-core/src/sandbox.rs`
- `SandboxMode::stricter(&self, &other)` — returns whichever mode is more restrictive (`None < Project < Strict`)
- `stricter_returns_higher_level` test — exhaustive coverage of all 9 combinations

### `koda-core/src/sub_agent_dispatch.rs`
- One-liner after agent config load: `cfg.sandbox = parent_config.sandbox.stricter(&cfg.sandbox);`
- Tracing log when escalation occurs for debuggability

## Inheritance matrix

| Parent | Agent JSON | Effective | Why |
|---|---|---|---|
| `strict` | *(none)* | `strict` | Inherits parent |
| `strict` | `project` | `strict` | Can't weaken parent |
| `project` | `strict` | `strict` | Agent opted stricter |
| `project` | *(none)* | `project` | Inherits parent |
| `none` | `project` | `project` | Agent opted stricter |
| `none` | *(none)* | `none` | Both default |

Fork path was already safe (`parent_config.clone()` copies sandbox). ✅

## Test results
- 21 sandbox tests pass (including new `stricter_returns_higher_level`)
- 4 e2e agent tests pass (sub-agent invocation, caching, memory isolation)
- Pre-push: fmt ✅ clippy ✅ check ✅

Closes #845