### PR TITLE
test(providers): introduce FakeLlmServer + HTTP-layer tests for openai_compat (#858)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +751,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deltae"
@@ -1351,6 +1379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +1987,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "wiremock",
 ]
 
 [[package]]
@@ -2267,6 +2302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5102,6 +5147,29 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/koda-core/tests/openai_compat_http_test.rs
+++ b/koda-core/tests/openai_compat_http_test.rs
@@ -1,0 +1,177 @@
+//! HTTP-layer integration tests for [`OpenAiCompatProvider`] using
+//! [`koda_test_utils::network::FakeLlmServer`].
+//!
+//! These tests complement the in-module unit tests at the bottom of
+//! `koda-core/src/providers/openai_compat.rs`, which cover request
+//! construction and response deserialization against static strings.
+//! The tests here exercise the *actual* `reqwest::Client` round-trip:
+//! URL routing, bearer-auth header injection, status-code error paths,
+//! and SSE chunk framing over a real TCP socket on loopback.
+//!
+//! Together they form the "HTTP integration coverage" leg of #858 Phase 2
+//! (kicked off in this PR for `openai_compat`; follow-ups extend the same
+//! pattern to `anthropic` and `gemini`).
+
+use koda_core::config::{ModelSettings, ProviderType};
+use koda_core::providers::openai_compat::OpenAiCompatProvider;
+use koda_core::providers::{ChatMessage, LlmProvider, StreamChunk};
+use koda_test_utils::network::FakeLlmServer;
+use serde_json::{Value, json};
+
+/// Minimal, well-formed `chat/completions` response body.
+fn ok_chat_body() -> Value {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": "ok" },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+    })
+}
+
+fn settings() -> ModelSettings {
+    ModelSettings::defaults_for("gpt-4o", &ProviderType::OpenAI)
+}
+
+fn user_msg(text: &str) -> ChatMessage {
+    ChatMessage::text("user", text)
+}
+
+// ── chat() ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_sends_post_to_chat_completions_endpoint() {
+    let server = FakeLlmServer::spawn().await;
+    server.mount_chat_ok(ok_chat_body()).await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), Some("sk-test".into()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat must succeed against 200 mock");
+
+    let reqs = server.received_requests().await;
+    assert_eq!(reqs.len(), 1, "exactly one POST expected");
+    assert_eq!(reqs[0].method.as_str(), "POST");
+    assert!(
+        reqs[0].url.path().ends_with("/chat/completions"),
+        "wrong path: {}",
+        reqs[0].url.path()
+    );
+}
+
+#[tokio::test]
+async fn chat_includes_bearer_token_when_api_key_set() {
+    let server = FakeLlmServer::spawn().await;
+    server.mount_chat_ok(ok_chat_body()).await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), Some("sk-secret-123".into()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+
+    let reqs = server.received_requests().await;
+    let auth = reqs[0]
+        .headers
+        .get("authorization")
+        .expect("Authorization header required when api_key is set");
+    assert_eq!(auth, "Bearer sk-secret-123");
+}
+
+#[tokio::test]
+async fn chat_omits_authorization_header_when_no_api_key() {
+    let server = FakeLlmServer::spawn().await;
+    server.mount_chat_ok(ok_chat_body()).await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), None);
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+
+    let reqs = server.received_requests().await;
+    assert!(
+        reqs[0].headers.get("authorization").is_none(),
+        "Authorization header must NOT be present when api_key is None"
+    );
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_5xx_with_status_in_message() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_chat_status(503, r#"{"error":"upstream down"}"#)
+        .await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), Some("k".into()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("5xx must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("503"), "error must mention status: {msg}");
+    assert!(
+        msg.contains("upstream down"),
+        "error must include body: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_4xx_unauthorized() {
+    // Regression guard: the same error path must fire for 4xx as for 5xx
+    // (the provider doesn't special-case auth errors yet — this test pins
+    // current behavior so any future retry-on-4xx work is intentional).
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_chat_status(401, r#"{"error":"invalid_api_key"}"#)
+        .await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), Some("bad".into()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("401 must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("401"), "error must mention status: {msg}");
+}
+
+// ── chat_stream() ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_stream_consumes_sse_chunks_via_real_tcp() {
+    // OpenAI streaming format: each SSE `data:` line is a JSON delta.
+    // We send three deltas plus the standard `[DONE]` sentinel and assert
+    // the SseCollector reassembles the full text.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_chat_sse(&[
+            r#"{"choices":[{"index":0,"delta":{"content":"hel"},"finish_reason":null}]}"#,
+            r#"{"choices":[{"index":0,"delta":{"content":"lo "},"finish_reason":null}]}"#,
+            r#"{"choices":[{"index":0,"delta":{"content":"world"},"finish_reason":"stop"}]}"#,
+            "[DONE]",
+        ])
+        .await;
+
+    let provider = OpenAiCompatProvider::new(&server.url(), Some("k".into()));
+    let mut collector = provider
+        .chat_stream(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat_stream must succeed");
+
+    let mut text = String::new();
+    while let Some(chunk) = collector.rx.recv().await {
+        if let StreamChunk::TextDelta(s) = chunk {
+            text.push_str(&s);
+        }
+    }
+
+    assert_eq!(text, "hello world", "all SSE deltas must be reassembled");
+}

--- a/koda-test-utils/Cargo.toml
+++ b/koda-test-utils/Cargo.toml
@@ -20,3 +20,4 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tempfile = "3"
 anyhow = "1"
 serde_json = "1"
+wiremock = "0.6"

--- a/koda-test-utils/src/lib.rs
+++ b/koda-test-utils/src/lib.rs
@@ -22,6 +22,7 @@
 
 mod env;
 pub mod golden;
+pub mod network;
 
 // ── Re-exports from koda-core (test-support gated) ─────────────────────────
 

--- a/koda-test-utils/src/network.rs
+++ b/koda-test-utils/src/network.rs
@@ -1,0 +1,148 @@
+//! In-process fake network services for HTTP-level provider tests.
+//!
+//! # Why this module exists
+//!
+//! Provider unit tests in `koda-core::providers::*` test serialization and
+//! parsing against static strings. They do **not** exercise the actual
+//! `reqwest::Client` round-trip: bearer-auth header injection, base-URL
+//! routing, status-code error handling, SSE chunk framing over a real TCP
+//! socket, retry/timeout behavior, or proxy interaction.
+//!
+//! [`FakeLlmServer`] closes that gap. It binds an ephemeral port on
+//! `127.0.0.1`, lets you stage canned responses (JSON, SSE, error status,
+//! delays), and lets you assert on what the provider actually sent.
+//!
+//! Built on [`wiremock`] for the matcher DSL — `koda-test-utils` already
+//! ships a `tokio` runtime so the cost is just one extra dev-dep.
+//!
+//! # Quick start
+//!
+//! ```rust,ignore
+//! use koda_test_utils::network::FakeLlmServer;
+//! use serde_json::json;
+//!
+//! #[tokio::test]
+//! async fn provider_sends_bearer_token() {
+//!     let server = FakeLlmServer::spawn().await;
+//!     server.mount_chat_ok(json!({
+//!         "choices": [{ "message": { "role": "assistant", "content": "ok" }, "finish_reason": "stop" }],
+//!         "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
+//!     })).await;
+//!
+//!     let provider = OpenAIProvider::new(&server.url(), Some("sk-test".into()));
+//!     let _ = provider.chat(&[], &[], &settings).await.unwrap();
+//!
+//!     let reqs = server.received_requests().await;
+//!     assert_eq!(reqs.len(), 1);
+//!     assert_eq!(reqs[0].headers.get("authorization").unwrap(), "Bearer sk-test");
+//! }
+//! ```
+//!
+//! # Design notes
+//!
+//! * **Path matching is permissive by default.** `mount_chat_ok` matches
+//!   any path ending in `/chat/completions` so the same fixture works for
+//!   both OpenAI (`/v1/chat/completions`) and a base URL that already
+//!   includes `/v1`. Tighten with `mount_with_matchers` when needed.
+//!
+//! * **One mount per response.** Each `mount_*` call adds a separate Mock
+//!   to the server. Multiple mounts on the same path are matched in
+//!   insertion order — see wiremock docs for the exact resolution rules.
+//!
+//! * **Lifetime = test function.** The server shuts down when `Self` is
+//!   dropped. Don't share across tests; spawn fresh per test for isolation.
+
+use std::time::Duration;
+
+use serde_json::Value;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// In-process fake LLM server for HTTP-level provider tests.
+///
+/// See module docs for usage and design notes.
+pub struct FakeLlmServer {
+    server: MockServer,
+}
+
+impl FakeLlmServer {
+    /// Bind an ephemeral port on `127.0.0.1` and start serving.
+    pub async fn spawn() -> Self {
+        Self {
+            server: MockServer::start().await,
+        }
+    }
+
+    /// Base URL with no trailing slash, e.g. `http://127.0.0.1:54321`.
+    ///
+    /// Pass this directly to provider constructors that take a `base_url`.
+    pub fn url(&self) -> String {
+        self.server.uri()
+    }
+
+    /// Mount a 200 OK JSON response for `POST */chat/completions`.
+    pub async fn mount_chat_ok(&self, body: Value) {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/chat/completions$"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mount a non-2xx response for `POST */chat/completions`.
+    ///
+    /// Use this to drive provider error-handling tests (4xx auth/rate-limit
+    /// errors, 5xx upstream failures).
+    pub async fn mount_chat_status(&self, status: u16, body: &str) {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/chat/completions$"))
+            .respond_with(ResponseTemplate::new(status).set_body_string(body))
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mount a 200 OK SSE-streaming response for `POST */chat/completions`.
+    ///
+    /// `chunks` are framed as `data: <chunk>\n\n` per SSE spec. Pass each
+    /// JSON delta as a separate string; do **not** pre-concatenate.
+    /// A trailing `data: [DONE]\n\n` is **not** added automatically — pass
+    /// `"[DONE]"` as the last chunk if your provider expects it.
+    pub async fn mount_chat_sse(&self, chunks: &[&str]) {
+        let body = chunks
+            .iter()
+            .map(|c| format!("data: {c}\n\n"))
+            .collect::<String>();
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/chat/completions$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&self.server)
+            .await;
+    }
+
+    /// Mount a 200 OK chat response that takes `delay` to start sending.
+    ///
+    /// Useful for client-timeout regression tests.
+    pub async fn mount_chat_delayed(&self, delay: Duration, body: Value) {
+        Mock::given(method("POST"))
+            .and(path_regex(r".*/chat/completions$"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(body)
+                    .set_delay(delay),
+            )
+            .mount(&self.server)
+            .await;
+    }
+
+    /// All requests received across all mounted endpoints, in order.
+    ///
+    /// Returns an empty vec if request-recording is disabled (it is enabled
+    /// by default in wiremock).
+    pub async fn received_requests(&self) -> Vec<Request> {
+        self.server.received_requests().await.unwrap_or_default()
+    }
+}


### PR DESCRIPTION
First PR of #858 Phase 2 (mock servers). Adds the reusable test
fixture and proves the pattern with **6 HTTP-layer tests** for
`openai_compat`.

## What was missing

Provider unit tests in `koda-core::providers::*` test serialization and
parsing against static strings. They do **not** exercise the actual
`reqwest::Client` round-trip: bearer-auth header injection, base-URL
routing, status-code error handling, SSE chunk framing over a real TCP
socket. #858 calls this out explicitly.

## What this PR ships

### New module: `koda_test_utils::network::FakeLlmServer`

`wiremock`-backed fixture that binds an ephemeral 127.0.0.1 port. Four
mount helpers covering the response shapes provider tests need:

| Helper | Purpose |
|---|---|
| `mount_chat_ok(json)` | 200 OK with a JSON body |
| `mount_chat_status(code, body)` | non-2xx for error-path tests |
| `mount_chat_sse(chunks)` | 200 OK `text/event-stream` body, framed per SSE |
| `mount_chat_delayed(d, body)` | 200 OK that takes `d` to start sending |

`received_requests()` returns `wiremock::Request`s for asserting on
method / URL / headers / body the provider actually sent.

Path matching is intentionally permissive (`.*/chat/completions$`) so
the same fixture works whether the base URL includes `/v1` or not.

### New integration test file: `openai_compat_http_test.rs`

Six tests covering the HTTP layer, complementing the 9 in-module
serialization tests:

- `chat_sends_post_to_chat_completions_endpoint`
- `chat_includes_bearer_token_when_api_key_set`
- `chat_omits_authorization_header_when_no_api_key`
- `chat_returns_error_on_5xx_with_status_in_message`
- `chat_returns_error_on_4xx_unauthorized` — regression guard, pins
  current 'no-retry-on-4xx' behavior so any future change is intentional
- `chat_stream_consumes_sse_chunks_via_real_tcp` — full reqwest →
  SseCollector → `StreamChunk::TextDelta` path with 3 deltas + `[DONE]`

## Why `wiremock` (not hand-rolled axum)

Followed user direction to take the ergonomic DSL even though the
existing `mcp_http_transport_test.rs` hand-rolls axum.

- **Cost**: one new dev-dep (`wiremock 0.6`) on `koda-test-utils`.
- **Benefit**: future provider tests in PRs 2–3 of this series can be
  one-liners — `server.mount_chat_status(429, …).await`.

## Out of scope (follow-up PRs in the #858 series)

- Same pattern for `anthropic` + `gemini` providers
- retry / timeout coverage (`mount_chat_delayed` already in place)
- proxy + `KODA_ACCEPT_INVALID_CERTS` coverage in `build_http_client`
- `FakeSmtpServer` + `FakeImapServer` for koda-email
- **Phase 3 (Windows/ARM CI) being closed as won't-fix** — `koda-cli`
  has `compile_error!` on non-Unix and the only Windows-specific code
  in the workspace is a single perf threshold constant.

## Validation

- `cargo test -p koda-core --test openai_compat_http_test` — 6/6 ✅
- `cargo test -p koda-core --lib providers::openai_compat` — 9/9 ✅ (no regression)
- `cargo clippy -p koda-test-utils --all-targets -- -D warnings` — clean
- `cargo clippy -p koda-core --tests --features test-support -- -D warnings` — clean
- `cargo fmt --check` — clean