### PR TITLE
feat(851): next/later queue lanes for typing during inference

### DIFF
--- a/docs/src/keybindings.md
+++ b/docs/src/keybindings.md
@@ -4,12 +4,14 @@
 
 | Key | Action |
 |-----|--------|
-| `Enter` | Send message |
+| `Enter` | Send message (or queue as **next** during inference) |
+| `Ctrl+J` | Queue message as **later** during inference (deferred turn) |
 | `Alt+Enter` | Insert newline (multi-line input) |
 | `Tab` | Autocomplete slash commands and `@file` paths |
 | `Shift+Tab` | Cycle trust mode (Safe ↔ Auto) |
 | `↑ / ↓` | Cycle through input history |
 | `Ctrl+R` | Reverse history search |
+| `Ctrl+U` | Clear deferred (`later`) queue during inference |
 
 ## Navigation
 

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -62,7 +62,13 @@ pub(crate) struct TuiContext {
 
     // ── Control flow ──────────────────────────────────────────
     pub paste_blocks: Vec<input::PasteBlock>,
-    pub input_queue: VecDeque<String>,
+    /// Inputs queued during inference for injection into the **next** turn
+    /// after the current one completes.  All pending items are joined with
+    /// `\n\n` and submitted as a single new turn ("later" lane).
+    ///
+    /// Mid-turn injection ("next" lane) is handled by sending
+    /// `EngineCommand::QueueNext` directly to the engine via `cmd_tx`.
+    pub later_queue: VecDeque<String>,
     pub pending_command: Option<String>,
     pub should_quit: bool,
     pub silent_compact_deferred: bool,
@@ -316,7 +322,7 @@ impl TuiContext {
             provider_wizard: None,
             pending_approval_id: None,
             paste_blocks: Vec::new(),
-            input_queue: VecDeque::new(),
+            later_queue: VecDeque::new(),
             pending_command: None,
             should_quit: false,
             silent_compact_deferred: false,
@@ -351,7 +357,7 @@ impl TuiContext {
         let ctx = self.context_pct;
         let tui_state = self.tui_state;
         let prompt_mode = &self.prompt_mode;
-        let queue_len = self.input_queue.len();
+        let queue_len = self.later_queue.len();
         let elapsed = self
             .inference_start
             .map(|s| s.elapsed().as_secs())
@@ -452,30 +458,38 @@ impl TuiContext {
     // Command dispatch (slash commands, dropdown openers, inference prep)
     // ═══════════════════════════════════════════════════════════
 
-    /// Dequeue the next pending or queued input string, if any.
+    /// Dequeue the next pending input, if any.
+    ///
+    /// Priority order:
+    /// 1. `pending_command` — set by slash commands that need a follow-up prompt
+    /// 2. `later_queue` — all items are joined with `\n\n` and returned as one
+    ///    batched string so they become a single new inference turn.
     fn dequeue_input(&mut self) -> Option<String> {
         if let Some(cmd) = self.pending_command.take() {
             return Some(cmd);
         }
-        if let Some(queued) = self.input_queue.pop_front() {
+        if !self.later_queue.is_empty() {
+            // Drain the whole later_queue and batch into one turn.
+            let items: Vec<String> = self.later_queue.drain(..).collect();
             let mode = trust::read_trust(&self.shared_mode);
             let icon = match mode {
                 TrustMode::Plan => "\u{1f4cb}",
                 TrustMode::Safe => "\u{1f512}",
                 TrustMode::Auto => "\u{26a1}",
             };
-            let remaining = self.input_queue.len();
-            let suffix = if remaining > 0 {
-                format!(" (+{remaining} queued)")
-            } else {
-                String::new()
-            };
             self.scroll_buffer.push(Line::from(vec![
                 Span::styled(format!("{icon}> "), Style::default().fg(Color::Cyan)),
-                Span::raw(queued.clone()),
-                Span::styled(suffix, Style::default().fg(Color::DarkGray)),
+                Span::raw(items[0].clone()),
+                if items.len() > 1 {
+                    Span::styled(
+                        format!(" (+{} batched)", items.len() - 1),
+                        Style::default().fg(Color::DarkGray),
+                    )
+                } else {
+                    Span::raw("")
+                },
             ]));
-            return Some(queued);
+            return Some(items.join("\n\n"));
         }
         None
     }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -75,7 +75,7 @@ impl TuiContext {
                         ctx,
                         self.tui_state,
                         &self.prompt_mode,
-                        self.input_queue.len(),
+                        self.later_queue.len(),
                         self.inference_start
                             .map(|s| s.elapsed().as_secs())
                             .unwrap_or(0),
@@ -111,7 +111,7 @@ impl TuiContext {
                             &mut self.completer,
                             &mut self.history,
                             &mut self.history_idx,
-                            &mut self.input_queue,
+                            &mut self.later_queue,
                             &mut self.paste_blocks,
                             &db_handle,
                         ).await;
@@ -170,16 +170,16 @@ impl TuiContext {
     // ── Post-turn cleanup ──────────────────────────────────────
 
     async fn post_turn_cleanup(&mut self, ui_rx: &mut mpsc::UnboundedReceiver<UiEvent>) {
-        // If the turn was cancelled, clear the input queue so queued
-        // messages don't immediately start a new turn that may block
-        // on a single-slot local server (LM Studio, ollama) (#825).
-        if self.session.cancel.is_cancelled() && !self.input_queue.is_empty() {
-            let n = self.input_queue.len();
-            self.input_queue.clear();
+        // If the turn was cancelled, clear the later_queue so deferred
+        // messages don’t immediately fire a new turn that may block on a
+        // single-slot local server (LM Studio, ollama) (#825).
+        if self.session.cancel.is_cancelled() && !self.later_queue.is_empty() {
+            let n = self.later_queue.len();
+            self.later_queue.clear();
             self.scroll_buffer.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    format!("\u{1f6ab} Cleared {n} queued message(s)"),
+                    format!("\u{1f6ab} Cleared {n} deferred message(s)"),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]));
@@ -305,7 +305,7 @@ async fn handle_crossterm_event_inline(
     completer: &mut crate::completer::InputCompleter,
     history: &mut Vec<String>,
     history_idx: &mut Option<usize>,
-    input_queue: &mut std::collections::VecDeque<String>,
+    later_queue: &mut std::collections::VecDeque<String>,
     paste_blocks: &mut Vec<input::PasteBlock>,
     db: &koda_core::db::Database,
 ) {
@@ -353,7 +353,7 @@ async fn handle_crossterm_event_inline(
                 completer,
                 history,
                 history_idx,
-                input_queue,
+                later_queue,
                 db,
             )
             .await;
@@ -377,7 +377,7 @@ async fn handle_inference_key_inline(
     completer: &mut crate::completer::InputCompleter,
     history: &mut Vec<String>,
     history_idx: &mut Option<usize>,
-    input_queue: &mut std::collections::VecDeque<String>,
+    later_queue: &mut std::collections::VecDeque<String>,
     db: &koda_core::db::Database,
 ) {
     // Approval hotkeys
@@ -527,6 +527,9 @@ async fn handle_inference_key_inline(
         (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
             textarea.insert_newline();
         }
+        // Enter during inference — default lane is "next" (mid-turn steer).
+        // The text is sent directly to the engine as QueueNext; it will be
+        // injected before the next provider request in the current turn.
         (KeyCode::Enter, KeyModifiers::NONE) => {
             let text = textarea.lines().join("\n");
             if !text.trim().is_empty() {
@@ -536,15 +539,40 @@ async fn handle_inference_key_inline(
                 let _ = db.history_push(&text).await;
                 *history_idx = None;
 
-                // Visual echo so the user can see what they queued.
                 let preview = truncate_preview(&text, 80);
                 scroll_buffer.push(Line::from(vec![
                     Span::raw("  "),
-                    Span::styled("📋 Queued: ", Style::default().fg(Color::Yellow)),
+                    Span::styled("\u{1f4e5} Next: ", Style::default().fg(Color::Green)),
                     Span::styled(preview, Style::default().fg(Color::DarkGray)),
                 ]));
 
-                input_queue.push_back(text);
+                let _ = cmd_tx.send(EngineCommand::QueueNext { text }).await;
+            }
+        }
+        // Ctrl+J during inference — "later" lane: defer text until after the
+        // current turn fully completes, then batch with other later items into
+        // one new turn.
+        (KeyCode::Char('j'), m) if m.contains(KeyModifiers::CONTROL) => {
+            let text = textarea.lines().join("\n");
+            if !text.trim().is_empty() {
+                textarea.select_all();
+                textarea.cut();
+                history.push(text.clone());
+                let _ = db.history_push(&text).await;
+                *history_idx = None;
+
+                let preview = truncate_preview(&text, 80);
+                let later_n = later_queue.len() + 1;
+                scroll_buffer.push(Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(
+                        format!("\u{1f4cb} Later ({later_n}): "),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::styled(preview, Style::default().fg(Color::DarkGray)),
+                ]));
+
+                later_queue.push_back(text);
             }
         }
         (KeyCode::Esc, _) => {
@@ -553,15 +581,15 @@ async fn handle_inference_key_inline(
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
             cancel_token.cancel();
         }
-        // Ctrl+U: clear the input queue without cancelling inference.
+        // Ctrl+U: clear the later_queue (deferred messages) without cancelling inference.
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => {
-            if !input_queue.is_empty() {
-                let n = input_queue.len();
-                input_queue.clear();
+            if !later_queue.is_empty() {
+                let n = later_queue.len();
+                later_queue.clear();
                 scroll_buffer.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
-                        format!("🚫 Cleared {n} queued message(s)"),
+                        format!("\u{1f6ab} Cleared {n} deferred message(s)"),
                         Style::default().fg(Color::DarkGray),
                     ),
                 ]));

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -340,6 +340,19 @@ pub enum EngineCommand {
     ///
     /// Currently handled client-side. Defined for wire protocol completeness.
     Quit,
+
+    /// User typed a message during inference and wants it injected into the
+    /// **current** turn before the next provider request.
+    ///
+    /// The engine drains all pending `QueueNext` commands at the top of each
+    /// loop iteration, batches them with `\n\n`, and inserts one user message
+    /// into session history before re-querying the provider.  This is the
+    /// "mid-turn steer" lane — the TUI's `later_queue` handles the separate
+    /// "after this turn" lane entirely on the client side.
+    QueueNext {
+        /// The text the user submitted.
+        text: String,
+    },
 }
 
 /// An image attached to a user prompt.
@@ -693,6 +706,19 @@ mod tests {
         };
         let json = serde_json::to_string(&cmd_stop).unwrap();
         let _: EngineCommand = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn test_queue_next_roundtrip() {
+        let cmd = EngineCommand::QueueNext {
+            text: "also add tests".into(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("\"type\":\"queue_next\""));
+        let deserialized: EngineCommand = serde_json::from_str(&json).unwrap();
+        assert!(
+            matches!(deserialized, EngineCommand::QueueNext { ref text } if text == "also add tests")
+        );
     }
 
     #[test]

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -652,6 +652,43 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 .await?;
         }
 
+        // Drain any `QueueNext` inputs the client sent during the previous
+        // iteration ("mid-turn steer" lane).  We non-blockingly drain the
+        // whole channel, collect texts, and batch-insert one user message
+        // before re-querying the provider.
+        //
+        // Other command types (ApprovalResponse, AskUserResponse, LoopDecision)
+        // are only ever sent while the engine is actively blocking on cmd_rx
+        // inside their respective select! arms, so they will not be present
+        // here at iteration start.  Any unexpected commands are logged and
+        // discarded — they are benign at this position.
+        {
+            let mut next_texts: Vec<String> = Vec::new();
+            while let Ok(cmd) = cmd_rx.try_recv() {
+                match cmd {
+                    EngineCommand::QueueNext { text } => next_texts.push(text),
+                    other => {
+                        tracing::warn!(
+                            "inference_loop: unexpected command at iteration start (discarded): {:?}",
+                            std::mem::discriminant(&other)
+                        );
+                    }
+                }
+            }
+            if !next_texts.is_empty() {
+                let combined = next_texts.join("\n\n");
+                sink.emit(EngineEvent::Info {
+                    message: format!(
+                        "  \u{1f4e5} Injecting {} steer{} into current turn",
+                        next_texts.len(),
+                        if next_texts.len() == 1 { "" } else { "s" },
+                    ),
+                });
+                db.insert_message(session_id, &Role::User, Some(&combined), None, None, None)
+                    .await?;
+            }
+        }
+
         if iteration >= hard_cap {
             let recent = loop_detector.recent_names();
             sink.emit(EngineEvent::LoopCapReached {


### PR DESCRIPTION
Implements the MVP for #851 — two distinct lanes for typing during inference.

## What changed

### Next lane — mid-turn steer (default)

Pressing **Enter** during inference no longer queues a message to run after the current turn. Instead it sends `EngineCommand::QueueNext` directly to the engine. At the top of each inference loop iteration (after draining background agents, before the next provider request), the engine does a non-blocking drain of all pending `QueueNext` commands, batches them with `\n\n`, and inserts one user message into session history. The model sees the steer in the same turn without interruption.

Visual echo: `📥 Next: <preview>` in green.

### Later lane — deferred turn (`Ctrl+J`)

`Ctrl+J` during inference pushes text to `later_queue` on the TUI side. When the current turn fully completes, `dequeue_input()` drains the whole `later_queue`, joins all items with `\n\n`, and returns one combined string — which becomes exactly **one** new inference turn (not one turn per queued item, which was the old behavior).

Visual echo: `📋 Later (N): <preview>` in yellow.

### Queue management

- `Ctrl+U` clears `later_queue` (deferred messages only).
- Turn cancellation (Esc / Ctrl+C) also clears `later_queue` so a cancelled turn doesn't fire unwanted follow-up work (same guard as #825).
- Status bar queue count shows `later_queue.len()` only — next items are already in flight to the engine.

### Protocol

`EngineCommand::QueueNext { text: String }` added to `engine/event.rs`. Serde roundtrip test included. No breaking changes to existing variants. `QueueLater` is intentionally absent — the later lane is TUI-side only; the engine has no concept of it.

### Docs

`docs/src/keybindings.md` updated with the new Enter / `Ctrl+J` / `Ctrl+U` semantics during inference.

---

## Design decisions (from #851 discussion)

- **Default to `next`** — aligns with Claude Code's product decision that typing during inference most often means "also do this now", not "after you're done".
- **`later` must be explicit** — `Ctrl+J` is an intentional gesture; users who want deferred work can use it.
- **`later` batches into one turn** — all deferred items become one turn, not N turns (matches Gemini's correct behavior and replaces old VecDeque drain).
- **Engine stays mechanical** — the engine does not interpret intent. It just applies pending `next` inputs at the loop boundary it already owns. Same pattern as bg-agent drain and cancellation.
- **Small data model** — `later_queue: VecDeque<String>` on the TUI, `QueueNext { text }` in the protocol. No metadata schema.

---

## What this does NOT include (follow-up issues)

- Persistent queue preview widget in the TUI (replace echo-only feedback)
- Up-arrow pop-from-queue editing
- Background job UX (`/bg ...`)
- `now` priority lane

---

## Test evidence

```
378 tests, 0 failed
cargo clippy — 0 warnings
cargo fmt --check — clean
```

Closes #851
