### PR TITLE
ci(coverage): distinguish infra flakes from real coverage regressions (#930)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,10 +29,17 @@ jobs:
         with:
           shared-key: coverage-${{ runner.os }}
       - uses: taiki-e/install-action@v2
+        id: install
+        # The action's CDN download already retries 11 times. We tolerate the
+        # remaining 0.x% of cases (GitHub releases CDN returning sustained
+        # 504s for >1 min) by surviving the failure and converting it into
+        # a clearly-labelled "infra flake" downstream so we don't open a
+        # bogus coverage-regression issue against a clean main. See #930.
+        continue-on-error: true
         with:
           tool: cargo-llvm-cov
       - name: Set up Linux sandbox (bubblewrap)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && steps.install.outcome == 'success'
         run: |
           sudo apt-get install -y bubblewrap
           sudo sysctl -w kernel.unprivileged_userns_clone=1
@@ -42,6 +49,7 @@ jobs:
 
       - name: koda-core coverage (≥ 80% lines)
         id: core
+        if: steps.install.outcome == 'success'
         continue-on-error: true
         run: |
           # --test-threads=1: compact::test_circuit_breaker mutates global
@@ -56,6 +64,7 @@ jobs:
 
       - name: koda-ast coverage (≥ 80% lines)
         id: ast
+        if: steps.install.outcome == 'success'
         continue-on-error: true
         run: |
           cargo llvm-cov \
@@ -65,6 +74,7 @@ jobs:
 
       - name: koda-email coverage (≥ 70% lines)
         id: email
+        if: steps.install.outcome == 'success'
         continue-on-error: true
         run: |
           cargo llvm-cov \
@@ -72,21 +82,59 @@ jobs:
             --fail-under-lines 70 \
             --lcov --output-path lcov-email.info
 
+      # Drop a marker so the report job can distinguish "tooling broken,
+      # never measured coverage" from "actually measured, dropped below
+      # threshold". Without this, a CDN flake on either platform would
+      # auto-open / auto-close coverage-regression issues falsely.
+      - name: Mark infra flake (if install failed)
+        if: steps.install.outcome != 'success'
+        run: |
+          mkdir -p flake-markers
+          echo "taiki-e/install-action failed on ${{ runner.os }} " \
+               "— likely GitHub releases CDN flake. See run logs." \
+               > "flake-markers/${{ runner.os }}.flake"
+
+      - name: Upload infra-flake marker
+        if: steps.install.outcome != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: infra-flake-${{ runner.os }}
+          path: flake-markers/
+          retention-days: 7
+
       - name: Upload lcov reports
         uses: actions/upload-artifact@v4
-        if: always()
+        if: steps.install.outcome == 'success'
         with:
           name: lcov-reports-${{ runner.os }}
           path: lcov-*.info
           retention-days: 7
 
-      - name: Set outcome outputs
+      # Final guard: fail this matrix leg only on REAL coverage regressions.
+      # Infra flakes (install failed) emit a warning and exit 0 so they
+      # don't poison the regression-reporting job.
+      - name: Verify coverage outcomes
         if: always()
-        id: outcomes
         run: |
-          echo "core=${{ steps.core.outcome }}" >> $GITHUB_OUTPUT
-          echo "ast=${{ steps.ast.outcome }}" >> $GITHUB_OUTPUT
-          echo "email=${{ steps.email.outcome }}" >> $GITHUB_OUTPUT
+          if [ "${{ steps.install.outcome }}" != "success" ]; then
+            echo "::warning::Skipping coverage verification on ${{ runner.os }}: " \
+                 "cargo-llvm-cov install failed (likely transient CDN issue). " \
+                 "Will retry on next push to main."
+            exit 0
+          fi
+          fail=0
+          for crate_outcome in \
+              "core=${{ steps.core.outcome }}" \
+              "ast=${{ steps.ast.outcome }}" \
+              "email=${{ steps.email.outcome }}"; do
+            name="${crate_outcome%%=*}"
+            outcome="${crate_outcome#*=}"
+            if [ "$outcome" != "success" ]; then
+              echo "::error::koda-$name coverage check did not succeed: $outcome"
+              fail=1
+            fi
+          done
+          exit $fail
 
   # ── Merge lcov reports across platforms ────────────────────────────────
   merge:
@@ -148,7 +196,7 @@ jobs:
           path: reports/merged-*.info
           retention-days: 7
 
-  # ── Report regressions ────────────────────────────────────────────────
+  # ── Report regressions ──────────────────────────────────────────
   report:
     name: Report
     needs: coverage
@@ -157,12 +205,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Pull infra-flake markers (one per platform that failed to install
+      # cargo-llvm-cov). Their presence means coverage was never measured
+      # there — not a real regression. See #930 for the original false
+      # positive that motivated this guard.
+      - name: Download infra-flake markers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: infra-flake-*
+          merge-multiple: true
+          path: flake-markers
+        continue-on-error: true  # markers absent on healthy runs
+
+      - name: Detect infra flake
+        id: flake
+        run: |
+          if compgen -G "flake-markers/*.flake" > /dev/null; then
+            echo "detected=true" >> "$GITHUB_OUTPUT"
+            # Marker filenames are runner OS names (Linux / macOS) —
+            # plain alphanumerics, so `find -printf` is overkill.
+            platforms=$(find flake-markers -maxdepth 1 -name '*.flake' \
+                          -exec basename {} .flake \; | tr '\n' ' ')
+            echo "::warning::Coverage matrix contained an infra flake " \
+                 "(cargo-llvm-cov install failed on ${platforms}). " \
+                 "Skipping regression-issue bookkeeping; will retry on next push."
+            cat flake-markers/*.flake
+          else
+            echo "detected=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Check if ANY platform reported a failure for any crate.
       # The matrix outputs aren't directly accessible, so we check
       # the overall job result — if any matrix leg failed, the job
-      # result is 'failure'.
+      # result is 'failure'. Suppress when an infra flake was detected:
+      # we can't trust 'failure' to mean "real regression" in that case.
       - name: Report regression
-        if: needs.coverage.result == 'failure'
+        if: needs.coverage.result == 'failure' && steps.flake.outputs.detected != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -197,8 +275,11 @@ jobs:
           fi
 
       # Auto-close the regression issue when coverage is green again.
+      # Only act on REAL green runs — if this run flaked at the install
+      # step we never measured coverage, so we mustn't close a legitimate
+      # open regression issue.
       - name: Close regression issue if green
-        if: needs.coverage.result == 'success'
+        if: needs.coverage.result == 'success' && steps.flake.outputs.detected != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -216,6 +297,8 @@ jobs:
           fi
 
       # Fail the workflow run so the badge goes red and GitHub notifies you.
+      # Suppressed on infra flakes: those should show as a yellow warning,
+      # not a red badge, since coverage was never actually measured.
       - name: Fail if any crate below threshold
-        if: needs.coverage.result == 'failure'
+        if: needs.coverage.result == 'failure' && steps.flake.outputs.detected != 'true'
         run: exit 1


### PR DESCRIPTION
## Summary

Closes #930. Hardens the Coverage workflow so transient infrastructure failures (specifically `taiki-e/install-action` getting sustained CDN 504s while downloading `cargo-llvm-cov`) no longer auto-open bogus regression issues against a clean `main`.

## The bug we lived through

Run [`24610129503`](https://github.com/lijunzh/koda/actions/runs/24610129503) on commit `0be204b` (the v0.2.14 release) failed with:

```
info: downloading https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.8.5/cargo-llvm-cov-aarch64-apple-darwin.tar.gz
curl: (56) The requested URL returned error: 504
[…11 retries, all 504…]
##[error]Process completed with exit code 56.
```

This was a **GitHub releases CDN flake on the arm64 macOS runner**. Coverage was never measured on that platform, but:

- The matrix job's `failure` result tripped the `Report regression` step
- It auto-filed issue #930 ("Coverage regression on main (0be204b)")
- The `Fail if any crate below threshold` step painted the badge red

A re-run on the same commit went clean and #930 auto-closed — confirming the false positive — but the noise is exactly what we want to avoid.

## What changed

### Coverage matrix job

* `taiki-e/install-action` is now `continue-on-error: true` with `id: install`. The action's CDN download already retries 11×; this absorbs the residual ~0.x% case instead of nuking the run.
* The three `cargo llvm-cov` steps gate on `if: steps.install.outcome == 'success'` — no point compiling for ~2 minutes when we know we can't run coverage.
* New **`Mark infra flake`** + **`Upload infra-flake marker`** steps drop a one-line marker artifact (`infra-flake-<OS>`) per platform whose install failed. The artifact carries a human-readable note so a future debugger sees the reason without spelunking logs.
* The unused `Set outcome outputs` step is replaced by **`Verify coverage outcomes`**, a single guard that:
  - On install flake → `::warning::` + `exit 0` (matrix leg succeeds; no false alarm)
  - On real per-crate threshold breach → `::error::` per crate + `exit 1` (downstream regression-issue pipeline kicks in normally)

### Report job

Downloads any flake markers (`continue-on-error: true` since healthy runs have none), exposes a `flake.outputs.detected` boolean, and gates all three of its mutating steps on `detected != 'true'`:

| Step | Behavior on flake |
|------|---|
| `Report regression` | Skipped — won't open / comment on a regression issue when the failure is a flake |
| `Close regression issue if green` | Skipped — won't close a legitimately open regression issue if THIS run never measured coverage |
| `Fail if any crate below threshold` | Skipped — surfaces as a yellow warning instead of red badge |

## Edge case considered

A flake on the run immediately after a real regression would NOT auto-close the open issue (because we never measured coverage on the flaked platform). The next clean green run closes it normally. This is the conservative direction — **false-negatives on auto-close beat false-positives that bury real regressions under noise**.

## Validation

- `actionlint .github/workflows/coverage.yml` — clean for new code (two pre-existing SC2086 warnings on the lcov merge loop unchanged)
- `python -m yaml.safe_load` parses the file
- Logic traced end-to-end against three scenarios:
  1. CDN flake on macOS (the #930 case) → no issue, badge stays clean ✅
  2. Real regression on Linux while macOS flakes → suppressed (avoids ambiguous report) ✅
  3. Real regression alone (no flake) → issue filed normally ✅

## How to verify after merge

The workflow only runs on push to `main`, so merging this is the test. The next push will exercise the happy path (no flake → no behavior change). To prove the flake path works, we can either wait for the next CDN burp (likely ≤2 weeks) or temporarily inject a failing install in a follow-up PR if curiosity strikes.

## Stats

`1 file changed, 95 insertions(+), 12 deletions(-)`
