### PR TITLE
feat(#878): /export defaults to verbose; add --summary for concise

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -27,8 +27,8 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
     ("/expand", "Show full output of last tool call", None),
     (
         "/export",
-        "Export full session transcript to file",
-        Some("[file.md]"),
+        "Export session transcript (verbose default, --summary for concise)",
+        Some("[--summary] [file.md]"),
     ),
     ("/help", "Show commands and shortcuts", None),
     ("/key", "Manage API keys", None),

--- a/koda-cli/src/repl.rs
+++ b/koda-cli/src/repl.rs
@@ -75,11 +75,11 @@ pub enum ReplAction {
     ///
     /// `n` defaults to 1 (most recent). `/copy 2` copies the second-to-last, etc.
     CopyResponse(usize),
-    /// `/export [<file.md>]` — export the full session transcript.
+    /// `/export [--summary] [<file.md>]` — export the full session transcript.
     ///
-    /// Without an argument: write to a auto-named file in the current directory.
-    /// With a filename: write Markdown to that path.
-    Export(Option<String>),
+    /// Default: verbose (full fidelity — timestamps, token counts, all tool output).
+    /// `--summary`: concise, human-readable format.
+    Export { dest: Option<String>, summary: bool },
     /// `/mcp` or `/mcp list` — show MCP server list and status.
     McpList,
     /// `/mcp add <name> <command> [args...]` — add a stdio MCP server.
@@ -201,7 +201,21 @@ pub async fn handle_command(
             let n: usize = arg.and_then(|s| s.parse().ok()).unwrap_or(1).max(1);
             ReplAction::CopyResponse(n)
         }
-        "/export" => ReplAction::Export(arg.map(|s| s.to_string())),
+        "/export" => {
+            // Parse optional `--summary` flag and destination.
+            let (summary, dest) = match arg {
+                Some(s) => {
+                    let parts: Vec<&str> = s.splitn(2, ' ').collect();
+                    if parts.first() == Some(&"--summary") {
+                        (true, parts.get(1).map(|d| d.to_string()))
+                    } else {
+                        (false, Some(s.to_string()))
+                    }
+                }
+                None => (false, None),
+            };
+            ReplAction::Export { dest, summary }
+        }
 
         "/mcp" => parse_mcp_subcommand(arg),
 
@@ -578,11 +592,39 @@ mod tests {
         assert!(matches!(dispatch("/set"), ReplAction::NotACommand));
         assert!(matches!(dispatch("/config"), ReplAction::NotACommand));
         assert!(matches!(dispatch("/transcript"), ReplAction::NotACommand));
-        assert!(matches!(dispatch("/export"), ReplAction::Export(None)));
+        assert!(matches!(
+            dispatch("/export"),
+            ReplAction::Export {
+                dest: None,
+                summary: false
+            }
+        ));
         assert!(matches!(
             dispatch("/export koda.md"),
-            ReplAction::Export(Some(_))
+            ReplAction::Export {
+                dest: Some(_),
+                summary: false
+            }
         ));
+        assert!(matches!(
+            dispatch("/export --summary"),
+            ReplAction::Export {
+                dest: None,
+                summary: true
+            }
+        ));
+        assert!(matches!(
+            dispatch("/export --summary notes.md"),
+            ReplAction::Export {
+                dest: Some(_),
+                summary: true
+            }
+        ));
+        // Verify the destination is correct when --summary has a filename.
+        if let ReplAction::Export { dest, summary } = dispatch("/export --summary notes.md") {
+            assert!(summary);
+            assert_eq!(dest.as_deref(), Some("notes.md"));
+        }
     }
 
     #[test]

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -1,34 +1,56 @@
 //! Conversation transcript generator.
 //!
-//! Converts a session's `Message` slice into a human-readable Markdown
-//! document suitable for clipboard copy or file export.
+//! Converts a session's `Message` slice into a Markdown document for
+//! clipboard copy or file export. Two modes:
 //!
-//! ## Format
+//! - **Verbose** (default) — full fidelity: timestamps, token counts,
+//!   all tool output (including Bash), session metadata header.
+//! - **Summary** (`--summary`) — concise, human-readable: hides Bash
+//!   output, omits token counts and timestamps.
+//!
+//! ## Verbose format
 //!
 //! ```text
-//! # Koda Session — 2026-04-10 10:32
+//! # Koda Session — My Task
 //!
-//! ## User
+//! | Field | Value |
+//! |---|---|
+//! | Session | abc123 |
+//! | Model | claude-sonnet-4-20250514 |
+//! | Started | 2026-04-10 10:32 UTC |
+//!
+//! ---
+//!
+//! ## 🧑 User  <sub>10:32:01</sub>
 //! What does this function do?
 //!
-//! ## Assistant
+//! ## 🤖 Assistant  <sub>10:32:05</sub>
 //! The function `foo()` does …
 //!
-//! ### 🔍 Read `src/main.rs`
-//! > (3 lines shown)
-//! > fn main() { … }
+//! <sub>tokens: 1234 prompt · 567 completion · 890 cache-read</sub>
 //!
-//! ### ✏️ Edit `src/main.rs`
-//! > Applied 1 change
+//! ### 📄 **Read** `src/main.rs`
+//!
+//! (full tool output shown)
 //! ```
-//!
-//! Tool results are summarised (not dumped verbatim) to keep the export
-//! concise. The `full_content` field is intentionally ignored \u2014 if users
-//! want raw output they can re-run the tool.
 
 use koda_core::persistence::{Message, Role};
 use koda_core::tools::{ToolEffect, classify_tool};
 use std::collections::HashMap;
+
+/// Session metadata for the verbose transcript header.
+///
+/// Assembled by the caller (`handle_export`) from live config — not stored
+/// in the DB (see #878 design discussion).
+#[derive(Debug, Default)]
+pub struct SessionMeta {
+    pub session_id: String,
+    pub title: Option<String>,
+    pub started_at: Option<String>,
+    pub model: String,
+    pub provider: String,
+    pub project_root: String,
+}
 
 /// Truncate a string to at most `max` characters, appending `…` if truncated.
 /// Safe on multi-byte UTF-8 (never splits a codepoint).
@@ -39,8 +61,17 @@ fn truncate_with_ellipsis(s: &str, max: usize) -> String {
     }
 }
 
-/// Maximum content lines to include per tool result in the transcript.
-const RESULT_PREVIEW_LINES: usize = 10;
+/// Maximum content lines to include per tool result in summary mode.
+const SUMMARY_RESULT_LINES: usize = 10;
+
+/// Maximum content lines to include per tool result in verbose mode.
+const VERBOSE_RESULT_LINES: usize = 50;
+
+/// Bash command truncation limit in summary mode.
+const SUMMARY_BASH_CHARS: usize = 80;
+
+/// Bash command truncation limit in verbose mode (effectively unlimited).
+const VERBOSE_BASH_CHARS: usize = 500;
 
 /// Format the current UTC time as `YYYY-MM-DD HH:MM UTC` for the transcript header.
 fn format_utc_now() -> String {
@@ -57,15 +88,23 @@ fn format_utc_now() -> String {
 
 /// Generate a Markdown transcript from a slice of session messages.
 ///
+/// - `verbose = true` (default): full fidelity — timestamps, token counts,
+///   all tool output, session metadata header.
+/// - `verbose = false` (`--summary`): concise, human-readable.
+///
 /// Returns the transcript as a `String`. The caller is responsible for
 /// writing it to the clipboard or a file.
-pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
-    let mut out = String::with_capacity(4096);
+pub fn render(messages: &[Message], meta: &SessionMeta, verbose: bool) -> String {
+    let mut out = String::with_capacity(if verbose { 16384 } else { 4096 });
 
     // Header
-    let title = session_title.unwrap_or("Koda Session");
+    let title = meta.title.as_deref().unwrap_or("Koda Session");
     let now = format_utc_now();
     out.push_str(&format!("# {title} — {now}\n\n"));
+
+    if verbose {
+        render_metadata_table(&mut out, meta);
+    }
 
     // Build tool_call_id → tool_name mapping for result correlation
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
@@ -89,7 +128,8 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
             Role::System => {} // Skip — internal plumbing
 
             Role::User => {
-                out.push_str("---\n\n## \u{1f9d1} User\n\n");
+                out.push_str("---\n\n");
+                render_role_header(&mut out, "\u{1f9d1} User", msg, verbose);
                 if let Some(ref content) = msg.content {
                     out.push_str(content.trim());
                     out.push_str("\n\n");
@@ -97,7 +137,7 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
             }
 
             Role::Assistant => {
-                out.push_str("## 🤖 Assistant\n\n");
+                render_role_header(&mut out, "🤖 Assistant", msg, verbose);
 
                 // Thinking block (Claude extended thinking) — before text
                 if let Some(ref thinking) = msg.thinking_content
@@ -125,10 +165,15 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
                 if let Some(ref tc_json) = msg.tool_calls
                     && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
                 {
+                    let bash_limit = if verbose {
+                        VERBOSE_BASH_CHARS
+                    } else {
+                        SUMMARY_BASH_CHARS
+                    };
                     for call in &calls {
                         let name = call["function"]["name"].as_str().unwrap_or("Tool");
                         let args_json = call["function"]["arguments"].as_str().unwrap_or("{}");
-                        let detail = tool_detail_summary(name, args_json);
+                        let detail = tool_detail_summary(name, args_json, bash_limit);
                         let icon = tool_icon(name);
                         out.push_str(&format!("### {icon} **{name}**"));
                         if !detail.is_empty() {
@@ -137,6 +182,11 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
                         out.push('\n');
                     }
                     out.push('\n');
+                }
+
+                // Token counts (verbose only)
+                if verbose {
+                    render_token_counts(&mut out, msg);
                 }
             }
 
@@ -153,30 +203,27 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
 
                 if !content.is_empty() {
                     let effect = classify_tool(tool_name);
-                    // Only surface read-only tool output \u2014 write/bash output
-                    // is usually noise (diffs, compiler output). Still summarise it.
-                    match effect {
-                        ToolEffect::ReadOnly => {
-                            out.push_str("**Output:**\n\n```\n");
-                            let preview_lines: Vec<&str> =
-                                content.lines().take(RESULT_PREVIEW_LINES).collect();
-                            out.push_str(&preview_lines.join("\n"));
-                            if total_lines > RESULT_PREVIEW_LINES {
-                                out.push_str(&format!(
-                                    "\n… ({} more lines)",
-                                    total_lines - RESULT_PREVIEW_LINES
-                                ));
-                            }
-                            out.push_str("\n```\n\n");
+                    let max_lines = if verbose {
+                        VERBOSE_RESULT_LINES
+                    } else {
+                        SUMMARY_RESULT_LINES
+                    };
+
+                    // Verbose: show all tool output. Summary: only read-only.
+                    let show_content = verbose || effect == ToolEffect::ReadOnly;
+
+                    if show_content {
+                        out.push_str("**Output:**\n\n```\n");
+                        let preview_lines: Vec<&str> = content.lines().take(max_lines).collect();
+                        out.push_str(&preview_lines.join("\n"));
+                        if total_lines > max_lines {
+                            out.push_str(&format!("\n… ({} more lines)", total_lines - max_lines));
                         }
-                        _ => {
-                            // Mutating tools: just note how many lines of output
-                            if total_lines > 0 {
-                                out.push_str(&format!(
-                                    "> _{total_lines} line(s) of output — run tool to see full result_\n\n"
-                                ));
-                            }
-                        }
+                        out.push_str("\n```\n\n");
+                    } else if total_lines > 0 {
+                        out.push_str(&format!(
+                            "> _{total_lines} line(s) of output — run tool to see full result_\n\n"
+                        ));
                     }
                 }
             }
@@ -184,6 +231,61 @@ pub fn render(messages: &[Message], session_title: Option<&str>) -> String {
     }
 
     out
+}
+
+// ── Verbose-mode helpers ─────────────────────────────────────────────
+
+/// Render the metadata table at the top of a verbose transcript.
+fn render_metadata_table(out: &mut String, meta: &SessionMeta) {
+    out.push_str("| Field | Value |\n|---|---|\n");
+    out.push_str(&format!("| Session | `{}` |\n", meta.session_id));
+    out.push_str(&format!("| Model | {} |\n", meta.model));
+    out.push_str(&format!("| Provider | {} |\n", meta.provider));
+    out.push_str(&format!("| Project | `{}` |\n", meta.project_root));
+    if let Some(ref started) = meta.started_at {
+        out.push_str(&format!("| Started | {started} |\n"));
+    }
+    out.push('\n');
+}
+
+/// Render a role header with an optional timestamp (verbose mode).
+fn render_role_header(out: &mut String, label: &str, msg: &Message, verbose: bool) {
+    out.push_str(&format!("## {label}"));
+    if verbose && let Some(ref ts) = msg.created_at {
+        // Show HH:MM:SS portion if it looks like an ISO timestamp.
+        let time_part = ts.split('T').nth(1).and_then(|t| t.get(..8)).unwrap_or(ts);
+        out.push_str(&format!("  <sub>{time_part}</sub>"));
+    }
+    out.push_str("\n\n");
+}
+
+/// Render token counts after an assistant message (verbose mode).
+fn render_token_counts(out: &mut String, msg: &Message) {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(p) = msg.prompt_tokens {
+        parts.push(format!("{p} prompt"));
+    }
+    if let Some(c) = msg.completion_tokens {
+        parts.push(format!("{c} completion"));
+    }
+    if let Some(cr) = msg.cache_read_tokens
+        && cr > 0
+    {
+        parts.push(format!("{cr} cache-read"));
+    }
+    if let Some(cc) = msg.cache_creation_tokens
+        && cc > 0
+    {
+        parts.push(format!("{cc} cache-write"));
+    }
+    if let Some(t) = msg.thinking_tokens
+        && t > 0
+    {
+        parts.push(format!("{t} thinking"));
+    }
+    if !parts.is_empty() {
+        out.push_str(&format!("<sub>tokens: {}</sub>\n\n", parts.join(" · ")));
+    }
 }
 
 /// Human-readable icon for each tool type.
@@ -206,7 +308,9 @@ fn tool_icon(name: &str) -> &'static str {
 }
 
 /// One-line summary of a tool call's arguments (mirrors `history_render`).
-fn tool_detail_summary(name: &str, args_json: &str) -> String {
+///
+/// `bash_limit` controls Bash command truncation (80 in summary, 500 in verbose).
+fn tool_detail_summary(name: &str, args_json: &str, bash_limit: usize) -> String {
     let args: serde_json::Value =
         serde_json::from_str(args_json).unwrap_or(serde_json::Value::Null);
     match name {
@@ -215,8 +319,8 @@ fn tool_detail_summary(name: &str, args_json: &str) -> String {
         }
         "Bash" => {
             let cmd = args["command"].as_str().unwrap_or("");
-            if cmd.chars().count() > 80 {
-                truncate_with_ellipsis(cmd, 77)
+            if cmd.chars().count() > bash_limit {
+                truncate_with_ellipsis(cmd, bash_limit.saturating_sub(3))
             } else {
                 cmd.to_string()
             }
@@ -276,26 +380,41 @@ mod tests {
         }
     }
 
+    fn default_meta() -> SessionMeta {
+        SessionMeta {
+            session_id: "test-session".into(),
+            title: None,
+            started_at: None,
+            model: "test-model".into(),
+            provider: "test-provider".into(),
+            project_root: "/tmp/project".into(),
+        }
+    }
+
     #[test]
     fn empty_messages_produces_header_only() {
-        let out = render(&[], Some("Test Session"));
+        let meta = SessionMeta {
+            title: Some("Test Session".into()),
+            ..default_meta()
+        };
+        let out = render(&[], &meta, false);
         assert!(out.contains("# Test Session"));
-        assert!(!out.contains("## 🧑 User"));
+        assert!(!out.contains("🧑 User"));
     }
 
     #[test]
     fn user_message_renders_correctly() {
         let msgs = vec![make_msg(Role::User, "hello koda")];
-        let out = render(&msgs, None);
-        assert!(out.contains("## 🧑 User"));
+        let out = render(&msgs, &default_meta(), false);
+        assert!(out.contains("🧑 User"));
         assert!(out.contains("hello koda"));
     }
 
     #[test]
     fn assistant_message_renders_correctly() {
         let msgs = vec![make_msg(Role::Assistant, "I can help!")];
-        let out = render(&msgs, None);
-        assert!(out.contains("## 🤖 Assistant"));
+        let out = render(&msgs, &default_meta(), false);
+        assert!(out.contains("🤖 Assistant"));
         assert!(out.contains("I can help!"));
     }
 
@@ -305,7 +424,7 @@ mod tests {
             make_msg(Role::System, "secret prompt"),
             make_msg(Role::User, "hi"),
         ];
-        let out = render(&msgs, None);
+        let out = render(&msgs, &default_meta(), false);
         assert!(!out.contains("secret prompt"));
     }
 
@@ -324,7 +443,7 @@ mod tests {
         );
 
         let msgs = vec![assistant_msg, result_msg];
-        let out = render(&msgs, None);
+        let out = render(&msgs, &default_meta(), false);
         assert!(out.contains("```"));
         assert!(out.contains("fn main()"));
     }
@@ -344,8 +463,8 @@ mod tests {
         );
 
         let msgs = vec![assistant_msg, result_msg];
-        let out = render(&msgs, None);
-        // Bash is mutating → summarised, not shown verbatim
+        let out = render(&msgs, &default_meta(), false);
+        // Bash is mutating → summarised in summary mode, not shown verbatim
         assert!(!out.contains("line1"));
         assert!(out.contains("3 line(s) of output"));
     }
@@ -358,7 +477,7 @@ mod tests {
         let mut msg = make_msg(Role::Assistant, "The answer is 42.");
         msg.thinking_content = Some("Let me think step by step: 6 x 7 = 42.".into());
 
-        let out = render(&[msg], None);
+        let out = render(&[msg], &default_meta(), false);
         assert!(
             out.contains("The answer is 42."),
             "response text must appear"
@@ -369,7 +488,86 @@ mod tests {
         );
         assert!(
             out.contains("Let me think step by step"),
-            "thinking content must appear in transcript"
+            "thinking content must appear in transcript",
         );
+    }
+
+    #[test]
+    fn verbose_header_includes_metadata() {
+        let meta = SessionMeta {
+            session_id: "sess-42".into(),
+            title: Some("Debug Session".into()),
+            started_at: Some("2026-04-14T12:00:00Z".into()),
+            model: "claude-sonnet-4-20250514".into(),
+            provider: "anthropic".into(),
+            project_root: "/home/user/project".into(),
+        };
+        let out = render(&[], &meta, true);
+        assert!(out.contains("sess-42"), "session ID in header");
+        assert!(out.contains("claude-sonnet-4-20250514"), "model in header");
+        assert!(out.contains("anthropic"), "provider in header");
+        assert!(out.contains("/home/user/project"), "project root in header");
+    }
+
+    #[test]
+    fn verbose_shows_token_counts() {
+        let mut msg = make_msg(Role::Assistant, "The answer.");
+        msg.prompt_tokens = Some(100);
+        msg.completion_tokens = Some(50);
+        msg.cache_read_tokens = Some(80);
+
+        let out = render(&[msg], &default_meta(), true);
+        assert!(out.contains("100 prompt"), "prompt tokens shown");
+        assert!(out.contains("50 completion"), "completion tokens shown");
+        assert!(out.contains("80 cache-read"), "cache-read tokens shown");
+    }
+
+    #[test]
+    fn summary_hides_token_counts() {
+        let mut msg = make_msg(Role::Assistant, "The answer.");
+        msg.prompt_tokens = Some(100);
+        msg.completion_tokens = Some(50);
+
+        let out = render(&[msg], &default_meta(), false);
+        assert!(!out.contains("100 prompt"));
+    }
+
+    #[test]
+    fn verbose_shows_timestamps() {
+        let mut msg = make_msg(Role::User, "hello");
+        msg.created_at = Some("2026-04-14T09:15:30Z".into());
+
+        let out = render(&[msg], &default_meta(), true);
+        assert!(out.contains("09:15:30"), "timestamp shown in verbose");
+    }
+
+    #[test]
+    fn summary_hides_timestamps() {
+        let mut msg = make_msg(Role::User, "hello");
+        msg.created_at = Some("2026-04-14T09:15:30Z".into());
+
+        let out = render(&[msg], &default_meta(), false);
+        assert!(!out.contains("09:15:30"), "timestamp hidden in summary");
+    }
+
+    #[test]
+    fn bash_result_shown_in_verbose_mode() {
+        let mut result_msg = make_msg(Role::Tool, "line1\nline2\nline3");
+        result_msg.tool_call_id = Some("call_3".into());
+
+        let mut assistant_msg = make_msg(Role::Assistant, "");
+        assistant_msg.tool_calls = Some(
+            serde_json::json!([{
+                "id": "call_3",
+                "function": { "name": "Bash", "arguments": r#"{"command":"ls"}"# }
+            }])
+            .to_string(),
+        );
+
+        let msgs = vec![assistant_msg, result_msg];
+        let out = render(&msgs, &default_meta(), true);
+        // Verbose mode shows all tool output, including Bash
+        assert!(out.contains("line1"));
+        assert!(out.contains("line3"));
     }
 }

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -179,8 +179,16 @@ pub async fn handle_slash_command(
             handle_copy_response(buffer, session, n).await;
             SlashAction::Continue
         }
-        ReplAction::Export(ref dest) => {
-            handle_export(buffer, session, dest.as_deref()).await;
+        ReplAction::Export { ref dest, summary } => {
+            handle_export(
+                buffer,
+                session,
+                dest.as_deref(),
+                summary,
+                config,
+                project_root,
+            )
+            .await;
             SlashAction::Continue
         }
         ReplAction::McpList => {
@@ -571,10 +579,9 @@ async fn handle_copy_response(
     }
 }
 
-/// `/export [<file.md>]` — export the full session transcript.
+/// `/export [--summary] [<file.md>]` — export the session transcript.
 ///
-/// - `dest = None`        → auto-name from first user prompt + timestamp, write to CWD
-/// - `dest = Some(path)`  → write Markdown to that explicit path
+/// Default: verbose (full fidelity). `--summary`: concise, human-readable.
 ///
 /// Uses `transcript::render` to produce a structured Markdown document
 /// from all session messages (system messages excluded).
@@ -582,6 +589,9 @@ async fn handle_export(
     buffer: &mut ScrollBuffer,
     session: &koda_core::session::KodaSession,
     dest: Option<&str>,
+    summary: bool,
+    config: &KodaConfig,
+    project_root: &std::path::Path,
 ) {
     // Fetch all messages — `load_all_messages` includes compacted history.
     let messages = match session.db.load_all_messages(&session.id).await {
@@ -592,24 +602,34 @@ async fn handle_export(
         }
     };
 
-    // Try to get the session title for a nicer header.
+    // Try to get the session title and start time for the header.
     let title_storage;
-    let session_title: Option<&str> = match session
+    let started_storage;
+    let (session_title, started_at): (Option<&str>, Option<&str>) = match session
         .db
         .list_sessions(200, std::path::Path::new("/"))
         .await
     {
         Ok(sessions) => {
-            title_storage = sessions
-                .into_iter()
-                .find(|s| s.id == session.id)
-                .and_then(|s| s.title);
-            title_storage.as_deref()
+            let found = sessions.into_iter().find(|s| s.id == session.id);
+            title_storage = found.as_ref().and_then(|s| s.title.clone());
+            started_storage = found.map(|s| s.created_at);
+            (title_storage.as_deref(), started_storage.as_deref())
         }
-        Err(_) => None,
+        Err(_) => (None, None),
     };
 
-    let md = transcript::render(&messages, session_title);
+    let meta = transcript::SessionMeta {
+        session_id: session.id.clone(),
+        title: session_title.map(|s| s.to_string()),
+        started_at: started_at.map(|s| s.to_string()),
+        model: config.model.clone(),
+        provider: session.provider.provider_name().to_string(),
+        project_root: project_root.display().to_string(),
+    };
+
+    let verbose = !summary;
+    let md = transcript::render(&messages, &meta, verbose);
 
     let path_owned;
     let path: &str = match dest {


### PR DESCRIPTION
## Problem

`/export` is primarily used for debugging — filing bug reports, sharing sessions for diagnosis. The previous format optimized for *readability* at the cost of *fidelity*: Bash output suppressed, no timestamps, no token counts, no session metadata.

## Fix

Flip the default. `/export` now produces full-fidelity verbose output. The previous concise format is available via `/export --summary`.

### Verbose mode (new default) adds:

| Feature | Before | After |
|---|---|---|
| **Session metadata** | Timestamp only | ID, model, provider, project root, start time |
| **Timestamps** | ❌ | `<sub>HH:MM:SS</sub>` on every message |
| **Token counts** | ❌ | `<sub>tokens: 1234 prompt · 567 completion · 890 cache-read</sub>` after each assistant turn |
| **Bash output** | Suppressed (`ToolEffect::LocalMutation`) | Shown (up to 50 lines) |
| **Bash command display** | Truncated at 80 chars | 500 chars |
| **Tool result preview** | 10 lines | 50 lines |

### Summary mode (`/export --summary`)

Identical to the previous `/export` behavior — concise, human-readable. Bash output suppressed, no timestamps, no token counts.

## Design decisions

- **No DB schema changes** — model/provider are threaded from live `KodaConfig` and `session.provider.provider_name()`. See #878 discussion on why we decided against storing model in the DB.
- **No error/termination events** — would require new DB columns; deferred.

## Files changed

| File | Change |
|---|---|
| `koda-cli/src/transcript.rs` | `SessionMeta` struct, verbose/summary branching, `render_metadata_table`, `render_role_header`, `render_token_counts` |
| `koda-cli/src/repl.rs` | `Export { dest, summary }` variant, `--summary` flag parsing |
| `koda-cli/src/tui_commands.rs` | Thread `config`/`project_root` into `handle_export`, assemble `SessionMeta` |
| `koda-cli/src/completer.rs` | Updated hint text |

## Tests

6 new tests + 7 updated existing tests:
- ✅ `verbose_header_includes_metadata` — session ID, model, provider, project root
- ✅ `verbose_shows_token_counts` / `summary_hides_token_counts`
- ✅ `verbose_shows_timestamps` / `summary_hides_timestamps`
- ✅ `bash_result_shown_in_verbose_mode` — Bash output no longer suppressed
- ✅ `--summary` and `--summary <file>` repl parsing tests

Closes #878