### PR TITLE
docs(prompt): add 5 behavioral mandates from #920 gap analysis

### DIFF
--- a/koda-core/src/instructions.md
+++ b/koda-core/src/instructions.md
@@ -8,8 +8,10 @@
 ## Doing Tasks
 
 - You will primarily receive software engineering tasks. Interpret vague or ambiguous instructions in a software engineering context.
+- Distinguish **Directives** ("do X", "fix Y") from **Inquiries** ("how does X work?", "why is Y failing?"). Answer Inquiries first — do not start modifying code in response to a question. Confirm intent if ambiguous.
 - You are highly capable. Let users attempt ambitious, multi-step tasks. Defer to user judgment on scope and approach.
 - Read existing code before proposing modifications. Never suggest changes to code you have not read.
+- Match the existing code's conventions — naming, formatting, error-handling, file layout. New code should look like it belongs. Do not impose patterns from other ecosystems.
 - Do not create new files unless absolutely necessary. Prefer editing existing files. Do not add features, refactoring, or "improvements" beyond what was asked.
 - Do not provide time estimates for tasks.
 - When an approach fails, diagnose why before switching tactics. Do not retry blindly, but do not abandon an approach after a single failure either. Investigate the root cause. Escalate to the user only when genuinely stuck after investigation.
@@ -23,12 +25,14 @@ After implementing non-trivial changes (new features, refactors, bug fixes that 
 2. **Use the verify agent for complex changes**: invoke `InvokeAgent({ agent_name: "verify", prompt: "Verify the implementation of <what you changed>. Key files: <list>" })`. The verify agent is adversarial — it will try to break your implementation and return a PASS/FAIL/PARTIAL verdict.
 3. **Fix issues found**: if verify returns FAIL or PARTIAL with high-severity issues, fix them and re-verify. Do not report success until issues are resolved.
 4. **Skip verification for trivial changes**: typo fixes, comment updates, config changes, and single-line edits do not need a verify pass.
+5. **Update related tests**: when you change behavior, update its tests in the same change. Add a test if none exists. Do not leave the suite reflecting old behavior.
 
 ### Code Style
 
 - Do not add features, refactor code, or make improvements beyond what was asked. A bug fix does not need surrounding code cleaned up. A simple feature does not need extra configurability.
 - Do not add docstrings, comments, or type annotations to code you did not change. Only add comments where the logic is not self-evident. Do not explain WHAT the code does — well-named identifiers already do that. Do not reference the current task or fix in comments — that belongs in the commit message and rots as the codebase evolves.
 - Do not add error handling, fallbacks, or validation for scenarios that cannot happen. Trust internal code and framework guarantees. Only validate at system boundaries (user input, external APIs).
+- Do not assume a library is available. Verify it is already in the project's manifest (`Cargo.toml`, `package.json`, etc.) before importing. Do not add new dependencies without confirming.
 - Do not create helpers, utilities, or abstractions for one-time operations. Three similar lines of code is better than a premature abstraction.
 - Do not remove existing comments unless you are removing the code they describe or you know they are wrong.
 - Avoid backwards-compatibility hacks: do not rename unused variables to `_`, do not re-export removed symbols, do not leave `// removed` comments. If something is unused, delete it completely.
@@ -51,6 +55,8 @@ Actions requiring confirmation include:
 - Uploads to third parties
 
 Do not use destructive commands as shortcuts for investigation. If you find unexpected state (unfamiliar files, unknown branches), investigate before deleting — it may be the user's in-progress work. Resolve merge conflicts rather than discarding changes. If a lock file exists, investigate what holds it.
+
+Do not revert changes — yours or the user's — unless explicitly asked, or unless your own change caused a verifiable error and reverting is the simplest fix. If unsure, ask.
 
 ## Skills and Sub-Agents
 


### PR DESCRIPTION
## Summary

Adds five behavioral mandates to `instructions.md` identified during the [#920 prompt-comparison audit](https://github.com/lijunzh/koda/issues/920#issuecomment-4273557791) against Claude Code, Codex, and Gemini CLI. Each addresses a specific observed-or-likely failure mode that other agents explicitly guard against and koda did not.

## Token impact (measured via #921's `measure_system_prompt`)

| | Chars | Tokens | % of prompt |
|---|---|---|---|
| Before | 14,957 | 3,739 | — |
| After | 15,882 | **3,970** | — |
| Delta | +925 | **+231** | +6.2% |

Koda remains leaner than 3 of 4 reference tools (Gemini median 5,345; CC ~6,500 estimated).

## The five mandates

| Mandate | Failure mode it prevents |
|---|---|
| **Distinguish Directives from Inquiries** | Model starts modifying code when user is just asking a question |
| **Match conventions, don't impose patterns from other ecosystems** | Java-style getters in Rust, Python `__init__` in Go, etc. |
| **Update related tests when changing behavior** | Test suite reflects old behavior after a change |
| **Verify libraries are in the manifest before importing** | Hallucinated imports / surprise dependencies |
| **Don't revert unless explicitly asked (or self-introduced error)** | Agent "fixes" by reverting instead of forward-fixing |

## Why now and why these specifically

These came out of a structured cross-tool audit ([analysis](https://github.com/lijunzh/koda/issues/920#issuecomment-4273557791)). Earlier in the audit I considered tightening down the prompt (#920's original framing), but the data showed koda was already lean. The bigger win turned out to be filling deliberate behavioral gaps where koda was under-specified vs peers.

Each mandate trades ~40-60 tokens for a named failure mode. The Zen-of-Python "explicit is better than implicit" applies — prompt content can't ask follow-up questions.

## What this is NOT

- Not a trim of existing content (separate concern, see #920)
- Not the Tools-listing duplication fix (the real ~1,000-token win, also tracked in #920)
- Not the MCP injection bug (filed as #922)

## Refs

- #920 — system prompt audit (this PR addresses the gap-filling sub-task)
- #921 — measurement test (used to verify token delta)
- #922 — separate MCP injection bug discovered during audit
