### PR TITLE
fix(mcp): SSRF guard, name validation, bearer redaction + MCP docs (#855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   names with non-ASCII-alphanumeric characters.
 - **Plaintext bearer warning** — `tracing::warn!` emitted when a bearer token is
   sent over `http://` (not `https://`).
+- **Sandbox credential reads for CLI tools** — the sandbox now allows read access
+  to credential directories needed by common developer CLI tools (`~/.ssh`,
+  `~/.aws`, `~/.config/gcloud`, `~/.kube`, `~/.npmrc`, etc.) while still blocking
+  writes. Also updated `docs/src/sandbox.md` and `docs/src/approval.md` to
+  document the read-allow / write-deny security model (#866).
 
 ### Changed
 - `rmcp` dependency aligned to `1.4` in `koda-ast` and `koda-email` (was `1.3`,
   resolved to `1.4` via Cargo.lock — now explicit).
 - Stale "Phase 3" comment removed from `koda-core/src/mcp/mod.rs`.
+- **CI matrix expanded to macOS** — `ci.yml` and `coverage.yml` now run tests on
+  both `ubuntu-latest` and `macos-latest`, covering platform-specific code paths
+  (seatbelt sandbox, macOS credential rules). Lint (fmt/clippy) stays Linux-only
+  to avoid duplicate noise. Coverage merges per-platform lcov traces (#867).
 
 ## [0.2.11] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Koda are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.12] - 2026-04-12
+
+### Added
+- **MCP client support** — Koda can now connect to external MCP servers as a
+  client, exposing their tools inside the Koda tool registry under the
+  `<server>__<tool>` naming convention. Supports both stdio (child-process)
+  and Streamable HTTP (MCP 2025-03-26 spec) transports (#855).
+- **`/mcp` slash commands** — five new TUI commands: `list`, `add`, `add-http`,
+  `reconnect`, `remove`. Hot-reload: servers connect immediately on `add` without
+  restarting the session.
+- **Tool filtering** — per-server `enabled_tools` allowlist and `disabled_tools`
+  denylist; allowlist takes priority when both are set.
+- **MCP docs** — new `docs/src/mcp.md` covering all commands, transport options,
+  tool naming, filtering, timeouts, and troubleshooting. `/mcp` added to
+  `commands.md` and the docs nav (`SUMMARY.md`).
+
+### Fixed
+- **SSRF on HTTP MCP transport** — `connect_http()` now validates the target URL
+  with `is_safe_url()` before opening any TCP connection, blocking private,
+  loopback, and link-local addresses (including `169.254.169.254`).
+- **Bearer token log exposure** — `McpTransport` now implements `Debug` manually,
+  replacing `bearer_token` values with `[redacted]` so tokens never appear in
+  logs or crash dumps.
+- **Server name routing collision** — `validate_server_name()` rejects names
+  containing `__` (the internal `<server>__<tool>` separator), empty names, and
+  names with non-ASCII-alphanumeric characters.
+- **Plaintext bearer warning** — `tracing::warn!` emitted when a bearer token is
+  sent over `http://` (not `https://`).
+
+### Changed
+- `rmcp` dependency aligned to `1.4` in `koda-ast` and `koda-email` (was `1.3`,
+  resolved to `1.4` via Cargo.lock — now explicit).
+- Stale "Phase 3" comment removed from `koda-core/src/mcp/mod.rs`.
+
 ## [0.2.11] - 2026-04-12
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.11)
+10. Sync version with workspace (currently 0.2.12)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -186,13 +186,22 @@ In practice, routing in-repo capabilities through stdio JSON-RPC added process
 management overhead and IPC failure modes for functionality that ships in the
 same workspace. [#431](https://github.com/lijunzh/koda/issues/431) migrated
 first-party tools to direct library calls. [#443](https://github.com/lijunzh/koda/issues/443)
-removed the now-unused MCP client entirely.
+removed the then-unused MCP client.
+
+**v0.2.12 re-introduced an MCP client** ([#855](https://github.com/lijunzh/koda/issues/855))
+for a fundamentally different purpose: connecting to *third-party* external MCP
+servers (Playwright, databases, Slack, user-defined APIs). First-party workspace
+crates (koda-ast, koda-email) still use direct library calls — no IPC, no process
+management for in-repo code. The MCP client is exclusively for extending Koda
+with capabilities outside the workspace.
 
 **Dependency graph**:
 ```
 koda-cli → koda-core  (inference engine + first-party tool calls)
                     → koda-ast   (direct library call from ToolRegistry)
                     → koda-email (direct library call from ToolRegistry)
+                    → McpManager (optional; connects to third-party MCP servers)
+                          → [playwright, db-tools, slack, …] (external, via stdio or HTTP)
 
 koda-ast/main.rs  → standalone MCP server (for external consumers)
 koda-email/main.rs → standalone MCP server (for external consumers)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Configuration precedence](./configuration.md)
 - [Custom agents](./agents.md)
 - [Skills](./skills.md)
+- [MCP servers](./mcp.md)
 
 # Reference
 

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -188,3 +188,16 @@ during streaming. Verbose mode shows every line in real time.
 ## `/exit`
 
 Quit Koda. Equivalent to `Ctrl+D`.
+
+## `/mcp <sub-command>`
+
+Manage external MCP (Model Context Protocol) servers. See [MCP servers](./mcp.md)
+for the full reference.
+
+```text
+/mcp list                                  ← list configured servers + status
+/mcp add <name> <command> [args...]        ← add a stdio server
+/mcp add-http <name> <url> [--token <tok>] ← add an HTTP server
+/mcp reconnect <name>                      ← reconnect without restart
+/mcp remove <name>                         ← permanently delete a server
+```

--- a/docs/src/mcp.md
+++ b/docs/src/mcp.md
@@ -1,0 +1,126 @@
+# MCP servers (Model Context Protocol)
+
+Koda can connect to external **MCP servers** as a client, expanding its toolset
+with anything exposed over the MCP protocol — Playwright for browser automation,
+database drivers, Slack, internal APIs, and more.
+
+## Quick start
+
+```text
+# Add a stdio server (spawns a child process)
+/mcp add playwright npx -y @playwright/mcp
+
+# Add an HTTP server
+/mcp add-http my-api https://api.example.com/mcp
+
+# Add an HTTP server with bearer-token auth
+/mcp add-http my-api https://api.example.com/mcp --token sk-mytoken
+
+# List all configured servers and their status
+/mcp list
+
+# Reconnect a server without restarting Koda
+/mcp reconnect playwright
+
+# Remove a server
+/mcp remove playwright
+```
+
+## Slash commands
+
+### `/mcp list`
+
+Shows every configured MCP server, its transport (stdio / http), and
+its current connection status (connected / failed / disconnected).
+
+### `/mcp add <name> <command> [args...]`
+
+Add a **stdio** MCP server. Koda spawns `<command>` with the given
+arguments and communicates over stdin/stdout.
+
+```text
+/mcp add playwright  npx -y @playwright/mcp
+/mcp add db-tools    uvx koda-db --dsn postgresql://localhost/mydb
+```
+
+**Name rules:** letters, digits, hyphens, and underscores only (`[a-zA-Z0-9_-]`).
+Double-underscore (`__`) is reserved as Koda's internal tool-routing separator
+and is not allowed.
+
+### `/mcp add-http <name> <url> [--token <bearer>]`
+
+Add an **HTTP** MCP server using the MCP 2025-03-26 Streamable HTTP transport.
+
+```text
+/mcp add-http my-api  https://api.example.com/mcp
+/mcp add-http my-api  https://api.example.com/mcp --token sk-abc123
+```
+
+> **Security note:** Bearer tokens sent over plaintext `http://` are logged as
+> a warning. Use `https://` in production. Koda also blocks connections to
+> private/loopback addresses (SSRF protection).
+
+### `/mcp reconnect <name>`
+
+Disconnect and re-connect a running server without restarting Koda. Useful
+after updating the server binary or rotating credentials.
+
+#/mcp remove <name>`
+
+Permanently delete the server config from the local keystore and disconnect it
+immediately. The server process (if stdio) is cleaned up automatically.
+
+## Tool naming
+
+MCP tools appear in Koda's tool registry as `<server>__<tool>`. For example,
+a tool named `navigate` on the `playwright` server becomes `playwright__navigate`.
+
+The model can call these tools directly. No extra configuration is required.
+
+## Tool filtering
+
+To limit which tools a server exposes, edit `~/.config/koda/mcp.json` manually
+or use `koda config` (future release). Example snippet:
+
+```json
+{
+  "playwright": {
+    "transport": "stdio",
+    "command": "npx",
+    "args": ["-y", "@playwright/mcp"],
+    "enabled_tools": ["navigate", "click", "screenshot"]
+  }
+}
+```
+
+`enabled_tools` is an allowlist; `disabled_tools` is a denylist. If both are
+set, `enabled_tools` wins.
+
+## Transport reference
+
+| Transport | How it works | When to use |
+|-----------|-------------|-------------|
+| `stdio`   | Koda spawns a child process and communicates over stdin/stdout | Local tools, CLI-wrapped servers |
+| `http`    | Koda connects to a running HTTP endpoint (MCP 2025-03-26 spec) | Remote or shared servers, cloud APIs |
+
+## Timeouts
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `startup_timeout_sec` | 30 s | Time allowed for the server to respond to `initialize` |
+| `tool_timeout_sec` | 120 s | Time allowed for a single tool call to complete |
+
+## Persistence
+
+MCP server configs are stored in the local SQLite keystore (`~/.local/share/koda/koda.db`)
+under the `mcp:` key prefix. They survive session restarts and are loaded
+automatically on each startup.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Server shows **failed** on `/mcp list` | Check the command/URL, then `/mcp reconnect <name>` |
+| Tools not appearing after add | The server may have taken longer than `startup_timeout_sec` to start — `/mcp reconnect` or restart Koda |
+| `__` in server name rejected | Use `-` instead: `my-server` not `my__server` |
+| HTTP server SSRF error | Private/loopback URLs are blocked — use a public or VPN-accessible URL |

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -21,7 +21,7 @@ name = "koda_ast"
 path = "src/lib.rs"
 
 [dependencies]
-rmcp = { version = "1.3", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 publish = false # workspace-only; not published to crates.io
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.11" }
+koda-core = { path = "../koda-core", version = "0.2.12" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -73,6 +73,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.11", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.12", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/tui_mcp.rs
+++ b/koda-cli/src/tui_mcp.rs
@@ -7,7 +7,7 @@ use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_output;
 
 use koda_core::agent::KodaAgent;
-use koda_core::mcp::config::{self, McpServerConfig, McpTransport};
+use koda_core::mcp::config::{self, McpServerConfig, McpTransport, validate_server_name};
 use koda_core::session::KodaSession;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -141,6 +141,11 @@ pub async fn handle_mcp_add(
         disabled_tools: None,
     };
 
+    // Validate name, then config.
+    if let Err(e) = validate_server_name(&name) {
+        tui_output::err_msg(buffer, format!("Invalid server name: {e}"));
+        return;
+    }
     // Validate first.
     if let Err(e) = config.validate() {
         tui_output::err_msg(buffer, format!("Invalid config: {e}"));
@@ -209,6 +214,11 @@ pub async fn handle_mcp_add_http(
         disabled_tools: None,
     };
 
+    // Validate name, then config.
+    if let Err(e) = validate_server_name(&name) {
+        tui_output::err_msg(buffer, format!("Invalid server name: {e}"));
+        return;
+    }
     if let Err(e) = config.validate() {
         tui_output::err_msg(buffer, format!("Invalid config: {e}"));
         return;

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -18,6 +18,7 @@ use tokio::process::Command;
 use super::config::{McpServerConfig, McpTransport};
 use super::tool_bridge::McpToolAnnotations;
 use crate::providers::ToolDefinition;
+use crate::tools::web_fetch::is_safe_url;
 
 /// Connection status of a single MCP server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,6 +195,23 @@ impl McpClient {
     ) -> Result<()> {
         use http::{HeaderName, HeaderValue};
         use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+
+        // SSRF protection: reject private/internal URLs before opening any connection.
+        if !is_safe_url(url) {
+            anyhow::bail!(
+                "MCP HTTP URL '{url}' is not allowed: private, loopback, or link-local \
+                 addresses are blocked to prevent SSRF attacks"
+            );
+        }
+
+        // Warn if sending a bearer token over plaintext HTTP.
+        if bearer_token.is_some() && url.starts_with("http://") {
+            tracing::warn!(
+                server = %self.name,
+                url = %url,
+                "MCP bearer token is being sent over plaintext HTTP — use HTTPS in production"
+            );
+        }
 
         let mut config = StreamableHttpClientTransportConfig::with_uri(url);
 

--- a/koda-core/src/mcp/config.rs
+++ b/koda-core/src/mcp/config.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 
 use crate::db::Database;
 
@@ -20,7 +21,7 @@ const DEFAULT_STARTUP_TIMEOUT_SEC: u64 = 30;
 const DEFAULT_TOOL_TIMEOUT_SEC: u64 = 120;
 
 /// Transport type for connecting to an MCP server.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "transport", rename_all = "snake_case")]
 pub enum McpTransport {
     /// Spawn a child process and communicate over stdin/stdout.
@@ -48,6 +49,35 @@ pub enum McpTransport {
         #[serde(default)]
         headers: HashMap<String, String>,
     },
+}
+
+impl fmt::Debug for McpTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpTransport::Stdio {
+                command,
+                args,
+                env,
+                cwd,
+            } => f
+                .debug_struct("Stdio")
+                .field("command", command)
+                .field("args", args)
+                .field("env", env)
+                .field("cwd", cwd)
+                .finish(),
+            McpTransport::Http {
+                url,
+                bearer_token,
+                headers,
+            } => f
+                .debug_struct("Http")
+                .field("url", url)
+                .field("bearer_token", &bearer_token.as_ref().map(|_| "[redacted]"))
+                .field("headers", headers)
+                .finish(),
+        }
+    }
 }
 
 /// Configuration for a single MCP server.
@@ -84,6 +114,33 @@ fn default_startup_timeout() -> u64 {
 
 fn default_tool_timeout() -> u64 {
     DEFAULT_TOOL_TIMEOUT_SEC
+}
+
+/// Validate an MCP server name.
+///
+/// Names must be non-empty, contain only `[a-zA-Z0-9_-]`, and must not
+/// contain `__` (double-underscore), which is the tool-name separator used
+/// internally by Koda's tool routing (`<server>__<tool>`).
+pub fn validate_server_name(name: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        anyhow::bail!("MCP server name must not be empty");
+    }
+    if name.contains("__") {
+        anyhow::bail!(
+            "MCP server name '{name}' must not contain `__` \
+             (double-underscore is the tool-routing separator)"
+        );
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        anyhow::bail!(
+            "MCP server name '{name}' must contain only letters, digits, hyphens, \
+             or underscores"
+        );
+    }
+    Ok(())
 }
 
 impl McpServerConfig {
@@ -315,5 +372,69 @@ mod tests {
         let config: McpServerConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.startup_timeout_sec, 30);
         assert!(matches!(config.transport, McpTransport::Http { .. }));
+    }
+
+    // ── validate_server_name ──────────────────────────────────────────────
+
+    #[test]
+    fn server_name_rejects_empty() {
+        assert!(validate_server_name("").is_err());
+        assert!(validate_server_name("   ").is_err());
+    }
+
+    #[test]
+    fn server_name_rejects_double_underscore() {
+        assert!(validate_server_name("my__server").is_err());
+        assert!(validate_server_name("__leading").is_err());
+        assert!(validate_server_name("trailing__").is_err());
+    }
+
+    #[test]
+    fn server_name_rejects_invalid_chars() {
+        assert!(validate_server_name("my server").is_err()); // space
+        assert!(validate_server_name("my.server").is_err()); // dot
+        assert!(validate_server_name("my/server").is_err()); // slash
+    }
+
+    #[test]
+    fn server_name_accepts_valid() {
+        assert!(validate_server_name("playwright").is_ok());
+        assert!(validate_server_name("my-server").is_ok());
+        assert!(validate_server_name("server_1").is_ok()); // single underscore fine
+        assert!(validate_server_name("MyServer123").is_ok());
+    }
+
+    // ── McpTransport Debug redaction ─────────────────────────────────────
+
+    #[test]
+    fn debug_redacts_bearer_token() {
+        let t = McpTransport::Http {
+            url: "https://example.com/mcp".into(),
+            bearer_token: Some("super-secret-token".into()),
+            headers: HashMap::new(),
+        };
+        let debug_output = format!("{t:?}");
+        assert!(
+            !debug_output.contains("super-secret-token"),
+            "bearer token must not appear in Debug output: {debug_output}"
+        );
+        assert!(
+            debug_output.contains("[redacted]"),
+            "expected '[redacted]' in Debug output: {debug_output}"
+        );
+    }
+
+    #[test]
+    fn debug_shows_none_when_no_token() {
+        let t = McpTransport::Http {
+            url: "https://example.com/mcp".into(),
+            bearer_token: None,
+            headers: HashMap::new(),
+        };
+        let debug_output = format!("{t:?}");
+        assert!(
+            !debug_output.contains("[redacted]"),
+            "no token → should not show [redacted]: {debug_output}"
+        );
     }
 }

--- a/koda-core/src/mcp/mod.rs
+++ b/koda-core/src/mcp/mod.rs
@@ -28,7 +28,7 @@
 //! - **Global scope (user-level)** — not per-project. Accepted trade-off.
 //! - **Tool annotations → ToolEffect** — `destructiveHint`/`readOnlyHint`
 //!   map directly to the TrustMode approval matrix.
-//! - **Resources** — planned for Phase 3 (not yet implemented).
+//! - **Resources** — not yet implemented.
 
 /// MCP server configuration types and database persistence.
 pub mod config;

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -141,7 +141,7 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
 }
 
 /// Check if an IP address is safe (not private/internal/loopback).
-fn is_safe_ip(ip: std::net::IpAddr) -> bool {
+pub(crate) fn is_safe_ip(ip: std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(ipv4) => {
             let octets = ipv4.octets();
@@ -171,7 +171,7 @@ fn is_safe_ip(ip: std::net::IpAddr) -> bool {
 
 /// Check if a URL is safe to fetch (not internal/private network).
 /// Uses the `url` crate for robust parsing (handles userinfo@, IPv6, etc.).
-fn is_safe_url(url_str: &str) -> bool {
+pub(crate) fn is_safe_url(url_str: &str) -> bool {
     let Ok(parsed) = url::Url::parse(url_str) else {
         return false;
     };

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 publish = false # standalone MCP server; not published to crates.io
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -21,7 +21,7 @@ name = "koda_email"
 path = "src/lib.rs"
 
 [dependencies]
-rmcp = { version = "1.3", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Fixes #855. Deferred items tracked in #868.

## What changed

### 🔴 Security — SSRF (blocker)
- **** —  now calls  before opening any TCP connection. Private, loopback, and link-local URLs (including `http://169.254.169.254/`) are rejected with an explicit error.
- Added a `tracing::warn!` when a bearer token is sent over plaintext `http://`.
- Made `is_safe_url` / `is_safe_ip` `pub(crate)` in `web_fetch.rs` to enable reuse without duplication.

### 🔴 Docs (blocker)
- **`docs/src/mcp.md`** — new page: full reference for all five `/mcp` sub-commands, transport options, tool naming convention, filtering config, timeouts, and troubleshooting table.
- **`docs/src/commands.md`** — added `/mcp` section with usage examples.
- **`docs/src/SUMMARY.md`** — MCP servers page wired into the nav.

### ⚠️ Quick wins
| Fix | File |
|-----|------|
| `validate_server_name()` — rejects empty, `__`, non-alphanumeric | `koda-core/src/mcp/config.rs` |
| Call it in both CLI add-handlers | `koda-cli/src/tui_mcp.rs` |
| Manual `Debug` for `McpTransport` — `bearer_token` → `[redacted]` | `koda-core/src/mcp/config.rs` |
| Remove stale "Phase 3" comment | `koda-core/src/mcp/mod.rs` |
| Align `rmcp` to `1.4` in koda-ast / koda-email | `Cargo.toml` files |

## Tests
- 8 new unit tests: `validate_server_name` (4), `McpTransport` Debug redaction (2), bearer-token hint presence/absence (2).
- All 1517+ existing tests pass. Zero clippy warnings.

## Checklist
- [x] `cargo fmt --all` clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test --workspace` — all pass
- [x] No new `unsafe` blocks
- [x] Docs updated