### PR TITLE
feat(mcp): HTTP transport + /mcp add-http (#855 Phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "base64",
  "futures-util",
  "glob",
+ "http",
  "ignore",
  "insta",
  "koda-test-utils",
@@ -2988,13 +2989,16 @@ dependencies = [
  "base64",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
  "process-wrap",
+ "reqwest",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3531,6 +3535,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -82,7 +82,7 @@ pub enum ReplAction {
     Export(Option<String>),
     /// `/mcp` or `/mcp list` — show MCP server list and status.
     McpList,
-    /// `/mcp add <name> <command> [args...]` — add a new MCP server.
+    /// `/mcp add <name> <command> [args...]` — add a stdio MCP server.
     McpAdd {
         /// Server name (user-chosen identifier).
         name: String,
@@ -90,6 +90,15 @@ pub enum ReplAction {
         command: String,
         /// Arguments for the command.
         args: Vec<String>,
+    },
+    /// `/mcp add-http <name> <url> [--token <bearer>]` — add an HTTP MCP server.
+    McpAddHttp {
+        /// Server name (user-chosen identifier).
+        name: String,
+        /// Server URL.
+        url: String,
+        /// Optional bearer token.
+        bearer_token: Option<String>,
     },
     /// `/mcp remove <name>` — remove an MCP server.
     McpRemove {
@@ -199,7 +208,8 @@ pub async fn handle_command(
 ///
 /// Syntax:
 /// - `/mcp` or `/mcp list`       — list servers
-/// - `/mcp add <name> <cmd> [args...]`  — add a server
+/// - `/mcp add <name> <cmd> [args...]`  — add a stdio server
+/// - `/mcp add-http <name> <url> [--token <t>]` — add an HTTP server
 /// - `/mcp remove <name>`        — remove a server
 fn parse_mcp_subcommand(arg: Option<&str>) -> ReplAction {
     let arg = match arg {
@@ -230,6 +240,24 @@ fn parse_mcp_subcommand(arg: Option<&str>) -> ReplAction {
             }
         }
 
+        "add-http" | "add_http" => {
+            let name = match tokens.next() {
+                Some(n) => n.to_string(),
+                None => return ReplAction::McpList,
+            };
+            let url = match tokens.next() {
+                Some(u) => u.to_string(),
+                None => return ReplAction::McpList,
+            };
+            // Parse optional --token <value>
+            let bearer_token = parse_optional_flag(&mut tokens, "--token");
+            ReplAction::McpAddHttp {
+                name,
+                url,
+                bearer_token,
+            }
+        }
+
         "remove" | "rm" | "delete" => {
             let name = match tokens.next() {
                 Some(n) => n.to_string(),
@@ -240,6 +268,22 @@ fn parse_mcp_subcommand(arg: Option<&str>) -> ReplAction {
 
         _ => ReplAction::McpList,
     }
+}
+
+/// Parse `--flag <value>` from remaining tokens. Consumes both tokens if found.
+fn parse_optional_flag(tokens: &mut std::str::SplitWhitespace<'_>, flag: &str) -> Option<String> {
+    // Peek: if the next token is the flag, consume it and the value.
+    // Unfortunately SplitWhitespace doesn't support peek, so we collect remaining.
+    // But this is called at the end of parsing so it's fine.
+    let remaining: Vec<&str> = tokens.collect();
+    let mut i = 0;
+    while i < remaining.len() {
+        if remaining[i] == flag && i + 1 < remaining.len() {
+            return Some(remaining[i + 1].to_string());
+        }
+        i += 1;
+    }
+    None
 }
 
 /// Available providers for the interactive picker.
@@ -626,5 +670,60 @@ mod tests {
     #[test]
     fn mcp_unknown_subcommand_shows_list() {
         assert!(matches!(dispatch("/mcp foobar"), ReplAction::McpList));
+    }
+
+    // ── /mcp add-http parsing ─────────────────────────────────
+
+    #[test]
+    fn mcp_add_http_basic() {
+        match dispatch("/mcp add-http myapi http://localhost:8080/mcp") {
+            ReplAction::McpAddHttp {
+                name,
+                url,
+                bearer_token,
+            } => {
+                assert_eq!(name, "myapi");
+                assert_eq!(url, "http://localhost:8080/mcp");
+                assert!(bearer_token.is_none());
+            }
+            other => panic!("expected McpAddHttp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_add_http_with_token() {
+        match dispatch("/mcp add-http myapi http://localhost:8080/mcp --token secret123") {
+            ReplAction::McpAddHttp {
+                name,
+                url,
+                bearer_token,
+            } => {
+                assert_eq!(name, "myapi");
+                assert_eq!(url, "http://localhost:8080/mcp");
+                assert_eq!(bearer_token.as_deref(), Some("secret123"));
+            }
+            other => panic!("expected McpAddHttp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mcp_add_http_underscore_alias() {
+        assert!(matches!(
+            dispatch("/mcp add_http myapi http://example.com"),
+            ReplAction::McpAddHttp { .. }
+        ));
+    }
+
+    #[test]
+    fn mcp_add_http_missing_url_shows_list() {
+        assert!(matches!(
+            dispatch("/mcp add-http myapi"),
+            ReplAction::McpList
+        ));
+    }
+
+    #[test]
+    fn mcp_add_http_missing_name_shows_list() {
+        assert!(matches!(dispatch("/mcp add-http"), ReplAction::McpList));
     }
 }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -207,6 +207,22 @@ pub async fn handle_slash_command(
             crate::tui_mcp::handle_mcp_remove(buffer, session, agent, name.clone()).await;
             SlashAction::Continue
         }
+        ReplAction::McpAddHttp {
+            ref name,
+            ref url,
+            ref bearer_token,
+        } => {
+            crate::tui_mcp::handle_mcp_add_http(
+                buffer,
+                session,
+                agent,
+                name.clone(),
+                url.clone(),
+                bearer_token.clone(),
+            )
+            .await;
+            SlashAction::Continue
+        }
         ReplAction::Handled => SlashAction::Continue,
         ReplAction::NotACommand => SlashAction::Continue,
     }

--- a/koda-cli/src/tui_mcp.rs
+++ b/koda-cli/src/tui_mcp.rs
@@ -7,7 +7,7 @@ use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_output;
 
 use koda_core::agent::KodaAgent;
-use koda_core::mcp::config::{self, McpServerConfig};
+use koda_core::mcp::config::{self, McpServerConfig, McpTransport};
 use koda_core::session::KodaSession;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -37,11 +37,13 @@ pub async fn handle_mcp_list(
              \n\
              Usage:\n  \
              /mcp add <name> <command> [args...]\n  \
+             /mcp add-http <name> <url> [--token <bearer>]\n  \
              /mcp remove <name>\n  \
              /mcp list\n\
              \n\
-             Example:\n  \
-             /mcp add playwright npx -y @anthropic/mcp-playwright"
+             Examples:\n  \
+             /mcp add playwright npx -y @anthropic/mcp-playwright\n  \
+             /mcp add-http myapi http://localhost:8080/mcp --token secret123"
                 .to_string(),
         );
         return;
@@ -81,14 +83,19 @@ pub async fn handle_mcp_list(
         };
 
         let cmd_info = match config {
-            Some(c) => {
-                let full = if c.args.is_empty() {
-                    c.command.clone()
-                } else {
-                    format!("{} {}", c.command, c.args.join(" "))
-                };
-                format!("  cmd: {full}")
-            }
+            Some(c) => match &c.transport {
+                McpTransport::Stdio { command, args, .. } => {
+                    let full = if args.is_empty() {
+                        command.clone()
+                    } else {
+                        format!("{command} {}", args.join(" "))
+                    };
+                    format!("  cmd: {full}")
+                }
+                McpTransport::Http { url, .. } => {
+                    format!("  url: {url}")
+                }
+            },
             None => String::new(),
         };
 
@@ -121,10 +128,12 @@ pub async fn handle_mcp_add(
     args: Vec<String>,
 ) {
     let config = McpServerConfig {
-        command: command.clone(),
-        args: args.clone(),
-        env: HashMap::new(),
-        cwd: None,
+        transport: McpTransport::Stdio {
+            command: command.clone(),
+            args: args.clone(),
+            env: HashMap::new(),
+            cwd: None,
+        },
         startup_timeout_sec: 30,
         tool_timeout_sec: 120,
         enabled_tools: None,
@@ -157,6 +166,74 @@ pub async fn handle_mcp_add(
                 buffer,
                 format!(
                     "MCP server '{name}' added and connected ({tool_count} tools)\n  cmd: {cmd_display}"
+                ),
+            );
+        }
+        Some(Err(e)) => {
+            tui_output::warn_msg(
+                buffer,
+                format!(
+                    "MCP server '{name}' saved but failed to connect: {e}\n\
+                     It will retry on next session start."
+                ),
+            );
+        }
+        None => {
+            tui_output::ok_msg(
+                buffer,
+                format!("MCP server '{name}' saved. Will connect on next session start."),
+            );
+        }
+    }
+}
+
+/// Handle `/mcp add-http <name> <url> [--token <bearer>]`.
+pub async fn handle_mcp_add_http(
+    buffer: &mut ScrollBuffer,
+    session: &KodaSession,
+    agent: &Arc<KodaAgent>,
+    name: String,
+    url: String,
+    bearer_token: Option<String>,
+) {
+    let config = McpServerConfig {
+        transport: McpTransport::Http {
+            url: url.clone(),
+            bearer_token: bearer_token.clone(),
+            headers: HashMap::new(),
+        },
+        startup_timeout_sec: 30,
+        tool_timeout_sec: 120,
+        enabled_tools: None,
+        disabled_tools: None,
+    };
+
+    if let Err(e) = config.validate() {
+        tui_output::err_msg(buffer, format!("Invalid config: {e}"));
+        return;
+    }
+
+    // Persist to DB.
+    if let Err(e) = config::save_mcp_config(&session.db, &name, &config).await {
+        tui_output::err_msg(buffer, format!("Failed to save MCP config: {e}"));
+        return;
+    }
+
+    // Hot-reload: connect immediately if we have a manager.
+    let connect_result = try_add_to_live_manager(agent, name.clone(), config).await;
+
+    let token_hint = if bearer_token.is_some() {
+        " (with auth)"
+    } else {
+        ""
+    };
+
+    match connect_result {
+        Some(Ok((tool_count,))) => {
+            tui_output::ok_msg(
+                buffer,
+                format!(
+                    "MCP server '{name}' added via HTTP and connected ({tool_count} tools)\n  url: {url}{token_hint}"
                 ),
             );
         }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -73,7 +73,11 @@ rmcp = { version = "1.4", default-features = false, features = [
     "client",
     "base64",
     "transport-child-process",
+    "transport-streamable-http-client-reqwest",
 ] }
+
+# HTTP types (HeaderName, HeaderValue) for MCP HTTP transport headers
+http = "1"
 
 # First-party workspace libraries (direct calls)
 

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -1,7 +1,8 @@
 //! Single MCP server client — wraps rmcp connection lifecycle.
 //!
-//! Each `McpClient` owns one connection to one MCP server process.
-//! It handles spawning, initialization, tool discovery, and tool invocation.
+//! Each `McpClient` owns one connection to one MCP server.
+//! It handles spawning (stdio) or connecting (HTTP), initialization,
+//! tool discovery, and tool invocation.
 
 use std::time::Duration;
 
@@ -9,11 +10,12 @@ use anyhow::{Context, Result};
 use rmcp::ServiceExt;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::RunningService;
+use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::transport::child_process::TokioChildProcess;
 use serde_json::Value;
 use tokio::process::Command;
 
-use super::config::McpServerConfig;
+use super::config::{McpServerConfig, McpTransport};
 use super::tool_bridge::McpToolAnnotations;
 use crate::providers::ToolDefinition;
 
@@ -92,8 +94,7 @@ impl McpClient {
 
     /// Connect to the MCP server, initialize, and discover tools.
     ///
-    /// Spawns the server process via stdio transport, performs the MCP
-    /// handshake, and fetches the tool list.
+    /// Dispatches to stdio or HTTP transport based on config.
     pub async fn connect(&mut self) -> Result<()> {
         self.status = McpClientStatus::Connecting;
         self.last_error = None;
@@ -102,9 +103,14 @@ impl McpClient {
 
         match tokio::time::timeout(timeout, self.connect_inner()).await {
             Ok(Ok(())) => {
+                let transport_label = match &self.config.transport {
+                    McpTransport::Stdio { .. } => "stdio",
+                    McpTransport::Http { .. } => "http",
+                };
                 self.status = McpClientStatus::Connected;
                 tracing::info!(
                     server = %self.name,
+                    transport = transport_label,
                     tools = self.tools.len(),
                     "MCP server connected"
                 );
@@ -133,35 +139,89 @@ impl McpClient {
         }
     }
 
-    /// Inner connect logic (without timeout wrapper).
+    /// Inner connect logic — dispatches to the right transport.
     async fn connect_inner(&mut self) -> Result<()> {
-        // Build the command to spawn.
-        let mut cmd = Command::new(&self.config.command);
-        cmd.args(&self.config.args);
+        // Clone transport to avoid borrowing self.config while calling &mut self methods.
+        let transport = self.config.transport.clone();
+        match transport {
+            McpTransport::Stdio {
+                ref command,
+                ref args,
+                ref env,
+                ref cwd,
+            } => self.connect_stdio(command, args, env, cwd.as_deref()).await,
+            McpTransport::Http {
+                ref url,
+                ref bearer_token,
+                ref headers,
+            } => {
+                self.connect_http(url, bearer_token.as_deref(), headers)
+                    .await
+            }
+        }
+    }
 
-        // Set environment variables.
-        for (key, val) in &self.config.env {
+    /// Connect via stdio transport (spawn child process).
+    async fn connect_stdio(
+        &mut self,
+        command: &str,
+        args: &[String],
+        env: &std::collections::HashMap<String, String>,
+        cwd: Option<&str>,
+    ) -> Result<()> {
+        let mut cmd = Command::new(command);
+        cmd.args(args);
+        for (key, val) in env {
             cmd.env(key, val);
         }
-
-        // Set working directory if specified.
-        if let Some(ref cwd) = self.config.cwd {
+        if let Some(cwd) = cwd {
             cmd.current_dir(cwd);
         }
 
-        // Spawn via stdio transport.
         let transport =
             TokioChildProcess::new(cmd).context("failed to spawn MCP server process")?;
-
-        // Connect and initialize as a client.
         let service = ().serve(transport).await.context("MCP handshake failed")?;
-
         self.service = Some(service);
+        self.discover_tools().await
+    }
 
-        // Discover tools.
-        self.discover_tools().await?;
+    /// Connect via Streamable HTTP transport.
+    async fn connect_http(
+        &mut self,
+        url: &str,
+        bearer_token: Option<&str>,
+        headers: &std::collections::HashMap<String, String>,
+    ) -> Result<()> {
+        use http::{HeaderName, HeaderValue};
+        use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 
-        Ok(())
+        let mut config = StreamableHttpClientTransportConfig::with_uri(url);
+
+        // Set bearer token.
+        if let Some(token) = bearer_token {
+            config.auth_header = Some(format!("Bearer {token}"));
+        }
+
+        // Set custom headers.
+        if !headers.is_empty() {
+            let mut header_map = std::collections::HashMap::new();
+            for (k, v) in headers {
+                let name = HeaderName::try_from(k.as_str())
+                    .with_context(|| format!("invalid HTTP header name: {k}"))?;
+                let value = HeaderValue::try_from(v.as_str())
+                    .with_context(|| format!("invalid HTTP header value for {k}"))?;
+                header_map.insert(name, value);
+            }
+            config.custom_headers = header_map;
+        }
+
+        // Enable session recovery for remote servers.
+        config.reinit_on_expired_session = true;
+
+        let transport = StreamableHttpClientTransport::from_config(config);
+        let service = ().serve(transport).await.context("MCP HTTP handshake failed")?;
+        self.service = Some(service);
+        self.discover_tools().await
     }
 
     /// Fetch the tool list from the connected server.

--- a/koda-core/src/mcp/config.rs
+++ b/koda-core/src/mcp/config.rs
@@ -19,29 +19,47 @@ const DEFAULT_STARTUP_TIMEOUT_SEC: u64 = 30;
 /// Default timeout (seconds) for individual tool calls.
 const DEFAULT_TOOL_TIMEOUT_SEC: u64 = 120;
 
+/// Transport type for connecting to an MCP server.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "transport", rename_all = "snake_case")]
+pub enum McpTransport {
+    /// Spawn a child process and communicate over stdin/stdout.
+    Stdio {
+        /// Command to spawn.
+        command: String,
+        /// Arguments passed to the command.
+        #[serde(default)]
+        args: Vec<String>,
+        /// Additional environment variables for the server process.
+        #[serde(default)]
+        env: HashMap<String, String>,
+        /// Working directory for the server process.
+        #[serde(default)]
+        cwd: Option<String>,
+    },
+    /// Connect via Streamable HTTP (MCP 2025-03-26 spec).
+    Http {
+        /// Server URL (e.g. `http://localhost:8080/mcp`).
+        url: String,
+        /// Optional bearer token for `Authorization: Bearer <token>`.
+        #[serde(default)]
+        bearer_token: Option<String>,
+        /// Custom HTTP headers included with every request.
+        #[serde(default)]
+        headers: HashMap<String, String>,
+    },
+}
+
 /// Configuration for a single MCP server.
 ///
-/// Supports stdio transport (command + args) for v1.
-/// HTTP transport (`url` field) is reserved for v2.
+/// Supports stdio and HTTP (Streamable HTTP) transports.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct McpServerConfig {
-    // ── Stdio transport ───────────────────────────────────────────────
-    /// Command to spawn the MCP server process.
-    pub command: String,
+    /// Transport configuration.
+    #[serde(flatten)]
+    pub transport: McpTransport,
 
-    /// Arguments passed to the command.
-    #[serde(default)]
-    pub args: Vec<String>,
-
-    /// Additional environment variables for the server process.
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-
-    /// Working directory for the server process.
-    #[serde(default)]
-    pub cwd: Option<String>,
-
-    // ── Timeouts ──────────────────────────────────────────────────────
+    // ── Timeouts ───────────────────────────────────────────────────────
     /// Seconds to wait for the server to start and respond to `initialize`.
     #[serde(default = "default_startup_timeout")]
     pub startup_timeout_sec: u64,
@@ -71,8 +89,17 @@ fn default_tool_timeout() -> u64 {
 impl McpServerConfig {
     /// Validate the config. Returns an error if essential fields are missing.
     pub fn validate(&self) -> Result<()> {
-        if self.command.trim().is_empty() {
-            anyhow::bail!("MCP server config must specify a `command`");
+        match &self.transport {
+            McpTransport::Stdio { command, .. } => {
+                if command.trim().is_empty() {
+                    anyhow::bail!("MCP server config must specify a `command`");
+                }
+            }
+            McpTransport::Http { url, .. } => {
+                if url.trim().is_empty() {
+                    anyhow::bail!("MCP server config must specify a `url`");
+                }
+            }
         }
         Ok(())
     }
@@ -159,48 +186,61 @@ pub async fn list_mcp_server_names(db: &Database) -> Result<Vec<String>> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn validate_rejects_empty_command() {
-        let config = McpServerConfig {
-            command: "".into(),
-            args: vec![],
-            env: HashMap::new(),
-            cwd: None,
+    /// Helper: build a stdio config with defaults.
+    fn stdio_config(command: &str) -> McpServerConfig {
+        McpServerConfig {
+            transport: McpTransport::Stdio {
+                command: command.into(),
+                args: vec![],
+                env: HashMap::new(),
+                cwd: None,
+            },
             startup_timeout_sec: 30,
             tool_timeout_sec: 120,
             enabled_tools: None,
             disabled_tools: None,
-        };
-        assert!(config.validate().is_err());
+        }
+    }
+
+    /// Helper: build an HTTP config with defaults.
+    fn http_config(url: &str) -> McpServerConfig {
+        McpServerConfig {
+            transport: McpTransport::Http {
+                url: url.into(),
+                bearer_token: None,
+                headers: HashMap::new(),
+            },
+            startup_timeout_sec: 30,
+            tool_timeout_sec: 120,
+            enabled_tools: None,
+            disabled_tools: None,
+        }
     }
 
     #[test]
-    fn validate_accepts_valid_config() {
-        let config = McpServerConfig {
-            command: "npx".into(),
-            args: vec!["-y".into(), "@anthropic/mcp-playwright".into()],
-            env: HashMap::new(),
-            cwd: None,
-            startup_timeout_sec: 30,
-            tool_timeout_sec: 120,
-            enabled_tools: None,
-            disabled_tools: None,
-        };
-        assert!(config.validate().is_ok());
+    fn validate_rejects_empty_command() {
+        assert!(stdio_config("").validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_url() {
+        assert!(http_config("").validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_valid_stdio_config() {
+        assert!(stdio_config("npx").validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_valid_http_config() {
+        assert!(http_config("http://localhost:8080/mcp").validate().is_ok());
     }
 
     #[test]
     fn tool_filter_allowlist() {
-        let config = McpServerConfig {
-            command: "test".into(),
-            args: vec![],
-            env: HashMap::new(),
-            cwd: None,
-            startup_timeout_sec: 30,
-            tool_timeout_sec: 120,
-            enabled_tools: Some(vec!["navigate".into(), "click".into()]),
-            disabled_tools: None,
-        };
+        let mut config = stdio_config("test");
+        config.enabled_tools = Some(vec!["navigate".into(), "click".into()]);
         assert!(config.is_tool_allowed("navigate"));
         assert!(config.is_tool_allowed("click"));
         assert!(!config.is_tool_allowed("screenshot"));
@@ -208,43 +248,30 @@ mod tests {
 
     #[test]
     fn tool_filter_denylist() {
-        let config = McpServerConfig {
-            command: "test".into(),
-            args: vec![],
-            env: HashMap::new(),
-            cwd: None,
-            startup_timeout_sec: 30,
-            tool_timeout_sec: 120,
-            enabled_tools: None,
-            disabled_tools: Some(vec!["dangerous_tool".into()]),
-        };
+        let mut config = stdio_config("test");
+        config.disabled_tools = Some(vec!["dangerous_tool".into()]);
         assert!(config.is_tool_allowed("navigate"));
         assert!(!config.is_tool_allowed("dangerous_tool"));
     }
 
     #[test]
     fn tool_filter_allowlist_beats_denylist() {
-        let config = McpServerConfig {
-            command: "test".into(),
-            args: vec![],
-            env: HashMap::new(),
-            cwd: None,
-            startup_timeout_sec: 30,
-            tool_timeout_sec: 120,
-            enabled_tools: Some(vec!["safe".into()]),
-            disabled_tools: Some(vec!["safe".into()]), // contradicts — allowlist wins
-        };
+        let mut config = stdio_config("test");
+        config.enabled_tools = Some(vec!["safe".into()]);
+        config.disabled_tools = Some(vec!["safe".into()]); // contradicts — allowlist wins
         assert!(config.is_tool_allowed("safe"));
         assert!(!config.is_tool_allowed("other"));
     }
 
     #[test]
-    fn roundtrip_serde() {
+    fn roundtrip_serde_stdio() {
         let config = McpServerConfig {
-            command: "npx".into(),
-            args: vec!["-y".into(), "playwright-mcp".into()],
-            env: HashMap::from([("FOO".into(), "bar".into())]),
-            cwd: Some("/tmp".into()),
+            transport: McpTransport::Stdio {
+                command: "npx".into(),
+                args: vec!["-y".into(), "playwright-mcp".into()],
+                env: HashMap::from([("FOO".into(), "bar".into())]),
+                cwd: Some("/tmp".into()),
+            },
             startup_timeout_sec: 10,
             tool_timeout_sec: 60,
             enabled_tools: Some(vec!["navigate".into()]),
@@ -256,12 +283,37 @@ mod tests {
     }
 
     #[test]
-    fn serde_defaults_applied() {
-        let json = r#"{"command": "npx", "args": ["-y", "test"]}"#;
+    fn roundtrip_serde_http() {
+        let config = McpServerConfig {
+            transport: McpTransport::Http {
+                url: "http://localhost:8080/mcp".into(),
+                bearer_token: Some("my-secret".into()),
+                headers: HashMap::from([("X-Custom".into(), "value".into())]),
+            },
+            startup_timeout_sec: 15,
+            tool_timeout_sec: 90,
+            enabled_tools: None,
+            disabled_tools: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: McpServerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, parsed);
+    }
+
+    #[test]
+    fn serde_defaults_applied_stdio() {
+        let json = r#"{"transport": "stdio", "command": "npx", "args": ["-y", "test"]}"#;
         let config: McpServerConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.startup_timeout_sec, 30);
         assert_eq!(config.tool_timeout_sec, 120);
-        assert!(config.env.is_empty());
         assert!(config.enabled_tools.is_none());
+    }
+
+    #[test]
+    fn serde_defaults_applied_http() {
+        let json = r#"{"transport": "http", "url": "http://localhost:8080/mcp"}"#;
+        let config: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.startup_timeout_sec, 30);
+        assert!(matches!(config.transport, McpTransport::Http { .. }));
     }
 }

--- a/koda-core/src/mcp/mod.rs
+++ b/koda-core/src/mcp/mod.rs
@@ -18,8 +18,10 @@
 //! ## Config storage
 //!
 //! MCP server configs are stored globally in the SQLite `kv_store` table
-//! under the `mcp:` key prefix. Managed via `/mcp add`, `/mcp remove`,
-//! and `/mcp list` slash commands.
+//! under the `mcp:` key prefix. Managed via `/mcp add`, `/mcp add-http`,
+//! `/mcp remove`, and `/mcp list` slash commands.
+//!
+//! Supports both stdio (child process) and HTTP (Streamable HTTP) transports.
 //!
 //! ## Design decisions (#662)
 //!


### PR DESCRIPTION
## Summary

Phase 3 of MCP client support (#855). Adds **Streamable HTTP transport** so users can connect to remote MCP servers — not just local stdio processes.

## What's New

### New Slash Command
```
/mcp add-http <name> <url> [--token <bearer>]
```

### Examples
```
/mcp add-http myapi http://localhost:8080/mcp
/mcp add-http secure https://mcp.example.com --token secret123
/mcp
```

Output:
```
MCP Servers:

  🟢 myapi (12 tools)
    url: http://localhost:8080/mcp
  🟢 secure (5 tools)
    url: https://mcp.example.com
  🟢 playwright (5 tools)
    cmd: npx -y @anthropic/mcp-playwright
```

## Architecture

### McpTransport enum (new)
```rust
enum McpTransport {
    Stdio { command, args, env, cwd },
    Http  { url, bearer_token, headers },
}
```

### Transport dispatch
```
McpClient::connect()
    ├── Stdio → TokioChildProcess (existing)
    └── Http  → StreamableHttpClientTransport (new)
                 ├── Bearer auth support
                 ├── Custom headers
                 └── Session recovery (reinit_on_expired_session)
```

## Changes

### koda-core
- **Cargo.toml**: Added `transport-streamable-http-client-reqwest` feature + `http` crate
- **config.rs**: `McpTransport` enum with `#[serde(tag = "transport")]` + updated validation
- **client.rs**: `connect_http()` method using `StreamableHttpClientTransport`
- **mod.rs**: Updated docs

### koda-cli
- **repl.rs**: `McpAddHttp` variant + `parse_optional_flag()` for `--token`
- **tui_commands.rs**: Dispatch for `McpAddHttp`
- **tui_mcp.rs**: `handle_mcp_add_http()` + updated list display (`url:` vs `cmd:`)

### Tests
- 5 new `/mcp add-http` parsing tests
- 4 new config tests (HTTP validate, roundtrip serde, defaults)
- All existing tests updated for `McpTransport` enum
- 902 koda-core + 309 koda-cli tests pass

## Backward Compatibility

Existing stdio configs stored in the DB use the old flat format. The new tagged enum (`"transport": "stdio"`) is used for new configs. Old configs will fail to deserialize — users should re-add their servers with `/mcp add`. This is acceptable since MCP support is new and no one has production configs yet.

Closes #855 (Phase 3)