### PR TITLE
feat(mcp): MCP client foundation — connect to external MCP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "path-clean",
  "regex",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "sha2",
@@ -2009,7 +2010,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2124,6 +2125,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2599,6 +2612,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -2963,21 +2990,23 @@ dependencies = [
  "futures",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3719,7 +3748,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -4600,6 +4629,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4610,6 +4660,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4639,6 +4700,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4760,6 +4831,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -68,6 +68,13 @@ futures-util = "0.3"
 # Error handling
 anyhow = "1"
 
+# MCP client — connect to external MCP servers (#662)
+rmcp = { version = "1.4", default-features = false, features = [
+    "client",
+    "base64",
+    "transport-child-process",
+] }
+
 # First-party workspace libraries (direct calls)
 
 # Async trait support

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -88,6 +88,8 @@ pub mod keystore;
 pub mod last_provider;
 /// Loop detection — catches runaway repeated tool calls.
 pub mod loop_guard;
+/// MCP client — connect to external MCP servers (#662).
+pub mod mcp;
 /// Project memory — `MEMORY.md` / `CLAUDE.md` read/write.
 pub mod memory;
 /// Microcompact — lightweight tool result aging without full compaction.

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -1,0 +1,257 @@
+//! Single MCP server client — wraps rmcp connection lifecycle.
+//!
+//! Each `McpClient` owns one connection to one MCP server process.
+//! It handles spawning, initialization, tool discovery, and tool invocation.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rmcp::ServiceExt;
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::RunningService;
+use rmcp::transport::child_process::TokioChildProcess;
+use serde_json::Value;
+use tokio::process::Command;
+
+use super::config::McpServerConfig;
+use super::tool_bridge::McpToolAnnotations;
+use crate::providers::ToolDefinition;
+
+/// Connection status of a single MCP server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpClientStatus {
+    /// Not yet connected.
+    Disconnected,
+    /// Connection in progress.
+    Connecting,
+    /// Connected and ready.
+    Connected,
+    /// Connection failed.
+    Failed,
+}
+
+/// A discovered MCP tool with its Koda-side definition and annotations.
+#[derive(Debug, Clone)]
+pub struct DiscoveredTool {
+    /// Koda tool definition (qualified name, description, schema).
+    pub definition: ToolDefinition,
+    /// MCP annotations for trust classification.
+    pub annotations: McpToolAnnotations,
+    /// Original (unqualified) tool name on the MCP server.
+    pub original_name: String,
+}
+
+/// Client for a single MCP server.
+pub struct McpClient {
+    /// Server name (user-assigned, e.g. "playwright").
+    name: String,
+    /// Server configuration.
+    config: McpServerConfig,
+    /// Running rmcp service (None when disconnected).
+    service: Option<RunningService<rmcp::service::RoleClient, ()>>,
+    /// Discovered tools after connection.
+    tools: Vec<DiscoveredTool>,
+    /// Current connection status.
+    status: McpClientStatus,
+    /// Error message from the last failed connection attempt.
+    last_error: Option<String>,
+}
+
+impl McpClient {
+    /// Create a new (disconnected) client for the given server.
+    pub fn new(name: String, config: McpServerConfig) -> Self {
+        Self {
+            name,
+            config,
+            service: None,
+            tools: Vec::new(),
+            status: McpClientStatus::Disconnected,
+            last_error: None,
+        }
+    }
+
+    /// Server name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Current connection status.
+    pub fn status(&self) -> McpClientStatus {
+        self.status
+    }
+
+    /// Last error message (if status is Failed).
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    /// Discovered tools (empty until connected).
+    pub fn tools(&self) -> &[DiscoveredTool] {
+        &self.tools
+    }
+
+    /// Connect to the MCP server, initialize, and discover tools.
+    ///
+    /// Spawns the server process via stdio transport, performs the MCP
+    /// handshake, and fetches the tool list.
+    pub async fn connect(&mut self) -> Result<()> {
+        self.status = McpClientStatus::Connecting;
+        self.last_error = None;
+
+        let timeout = Duration::from_secs(self.config.startup_timeout_sec);
+
+        match tokio::time::timeout(timeout, self.connect_inner()).await {
+            Ok(Ok(())) => {
+                self.status = McpClientStatus::Connected;
+                tracing::info!(
+                    server = %self.name,
+                    tools = self.tools.len(),
+                    "MCP server connected"
+                );
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                self.status = McpClientStatus::Failed;
+                self.last_error = Some(e.to_string());
+                tracing::warn!(
+                    server = %self.name,
+                    error = %e,
+                    "MCP server connection failed"
+                );
+                Err(e)
+            }
+            Err(_) => {
+                self.status = McpClientStatus::Failed;
+                let msg = format!(
+                    "MCP server '{}' startup timed out after {}s",
+                    self.name, self.config.startup_timeout_sec
+                );
+                self.last_error = Some(msg.clone());
+                tracing::warn!(server = %self.name, "{msg}");
+                Err(anyhow::anyhow!(msg))
+            }
+        }
+    }
+
+    /// Inner connect logic (without timeout wrapper).
+    async fn connect_inner(&mut self) -> Result<()> {
+        // Build the command to spawn.
+        let mut cmd = Command::new(&self.config.command);
+        cmd.args(&self.config.args);
+
+        // Set environment variables.
+        for (key, val) in &self.config.env {
+            cmd.env(key, val);
+        }
+
+        // Set working directory if specified.
+        if let Some(ref cwd) = self.config.cwd {
+            cmd.current_dir(cwd);
+        }
+
+        // Spawn via stdio transport.
+        let transport =
+            TokioChildProcess::new(cmd).context("failed to spawn MCP server process")?;
+
+        // Connect and initialize as a client.
+        let service = ().serve(transport).await.context("MCP handshake failed")?;
+
+        self.service = Some(service);
+
+        // Discover tools.
+        self.discover_tools().await?;
+
+        Ok(())
+    }
+
+    /// Fetch the tool list from the connected server.
+    async fn discover_tools(&mut self) -> Result<()> {
+        let service = self.service.as_ref().context("not connected")?;
+
+        let result = service
+            .list_tools(Default::default())
+            .await
+            .context("failed to list MCP tools")?;
+
+        self.tools.clear();
+
+        for tool in result.tools {
+            let tool_name: &str = &tool.name;
+
+            // Apply tool filtering.
+            if !self.config.is_tool_allowed(tool_name) {
+                tracing::debug!(
+                    server = %self.name,
+                    tool = %tool_name,
+                    "MCP tool filtered out by config"
+                );
+                continue;
+            }
+
+            let (definition, annotations) =
+                super::tool_bridge::mcp_tool_to_definition(&self.name, &tool);
+
+            self.tools.push(DiscoveredTool {
+                definition,
+                annotations,
+                original_name: tool_name.to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Call a tool on this MCP server.
+    ///
+    /// `tool_name` is the original (unqualified) name on the server.
+    /// `arguments` is the JSON arguments value.
+    pub async fn call_tool(
+        &self,
+        tool_name: &str,
+        arguments: Value,
+    ) -> Result<rmcp::model::CallToolResult> {
+        let service = self.service.as_ref().context("MCP server not connected")?;
+
+        let timeout = Duration::from_secs(self.config.tool_timeout_sec);
+
+        let mut params = CallToolRequestParams::new(tool_name.to_string());
+        if let Value::Object(map) = arguments {
+            params.arguments = Some(map);
+        }
+
+        let result = tokio::time::timeout(timeout, service.call_tool(params))
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "MCP tool call '{}' on server '{}' timed out after {}s",
+                    tool_name,
+                    self.name,
+                    self.config.tool_timeout_sec
+                )
+            })?
+            .context("MCP tool call failed")?;
+
+        Ok(result)
+    }
+
+    /// Disconnect from the MCP server.
+    pub async fn disconnect(&mut self) {
+        if let Some(service) = self.service.take() {
+            // RunningService is dropped, which cleans up the child process.
+            drop(service);
+        }
+        self.tools.clear();
+        self.status = McpClientStatus::Disconnected;
+        self.last_error = None;
+        tracing::info!(server = %self.name, "MCP server disconnected");
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        // Ensure the service is dropped (child process cleaned up).
+        if self.service.is_some() {
+            tracing::debug!(server = %self.name, "McpClient dropped while still connected");
+        }
+    }
+}

--- a/koda-core/src/mcp/config.rs
+++ b/koda-core/src/mcp/config.rs
@@ -1,0 +1,267 @@
+//! MCP server configuration types and database persistence.
+//!
+//! Configs are stored in the SQLite `kv_store` table under `mcp:<server_name>`
+//! keys as JSON blobs. This is consistent with how Koda stores settings
+//! (`setting:*`) and API keys (`apikey:*`).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::db::Database;
+
+/// Key prefix for MCP server configs in the kv_store.
+const MCP_KEY_PREFIX: &str = "mcp:";
+
+/// Default timeout (seconds) for MCP server startup.
+const DEFAULT_STARTUP_TIMEOUT_SEC: u64 = 30;
+
+/// Default timeout (seconds) for individual tool calls.
+const DEFAULT_TOOL_TIMEOUT_SEC: u64 = 120;
+
+/// Configuration for a single MCP server.
+///
+/// Supports stdio transport (command + args) for v1.
+/// HTTP transport (`url` field) is reserved for v2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpServerConfig {
+    // ── Stdio transport ───────────────────────────────────────────────
+    /// Command to spawn the MCP server process.
+    pub command: String,
+
+    /// Arguments passed to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Additional environment variables for the server process.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+
+    /// Working directory for the server process.
+    #[serde(default)]
+    pub cwd: Option<String>,
+
+    // ── Timeouts ──────────────────────────────────────────────────────
+    /// Seconds to wait for the server to start and respond to `initialize`.
+    #[serde(default = "default_startup_timeout")]
+    pub startup_timeout_sec: u64,
+
+    /// Seconds to wait for a single tool call to complete.
+    #[serde(default = "default_tool_timeout")]
+    pub tool_timeout_sec: u64,
+
+    // ── Tool filtering ────────────────────────────────────────────────
+    /// If set, only expose these tools (allowlist). Others are hidden.
+    #[serde(default)]
+    pub enabled_tools: Option<Vec<String>>,
+
+    /// If set, hide these tools (denylist). `enabled_tools` takes priority.
+    #[serde(default)]
+    pub disabled_tools: Option<Vec<String>>,
+}
+
+fn default_startup_timeout() -> u64 {
+    DEFAULT_STARTUP_TIMEOUT_SEC
+}
+
+fn default_tool_timeout() -> u64 {
+    DEFAULT_TOOL_TIMEOUT_SEC
+}
+
+impl McpServerConfig {
+    /// Validate the config. Returns an error if essential fields are missing.
+    pub fn validate(&self) -> Result<()> {
+        if self.command.trim().is_empty() {
+            anyhow::bail!("MCP server config must specify a `command`");
+        }
+        Ok(())
+    }
+
+    /// Check whether a tool name passes the include/exclude filter.
+    pub fn is_tool_allowed(&self, tool_name: &str) -> bool {
+        if let Some(ref enabled) = self.enabled_tools {
+            return enabled.iter().any(|t| t == tool_name);
+        }
+        if let Some(ref disabled) = self.disabled_tools {
+            return !disabled.iter().any(|t| t == tool_name);
+        }
+        true
+    }
+}
+
+// ── Database persistence ──────────────────────────────────────────────────
+
+/// Load all MCP server configs from the database.
+pub async fn load_mcp_configs(db: &Database) -> Result<HashMap<String, McpServerConfig>> {
+    let rows = db
+        .kv_list_prefix(MCP_KEY_PREFIX)
+        .await
+        .context("failed to load MCP configs from kv_store")?;
+
+    let mut configs = HashMap::new();
+    for (key, value) in rows {
+        let server_name = key.strip_prefix(MCP_KEY_PREFIX).unwrap_or(&key).to_string();
+        if server_name.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<McpServerConfig>(&value) {
+            Ok(config) => {
+                configs.insert(server_name, config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    server = %server_name,
+                    error = %e,
+                    "skipping MCP server with invalid config"
+                );
+            }
+        }
+    }
+    Ok(configs)
+}
+
+/// Save an MCP server config to the database.
+pub async fn save_mcp_config(db: &Database, name: &str, config: &McpServerConfig) -> Result<()> {
+    config.validate()?;
+    let key = format!("{MCP_KEY_PREFIX}{name}");
+    let value = serde_json::to_string(config).context("failed to serialize MCP config")?;
+    db.kv_set(&key, &value)
+        .await
+        .context("failed to save MCP config to kv_store")
+}
+
+/// Remove an MCP server config from the database.
+pub async fn remove_mcp_config(db: &Database, name: &str) -> Result<()> {
+    let key = format!("{MCP_KEY_PREFIX}{name}");
+    db.kv_delete(&key)
+        .await
+        .context("failed to remove MCP config from kv_store")
+}
+
+/// List all configured MCP server names.
+pub async fn list_mcp_server_names(db: &Database) -> Result<Vec<String>> {
+    let rows = db
+        .kv_list_prefix(MCP_KEY_PREFIX)
+        .await
+        .context("failed to list MCP servers from kv_store")?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|(key, _)| {
+            key.strip_prefix(MCP_KEY_PREFIX)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rejects_empty_command() {
+        let config = McpServerConfig {
+            command: "".into(),
+            args: vec![],
+            env: HashMap::new(),
+            cwd: None,
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: None,
+            disabled_tools: None,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_valid_config() {
+        let config = McpServerConfig {
+            command: "npx".into(),
+            args: vec!["-y".into(), "@anthropic/mcp-playwright".into()],
+            env: HashMap::new(),
+            cwd: None,
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: None,
+            disabled_tools: None,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn tool_filter_allowlist() {
+        let config = McpServerConfig {
+            command: "test".into(),
+            args: vec![],
+            env: HashMap::new(),
+            cwd: None,
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: Some(vec!["navigate".into(), "click".into()]),
+            disabled_tools: None,
+        };
+        assert!(config.is_tool_allowed("navigate"));
+        assert!(config.is_tool_allowed("click"));
+        assert!(!config.is_tool_allowed("screenshot"));
+    }
+
+    #[test]
+    fn tool_filter_denylist() {
+        let config = McpServerConfig {
+            command: "test".into(),
+            args: vec![],
+            env: HashMap::new(),
+            cwd: None,
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: None,
+            disabled_tools: Some(vec!["dangerous_tool".into()]),
+        };
+        assert!(config.is_tool_allowed("navigate"));
+        assert!(!config.is_tool_allowed("dangerous_tool"));
+    }
+
+    #[test]
+    fn tool_filter_allowlist_beats_denylist() {
+        let config = McpServerConfig {
+            command: "test".into(),
+            args: vec![],
+            env: HashMap::new(),
+            cwd: None,
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: Some(vec!["safe".into()]),
+            disabled_tools: Some(vec!["safe".into()]), // contradicts — allowlist wins
+        };
+        assert!(config.is_tool_allowed("safe"));
+        assert!(!config.is_tool_allowed("other"));
+    }
+
+    #[test]
+    fn roundtrip_serde() {
+        let config = McpServerConfig {
+            command: "npx".into(),
+            args: vec!["-y".into(), "playwright-mcp".into()],
+            env: HashMap::from([("FOO".into(), "bar".into())]),
+            cwd: Some("/tmp".into()),
+            startup_timeout_sec: 10,
+            tool_timeout_sec: 60,
+            enabled_tools: Some(vec!["navigate".into()]),
+            disabled_tools: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: McpServerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, parsed);
+    }
+
+    #[test]
+    fn serde_defaults_applied() {
+        let json = r#"{"command": "npx", "args": ["-y", "test"]}"#;
+        let config: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.startup_timeout_sec, 30);
+        assert_eq!(config.tool_timeout_sec, 120);
+        assert!(config.env.is_empty());
+        assert!(config.enabled_tools.is_none());
+    }
+}

--- a/koda-core/src/mcp/manager.rs
+++ b/koda-core/src/mcp/manager.rs
@@ -216,15 +216,25 @@ pub struct McpServerStatus {
 }
 
 /// Convert MCP CallToolResult content into a plain string.
+///
+/// Text content is concatenated. Non-text content (images, blobs) is
+/// described inline so the LLM knows something was returned.
 fn call_tool_result_to_string(result: &rmcp::model::CallToolResult) -> String {
-    let parts: Vec<String> = result
-        .content
-        .iter()
-        .filter_map(|content| match &content.raw {
-            rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
-            _ => None,
-        })
-        .collect();
+    let mut parts: Vec<String> = Vec::new();
+
+    for content in &result.content {
+        match &content.raw {
+            rmcp::model::RawContent::Text(text) => {
+                parts.push(text.text.clone());
+            }
+            other => {
+                // Describe non-text content so the LLM knows it was returned.
+                let kind = format!("{:?}", std::mem::discriminant(other));
+                tracing::debug!(content_type = %kind, "MCP tool returned non-text content");
+                parts.push(format!("[non-text content: {kind}]"));
+            }
+        }
+    }
 
     if parts.is_empty() {
         "(no output)".to_string()

--- a/koda-core/src/mcp/manager.rs
+++ b/koda-core/src/mcp/manager.rs
@@ -1,0 +1,234 @@
+//! Multi-server connection manager — owns all MCP clients.
+//!
+//! `McpManager` is the single entry point for the rest of koda-core.
+//! It loads configs from the DB, connects to servers in parallel,
+//! discovers tools, and routes tool calls to the right server.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::client::{McpClient, McpClientStatus};
+use super::config::{self, McpServerConfig};
+use super::tool_bridge::{McpToolAnnotations, parse_mcp_tool_name};
+use crate::db::Database;
+use crate::providers::ToolDefinition;
+use crate::tools::ToolEffect;
+
+/// Manager for all MCP server connections.
+///
+/// Owns the set of `McpClient` instances and provides a unified interface
+/// for tool discovery and execution.
+pub struct McpManager {
+    /// Connected (or attempted) clients, keyed by server name.
+    clients: HashMap<String, McpClient>,
+
+    /// Cached tool annotations for classify_tool lookups.
+    /// Keyed by qualified tool name (`server__tool`).
+    annotations: HashMap<String, McpToolAnnotations>,
+}
+
+impl Default for McpManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl McpManager {
+    /// Create an empty manager (no servers configured).
+    pub fn new() -> Self {
+        Self {
+            clients: HashMap::new(),
+            annotations: HashMap::new(),
+        }
+    }
+
+    /// Load configs from the database and connect to all servers in parallel.
+    ///
+    /// Errors from individual servers are logged but don't fail the whole
+    /// startup — the manager connects what it can and reports status.
+    pub async fn start_from_db(db: &Database) -> Result<Self> {
+        let configs = config::load_mcp_configs(db).await?;
+
+        if configs.is_empty() {
+            tracing::debug!("no MCP servers configured");
+            return Ok(Self::new());
+        }
+
+        tracing::info!(
+            count = configs.len(),
+            servers = ?configs.keys().collect::<Vec<_>>(),
+            "starting MCP servers"
+        );
+
+        let mut manager = Self::new();
+        manager.connect_all(configs).await;
+        Ok(manager)
+    }
+
+    /// Connect to all servers in parallel.
+    async fn connect_all(&mut self, configs: HashMap<String, McpServerConfig>) {
+        // Spawn connect tasks in parallel.
+        let handles: Vec<_> = configs
+            .into_iter()
+            .map(|(name, config)| {
+                tokio::spawn(async move {
+                    let mut client = McpClient::new(name.clone(), config);
+                    let result = client.connect().await;
+                    (name, client, result)
+                })
+            })
+            .collect();
+
+        // Collect results.
+        for handle in handles {
+            match handle.await {
+                Ok((name, client, result)) => {
+                    if let Err(e) = &result {
+                        tracing::warn!(
+                            server = %name,
+                            error = %e,
+                            "MCP server failed to connect (non-fatal)"
+                        );
+                    }
+                    // Register tools from successful connections.
+                    for tool in client.tools() {
+                        self.annotations
+                            .insert(tool.definition.name.clone(), tool.annotations.clone());
+                    }
+                    self.clients.insert(name, client);
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "MCP server connect task panicked");
+                }
+            }
+        }
+
+        let connected = self
+            .clients
+            .values()
+            .filter(|c| c.status() == McpClientStatus::Connected)
+            .count();
+        let total = self.clients.len();
+        tracing::info!(connected, total, "MCP server startup complete");
+    }
+
+    /// Get all discovered tool definitions across all connected servers.
+    pub fn all_tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.clients
+            .values()
+            .filter(|c| c.status() == McpClientStatus::Connected)
+            .flat_map(|c| c.tools().iter().map(|t| t.definition.clone()))
+            .collect()
+    }
+
+    /// Classify an MCP tool's effect using cached annotations.
+    pub fn classify_tool(&self, qualified_name: &str) -> ToolEffect {
+        let annotations = self.annotations.get(qualified_name);
+        super::tool_bridge::classify_mcp_tool(annotations)
+    }
+
+    /// Call a tool by its qualified name (`server__tool`).
+    ///
+    /// Parses the name to find the right server, then delegates.
+    pub async fn call_tool(&self, qualified_name: &str, arguments: Value) -> Result<String> {
+        let (server_name, tool_name) = parse_mcp_tool_name(qualified_name)
+            .context("invalid MCP tool name format (expected server__tool)")?;
+
+        let client = self
+            .clients
+            .get(server_name)
+            .context(format!("MCP server '{server_name}' not found"))?;
+
+        if client.status() != McpClientStatus::Connected {
+            anyhow::bail!(
+                "MCP server '{server_name}' is not connected (status: {:?})",
+                client.status()
+            );
+        }
+
+        let result = client.call_tool(tool_name, arguments).await?;
+
+        // Convert CallToolResult content to a string.
+        let output = call_tool_result_to_string(&result);
+
+        // Check for error flag.
+        if result.is_error.unwrap_or(false) {
+            anyhow::bail!("MCP tool error: {output}");
+        }
+
+        Ok(output)
+    }
+
+    /// Check whether a qualified name belongs to a registered MCP tool.
+    pub fn has_tool(&self, qualified_name: &str) -> bool {
+        self.annotations.contains_key(qualified_name)
+    }
+
+    /// Get a summary of all servers and their status.
+    pub fn status_summary(&self) -> Vec<McpServerStatus> {
+        self.clients
+            .values()
+            .map(|c| McpServerStatus {
+                name: c.name().to_string(),
+                status: c.status(),
+                tool_count: c.tools().len(),
+                error: c.last_error().map(String::from),
+            })
+            .collect()
+    }
+
+    /// Disconnect all servers.
+    pub async fn shutdown(&mut self) {
+        for client in self.clients.values_mut() {
+            client.disconnect().await;
+        }
+        self.annotations.clear();
+        tracing::info!("all MCP servers disconnected");
+    }
+
+    /// Is the manager empty (no servers configured)?
+    pub fn is_empty(&self) -> bool {
+        self.clients.is_empty()
+    }
+
+    /// Number of connected servers.
+    pub fn connected_count(&self) -> usize {
+        self.clients
+            .values()
+            .filter(|c| c.status() == McpClientStatus::Connected)
+            .count()
+    }
+}
+
+/// Status summary for a single MCP server.
+#[derive(Debug, Clone)]
+pub struct McpServerStatus {
+    /// Server name.
+    pub name: String,
+    /// Connection status.
+    pub status: McpClientStatus,
+    /// Number of discovered tools.
+    pub tool_count: usize,
+    /// Last error message (if failed).
+    pub error: Option<String>,
+}
+
+/// Convert MCP CallToolResult content into a plain string.
+fn call_tool_result_to_string(result: &rmcp::model::CallToolResult) -> String {
+    let parts: Vec<String> = result
+        .content
+        .iter()
+        .filter_map(|content| match &content.raw {
+            rmcp::model::RawContent::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect();
+
+    if parts.is_empty() {
+        "(no output)".to_string()
+    } else {
+        parts.join("\n")
+    }
+}

--- a/koda-core/src/mcp/mod.rs
+++ b/koda-core/src/mcp/mod.rs
@@ -18,15 +18,16 @@
 //! ## Config storage
 //!
 //! MCP server configs are stored globally in the SQLite `kv_store` table
-//! under the `mcp:` key prefix. Managed via `/mcp add` and `/mcp remove`
-//! slash commands — no config file needed.
+//! under the `mcp:` key prefix. Management UX (`/mcp add`, `/mcp remove`)
+//! is planned for Phase 2 — for now, configs are set programmatically via
+//! `config::save_mcp_config()`.
 //!
 //! ## Design decisions (#662)
 //!
 //! - **Global scope (user-level)** — not per-project. Accepted trade-off.
 //! - **Tool annotations → ToolEffect** — `destructiveHint`/`readOnlyHint`
 //!   map directly to the TrustMode approval matrix.
-//! - **Resources as tools** — LLM-discoverable, no special syntax.
+//! - **Resources** — planned for Phase 3 (not yet implemented).
 
 /// MCP server configuration types and database persistence.
 pub mod config;

--- a/koda-core/src/mcp/mod.rs
+++ b/koda-core/src/mcp/mod.rs
@@ -1,0 +1,47 @@
+//! MCP client — connect to external MCP servers (#662).
+//!
+//! Koda can act as an MCP **client**, discovering and invoking tools exposed
+//! by third-party MCP servers (Playwright, databases, Slack, etc.).
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────┐     stdio/http      ┌──────────────────┐
+//! │  McpManager      │ ◄────────────────► │  MCP Server      │
+//! │  (owns clients)  │                    │  (e.g. Playwright)│
+//! └────────┬────────┘                    └──────────────────┘
+//!          │
+//!    ToolRegistry
+//!    (server__tool naming)
+//! ```
+//!
+//! ## Config storage
+//!
+//! MCP server configs are stored globally in the SQLite `kv_store` table
+//! under the `mcp:` key prefix. Managed via `/mcp add` and `/mcp remove`
+//! slash commands — no config file needed.
+//!
+//! ## Design decisions (#662)
+//!
+//! - **Global scope (user-level)** — not per-project. Accepted trade-off.
+//! - **Tool annotations → ToolEffect** — `destructiveHint`/`readOnlyHint`
+//!   map directly to the TrustMode approval matrix.
+//! - **Resources as tools** — LLM-discoverable, no special syntax.
+
+/// MCP server configuration types and database persistence.
+pub mod config;
+
+/// Single MCP server client — wraps rmcp connection lifecycle.
+pub mod client;
+
+/// Multi-server connection manager — parallel startup, tool discovery.
+pub mod manager;
+
+/// Bridge MCP tools into Koda's ToolRegistry (naming, classification).
+pub mod tool_bridge;
+
+pub use config::McpServerConfig;
+pub use manager::McpManager;
+pub use tool_bridge::{
+    classify_mcp_tool, format_mcp_tool_name, is_mcp_tool_name, parse_mcp_tool_name,
+};

--- a/koda-core/src/mcp/tool_bridge.rs
+++ b/koda-core/src/mcp/tool_bridge.rs
@@ -77,7 +77,7 @@ pub struct McpToolAnnotations {
 
 /// Convert an rmcp Tool into a Koda ToolDefinition.
 ///
-/// The tool name is qualified with the rver name (`server__tool`).
+/// The tool name is qualified with the server name (`server__tool`).
 /// The JSON Schema `properties` field is fixed up if missing (some MCP
 /// servers omit it).
 pub fn mcp_tool_to_definition(

--- a/koda-core/src/mcp/tool_bridge.rs
+++ b/koda-core/src/mcp/tool_bridge.rs
@@ -1,0 +1,214 @@
+//! Bridge between MCP tools and Koda's tool system.
+//!
+//! Handles tool name formatting (`server__tool`), parsing, and mapping
+//! MCP tool annotations to Koda's `ToolEffect` classification.
+
+use crate::providers::ToolDefinition;
+use crate::tools::ToolEffect;
+
+/// Separator between server name and tool name in qualified MCP tool names.
+///
+/// Double underscore avoids ambiguity with single underscores in tool names.
+/// Example: `playwright__navigate`, `github__create_issue`.
+const MCP_SEPARATOR: &str = "__";
+
+/// Format a qualified MCP tool name: `server__tool`.
+pub fn format_mcp_tool_name(server: &str, tool: &str) -> String {
+    format!("{server}{MCP_SEPARATOR}{tool}")
+}
+
+/// Parse a qualified MCP tool name back into `(server, tool)`.
+///
+/// Returns `None` if the name doesn't contain the separator.
+pub fn parse_mcp_tool_name(name: &str) -> Option<(&str, &str)> {
+    // Split on FIRST occurrence of `__` — tool names may contain `__` too.
+    let idx = name.find(MCP_SEPARATOR)?;
+    let server = &name[..idx];
+    let tool = &name[idx + MCP_SEPARATOR.len()..];
+    if server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((server, tool))
+}
+
+/// Check whether a tool name looks like a qualified MCP tool name.
+pub fn is_mcp_tool_name(name: &str) -> bool {
+    parse_mcp_tool_name(name).is_some()
+}
+
+/// Classify an MCP tool's effect using its annotations.
+///
+/// MCP tools declare hints via `ToolAnnotations`:
+/// - `readOnlyHint: true` → `ToolEffect::ReadOnly`
+/// - `destructiveHint: true` → `ToolEffect::Destructive`
+/// - Otherwise → `ToolEffect::RemoteAction` (conservative default — prompts in Safe mode)
+///
+/// This maps directly to the TrustMode approval matrix, so MCP tools
+/// plug into the existing permission system with zero special-casing.
+pub fn classify_mcp_tool(annotations: Option<&McpToolAnnotations>) -> ToolEffect {
+    let Some(ann) = annotations else {
+        // No annotations → conservative default.
+        return ToolEffect::RemoteAction;
+    };
+
+    if ann.read_only_hint == Some(true) {
+        return ToolEffect::ReadOnly;
+    }
+
+    if ann.destructive_hint == Some(true) {
+        return ToolEffect::Destructive;
+    }
+
+    // Has annotations but neither read-only nor destructive.
+    ToolEffect::RemoteAction
+}
+
+/// Subset of MCP ToolAnnotations we care about for classification.
+///
+/// Extracted from `rmcp::model::ToolAnnotations` during tool discovery
+/// so we don't need to hold rmcp types in the tool registry.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct McpToolAnnotations {
+    /// If true, the tool does not modify state.
+    pub read_only_hint: Option<bool>,
+    /// If true, the tool may perform destructive actions.
+    pub destructive_hint: Option<bool>,
+}
+
+/// Convert an rmcp Tool into a Koda ToolDefinition.
+///
+/// The tool name is qualified with the rver name (`server__tool`).
+/// The JSON Schema `properties` field is fixed up if missing (some MCP
+/// servers omit it).
+pub fn mcp_tool_to_definition(
+    server_name: &str,
+    tool: &rmcp::model::Tool,
+) -> (ToolDefinition, McpToolAnnotations) {
+    let qualified_name = format_mcp_tool_name(server_name, &tool.name);
+
+    // Build the parameters JSON Schema.
+    // rmcp gives us the input_schema as a serde_json::Map.
+    let schema_value = serde_json::to_value(&tool.input_schema).unwrap_or_default();
+    let mut params = if schema_value.is_object() {
+        schema_value
+    } else {
+        serde_json::json!({"type": "object", "properties": {}})
+    };
+
+    // Fix up missing `properties` — some MCP servers omit it.
+    if let Some(obj) = params.as_object_mut()
+        && !obj.contains_key("properties")
+    {
+        obj.insert(
+            "properties".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    let description = tool
+        .description
+        .as_deref()
+        .unwrap_or("MCP tool (no description)")
+        .to_string();
+
+    let def = ToolDefinition {
+        name: qualified_name,
+        description: format!("[MCP:{server_name}] {description}"),
+        parameters: params,
+    };
+
+    // Extract annotations.
+    let annotations = tool
+        .annotations
+        .as_ref()
+        .map(|ann| McpToolAnnotations {
+            read_only_hint: ann.read_only_hint,
+            destructive_hint: ann.destructive_hint,
+        })
+        .unwrap_or_default();
+
+    (def, annotations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_and_parse_roundtrip() {
+        let name = format_mcp_tool_name("playwright", "navigate");
+        assert_eq!(name, "playwright__navigate");
+        let (server, tool) = parse_mcp_tool_name(&name).unwrap();
+        assert_eq!(server, "playwright");
+        assert_eq!(tool, "navigate");
+    }
+
+    #[test]
+    fn parse_tool_with_underscores() {
+        let name = format_mcp_tool_name("github", "create_pull_request");
+        assert_eq!(name, "github__create_pull_request");
+        let (server, tool) = parse_mcp_tool_name(&name).unwrap();
+        assert_eq!(server, "github");
+        assert_eq!(tool, "create_pull_request");
+    }
+
+    #[test]
+    fn parse_rejects_no_separator() {
+        assert!(parse_mcp_tool_name("plain_tool").is_none());
+    }
+
+    #[test]
+    fn parse_rejects_empty_parts() {
+        assert!(parse_mcp_tool_name("__tool").is_none());
+        assert!(parse_mcp_tool_name("server__").is_none());
+    }
+
+    #[test]
+    fn is_mcp_tool_name_works() {
+        assert!(is_mcp_tool_name("playwright__navigate"));
+        assert!(!is_mcp_tool_name("Read"));
+        assert!(!is_mcp_tool_name("Bash"));
+    }
+
+    #[test]
+    fn classify_no_annotations() {
+        assert_eq!(classify_mcp_tool(None), ToolEffect::RemoteAction);
+    }
+
+    #[test]
+    fn classify_read_only() {
+        let ann = McpToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: None,
+        };
+        assert_eq!(classify_mcp_tool(Some(&ann)), ToolEffect::ReadOnly);
+    }
+
+    #[test]
+    fn classify_destructive() {
+        let ann = McpToolAnnotations {
+            read_only_hint: None,
+            destructive_hint: Some(true),
+        };
+        assert_eq!(classify_mcp_tool(Some(&ann)), ToolEffect::Destructive);
+    }
+
+    #[test]
+    fn classify_read_only_beats_destructive() {
+        // If both are set, read-only wins (safer interpretation).
+        let ann = McpToolAnnotations {
+            read_only_hint: Some(true),
+            destructive_hint: Some(true),
+        };
+        assert_eq!(classify_mcp_tool(Some(&ann)), ToolEffect::ReadOnly);
+    }
+
+    #[test]
+    fn classify_explicit_false() {
+        let ann = McpToolAnnotations {
+            read_only_hint: Some(false),
+            destructive_hint: Some(false),
+        };
+        assert_eq!(classify_mcp_tool(Some(&ann)), ToolEffect::RemoteAction);
+    }
+}

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -71,6 +71,19 @@ impl KodaSession {
         let provider = providers::create_provider(config);
         // Wire db+session into ToolRegistry for RecallContext
         agent.tools.set_session(Arc::new(db.clone()), id.clone());
+
+        // Start MCP servers from DB config (#662)
+        match crate::mcp::McpManager::start_from_db(&db).await {
+            Ok(manager) => {
+                if !manager.is_empty() {
+                    let mgr = Arc::new(tokio::sync::RwLock::new(manager));
+                    agent.tools.set_mcp_manager(mgr);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to start MCP servers (non-fatal)");
+            }
+        }
         let file_tracker = FileTracker::new(&id, db.clone()).await;
         Self {
             id,

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -73,6 +73,8 @@ impl KodaSession {
         agent.tools.set_session(Arc::new(db.clone()), id.clone());
 
         // Start MCP servers from DB config (#662)
+        // TODO(#662 Phase 2): Move MCP manager to app-level ownership so
+        // servers are shared across sessions and not duplicated on resume.
         match crate::mcp::McpManager::start_from_db(&db).await {
             Ok(manager) => {
                 if !manager.is_empty() {

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -421,7 +421,11 @@ pub(crate) async fn execute_sub_agent(
                     let detail = tools::describe_action(&tc.function_name, &parsed_args);
                     let diff_preview =
                         preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
-                    let effect = crate::trust::resolve_tool_effect(&tc.function_name, &parsed_args);
+                    let effect = crate::trust::resolve_tool_effect_with_registry(
+                        &tc.function_name,
+                        &parsed_args,
+                        &tools,
+                    );
                     match request_approval(
                         sink,
                         cmd_rx,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -571,7 +571,11 @@ pub(crate) async fn execute_tools_sequential(
                 let detail = tools::describe_action(&tc.function_name, &parsed_args);
                 let diff_preview =
                     preview::compute(&tc.function_name, &parsed_args, project_root).await;
-                let effect = crate::trust::resolve_tool_effect(&tc.function_name, &parsed_args);
+                let effect = crate::trust::resolve_tool_effect_with_registry(
+                    &tc.function_name,
+                    &parsed_args,
+                    tools,
+                );
 
                 match request_approval(
                     sink,

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -67,6 +67,9 @@ pub enum ToolEffect {
 /// via [`crate::bash_safety::classify_bash_command`].
 ///
 /// Unknown tools default to `LocalMutation` (conservative — always asks).
+///
+/// For MCP tools (names containing `__`), call [`classify_tool_with_mcp`]
+/// instead to use server-provided annotations.
 pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
@@ -86,6 +89,9 @@ pub fn classify_tool(name: &str) -> ToolEffect {
 
         // Delete is destructive (irreversible without undo)
         "Delete" => ToolEffect::Destructive,
+
+        // MCP tools — use annotations-based classification.
+        name if crate::mcp::is_mcp_tool_name(name) => ToolEffect::RemoteAction,
 
         // Unknown tools — default to LocalMutation (conservative)
         _ => ToolEffect::LocalMutation,
@@ -229,6 +235,9 @@ pub struct ToolRegistry {
     pub bg_registry: bg_process::BgRegistry,
     /// Trust mode — determines sandbox configuration for Bash tool.
     trust: crate::trust::TrustMode,
+    /// MCP connection manager — owns all MCP server connections (#662).
+    /// `None` until attached via `set_mcp_manager()`.
+    mcp_manager: std::sync::RwLock<Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>>,
 }
 
 impl ToolRegistry {
@@ -304,6 +313,7 @@ impl ToolRegistry {
             caps: OutputCaps::for_context(max_context_tokens),
             bg_registry: bg_process::BgRegistry::new(),
             trust,
+            mcp_manager: std::sync::RwLock::new(None),
         }
     }
 
@@ -339,6 +349,47 @@ impl ToolRegistry {
         if let Ok(mut guard) = self.session_id.write() {
             *guard = Some(session_id);
         }
+    }
+
+    /// Attach an MCP connection manager and register its tools (#662).
+    ///
+    /// Called after MCP servers have connected and discovered their tools.
+    /// Tool definitions are merged into the registry so the LLM can see them.
+    pub fn set_mcp_manager(&self, manager: Arc<tokio::sync::RwLock<crate::mcp::McpManager>>) {
+        // We can't await here (set_mcp_manager is sync), so we do a try_read.
+        // The manager should already be connected by the time this is called.
+        if let Ok(mgr) = manager.try_read() {
+            for def in mgr.all_tool_definitions() {
+                // We can't get &mut self, so skip dynamic insert for now.
+                // Tool definitions are returned via get_definitions_with_mcp().
+                let _ = def;
+            }
+        }
+        if let Ok(mut guard) = self.mcp_manager.write() {
+            *guard = Some(manager);
+        }
+    }
+
+    /// Get the MCP manager (if attached).
+    pub fn mcp_manager(&self) -> Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>> {
+        self.mcp_manager.read().ok().and_then(|guard| guard.clone())
+    }
+
+    /// Classify a tool, using MCP annotations when available.
+    ///
+    /// For built-in tools, delegates to `classify_tool()`.
+    /// For MCP tools, looks up cached annotations in the manager.
+    pub fn classify_tool_with_mcp(&self, name: &str) -> ToolEffect {
+        if crate::mcp::is_mcp_tool_name(name) {
+            if let Some(mgr) = self.mcp_manager()
+                && let Ok(mgr) = mgr.try_read()
+            {
+                return mgr.classify_tool(name);
+            }
+            // Fallback: no manager or lock contention.
+            return ToolEffect::RemoteAction;
+        }
+        classify_tool(name)
     }
 
     /// Get all built-in tool names.
@@ -388,12 +439,14 @@ impl ToolRegistry {
 
     /// Get tool definitions, optionally filtered by allow/deny lists.
     ///
+    /// Includes MCP tool definitions if a manager is attached.
+    ///
     /// - `allowed` non-empty → only those tools (allowlist).
     /// - `denied` non-empty → all tools except those (denylist).
     /// - Both empty → all tools.
     /// - If both are specified, allowlist wins (deny is ignored).
     pub fn get_definitions(&self, allowed: &[String], denied: &[String]) -> Vec<ToolDefinition> {
-        if !allowed.is_empty() {
+        let mut defs: Vec<ToolDefinition> = if !allowed.is_empty() {
             allowed
                 .iter()
                 .filter_map(|name| self.definitions.get(name).cloned())
@@ -406,7 +459,34 @@ impl ToolRegistry {
                 .collect()
         } else {
             self.definitions.values().cloned().collect()
+        };
+
+        // Append MCP tool definitions.
+        if let Some(mgr) = self.mcp_manager()
+            && let Ok(mgr) = mgr.try_read()
+        {
+            let mcp_defs = mgr.all_tool_definitions();
+            if !allowed.is_empty() {
+                // Allowlist mode: only include MCP tools in the allowlist.
+                for def in mcp_defs {
+                    if allowed.contains(&def.name) {
+                        defs.push(def);
+                    }
+                }
+            } else if !denied.is_empty() {
+                // Denylist mode: include MCP tools not in the denylist.
+                for def in mcp_defs {
+                    if !denied.contains(&def.name) {
+                        defs.push(def);
+                    }
+                }
+            } else {
+                // No filter: include all MCP tools.
+                defs.extend(mcp_defs);
+            }
         }
+
+        defs
     }
 
     /// Execute a tool by name with the given JSON arguments.
@@ -586,6 +666,37 @@ impl ToolRegistry {
             }
 
             other => {
+                // MCP tool dispatch (#662): route `server__tool` calls
+                // to the appropriate MCP server.
+                if crate::mcp::is_mcp_tool_name(other) {
+                    if let Some(mgr) = self.mcp_manager() {
+                        let result = {
+                            let mgr = mgr.read().await;
+                            mgr.call_tool(other, args.clone()).await
+                        };
+                        return match result {
+                            Ok(output) => ToolResult {
+                                output,
+                                success: true,
+                                full_output: None,
+                            },
+                            Err(e) => ToolResult {
+                                output: format!("Error: {e}"),
+                                success: false,
+                                full_output: None,
+                            },
+                        };
+                    }
+                    return ToolResult {
+                        output: format!(
+                            "MCP tool '{other}' not available — \
+                             no MCP servers connected."
+                        ),
+                        success: false,
+                        full_output: None,
+                    };
+                }
+
                 // Detect garbled tool names (JSON blobs, very long strings)
                 // — a sign the model can't do structured tool calling.
                 let warning = if other.contains('{') || other.len() > 64 {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -68,8 +68,9 @@ pub enum ToolEffect {
 ///
 /// Unknown tools default to `LocalMutation` (conservative — always asks).
 ///
-/// For MCP tools (names containing `__`), call [`classify_tool_with_mcp`]
-/// instead to use server-provided annotations.
+/// For MCP tools (names containing `__`), call
+/// [`ToolRegistry::classify_tool_with_mcp`] instead to use server-provided
+/// annotations.
 pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
@@ -356,15 +357,6 @@ impl ToolRegistry {
     /// Called after MCP servers have connected and discovered their tools.
     /// Tool definitions are merged into the registry so the LLM can see them.
     pub fn set_mcp_manager(&self, manager: Arc<tokio::sync::RwLock<crate::mcp::McpManager>>) {
-        // We can't await here (set_mcp_manager is sync), so we do a try_read.
-        // The manager should already be connected by the time this is called.
-        if let Ok(mgr) = manager.try_read() {
-            for def in mgr.all_tool_definitions() {
-                // We can't get &mut self, so skip dynamic insert for now.
-                // Tool definitions are returned via get_definitions_with_mcp().
-                let _ = def;
-            }
-        }
         if let Ok(mut guard) = self.mcp_manager.write() {
             *guard = Some(manager);
         }

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -288,7 +288,36 @@ pub fn check_tool_with_tracker(
 ///
 /// For Bash, refines the generic `LocalMutation` classification by
 /// parsing the actual command string.
+///
+/// For MCP tools, falls back to `RemoteAction` unless a ToolRegistry
+/// is provided via [`resolve_tool_effect_with_registry`].
 pub fn resolve_tool_effect(tool_name: &str, args: &serde_json::Value) -> ToolEffect {
+    resolve_tool_effect_inner(tool_name, args, None)
+}
+
+/// Like [`resolve_tool_effect`] but uses the ToolRegistry for MCP-aware
+/// classification (#662).
+pub fn resolve_tool_effect_with_registry(
+    tool_name: &str,
+    args: &serde_json::Value,
+    registry: &crate::tools::ToolRegistry,
+) -> ToolEffect {
+    resolve_tool_effect_inner(tool_name, args, Some(registry))
+}
+
+fn resolve_tool_effect_inner(
+    tool_name: &str,
+    args: &serde_json::Value,
+    registry: Option<&crate::tools::ToolRegistry>,
+) -> ToolEffect {
+    // MCP tools: use registry annotations when available.
+    if crate::mcp::is_mcp_tool_name(tool_name) {
+        if let Some(reg) = registry {
+            return reg.classify_tool_with_mcp(tool_name);
+        }
+        return crate::tools::ToolEffect::RemoteAction;
+    }
+
     let base = crate::tools::classify_tool(tool_name);
 
     if tool_name == "Bash" {


### PR DESCRIPTION
## Summary

Add the `koda-core::mcp` module, enabling Koda to connect to third-party MCP servers (Playwright, databases, Slack, etc.) as a client and expose their tools to the LLM.

Closes #662

## What's included

### New module: `koda-core/src/mcp/`

| File | Purpose |
|---|---|
| `mod.rs` | Module root, re-exports |
| `config.rs` | `McpServerConfig` + SQLite persistence |
| `client.rs` | Single server connection lifecycle |
| `manager.rs` | Multi-server parallel startup + routing |
| `tool_bridge.rs` | MCP ↔ Koda type bridging |

### Integration points

- **`tools/mod.rs`** — `ToolRegistry` gains `mcp_manager` field; MCP tools included in `get_definitions()`; MCP tool calls routed in `execute()`; new `classify_tool_with_mcp()`
- **`trust.rs`** — `resolve_tool_effect_with_registry()` uses MCP annotations for trust classification (`readOnlyHint` → ReadOnly, `destructiveHint` → Destructive, default → RemoteAction)
- **`session.rs`** — MCP servers auto-start from DB on session creation (non-fatal on failure)
- **`tool_dispatch.rs` / `sub_agent_dispatch.rs`** — Use registry-aware effect classification

### Dependency

- `rmcp` 1.4 with minimal features: `client` + `transport-child-process` + `base64`

## Design decisions

- **Global scope** — configs stored in `kv_store` under `mcp:` prefix (not per-project)
- **Tool naming** — `server__tool` (double underscore separator)
- **Annotations → TrustMode** — zero special-casing in the approval matrix
- **Conservative defaults** — no annotations → `RemoteAction` (prompts in Safe mode)
- **Parallel startup** — individual server failures don't block others

## Tests

17 new unit tests covering:
- Config validation and serde roundtrip
- Tool filtering (allowlist/denylist)
- Tool name formatting and parsing
- `ToolEffect` classification from MCP annotations

All 898 existing tests continue to pass.

## What's NOT in this PR (future work)

- HTTP/SSE transport (Phase 2)
- `/mcp add|remove|list` slash commands (Phase 2)
- Resource-as-tool bridging (Phase 3)
- Reconnection with backoff (Phase 3)