### PR TITLE
test(queue-lanes): extract pure helpers + 18 lifecycle tests for later_queue (#897)

### DIFF
--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod input;
 pub(crate) mod md_render;
 pub(crate) mod mouse_select;
 pub(crate) mod onboarding;
+pub(crate) mod queue_lanes;
 pub(crate) mod repl;
 pub(crate) mod scroll_buffer;
 pub(crate) mod server;

--- a/koda-cli/src/queue_lanes.rs
+++ b/koda-cli/src/queue_lanes.rs
@@ -1,0 +1,283 @@
+//! Pure helpers for the TUI's two input queue lanes.
+//!
+//! Koda's TUI exposes two input queues that fire while inference is running:
+//!
+//! - **`next_queue`** (Enter mid-turn) — sent to the engine immediately as a
+//!   `QueueNext` command to *steer the current turn*.
+//! - **`later_queue`** (Ctrl+J) — deferred until the current turn fully
+//!   completes, then **batched into one new turn** (FIFO order).
+//!
+//! Up arrow during inference pops the most recently deferred item back into
+//! the editor (LIFO — like a back button). Ctrl+U clears the whole later
+//! queue without cancelling inference.
+//!
+//! The actual keystroke handler in `tui_handlers_inference.rs` is huge and
+//! takes ~10 parameters (textarea, history, scroll buffer, db, …). The pure
+//! `VecDeque<String>` operations are extracted here so they can be unit
+//! tested without spinning up the whole TUI.
+//!
+//! Production callers (`tui_handlers_inference.rs`, `tui_context::dequeue_input`)
+//! use these helpers and add their own UI side effects (scroll-buffer lines,
+//! tracing, etc.) around the returned counts.
+
+use std::collections::VecDeque;
+
+/// Push `text` onto the later queue if it is non-empty after trimming.
+///
+/// Returns the new queue length on success, or `None` if the input was
+/// blank/whitespace-only and was dropped.
+///
+/// Mirrors the guard in `tui_handlers_inference.rs` Ctrl+J handler:
+/// `if !text.trim().is_empty() { ... later_queue.push_back(text); }`.
+pub(crate) fn enqueue_later(queue: &mut VecDeque<String>, text: String) -> Option<usize> {
+    if text.trim().is_empty() {
+        return None;
+    }
+    queue.push_back(text);
+    Some(queue.len())
+}
+
+/// Pop the most recently deferred item (LIFO) — used by Up arrow during
+/// inference to bring the last `Ctrl+J`'d message back into the editor.
+///
+/// Returns `None` when the queue is empty (caller falls through to normal
+/// textarea cursor movement).
+pub(crate) fn pop_later(queue: &mut VecDeque<String>) -> Option<String> {
+    queue.pop_back()
+}
+
+/// Clear the later queue, returning the number of items dropped.
+///
+/// Used by Ctrl+U during inference. Returns `0` for an empty queue so the
+/// caller can decide whether to show the "Cleared N message(s)" line.
+pub(crate) fn clear_later(queue: &mut VecDeque<String>) -> usize {
+    let n = queue.len();
+    queue.clear();
+    n
+}
+
+/// Drain the later queue and join all items into one batched turn (FIFO).
+///
+/// Used by `tui_context::dequeue_input` after inference completes: every
+/// deferred item gets concatenated with `\n\n` separators and submitted as
+/// a single new inference turn so the model sees them as one coherent
+/// follow-up.
+///
+/// Returns `Some((joined_text, item_count))` when at least one item was
+/// drained, or `None` when the queue was empty.
+pub(crate) fn drain_later_as_batch(queue: &mut VecDeque<String>) -> Option<(String, usize)> {
+    if queue.is_empty() {
+        return None;
+    }
+    let items: Vec<String> = queue.drain(..).collect();
+    let count = items.len();
+    Some((items.join("\n\n"), count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty() -> VecDeque<String> {
+        VecDeque::new()
+    }
+
+    fn seeded(items: &[&str]) -> VecDeque<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── enqueue_later ─────────────────────────────────────────────────────
+
+    #[test]
+    fn enqueue_later_pushes_text_and_returns_new_count() {
+        let mut q = empty();
+        assert_eq!(enqueue_later(&mut q, "first".into()), Some(1));
+        assert_eq!(enqueue_later(&mut q, "second".into()), Some(2));
+        assert_eq!(enqueue_later(&mut q, "third".into()), Some(3));
+        assert_eq!(q.len(), 3);
+    }
+
+    #[test]
+    fn enqueue_later_ignores_empty_string() {
+        let mut q = empty();
+        assert_eq!(enqueue_later(&mut q, String::new()), None);
+        assert!(q.is_empty(), "empty input must not be queued");
+    }
+
+    #[test]
+    fn enqueue_later_ignores_whitespace_only_string() {
+        let mut q = empty();
+        assert_eq!(enqueue_later(&mut q, "   \n\t  \n".into()), None);
+        assert!(q.is_empty(), "whitespace-only input must not be queued");
+    }
+
+    #[test]
+    fn enqueue_later_preserves_text_with_internal_whitespace() {
+        let mut q = empty();
+        // The trim is only for the *guard*; the text itself is stored as-is
+        // (model needs the original formatting).
+        assert_eq!(enqueue_later(&mut q, "  hello  world  ".into()), Some(1));
+        assert_eq!(q.front().unwrap(), "  hello  world  ");
+    }
+
+    // ── pop_later ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn pop_later_returns_most_recently_pushed_item() {
+        // LIFO behavior: Up arrow during inference brings back the LAST
+        // thing the user deferred (the most recent Ctrl+J).
+        let mut q = seeded(&["alpha", "beta", "gamma"]);
+        assert_eq!(pop_later(&mut q), Some("gamma".into()));
+        assert_eq!(pop_later(&mut q), Some("beta".into()));
+        assert_eq!(pop_later(&mut q), Some("alpha".into()));
+        assert_eq!(pop_later(&mut q), None);
+    }
+
+    #[test]
+    fn pop_later_on_empty_queue_returns_none() {
+        let mut q = empty();
+        assert_eq!(pop_later(&mut q), None);
+    }
+
+    // ── clear_later ───────────────────────────────────────────────────────
+
+    #[test]
+    fn clear_later_drains_queue_and_returns_count() {
+        let mut q = seeded(&["a", "b", "c", "d"]);
+        let dropped = clear_later(&mut q);
+        assert_eq!(dropped, 4);
+        assert!(q.is_empty(), "queue must be empty after clear");
+    }
+
+    #[test]
+    fn clear_later_on_empty_returns_zero() {
+        let mut q = empty();
+        assert_eq!(clear_later(&mut q), 0);
+    }
+
+    // ── drain_later_as_batch ──────────────────────────────────────────────
+
+    #[test]
+    fn drain_as_batch_returns_none_when_empty() {
+        let mut q = empty();
+        assert!(drain_later_as_batch(&mut q).is_none());
+    }
+
+    #[test]
+    fn drain_as_batch_preserves_fifo_order() {
+        // FIFO: items deferred earliest appear FIRST in the batched turn,
+        // matching natural reading order. This is the regression guard the
+        // QA expert called out by name (queue_items_sent_in_fifo_order).
+        let mut q = seeded(&["one", "two", "three", "four"]);
+        let (joined, count) = drain_later_as_batch(&mut q).unwrap();
+        assert_eq!(count, 4);
+        assert_eq!(joined, "one\n\ntwo\n\nthree\n\nfour");
+        assert!(q.is_empty(), "drain must empty the queue");
+    }
+
+    #[test]
+    fn drain_as_batch_single_item_has_no_separator() {
+        let mut q = seeded(&["only"]);
+        let (joined, count) = drain_later_as_batch(&mut q).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            joined, "only",
+            "single item must not gain a trailing \\n\\n"
+        );
+    }
+
+    #[test]
+    fn drain_as_batch_uses_double_newline_separator() {
+        // Regression guard: must be \n\n, not \n. The model sees each item
+        // as a logically separate paragraph.
+        let mut q = seeded(&["a", "b"]);
+        let (joined, _) = drain_later_as_batch(&mut q).unwrap();
+        assert!(
+            joined.contains("\n\n"),
+            "batch separator must be a blank line: got {joined:?}"
+        );
+        assert!(
+            !joined.contains("\n\n\n"),
+            "no triple newlines: got {joined:?}"
+        );
+    }
+
+    // ── End-to-end lifecycle (#897 explicit list) ─────────────────────────
+
+    #[test]
+    fn push_to_later_queue_during_inference_enqueues() {
+        // QA-named: "push_to_later_queue_during_inference_enqueues"
+        let mut q = empty();
+        enqueue_later(&mut q, "deferred 1".into()).unwrap();
+        enqueue_later(&mut q, "deferred 2".into()).unwrap();
+        assert_eq!(q.len(), 2);
+        assert_eq!(q.front().unwrap(), "deferred 1");
+        assert_eq!(q.back().unwrap(), "deferred 2");
+    }
+
+    #[test]
+    fn up_arrow_pops_from_later_queue() {
+        // QA-named: "up_arrow_pops_from_later_queue"
+        let mut q = empty();
+        enqueue_later(&mut q, "first".into());
+        enqueue_later(&mut q, "second".into());
+        // Up arrow → pop the most recent.
+        assert_eq!(pop_later(&mut q), Some("second".into()));
+        assert_eq!(q.len(), 1);
+    }
+
+    #[test]
+    fn ctrl_u_clears_later_queue() {
+        // QA-named: "ctrl_u_clears_later_queue"
+        let mut q = seeded(&["one", "two", "three"]);
+        let n = clear_later(&mut q);
+        assert_eq!(n, 3);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn queue_empty_after_all_items_popped() {
+        // QA-named: "queue_empty_after_all_items_popped"
+        let mut q = seeded(&["x", "y"]);
+        pop_later(&mut q);
+        pop_later(&mut q);
+        assert!(q.is_empty());
+        // And one more pop must yield None, not panic.
+        assert_eq!(pop_later(&mut q), None);
+    }
+
+    #[test]
+    fn queue_items_sent_in_fifo_order_after_inference() {
+        // QA-named: "queue_items_sent_in_fifo_order_after_inference"
+        let mut q = empty();
+        enqueue_later(&mut q, "step 1".into());
+        enqueue_later(&mut q, "step 2".into());
+        enqueue_later(&mut q, "step 3".into());
+        let (batched, _) = drain_later_as_batch(&mut q).unwrap();
+        // Order in the batched turn matches insertion order.
+        let s1 = batched.find("step 1").expect("step 1 in batch");
+        let s2 = batched.find("step 2").expect("step 2 in batch");
+        let s3 = batched.find("step 3").expect("step 3 in batch");
+        assert!(s1 < s2 && s2 < s3, "FIFO order required: got {batched:?}");
+    }
+
+    // ── Mixed lifecycle: push → pop → clear → drain ───────────────────────
+
+    #[test]
+    fn full_lifecycle_push_pop_clear_drain() {
+        let mut q = empty();
+        // Push 3, pop 1, clear 2.
+        enqueue_later(&mut q, "a".into());
+        enqueue_later(&mut q, "b".into());
+        enqueue_later(&mut q, "c".into());
+        assert_eq!(pop_later(&mut q), Some("c".into()));
+        assert_eq!(clear_later(&mut q), 2);
+        assert!(drain_later_as_batch(&mut q).is_none());
+
+        // After a full clear the queue is reusable.
+        enqueue_later(&mut q, "fresh".into());
+        let (batched, count) = drain_later_as_batch(&mut q).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(batched, "fresh");
+    }
+}

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -477,9 +477,10 @@ impl TuiContext {
         if let Some(cmd) = self.pending_command.take() {
             return Some(cmd);
         }
-        if !self.later_queue.is_empty() {
+        if let Some(first) = self.later_queue.front().cloned() {
             // Drain the whole later_queue and batch into one turn.
-            let items: Vec<String> = self.later_queue.drain(..).collect();
+            let (joined, count) = crate::queue_lanes::drain_later_as_batch(&mut self.later_queue)
+                .expect("front() returned Some, drain must too");
             let mode = trust::read_trust(&self.shared_mode);
             let icon = match mode {
                 TrustMode::Plan => "\u{1f4cb}",
@@ -488,17 +489,17 @@ impl TuiContext {
             };
             self.scroll_buffer.push(Line::from(vec![
                 Span::styled(format!("{icon}> "), Style::default().fg(Color::Cyan)),
-                Span::raw(items[0].clone()),
-                if items.len() > 1 {
+                Span::raw(first),
+                if count > 1 {
                     Span::styled(
-                        format!(" (+{} batched)", items.len() - 1),
+                        format!(" (+{} batched)", count - 1),
                         Style::default().fg(Color::DarkGray),
                     )
                 } else {
                     Span::raw("")
                 },
             ]));
-            return Some(items.join("\n\n"));
+            return Some(joined);
         }
         None
     }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -570,17 +570,16 @@ async fn handle_inference_key_inline(
                 *history_idx = None;
 
                 let preview = truncate_preview(&text, 80);
-                let later_n = later_queue.len() + 1;
-                scroll_buffer.push(Line::from(vec![
-                    Span::raw("  "),
-                    Span::styled(
-                        format!("\u{1f4cb} Later ({later_n}): "),
-                        Style::default().fg(Color::Yellow),
-                    ),
-                    Span::styled(preview, Style::default().fg(Color::DarkGray)),
-                ]));
-
-                later_queue.push_back(text);
+                if let Some(later_n) = crate::queue_lanes::enqueue_later(later_queue, text) {
+                    scroll_buffer.push(Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(
+                            format!("\u{1f4cb} Later ({later_n}): "),
+                            Style::default().fg(Color::Yellow),
+                        ),
+                        Span::styled(preview, Style::default().fg(Color::DarkGray)),
+                    ]));
+                }
             }
         }
         (KeyCode::Esc, _) => {
@@ -591,9 +590,8 @@ async fn handle_inference_key_inline(
         }
         // Ctrl+U: clear the later_queue (deferred messages) without cancelling inference.
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => {
-            if !later_queue.is_empty() {
-                let n = later_queue.len();
-                later_queue.clear();
+            let n = crate::queue_lanes::clear_later(later_queue);
+            if n > 0 {
                 scroll_buffer.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
@@ -610,7 +608,7 @@ async fn handle_inference_key_inline(
         // editor so the user can edit it before re-submitting.
         // Falls back to normal textarea movement when the queue is empty.
         (KeyCode::Up, KeyModifiers::NONE) => {
-            if let Some(popped) = later_queue.pop_back() {
+            if let Some(popped) = crate::queue_lanes::pop_later(later_queue) {
                 textarea.select_all();
                 textarea.cut();
                 textarea.insert_str(&popped);


### PR DESCRIPTION
Closes #897.

QA-expert flagged that the next/later queue lane logic in
`tui_handlers_inference.rs` and `tui_context/mod.rs` has no unit tests
covering push / pop / clear / FIFO ordering. The challenge: the keystroke
handler is a single ~700-line function taking ~10 parameters
(`textarea`, `history`, `scroll_buffer`, `db`, …) — totally unmockable.

## Approach

Extract the four pure `VecDeque<String>` operations into a new module
(`koda-cli/src/queue_lanes.rs`) and refactor the three production call
sites to use them. The keystroke handler keeps all the UI side effects
(scroll-buffer lines, tracing); the helpers do nothing but move strings
around. **Behavior identical in production.**

## New module: `koda-cli/src/queue_lanes.rs`

| Helper | Used by | Semantics |
|---|---|---|
| `enqueue_later(queue, text) -> Option<usize>` | Ctrl+J handler | Push if non-empty after trim; returns new length |
| `pop_later(queue) -> Option<String>` | Up arrow during inference | Pop most recent (**LIFO**) |
| `clear_later(queue) -> usize` | Ctrl+U during inference | Drain, return count |
| `drain_later_as_batch(queue) -> Option<(String, usize)>` | `tui_context::dequeue_input` | Drain all, join with `\\n\\n` (**FIFO**) |

## Production refactors

- Ctrl+J handler now calls `enqueue_later` (was: inline `len() + push_back()`).
- Ctrl+U handler now calls `clear_later`.
- Up arrow now calls `pop_later`.
- `dequeue_input` now calls `drain_later_as_batch` (with a `front().cloned()` peek so the UI line still shows the first item).

## Tests added: **18** in `queue_lanes::tests`

The five tests the QA expert called out by name are present **verbatim**:

- `push_to_later_queue_during_inference_enqueues`
- `up_arrow_pops_from_later_queue`
- `ctrl_u_clears_later_queue`
- `queue_empty_after_all_items_popped`
- `queue_items_sent_in_fifo_order_after_inference`

Plus 13 covering edge cases:

- `enqueue_later_ignores_empty_string` / `whitespace_only`
- `enqueue_later_preserves_text_with_internal_whitespace`
- `pop_later_returns_most_recently_pushed_item` — LIFO contract
- `pop_later_on_empty_queue_returns_none`
- `clear_later_drains_queue_and_returns_count`
- `clear_later_on_empty_returns_zero`
- `drain_as_batch_returns_none_when_empty`
- `drain_as_batch_preserves_fifo_order`
- `drain_as_batch_single_item_has_no_separator`
- `drain_as_batch_uses_double_newline_separator` — regression guard: must be `\\n\\n`, not `\\n` or `\\n\\n\\n`
- `full_lifecycle_push_pop_clear_drain`
- `enqueue_later_pushes_text_and_returns_new_count`

Net production lines: **+52** helpers in new file, **~12 lines** of inline
logic replaced with helper calls in two existing files. clippy clean,
fmt clean, full koda-cli test suite green.