### PR TITLE
ux(help): /help card improvements — drop Approval, add drag & drop

### DIFF
--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -458,32 +458,6 @@ fn show_help(buffer: &mut ScrollBuffer) {
         );
     }
 
-    // ── Approval (shown when a tool needs confirmation) ────────
-    tui_output::blank(buffer);
-    tui_output::emit_line(
-        buffer,
-        Line::from(vec![
-            Span::styled("  Approval ", BOLD),
-            Span::styled("(when the agent asks to run a tool)", DIM),
-        ]),
-    );
-    tui_output::blank(buffer);
-    let approval_keys: &[(&str, &str)] = &[
-        ("y", "Approve this tool call"),
-        ("n", "Reject this tool call"),
-        ("a", "Approve and switch to auto mode (no more prompts)"),
-        ("f", "Reject and provide written feedback"),
-        ("Esc", "Reject (same as n)"),
-    ];
-    for (key, desc) in approval_keys {
-        tui_output::emit_line(
-            buffer,
-            Line::from(vec![
-                Span::styled(format!("  {key:<col$}"), CYAN),
-                Span::styled(*desc, DIM),
-            ]),
-        );
-    }
     tui_output::blank(buffer);
 }
 

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -405,7 +405,10 @@ fn show_help(buffer: &mut ScrollBuffer) {
         ("Alt+Enter", "Insert newline (multi-line input)"),
         ("@file.rs", "Attach file context to your message"),
         ("@image.png", "Attach image (vision-capable models)"),
-        ("drag & drop", "Drop an image into the terminal to attach it"),
+        (
+            "drag & drop",
+            "Drop an image into the terminal to attach it",
+        ),
         ("↑ / ↓", "Cycle through input history"),
         ("Ctrl+R", "Reverse history search"),
         ("Tab", "Autocomplete @file path or /command"),

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -405,6 +405,7 @@ fn show_help(buffer: &mut ScrollBuffer) {
         ("Alt+Enter", "Insert newline (multi-line input)"),
         ("@file.rs", "Attach file context to your message"),
         ("@image.png", "Attach image (vision-capable models)"),
+        ("drag & drop", "Drop an image into the terminal to attach it"),
         ("↑ / ↓", "Cycle through input history"),
         ("Ctrl+R", "Reverse history search"),
         ("Tab", "Autocomplete @file path or /command"),


### PR DESCRIPTION
## Summary

Two small UX improvements to the `/help` card (`show_help` in `tui_commands.rs`).

### 1. Remove Approval section

The `y / n / a / f / Esc` keys are already shown **inline at the approval prompt**, exactly when the user needs them. Duplicating them in `/help` is noise — the contextual version is strictly more useful.

### 2. Add drag & drop to Input section

Drag-and-drop onto the terminal already works — it's implemented in `input.rs` via the bracketed paste path (`Event::Paste` → `process_input()` detects bare image paths and loads them, handling escaped spaces too). Just wasn't documented.

The comment in the code is explicit:
```rust
// ── Bare image paths (drag-and-drop) ──────────────────
// Detect absolute/relative paths to image files pasted directly.
```

## Changes
- `koda-cli/src/tui_commands.rs`: 26 deletions (Approval section), 1 insertion (drag & drop hint)

## /help before → after

```
Input
  Enter            Send message
  Alt+Enter        Insert newline (multi-line input)
  @file.rs         Attach file context to your message
  @image.png       Attach image (vision-capable models)
+ drag & drop      Drop an image into the terminal to attach it
  ↑ / ↓            Cycle through input history
  Ctrl+R           Reverse history search
  Tab              Autocomplete @file path or /command
  Shift+Tab        Cycle approval mode (auto ↔ confirm)

- Approval (when the agent asks to run a tool)
-   y    Approve this tool call
-   n    Reject this tool call
-   a    Approve and switch to auto mode (no more prompts)
-   f    Reject and provide written feedback
-   Esc  Reject (same as n)
```