### PR TITLE
chore: release v0.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,40 @@ All notable changes to Koda are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.2.13] - 2026-04-14
+
+### Added
+- **Queue lanes for typing during inference** — users can now type while the
+  model is thinking. `Enter` sends mid-turn input (`QueueNext` — steers the
+  current turn); `Ctrl+J` defers to a `later_queue` that fires as one
+  combined turn after inference completes (#851, #892).
+- **Queue preview widget** — a `📋`-prefixed panel above the status bar shows
+  up to 3 pending later-queue items with index numbers, an overflow count,
+  and keybinding hints (`↑ pop · Ctrl+U clear`). Hidden when the queue is
+  empty (#851, #893).
+- **Up Arrow pops from later queue** — during inference, pressing `↑` pops
+  the last deferred item back into the editor for re-editing (#893).
+- **`/export` defaults to verbose** — transcripts now include full tool-call
+  output, timestamps, and token counts by default. The new `--summary` flag
+  restores the old concise format (#878, #887).
+- **Sandbox credential hardening** — 8 new credential directories protected
+  from subprocess writes: `.claude`, `.android`, `netlify`, `vercel`, `fly`,
+  `doppler`, `stripe`, `heroku`. Linux bwrap integration tests added (#868,
+  #879).
+- **10 missing docs pages added to `koda_docs` skill index** (#871, #873).
+
+### Changed
+- **Context window % shows actual tokens** — the status-bar percentage now
+  uses `prompt_tokens` from the provider response instead of the `chars/3.5`
+  heuristic, giving accurate readings across all models (#874, #881).
+- **Unrestricted file reads** — Read/List/Grep/Glob now work on any path.
+  Write/Edit/Delete remain scoped to the project root. The koda database
+  (`~/.config/koda/db`) is fully denied for both reads and writes (#876,
+  #882).
+- **`/help` card improvements** — removed Approval section, added drag & drop
+  hint (#870).
+- **Reverted supervisor/worker IPC foundation** — the Phase 1 IPC code from
+  #884 was reverted cleanly in #890; no residual code remains.
 
 ### Fixed
 - **Ctrl+C resume broken across all providers** — typing `continue` after an
@@ -13,9 +46,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   synthetic assistant sentinel between any consecutive user-side messages
   at assembly time (never written to DB, disappears after the next real
   reply). Covers both the streaming-interrupted case (`user → user`) and the
-  tool-result-interrupted case (`tool → user`), which Anthropic and Gemini
-  both treat as two consecutive user messages after their internal remapping
-  (#875).
+  tool-result-interrupted case (`tool → user`) (#875, #886).
+- **Incomplete assistant messages poisoning context** — `load_context` now
+  filters out assistant messages without `completed_at`, preventing garbled
+  DB state from corrupting future turns (#855, #885).
+- **Scrolling up during inference snaps back to bottom** — viewport now holds
+  position when new tokens arrive while the user is scrolled up (#872).
+- **Queue preview hint row clipped** — `height_for` now always includes a
+  row for keybinding hints, so `↑ pop · Ctrl+U clear` is visible even with
+  1–3 queued items.
+- **Newlines in long queue previews** — text is now flattened to spaces
+  before truncation, preventing embedded newlines from breaking the widget
+  layout.
+- **`resolve_path_unrestricted` narrowed to `pub(crate)`** — no external
+  callers; reduces public API surface.
+
+### Dependencies
+- `rand` 0.9.2 → 0.9.3 (#891).
 
 ## [0.2.12] - 2026-04-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.12)
+10. Sync version with workspace (currently 0.2.13)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 publish = false # workspace-only; not published to crates.io
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.12" }
+koda-core = { path = "../koda-core", version = "0.2.13" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -73,6 +73,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.12", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.13", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/widgets/queue_preview.rs
+++ b/koda-cli/src/widgets/queue_preview.rs
@@ -51,8 +51,8 @@ impl<'a> QueuePreview<'a> {
             return 0;
         }
         let item_rows = total.min(MAX_VISIBLE) as u16;
-        let overflow_row = if total > MAX_VISIBLE { 1 } else { 0 };
-        item_rows + overflow_row
+        let hint_row = 1u16; // always show keybinding hints
+        item_rows + hint_row
     }
 }
 
@@ -66,14 +66,15 @@ impl Widget for QueuePreview<'_> {
                 break;
             }
 
-            // Truncate to terminal width, replacing the last char with '…'
-            // when the text is longer than available space.
-            let preview: String = if item.chars().count() > max_text_w {
-                let mut s: String = item.chars().take(max_text_w.saturating_sub(1)).collect();
+            // Flatten newlines first, then truncate to terminal width
+            // with a trailing ellipsis when the text is too long.
+            let flat = item.replace('\n', " ");
+            let preview: String = if flat.chars().count() > max_text_w {
+                let mut s: String = flat.chars().take(max_text_w.saturating_sub(1)).collect();
                 s.push('…');
                 s
             } else {
-                item.replace('\n', " ") // flatten multi-line to single row
+                flat
             };
 
             let line = Line::from(vec![
@@ -149,19 +150,20 @@ mod tests {
     }
 
     #[test]
-    fn height_one_item_no_overflow() {
-        // 1 item row + 0 overflow row = 1
-        assert_eq!(QueuePreview::height_for(1), 1);
+    fn height_one_item_includes_hint_row() {
+        // 1 item row + 1 hint row = 2
+        assert_eq!(QueuePreview::height_for(1), 2);
     }
 
     #[test]
-    fn height_three_items_no_overflow() {
-        assert_eq!(QueuePreview::height_for(3), 3);
+    fn height_three_items_includes_hint_row() {
+        // 3 item rows + 1 hint row = 4
+        assert_eq!(QueuePreview::height_for(3), 4);
     }
 
     #[test]
-    fn height_four_items_has_overflow_row() {
-        // 3 visible + 1 overflow = 4
+    fn height_four_items_capped_plus_hint() {
+        // 3 visible + 1 hint = 4
         assert_eq!(QueuePreview::height_for(4), 4);
     }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -799,7 +799,7 @@ pub(crate) fn resolve_path_unrestricted(project_root: &Path, requested: &str) ->
 /// Normalise a read-only path and enforce the fully-denied list.
 ///
 /// This is the entry-point for **all read-only tools** (Read, List, Grep,
-/// Glob).  It wraps [`resolve_path_unrestricted`] with a check against
+/// Glob).  It wraps `resolve_path_unrestricted` with a check against
 /// `sandbox::is_fully_denied` so that the same paths blocked by the
 /// subprocess sandbox (bwrap / Seatbelt) are also blocked when the model
 /// accesses them through in-process tools.

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -787,7 +787,7 @@ pub fn safe_resolve_path(project_root: &Path, requested: &str) -> Result<PathBuf
 ///
 /// Relative paths are resolved against `project_root`; absolute paths are
 /// cleaned in-place.  The result may point anywhere on the filesystem.
-pub fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBuf {
+pub(crate) fn resolve_path_unrestricted(project_root: &Path, requested: &str) -> PathBuf {
     let path = Path::new(requested);
     if path.is_absolute() {
         path.to_path_buf().clean()

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 publish = false # standalone MCP server; not published to crates.io
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"


### PR DESCRIPTION
## Release v0.2.13

**Version:** 0.2.12 → 0.2.13

### What's in this release

#### Added
- **Queue lanes for typing during inference** — `Enter` sends mid-turn input; `Ctrl+J` defers to a `later_queue` (#851, #892)
- **Queue preview widget** — `📋` panel above status bar showing pending items with `↑ pop · Ctrl+U clear` hints (#893)
- **Up Arrow pops from later queue** during inference (#893)
- **`/export` defaults to verbose** — `--summary` flag for concise (#878, #887)
- **Sandbox credential hardening** — 8 new dirs: `.claude`, `.android`, `netlify`, `vercel`, `fly`, `doppler`, `stripe`, `heroku` (#868, #879)
- **10 missing docs pages** added to `koda_docs` skill index (#871, #873)

#### Changed
- **Context window %** uses actual `prompt_tokens` instead of `chars/3.5` heuristic (#874, #881)
- **Unrestricted file reads** — Read/List/Grep/Glob work on any path; writes scoped to project root (#876, #882)
- **`/help` card** — removed Approval section, added drag & drop hint (#870)
- **Reverted supervisor/worker IPC** from #884 cleanly (#890)

#### Fixed
- **Ctrl+C resume** — synthetic sentinel injection for broken role alternation (#875, #886)
- **Incomplete assistant messages** — `load_context` filters messages without `completed_at` (#855, #885)
- **Scroll-up during inference** no longer snaps back (#872)
- **Queue preview hint row clipped** for 1–3 items — `height_for` now always includes hint row
- **Newlines in long queue previews** — text flattened before truncation
- **`resolve_path_unrestricted`** narrowed to `pub(crate)`

#### Dependencies
- `rand` 0.9.2 → 0.9.3 (#891)

---

### Sub-agent review summary

| Agent | Verdict |
|---|---|
| Code Reviewer | ✅ Ship — found 2 widget bugs (fixed in this PR) |
| Rust Programmer | ✅ All 4 gates pass (fmt, clippy, test, doc) |
| Security Auditor | ✅ Ship — 0 vulns, sandbox hardening verified |
| QA Expert | ✅ Ship — 1,050+ tests, coverage gaps noted for backlog |

### Follow-up items (backlog)
- [ ] Queue lane state management unit tests (#851)
- [ ] `/export` integration tests (file creation, verbose vs summary)
- [ ] MCP manager reconnect/remove test coverage
- [ ] `is_fully_denied` fallback when `$HOME` unset

### Deferred items (tracked)
- [ ] #897 — test: queue lane state management unit tests (P1)
- [ ] #895 — test: /export integration tests (P2)
- [ ] #896 — test: MCP manager reconnect/remove test coverage (P3)
- [ ] #898 — security: is_fully_denied returns false when HOME is unset (P3)
