### PR TITLE
chore: sync koda-ast, koda-email, and koda-cli dep version to v0.2.14

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.13)
+10. Sync version with workspace (currently 0.2.14)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 publish = false # workspace-only; not published to crates.io
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.13" }
+koda-core = { path = "../koda-core", version = "0.2.14" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -73,6 +73,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.13", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.14", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 publish = false # standalone MCP server; not published to crates.io
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"


### PR DESCRIPTION
## Summary

Cleanup PR closing four version-bump misses from the v0.2.14 release commit (#928), which only updated `koda-core` and `koda-cli` package versions.

## What was missed

| File | Was | Now |
|------|-----|-----|
| `koda-ast/Cargo.toml` (package) | `0.2.13` | `0.2.14` |
| `koda-email/Cargo.toml` (package) | `0.2.13` | `0.2.14` |
| `koda-cli/Cargo.toml` koda-core path-dep | `version = "0.2.13"` | `version = "0.2.14"` |
| `Cargo.lock` (koda-ast, koda-email entries) | `0.2.13` | `0.2.14` |
| `CLAUDE.md` MCP-server release-checklist note | "currently 0.2.13" | "currently 0.2.14" |

## Why cargo didn't catch it

For the koda-cli → koda-core dep, cargo accepts a stale `version = "0.2.13"` constraint when the path-dep already resolves locally; the path takes precedence. A sibling consumer pulling koda-cli (or a future workspace split) would have hit a resolution mismatch.

## Validation

`cargo check --workspace` passes locally. No behavior change — just version hygiene.

## Follow-up suggestion

Worth adding a release-checklist step that does a workspace-wide `rg "\"$OLD_VERSION\""` after the bump to catch this class of miss before tagging.