### PR TITLE
feat(skills): add create-agent + create-skill bundled skills (#850 Phase 1)

### DIFF
--- a/koda-core/skills/create-agent/SKILL.md
+++ b/koda-core/skills/create-agent/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: create-agent
+description: Scaffold a new sub-agent JSON file (.koda/agents/<name>.json) with the correct schema, tool scoping, and write-access settings.
+tags: [agent, subagent, scaffold, create, meta]
+when_to_use: Use when the user asks to create a new sub-agent, custom agent, specialist, or worker — anything that should be invokable via InvokeAgent.
+allowed_tools: [Read, Write, Glob, List, AskUser]
+---
+
+# Create Agent
+
+You are scaffolding a new koda sub-agent. The goal: produce a working
+`.koda/agents/<name>.json` (or `~/.config/koda/agents/<name>.json`) that
+the user can immediately invoke via `InvokeAgent`.
+
+## Principles
+
+- **Read before writing.** Open `koda-core/agents/explore.json` (or
+  `plan.json`, `verify.json`) to ground yourself in the canonical patterns
+  before generating the file.
+- **Read-only by default.** `write_access` defaults to `false`. If the
+  user describes any task that creates, edits, or deletes files, set
+  `write_access: true` explicitly. **This is the #1 footgun.** An agent
+  meant to "fix bugs" without `write_access: true` will silently lack
+  Write/Edit/Delete and fail opaquely.
+- **Principle of least privilege.** Use `disallowed_tools` to forbid
+  tools the agent shouldn't have, and prefer cheap models (`gemini-2.5-flash`)
+  for high-volume worker agents.
+- **One agent, one purpose.** A good `description` is a single sentence
+  that lets the main agent know when to invoke it.
+
+## Process
+
+### 1. Clarify intent (if ambiguous)
+
+Use `AskUser` only when the request is genuinely ambiguous. Skip it for
+obvious requests like "make me a test-running agent." Things worth asking
+about when unclear:
+
+- **Read-only or write-capable?** ("Will this agent modify files?")
+- **Project or personal scope?** Project = `.koda/agents/<name>.json`,
+  personal/cross-project = `~/.config/koda/agents/<name>.json`
+- **Cheap model or default?** Default uses the main agent's model;
+  `gemini-2.5-flash` saves cost for high-volume work.
+
+### 2. Choose the file path
+
+| Scope    | Path                                          | When                                                  |
+| -------- | --------------------------------------------- | ----------------------------------------------------- |
+| Project  | `.koda/agents/<name>.json`                    | Workflow specific to this repo, shared with the team. |
+| Personal | `~/.config/koda/agents/<name>.json`           | Cross-project specialist that follows the user.       |
+
+**Note:** Personal path is `~/.config/koda/`, **not** `~/.koda/`.
+
+### 3. Pick the right shape
+
+#### Read-only specialist (modeled after `explore`)
+
+```json
+{
+  "name": "reviewer",
+  "description": "Read-only code reviewer. Use when asked to critique code without making changes.",
+  "system_prompt": "You are a senior code reviewer. Find bugs, anti-patterns, and improvements. Do NOT modify files.",
+  "disallowed_tools": ["Write", "Edit", "Delete"],
+  "skip_memory": true
+}
+```
+
+Use this shape for: explorers, reviewers, planners, analyzers, anything
+that only reads. `skip_memory: true` saves tokens since read-only agents
+don't need memory context.
+
+#### Write-capable worker
+
+```json
+{
+  "name": "refactor",
+  "description": "Refactors code per user instructions while preserving behavior.",
+  "system_prompt": "You refactor code while preserving behavior. Run tests after each change.",
+  "write_access": true,
+  "model": "gemini-2.5-flash"
+}
+```
+
+Use this shape for: refactorers, fixers, generators, anything that
+modifies the workspace. `model` override lets you save cost for
+high-volume workers.
+
+### 4. Field reference
+
+**Required:**
+
+- `name` — agent identifier (used with `InvokeAgent`)
+- `system_prompt` — behavioral instructions for the LLM
+
+**Highly recommended:**
+
+- `description` — one-line purpose; shown in the main agent's sub-agent
+  listing. Without this, the main agent has no signal for when to invoke.
+
+**Tool scoping (pick at most one approach):**
+
+- `allowed_tools` — allowlist; empty (default) = all tools available
+- `disallowed_tools` — denylist; useful for locking down read-only agents
+
+**Write/memory:**
+
+- `write_access` — default `false`. Set `true` only when the agent must
+  modify files. Without it, Write/Edit/Delete are silently unavailable.
+- `skip_memory` — default `false`. Set `true` for read-only agents to
+  avoid injecting MEMORY.md into the system prompt (saves tokens).
+
+**Model overrides (optional — omit to inherit main agent settings):**
+
+- `model` — e.g. `"gemini-2.5-flash"` for cheap workers
+- `provider`, `base_url` — for non-default providers
+- `max_tokens`, `temperature`, `thinking_budget`, `reasoning_effort`
+- `max_context_tokens`, `max_iterations`
+
+### 5. Write and confirm
+
+1. Use `Write` to create the file at the chosen path.
+2. Tell the user:
+   - Where the file was saved
+   - How to invoke it: `InvokeAgent("<name>", "<task>")`
+   - That they can edit the JSON directly to refine it
+
+## Anti-patterns to avoid
+
+- **Don't omit `write_access: true` for write-capable agents.** Silent
+  tool unavailability is the worst kind of bug.
+- **Don't put both `allowed_tools` and `disallowed_tools`.** Pick one.
+  When `allowed_tools` is non-empty, `disallowed_tools` is redundant.
+- **Don't set the agent's `model` to something the user hasn't
+  configured.** If they're on Anthropic, `gemini-2.5-flash` won't work
+  unless they've set up Gemini credentials too.
+- **Don't write a 500-word `system_prompt`.** Bundled agents like
+  `explore.json` keep it focused — 1-3 paragraphs of role + constraints
+  + workflow.
+
+## Reference
+
+For a battle-tested example, read `koda-core/agents/explore.json`. It
+demonstrates: read-only locking via `disallowed_tools`, `skip_memory`
+for token savings, and a tight `description` that the main agent can
+reason about.

--- a/koda-core/skills/create-skill/SKILL.md
+++ b/koda-core/skills/create-skill/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: create-skill
+description: Scaffold a new bundled skill (.koda/skills/<name>/SKILL.md) with correct frontmatter, tool scoping, and a clear when_to_use trigger.
+tags: [skill, scaffold, create, meta]
+when_to_use: Use when the user asks to create a new skill, capture a workflow as a skill, or extend koda with reusable expert instructions.
+allowed_tools: [Read, Write, Glob, List, AskUser]
+---
+
+# Create Skill
+
+You are scaffolding a new koda skill. The goal: produce a working
+`.koda/skills/<name>/SKILL.md` (or `~/.config/koda/skills/<name>/SKILL.md`)
+that the user can immediately invoke via `ActivateSkill` or `/<name>`.
+
+## Principles
+
+- **Read before writing.** Open `koda-core/skills/code-review/SKILL.md`
+  or `koda-core/skills/debug/SKILL.md` first to ground yourself in the
+  canonical structure before generating the file.
+- **Concise is key.** The skill body is loaded into context every time
+  the skill is activated. Don't pad. Skip explanations koda already knows
+  (it's a code agent, you don't need to explain what `Grep` is).
+- **`when_to_use` is the most important field.** It's what the model uses
+  to decide whether to auto-activate the skill. Include trigger phrases.
+- **Scope tools.** A code-review skill should not have `Write` access. A
+  scaffolding skill should not have `Delete`. Use `allowed_tools` to
+  enforce least privilege.
+
+## Process
+
+### 1. Clarify intent (if ambiguous)
+
+Use `AskUser` only when genuinely ambiguous. Skip it for obvious requests
+like "create a skill that runs the tests." Things worth asking when unclear:
+
+- **Project or personal scope?** Project = `.koda/skills/<name>/`,
+  personal/cross-project = `~/.config/koda/skills/<name>/`
+- **What triggers it?** Slash command (`/<name>`)? Auto-activated when
+  the model sees a matching task? Both?
+- **What tools does it need?** Read-only analysis (`Read`, `Grep`,
+  `Glob`), or also write (`Write`, `Edit`)?
+
+### 2. Choose the file path
+
+| Scope    | Path                                                    | When                                           |
+| -------- | ------------------------------------------------------- | ---------------------------------------------- |
+| Project  | `.koda/skills/<name>/SKILL.md`                          | Workflow specific to this repo.                |
+| Personal | `~/.config/koda/skills/<name>/SKILL.md`                 | Cross-project workflow that follows the user.  |
+
+**Note:** Personal path is `~/.config/koda/`, **not** `~/.koda/`.
+
+The `<name>` is both the directory name and the slash-command name (e.g.
+`code-review` becomes `/code-review`). Use kebab-case.
+
+### 3. Write the SKILL.md
+
+```markdown
+---
+name: my-skill
+description: One-line purpose (shown in skill listing — keep under 200 chars)
+when_to_use: Use when the user asks to <trigger>. Example phrases: "<phrase>", "<phrase>".
+tags: [topic-a, topic-b]
+allowed_tools: [Read, Grep, Glob, List, Bash]
+---
+
+# My Skill
+
+You are <role>. <One-sentence statement of the goal>.
+
+## Principles
+- <key behavioral constraint #1>
+- <key behavioral constraint #2>
+
+## Process
+1. <First concrete step>
+2. <Second concrete step>
+...
+
+## Anti-patterns
+- <thing not to do, with reason>
+```
+
+### 4. Field reference
+
+**Required frontmatter:**
+
+- `name` — skill identifier; matches the directory name and the
+  slash-command name (`/<name>`)
+- `description` — one-line purpose shown in the skill listing in the
+  system prompt. **Keep it ≤200 chars** — the listing is for discovery
+  only, the model loads full content on activation.
+
+**Highly recommended:**
+
+- `when_to_use` — guidance for the model on when to auto-activate. Start
+  with "Use when…" and include 1-2 example trigger phrases. **This drives
+  auto-activation accuracy.**
+- `tags` — searchable tags; helps users find the skill via `/skills`
+- `allowed_tools` — security/scoping. Empty = all tools (rare). Most
+  skills should explicitly list only what they need.
+
+**Optional:**
+
+- `argument_hint` — usage hint for skills that take parameters,
+  e.g. `"<file_path>"` or `"[issue description]"`
+- `user_invocable` — defaults to `true`. Set `false` for model-only
+  skills (hidden from `/skills` but still activatable by the model).
+
+### 5. Anatomy of the body
+
+Mirror the structure of bundled skills:
+
+- **Title** — `# Skill Name` (markdown H1)
+- **Role + goal** — one or two sentences
+- **Principles** — 3-5 bullets of key behavioral constraints
+- **Process** — numbered steps; each step concrete and actionable
+- **Anti-patterns / gotchas** — what NOT to do, with brief reasoning
+
+Optionally add:
+
+- **Reference example** — point at a real file the model can `Read`
+- **Output format** — if the skill produces structured output
+
+### 6. Write and confirm
+
+1. Use `Write` to create the file at `<chosen-path>/<name>/SKILL.md`.
+   Note: koda needs the **directory** to exist; the `Write` tool will
+   create parent directories if needed.
+2. Tell the user:
+   - Where the file was saved
+   - How to invoke it: `/<name>` or via `ActivateSkill("<name>")`
+   - That they can edit the SKILL.md directly to refine it
+
+## Anti-patterns to avoid
+
+- **Don't omit `when_to_use`.** Without it, the model has no signal for
+  when to auto-activate. The skill becomes user-invoke-only by accident.
+- **Don't grant `Write`/`Edit`/`Delete` unless the skill actually modifies
+  files.** A code-review skill with `Write` access is a footgun.
+- **Don't write a 500-line SKILL.md for a 5-step workflow.** Concision is
+  a public good — every skill activation pays the token cost.
+- **Don't duplicate context the model already has.** Don't explain what
+  `Grep` does. Don't list every git command. Skills add value by
+  encoding *workflow* and *constraints*, not basic knowledge.
+- **Don't conflate creating a skill with capturing a session.** This
+  skill scaffolds a new SKILL.md from a description. If the user wants
+  to capture an in-progress workflow, that's a different (future)
+  skillify-style operation.
+
+## Reference
+
+For a battle-tested example, read `koda-core/skills/code-review/SKILL.md`
+or `koda-core/skills/debug/SKILL.md`. They demonstrate: tight `when_to_use`
+phrasing, scoped `allowed_tools`, and concise process sections.

--- a/koda-core/src/skills.rs
+++ b/koda-core/src/skills.rs
@@ -141,6 +141,14 @@ impl SkillRegistry {
             ("simplify", include_str!("../skills/simplify/SKILL.md")),
             ("debug", include_str!("../skills/debug/SKILL.md")),
             ("remember", include_str!("../skills/remember/SKILL.md")),
+            (
+                "create-agent",
+                include_str!("../skills/create-agent/SKILL.md"),
+            ),
+            (
+                "create-skill",
+                include_str!("../skills/create-skill/SKILL.md"),
+            ),
         ];
 
         for (name, content) in builtins {
@@ -515,6 +523,94 @@ Do the review.
         assert!(registry.activate("simplify").is_some());
         assert!(registry.activate("debug").is_some());
         assert!(registry.activate("remember").is_some());
+        assert!(registry.activate("create-agent").is_some());
+        assert!(registry.activate("create-skill").is_some());
+    }
+
+    /// Pin the create-agent + create-skill bundled skills so they don't get
+    /// silently broken. Each assertion maps to a specific user-facing failure:
+    /// missing front-matter field => skill won't load; missing key guidance
+    /// in the body => generated agents/skills will have known footguns.
+    #[test]
+    fn test_creation_skills_are_complete() {
+        let mut registry = SkillRegistry::default();
+        registry.load_builtin();
+
+        // ── create-agent ────────────────────────────────────────
+        let agent = registry
+            .get("create-agent")
+            .expect("create-agent skill must load");
+        assert!(
+            agent.meta.when_to_use.is_some(),
+            "create-agent needs when_to_use for auto-activation"
+        );
+        assert!(
+            !agent.meta.allowed_tools.is_empty(),
+            "create-agent should scope its tools (least privilege)"
+        );
+        // The body must include the write_access footgun warning — this is
+        // the #1 thing that breaks generated agents if missing.
+        let agent_body = registry.activate("create-agent").unwrap();
+        assert!(
+            agent_body.contains("write_access"),
+            "create-agent must teach the write_access field"
+        );
+        assert!(
+            agent_body.contains("footgun") || agent_body.contains("silently"),
+            "create-agent must warn about the write_access default-false footgun"
+        );
+        // Both scope paths documented + correct personal path.
+        assert!(
+            agent_body.contains(".koda/agents/"),
+            "create-agent must document project-scope path"
+        );
+        assert!(
+            agent_body.contains("~/.config/koda/agents/"),
+            "create-agent must document personal-scope path (~/.config/koda/, NOT ~/.koda/)"
+        );
+        // Reference to a canonical example so the model can crib.
+        assert!(
+            agent_body.contains("koda-core/agents/explore.json"),
+            "create-agent must point at a reference example"
+        );
+
+        // ── create-skill ────────────────────────────────────────
+        let skill = registry
+            .get("create-skill")
+            .expect("create-skill skill must load");
+        assert!(
+            skill.meta.when_to_use.is_some(),
+            "create-skill needs when_to_use for auto-activation"
+        );
+        assert!(
+            !skill.meta.allowed_tools.is_empty(),
+            "create-skill should scope its tools (least privilege)"
+        );
+        let skill_body = registry.activate("create-skill").unwrap();
+        // Frontmatter fields the model must teach.
+        assert!(
+            skill_body.contains("when_to_use"),
+            "create-skill must teach the when_to_use field"
+        );
+        assert!(
+            skill_body.contains("allowed_tools"),
+            "create-skill must teach allowed_tools scoping"
+        );
+        // Both scope paths documented + correct personal path.
+        assert!(
+            skill_body.contains(".koda/skills/"),
+            "create-skill must document project-scope path"
+        );
+        assert!(
+            skill_body.contains("~/.config/koda/skills/"),
+            "create-skill must document personal-scope path"
+        );
+        // Reference to a canonical example so the model can crib.
+        assert!(
+            skill_body.contains("koda-core/skills/code-review/SKILL.md")
+                || skill_body.contains("koda-core/skills/debug/SKILL.md"),
+            "create-skill must point at a reference example"
+        );
     }
 
     #[test]
@@ -579,13 +675,16 @@ Do the review.
 
         let list = registry.list();
         let names: Vec<&str> = list.iter().map(|s| s.name.as_str()).collect();
-        // Sorted alphabetically: code-review, debug, remember, security-audit, simplify
-        assert!(list.len() >= 5);
+        // Sorted alphabetically: code-review, create-agent, create-skill,
+        // debug, remember, security-audit, simplify
+        assert!(list.len() >= 7);
         assert_eq!(names[0], "code-review");
-        assert_eq!(names[1], "debug");
-        assert_eq!(names[2], "remember");
-        assert_eq!(names[3], "security-audit");
-        assert_eq!(names[4], "simplify");
+        assert_eq!(names[1], "create-agent");
+        assert_eq!(names[2], "create-skill");
+        assert_eq!(names[3], "debug");
+        assert_eq!(names[4], "remember");
+        assert_eq!(names[5], "security-audit");
+        assert_eq!(names[6], "simplify");
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 of #850. Teaches the model how to scaffold `.koda/agents/*.json` and `.koda/skills/<name>/SKILL.md` files — but as **on-demand bundled skills**, not in the always-on system prompt.

> **Design history:** the first version of this PR put the guidance directly in the system prompt (~167 lines added). After cross-checking against three reference tools, I rewrote it to use bundled skills. See 'Why this design' below for the data.

## Why this design (validated against 3 reference tools)

| Tool | Creation guidance in system prompt? | Bundled creation tool |
|---|---|---|
| **Claude Code** | ❌ | `skillify` skill (~150 lines), `userInvocable: true, disableModelInvocation: true` |
| **Gemini CLI** | ❌ (system prompt is 42 lines, zero mention) | `skill-creator` skill (382 lines bundled SKILL.md) |
| **Codex** | N/A — no file-based custom agents | N/A |

**All three tools that DO support custom agents/skills put creation guidance in on-demand bundled skills.** Quoting the source:

- Claude Code's `SkillTool/prompt.ts`: *'verbose whenToUse strings waste turn-1 cache_creation tokens without improving match rate.'*
- Gemini CLI's `skill-creator`: *'The context window is a public good... Default assumption: Gemini CLI is already very smart. Only add context Gemini CLI doesn't already have.'*

## Token-cost comparison

| Approach | Baseline cost (every request) | Cost when used |
|---|---|---|
| System prompt (original PR) | ~500 tokens | 0 round-trips |
| Bundled skills (this PR) | ~30 tokens (2 listing entries) | ~1 `ActivateSkill` call → ~1500 tokens loaded |

For a feature used <1×/week, the bundled-skills math wins by orders of magnitude. Also matches koda's own existing pattern (5 bundled skills already work this way).

## What this PR ships

Two new bundled skills under `koda-core/skills/`:

### `create-agent` (~135 lines)
- Both example shapes side-by-side: read-only specialist + write-capable worker
- **`write_access` default-false footgun warning** (the #1 source of broken generated agents)
- Field reference: required, recommended, scoping, model overrides
- Both scope paths with the **corrected** `~/.config/koda/` (NOT `~/.koda/` from the issue text)
- Anti-patterns section
- Pointer to `koda-core/agents/explore.json` as canonical reference

### `create-skill` (~140 lines)
- Full SKILL.md frontmatter format with `name:` + `allowed_tools:`
- `when_to_use` guidance (the most important field for auto-activation)
- Both scope paths with the corrected `~/.config/koda/`
- Anatomy section: title, role, principles, process, anti-patterns
- Anti-patterns section
- Pointer to `koda-core/skills/code-review/SKILL.md` as canonical reference

Both skills:
- `user_invocable: true` (appear as `/create-agent` and `/create-skill`)
- Scoped `allowed_tools: [Read, Write, Glob, List, AskUser]` — least privilege even for meta-skills
- Loaded via `include_str!` at compile time alongside existing 5 bundled skills

## Tests added

- **`test_creation_skills_are_complete`** (in `skills.rs`) — 14 assertions pinning every must-have piece of guidance:
  - Both skills have `when_to_use` + non-empty `allowed_tools`
  - `create-agent` body teaches `write_access` + the default-false footgun warning
  - Both scope paths documented in both skills (`~/.config/koda/`, **not** `~/.koda/`) — explicit guard against the issue-text typo recurring
  - Both skills point to canonical reference examples
- `test_builtin_skills_load` extended for the new skills
- `test_list_sorted` updated for new alphabetical ordering

## Validation

- **963/963** koda-core lib tests green
- Workspace-wide tests green
- `cargo clippy` clean, `cargo fmt` clean

## What this PR does NOT do

- **Phase 2** (skillify-style **session-capture** skill): different use case — `create-skill` scaffolds from a description; a future `/skillify` would capture an in-progress workflow. Defer until pain felt.
- **Phase 3** (TUI agent wizard): YAGNI per original issue.
- **Phase 4** (Write-tool permission check): not needed today.

Refs #850. Phase 1 only — issue stays open until we decide on Phase 2.
