### PR TITLE
feat(mcp): /mcp slash commands + hot-reload (#855 Phase 2)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -32,6 +32,11 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
     ),
     ("/help", "Show commands and shortcuts", None),
     ("/key", "Manage API keys", None),
+    (
+        "/mcp",
+        "Manage MCP servers (add, remove, list)",
+        Some("[add|remove|list]"),
+    ),
     ("/memory", "View/save project & global memory", None),
     ("/model", "Pick a model (aliases + local)", None),
     ("/provider", "Browse all models from a provider", None),

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) mod tui_app;
 pub(crate) mod tui_commands;
 pub(crate) mod tui_context;
 pub(crate) mod tui_handlers_inference;
+pub(crate) mod tui_mcp;
 pub(crate) mod tui_output;
 pub(crate) mod tui_render;
 pub(crate) mod tui_types;

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -16,6 +16,7 @@ use tokio::sync::RwLock;
 /// Returned by [`handle_command`] and translated into UI-specific
 /// behavior by the TUI event loop (`tui_app.rs`) or the headless runner.
 /// Variants with no data are signals; variants with data carry parsed arguments.
+#[derive(Debug)]
 pub enum ReplAction {
     /// `/exit` — terminate the session.
     Quit,
@@ -79,6 +80,22 @@ pub enum ReplAction {
     /// Without an argument: write to a auto-named file in the current directory.
     /// With a filename: write Markdown to that path.
     Export(Option<String>),
+    /// `/mcp` or `/mcp list` — show MCP server list and status.
+    McpList,
+    /// `/mcp add <name> <command> [args...]` — add a new MCP server.
+    McpAdd {
+        /// Server name (user-chosen identifier).
+        name: String,
+        /// Command to spawn.
+        command: String,
+        /// Arguments for the command.
+        args: Vec<String>,
+    },
+    /// `/mcp remove <name>` — remove an MCP server.
+    McpRemove {
+        /// Server name to remove.
+        name: String,
+    },
 }
 
 /// Parse and handle a slash command. Returns the action for the main loop.
@@ -172,7 +189,56 @@ pub async fn handle_command(
         }
         "/export" => ReplAction::Export(arg.map(|s| s.to_string())),
 
+        "/mcp" => parse_mcp_subcommand(arg),
+
         _ => ReplAction::NotACommand,
+    }
+}
+
+/// Parse `/mcp` subcommands.
+///
+/// Syntax:
+/// - `/mcp` or `/mcp list`       — list servers
+/// - `/mcp add <name> <cmd> [args...]`  — add a server
+/// - `/mcp remove <name>`        — remove a server
+fn parse_mcp_subcommand(arg: Option<&str>) -> ReplAction {
+    let arg = match arg {
+        Some(a) if !a.is_empty() => a,
+        _ => return ReplAction::McpList,
+    };
+
+    let mut tokens = arg.split_whitespace();
+    let sub = tokens.next().unwrap_or("");
+
+    match sub {
+        "list" | "status" => ReplAction::McpList,
+
+        "add" => {
+            let name = match tokens.next() {
+                Some(n) => n.to_string(),
+                None => return ReplAction::McpList, // show usage via list
+            };
+            let command = match tokens.next() {
+                Some(c) => c.to_string(),
+                None => return ReplAction::McpList,
+            };
+            let args: Vec<String> = tokens.map(String::from).collect();
+            ReplAction::McpAdd {
+                name,
+                command,
+                args,
+            }
+        }
+
+        "remove" | "rm" | "delete" => {
+            let name = match tokens.next() {
+                Some(n) => n.to_string(),
+                None => return ReplAction::McpList,
+            };
+            ReplAction::McpRemove { name }
+        }
+
+        _ => ReplAction::McpList,
     }
 }
 
@@ -476,5 +542,89 @@ mod tests {
     fn copy_with_zero_clamps_to_one() {
         // 0 is nonsensical — clamp to 1 via .max(1)
         assert!(matches!(dispatch("/copy 0"), ReplAction::CopyResponse(1)));
+    }
+
+    // ── /mcp parsing ────────────────────────────────────────
+
+    #[test]
+    fn mcp_bare_returns_list() {
+        assert!(matches!(dispatch("/mcp"), ReplAction::McpList));
+    }
+
+    #[test]
+    fn mcp_list_subcommand() {
+        assert!(matches!(dispatch("/mcp list"), ReplAction::McpList));
+        assert!(matches!(dispatch("/mcp status"), ReplAction::McpList));
+    }
+
+    #[test]
+    fn mcp_add_parses_name_and_command() {
+        match dispatch("/mcp add playwright npx -y @anthropic/mcp-playwright") {
+            ReplAction::McpAdd {
+                name,
+                command,
+                args,
+            } => {
+                assert_eq!(name, "playwright");
+                assert_eq!(command, "npx");
+                assert_eq!(args, vec!["-y", "@anthropic/mcp-playwright"]);
+            }
+            other => panic!("expected McpAdd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_add_no_args() {
+        match dispatch("/mcp add mydb node") {
+            ReplAction::McpAdd {
+                name,
+                command,
+                args,
+            } => {
+                assert_eq!(name, "mydb");
+                assert_eq!(command, "node");
+                assert!(args.is_empty());
+            }
+            other => panic!("expected McpAdd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_add_missing_command_shows_list() {
+        // Missing command falls back to list (shows usage)
+        assert!(matches!(
+            dispatch("/mcp add playwright"),
+            ReplAction::McpList
+        ));
+    }
+
+    #[test]
+    fn mcp_add_missing_name_shows_list() {
+        assert!(matches!(dispatch("/mcp add"), ReplAction::McpList));
+    }
+
+    #[test]
+    fn mcp_remove_parses_name() {
+        match dispatch("/mcp remove playwright") {
+            ReplAction::McpRemove { name } => assert_eq!(name, "playwright"),
+            other => panic!("expected McpRemove, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_remove_aliases() {
+        assert!(matches!(
+            dispatch("/mcp rm playwright"),
+            ReplAction::McpRemove { .. }
+        ));
+        assert!(matches!(
+            dispatch("/mcp delete playwright"),
+            ReplAction::McpRemove { .. }
+        ));
+    }
+
+    #[test]
+    fn mcp_unknown_subcommand_shows_list() {
+        assert!(matches!(dispatch("/mcp foobar"), ReplAction::McpList));
     }
 }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -183,6 +183,30 @@ pub async fn handle_slash_command(
             handle_export(buffer, session, dest.as_deref()).await;
             SlashAction::Continue
         }
+        ReplAction::McpList => {
+            crate::tui_mcp::handle_mcp_list(buffer, session, agent).await;
+            SlashAction::Continue
+        }
+        ReplAction::McpAdd {
+            ref name,
+            ref command,
+            ref args,
+        } => {
+            crate::tui_mcp::handle_mcp_add(
+                buffer,
+                session,
+                agent,
+                name.clone(),
+                command.clone(),
+                args.clone(),
+            )
+            .await;
+            SlashAction::Continue
+        }
+        ReplAction::McpRemove { ref name } => {
+            crate::tui_mcp::handle_mcp_remove(buffer, session, agent, name.clone()).await;
+            SlashAction::Continue
+        }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
     }

--- a/koda-cli/src/tui_mcp.rs
+++ b/koda-cli/src/tui_mcp.rs
@@ -1,0 +1,260 @@
+//! MCP server management handlers for `/mcp` slash commands.
+//!
+//! Extracted from [`crate::tui_commands`] to keep file sizes manageable.
+//! All output flows through the [`crate::scroll_buffer::ScrollBuffer`].
+
+use crate::scroll_buffer::ScrollBuffer;
+use crate::tui_output;
+
+use koda_core::agent::KodaAgent;
+use koda_core::mcp::config::{self, McpServerConfig};
+use koda_core::session::KodaSession;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Handle `/mcp list` — show all configured servers and their status.
+pub async fn handle_mcp_list(
+    buffer: &mut ScrollBuffer,
+    session: &KodaSession,
+    agent: &Arc<KodaAgent>,
+) {
+    // Show status from live McpManager (if attached).
+    let live_statuses = get_live_statuses(agent).await;
+
+    // Also load configs from DB for servers that may not be connected.
+    let db_configs = match config::load_mcp_configs(&session.db).await {
+        Ok(c) => c,
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Failed to load MCP configs: {e}"));
+            return;
+        }
+    };
+
+    if db_configs.is_empty() && live_statuses.is_empty() {
+        tui_output::dim_msg(
+            buffer,
+            "No MCP servers configured.\n\
+             \n\
+             Usage:\n  \
+             /mcp add <name> <command> [args...]\n  \
+             /mcp remove <name>\n  \
+             /mcp list\n\
+             \n\
+             Example:\n  \
+             /mcp add playwright npx -y @anthropic/mcp-playwright"
+                .to_string(),
+        );
+        return;
+    }
+
+    let mut lines: Vec<String> = vec!["MCP Servers:".to_string(), String::new()];
+
+    // Merge DB configs with live status.
+    let all_names = {
+        let mut names: Vec<String> = db_configs.keys().cloned().collect();
+        for status in &live_statuses {
+            if !names.contains(&status.name) {
+                names.push(status.name.clone());
+            }
+        }
+        names.sort();
+        names
+    };
+
+    for name in &all_names {
+        let status = live_statuses.iter().find(|s| &s.name == name);
+        let config = db_configs.get(name);
+
+        let status_icon = match status {
+            Some(s) => match s.status {
+                koda_core::mcp::client::McpClientStatus::Connected => "🟢",
+                koda_core::mcp::client::McpClientStatus::Connecting => "🟡",
+                koda_core::mcp::client::McpClientStatus::Failed => "🔴",
+                koda_core::mcp::client::McpClientStatus::Disconnected => "⚪",
+            },
+            None => "⚪",
+        };
+
+        let tools_info = match status {
+            Some(s) if s.tool_count > 0 => format!(" ({} tools)", s.tool_count),
+            _ => String::new(),
+        };
+
+        let cmd_info = match config {
+            Some(c) => {
+                let full = if c.args.is_empty() {
+                    c.command.clone()
+                } else {
+                    format!("{} {}", c.command, c.args.join(" "))
+                };
+                format!("  cmd: {full}")
+            }
+            None => String::new(),
+        };
+
+        let error_info = match status {
+            Some(s) if s.error.is_some() => {
+                format!("  error: {}", s.error.as_deref().unwrap_or(""))
+            }
+            _ => String::new(),
+        };
+
+        lines.push(format!("  {status_icon} {name}{tools_info}"));
+        if !cmd_info.is_empty() {
+            lines.push(cmd_info);
+        }
+        if !error_info.is_empty() {
+            lines.push(error_info);
+        }
+    }
+
+    tui_output::dim_msg(buffer, lines.join("\n"));
+}
+
+/// Handle `/mcp add <name> <command> [args...]`.
+pub async fn handle_mcp_add(
+    buffer: &mut ScrollBuffer,
+    session: &KodaSession,
+    agent: &Arc<KodaAgent>,
+    name: String,
+    command: String,
+    args: Vec<String>,
+) {
+    let config = McpServerConfig {
+        command: command.clone(),
+        args: args.clone(),
+        env: HashMap::new(),
+        cwd: None,
+        startup_timeout_sec: 30,
+        tool_timeout_sec: 120,
+        enabled_tools: None,
+        disabled_tools: None,
+    };
+
+    // Validate first.
+    if let Err(e) = config.validate() {
+        tui_output::err_msg(buffer, format!("Invalid config: {e}"));
+        return;
+    }
+
+    // Save to DB.
+    if let Err(e) = config::save_mcp_config(&session.db, &name, &config).await {
+        tui_output::err_msg(buffer, format!("Failed to save config: {e}"));
+        return;
+    }
+
+    // Hot-reload: connect immediately if we have a manager.
+    let connect_result = try_add_to_live_manager(agent, name.clone(), config).await;
+
+    match connect_result {
+        Some(Ok((tool_count,))) => {
+            let cmd_display = if args.is_empty() {
+                command
+            } else {
+                format!("{command} {}", args.join(" "))
+            };
+            tui_output::ok_msg(
+                buffer,
+                format!(
+                    "MCP server '{name}' added and connected ({tool_count} tools)\n  cmd: {cmd_display}"
+                ),
+            );
+        }
+        Some(Err(e)) => {
+            tui_output::warn_msg(
+                buffer,
+                format!(
+                    "MCP server '{name}' saved but failed to connect: {e}\n\
+                     It will retry on next session start."
+                ),
+            );
+        }
+        None => {
+            tui_output::ok_msg(
+                buffer,
+                format!("MCP server '{name}' saved. Will connect on next session start."),
+            );
+        }
+    }
+}
+
+/// Handle `/mcp remove <name>`.
+pub async fn handle_mcp_remove(
+    buffer: &mut ScrollBuffer,
+    session: &KodaSession,
+    agent: &Arc<KodaAgent>,
+    name: String,
+) {
+    // Check it exists in DB.
+    let exists = match config::list_mcp_server_names(&session.db).await {
+        Ok(names) => names.contains(&name),
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Failed to check MCP configs: {e}"));
+            return;
+        }
+    };
+
+    if !exists {
+        tui_output::err_msg(buffer, format!("MCP server '{name}' not found."));
+        return;
+    }
+
+    // Remove from DB.
+    if let Err(e) = config::remove_mcp_config(&session.db, &name).await {
+        tui_output::err_msg(buffer, format!("Failed to remove config: {e}"));
+        return;
+    }
+
+    // Hot-reload: disconnect if live.
+    let was_live = try_remove_from_live_manager(agent, &name).await;
+
+    let extra = if was_live { " and disconnected" } else { "" };
+    tui_output::ok_msg(buffer, format!("MCP server '{name}' removed{extra}."));
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Get live status summaries from the McpManager (if attached).
+async fn get_live_statuses(
+    agent: &Arc<KodaAgent>,
+) -> Vec<koda_core::mcp::manager::McpServerStatus> {
+    let Some(mgr) = agent.tools.mcp_manager() else {
+        return vec![];
+    };
+    let Ok(mgr) = mgr.try_read() else {
+        return vec![];
+    };
+    mgr.status_summary()
+}
+
+/// Try to add a server to the live McpManager. Returns None if no manager.
+async fn try_add_to_live_manager(
+    agent: &Arc<KodaAgent>,
+    name: String,
+    config: McpServerConfig,
+) -> Option<Result<(usize,), anyhow::Error>> {
+    let mgr = agent.tools.mcp_manager()?;
+    let mut mgr = mgr.write().await;
+    let result = mgr.add_server(name.clone(), config).await;
+    match &result {
+        Ok(()) => {
+            let tool_count = mgr
+                .status_summary()
+                .iter()
+                .find(|s| s.name == name)
+                .map(|s| s.tool_count)
+                .unwrap_or(0);
+            Some(Ok((tool_count,)))
+        }
+        Err(e) => Some(Err(anyhow::anyhow!("{e}"))),
+    }
+}
+
+/// Try to remove a server from the live McpManager. Returns whether it was live.
+async fn try_remove_from_live_manager(agent: &Arc<KodaAgent>, name: &str) -> bool {
+    let Some(mgr) = agent.tools.mcp_manager() else {
+        return false;
+    };
+    let mut mgr = mgr.write().await;
+    mgr.remove_server(name).await
+}

--- a/koda-core/src/mcp/manager.rs
+++ b/koda-core/src/mcp/manager.rs
@@ -188,6 +188,53 @@ impl McpManager {
         tracing::info!("all MCP servers disconnected");
     }
 
+    /// Add a server at runtime (hot-reload).
+    ///
+    /// Connects immediately. If a server with this name already exists,
+    /// it is disconnected first.
+    pub async fn add_server(&mut self, name: String, config: McpServerConfig) -> Result<()> {
+        // Disconnect any existing server with this name.
+        if let Some(mut old) = self.clients.remove(&name) {
+            old.disconnect().await;
+            // Remove stale annotations.
+            self.annotations.retain(|k, _| {
+                parse_mcp_tool_name(k)
+                    .map(|(s, _)| s != name)
+                    .unwrap_or(true)
+            });
+        }
+
+        let mut client = McpClient::new(name.clone(), config);
+        client.connect().await?;
+
+        // Cache annotations for the new tools.
+        for tool in client.tools() {
+            self.annotations
+                .insert(tool.definition.name.clone(), tool.annotations.clone());
+        }
+
+        self.clients.insert(name, client);
+        Ok(())
+    }
+
+    /// Remove and disconnect a server by name.
+    ///
+    /// Returns `true` if a server was found and removed.
+    pub async fn remove_server(&mut self, name: &str) -> bool {
+        if let Some(mut client) = self.clients.remove(name) {
+            client.disconnect().await;
+            self.annotations.retain(|k, _| {
+                parse_mcp_tool_name(k)
+                    .map(|(s, _)| s != name)
+                    .unwrap_or(true)
+            });
+            tracing::info!(server = %name, "MCP server removed");
+            true
+        } else {
+            false
+        }
+    }
+
     /// Is the manager empty (no servers configured)?
     pub fn is_empty(&self) -> bool {
         self.clients.is_empty()

--- a/koda-core/src/mcp/mod.rs
+++ b/koda-core/src/mcp/mod.rs
@@ -18,9 +18,8 @@
 //! ## Config storage
 //!
 //! MCP server configs are stored globally in the SQLite `kv_store` table
-//! under the `mcp:` key prefix. Management UX (`/mcp add`, `/mcp remove`)
-//! is planned for Phase 2 — for now, configs are set programmatically via
-//! `config::save_mcp_config()`.
+//! under the `mcp:` key prefix. Managed via `/mcp add`, `/mcp remove`,
+//! and `/mcp list` slash commands.
 //!
 //! ## Design decisions (#662)
 //!


### PR DESCRIPTION
## Summary

Phase 2 of MCP client support (#855). Adds `/mcp` slash commands so users can actually configure and manage MCP servers at runtime — no restart needed.

## Slash Commands

| Command | Description |
|---------|-------------|
| `/mcp` | List servers + live status |
| `/mcp list` | Same as bare `/mcp` |
| `/mcp add <name> <cmd> [args...]` | Add & connect immediately |
| `/mcp remove <name>` | Disconnect & remove |

### Example

```
/mcp add playwright npx -y @anthropic/mcp-playwright
/mcp add mydb node ./db-server.js --port 5432
/mcp remove playwright
/mcp
```

Output shows live status per server:
```
MCP Servers:

  🟢 playwright (5 tools)
    cmd: npx -y @anthropic/mcp-playwright
  🔴 mydb
    cmd: node ./db-server.js --port 5432
    error: Connection refused
```

## Changes

### koda-core (manager.rs)
- `McpManager::add_server()` — connect a new server at runtime, replaces existing
- `McpManager::remove_server()` — disconnect + clean up annotation cache

### koda-cli
- **tui_mcp.rs** (new, 260 lines) — MCP slash command handlers, extracted to keep tui_commands.rs lean
- **repl.rs** — `parse_mcp_subcommand()` with aliases (`rm`, `delete`, `status`)
- **completer.rs** — `/mcp` in `SLASH_COMMANDS` for tab completion
- **tui_commands.rs** — thin 24-line dispatch to tui_mcp.rs

### Tests
- 9 new unit tests for `/mcp` parsing edge cases (bare, list, add, remove, aliases, missing args)

## Architecture

```
User types /mcp add foo npx bar
       │
  repl.rs::parse_mcp_subcommand()
       │ → ReplAction::McpAdd { name, command, args }
       │
  tui_commands.rs (thin dispatch)
       │
  tui_mcp.rs::handle_mcp_add()
       │
       ├─ config::save_mcp_config(db)     # persist to SQLite
       └─ McpManager::add_server()        # hot-reload: connect now
```

## What's NOT in this PR (Phase 3+)
- HTTP/SSE transport (many remote MCP servers need this)
- MCP Resources
- OAuth authentication
- App-level McpManager (currently session-scoped)
- Status bar indicator

Closes #855 (Phase 2)