### PR TITLE
ci(coverage): probe artifact API before downloading flake markers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -209,13 +209,33 @@ jobs:
       # cargo-llvm-cov). Their presence means coverage was never measured
       # there — not a real regression. See #930 for the original false
       # positive that motivated this guard.
+      #
+      # We CANNOT use `continue-on-error: true` on the download itself:
+      # that would swallow genuine artifact-service outages and let us
+      # auto-close real regression issues during a GitHub incident
+      # (false negative, the dangerous direction). Instead we probe the
+      # API first — a 200 with zero matching artifacts is the legitimate
+      # "healthy run, no flake" case; any other API result fails loudly.
+      # See #938.
+      - name: Probe for infra-flake markers
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          count=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '[.artifacts[] | select(.name | startswith("infra-flake-"))] | length')
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+          echo "Found ${count} infra-flake marker artifact(s) on this run."
+
       - name: Download infra-flake markers
+        if: steps.probe.outputs.count != '0'
         uses: actions/download-artifact@v4
         with:
           pattern: infra-flake-*
           merge-multiple: true
           path: flake-markers
-        continue-on-error: true  # markers absent on healthy runs
 
       - name: Detect infra flake
         id: flake
@@ -244,6 +264,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           COMMIT="${{ github.sha }}"
           SHORT="${COMMIT:0:7}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -283,6 +304,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           EXISTING=$(gh issue list \
             --label "coverage-regression" \
             --state open \


### PR DESCRIPTION
Closes #938.

## Problem

The previous `continue-on-error: true` on `actions/download-artifact@v4` (in the report job) swallowed **every** failure, not just the legitimate "no markers found on a healthy run" case. A genuine artifact-service outage (502/503/504 from GitHub's artifact backend during an incident) would render an **identical green status**, causing the report job to think it had cleanly observed "no flake" when it had in fact observed nothing at all \u2014 then auto-close real coverage-regression issues during the outage.

That's the **wrong direction**: false negatives that hide real regressions. Better to fail closed (keep the issue open) on infrastructure outages.

## Fix

Replace the unconditional best-effort download with an explicit two-phase:

1. **Probe** via the GitHub Actions API (`/repos/.../actions/runs/.../artifacts`) to count how many `infra-flake-*` artifacts exist on this run. A non-2xx response (the actual outage case) fails the step loudly with `set -euo pipefail`, which keeps any open regression issue safely open until the next run can verify.
2. **Download** only when `count > 0`. The action's own failure modes are no longer masked.

Also adds `set -euo pipefail` to the remaining bash steps in the job ("Report regression", "Close regression issue if green") so a typo or gh-cli error can never silently exit 0 and corrupt regression-issue state.

## Diff
```
.github/workflows/coverage.yml | 24 +++++++++++++++++++++++-
1 file changed, 23 insertions(+), 1 deletion(-)
```

## Note on PR ordering

PR #940 (#937 fix) also touches `coverage.yml` (sanitizes marker filenames + adds pipefail to two upstream steps). These two PRs touch disjoint sections \u2014 #940 hits the coverage job, this one hits the report job \u2014 but whichever lands second may need a trivial rebase. Either order is fine.

## Risk
- `set -euo pipefail` only changes behavior on actual failures (today silently exit 0).
- Probe step adds one API call per run (cheap, same token already in env).
- Download is now conditional, but it was a no-op when no markers existed anyway. Net behavior on the happy path is identical.

Found during v0.2.15 release validation by code-reviewer (#939).