### PR TITLE
fix(db): restart inference cleanly after interruption (#855)

### DIFF
--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -287,6 +287,7 @@ impl Persistence for Database {
     /// Returns messages in chronological order. Compacted messages
     /// (archived by `/compact`) are excluded — their summary replaces them.
     /// Several sanitisation passes run before returning:
+    /// - Incomplete assistant messages (interrupted/network-error) are excluded (#875, #877)
     /// - Mismatched tool_use / tool_result pairs are pruned (#428)
     /// - Null-content assistant messages with no tool calls are dropped (#594)
     /// - Whitespace-only assistant messages are dropped (#594)
@@ -298,6 +299,7 @@ impl Persistence for Database {
                     created_at
              FROM messages
              WHERE session_id = ? AND compacted_at IS NULL
+               AND (role != 'assistant' OR completed_at IS NOT NULL)
              ORDER BY id ASC",
         )
         .bind(session_id)
@@ -598,13 +600,14 @@ impl Persistence for Database {
         .execute(&mut *tx)
         .await?;
 
-        // Insert a continuation hint so the LLM knows how to behave
+        // Insert a continuation hint so the LLM knows how to behave.
+        // Set completed_at immediately — synthetic messages are complete from birth.
         let continuation = "Your context was compacted. The previous message contains a summary of our earlier conversation. \
             Do not mention the summary or that compaction occurred. \
             Continue the conversation naturally based on the summarized context.";
         sqlx::query(
-            "INSERT INTO messages (session_id, role, content, tool_calls, tool_call_id, prompt_tokens, completion_tokens)
-             VALUES (?, 'assistant', ?, NULL, NULL, NULL, NULL)",
+            "INSERT INTO messages (session_id, role, content, tool_calls, tool_call_id, prompt_tokens, completion_tokens, completed_at)
+             VALUES (?, 'assistant', ?, NULL, NULL, NULL, NULL, datetime('now'))",
         )
         .bind(session_id)
         .bind(continuation)

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -19,6 +19,23 @@ async fn setup() -> (Database, TempDir) {
     (db, tmp)
 }
 
+/// Insert an assistant message and immediately mark it complete.
+/// Most tests need "born-complete" assistant messages; only interruption
+/// tests deliberately omit the `mark_message_complete` call.
+async fn insert_complete_assistant(
+    db: &Database,
+    session: &str,
+    content: Option<&str>,
+    tool_calls: Option<&str>,
+) -> i64 {
+    let mid = db
+        .insert_message(session, &Role::Assistant, content, tool_calls, None, None)
+        .await
+        .unwrap();
+    db.mark_message_complete(mid).await.unwrap();
+    mid
+}
+
 #[tokio::test]
 async fn test_create_session() {
     let (db, _tmp) = setup().await;
@@ -34,16 +51,7 @@ async fn test_insert_and_load_messages() {
     db.insert_message(&session, &Role::User, Some("hello"), None, None, None)
         .await
         .unwrap();
-    db.insert_message(
-        &session,
-        &Role::Assistant,
-        Some("hi there!"),
-        None,
-        None,
-        None,
-    )
-    .await
-    .unwrap();
+    insert_complete_assistant(&db, &session, Some("hi there!"), None).await;
 
     let msgs = db.load_context(&session).await.unwrap();
     assert_eq!(msgs.len(), 2);
@@ -178,16 +186,21 @@ async fn test_compact_session() {
     let (db, _tmp) = setup().await;
     let session = db.create_session("default", _tmp.path()).await.unwrap();
 
-    // Insert several messages
+    // Insert several messages; assistant messages are marked complete
+    // (they represent finished turns that load_context must return).
     for i in 0..10 {
         let role = if i % 2 == 0 {
             &Role::User
         } else {
             &Role::Assistant
         };
-        db.insert_message(&session, role, Some(&format!("msg {i}")), None, None, None)
+        let mid = db
+            .insert_message(&session, role, Some(&format!("msg {i}")), None, None, None)
             .await
             .unwrap();
+        if *role == Role::Assistant {
+            db.mark_message_complete(mid).await.unwrap();
+        }
     }
 
     // Compact preserving the last 2 messages
@@ -308,16 +321,18 @@ async fn test_prune_mismatched_tool_calls() {
     db.insert_message(&session, &Role::User, Some("hello"), None, None, None)
         .await
         .unwrap();
-    db.insert_message(
-        &session,
-        &Role::Assistant,
-        Some("Let me read that."),
-        Some(r#"[{"id":"tc1","name":"Read","arguments":"{}"}]"#),
-        None,
-        None,
-    )
-    .await
-    .unwrap();
+    let mid = db
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("Let me read that."),
+            Some(r#"[{"id":"tc1","name":"Read","arguments":"{}"}]"#),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    db.mark_message_complete(mid).await.unwrap();
     db.insert_message(
         &session,
         &Role::Tool,
@@ -329,7 +344,7 @@ async fn test_prune_mismatched_tool_calls() {
     .await
     .unwrap();
 
-    // Interrupted turn: assistant with tool_calls but NO tool result
+    // Interrupted turn: assistant with tool_calls but NO tool result and NOT marked complete
     db.insert_message(
         &session,
         &Role::Assistant,
@@ -340,6 +355,7 @@ async fn test_prune_mismatched_tool_calls() {
     )
     .await
     .unwrap();
+    // deliberately no mark_message_complete — simulates interrupted turn
 
     let msgs = db.load_context(&session).await.unwrap();
 
@@ -801,6 +817,7 @@ async fn test_insert_message_with_agent() {
         .await
         .unwrap();
     assert!(id > 0);
+    db.mark_message_complete(id).await.unwrap();
 
     let msgs = db.load_context(&session).await.unwrap();
     assert_eq!(msgs.len(), 1);
@@ -1179,6 +1196,7 @@ async fn thinking_content_round_trip() {
         .insert_message(&session, &Role::Assistant, Some("answer"), None, None, None)
         .await
         .unwrap();
+    db.mark_message_complete(id).await.unwrap();
 
     db.update_message_thinking_content(id, "I should think carefully about this…")
         .await
@@ -1244,6 +1262,7 @@ async fn thinking_content_persists_and_is_loaded_in_context() {
         )
         .await
         .unwrap();
+    db.mark_message_complete(assistant_id).await.unwrap();
 
     db.update_message_thinking_content(assistant_id, "2+2=4 trivially")
         .await
@@ -1256,5 +1275,141 @@ async fn thinking_content_persists_and_is_loaded_in_context() {
         assistant.thinking_content.as_deref(),
         Some("2+2=4 trivially"),
         "thinking_content must survive context reload (session resume path)"
+    );
+}
+
+// ── Incomplete assistant messages excluded from load_context (#875, #877) ──
+
+/// Assistant messages without `completed_at` (interrupted/network-error turns)
+/// must be excluded from `load_context()` so the model gets a clean slate —
+/// as if the interrupted turn never happened. They should still be present
+/// in `load_all_messages()` for history/recall purposes.
+#[tokio::test]
+async fn load_context_excludes_incomplete_assistant_messages() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // User sends a message
+    db.insert_message(
+        &session,
+        &Role::User,
+        Some("research inference"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Assistant starts responding but is interrupted (no mark_message_complete)
+    let _incomplete_id = db
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("I'll start by looking at"),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+    // load_context should exclude the incomplete assistant message
+    let context = db.load_context(&session).await.unwrap();
+    assert_eq!(
+        context.len(),
+        1,
+        "only the user message should be in context"
+    );
+    assert_eq!(context[0].role, Role::User);
+    assert_eq!(context[0].content.as_deref(), Some("research inference"));
+
+    // load_all_messages should still include it (for history/recall)
+    let all = db.load_all_messages(&session).await.unwrap();
+    assert_eq!(all.len(), 2, "both messages should be in full history");
+}
+
+/// Completed assistant messages (with `completed_at` set) must still appear
+/// in `load_context()` — only incomplete ones are excluded.
+#[tokio::test]
+async fn load_context_includes_completed_assistant_messages() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&session, &Role::User, Some("hello"), None, None, None)
+        .await
+        .unwrap();
+
+    let msg_id = db
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("hi there!"),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    db.mark_message_complete(msg_id).await.unwrap();
+
+    let context = db.load_context(&session).await.unwrap();
+    assert_eq!(
+        context.len(),
+        2,
+        "completed assistant message must be in context"
+    );
+    assert_eq!(context[1].role, Role::Assistant);
+    assert_eq!(context[1].content.as_deref(), Some("hi there!"));
+}
+
+/// After an interrupted turn, detect_interruption should see the user message
+/// as the last relevant message (the incomplete assistant was filtered out).
+#[tokio::test]
+async fn interrupted_turn_detected_after_incomplete_filtered() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Complete first exchange
+    db.insert_message(&session, &Role::User, Some("hello"), None, None, None)
+        .await
+        .unwrap();
+    let mid = db
+        .insert_message(&session, &Role::Assistant, Some("hi!"), None, None, None)
+        .await
+        .unwrap();
+    db.mark_message_complete(mid).await.unwrap();
+
+    // Second turn: user sends, assistant interrupted
+    db.insert_message(
+        &session,
+        &Role::User,
+        Some("research inference"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    db.insert_message(
+        &session,
+        &Role::Assistant,
+        Some("partial response"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    // No mark_message_complete — simulates Ctrl+C
+
+    let context = db.load_context(&session).await.unwrap();
+    // Should be: [user "hello", assistant "hi!", user "research inference"]
+    assert_eq!(context.len(), 3, "incomplete assistant should be filtered");
+
+    let interruption = detect_interruption(&context);
+    assert!(
+        matches!(interruption, Some(InterruptionKind::Prompt(_))),
+        "should detect unanswered user prompt; got {interruption:?}"
     );
 }

--- a/koda-core/src/microcompact.rs
+++ b/koda-core/src/microcompact.rs
@@ -327,9 +327,12 @@ mod tests {
             let tc_id = format!("tc_{i}");
             let tc_json =
                 format!(r#"[{{"id":"{tc_id}","function_name":"Read","arguments":"{{}}"}}]"#);
-            db.insert_message(&session, &Role::Assistant, None, Some(&tc_json), None, None)
+            let mid = db
+                .insert_message(&session, &Role::Assistant, None, Some(&tc_json), None, None)
                 .await
                 .unwrap();
+            // Mark complete — these represent finished turns that load_context must see.
+            db.mark_message_complete(mid).await.unwrap();
             db.insert_message(
                 &session,
                 &Role::Tool,

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -232,15 +232,22 @@ pub(crate) async fn execute_sub_agent(
             if is_fork {
                 let parent_history = db.load_context(parent_session_id).await?;
                 for msg in &parent_history {
-                    db.insert_message(
-                        &sid,
-                        &msg.role,
-                        msg.content.as_deref(),
-                        msg.tool_calls.as_deref(),
-                        msg.tool_call_id.as_deref(),
-                        None, // don't duplicate usage stats
-                    )
-                    .await?;
+                    let mid = db
+                        .insert_message(
+                            &sid,
+                            &msg.role,
+                            msg.content.as_deref(),
+                            msg.tool_calls.as_deref(),
+                            msg.tool_call_id.as_deref(),
+                            None, // don't duplicate usage stats
+                        )
+                        .await?;
+                    // Copied assistant messages are already complete in the
+                    // parent — mark them complete in the child session so
+                    // load_context includes them (#875).
+                    if msg.role == Role::Assistant {
+                        db.mark_message_complete(mid).await?;
+                    }
                 }
             }
             sid

--- a/koda-core/tests/e2e_skills_test.rs
+++ b/koda-core/tests/e2e_skills_test.rs
@@ -160,7 +160,8 @@ async fn test_compact_session_summarizes_and_reduces_messages() {
             )
             .await
             .unwrap();
-        env.db
+        let mid = env
+            .db
             .insert_message(
                 &env.session_id,
                 &Role::Assistant,
@@ -173,6 +174,7 @@ async fn test_compact_session_summarizes_and_reduces_messages() {
             )
             .await
             .unwrap();
+        env.db.mark_message_complete(mid).await.unwrap();
     }
 
     let before = env.db.load_context(&env.session_id).await.unwrap();
@@ -215,7 +217,8 @@ async fn test_compact_skips_short_conversation() {
 
     let env = Env::new().await;
     env.insert_user_message("hello").await;
-    env.db
+    let mid = env
+        .db
         .insert_message(
             &env.session_id,
             &Role::Assistant,
@@ -226,6 +229,7 @@ async fn test_compact_skips_short_conversation() {
         )
         .await
         .unwrap();
+    env.db.mark_message_complete(mid).await.unwrap();
 
     let provider: Arc<RwLock<Box<dyn LlmProvider>>> =
         Arc::new(RwLock::new(Box::new(MockProvider::new(vec![]))));

--- a/koda-core/tests/inference_recovery_test.rs
+++ b/koda-core/tests/inference_recovery_test.rs
@@ -148,3 +148,144 @@ async fn test_context_overflow_too_few_messages_fails() {
         "error should mention overflow: {err}"
     );
 }
+
+// ── Network error clean resume tests (#875, #877) ───────────────────────
+
+/// After a network error, the next inference turn should see only the
+/// original user message — no partial responses, no sentinel messages.
+/// This verifies that `load_context()` filters incomplete assistant
+/// messages (those without `completed_at`).
+#[tokio::test]
+async fn test_network_error_next_turn_gets_clean_context() {
+    let env = Env::builder().max_context_tokens(100_000).build().await;
+    env.insert_user_message("research the inference loop").await;
+
+    // First call: network error after partial text
+    let provider = MockProvider::new(vec![MockResponse::NetworkError {
+        partial_text: "I'll start by".into(),
+        error: "connection reset".into(),
+    }]);
+
+    let (result, events) = env.run_inference_result(&provider).await;
+    assert!(
+        result.is_ok(),
+        "network error should not propagate: {result:?}"
+    );
+
+    let has_network_warn = events.iter().any(|e| {
+        matches!(e, EngineEvent::Warn { message } if message.contains("network") || message.contains("Network") || message.contains("connection"))
+    });
+    assert!(
+        has_network_warn,
+        "expected network warning; events: {events:?}"
+    );
+
+    // Now simulate the user typing "continue" — second turn
+    env.insert_user_message("continue").await;
+
+    let provider2 = MockProvider::new(vec![MockResponse::Text(
+        "Here is the full research on the inference loop.".into(),
+    )]);
+
+    let _events2 = env.run_inference(&provider2).await;
+
+    // The recorded call should contain the original user message, the
+    // "continue" message, and NO partial response or sentinel.
+    let calls = provider2.recorded_calls();
+    assert!(!calls.is_empty(), "provider should have been called");
+    let messages = &calls[0];
+
+    // No message should contain the partial text "I'll start by"
+    for msg in messages {
+        if let Some(ref content) = msg.content {
+            assert!(
+                !content.contains("I'll start by"),
+                "partial response from network error should NOT be in context: {content}"
+            );
+            assert!(
+                !content.contains("[System]"),
+                "no sentinel system messd be in context: {content}"
+            );
+        }
+    }
+
+    // The original user message should be present
+    let has_original = messages.iter().any(|m| {
+        m.content
+            .as_deref()
+            .is_some_and(|c| c.contains("research the inference loop"))
+    });
+    assert!(has_original, "original user message should be in context");
+
+    // The "continue" message should be present
+    let has_continue = messages
+        .iter()
+        .any(|m| m.content.as_deref().is_some_and(|c| c.contains("continue")));
+    assert!(has_continue, "continue message should be in context");
+}
+
+/// After a Ctrl+C interruption, the partial assistant response is saved
+/// but should be filtered from context on the next turn (since
+/// `mark_message_complete` was never called).
+#[tokio::test]
+async fn test_ctrl_c_next_turn_excludes_partial_response() {
+    use tokio_util::sync::CancellationToken;
+
+    let env = Env::builder().max_context_tokens(100_000).build().await;
+    env.insert_user_message("write a poem about cats").await;
+
+    // Simulate: model streams text, then user hits Ctrl+C
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    // Use a normal text response but cancel immediately after starting
+    let provider = MockProvider::new(vec![MockResponse::Text(
+        "Whiskers twitch in moonlit night".into(),
+    )]);
+
+    // Cancel before inference even starts streaming — the cancellation
+    // token will be checked during stream collection.
+    cancel_clone.cancel();
+
+    let (result, _events) = env.run_inference_cancellable(&provider, cancel).await;
+    assert!(result.is_ok(), "cancellation should not error: {result:?}");
+
+    // Next turn: user types something new
+    env.insert_user_message("now write about dogs").await;
+
+    let provider2 = MockProvider::new(vec![MockResponse::Text("Dogs are loyal and true.".into())]);
+
+    let _events2 = env.run_inference(&provider2).await;
+
+    let calls = provider2.recorded_calls();
+    assert!(!calls.is_empty());
+    let messages = &calls[0];
+
+    // The original user message should be present
+    let has_poem = messages.iter().any(|m| {
+        m.content
+            .as_deref()
+            .is_some_and(|c| c.contains("poem about cats"))
+    });
+    assert!(has_poem, "original prompt should be in context");
+
+    // The "dogs" message should be present
+    let has_dogs = messages.iter().any(|m| {
+        m.content
+            .as_deref()
+            .is_some_and(|c| c.contains("about dogs"))
+    });
+    assert!(has_dogs, "new prompt should be in context");
+
+    // No incomplete assistant response should be in context
+    // (it wasn't marked complete, so load_context filters it)
+    let assistant_msgs: Vec<_> = messages.iter().filter(|m| m.role == "assistant").collect();
+    for m in &assistant_msgs {
+        if let Some(ref content) = m.content {
+            assert!(
+                !content.contains("Whiskers"),
+                "incomplete response should be filtered from context: {content}"
+            );
+        }
+    }
+}

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -130,11 +130,19 @@ impl Env {
     }
 
     /// Insert a message with any role into the test session.
+    /// Assistant messages are immediately marked complete — they represent
+    /// finished turns, not in-progress streams. Tests that want to simulate
+    /// an interrupted turn should call `db.insert_message` directly and
+    /// omit `mark_message_complete`.
     pub async fn insert_message(&self, role: &Role, text: &str) {
-        self.db
+        let mid = self
+            .db
             .insert_message(&self.session_id, role, Some(text), None, None, None)
             .await
             .unwrap();
+        if *role == Role::Assistant {
+            self.db.mark_message_complete(mid).await.unwrap();
+        }
     }
 
     /// Run inference with a MockProvider (convenience wrapper, asserts success).


### PR DESCRIPTION
## Problem

When a turn is interrupted (Ctrl+C, network error, or any unclean stop), the partial assistant response written mid-stream has `completed_at = NULL` — `mark_message_complete` is only called after a legitimate `StreamChunk::Done`. But `load_context()` was returning ALL non-compacted messages regardless of completion status, so the model would see a truncated, broken response and try to "continue" from a corrupted state.

## Root cause

```sql
-- Before: returns incomplete assistant messages
WHERE session_id = ? AND compacted_at IS NULL

-- After: skips assistant messages that were never marked complete
WHERE session_id = ? AND compacted_at IS NULL
  AND (role != 'assistant' OR completed_at IS NOT NULL)
```

The `completed_at` column and `mark_message_complete()` already existed and were set correctly in the inference loop. The filter was just never applied at read time.

## What this achieves

After any interruption — intentional or not — the next inference turn sees:

```
[user] research the inference loop     ← still here
                                        ← no broken partial response
                                        ← no sentinel system message
```

The model gets a clean slate and produces a fresh, complete response. No sentinel. No synthetic "continue" prompt. No extra context tokens. Exactly like Claude Code's `filterUnresolvedToolUses` / `filterWhitespaceOnlyAssistantMessages` pattern — except simpler because we use the `completed_at` column already in our schema.

## Companion fixes

- **`compact_session`**: the assistant continuation hint is now inserted with `completed_at = datetime('now')` — synthetic messages are born complete.
- **`sub_agent_dispatch` fork**: copied parent assistant messages are immediately marked complete in the child session so the fork's `load_context` sees them.
- **`Env::insert_message`** test helper: marks assistant messages complete, matching the production invariant.

## Tests added

| Test | What it verifies |
|------|-----------------|
| `load_context_excludes_incomplete_assistant_messages` | Core SQL filter works; incomplete assistant excluded, user message stays |
| `load_context_includes_completed_assistant_messages` | Completed turns not accidentally filtered |
| `interrupted_turn_detected_after_incomplete_filtered` | After filter, `detect_interruption` correctly sees unanswered user prompt |
| `test_network_error_next_turn_gets_clean_context` | No partial text or sentinel in API context after network error |
| `test_ctrl_c_next_turn_excludes_partial_response` | Ctrl+C partial response excluded from next turn's API call |

Closes #855