### PR TITLE
fix(inference): context window % now reflects actual prompt_tokens, not heuristic (#874)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -945,6 +945,21 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
 
             let context = crate::context::format_footer();
 
+            // Correct the heuristic context estimate with the actual
+            // prompt_tokens reported by the provider.  The estimate emitted
+            // in assemble_context() was based on chars/3.5, which consistently
+            // underreports for code, tool results, and JSON payloads.
+            // This corrective event fires once per completed turn, after all
+            // tool calls resolve, so the status bar reflects real usage.
+            crate::context::update(
+                total_prompt_tokens as usize,
+                config.max_context_tokens,
+            );
+            sink.emit(EngineEvent::ContextUsage {
+                used: total_prompt_tokens as usize,
+                max: config.max_context_tokens,
+            });
+
             sink.emit(EngineEvent::Footer {
                 prompt_tokens: total_prompt_tokens,
                 completion_tokens: total_completion_tokens,

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -951,10 +951,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             // underreports for code, tool results, and JSON payloads.
             // This corrective event fires once per completed turn, after all
             // tool calls resolve, so the status bar reflects real usage.
-            crate::context::update(
-                total_prompt_tokens as usize,
-                config.max_context_tokens,
-            );
+            crate::context::update(total_prompt_tokens as usize, config.max_context_tokens);
             sink.emit(EngineEvent::ContextUsage {
                 used: total_prompt_tokens as usize,
                 max: config.max_context_tokens,

--- a/koda-core/tests/inference_context_test.rs
+++ b/koda-core/tests/inference_context_test.rs
@@ -1,0 +1,95 @@
+//! Tests that the context-window percentage display reflects actual token
+//! counts rather than only the pre-send heuristic estimate.
+//!
+//! Regression test for #874: the heuristic (chars/3.5 + 10/message) was the
+//! only signal driving the status-bar %, causing it to underreport by up to
+//! 2× for code/JSON-heavy sessions.
+
+use koda_core::engine::EngineEvent;
+use koda_test_utils::{Env, MockProvider, MockResponse};
+
+/// After a completed turn the event stream must contain a corrective
+/// `ContextUsage` event whose `used` field equals the actual `prompt_tokens`
+/// reported by the provider — NOT the pre-send heuristic estimate.
+///
+/// MockProvider::Text always reports `prompt_tokens = 10`.
+/// The pre-send heuristic for a short "hello" message gives > 10
+/// (formula: chars/3.5 + 10 per message ≈ 11-12).
+/// So the last ContextUsage.used must equal 10.
+#[tokio::test]
+async fn corrective_context_usage_uses_actual_prompt_tokens() {
+    let env = Env::builder().max_context_tokens(200_000).build().await;
+    env.insert_user_message("hello").await;
+
+    let provider = MockProvider::new(vec![MockResponse::Text("hi".into())]);
+    let (result, events) = env.run_inference_result(&provider).await;
+    assert!(result.is_ok(), "inference must succeed: {:?}", result.err());
+
+    let context_events: Vec<(usize, usize)> = events
+        .iter()
+        .filter_map(|e| match e {
+            EngineEvent::ContextUsage { used, max } => Some((*used, *max)),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        context_events.len() >= 2,
+        "expected at least 2 ContextUsage events (heuristic + corrective), \
+         got {}: {context_events:?}",
+        context_events.len()
+    );
+
+    // The LAST ContextUsage must be the corrective one with actual tokens.
+    let (last_used, last_max) = *context_events.last().unwrap();
+    assert_eq!(
+        last_used, 10,
+        "last ContextUsage.used must equal actual prompt_tokens (10 from mock), \
+         got {last_used}"
+    );
+    assert_eq!(last_max, 200_000, "max must match configured context window");
+
+    // The FIRST ContextUsage is the heuristic; it should differ from 10
+    // for any non-trivial message (proves the correction is actually updating).
+    let (first_used, _) = context_events[0];
+    assert_ne!(
+        first_used, last_used,
+        "heuristic and corrective ContextUsage.used should differ, \
+         both were {first_used} — corrective event may not be firing"
+    );
+}
+
+/// The corrective event must also update the global context atomic so that
+/// `context::percentage()` reflects real usage after the turn.
+#[tokio::test]
+async fn context_percentage_reflects_actual_tokens_after_turn() {
+    let env = Env::builder().max_context_tokens(100_000).build().await;
+    env.insert_user_message("test message for context accuracy").await;
+
+    let provider = MockProvider::new(vec![MockResponse::Text("response".into())]);
+    let (result, events) = env.run_inference_result(&provider).await;
+    assert!(result.is_ok());
+
+    // Confirm Footer also reports the same actual token count.
+    let footer = events.iter().find_map(|e| match e {
+        EngineEvent::Footer { prompt_tokens, .. } => Some(*prompt_tokens),
+        _ => None,
+    });
+    assert!(footer.is_some(), "Footer event must be emitted");
+
+    let footer_tokens = footer.unwrap();
+    let last_context_used = events
+        .iter()
+        .filter_map(|e| match e {
+            EngineEvent::ContextUsage { used, .. } => Some(*used),
+            _ => None,
+        })
+        .last()
+        .expect("at least one ContextUsage event required");
+
+    assert_eq!(
+        last_context_used as i64, footer_tokens,
+        "last ContextUsage.used ({last_context_used}) must match \
+         Footer.prompt_tokens ({footer_tokens})"
+    );
+}

--- a/koda-core/tests/inference_context_test.rs
+++ b/koda-core/tests/inference_context_test.rs
@@ -47,7 +47,10 @@ async fn corrective_context_usage_uses_actual_prompt_tokens() {
         "last ContextUsage.used must equal actual prompt_tokens (10 from mock), \
          got {last_used}"
     );
-    assert_eq!(last_max, 200_000, "max must match configured context window");
+    assert_eq!(
+        last_max, 200_000,
+        "max must match configured context window"
+    );
 
     // The FIRST ContextUsage is the heuristic; it should differ from 10
     // for any non-trivial message (proves the correction is actually updating).
@@ -64,7 +67,8 @@ async fn corrective_context_usage_uses_actual_prompt_tokens() {
 #[tokio::test]
 async fn context_percentage_reflects_actual_tokens_after_turn() {
     let env = Env::builder().max_context_tokens(100_000).build().await;
-    env.insert_user_message("test message for context accuracy").await;
+    env.insert_user_message("test message for context accuracy")
+        .await;
 
     let provider = MockProvider::new(vec![MockResponse::Text("response".into())]);
     let (result, events) = env.run_inference_result(&provider).await;

--- a/koda-core/tests/inference_context_test.rs
+++ b/koda-core/tests/inference_context_test.rs
@@ -88,7 +88,7 @@ async fn context_percentage_reflects_actual_tokens_after_turn() {
             EngineEvent::ContextUsage { used, .. } => Some(*used),
             _ => None,
         })
-        .last()
+        .next_back()
         .expect("at least one ContextUsage event required");
 
     assert_eq!(


### PR DESCRIPTION
## Problem

The status-bar context % is driven by a pre-send heuristic (`chars / 3.5 + 10 per message`). The actual `prompt_tokens` value from the provider API is only used in the `Footer` event and never fed back to the context tracker.

For code/JSON/tool-result-heavy sessions the heuristic underestimates by up to 2×: a session at 40k tokens on a 200k model shows 20% in the status bar when it's actually at 40%.

## Fix

After the final iteration of each turn (when all tool calls are resolved), emit a corrective `ContextUsage` event with the actual `total_prompt_tokens` and call `context::update()` with the real value. The pre-send heuristic remains as a leading indicator during streaming.

```rust
crate::context::update(total_prompt_tokens as usize, config.max_context_tokens);
sink.emit(EngineEvent::ContextUsage {
    used: total_prompt_tokens as usize,
    max: config.max_context_tokens,
});
```

## Tests

New file `koda-core/tests/inference_context_test.rs`:
- `corrective_context_usage_uses_actual_prompt_tokens` — verifies last `ContextUsage.used` equals mock's `prompt_tokens = 10`, not the heuristic
- `context_percentage_reflects_actual_tokens_after_turn` — verifies last `ContextUsage.used` matches `Footer.prompt_tokens`

Both pass. ✅

Closes #874