### PR TITLE
chore(hooks): scale back pre-push to fmt + clippy only (~40x faster)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# .githooks/pre-push — mirrors the Lint CI job locally.
+# .githooks/pre-push — fast local sanity check before pushing.
 #
-# Runs before every `git push`. Skip with `git push --no-verify` if you
-# need to push a WIP branch and let CI catch issues instead.
+# Philosophy: catch trivial mistakes (typos, formatting) that would
+# fail CI in 60+ minutes and block a push for nothing. Everything
+# else — full test suite, feature-gated builds, integration tests —
+# runs in CI on both ubuntu-latest and macos-latest. Trust CI.
+#
+# Skip with `git push --no-verify` if you need to push WIP.
 #
 # One-time setup (per clone):
 #   git config core.hooksPath .githooks
+#
+# For comprehensive pre-PR validation (the old behavior), run:
+#   ./scripts/preflight.sh
 
 set -euo pipefail
 
@@ -22,7 +29,9 @@ info "Running pre-push checks (skip with --no-verify)..."
 echo
 
 # --- Format ------------------------------------------------------------------
-info "cargo fmt"
+# Instant, and a fmt failure in CI is the most annoying possible reason
+# to wait an hour for a re-run.
+info "cargo fmt --check"
 if cargo fmt --all --check; then
     ok "fmt clean"
 else
@@ -31,6 +40,9 @@ else
 fi
 
 # --- Clippy ------------------------------------------------------------------
+# --all-targets is essentially free on warm cache (~1.5s) thanks to
+# incremental compile, and it covers the user-facing `koda` CLI binary
+# that --lib --tests would skip. Don't be clever about scoping this down.
 info "cargo clippy"
 if cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings; then
     ok "clippy clean"
@@ -39,48 +51,5 @@ else
     exit 1
 fi
 
-# --- Check (no features) -----------------------------------------------------
-# Compiles every target without optional features to catch cfg-gated items
-# that are invisible when a feature flag is active. Mirrors CI exactly.
-# (This is what caught the missing required-features stanza in #737.)
-info "cargo check (no features)"
-if cargo check --workspace --all-targets; then
-    ok "check clean"
-else
-    fail "check: fix the errors above"
-    exit 1
-fi
-
-# --- Tests -------------------------------------------------------------------
-# Runs unit tests (--lib, fast) plus the integration test suites that are
-# policy-critical and complete in <5s. Slow suites (mcp_http_transport,
-# inference_edge, inference_recovery) are skipped here because they involve
-# real sleep/retry loops and would make the hook unusably slow; CI covers
-# them on every push.
-#
-# Root cause of #882: the hook ran lint only, missing an integration test
-# regression in e2e_safety_test. The unit-test pass (--lib) doesn't run
-# tests in tests/*.rs — you must name them explicitly.
-info "cargo test (unit + fast integration suites)"
-if cargo test --workspace --features koda-core/test-support --lib && \
-   cargo test -p koda-core --features koda-core/test-support \
-       --test bash_safety_test \
-       --test e2e_safety_test \
-       --test e2e_tools_test \
-       --test e2e_test \
-       --test e2e_agent_test \
-       --test e2e_skills_test \
-       --test file_tools_test \
-       --test golden_test \
-       --test guarantee_matrix_test \
-       --test new_tools_test \
-       --test tool_normalize_test \
-       --test tool_wiring_test; then
-    ok "all tests pass"
-else
-    fail "tests: fix failures above before pushing"
-    exit 1
-fi
-
 echo
-ok "All checks passed — pushing."
+ok "Pre-push checks passed. Full test suite runs in CI."

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# scripts/preflight.sh — comprehensive pre-PR validation.
+#
+# Mirrors what CI runs on both ubuntu-latest and macos-latest. Use this
+# before opening a PR if you want full confidence — the pre-push hook
+# only runs fmt + lib clippy for speed.
+#
+# Usage:
+#   ./scripts/preflight.sh
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ok()   { echo -e "${GREEN}✓${NC} $*"; }
+fail() { echo -e "${RED}✗${NC} $*"; }
+info() { echo -e "${YELLOW}→${NC} $*"; }
+
+START=$(date +%s)
+
+info "fmt"
+cargo fmt --all --check && ok "fmt"
+
+info "clippy (full)"
+cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings && ok "clippy"
+
+info "check (no features — catches feature-gating)"
+cargo check --workspace --all-targets && ok "check"
+
+info "unit tests"
+cargo test --workspace --features koda-core/test-support --lib && ok "unit"
+
+info "integration tests (policy-critical, fast)"
+cargo test -p koda-core --features koda-core/test-support \
+    --test bash_safety_test \
+    --test e2e_safety_test \
+    --test e2e_tools_test \
+    --test e2e_test \
+    --test e2e_agent_test \
+    --test e2e_skills_test \
+    --test file_tools_test \
+    --test golden_test \
+    --test guarantee_matrix_test \
+    --test new_tools_test \
+    --test tool_normalize_test \
+    --test tool_wiring_test && ok "integration"
+
+ELAPSED=$(($(date +%s) - START))
+echo
+ok "Preflight passed in ${ELAPSED}s — safe to open PR."


### PR DESCRIPTION
## Summary

Scale back the pre-push hook from full lint+check+test (90+ seconds) to fmt + clippy only (**2.2s warm**). The CI matrix now covers both ubuntu-latest and macos-latest on every push, so local duplication of the full test suite is just slow feedback for no gain.

## Measured timing

| Variant | Warm cache | Coverage |
|---|---|---|
| **Old hook** | 90+ seconds | fmt + clippy + check + lib tests + 12 integration suites |
| **New hook** | **2.2s** | fmt + clippy `--all-targets` |
| `cargo clippy --workspace --all-targets` alone | 1.36s | full clippy |
| `cargo clippy --workspace --lib --tests` alone | 1.45s | skips bins/benches |

**Key surprise:** scoping clippy to `--lib --tests` provided **zero speedup** (1.45s vs 1.36s) because cargo's incremental compile fingerprint dominates. Dropping `--all-targets` would have skipped the user-facing `koda` CLI binary for no real time saving. Kept `--all-targets`.

## What's dropped and why

| Stage | Why dropped |
|---|---|
| `cargo check --workspace --all-targets` (no features) | Catches feature-gating bugs (#737-style), but rare; CI catches on both OSes |
| `cargo test --workspace --lib` | 5-60s; CI catches on both OSes; rare for unit tests to break only locally |
| 12 integration suites | 30-60s; CI catches on both OSes; the #882 regression that motivated adding them is now caught by macOS CI runner |

## Safety net preserved

For comprehensive pre-PR validation (mirrors the old hook), run `./scripts/preflight.sh`. Opt-in instead of opt-out — the right tradeoff now that CI is comprehensive.

Skip the hook entirely with `git push --no-verify` for WIP branches (unchanged).

## History

- Hook was expanded in response to #882 (an integration regression slipped to main when the hook ran lint only)
- That expansion made sense when CI was Linux-only
- macOS CI runner (added recently) now catches the same class of regressions
- Time to scale back
