### PR TITLE
test(providers): HTTP-layer tests for anthropic + gemini (#858)

### DIFF
--- a/koda-core/tests/anthropic_http_test.rs
+++ b/koda-core/tests/anthropic_http_test.rs
@@ -1,0 +1,204 @@
+//! HTTP-layer integration tests for [`AnthropicProvider`] using
+//! [`koda_test_utils::network::FakeLlmServer`].
+//!
+//! Companion to `openai_compat_http_test.rs`. Anthropic differs from
+//! OpenAI in three ways that motivate dedicated tests:
+//!
+//! * Endpoint is `POST /v1/messages` (not `/chat/completions`).
+//! * Auth is the `x-api-key` header (not `Authorization: Bearer …`).
+//! * `anthropic-version` is required on every request.
+//!
+//! These tests pin all three behaviors against a real reqwest round-trip.
+
+use koda_core::config::{ModelSettings, ProviderType};
+use koda_core::providers::anthropic::AnthropicProvider;
+use koda_core::providers::{ChatMessage, LlmProvider, StreamChunk};
+use koda_test_utils::network::FakeLlmServer;
+use serde_json::{Value, json};
+
+/// Minimal well-formed `/v1/messages` non-streaming response.
+fn ok_messages_body() -> Value {
+    json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [{ "type": "text", "text": "ok" }],
+        "stop_reason": "end_turn",
+        "usage": { "input_tokens": 1, "output_tokens": 1 }
+    })
+}
+
+fn settings() -> ModelSettings {
+    ModelSettings::defaults_for("claude-sonnet-4-5-20250929", &ProviderType::Anthropic)
+}
+
+fn user_msg(text: &str) -> ChatMessage {
+    ChatMessage::text("user", text)
+}
+
+// ── chat() ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_sends_post_to_v1_messages_endpoint() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_ok("POST", r".*/v1/messages$", ok_messages_body())
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-test".into(), Some(&server.url()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat must succeed against 200 mock");
+
+    let reqs = server.received_requests().await;
+    assert_eq!(reqs.len(), 1);
+    assert_eq!(reqs[0].method.as_str(), "POST");
+    assert!(
+        reqs[0].url.path().ends_with("/v1/messages"),
+        "wrong path: {}",
+        reqs[0].url.path()
+    );
+}
+
+#[tokio::test]
+async fn chat_sends_x_api_key_header_not_bearer() {
+    // Anthropic uses `x-api-key`, NOT `Authorization: Bearer …`.
+    // This is the most common provider-confusion bug; pin it explicitly.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_ok("POST", r".*/v1/messages$", ok_messages_body())
+        .await;
+
+    let provider = AnthropicProvider::new("sk-ant-secret".into(), Some(&server.url()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+
+    let reqs = server.received_requests().await;
+    let api_key = reqs[0]
+        .headers
+        .get("x-api-key")
+        .expect("x-api-key header required");
+    assert_eq!(api_key, "sk-ant-secret");
+    assert!(
+        reqs[0].headers.get("authorization").is_none(),
+        "Anthropic must NOT send Authorization header"
+    );
+}
+
+#[tokio::test]
+async fn chat_sends_anthropic_version_header() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_ok("POST", r".*/v1/messages$", ok_messages_body())
+        .await;
+
+    let provider = AnthropicProvider::new("k".into(), Some(&server.url()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+
+    let reqs = server.received_requests().await;
+    let version = reqs[0]
+        .headers
+        .get("anthropic-version")
+        .expect("anthropic-version header required on every request");
+    // Don't pin the exact date — that's an implementation detail of
+    // the constant ANTHROPIC_API_VERSION. Just assert it looks like a date.
+    let v = version.to_str().unwrap();
+    assert!(
+        v.len() >= 10 && v.chars().nth(4) == Some('-'),
+        "version must look like YYYY-MM-DD, got: {v}"
+    );
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_5xx_with_status_in_message() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_status(
+            "POST",
+            r".*/v1/messages$",
+            503,
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"upstream"}}"#,
+        )
+        .await;
+
+    let provider = AnthropicProvider::new("k".into(), Some(&server.url()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("5xx must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("503"), "error must mention status: {msg}");
+    assert!(msg.contains("overloaded_error"), "error must include body");
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_401_invalid_api_key() {
+    // Regression guard: pins current 'no-retry-on-4xx' behavior.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_status(
+            "POST",
+            r".*/v1/messages$",
+            401,
+            r#"{"type":"error","error":{"type":"authentication_error"}}"#,
+        )
+        .await;
+
+    let provider = AnthropicProvider::new("bad".into(), Some(&server.url()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("401 must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("401"), "error must mention status: {msg}");
+}
+
+// ── chat_stream() ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_stream_consumes_anthropic_sse_event_format_via_real_tcp() {
+    // Anthropic SSE uses a different chunk shape than OpenAI:
+    // each event has a `type` field and `content_block_delta` events
+    // carry text in `delta.text`.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_sse(
+            "POST",
+            r".*/v1/messages$",
+            &[
+                r#"{"type":"message_start","message":{"usage":{"input_tokens":5,"output_tokens":0}}}"#,
+                r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+                r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hel"}}"#,
+                r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo "}}"#,
+                r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}"#,
+                r#"{"type":"content_block_stop","index":0}"#,
+                r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":0,"output_tokens":3}}"#,
+                r#"{"type":"message_stop"}"#,
+            ],
+        )
+        .await;
+
+    let provider = AnthropicProvider::new("k".into(), Some(&server.url()));
+    let mut collector = provider
+        .chat_stream(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat_stream must succeed");
+
+    let mut text = String::new();
+    while let Some(chunk) = collector.rx.recv().await {
+        if let StreamChunk::TextDelta(s) = chunk {
+            text.push_str(&s);
+        }
+    }
+
+    assert_eq!(text, "hello world", "all SSE deltas must be reassembled");
+}

--- a/koda-core/tests/gemini_http_test.rs
+++ b/koda-core/tests/gemini_http_test.rs
@@ -1,0 +1,237 @@
+//! HTTP-layer integration tests for [`GeminiProvider`] using
+//! [`koda_test_utils::network::FakeLlmServer`].
+//!
+//! Companion to `openai_compat_http_test.rs` and `anthropic_http_test.rs`.
+//! Gemini differs from both:
+//!
+//! * Non-streaming endpoint: `POST /v1beta/models/{model}:generateContent`.
+//! * Streaming endpoint:     `POST /v1beta/models/{model}:streamGenerateContent?alt=sse`.
+//! * Auth lives in the URL **query string** (`?key=…`), not in a header.
+//! * SSE chunks have a different shape: `candidates[].content.parts[].text`.
+//!
+//! These tests pin all four behaviors against a real reqwest round-trip.
+//!
+//! ## Path-regex notes
+//!
+//! Gemini's two endpoints differ only by the `stream` prefix. Anchor the
+//! non-streaming matcher with `:generateContent$` so it does **not** also
+//! match `:streamGenerateContent` (the substring before `generateContent`
+//! is `:` for non-stream vs `m` for stream — the leading `:` in the regex
+//! disambiguates).
+
+use koda_core::config::{ModelSettings, ProviderType};
+use koda_core::providers::gemini::GeminiProvider;
+use koda_core::providers::{ChatMessage, LlmProvider, StreamChunk};
+use koda_test_utils::network::FakeLlmServer;
+use serde_json::{Value, json};
+
+/// Minimal well-formed `:generateContent` non-streaming response.
+fn ok_generate_body() -> Value {
+    json!({
+        "candidates": [{
+            "content": {
+                "role": "model",
+                "parts": [{ "text": "ok" }]
+            },
+            "finishReason": "STOP"
+        }],
+        "usageMetadata": {
+            "promptTokenCount": 1,
+            "candidatesTokenCount": 1,
+            "cachedContentTokenCount": 0,
+            "thoughtsTokenCount": 0
+        }
+    })
+}
+
+fn settings() -> ModelSettings {
+    ModelSettings::defaults_for("gemini-2.5-flash", &ProviderType::Gemini)
+}
+
+fn user_msg(text: &str) -> ChatMessage {
+    ChatMessage::text("user", text)
+}
+
+// ── chat() ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_sends_post_to_generate_content_endpoint() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_ok("POST", r".*:generateContent$", ok_generate_body())
+        .await;
+
+    let provider = GeminiProvider::new("gem-test".into(), Some(&server.url()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat must succeed against 200 mock");
+
+    let reqs = server.received_requests().await;
+    assert_eq!(reqs.len(), 1);
+    assert_eq!(reqs[0].method.as_str(), "POST");
+    assert!(
+        reqs[0].url.path().ends_with(":generateContent"),
+        "wrong path: {}",
+        reqs[0].url.path()
+    );
+    assert!(
+        reqs[0]
+            .url
+            .path()
+            .contains("/v1beta/models/gemini-2.5-flash:"),
+        "model must be embedded in the path, got: {}",
+        reqs[0].url.path()
+    );
+}
+
+#[tokio::test]
+async fn chat_sends_api_key_as_query_param_not_header() {
+    // Gemini's defining quirk: API key goes in `?key=…`, NOT in any header.
+    // This is the test that matters most for an HTTP-layer suite.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_ok("POST", r".*:generateContent$", ok_generate_body())
+        .await;
+
+    let provider = GeminiProvider::new("gem-secret-123".into(), Some(&server.url()));
+    provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+
+    let reqs = server.received_requests().await;
+
+    // Auth via query param.
+    let query = reqs[0].url.query().unwrap_or("");
+    assert!(
+        query.contains("key=gem-secret-123"),
+        "API key must appear in query string, got: {query}"
+    );
+
+    // No auth headers (Gemini sends none of these).
+    assert!(reqs[0].headers.get("authorization").is_none());
+    assert!(reqs[0].headers.get("x-api-key").is_none());
+    assert!(reqs[0].headers.get("x-goog-api-key").is_none());
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_5xx_with_status_in_message() {
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_status(
+            "POST",
+            r".*:generateContent$",
+            503,
+            r#"{"error":{"code":503,"message":"service unavailable","status":"UNAVAILABLE"}}"#,
+        )
+        .await;
+
+    let provider = GeminiProvider::new("k".into(), Some(&server.url()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("5xx must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("503"), "error must mention status: {msg}");
+    assert!(msg.contains("UNAVAILABLE"), "error must include body");
+}
+
+#[tokio::test]
+async fn chat_returns_error_on_400_invalid_request() {
+    // Regression guard: pins current 'no-retry-on-4xx' behavior.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_status(
+            "POST",
+            r".*:generateContent$",
+            400,
+            r#"{"error":{"code":400,"message":"bad request"}}"#,
+        )
+        .await;
+
+    let provider = GeminiProvider::new("k".into(), Some(&server.url()));
+    let err = provider
+        .chat(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect_err("400 must surface as Err");
+
+    let msg = format!("{err:#}");
+    assert!(msg.contains("400"), "error must mention status: {msg}");
+}
+
+// ── chat_stream() ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chat_stream_consumes_gemini_sse_format_via_real_tcp() {
+    // Gemini SSE chunks: each line is a full `GenerateResponse` JSON with
+    // a `candidates[].content.parts[].text` field. Final chunk carries the
+    // `finishReason` and `usageMetadata` totals.
+    //
+    // Note: Gemini does NOT send a `[DONE]` sentinel — the stream just
+    // closes after the last chunk.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_sse(
+            "POST",
+            r".*:streamGenerateContent$",
+            &[
+                r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"hel"}]}}]}"#,
+                r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"lo "}]}}]}"#,
+                r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"cachedContentTokenCount":0,"thoughtsTokenCount":0}}"#,
+            ],
+        )
+        .await;
+
+    let provider = GeminiProvider::new("k".into(), Some(&server.url()));
+    let mut collector = provider
+        .chat_stream(&[user_msg("hi")], &[], &settings())
+        .await
+        .expect("chat_stream must succeed");
+
+    let mut text = String::new();
+    while let Some(chunk) = collector.rx.recv().await {
+        if let StreamChunk::TextDelta(s) = chunk {
+            text.push_str(&s);
+        }
+    }
+
+    assert_eq!(text, "hello world", "all SSE deltas must be reassembled");
+}
+
+#[tokio::test]
+async fn chat_stream_sends_alt_sse_query_param() {
+    // Regression guard: the streaming endpoint must include `alt=sse` so
+    // Gemini returns SSE-framed chunks instead of newline-delimited JSON.
+    // Drop this and the stream silently switches format.
+    let server = FakeLlmServer::spawn().await;
+    server
+        .mount_sse(
+            "POST",
+            r".*:streamGenerateContent$",
+            &[
+                r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"x"}]},"finishReason":"STOP"}]}"#,
+            ],
+        )
+        .await;
+
+    let provider = GeminiProvider::new("k".into(), Some(&server.url()));
+    let mut collector = provider
+        .chat_stream(&[user_msg("hi")], &[], &settings())
+        .await
+        .unwrap();
+    // Drain so the request completes.
+    while collector.rx.recv().await.is_some() {}
+
+    let reqs = server.received_requests().await;
+    let query = reqs[0].url.query().unwrap_or("");
+    assert!(
+        query.contains("alt=sse"),
+        "streaming request must include alt=sse, got: {query}"
+    );
+    assert!(
+        query.contains("key=k"),
+        "streaming request must include API key, got: {query}"
+    );
+}

--- a/koda-test-utils/src/network.rs
+++ b/koda-test-utils/src/network.rs
@@ -15,35 +15,32 @@
 //! Built on [`wiremock`] for the matcher DSL — `koda-test-utils` already
 //! ships a `tokio` runtime so the cost is just one extra dev-dep.
 //!
-//! # Quick start
+//! # Quick start (generic API — works for any provider)
 //!
 //! ```rust,ignore
 //! use koda_test_utils::network::FakeLlmServer;
 //! use serde_json::json;
 //!
-//! #[tokio::test]
-//! async fn provider_sends_bearer_token() {
-//!     let server = FakeLlmServer::spawn().await;
-//!     server.mount_chat_ok(json!({
-//!         "choices": [{ "message": { "role": "assistant", "content": "ok" }, "finish_reason": "stop" }],
-//!         "usage": { "prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2 }
-//!     })).await;
+//! let server = FakeLlmServer::spawn().await;
 //!
-//!     let provider = OpenAIProvider::new(&server.url(), Some("sk-test".into()));
-//!     let _ = provider.chat(&[], &[], &settings).await.unwrap();
+//! // OpenAI-compat:
+//! server.mount_ok("POST", r".*/chat/completions$", json!({...})).await;
 //!
-//!     let reqs = server.received_requests().await;
-//!     assert_eq!(reqs.len(), 1);
-//!     assert_eq!(reqs[0].headers.get("authorization").unwrap(), "Bearer sk-test");
-//! }
+//! // Anthropic:
+//! server.mount_ok("POST", r".*/v1/messages$", json!({...})).await;
+//!
+//! // Gemini:
+//! server.mount_ok("POST", r".*:generateContent.*", json!({...})).await;
 //! ```
+//!
+//! Convenience wrappers like [`FakeLlmServer::mount_chat_ok`] exist for the
+//! OpenAI-compat path; they are 3-line shims around the generic primitives.
 //!
 //! # Design notes
 //!
-//! * **Path matching is permissive by default.** `mount_chat_ok` matches
-//!   any path ending in `/chat/completions` so the same fixture works for
-//!   both OpenAI (`/v1/chat/completions`) and a base URL that already
-//!   includes `/v1`. Tighten with `mount_with_matchers` when needed.
+//! * **Path matching uses regex.** Matchers are *substring-anchored* via
+//!   `path_regex` — i.e. they match anywhere in the path. Anchor with
+//!   `$` for "ends with" or `^` for "starts with" as needed.
 //!
 //! * **One mount per response.** Each `mount_*` call adds a separate Mock
 //!   to the server. Multiple mounts on the same path are matched in
@@ -80,40 +77,51 @@ impl FakeLlmServer {
         self.server.uri()
     }
 
-    /// Mount a 200 OK JSON response for `POST */chat/completions`.
-    pub async fn mount_chat_ok(&self, body: Value) {
-        Mock::given(method("POST"))
-            .and(path_regex(r".*/chat/completions$"))
+    /// All requests received across all mounted endpoints, in order.
+    ///
+    /// Returns an empty vec if request-recording is disabled (it is enabled
+    /// by default in wiremock).
+    pub async fn received_requests(&self) -> Vec<Request> {
+        self.server.received_requests().await.unwrap_or_default()
+    }
+
+    // ── Generic primitives ────────────────────────────────────────────────
+    //
+    // These take an HTTP method + path regex so any provider's endpoint
+    // shape can be mocked. The provider-specific wrappers below are 3-line
+    // shims that call these.
+
+    /// Mount a 200 OK JSON response for `<method> <path matching regex>`.
+    pub async fn mount_ok(&self, http_method: &str, path_re: &str, body: Value) {
+        Mock::given(method(http_method))
+            .and(path_regex(path_re))
             .respond_with(ResponseTemplate::new(200).set_body_json(body))
             .mount(&self.server)
             .await;
     }
 
-    /// Mount a non-2xx response for `POST */chat/completions`.
-    ///
-    /// Use this to drive provider error-handling tests (4xx auth/rate-limit
-    /// errors, 5xx upstream failures).
-    pub async fn mount_chat_status(&self, status: u16, body: &str) {
-        Mock::given(method("POST"))
-            .and(path_regex(r".*/chat/completions$"))
+    /// Mount a non-2xx response. For driving provider error-path tests.
+    pub async fn mount_status(&self, http_method: &str, path_re: &str, status: u16, body: &str) {
+        Mock::given(method(http_method))
+            .and(path_regex(path_re))
             .respond_with(ResponseTemplate::new(status).set_body_string(body))
             .mount(&self.server)
             .await;
     }
 
-    /// Mount a 200 OK SSE-streaming response for `POST */chat/completions`.
+    /// Mount a 200 OK SSE-streaming response.
     ///
     /// `chunks` are framed as `data: <chunk>\n\n` per SSE spec. Pass each
-    /// JSON delta as a separate string; do **not** pre-concatenate.
-    /// A trailing `data: [DONE]\n\n` is **not** added automatically — pass
+    /// JSON delta as a separate string; do **not** pre-concatenate. A
+    /// trailing `data: [DONE]\n\n` is **not** added automatically — pass
     /// `"[DONE]"` as the last chunk if your provider expects it.
-    pub async fn mount_chat_sse(&self, chunks: &[&str]) {
+    pub async fn mount_sse(&self, http_method: &str, path_re: &str, chunks: &[&str]) {
         let body = chunks
             .iter()
             .map(|c| format!("data: {c}\n\n"))
             .collect::<String>();
-        Mock::given(method("POST"))
-            .and(path_regex(r".*/chat/completions$"))
+        Mock::given(method(http_method))
+            .and(path_regex(path_re))
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("content-type", "text/event-stream")
@@ -123,12 +131,18 @@ impl FakeLlmServer {
             .await;
     }
 
-    /// Mount a 200 OK chat response that takes `delay` to start sending.
+    /// Mount a 200 OK JSON response that takes `delay` to start sending.
     ///
     /// Useful for client-timeout regression tests.
-    pub async fn mount_chat_delayed(&self, delay: Duration, body: Value) {
-        Mock::given(method("POST"))
-            .and(path_regex(r".*/chat/completions$"))
+    pub async fn mount_delayed(
+        &self,
+        http_method: &str,
+        path_re: &str,
+        delay: Duration,
+        body: Value,
+    ) {
+        Mock::given(method(http_method))
+            .and(path_regex(path_re))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_json(body)
@@ -138,11 +152,32 @@ impl FakeLlmServer {
             .await;
     }
 
-    /// All requests received across all mounted endpoints, in order.
-    ///
-    /// Returns an empty vec if request-recording is disabled (it is enabled
-    /// by default in wiremock).
-    pub async fn received_requests(&self) -> Vec<Request> {
-        self.server.received_requests().await.unwrap_or_default()
+    // ── OpenAI-compat convenience wrappers ────────────────────────────────
+    //
+    // These hard-code `POST .*/chat/completions$`. They predate the generic
+    // primitives above and are kept for the openai_compat_http_test.rs
+    // call sites. New per-provider tests should call the generics directly.
+
+    /// 200 OK JSON response for `POST .*/chat/completions$`.
+    pub async fn mount_chat_ok(&self, body: Value) {
+        self.mount_ok("POST", r".*/chat/completions$", body).await
+    }
+
+    /// Non-2xx response for `POST .*/chat/completions$`.
+    pub async fn mount_chat_status(&self, status: u16, body: &str) {
+        self.mount_status("POST", r".*/chat/completions$", status, body)
+            .await
+    }
+
+    /// 200 OK SSE-streaming response for `POST .*/chat/completions$`.
+    pub async fn mount_chat_sse(&self, chunks: &[&str]) {
+        self.mount_sse("POST", r".*/chat/completions$", chunks)
+            .await
+    }
+
+    /// 200 OK JSON response with delay for `POST .*/chat/completions$`.
+    pub async fn mount_chat_delayed(&self, delay: Duration, body: Value) {
+        self.mount_delayed("POST", r".*/chat/completions$", delay, body)
+            .await
     }
 }


### PR DESCRIPTION
PR 2 of #858 Phase 2. Builds on PR #911 (FakeLlmServer) by extending HTTP-layer coverage to the other two first-party providers.

## What's in this PR

### `koda_test_utils::network::FakeLlmServer` — generic primitives

PR #911 only had path-hardcoded helpers (`mount_chat_*`). Anthropic uses `/v1/messages` and Gemini uses `:generateContent` / `:streamGenerateContent` — so the API needed to generalize.

| New generic primitive | Old wrapper (still works) |
|---|---|
| `mount_ok(method, path_re, body)` | `mount_chat_ok(body)` |
| `mount_status(method, path_re, code, body)` | `mount_chat_status(code, body)` |
| `mount_sse(method, path_re, chunks)` | `mount_chat_sse(chunks)` |
| `mount_delayed(method, path_re, dur, body)` | `mount_chat_delayed(dur, body)` |

Existing `mount_chat_*` helpers kept as 3-line wrappers — no breakage for the openai_compat tests from PR #911.

### `anthropic_http_test.rs` (6 tests)

- `chat_sends_post_to_v1_messages_endpoint`
- `chat_sends_x_api_key_header_not_bearer` ← **THE classic provider-confusion bug** pinned explicitly. Asserts both `x-api-key` present AND `Authorization` absent.
- `chat_sends_anthropic_version_header` — validates date format, doesn't pin the exact constant
- `chat_returns_error_on_5xx_with_status_in_message`
- `chat_returns_error_on_401_invalid_api_key` — regression guard
- `chat_stream_consumes_anthropic_sse_event_format_via_real_tcp` — full `message_start` → 3× `content_block_delta` → `message_stop` over real TCP

### `gemini_http_test.rs` (6 tests)

- `chat_sends_post_to_generate_content_endpoint` — also pins the `/v1beta/models/{model}:…` shape
- `chat_sends_api_key_as_query_param_not_header` ← **Gemini's defining HTTP quirk** (`?key=…`). Asserts query has `key=` AND no auth header (`Authorization`, `x-api-key`, `x-goog-api-key`) leaks
- `chat_returns_error_on_5xx_with_status_in_message`
- `chat_returns_error_on_400_invalid_request` — regression guard
- `chat_stream_consumes_gemini_sse_format_via_real_tcp` — Gemini's `candidates[].content.parts[].text` shape, no `[DONE]` sentinel
- `chat_stream_sends_alt_sse_query_param` — drop `alt=sse` and Gemini silently switches stream format

### Path-regex disambiguation note (documented in test header)

Gemini's two endpoints differ only by the `stream` prefix. The non-streaming matcher uses `r'.*:generateContent$'` — the leading `:` anchors it so it does **not** also match `:streamGenerateContent` (substring before `generateContent` is `:` for non-stream vs `m` for stream).

## Validation

- **18/18** HTTP-layer tests green (6 per provider, all <50ms each)
- `cargo test -p koda-core --lib providers` — **145/145** still green
- `cargo clippy` — clean on `koda-core --tests` and `koda-test-utils`
- `cargo fmt --check` — clean

## Reference

Cross-checked SSE shapes against first-party suites:
- `../codex` (OpenAI's official agent): same `wiremock` + `ResponseTemplate` + `text/event-stream` pattern — validates the design
- `../gemini-cli`: `candidates[].content.parts[].text` shape
- Anthropic shapes from in-source unit tests in `anthropic.rs`

## Next in series

- **PR 3**: retry / timeout / proxy / `KODA_ACCEPT_INVALID_CERTS` (uses `mount_delayed`, already in place)
- **PR 4**: `FakeSmtpServer` + email tests
- **Phase 3** (Windows/ARM) still proposed as won't-fix