### PR TITLE
fix(prompt): inject MCP server instructions into system prompt

### DIFF
--- a/koda-core/src/agent.rs
+++ b/koda-core/src/agent.rs
@@ -89,6 +89,9 @@ impl KodaAgent {
             &env,
             commands,
             &tools.skill_registry,
+            // MCP manager isn't attached yet at construction time —
+            // rebuild_system_prompt() picks up server instructions later (#922).
+            &[],
         );
 
         Ok(Self {
@@ -110,6 +113,14 @@ impl KodaAgent {
             model: &config.model,
             platform: std::env::consts::OS,
         };
+        // Pull MCP server instructions if a manager is attached and isn't
+        // currently locked. We use try_read() (non-blocking) so a stuck MCP
+        // server can never wedge prompt rebuilds (#922).
+        let mcp_instructions = self
+            .tools
+            .mcp_manager()
+            .and_then(|mgr| mgr.try_read().ok().map(|g| g.server_instructions()))
+            .unwrap_or_default();
         self.system_prompt = crate::prompt::build_system_prompt(
             &config.system_prompt,
             &semantic_memory,
@@ -117,6 +128,7 @@ impl KodaAgent {
             &env,
             commands,
             &self.tools.skill_registry,
+            &mcp_instructions,
         );
     }
 

--- a/koda-core/src/mcp/client.rs
+++ b/koda-core/src/mcp/client.rs
@@ -58,6 +58,10 @@ pub struct McpClient {
     status: McpClientStatus,
     /// Error message from the last failed connection attempt.
     last_error: Option<String>,
+    /// Optional human-readable instructions returned by the server during
+    /// `initialize`. Injected into the system prompt so the model picks up
+    /// per-server guidance (#922). `None` when the server provides none.
+    instructions: Option<String>,
 }
 
 impl McpClient {
@@ -70,6 +74,7 @@ impl McpClient {
             tools: Vec::new(),
             status: McpClientStatus::Disconnected,
             last_error: None,
+            instructions: None,
         }
     }
 
@@ -91,6 +96,12 @@ impl McpClient {
     /// Discovered tools (empty until connected).
     pub fn tools(&self) -> &[DiscoveredTool] {
         &self.tools
+    }
+
+    /// Server-provided instructions from the `initialize` response, if any.
+    /// Returns `None` if disconnected or the server didn't provide instructions.
+    pub fn instructions(&self) -> Option<&str> {
+        self.instructions.as_deref()
     }
 
     /// Connect to the MCP server, initialize, and discover tools.
@@ -182,8 +193,7 @@ impl McpClient {
         let transport =
             TokioChildProcess::new(cmd).context("failed to spawn MCP server process")?;
         let service = ().serve(transport).await.context("MCP handshake failed")?;
-        self.service = Some(service);
-        self.discover_tools().await
+        self.finish_handshake(service).await
     }
 
     /// Connect via Streamable HTTP transport.
@@ -240,6 +250,22 @@ impl McpClient {
 
         let transport = StreamableHttpClientTransport::from_config(config);
         let service = ().serve(transport).await.context("MCP HTTP handshake failed")?;
+        self.finish_handshake(service).await
+    }
+
+    /// Common post-handshake bookkeeping shared by stdio + HTTP connect paths.
+    /// Captures the server's `instructions` (#922) and discovers tools.
+    async fn finish_handshake(
+        &mut self,
+        service: RunningService<rmcp::service::RoleClient, ()>,
+    ) -> Result<()> {
+        // Capture server-provided instructions before storing the service so
+        // we don't have to re-borrow it. Filter empties to keep prompt clean.
+        self.instructions = service
+            .peer()
+            .peer_info()
+            .and_then(|info| info.instructions.clone())
+            .filter(|s| !s.trim().is_empty());
         self.service = Some(service);
         self.discover_tools().await
     }
@@ -332,6 +358,12 @@ impl McpClient {
     #[cfg(feature = "test-support")]
     pub fn set_status_for_test(&mut self, status: McpClientStatus) {
         self.status = status;
+    }
+
+    /// Force server instructions (test-only). Pass `None` to clear.
+    #[cfg(feature = "test-support")]
+    pub fn set_instructions_for_test(&mut self, instructions: Option<String>) {
+        self.instructions = instructions;
     }
 
     /// Force last error (test-only).

--- a/koda-core/src/mcp/manager.rs
+++ b/koda-core/src/mcp/manager.rs
@@ -123,6 +123,26 @@ impl McpManager {
             .collect()
     }
 
+    /// Server-provided instructions for every connected MCP server that
+    /// returned a non-empty `instructions` field during `initialize` (#922).
+    ///
+    /// Returns `(server_name, instructions)` pairs sorted by server name for
+    /// stable prompt rendering. Empty when no MCP server provided guidance —
+    /// non-MCP users pay zero tokens for the missing block.
+    pub fn server_instructions(&self) -> Vec<(String, String)> {
+        let mut out: Vec<(String, String)> = self
+            .clients
+            .iter()
+            .filter(|(_, c)| c.status() == McpClientStatus::Connected)
+            .filter_map(|(name, c)| {
+                c.instructions()
+                    .map(|instr| (name.clone(), instr.to_string()))
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Classify an MCP tool's effect using cached annotations.
     pub fn classify_tool(&self, qualified_name: &str) -> ToolEffect {
         let annotations = self.annotations.get(qualified_name);
@@ -867,6 +887,63 @@ mod tests {
         assert!(
             mgr.has_tool("db_archive__keep"),
             "add_server collision must not purge sibling-prefix server's tools"
+        );
+    }
+
+    // ── server_instructions() (#922) ────────────────────────────────────
+
+    #[test]
+    fn server_instructions_empty_when_no_clients() {
+        let mgr = McpManager::new();
+        assert!(mgr.server_instructions().is_empty());
+    }
+
+    #[test]
+    fn server_instructions_skips_unconnected_servers() {
+        let mut mgr = McpManager::new();
+        let mut c = McpClient::new("halfdead".into(), dummy_config());
+        c.set_status_for_test(McpClientStatus::Failed);
+        c.set_instructions_for_test(Some("will be ignored".into()));
+        mgr.insert_client_for_test(c);
+        assert!(
+            mgr.server_instructions().is_empty(),
+            "only Connected servers should contribute instructions"
+        );
+    }
+
+    #[test]
+    fn server_instructions_skips_connected_without_instructions() {
+        let mut mgr = McpManager::new();
+        let mut c = McpClient::new("silent".into(), dummy_config());
+        c.set_status_for_test(McpClientStatus::Connected);
+        // No instructions set — server didn't return any.
+        mgr.insert_client_for_test(c);
+        assert!(mgr.server_instructions().is_empty());
+    }
+
+    #[test]
+    fn server_instructions_returns_connected_with_instructions_sorted() {
+        let mut mgr = McpManager::new();
+        // Insert in reverse alpha order to verify sorting.
+        for (name, instr) in [
+            ("zebra", "Z guidance"),
+            ("alpha", "A guidance"),
+            ("middle", "M guidance"),
+        ] {
+            let mut c = McpClient::new(name.into(), dummy_config());
+            c.set_status_for_test(McpClientStatus::Connected);
+            c.set_instructions_for_test(Some(instr.into()));
+            mgr.insert_client_for_test(c);
+        }
+        let result = mgr.server_instructions();
+        assert_eq!(
+            result,
+            vec![
+                ("alpha".to_string(), "A guidance".to_string()),
+                ("middle".to_string(), "M guidance".to_string()),
+                ("zebra".to_string(), "Z guidance".to_string()),
+            ],
+            "results must be sorted by server name for stable prompt rendering"
         );
     }
 }

--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -39,6 +39,11 @@ pub struct EnvironmentInfo<'a> {
 /// `skill_registry` is used to build the live `## Skills` section so the model
 /// sees every available skill — with its `when_to_use` hint — without needing
 /// to call `ListSkills` first.
+///
+/// `mcp_instructions` carries `(server_name, instructions)` pairs harvested
+/// from each connected MCP server's `initialize` response (#922). The block
+/// is omitted entirely when the slice is empty so non-MCP users pay zero
+/// tokens.
 pub fn build_system_prompt(
     base_prompt: &str,
     semantic_memory: &str,
@@ -46,6 +51,7 @@ pub fn build_system_prompt(
     env: &EnvironmentInfo<'_>,
     commands: &[(&str, &str)],
     skill_registry: &SkillRegistry,
+    mcp_instructions: &[(String, String)],
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -179,6 +185,18 @@ pub fn build_system_prompt(
         );
     }
 
+    // MCP server instructions (#922). Each connected server can return a
+    // free-form `instructions` string in its `initialize` response telling
+    // the model how to use it best ("prefer tool X over Y", "this codebase
+    // uses Postgres flavor Z", etc). Render only when at least one server
+    // provided non-empty guidance — zero-cost for non-MCP users.
+    if !mcp_instructions.is_empty() {
+        prompt.push_str("\n\n# MCP Server Instructions\n");
+        for (server, instructions) in mcp_instructions {
+            prompt.push_str(&format!("\n## {server}\n{instructions}\n"));
+        }
+    }
+
     // Memory paths
     prompt.push_str(
         "\n## Memory\n\n\
@@ -249,7 +267,15 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("You are helpful.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt(
+            "You are helpful.",
+            "",
+            dir.path(),
+            &env,
+            &[],
+            &registry,
+            &[],
+        );
         assert!(result.starts_with("You are helpful."));
         assert!(result.contains("Doing Tasks"));
         assert!(result.contains("Koda Quick Reference"));
@@ -268,6 +294,7 @@ mod tests {
             &env,
             &[],
             &registry,
+            &[],
         );
         assert!(result.contains("Project Memory"));
         assert!(result.contains("Rust project"));
@@ -284,7 +311,7 @@ mod tests {
         .unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("scout"));
         assert!(result.contains("Scouting agent."));
         assert!(result.contains("Sub-Agents"));
@@ -305,7 +332,7 @@ mod tests {
         .unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         // koda (the main agent) must not appear in the sub-agents listing.
         // Check the full result: the agent formatter produces "- **name**" (with desc)
         // or "- name" (without). Neither should match "koda".
@@ -325,7 +352,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("## Environment"));
         assert!(result.contains("/test/project"));
         assert!(result.contains("test-model"));
@@ -337,7 +364,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         // Spot-check key sections from instructions.md
         assert!(result.contains("## Doing Tasks"));
         assert!(result.contains("## Executing Actions"));
@@ -351,7 +378,7 @@ mod tests {
         let env = test_env();
         let registry = SkillRegistry::default();
         let commands = &[("/help", "Show help"), ("/exit", "Quit")];
-        let result = build_system_prompt("Base.", "", dir.path(), &env, commands, &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, commands, &registry, &[]);
         assert!(result.contains("`/help`"));
         assert!(result.contains("Show help"));
         assert!(result.contains("`/exit`"));
@@ -363,7 +390,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(!result.contains("Commands (user types these in the REPL)"));
     }
 
@@ -372,7 +399,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("## Skills"));
         assert!(result.contains("No skills are currently available"));
     }
@@ -388,7 +415,7 @@ mod tests {
             Some("Use when asked to review code or a PR."),
             "# Review\nDo it.",
         );
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("code-review"));
         assert!(result.contains("Senior code review"));
         assert!(result.contains("Use when asked to review code or a PR."));
@@ -402,7 +429,7 @@ mod tests {
         let env = test_env();
         let mut registry = SkillRegistry::default();
         registry.add_builtin("plain", "Plain skill", None, "content");
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("**plain**"));
         assert!(result.contains("Plain skill"));
     }
@@ -431,7 +458,7 @@ mod tests {
                 content: "scoped content".to_string(),
             },
         );
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         assert!(result.contains("**scoped**"), "skill name");
         assert!(result.contains("Scoped skill"), "description");
         assert!(result.contains("Use for scoped work"), "when_to_use");
@@ -455,10 +482,72 @@ mod tests {
         .unwrap();
         let env = test_env();
         let registry = SkillRegistry::default();
-        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry);
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
         let alpha_pos = result.find("alpha").unwrap();
         let zebra_pos = result.find("zebra").unwrap();
         assert!(alpha_pos < zebra_pos, "agents should be sorted A→Z");
+    }
+
+    // ── MCP server instructions block (#922) ─────────────────────────────
+
+    #[test]
+    fn test_no_mcp_instructions_omits_block() {
+        let dir = TempDir::new().unwrap();
+        let env = test_env();
+        let registry = SkillRegistry::default();
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &[]);
+        assert!(
+            !result.contains("# MCP Server Instructions"),
+            "empty MCP slice must produce no block (zero-cost for non-MCP users)"
+        );
+    }
+
+    #[test]
+    fn test_mcp_instructions_renders_when_present() {
+        let dir = TempDir::new().unwrap();
+        let env = test_env();
+        let registry = SkillRegistry::default();
+        let mcp = vec![
+            (
+                "playwright".to_string(),
+                "Prefer locator-based queries over CSS selectors.".to_string(),
+            ),
+            (
+                "postgres".to_string(),
+                "Always use parameterized queries.".to_string(),
+            ),
+        ];
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &mcp);
+        assert!(result.contains("# MCP Server Instructions"));
+        assert!(result.contains("## playwright"));
+        assert!(result.contains("locator-based queries"));
+        assert!(result.contains("## postgres"));
+        assert!(result.contains("parameterized queries"));
+        // Block must come BEFORE ## Memory in the assembled prompt.
+        let mcp_pos = result.find("# MCP Server Instructions").unwrap();
+        let memory_pos = result.find("## Memory").unwrap();
+        assert!(mcp_pos < memory_pos, "MCP block belongs before Memory");
+    }
+
+    #[test]
+    fn test_mcp_instructions_renders_each_server_distinctly() {
+        // Regression guard: the renderer must produce one ## <name> subheader
+        // per server so model can attribute guidance correctly.
+        let dir = TempDir::new().unwrap();
+        let env = test_env();
+        let registry = SkillRegistry::default();
+        let mcp = vec![
+            ("alpha".to_string(), "first".to_string()),
+            ("beta".to_string(), "second".to_string()),
+        ];
+        let result = build_system_prompt("Base.", "", dir.path(), &env, &[], &registry, &mcp);
+        assert_eq!(
+            result.matches("# MCP Server Instructions").count(),
+            1,
+            "top-level header should appear exactly once"
+        );
+        assert!(result.contains("## alpha\nfirst"));
+        assert!(result.contains("## beta\nsecond"));
     }
 
     /// Measurement-only test for #920. Renders a realistic system prompt with
@@ -509,6 +598,7 @@ mod tests {
             &env,
             commands,
             &registry,
+            &[],
         );
 
         // ── Section breakdown by header position ─────────────────────────

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -319,6 +319,9 @@ pub(crate) async fn execute_sub_agent(
         &env,
         &[], // sub-agents have no REPL commands
         &tools.skill_registry,
+        // Sub-agents share parent prompt cache but get a fresh ToolRegistry
+        // without an MCP manager attached — they're isolated by design.
+        &[],
     );
 
     for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {


### PR DESCRIPTION
## Summary

Closes #922. Each MCP server can return a free-form `instructions` string in its `initialize` response (per the [MCP spec](https://spec.modelcontextprotocol.io/specification/server/lifecycle/#initialization)) telling the model how to use it best — e.g. *"Prefer locator-based queries over CSS selectors"* for Playwright, or *"Always use parameterized queries"* for a Postgres MCP. **Koda was silently dropping this guidance**, leading to suboptimal MCP tool usage.

This PR threads the field end-to-end so connected MCP servers actually influence model behavior.

## Architecture

```
MCP server  ──initialize.instructions──▶  rmcp peer_info
                                              │
                                              ▼
                                    McpClient::instructions  (#922 new field)
                                              │
                                              ▼
                              McpManager::server_instructions()  (#922 new method)
                                              │
                                              ▼
                              Agent::rebuild_system_prompt()
                                  │   (try_read, non-blocking)
                                  ▼
                            build_system_prompt(..., mcp_instructions)
                                              │
                                              ▼
                                ┌─ if non-empty ────────────────┐
                                │  # MCP Server Instructions   │
                                │                              │
                                │  ## <server>                 │
                                │  <instructions>              │
                                │  ...                         │
                                └──────────────────────────────┘
```

## Token impact

| Scenario | Cost |
|---|---|
| **No MCP servers** | **0 tokens** (block omitted entirely) |
| MCP server returns no instructions | 0 tokens (filtered at client level) |
| MCP server returns whitespace-only | 0 tokens (`.trim().is_empty()` filter) |
| MCP server returns real guidance | linear in guidance length |

Verified: `measure_system_prompt` test still reports **TOTAL: 3,657 tokens** unchanged for the default (no-MCP) configuration.

## Acceptance criteria checklist (from #922)

- [x] `prompt.rs` accepts an optional MCP-instructions block ✅ (`&[(String, String)]` slice param)
- [x] Block renders only when at least one connected MCP server provided non-empty instructions ✅
- [x] Test: (a) no MCP → no block ✅ `test_no_mcp_instructions_omits_block`
- [x] Test: (b) MCP without instructions → no block ✅ covered by 2 manager tests (failed server + connected-without-instructions)
- [x] Test: (c) MCP with instructions → block present with `# MCP Server Instructions` header ✅ `test_mcp_instructions_renders_when_present`
- [x] `measure_system_prompt` continues to pass ✅

## Files changed

| File | What |
|---|---|
| `mcp/client.rs` | Capture `instructions` field from `peer_info()` after handshake; expose accessor; new `finish_handshake()` helper shared by stdio + HTTP paths (DRY) |
| `mcp/manager.rs` | New `server_instructions()` aggregator returning sorted `(name, instructions)` pairs |
| `prompt.rs` | New `mcp_instructions` slice param; conditional render before `## Memory` section |
| `agent.rs` | `rebuild_system_prompt()` pulls instructions via existing `try_read()` non-blocking pattern (a wedged MCP server can't block prompt rebuild) |
| `sub_agent_dispatch.rs` | Pass `&[]` — sub-agents have isolated ToolRegistry without MCP, by design |

## Why I structured it this way

- **Capture once, render many** — `instructions` is stored on the client at handshake time. We don't re-query the MCP server every prompt rebuild. This matches how `tools` are cached.
- **Empty-filter at the source** — `.filter(|s| !s.trim().is_empty())` in `client.rs` means downstream code never has to worry about whitespace-only entries.
- **Sorted output** — `server_instructions()` sorts by server name so prompt rendering is deterministic across runs (helps prompt caching too).
- **Non-blocking read** — Reuses the `try_read().ok()` pattern already established by `mcp_status_bar_info()`. No new failure mode introduced.
- **Sub-agents excluded** — They're explicitly designed to be isolated from parent MCP state; passing `&[]` is the correct architectural choice, not a TODO.

## Test results

```
test result: ok. 969 passed; 0 failed; 1 ignored; 0 measured
```

All new tests:
- `prompt::tests::test_no_mcp_instructions_omits_block` ✅
- `prompt::tests::test_mcp_instructions_renders_when_present` ✅
- `prompt::tests::test_mcp_instructions_renders_each_server_distinctly` ✅
- `mcp::manager::tests::server_instructions_empty_when_no_clients` ✅
- `mcp::manager::tests::server_instructions_skips_unconnected_servers` ✅
- `mcp::manager::tests::server_instructions_skips_connected_without_instructions` ✅
- `mcp::manager::tests::server_instructions_returns_connected_with_instructions_sorted` ✅

`cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Risk

**Low.** Default (no-MCP) behavior is byte-identical — zero new content in the rendered prompt for users without MCP servers. For MCP users, the worst case is "model now sees the guidance the server wanted it to see," which is the entire point of the field existing.

The `try_read()` pattern means even a wedged MCP manager can't deadlock prompt rebuilding.

## Refs

- Closes #922
- Discovered during #920 prompt audit
- CC reference: `src/constants/prompts.ts:getMcpInstructions`
- Companion PRs in audit series: #921 (measurement), #923 (hooks), #924 (mandates), #926 (tools-listing removal)
