### PR TITLE
docs(skill): add 10 missing pages to koda_docs skill index

### DIFF
--- a/koda-cli/src/builtin_skills.rs
+++ b/koda-cli/src/builtin_skills.rs
@@ -19,10 +19,12 @@ const KODA_DOCS_URL: &str = "https://lijunzh.github.io/koda/";
 pub fn inject_builtin_skills(agent: &mut KodaAgent) {
     agent.tools.skill_registry.add_builtin(
         "koda_docs",
-        "Koda user manual: commands, TUI, configuration, sessions, providers, and more.",
+        "Koda user manual: commands, TUI, configuration, security, sandbox, privacy, sessions, providers, and more.",
         Some(
             "Use when the user asks how to use Koda: commands, flags, TUI keybindings, \
-             configuration, sessions, providers, approval modes, skills, sub-agents, \
+             configuration, sessions, providers, approval modes, trust modes, \
+             sandbox, security, safety, privacy, undo, tools, MCP servers, \
+             context management, memory, file attachments, skills, sub-agents, \
              ACP server, or any other feature documented in the user manual. \
              Fetch the manual from the URL below with WebFetch.",
         ),
@@ -38,7 +40,17 @@ pub fn inject_builtin_skills(agent: &mut KodaAgent) {
              - {url}skills.html — skill system\n\
              - {url}approval.html — approval modes\n\
              - {url}headless.html — headless / CI mode\n\
-             - {url}cli-reference.html — full CLI reference",
+             - {url}cli-reference.html — full CLI reference\n\
+             - {url}sandbox.html — kernel sandbox, write restrictions, credential protection\n\
+             - {url}privacy.html — zero telemetry, local-only data, deletion\n\
+             - {url}tools.html — tools reference (all available tools)\n\
+             - {url}mcp.html — MCP server integration\n\
+             - {url}attachments.html — file and image attachments (@file)\n\
+             - {url}context.html — context window management\n\
+             - {url}memory.html — cross-session memory\n\
+             - {url}keybindings.html — full keybinding reference\n\
+             - {url}acp.html — ACP server (editor integration)\n\
+             - {url}introduction.html — overview and getting started",
             url = KODA_DOCS_URL,
         ),
     );


### PR DESCRIPTION
Closes #871.

## Problem

The docs pages for sandbox, privacy, tools, MCP, attachments, context, memory, keybindings, ACP, and introduction **already exist and are well-written** — the `koda_docs` skill just didn't point at them.

When a user asked "does Koda sandbox my commands?" or "how does Koda handle privacy?", the agent might not activate the skill because those topics weren't in the trigger phrase.

## Fix

One file changed: `koda-cli/src/builtin_skills.rs`

### 1. Skill description
```diff
- "Koda user manual: commands, TUI, configuration, sessions, providers, and more."
+ "Koda user manual: commands, TUI, configuration, security, sandbox, privacy, sessions, providers, and more."
```

### 2. Trigger phrase — 6 new topics
```diff
- commands, flags, TUI keybindings, configuration, sessions, providers,
- approval modes, skills, sub-agents, ACP server
+ commands, flags, TUI keybindings, configuration, sessions, providers,
+ approval modes, trust modes, sandbox, security, safety, privacy, undo,
+ tools, MCP servers, context management, memory, file attachments,
+ skills, sub-agents, ACP server
```

### 3. Key pages list — 10 new entries
| Page | Topic |
|------|-------|
| `sandbox.html` | Kernel sandbox, write restrictions, credential protection |
| `privacy.html` | Zero telemetry, local-only data, deletion |
| `tools.html` | All available tools |
| `mcp.html` | MCP server integration |
| `attachments.html` | File and image attachments (`@file`) |
| `context.html` | Context window management |
| `memory.html` | Cross-session memory |
| `keybindings.html` | Full keybinding reference |
| `acp.html` | ACP server (editor integration) |
| `introduction.html` | Overview and getting started |

## Tests

Both `koda_docs` e2e tests pass:
- `koda_docs_skill_appears_in_list_skills` ✅
- `koda_docs_skill_activates_and_returns_manual_content` ✅