### PR TITLE
fix(inference): sentinel system msg anchors model to correct task after network-error resume (#875, #877)

### DIFF
--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -155,6 +155,19 @@ impl TuiContext {
                                     ),
                                 ]),
                             );
+                            // #875: guide the user before they type "continue"
+                            // — irrelevant early history is the most common cause
+                            // of the model responding to the wrong message (#877).
+                            self.scroll_buffer.push(
+                                Line::from(vec![
+                                    Span::raw("  "),
+                                    Span::styled(
+                                        "Tip: run /compact to trim unrelated early \
+                                         messages before typing \"continue\".",
+                                        Style::default().fg(Color::Yellow),
+                                    ),
+                                ]),
+                            );
                         }
                         break;
                     }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -839,6 +839,30 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         // Discard the partial response — storing it would corrupt the session.
         if stream_result.network_error.is_some() {
             sse_handle.abort();
+            // Write a sentinel system message so the model re-anchors to the
+            // correct task on the next "continue" (#875, #877).  Without this
+            // the model loads full session history and can latch onto an early
+            // unrelated user message instead of the current pending request.
+            let last_user = db.last_user_message(session_id).await.unwrap_or_default();
+            let sentinel = if last_user.is_empty() {
+                "[System] The previous inference turn terminated unexpectedly \
+                 due to a network error.  The session history above is intact. \
+                 Please resume from where you left off."
+                    .to_string()
+            } else {
+                format!(
+                    "[System] The previous inference turn terminated unexpectedly \
+                     due to a network error.  The session history above is intact. \
+                     The user's pending request was: \"{last_user}\". \
+                     Please resume from where you left off."
+                )
+            };
+            if let Err(e) = db
+                .insert_message(session_id, &Role::System, Some(&sentinel), None, None, None)
+                .await
+            {
+                tracing::warn!("Failed to write interruption sentinel to DB: {e:#}");
+            }
             return Ok(());
         }
 

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -148,3 +148,76 @@ async fn test_context_overflow_too_few_messages_fails() {
         "error should mention overflow: {err}"
     );
 }
+
+// ── Sentinel message tests (#875, #877) ─────────────────────
+
+/// After a network-error drop, a system sentinel must be written to the DB
+/// so the model can re-anchor to the correct task on the next "continue".
+/// Without the sentinel, load_context() returns the full unfiltered history
+/// and the model latches onto an earlier unrelated user message (#877).
+#[tokio::test]
+async fn network_error_writes_sentinel_with_user_request() {
+    let env = Env::builder().max_context_tokens(100_000).build().await;
+    env.insert_user_message("research the inference loop implementation").await;
+
+    let provider = MockProvider::new(vec![MockResponse::NetworkError {
+        partial_text: "I'll start by".into(),
+        error: "connection reset by peer".into(),
+    }]);
+
+    let (result, _events) = env.run_inference_result(&provider).await;
+    // Network errors are swallowed — inference_loop returns Ok(())
+    assert!(result.is_ok(), "network error must not propagate: {:?}", result.err());
+
+    // The DB must now contain a system sentinel that names the pending request.
+    let messages = env.db.load_context(&env.session_id).await.unwrap();
+    let sentinel = messages.iter().find(|m| {
+        m.role == Role::System
+            && m.content
+                .as_deref()
+                .unwrap_or("")
+                .contains("[System]")
+    });
+    assert!(
+        sentinel.is_some(),
+        "expected a [System] sentinel in DB after network drop; messages: {:?}",
+        messages.iter().map(|m| (&m.role, &m.content)).collect::<Vec<_>>()
+    );
+
+    let body = sentinel.unwrap().content.as_deref().unwrap_or("");
+    assert!(
+        body.contains("research the inference loop implementation"),
+        "sentinel must quote the user's pending request; got: {body}"
+    );
+    assert!(
+        body.contains("resume from where you left off"),
+        "sentinel must direct the model to resume; got: {body}"
+    );
+}
+
+/// Sentinel must be present even when the user message is empty (edge case).
+#[tokio::test]
+async fn network_error_writes_generic_sentinel_when_no_user_message() {
+    let env = Env::builder().max_context_tokens(100_000).build().await;
+    // Insert a user message but then simulate a completely empty session
+    // (content-wise) by checking the fallback branch.
+    env.insert_user_message("").await;
+
+    let provider = MockProvider::new(vec![MockResponse::NetworkError {
+        partial_text: String::new(),
+        error: "timeout".into(),
+    }]);
+
+    let (result, _events) = env.run_inference_result(&provider).await;
+    assert!(result.is_ok());
+
+    let messages = env.db.load_context(&env.session_id).await.unwrap();
+    let sentinel = messages.iter().find(|m| {
+        m.role == Role::System
+            && m.content.as_deref().unwrap_or("").contains("[System]")
+    });
+    assert!(
+        sentinel.is_some(),
+        "sentinel must be written even with empty user message"
+    );
+}


### PR DESCRIPTION
## Problem (shared root cause)

`load_context()` returns the full unfiltered session history on every resume. After an unexpected network-error termination:

- **#877 (correctness):** The model receives `continue` surrounded by a large history, loses track of which message is the current request, and latches onto an earlier unrelated user message (e.g., `ls`)—producing a completely wrong response.
- **#875 (efficiency):** The bloated context includes all session history from the beginning, wasting 2–3× tokens on irrelevant preamble.

## Fixes

### Fix 1 — `inference.rs`: write a `[System]` sentinel to DB on network drop

When `stream_result.network_error.is_some()`, before returning, insert a system message that re-anchors the model:

```
[System] The previous inference turn terminated unexpectedly due to a network
error. The session history above is intact. The user's pending request was:
"{last_user_message}". Please resume from where you left off.
```

The sentinel is the last message `load_context()` returns on the next turn, so the model sees an unambiguous "you are here" marker immediately before the user's "continue". Full history is still present (deeper compaction is tracked separately), but the anchor prevents the wrong-message correctness failure.

Write is best-effort: DB failure is warn-logged but never propagates.

### Fix 2 — `tui_handlers_inference.rs`: add /compact hint to the error banner

After the red `✗ Turn failed` line, add a yellow hint:

> Tip: run /compact to trim unrelated early messages before typing "continue".

This directly surfaces the #875 mitigation at the exact moment users need it.

## Tests

Added to `koda-core/tests/inference_recovery_test.rs`:
- `network_error_writes_sentinel_with_user_request` — verifies sentinel is in DB and quotes the pending request
- `network_error_writes_generic_sentinel_when_no_user_message` — edge case: empty user message still writes sentinel

All 6 recovery tests pass. ✅

Closes #875
Closes #877