### PR TITLE
chore: release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.15] - 2026-04-18
+
+Hotfix release. CI/infra changes only — no runtime, library, or user-facing
+behavior changes since v0.2.14. Safe to skip if you don't care about CI noise
+levels.
+
+### Changed
+- **Coverage workflow distinguishes infra flakes from real regressions**
+  (#930, #931). When `taiki-e/install-action` fails to install
+  `cargo-llvm-cov` (a known intermittent infra issue), the coverage report
+  job no longer treats it as a real coverage drop — it skips opening a
+  regression issue and skips updating the badge. Real coverage drops still
+  fail loudly. Reduces false-positive regression alerts.
+- **Workspace dependency versions synced** so all four crates pin their
+  internal `koda-core` dependency to the matching workspace version (#932).
+  Bookkeeping for crates.io publishing; no behavior change.
+
+### Coming next
+- **v0.3.0 will introduce capability-aware sandboxing** (tracking: #934,
+  design discussion: #933). Per-sub-agent filesystem and network policies,
+  pre-warmed sandbox slot pool for fast parallel dispatch, and stronger
+  isolation than the current `Bash`-only sandbox. Read the design and try
+  the alphas if you'd like to influence the implementation.
+
 ## [0.2.14] - 2026-04-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,7 +438,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.14)
+10. Sync version with workspace (currently 0.2.15)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "koda-ast"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "petgraph",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "koda-email"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "imap",

--- a/koda-ast/Cargo.toml
+++ b/koda-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-ast"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 publish = false # workspace-only; not published to crates.io
 description = "MCP server for tree-sitter AST analysis — part of the koda ecosystem"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.14" }
+koda-core = { path = "../koda-core", version = "0.2.15" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -73,6 +73,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.14", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.15", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"

--- a/koda-email/Cargo.toml
+++ b/koda-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-email"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 publish = false # standalone MCP server; not published to crates.io
 description = "MCP server for email read/send/search via IMAP/SMTP — part of the koda ecosystem"


### PR DESCRIPTION
## Release v0.2.14 → v0.2.15

Hotfix release. **CI/infra-only changes, zero runtime/library/user-facing
behavior changes.** Safe to skip if you don't care about CI noise levels.

## Changelog

### Changed
- **Coverage workflow distinguishes infra flakes from real regressions**
  (#930, #931). When `taiki-e/install-action` fails to install
  `cargo-llvm-cov` (a known intermittent infra issue), the coverage report
  job no longer treats it as a real coverage drop — it skips opening a
  regression issue and skips updating the badge. Real coverage drops still
  fail loudly. Reduces false-positive regression alerts.
- **Workspace dependency versions synced** so all four crates pin their
  internal `koda-core` dependency to the matching workspace version (#932).
  Bookkeeping for crates.io publishing; no behavior change.

### Coming next
- **v0.3.0 will introduce capability-aware sandboxing** (tracking: #934,
  design discussion: #933). Per-sub-agent filesystem and network policies,
  pre-warmed sandbox slot pool for fast parallel dispatch, and stronger
  isolation than the current `Bash`-only sandbox.

## Sub-agent validation summary

| Agent | Verdict | Notes |
|---|---|---|
| code-reviewer | ✅ Ship | Zero `.rs` changes since v0.2.14. 4 minor polish items deferred (see below). |
| rust-programmer | ✅ Ship | `fmt`/`clippy`/`test`/`doc` all pass clean. No semver concerns (no API changed). |
| security-auditor | ✅ Ship | `cargo audit` clean except pre-existing RUSTSEC-2025-0141 (deferred). No new `unsafe`, `sandbox.rs` untouched. |
| qa-expert | ✅ Ship | Both Linux + macOS CI green on post-v0.2.14 PRs. No new `#[ignore]` tests. No flaky tests reported. |

## Diff scope

```
 CHANGELOG.md          | 24 ++++++++++++++++++++++++
 CLAUDE.md             |  2 +-
 Cargo.lock            |  8 ++++----
 koda-ast/Cargo.toml   |  2 +-
 koda-cli/Cargo.toml   |  6 +++---
 koda-core/Cargo.toml  |  2 +-
 koda-email/Cargo.toml |  2 +-
 7 files changed, 35 insertions(+), 11 deletions(-)
```

Pure release bookkeeping. No source code touched.

## Pre-flight checks

- [x] Clean working tree before branch
- [x] Branched off latest `main`
- [x] All 4 crates bumped to 0.2.15 (koda-core, koda-cli, koda-ast, koda-email)
- [x] `koda-cli` → `koda-core` dep pins synced (both `[dependencies]` and `[dev-dependencies]`)
- [x] `Cargo.lock` regenerated via `cargo check --workspace`
- [x] `CLAUDE.md` step 10 updated (`currently 0.2.15`)
- [x] `CHANGELOG.md` v0.2.15 section added at top
- [x] No stale `0.2.14` references in user-facing docs
- [x] `koda_docs` skill page index in sync with `docs/src/`
- [x] Pre-push hooks pass (`fmt` + `clippy`)
- [x] Sub-agent validation complete

### Deferred items (tracked)

Non-blocking polish surfaced during validation, filed as their own issues:

- [ ] #935 — Replace syntect or push upstream for bincode-2 migration (RUSTSEC-2025-0141) [security]
- [ ] #936 — SHA-pin third-party GitHub Actions in coverage.yml [security]
- [ ] #937 — Harden marker filename sanitization in coverage.yml [enhancement]
- [ ] #938 — Tighten download-artifact failure mode in coverage.yml [enhancement]

🐾
