### PR TITLE
feat(http): add connect+read timeouts to build_http_client

### DIFF
--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -188,8 +188,33 @@ fn is_localhost_url(url: &str) -> bool {
 /// - Supports proxy auth via URL (http://user:pass@proxy:port)
 /// - Supports separate PROXY_USER / PROXY_PASS env vars
 /// - Bypasses proxy for localhost (LM Studio)
+/// - Applies a connect timeout (default 30s, env: `KODA_CONNECT_TIMEOUT_SECS`)
+///   and a read timeout (default 180s, env: `KODA_READ_TIMEOUT_SECS`).
+///   We deliberately avoid the total-request `.timeout()` because it would
+///   kill long-running SSE streams during slow tool/agent turns.
 pub fn build_http_client(base_url: Option<&str>) -> reqwest::Client {
     let mut builder = reqwest::Client::builder();
+
+    // ── Timeouts ──────────────────────────────────────────────────────────
+    //
+    // connect_timeout: time to establish the TCP+TLS connection. A stuck
+    // SYN or hung TLS handshake aborts after this. Always safe to apply
+    // because it only governs connection setup, not response reading.
+    //
+    // read_timeout: maximum idle time between successive reads from the
+    // socket. An actively-streaming SSE response keeps resetting this on
+    // every chunk, so it doesn't penalize long agent turns; but a server
+    // that goes silent (or a half-open connection a NAT box has dropped)
+    // will fail fast instead of hanging the agent forever.
+    let connect_timeout = crate::runtime_env::get("KODA_CONNECT_TIMEOUT_SECS")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(30);
+    let read_timeout = crate::runtime_env::get("KODA_READ_TIMEOUT_SECS")
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(180);
+    builder = builder
+        .connect_timeout(std::time::Duration::from_secs(connect_timeout))
+        .read_timeout(std::time::Duration::from_secs(read_timeout));
 
     let proxy_url = crate::runtime_env::get("HTTPS_PROXY")
         .or_else(|| crate::runtime_env::get("HTTP_PROXY"))

--- a/koda-core/tests/http_client_config_test.rs
+++ b/koda-core/tests/http_client_config_test.rs
@@ -250,3 +250,49 @@ async fn invalid_proxy_url_degrades_gracefully_to_no_proxy() {
     drop(env);
     restore_process_env(proc_snap);
 }
+
+#[tokio::test]
+async fn read_timeout_aborts_silent_servers_quickly() {
+    // Regression: previously the reqwest client had no read_timeout, so a
+    // server that accepted the connection but then went silent (or a
+    // half-open socket a NAT box quietly dropped) would hang the agent
+    // forever. Now KODA_READ_TIMEOUT_SECS bounds idle time between reads.
+    let _g = ENV_MUTEX.lock().await;
+    let proc_snap = snapshot_and_clear_process_proxy_env();
+
+    let upstream = FakeLlmServer::spawn().await;
+    // Server takes 3s to start sending; client should give up at ~1s.
+    upstream
+        .mount_chat_delayed(std::time::Duration::from_secs(3), ok_chat_body())
+        .await;
+
+    let mut env = EnvGuard::new();
+    env.set("KODA_READ_TIMEOUT_SECS", "1");
+
+    let provider = OpenAiCompatProvider::new(&upstream.url(), Some("sk-test".into()));
+
+    let started = std::time::Instant::now();
+    let result = provider.chat(&[user_msg()], &[], &settings()).await;
+    let elapsed = started.elapsed();
+
+    assert!(result.is_err(), "stalled server must produce an error");
+    // Generous bound: must abort well before the 3s server delay finishes.
+    // A passing test typically takes ~1.0–1.2s. >2s means the timeout
+    // didn't fire and reqwest waited for the full server delay.
+    assert!(
+        elapsed < std::time::Duration::from_millis(2500),
+        "should error in ~1s, took {elapsed:?} — read_timeout likely not applied"
+    );
+
+    let msg = format!("{:?}", result.unwrap_err()).to_lowercase();
+    // reqwest surfaces this as a timeout-flavored error. Don't pin the
+    // exact wording (varies by reqwest version) — just look for the
+    // expected vocabulary.
+    assert!(
+        msg.contains("timeout") || msg.contains("timed out") || msg.contains("operation"),
+        "error should mention timeout, got: {msg}"
+    );
+
+    drop(env);
+    restore_process_env(proc_snap);
+}


### PR DESCRIPTION
Addresses the timeout half of #914. The retry half is being closed as won't-fix — see #914 comment for full analysis.

## What

Adds two timeouts to the shared reqwest client used by every LLM provider (`openai_compat`, `anthropic`, `gemini`):

| Knob | Default | Env var |
|---|---|---|
| `connect_timeout` | 30s | `KODA_CONNECT_TIMEOUT_SECS` |
| `read_timeout` | 180s | `KODA_READ_TIMEOUT_SECS` |

Both vars read via `koda_core::runtime_env` so they pick up overrides from any source.

## Why these two and not `.timeout()`

reqwest exposes three timeout knobs:

| Knob | Scope | Safe for SSE? |
|---|---|---|
| `.timeout()` | total request (incl. body read) | ❌ |
| `.connect_timeout()` | TCP+TLS handshake only | ✅ |
| `.read_timeout()` | idle time between successive reads | ✅ (resets on each chunk) |

A total `.timeout()` would kill long SSE streams during slow tool/agent turns — e.g. a 10-minute Claude session with extended thinking would abort partway through. So we pick the two that *don't* care about total wall time.

`read_timeout` is the important one: it kills connections that are established but silent (server hung after accept, NAT box quietly dropped the half-open socket). Active streams keep resetting it on every chunk so they're unaffected.

## What this does NOT do

This intentionally ships **only the timeout half** of #914. The retry/backoff half is being **closed as won't-fix** because:

- POST `/chat/completions` is **not safely retriable** (token billing could double on lost-response races)
- Streaming complicates retry semantics (replay from start? resume?)
- Tool-call turns make retry dangerous (re-running side-effecting tools)
- Anthropic returns `overloaded_error` as **HTTP 200** with the error in the body — generic HTTP-status retry wouldn't catch it
- For a single-user / small-team Rust agent the manual 're-type prompt' workflow is fine; complexity isn't justified yet

If a concrete user-pain trigger appears later (e.g. losing a long session to a transient 529), retry can be revisited then.

## Test added

`read_timeout_aborts_silent_servers_quickly`:
- Spins a `FakeLlmServer` that takes 3s to respond
- Sets `KODA_READ_TIMEOUT_SECS=1`
- Asserts `chat()` errors in <2.5s (well before the 3s server delay)
- Asserts the error message mentions timeout vocabulary
- **Pins the regression**: previously this test would have hung for the full server delay (or forever, with a permanently-silent server)

## Validation

- **5/5** http_client_config tests green (was 4, +1 new)
- **145/145** provider unit tests still green
- All **22** HTTP-layer tests in koda-core still green
- `cargo clippy` clean, `cargo fmt` clean

Closes #914 (timeout half; retry half won't-fix per analysis).