### PR TITLE
ci: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           shared-key: ci-${{ runner.os }}
       # Lint steps run only on Linux to avoid duplicate noise.
@@ -64,8 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           shared-key: doc  # stable across branches & workflow edits
       - run: cargo doc --workspace --no-deps
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run audit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,13 +22,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           shared-key: coverage-${{ runner.os }}
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2
         id: install
         # The action's CDN download already retries 11 times. We tolerate the
         # remaining 0.x% of cases (GitHub releases CDN returning sustained

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install mdbook
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2
         with:
           tool: mdbook
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,8 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
       - name: Set up Linux sandbox (bubblewrap)
         if: runner.os == 'Linux'
         run: |
@@ -84,10 +84,10 @@ jobs:
             os: macos-14
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           key: ${{ matrix.target }}
 
@@ -116,7 +116,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       # Publish order follows dependency graph: koda-core → koda-cli
       # koda-ast, koda-email are publish=false — skipped automatically.
       - name: Publish koda-core
@@ -173,7 +173,7 @@ jobs:
           cat release_body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body_path: release_body.md
           files: artifacts/*.tar.gz


### PR DESCRIPTION
Closes #936.

## Problem

Major-version tags like `@v2` and `@stable` are **mutable references**: the upstream maintainer can repoint them at any commit, and a malicious or compromised upstream account could ship arbitrary code into our workflow runs without any signal in our git history.

This isn't theoretical \u2014 the [tj-actions/changed-files compromise (March 2025)](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) hit thousands of repos through exactly this attack vector. SHA-pinning is the OpenSSF Scorecard / NIST SP 800-204D / SLSA recommended baseline for any actions not authored by the workflow's repo owner.

## Scope

**Pinned (15 references across 4 workflows):**

| Action | From | To |
|---|---|---|
| `dtolnay/rust-toolchain` | `@stable` | `@29eef336…` (stable @ 2026-04-18) |
| `Swatinem/rust-cache` | `@v2` | `@e18b4977…` (v2.8.1) |
| `taiki-e/install-action` | `@v2` | `@58e86254…` (v2 @ 2026-04-17) |
| `softprops/action-gh-release` | `@v3.0.0` | `@b4309332…` (v3.0.0) |

**Not pinned (deliberately):** `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, `actions/upload-pages-artifact`, `actions/deploy-pages`. These are first-party actions owned by GitHub itself \u2014 the threat model that motivates SHA-pinning (compromised third-party maintainer) doesn't apply. If GitHub is compromised, SHA-pinning their own actions doesn't save us.

## Convention

Each pin keeps a trailing `# v\u2026` comment so reviewers see at a glance what version a SHA represents:

```yaml
- uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
- uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
```

## Won't this leave us on stale SHAs?

No. `.github/dependabot.yml` already configures the `github-actions` ecosystem with weekly cadence and prefix `ci(deps)`. Dependabot understands the SHA-pin + version-comment convention and will open PRs to bump both the SHA *and* the comment together as new upstream releases land. We will not be stuck on stale SHAs \u2014 we'll just have a clean audit trail of every bump.

## Diff
```
.github/workflows/ci.yml       | 12 ++++++------
.github/workflows/coverage.yml |  6 +++---
.github/workflows/docs.yml     |  2 +-
.github/workflows/release.yml  | 12 ++++++------
4 files changed, 16 insertions(+), 16 deletions(-)
```

## Risk
- Each pinned SHA was verified to belong to the same major version that was previously referenced by tag \u2014 no behavior change today.
- All four pinned actions were last updated within the last week (per `gh api /repos/.../commits/SHA --jq .commit.committer.date`), so we're pinning the *latest* major-version commits, not anything stale.

Found during v0.2.15 release validation by security-auditor (#939).