### PR TITLE
fix: inject assistant sentinel for interrupted-turn resume (all providers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Koda are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+- **Ctrl+C resume broken across all providers** — typing `continue` after an
+  interrupted turn sent two consecutive user-side messages to the API, causing
+  a 400/422 rejection on every provider. `assemble_messages` now injects a
+  synthetic assistant sentinel between any consecutive user-side messages
+  at assembly time (never written to DB, disappears after the next real
+  reply). Covers both the streaming-interrupted case (`user → user`) and the
+  tool-result-interrupted case (`tool → user`), which Anthropic and Gemini
+  both treat as two consecutive user messages after their internal remapping
+  (#875).
+
 ## [0.2.12] - 2026-04-12
 
 ### Added

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -65,25 +65,61 @@ pub fn estimate_tokens(messages: &[ChatMessage]) -> usize {
         .sum()
 }
 
+/// Synthetic assistant message injected between consecutive user-side messages.
+///
+/// Inserted in-memory by [`assemble_messages`] — never written to the DB.
+/// When Ctrl+C interrupts an inference turn the assistant message never lands,
+/// leaving the history ending on a user or tool message. The next user message
+/// (e.g. "continue") then produces back-to-back user-side turns that all three
+/// providers reject as invalid role alternation. The sentinel bridges the gap
+/// so the provider sees `user → assistant → user` regardless of where the
+/// interruption occurred. Self-correcting: once the model replies for real,
+/// the sentinel is no longer needed and disappears on the next load.
+pub const INTERRUPTED_TURN_SENTINEL: &str = "[Turn interrupted — pick up from where you left off.]";
+
 /// Assemble messages from DB history into ChatMessage vec.
+///
+/// Injects a synthetic `assistant` sentinel between any consecutive user-side
+/// messages (`user` or `tool` followed by a plain `user`). This repairs broken
+/// role alternation caused by an interrupted turn without touching the DB.
+/// All three providers (Anthropic, Gemini, OpenAI-compat) require alternating
+/// roles; Anthropic and Gemini remap `tool` → user-role internally, so the
+/// `tool → user` case is equally broken without the sentinel (#875).
 pub fn assemble_messages(
     system_message: &ChatMessage,
     history: &[crate::db::Message],
 ) -> Vec<ChatMessage> {
     let mut messages = vec![system_message.clone()];
+
     for msg in history {
+        let role = msg.role.as_str();
+        let is_plain_user = role == "user" && msg.tool_call_id.is_none();
+
+        // If a plain user message would immediately follow another user-side
+        // message, the provider will reject the request. Insert a sentinel
+        // assistant message to restore valid alternation (#875).
+        if is_plain_user {
+            let prev_is_user_side = messages
+                .last()
+                .is_some_and(|p| p.role == "user" || p.role == "tool");
+            if prev_is_user_side {
+                messages.push(ChatMessage::text("assistant", INTERRUPTED_TURN_SENTINEL));
+            }
+        }
+
         let tool_calls: Option<Vec<ToolCall>> = msg
             .tool_calls
             .as_deref()
             .and_then(|tc| serde_json::from_str(tc).ok());
         messages.push(ChatMessage {
-            role: msg.role.as_str().to_string(),
+            role: role.to_string(),
             content: msg.content.clone(),
             tool_calls,
             tool_call_id: msg.tool_call_id.clone(),
             images: None,
         });
     }
+
     messages
 }
 
@@ -215,6 +251,130 @@ pub fn is_image_rejection_error(err: &anyhow::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::persistence::{Message, Role};
+
+    /// Build a bare `Message` for unit tests — mirrors the helper in db/tests.rs.
+    fn msg(role: &str, content: Option<&str>, tool_call_id: Option<&str>) -> Message {
+        Message {
+            id: 0,
+            session_id: String::new(),
+            role: role.parse().unwrap_or(Role::User),
+            content: content.map(Into::into),
+            full_content: None,
+            tool_calls: None,
+            tool_call_id: tool_call_id.map(Into::into),
+            prompt_tokens: None,
+            completion_tokens: None,
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: None,
+            thinking_content: None,
+            created_at: None,
+        }
+    }
+
+    fn system() -> ChatMessage {
+        ChatMessage::text("system", "You are helpful.")
+    }
+
+    // ── assemble_messages sentinel injection (#875) ───────────────────────────
+
+    /// Clean conversation — no interruption, no sentinel ever injected.
+    #[test]
+    fn no_sentinel_for_clean_conversation() {
+        let history = vec![
+            msg("user", Some("hello"), None),
+            msg("assistant", Some("hi!"), None),
+            msg("user", Some("refactor X"), None),
+            msg("assistant", Some("done"), None),
+        ];
+        let out = assemble_messages(&system(), &history);
+        // system + 4 history messages — sentinel would make it 6
+        assert_eq!(out.len(), 5, "no sentinel expected; got {out:?}");
+        assert!(
+            out.iter()
+                .all(|m| m.content.as_deref() != Some(INTERRUPTED_TURN_SENTINEL)),
+            "sentinel must not appear in clean conversation",
+        );
+    }
+
+    /// Ctrl+C during streaming: last DB message is `user`, then user says
+    /// "continue" — two consecutive `user` messages need the sentinel.
+    #[test]
+    fn sentinel_injected_for_user_after_user() {
+        let history = vec![
+            msg("user", Some("refactor X"), None),
+            // no assistant reply (Ctrl+C filtered it out)
+            msg("user", Some("continue"), None),
+        ];
+        let out = assemble_messages(&system(), &history);
+        // system + user + sentinel + user(continue)
+        assert_eq!(out.len(), 4, "expected sentinel; got {out:?}");
+        assert_eq!(out[2].role, "assistant");
+        assert_eq!(out[2].content.as_deref(), Some(INTERRUPTED_TURN_SENTINEL));
+        assert_eq!(out[3].content.as_deref(), Some("continue"));
+    }
+
+    /// Ctrl+C during tool execution: DB ends with a `tool` result, then user
+    /// says "continue". Anthropic + Gemini both remap tool→user-side, so the
+    /// sentinel is required for all three providers.
+    #[test]
+    fn sentinel_injected_for_user_after_tool_result() {
+        let history = vec![
+            msg("user", Some("read the file"), None),
+            msg("assistant", Some("sure"), None),
+            msg("tool", Some("file contents"), Some("tc_1")),
+            // assistant never processed the result (Ctrl+C)
+            msg("user", Some("continue"), None),
+        ];
+        let out = assemble_messages(&system(), &history);
+        // system + user + assistant + tool + sentinel + user(continue)
+        assert_eq!(
+            out.len(),
+            6,
+            "expected sentinel after tool result; got {out:?}"
+        );
+        assert_eq!(out[4].role, "assistant");
+        assert_eq!(out[4].content.as_deref(), Some(INTERRUPTED_TURN_SENTINEL));
+    }
+
+    /// Tool result immediately following an assistant message is valid — no sentinel.
+    #[test]
+    fn no_sentinel_before_tool_result() {
+        let history = vec![
+            msg("user", Some("read it"), None),
+            msg("assistant", Some("ok"), None),
+            msg("tool", Some("contents"), Some("tc_1")),
+        ];
+        let out = assemble_messages(&system(), &history);
+        assert_eq!(out.len(), 4);
+        assert!(
+            out.iter().all(|m| m.role != "assistant"
+                || m.content.as_deref() != Some(INTERRUPTED_TURN_SENTINEL))
+        );
+    }
+
+    /// Multiple tool results back-to-back — no sentinel between them.
+    #[test]
+    fn no_sentinel_between_consecutive_tool_results() {
+        let history = vec![
+            msg("user", Some("do stuff"), None),
+            msg("assistant", Some("calling tools"), None),
+            msg("tool", Some("r1"), Some("tc_1")),
+            msg("tool", Some("r2"), Some("tc_2")),
+        ];
+        let out = assemble_messages(&system(), &history);
+        assert_eq!(out.len(), 5); // system + 4 messages, no sentinel
+    }
+
+    /// First user message follows system — system is not user-side, so no sentinel.
+    #[test]
+    fn no_sentinel_for_first_user_message() {
+        let history = vec![msg("user", Some("hello"), None)];
+        let out = assemble_messages(&system(), &history);
+        assert_eq!(out.len(), 2); // system + user
+        assert_eq!(out[1].role, "user");
+    }
 
     #[test]
     fn test_is_context_overflow_error() {


### PR DESCRIPTION
## Problem

After Ctrl+C, the incomplete assistant message is filtered by the `completed_at IS NULL` guard. The user's next message ("continue") then sits directly after the last user-side message in the DB, producing two consecutive user-side messages that every provider rejects.

**Every provider rejects this:**
| Sequence | Anthropic | Gemini | OpenAI-compat |
|---|---|---|---|
| `User → User` | ❌ 400 | ❌ 400 | ❌ 400 |
| `Tool → User` | ❌ 400 (`tool` remapped → `user`) | ❌ 400 (`tool` → `function`, model must respond first) | ❌ rejected |

## Fix

`assemble_messages()` in `inference_helpers.rs` now injects a synthetic `assistant` sentinel between any consecutive user-side messages **at assembly time**. The sentinel is never written to the DB — it self-corrects once the model issues a real reply.

```
// BEFORE (rejected by all providers)
[System, User("refactor X"), User("continue")]

// AFTER
[System, User("refactor X"), Asst("[Turn interrupted — pick up from where you left off.]"), User("continue")]
```

Same fix handles the tool-result case (Ctrl+C after tool result committed but before model processed it):
```
[System, User, Asst(tool_calls), Tool(result), Asst(sentinel), User("continue")]
```

## Why all three providers need this

- **Anthropic**: `Role::Tool → role:"user"` (tool_result block) — so `tool, user` is two consecutive user messages
- **Gemini**: `Role::Tool → role:"function"` — the model must respond to function results before the user speaks
- **OpenAI-compat**: passes `role:"tool"` through; `tool → user` without intervening assistant is rejected

## Tests

6 new unit tests in `inference_helpers::tests`:
- ✅ `sentinel_injected_for_user_after_user` — streaming interrupted
- ✅ `sentinel_injected_for_user_after_tool_result` — tool interrupted
- ✅ `no_sentinel_for_clean_conversation` — no false positives
- ✅ `no_sentinel_before_tool_result` — tool results after assistant are fine
- ✅ `no_sentinel_between_consecutive_tool_results` — parallel tools OK
- ✅ `no_sentinel_for_first_user_message` — first message after system OK