### PR TITLE
fix(deps): bump rand 0.9.2 -> 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,7 +2744,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2808,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -4341,7 +4341,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
 ]


### PR DESCRIPTION
## Summary

Fix the open GitHub Dependabot alert for `rand` by updating the vulnerable runtime dependency path from `rand 0.9.2` to `rand 0.9.3` in `Cargo.lock`.

Dependency path:
- `koda-cli`
- `tokio-tungstenite 0.29.0`
- `tungstenite 0.29.0`
- `rand 0.9.2` -> `0.9.3`

This is a lockfile-only change; no source code changes.

## Why

GitHub Dependabot alert:
- package: `rand`
- alert: #5
- advisory: `GHSA-cq8v-f236-94qc`
- patched version: `0.9.3`

## Validation

Used corporate proxy env vars for crates.io access when needed.

- `cargo check -p koda-cli`
- `cargo test -p koda-cli server_test -- --nocapture`
- `cargo tree -i rand@0.9.3`

## Notes

The workspace still contains multiple `rand` major/minor versions transitively, but the vulnerable runtime path reported by GitHub now resolves to `rand 0.9.3`.

