### PR TITLE
fix(tui): scrolling up during inference no longer snaps back to bottom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1793,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -601,6 +601,64 @@ mod tests {
         assert!(buf.is_sticky());
     }
 
+    /// Regression: clamp_offset must use the history panel viewport height,
+    /// NOT the full terminal height. Using a too-large viewport computes
+    /// max_offset too small, clamping the user's scroll position toward
+    /// the bottom and re-engaging sticky during inference streaming.
+    #[test]
+    fn test_clamp_offset_with_correct_viewport_preserves_scroll() {
+        let mut buf = ScrollBuffer::new(2500);
+        // 50 lines of content
+        for i in 0..50 {
+            buf.push(make_line(&format!("line {i}")));
+        }
+
+        // User scrolls up 15 lines from the bottom
+        buf.scroll_up(15, W, 30);
+        assert_eq!(buf.offset(), 15);
+        assert!(!buf.is_sticky());
+
+        // With correct viewport (30 lines): max_offset = 50 - 30 = 20.
+        // 15 < 20 → no clamping.
+        buf.clamp_offset(W, 30);
+        assert_eq!(buf.offset(), 15);
+        assert!(
+            !buf.is_sticky(),
+            "correct viewport must NOT re-engage sticky"
+        );
+
+        // BUG CASE: if caller mistakenly passes full terminal height (40),
+        // max_offset = 50 - 40 = 10.  15 > 10 → clamped to 10.
+        // This is the wrong behavior the fix prevents.
+        buf.clamp_offset(W, 40);
+        assert_eq!(buf.offset(), 10, "over-large viewport incorrectly clamps");
+    }
+
+    /// Streaming new content while scrolled up must not snap to bottom.
+    #[test]
+    fn test_push_during_scrolled_up_preserves_position() {
+        let mut buf = ScrollBuffer::new(2500);
+        for i in 0..30 {
+            buf.push(make_line(&format!("line {i}")));
+        }
+
+        // User scrolls up 10 lines
+        buf.scroll_up(10, W, 20);
+        assert!(!buf.is_sticky());
+        assert_eq!(buf.offset(), 10);
+
+        // New content arrives (simulating inference streaming)
+        buf.push(make_line("streamed token"));
+        buf.push(make_line("another token"));
+
+        // Offset and sticky must be unchanged
+        assert_eq!(buf.offset(), 10);
+        assert!(
+            !buf.is_sticky(),
+            "push must not re-engage sticky when user scrolled up"
+        );
+    }
+
     #[test]
     fn test_prepend_lines() {
         let mut buf = ScrollBuffer::new(2500);

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -9,8 +9,10 @@ impl TuiContext {
         match ev {
             Event::Resize(_, _) => {
                 // Clamp scroll offset for the new terminal dimensions.
-                let (w, h) = self.term_dims();
-                self.scroll_buffer.clamp_offset(w, h);
+                // Use history panel height, not full terminal height.
+                let (w, _) = self.term_dims();
+                let vh = (self.history_area_height as usize).max(1);
+                self.scroll_buffer.clamp_offset(w, vh);
             }
             Event::Mouse(mouse) => {
                 self.handle_mouse(mouse);

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -341,8 +341,11 @@ impl TuiContext {
     pub fn draw(&mut self) -> Result<()> {
         // Clamp scroll offset to valid bounds before rendering.
         // Necessary after terminal resize changes wrapping math.
-        let (w, h) = self.term_dims();
-        self.scroll_buffer.clamp_offset(w, h);
+        // Use history panel height, not full terminal height — otherwise
+        // max_offset is too small and scrolling up re-engages sticky.
+        let (w, _) = self.term_dims();
+        let vh = (self.history_area_height as usize).max(1);
+        self.scroll_buffer.clamp_offset(w, vh);
 
         let mode = trust::read_trust(&self.shared_mode);
         let ctx = self.context_pct;

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -52,10 +52,15 @@ impl TuiContext {
             loop {
                 // Clamp scroll offset before drawing (resize may have
                 // changed wrapping, making the old offset invalid).
-                let (term_w, term_h) = crossterm::terminal::size()
+                // Use the actual history panel height, not the full terminal
+                // height — otherwise max_offset is too small and scrolling
+                // up during inference gets clamped back toward the bottom,
+                // re-engaging sticky_bottom.
+                let (term_w, _) = crossterm::terminal::size()
                     .map(|(c, r)| (c as usize, r as usize))
                     .unwrap_or((80, 24));
-                self.scroll_buffer.clamp_offset(term_w, term_h);
+                let hist_viewport = (self.history_area_height as usize).max(1);
+                self.scroll_buffer.clamp_offset(term_w, hist_viewport);
 
                 // Redraw viewport
                 let mode = trust::read_trust(&self.shared_mode);
@@ -307,10 +312,11 @@ async fn handle_crossterm_event_inline(
     use crossterm::event::MouseEventKind;
     match ev {
         Event::Resize(_, _) => {
-            let (w, h) = crossterm::terminal::size()
+            let (w, _) = crossterm::terminal::size()
                 .map(|(c, r)| (c as usize, r as usize))
                 .unwrap_or((80, 24));
-            scroll_buffer.clamp_offset(w, h);
+            // Use hist_h (history panel height), not full terminal height.
+            scroll_buffer.clamp_offset(w, hist_h);
         }
         Event::Mouse(mouse) => {
             let (w, _) = crossterm::terminal::size()


### PR DESCRIPTION
## Bug

During inference streaming, if you scroll up to read earlier output, the TUI constantly pulls you back toward the bottom. Every new token effectively fights your scroll position.

## Root Cause

`clamp_offset()` was called with the **full terminal height** instead of the **history panel viewport height**. The three-panel layout (history + input + status bar) means the history panel is significantly shorter than the terminal:

```
Terminal: 40 rows
History:  30 rows (minus input box, status bar, menus)
```

`clamp_offset` computes:
```
max_offset = total_visual_lines - viewport_height
```

With terminal height (40): `max_offset = 50 - 40 = 10`
With panel height (30):    `max_offset = 50 - 30 = 20`

A user scrolled up 15 lines gets clamped to 10 (wrong) instead of staying at 15 (correct). Worse: when total visual lines ≤ terminal height, `max_offset = 0` and `sticky_bottom` **re-engages entirely**, snapping the view to the latest output.

This is called **every render cycle** during inference (the hot path at `tui_handlers_inference.rs:58`), so the snap-back is relentless.

## Fix

All 4 `clamp_offset()` call sites now use `history_area_height` (already tracked from `draw_viewport`'s return value):

| File | Line | Was | Now |
|------|------|-----|-----|
| `tui_handlers_inference.rs` | 58 | `term_h` | `self.history_area_height` |
| `tui_handlers_inference.rs` | 313 | `h` (terminal) | `hist_h` (already a param) |
| `tui_context/events.rs` | 13 | `h` (terminal) | `self.history_area_height` |
| `tui_context/mod.rs` | 345 | `h` (terminal) | `self.history_area_height` |

## Tests

Two regression tests added to `scroll_buffer::tests`:

- **`test_clamp_offset_with_correct_viewport_preserves_scroll`** — verifies correct viewport doesn't clamp, documents the over-large viewport bug case
- **`test_push_during_scrolled_up_preserves_position`** — verifies streaming new content while scrolled up doesn't re-engage sticky

All 27 scroll_buffer tests pass. Full workspace: 1517+ tests, 0 failures.