### PR TITLE
fix(tools): unrestricted reads, write/edit/delete scoped to project root (#876)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,5 +51,36 @@ else
     exit 1
 fi
 
+# --- Tests -------------------------------------------------------------------
+# Runs unit tests (--lib, fast) plus the integration test suites that are
+# policy-critical and complete in <5s. Slow suites (mcp_http_transport,
+# inference_edge, inference_recovery) are skipped here because they involve
+# real sleep/retry loops and would make the hook unusably slow; CI covers
+# them on every push.
+#
+# Root cause of #882: the hook ran lint only, missing an integration test
+# regression in e2e_safety_test. The unit-test pass (--lib) doesn't run
+# tests in tests/*.rs — you must name them explicitly.
+info "cargo test (unit + fast integration suites)"
+if cargo test --workspace --features koda-core/test-support --lib && \
+   cargo test -p koda-core --features koda-core/test-support \
+       --test bash_safety_test \
+       --test e2e_safety_test \
+       --test e2e_tools_test \
+       --test e2e_test \
+       --test e2e_agent_test \
+       --test e2e_skills_test \
+       --test file_tools_test \
+       --test golden_test \
+       --test guarantee_matrix_test \
+       --test new_tools_test \
+       --test tool_normalize_test \
+       --test tool_wiring_test; then
+    ok "all tests pass"
+else
+    fail "tests: fix failures above before pushing"
+    exit 1
+fi
+
 echo
 ok "All checks passed — pushing."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,28 @@ cargo test --workspace --features koda-core/test-support
 
 ## Local checks (one-time setup)
 
-Activate the pre-push hook to catch `fmt` and `clippy` failures before they
-hit CI:
+Activate the pre-push hook to catch `fmt`, `clippy`, and test failures before
+they hit CI:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-The hook mirrors the Lint CI job exactly. Skip it for a WIP push with
-`git push --no-verify`.
+The hook runs:
+1. `cargo fmt --all --check`
+2. `cargo clippy --workspace … -D warnings`
+3. `cargo check --workspace --all-targets`
+4. `cargo test --lib` across the workspace + all fast integration suites
+   (`e2e_safety_test`, `e2e_tools_test`, `file_tools_test`, `guarantee_matrix_test`, …)
+
+Slow suites (`mcp_http_transport`, `inference_edge`, `inference_recovery`) are
+skipped in the hook — they involve sleep/retry loops and would make every push
+take 5+ minutes. CI runs them on every push.
+
+> **`--no-verify` is for genuine WIP pushes only** (draft PR, CI debugging,
+> mid-refactor checkpoint). Using it on a branch you intend to merge defeats
+> the hook entirely — CI will catch what you skipped, usually at the worst
+> time.
 
 ## Reporting Issues
 

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -5,7 +5,57 @@ inside a sandboxed process. The sandbox enforces the perimeter; the
 [trust mode](./approval.md) controls whether you see a confirmation
 prompt before each mutation.
 
-## What's protected
+## File tool read policy
+
+Koda's **Read, List, Grep, and Glob** tools are intentionally unrestricted —
+they can access any path on the filesystem the OS permits, including paths
+outside the project directory (e.g. `../other-repo`, `~/.ssh/config`).
+
+Only **Write, Edit, and Delete** are gated to the project root.
+
+### Why reads are unrestricted
+
+1. **Reads cannot mutate state.** The worst-case outcome of an out-of-scope
+   read is that the model sees something sensitive in its context window — which
+   you, watching the terminal, can also see. No irreversible damage occurs.
+
+2. **Bash already has the same reach.** The Bash tool runs inside the kernel
+   sandbox but has read access to the full filesystem. Restricting the Read
+   tool while leaving Bash unrestricted is security theater — the model just
+   falls back to `cat ../secret.txt`.
+
+3. **OS-level sandboxing is the real boundary.** On macOS (Seatbelt) and Linux
+   (bwrap), the sandbox already defines what the process can access at the
+   kernel level. Duplicating that check in the tool layer adds friction without
+   adding protection.
+
+4. **Cross-repo workflows are common.** Developers routinely ask koda to read
+   a sibling repo, a shared library, or a dotfile — restricting this forces
+   awkward workarounds.
+
+   This follows the Claude Code approach — Claude Code's `Read` tool imposes
+   no project-root scope check at all.
+
+### Accepted risk
+
+> ⚠️ **A carefully crafted prompt could trick the model into reading and
+> summarising sensitive files** — for example `~/.aws/credentials`,
+> `~/.ssh/id_rsa`, or `~/.netrc` — without explicit user consent. The
+> content would appear in the chat window but not be exfiltrated unless
+> the model also makes a network request (Bash + `curl`, WebFetch, etc.).
+>
+> **Mitigations:**
+> - Those files are **write-protected** by the kernel sandbox, so the model
+>   cannot modify or delete them.
+> - Network exfiltration via Bash is constrained by the sandbox's outbound
+>   network policy.
+> - Trust-mode `safe` requires explicit approval before every Bash command,
+>   which catches `curl`-style exfiltration attempts.
+>
+> If you work with highly sensitive secrets and want file-level read
+> protection, run koda in a containerised environment with access to only
+> the files you intend to expose.
+
 
 ### Write restrictions
 

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -177,6 +177,30 @@ const CREDENTIAL_CONFIG_FULL_DENY: &[&str] = &[
     "koda/db", // SQLite DB with plaintext API keys in kv_store table (#847)
 ];
 
+/// Returns `true` when `path` falls inside a fully-denied location.
+///
+/// "Fully denied" means both reads **and** writes are blocked in the
+/// subprocess sandbox (bwrap / Seatbelt).  This function lets in-process
+/// file tools enforce the same policy so the restriction is uniform
+/// regardless of how the model accesses the path (Option A parity, #882).
+///
+/// Currently only `~/.config/koda/db` is fully denied — koda's own SQLite
+/// database containing plaintext API keys.  Ordinary credential directories
+/// (`~/.ssh`, `~/.aws`, …) are **not** included: reads are allowed there,
+/// mirroring the Bash sandbox which only write-protects them.
+///
+/// See issue #884 for the long-term plan (Option B: sandboxed worker process)
+/// which will replace this application-layer check with true OS enforcement.
+pub(crate) fn is_fully_denied(path: &Path) -> bool {
+    let Ok(home) = std::env::var("HOME") else {
+        return false;
+    };
+    let home = Path::new(&home);
+    CREDENTIAL_CONFIG_FULL_DENY
+        .iter()
+        .any(|rel| path.starts_with(home.join(".config").join(rel)))
+}
+
 /// Individual credential *files* under `$HOME` that are **write-protected**
 /// in Strict mode.  Reads are allowed so tools like `curl`, `git`, `npm`,
 /// and `docker` can authenticate.
@@ -638,6 +662,43 @@ mod tests {
         assert!(!SandboxMode::None.is_active());
         assert!(SandboxMode::Project.is_active());
         assert!(SandboxMode::Strict.is_active());
+    }
+
+    // ── Unit: is_fully_denied ──────────────────────────────────────────────
+
+    #[test]
+    fn fully_denied_blocks_koda_db() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+        let koda_db = Path::new(&home).join(".config/koda/db");
+        assert!(
+            is_fully_denied(&koda_db),
+            "~/.config/koda/db must be fully denied"
+        );
+        // Sub-paths inside it are also denied.
+        assert!(is_fully_denied(&koda_db.join("koda.db")));
+    }
+
+    #[test]
+    fn fully_denied_allows_credential_dirs() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+        let home = Path::new(&home);
+        // Credential dirs are write-protected but reads are allowed — they
+        // must NOT appear in the fully-denied list.
+        for rel in &[".ssh", ".aws", ".gnupg", ".config/gh", ".config/gcloud"] {
+            assert!(
+                !is_fully_denied(&home.join(rel)),
+                "{rel} must NOT be fully denied (reads allowed)"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_denied_allows_project_and_system_paths() {
+        assert!(!is_fully_denied(Path::new(
+            "/home/user/project/src/main.rs"
+        )));
+        assert!(!is_fully_denied(Path::new("/tmp/scratch.txt")));
+        assert!(!is_fully_denied(Path::new("/etc/hosts")));
     }
 
     // ── Unit: strict profile contains deny rules ───────────────────────────

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -1,7 +1,8 @@
 //! File system tools: Read, Write, Edit, Delete, and List.
 //!
-//! All paths are validated through `safe_resolve_path` to prevent escapes
-//! outside the project root.
+//! **Path policy** (see `docs/src/sandbox.md` for full rationale):
+//! - Read / List use `resolve_path_unrestricted` — any path on the filesystem.
+//! - Write / Edit / Delete use `safe_resolve_path` — restricted to project root.
 //!
 //! ## Tools
 //!
@@ -15,13 +16,13 @@
 //!
 //! ## Path safety
 //!
-//! All file paths are resolved relative to the project root. Attempts to
-//! access files outside the project (e.g., `../../../etc/passwd`) are blocked
-//! with an error. Absolute paths are also rejected unless they resolve within
-//! the project root.
+//! All file paths resolve relative to the project root for relative inputs, or
+//! as-is for absolute inputs.  Read / List accept any reachable path;
+//! Write / Edit / Delete are restricted to the project root (see sandbox.md).
 
 use sha2::{Digest, Sha256};
 
+use super::resolve_path_unrestricted;
 use super::safe_resolve_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
@@ -182,25 +183,9 @@ pub async fn read_file(
         .as_str()
         .or_else(|| args["path"].as_str())
         .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
-    let resolved = safe_resolve_path(project_root, path_str)?;
+    let resolved = resolve_path_unrestricted(project_root, path_str);
 
-    // Symlink traversal protection (#526): safe_resolve_path uses lexical
-    // normalization (path_clean) which can't detect symlinks. Since reads
-    // target existing files, we can canonicalize and verify the real path
-    // is still inside the project root.
-    if resolved.exists() {
-        let canon = resolved.canonicalize().unwrap_or_else(|_| resolved.clone());
-        let canon_root = project_root
-            .canonicalize()
-            .unwrap_or_else(|_| project_root.to_path_buf());
-        if !canon.starts_with(&canon_root) {
-            anyhow::bail!(
-                "Path escapes project root via symlink. Requested: {path_str:?}, \
-                 Real path: {}",
-                canon.display()
-            );
-        }
-    }
+    // No symlink traversal check — reads are unrestricted (docs/src/sandbox.md).
 
     let start_line = args["start_line"].as_u64();
     let num_lines = args["num_lines"].as_u64();
@@ -578,8 +563,7 @@ pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -
         .or_else(|| args["path"].as_str())
         .unwrap_or(".");
     let recursive = args["recursive"].as_bool().unwrap_or(false);
-    let resolved = safe_resolve_path(project_root, path_str)?;
-
+    let resolved = resolve_path_unrestricted(project_root, path_str);
     let mut entries = Vec::new();
     let mut total_count: usize = 0;
 
@@ -735,16 +719,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn read_file_path_escape_blocked() {
-        let tmp = tempfile::tempdir().unwrap();
-        let args = json!({"file_path": "../../../etc/passwd"});
-        let result = read_file(tmp.path(), &args, &cache()).await;
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
+    async fn read_file_can_reach_outside_project_root() {
+        // Reads are unrestricted (docs/src/sandbox.md).
+        // Create: /tmp/outer/secret.txt and /tmp/outer/project/
+        // Then read "../secret.txt" from project/.
+        let outer = tempfile::tempdir().unwrap();
+        let secret = outer.path().join("secret.txt");
+        std::fs::write(&secret, "outer content").unwrap();
+        let project = outer.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let args = json!({"file_path": "../secret.txt"});
+        let result = read_file(&project, &args, &cache()).await;
         assert!(
-            err.contains("escape") || err.contains("outside"),
-            "error should mention path escape: {err}"
+            result.is_ok(),
+            "read outside project root should succeed; got: {:?}",
+            result
         );
+        assert!(result.unwrap().contains("outer content"));
     }
 
     // ── Write ────────────────────────────────────────────────────

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -22,7 +22,7 @@
 
 use sha2::{Digest, Sha256};
 
-use super::resolve_path_unrestricted;
+use super::resolve_read_path;
 use super::safe_resolve_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
@@ -183,7 +183,7 @@ pub async fn read_file(
         .as_str()
         .or_else(|| args["path"].as_str())
         .ok_or_else(|| anyhow::anyhow!("Missing 'file_path' argument"))?;
-    let resolved = resolve_path_unrestricted(project_root, path_str);
+    let resolved = resolve_read_path(project_root, path_str)?;
 
     // No symlink traversal check — reads are unrestricted (docs/src/sandbox.md).
 
@@ -563,8 +563,8 @@ pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -
         .or_else(|| args["path"].as_str())
         .unwrap_or(".");
     let recursive = args["recursive"].as_bool().unwrap_or(false);
-    let resolved = resolve_path_unrestricted(project_root, path_str);
-    let mut entries = Vec::new();
+    let resolved = resolve_read_path(project_root, path_str)?;
+    let mut entries: Vec<String> = Vec::new();
     let mut total_count: usize = 0;
 
     if recursive {

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -14,7 +14,7 @@
 //! - Results are sorted alphabetically
 //! - Output is capped based on context window size
 
-use super::safe_resolve_path;
+use super::resolve_path_unrestricted;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
@@ -56,7 +56,7 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
         .as_str()
         .or_else(|| args["path"].as_str())
         .unwrap_or(".");
-    let base = safe_resolve_path(project_root, path_str)?;
+    let base = resolve_path_unrestricted(project_root, path_str);
 
     // Build full pattern relative to base directory
     let full_pattern = base.join(pattern);
@@ -71,11 +71,9 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
     for entry in glob_results {
         match entry {
             Ok(path) => {
-                // Security: ensure result is within project root
-                if !path.starts_with(project_root) {
-                    continue;
-                }
-                let relative = path.strip_prefix(project_root).unwrap_or(&path);
+                // Return paths relative to the search base; fall back to
+                // absolute if the path is somehow not under base.
+                let relative = path.strip_prefix(&base).unwrap_or(&path);
                 matches.push(relative.display().to_string());
                 if matches.len() >= max_results {
                     break;

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -14,7 +14,7 @@
 //! - Results are sorted alphabetically
 //! - Output is capped based on context window size
 
-use super::resolve_path_unrestricted;
+use super::resolve_read_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
@@ -56,7 +56,7 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
         .as_str()
         .or_else(|| args["path"].as_str())
         .unwrap_or(".");
-    let base = resolve_path_unrestricted(project_root, path_str);
+    let base = resolve_read_path(project_root, path_str)?;
 
     // Build full pattern relative to base directory
     let full_pattern = base.join(pattern);

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -20,7 +20,7 @@
 //! - **Grep tool**: fast, respects `.gitignore`, context-aware output caps
 //! - **`bash: grep/rg`**: only when you need complex flags the tool doesn't expose
 
-use super::safe_resolve_path;
+use super::resolve_path_unrestricted;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
@@ -69,7 +69,7 @@ pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Resu
         .unwrap_or(".");
     let case_insensitive = args["case_insensitive"].as_bool().unwrap_or(false);
 
-    let search_root = safe_resolve_path(project_root, path_str)?;
+    let search_root = resolve_path_unrestricted(project_root, path_str);
     let project_root = project_root.to_path_buf();
 
     // Run blocking file I/O off the tokio thread pool

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -20,7 +20,7 @@
 //! - **Grep tool**: fast, respects `.gitignore`, context-aware output caps
 //! - **`bash: grep/rg`**: only when you need complex flags the tool doesn't expose
 
-use super::resolve_path_unrestricted;
+use super::resolve_read_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
@@ -69,7 +69,7 @@ pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Resu
         .unwrap_or(".");
     let case_insensitive = args["case_insensitive"].as_bool().unwrap_or(false);
 
-    let search_root = resolve_path_unrestricted(project_root, path_str);
+    let search_root = resolve_read_path(project_root, path_str)?;
     let project_root = project_root.to_path_buf();
 
     // Run blocking file I/O off the tokio thread pool

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -800,7 +800,7 @@ pub fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBu
 ///
 /// This is the entry-point for **all read-only tools** (Read, List, Grep,
 /// Glob).  It wraps [`resolve_path_unrestricted`] with a check against
-/// [`crate::sandbox::is_fully_denied`] so that the same paths blocked by the
+/// `sandbox::is_fully_denied` so that the same paths blocked by the
 /// subprocess sandbox (bwrap / Seatbelt) are also blocked when the model
 /// accesses them through in-process tools.
 ///

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -765,9 +765,10 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
     if !resolved.starts_with(project_root) {
         anyhow::bail!(
             "Path {requested:?} is outside the project root ({project_root:?}). \
-             File tools (Read, Write, Edit, Glob, Grep) only work inside the \
-             project directory. Use the Bash tool to access files outside the \
-             project root."
+             File tools (Read, Write, Edit, Glob, Grep) are restricted to the \
+             project directory. Tell the user: to access this path, they can \
+             restart koda from a parent directory that contains both paths, or \
+             create a symlink inside the project root."
         );
     }
 
@@ -829,16 +830,21 @@ mod tests {
     }
 
     #[test]
-    fn test_outside_root_error_mentions_bash_tool() {
+    fn test_outside_root_error_is_actionable_for_user() {
         let err = safe_resolve_path(&root(), "../../etc/passwd").unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("Bash"),
-            "error message must direct the model to use Bash; got: {msg}"
+            msg.contains("outside the project root"),
+            "error must say 'outside the project root'; got: {msg}"
         );
         assert!(
-            msg.contains("outside the project root"),
-            "error message must say 'outside the project root'; got: {msg}"
+            msg.contains("Tell the user"),
+            "error must direct model to surface this to the user; got: {msg}"
+        );
+        // Must NOT suggest Bash — that would bypass the file-tool safety layer.
+        assert!(
+            !msg.contains("Bash"),
+            "error must not suggest Bash as a workaround; got: {msg}"
         );
     }
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -781,16 +781,12 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
 
 /// Normalise a path without enforcing any scope restriction.
 ///
-/// Used by **read-only** tools (Read, List, Grep, Glob).  Relative paths are
-/// resolved against `project_root` (the process cwd); absolute paths are
+/// Low-level primitive — **tool implementations should call
+/// [`resolve_read_path`] instead**, which adds the fully-denied list check
+/// that keeps in-process policy in sync with the subprocess sandbox.
+///
+/// Relative paths are resolved against `project_root`; absolute paths are
 /// cleaned in-place.  The result may point anywhere on the filesystem.
-///
-/// # Security tradeoff
-///
-/// Reads are intentionally unrestricted — see `docs/src/sandbox.md`.  The
-/// short version: reads cannot mutate state, Bash already gives the same
-/// access, and OS-level sandboxing (bwrap / Seatbelt) is the real boundary.
-/// Only Write / Edit / Delete are gated by `safe_resolve_path`.
 pub fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBuf {
     let path = Path::new(requested);
     if path.is_absolute() {
@@ -798,6 +794,30 @@ pub fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBu
     } else {
         project_root.join(path).clean()
     }
+}
+
+/// Normalise a read-only path and enforce the fully-denied list.
+///
+/// This is the entry-point for **all read-only tools** (Read, List, Grep,
+/// Glob).  It wraps [`resolve_path_unrestricted`] with a check against
+/// [`crate::sandbox::is_fully_denied`] so that the same paths blocked by the
+/// subprocess sandbox (bwrap / Seatbelt) are also blocked when the model
+/// accesses them through in-process tools.
+///
+/// Currently the only denied path is `~/.config/koda/db` — koda's own SQLite
+/// database containing plaintext API keys.  Ordinary credential directories
+/// (`~/.ssh`, `~/.aws`, …) are readable, matching the Bash sandbox policy.
+///
+/// See issue #884 for Option B (OS-level enforcement via sandboxed worker).
+pub fn resolve_read_path(project_root: &Path, requested: &str) -> Result<PathBuf> {
+    let resolved = resolve_path_unrestricted(project_root, requested);
+    if crate::sandbox::is_fully_denied(&resolved) {
+        anyhow::bail!(
+            "Access to {requested:?} is denied: this path contains koda's \
+             internal secrets and cannot be read by model tool calls."
+        );
+    }
+    Ok(resolved)
 }
 
 #[cfg(test)]
@@ -877,6 +897,32 @@ mod tests {
     fn test_empty_path_resolves_to_root() {
         let result = safe_resolve_path(&root(), "").unwrap();
         assert_eq!(result, PathBuf::from("/home/user/project"));
+    }
+
+    // ── resolve_read_path ──────────────────────────────────────────────────
+
+    #[test]
+    fn read_path_allows_project_file() {
+        let p = resolve_read_path(&root(), "src/lib.rs").unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/project/src/lib.rs"));
+    }
+
+    #[test]
+    fn read_path_allows_outside_project() {
+        // Reads outside the project root are intentionally unrestricted.
+        let p = resolve_read_path(&root(), "/etc/hosts").unwrap();
+        assert_eq!(p, PathBuf::from("/etc/hosts"));
+    }
+
+    #[test]
+    fn read_path_blocks_koda_db() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+        let koda_db = format!("{home}/.config/koda/db/koda.db");
+        let err = resolve_read_path(&root(), &koda_db).unwrap_err();
+        assert!(
+            err.to_string().contains("denied"),
+            "expected 'denied' in error, got: {err}"
+        );
     }
 }
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -752,6 +752,8 @@ impl ToolRegistry {
 /// assert!(safe_resolve_path(root, "../../etc/passwd").is_err());
 /// ```
 pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf> {
+    // NOTE: used only for Write / Edit / Delete.  Read-only tools call
+    // resolve_path_unrestricted — see docs/src/sandbox.md for the rationale.
     let requested_path = Path::new(requested);
 
     // Build absolute path and normalize (removes .., . etc.)
@@ -761,18 +763,41 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
         project_root.join(requested_path).clean()
     };
 
-    // Security check: must be within project root
+    // Security check: must be within project root.
+    // Only Write / Edit / Delete are gated here — reads are unrestricted
+    // (see resolve_path_unrestricted and docs/src/sandbox.md).
     if !resolved.starts_with(project_root) {
         anyhow::bail!(
             "Path {requested:?} is outside the project root ({project_root:?}). \
-             File tools (Read, Write, Edit, Glob, Grep) are restricted to the \
-             project directory. Tell the user: to access this path, they can \
-             restart koda from a parent directory that contains both paths, or \
-             create a symlink inside the project root."
+             Write, Edit, and Delete are restricted to the project directory to \
+             prevent accidental modification of files outside the project. \
+             Tell the user: to write outside the project, restart koda from a \
+             parent directory that contains both paths."
         );
     }
 
     Ok(resolved)
+}
+
+/// Normalise a path without enforcing any scope restriction.
+///
+/// Used by **read-only** tools (Read, List, Grep, Glob).  Relative paths are
+/// resolved against `project_root` (the process cwd); absolute paths are
+/// cleaned in-place.  The result may point anywhere on the filesystem.
+///
+/// # Security tradeoff
+///
+/// Reads are intentionally unrestricted — see `docs/src/sandbox.md`.  The
+/// short version: reads cannot mutate state, Bash already gives the same
+/// access, and OS-level sandboxing (bwrap / Seatbelt) is the real boundary.
+/// Only Write / Edit / Delete are gated by `safe_resolve_path`.
+pub fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBuf {
+    let path = Path::new(requested);
+    if path.is_absolute() {
+        path.to_path_buf().clean()
+    } else {
+        project_root.join(path).clean()
+    }
 }
 
 #[cfg(test)]

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -764,7 +764,10 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
     // Security check: must be within project root
     if !resolved.starts_with(project_root) {
         anyhow::bail!(
-            "Path escapes project root. Requested: {requested:?}, Resolved: {resolved:?}"
+            "Path {requested:?} is outside the project root ({project_root:?}). \
+             File tools (Read, Write, Edit, Glob, Grep) only work inside the \
+             project directory. Use the Bash tool to access files outside the \
+             project root."
         );
     }
 
@@ -823,6 +826,20 @@ mod tests {
     fn test_absolute_path_outside_root_blocked() {
         let result = safe_resolve_path(&root(), "/etc/shadow");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_outside_root_error_mentions_bash_tool() {
+        let err = safe_resolve_path(&root(), "../../etc/passwd").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Bash"),
+            "error message must direct the model to use Bash; got: {msg}"
+        );
+        assert!(
+            msg.contains("outside the project root"),
+            "error message must say 'outside the project root'; got: {msg}"
+        );
     }
 
     #[test]

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -35,14 +35,19 @@ fn find_all_tool_outputs(events: &[EngineEvent], tool: &str) -> Vec<String> {
         .collect()
 }
 
-// ── Symlink sandbox escape (Codex: safety_tests, Gemini: symlink-install) ──
+// ── Symlink reads (Codex: safety_tests, Gemini: symlink-install) ──────────
+//
+// Reads are intentionally unrestricted (docs/src/sandbox.md).  A symlink
+// inside the project that points outside is treated like any other read —
+// the content is returned.  Only Write / Edit / Delete are scoped to the
+// project root.
 
 #[tokio::test]
 #[cfg(unix)]
-async fn read_via_symlink_outside_sandbox_is_blocked() {
+async fn read_via_symlink_outside_project_succeeds() {
     let env = Env::new().await;
 
-    // Create a symlink inside project root pointing outside.
+    // Create a file outside the project root and symlink it in.
     let outside_dir = tempfile::tempdir().unwrap();
     let secret = outside_dir.path().join("secret.txt");
     std::fs::write(&secret, "TOP SECRET DATA").unwrap();
@@ -54,21 +59,17 @@ async fn read_via_symlink_outside_sandbox_is_blocked() {
 
     let provider = MockProvider::new(vec![
         MockResponse::tool_call("Read", serde_json::json!({"file_path": "sneaky_link"})),
-        MockResponse::Text("I tried to read it.".into()),
+        MockResponse::Text("I read it.".into()),
     ]);
     let events = env.run_inference(&provider).await;
 
-    // The Read tool result should contain an error about escaping.
+    // Read should succeed and return the file content.
     let read_output = find_tool_output(&events, "Read");
     assert!(read_output.is_some(), "expected Read result: {events:?}");
     let output = read_output.unwrap();
     assert!(
-        output.contains("escape")
-            || output.contains("symlink")
-            || output.contains("outside")
-            || output.contains("resolve")
-            || output.contains("denied"),
-        "should block symlink escape: {output}"
+        output.contains("TOP SECRET DATA"),
+        "symlink read should return content: {output}"
     );
 }
 

--- a/koda-core/tests/e2e_safety_test.rs
+++ b/koda-core/tests/e2e_safety_test.rs
@@ -73,7 +73,35 @@ async fn read_via_symlink_outside_project_succeeds() {
     );
 }
 
-// ── File paths with spaces (Gemini: file-system.test.ts) ───────────────────
+// ── Koda-internal secret protection (#882) ───────────────────────────────────
+//
+// The Read tool must reject ~/.config/koda/db regardless of trust mode.
+// This mirrors the bwrap/Seatbelt fully-deny rule applied to Bash.
+
+#[tokio::test]
+async fn read_tool_blocks_koda_db() {
+    let env = Env::new().await;
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+    let koda_db = format!("{home}/.config/koda/db/koda.db");
+
+    env.insert_user_message("read the koda database").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("Read", serde_json::json!({"file_path": koda_db})),
+        MockResponse::Text("I tried to read it.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let output = find_tool_output(&events, "Read");
+    assert!(output.is_some(), "expected Read result: {events:?}");
+    let output = output.unwrap();
+    assert!(
+        output.contains("denied"),
+        "Read tool must reject ~/.config/koda/db: {output}"
+    );
+}
+
+// ── File paths with spaces (Gemini: file-system.test.ts) ─────────────────────
 
 #[tokio::test]
 async fn read_and_write_file_with_spaces_in_path() {


### PR DESCRIPTION
## Summary

Adopts the Claude Code model for file-tool path policy, with a targeted
deny rule that keeps in-process tools in sync with the Bash subprocess sandbox.

| Tool | Path restriction |
|------|-----------------|
| Read, List, Grep, Glob | **Any OS-accessible path**, except `~/.config/koda/db` |
| Write, Edit, Delete | **Project root only** via `safe_resolve_path` |

## Why reads are (mostly) unrestricted

1. **Reads cannot mutate state** — worst case is sensitive content in context, not data loss.
2. **Bash already has full read reach** — a tool-level gate is bypassed the moment the model runs `cat`. Security theater.
3. **OS sandbox is the real perimeter** — bwrap (Linux) / Seatbelt (macOS) define what the process can access.
4. **Cross-repo workflows are the common case** — sibling repos, shared libraries, dotfile inspection.

The risk is documented with mitigations in `docs/src/sandbox.md`.

## Why `~/.config/koda/db` is the one exception

The Bash sandbox already fully denies this path (bwrap `--tmpfs` / Seatbelt `deny file-read*`
— see #847). It contains koda's own plaintext API keys; the model has no legitimate reason
to read it. Leaving it open in the in-process tools while blocking it in Bash was an
inconsistency introduced by this PR's original draft.

Long-term fix is issue #884 (Option B — sandboxed worker process). For now, Option A:
a single `sandbox::is_fully_denied(path)` function references the existing
`CREDENTIAL_CONFIG_FULL_DENY` constant, and all four read tools call
`resolve_read_path()` which wraps that check.

## Changes

### `sandbox.rs`
- `pub(crate) is_fully_denied(path: &Path) -> bool` — derives from `CREDENTIAL_CONFIG_FULL_DENY`; single source of truth for the deny list used by both bwrap/Seatbelt builders and in-process tools.

### `tools/mod.rs`
- `resolve_path_unrestricted` — low-level primitive, now explicitly documented as internal.
- **`resolve_read_path`** (new) — wraps `resolve_path_unrestricted` + `is_fully_denied` check; all read tools use this.
- `safe_resolve_path` error message now explicitly says "Write, Edit, and Delete".

### `file_tools.rs`
- `read_file` + `list_files` → `resolve_read_path`.
- Removed symlink-traversal guard from `read_file`.

### `grep.rs` / `glob_tool.rs`
- Switched to `resolve_read_path`.
- `glob_search` no longer silently drops out-of-project results; `strip_prefix` uses search root.

### `docs/src/sandbox.md`
- New **"File tool read policy"** section: rationale, Claude Code comparison, accepted risk, mitigations.

### `.githooks/pre-push`
- Added step 4: unit tests (`--lib`) + all fast integration suites.  
  Previously the hook ran lint only — `tests/*.rs` integration tests were invisible to it, which is why the CI failure wasn't caught locally.
- Slow suites (`mcp_http_transport`, `inference_edge`, `inference_recovery`) skipped in hook; CI covers them on every push.

### `CONTRIBUTING.md`
- Hook description updated to list all 4 steps.
- Explicit note: `--no-verify` is for genuine WIP pushes only.

### `koda-core/tests/e2e_safety_test.rs`
- `read_via_symlink_outside_sandbox_is_blocked` → `read_via_symlink_outside_project_succeeds` (policy change: symlink reads now succeed like any other read).
- `read_tool_blocks_koda_db` (new) — E2E: model calls `Read(~/.config/koda/db)` → denied.

## Policy comparison: Bash vs Read tools (after this PR)

| Path | Bash | Read/List/Grep/Glob |
|------|------|---------------------|
| Project files | ✅ | ✅ |
| Outside project (`../other-repo`) | ✅ | ✅ |
| `~/.ssh`, `~/.aws`, `~/.config/gh` | ✅ (read) | ✅ |
| `~/.config/koda/db` | ❌ blocked | ❌ blocked |

## Tests

- **937 unit tests** (up from 931) — 6 new: `is_fully_denied` × 3, `resolve_read_path` × 3.
- **17 `e2e_safety_test`** (up from 16) — new: `read_tool_blocks_koda_db`.
- All other integration suites unchanged and green.

## Related

Closes #876  
Supersedes #883  
Future work: #884 (Option B — sandboxed worker process)