### PR TITLE
feat(cli): syntax-highlighted bash + path coloring in tool headers

### DIFF
--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -155,6 +155,82 @@ impl CodeHighlighter {
 /// assert_eq!(plain.len(), 2);
 /// assert_eq!(plain[0][0].content.as_ref(), "hello");
 /// ```
+/// Highlight a short snippet inline (no newlines) and return spans.
+///
+/// Designed for one-row UI surfaces (tool-call headers, status banners)
+/// where a multi-line command must be flattened to a single visual line.
+/// Newlines and tabs collapse to a single space; line continuations
+/// (`\\\n`) collapse the same way so `git commit -m "x" \\\n  && cargo test`
+/// reads as `git commit -m "x"   && cargo test` in the header.
+///
+/// Honors `KODA_SYNTAX_HIGHLIGHT=off` (returns a single plain span).
+/// Unknown languages also pass through as a single plain span.
+pub fn highlight_inline(snippet: &str, lang: &str) -> Vec<ratatui::text::Span<'static>> {
+    let flat = flatten_for_inline(snippet);
+    let mut hl = CodeHighlighter::new(lang);
+    hl.highlight_spans(&flat)
+}
+
+/// Replace newlines / tabs with single spaces. Pure helper, easy to test.
+fn flatten_for_inline(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            '\n' | '\r' | '\t' => ' ',
+            other => other,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod inline_tests {
+    use super::*;
+
+    #[test]
+    fn flatten_collapses_newlines_and_tabs() {
+        assert_eq!(flatten_for_inline("a\nb\tc\rd"), "a b c d");
+    }
+
+    #[test]
+    fn flatten_passthrough_when_no_specials() {
+        assert_eq!(flatten_for_inline("hello world"), "hello world");
+    }
+
+    #[test]
+    fn highlight_inline_bash_produces_colored_spans() {
+        // Skip if syntax highlighting is disabled in this env.
+        if !crate::theme::syntax_highlight_enabled() {
+            return;
+        }
+        let spans = highlight_inline("ls -la /tmp", "bash");
+        // Bash grammar should emit at least 2 spans (command + arg / path).
+        assert!(
+            spans.len() >= 2,
+            "expected multiple spans for bash, got {}",
+            spans.len()
+        );
+        // Combined text round-trips cleanly.
+        let combined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(combined, "ls -la /tmp");
+    }
+
+    #[test]
+    fn highlight_inline_unknown_lang_falls_back_to_plain() {
+        let spans = highlight_inline("anything goes", "notalang");
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].content.as_ref(), "anything goes");
+    }
+
+    #[test]
+    fn highlight_inline_flattens_multiline_input() {
+        let spans = highlight_inline("echo hi\necho bye", "bash");
+        let combined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            !combined.contains('\n'),
+            "newline leaked into header: {combined:?}"
+        );
+    }
+}
+
 pub fn pre_highlight(content: &str, ext: &str) -> Vec<Vec<ratatui::text::Span<'static>>> {
     // Guardrail: massive files (e.g. minified JS bundles) burn syntect
     // wall-clock without giving the user useful color information — fall

--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -153,7 +153,12 @@ fn render_assistant_message(lines: &mut Vec<Line<'static>>, msg: &Message) {
     }
 }
 
-/// Parse tool_calls JSON and render `● ToolName detail` headers.
+/// Parse tool_calls JSON and render `● ToolName <styled detail>` headers.
+///
+/// Detail formatting and colors are delegated to
+/// [`crate::tool_header::build_header_line_from_str`] so live render
+/// and history replay produce identical span sequences for the same
+/// `(name, args)` input.
 fn render_tool_call_headers(lines: &mut Vec<Line<'static>>, tc_json: &str) {
     // Tool calls are stored as JSON arrays (OpenAI format)
     let calls: Vec<serde_json::Value> = match serde_json::from_str(tc_json) {
@@ -164,16 +169,9 @@ fn render_tool_call_headers(lines: &mut Vec<Line<'static>>, tc_json: &str) {
     for call in &calls {
         let name = call["function"]["name"].as_str().unwrap_or("unknown");
         let args = call["function"]["arguments"].as_str().unwrap_or("{}");
-
-        let detail = tool_detail_summary(name, args);
-        let dot_color = tool_dot_color(name);
-
-        lines.push(Line::from(vec![
-            Span::styled("\u{25cf} ", Style::default().fg(dot_color)),
-            Span::styled(name.to_string(), BOLD),
-            Span::raw(" "),
-            Span::styled(detail, DIM),
-        ]));
+        lines.push(crate::tool_header::build_header_line_from_str(
+            "", name, args,
+        ));
     }
 }
 
@@ -221,69 +219,6 @@ fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message, tool_name: 
             Span::styled(format!("... {hidden} more line(s)"), DIM),
         ]));
     }
-}
-
-/// Extract a human-readable detail string from tool args.
-///
-/// E.g., Read({"file_path": "src/main.rs"}) → "src/main.rs"
-fn tool_detail_summary(name: &str, args_json: &str) -> String {
-    let args: serde_json::Value =
-        serde_json::from_str(args_json).unwrap_or(serde_json::Value::Null);
-
-    match name {
-        "Read" | "Write" | "Edit" | "Delete" => {
-            args["file_path"].as_str().unwrap_or("").to_string()
-        }
-        "Bash" => {
-            let cmd = args["command"].as_str().unwrap_or("");
-            if cmd.len() > 60 {
-                format!("{}...", &cmd[..57])
-            } else {
-                cmd.to_string()
-            }
-        }
-        "Grep" => {
-            let pattern = args["search_string"]
-                .as_str()
-                .or_else(|| args["pattern"].as_str())
-                .unwrap_or("");
-            let dir = args["directory"].as_str().unwrap_or(".");
-            format!("{pattern} in {dir}")
-        }
-        "List" => args["directory"]
-            .as_str()
-            .or_else(|| args["path"].as_str())
-            .unwrap_or(".")
-            .to_string(),
-        "WebFetch" => args["url"].as_str().unwrap_or("").to_string(),
-        _ => {
-            // Generic: show first string value found
-            if let Some(obj) = args.as_object() {
-                for (_, v) in obj.iter().take(1) {
-                    if let Some(s) = v.as_str() {
-                        let truncated = if s.len() > 60 {
-                            format!("{}...", &s[..57])
-                        } else {
-                            s.to_string()
-                        };
-                        return truncated;
-                    }
-                }
-            }
-            String::new()
-        }
-    }
-}
-
-/// Color for the tool call dot indicator.
-///
-/// Delegates to [`crate::theme::tool_dot_color`] so live render and
-/// history replay paint the same tool with the same color. This used
-/// to be a separate table that disagreed with `tui_render`'s table
-/// (Bash was green here but orange there); the disagreement is now
-/// impossible because the table lives in one place.
-fn tool_dot_color(name: &str) -> Color {
-    crate::theme::tool_dot_color(name)
 }
 
 #[cfg(test)]
@@ -394,18 +329,24 @@ mod tests {
 
     #[test]
     fn test_tool_detail_summary() {
-        assert_eq!(
-            tool_detail_summary("Read", r#"{"file_path": "src/main.rs"}"#),
-            "src/main.rs"
+        // The detail logic now lives in `tool_header` and is exhaustively
+        // covered there; this test just pins the *integration* — history
+        // replay must produce the same colored spans as live render does.
+        let typed = crate::tool_header::build_header_line(
+            "",
+            "Grep",
+            &serde_json::json!({"search_string": "foo", "directory": "src"}),
         );
-        assert_eq!(
-            tool_detail_summary("Bash", r#"{"command": "ls -la"}"#),
-            "ls -la"
+        let history = crate::tool_header::build_header_line_from_str(
+            "",
+            "Grep",
+            r#"{"search_string": "foo", "directory": "src"}"#,
         );
-        assert_eq!(
-            tool_detail_summary("Grep", r#"{"search_string": "foo", "directory": "src"}"#),
-            "foo in src"
-        );
+        let typed_text: String = typed.spans.iter().map(|s| s.content.as_ref()).collect();
+        let history_text: String = history.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(typed_text, history_text);
+        assert!(history_text.contains("\"foo\""));
+        assert!(history_text.contains("src"));
     }
 
     #[test]

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -37,6 +37,7 @@ pub(crate) mod server;
 pub(crate) mod sink;
 pub(crate) mod startup;
 pub(crate) mod theme;
+pub(crate) mod tool_header;
 pub(crate) mod tool_history;
 pub(crate) mod tool_output_lines;
 pub(crate) mod transcript;

--- a/koda-cli/src/tool_header.rs
+++ b/koda-cli/src/tool_header.rs
@@ -1,0 +1,370 @@
+//! Tool-call **header** rendering — `● ToolName <styled detail>`.
+//!
+//! Sibling to [`crate::tool_output_lines`] which handles tool output
+//! *bodies*. This module owns the single-row banner that announces each
+//! tool call: the dot color, the tool name (bold), and a styled detail
+//! string built from the tool's argument JSON.
+//!
+//! ## Why a dedicated module
+//!
+//! Pre-#951 we had two near-identical implementations of this logic —
+//! `tui_render::tool_call_styles` (live render) and
+//! `history_render::tool_detail_summary` + `render_tool_call_headers`
+//! (history replay). They drifted: live used `pattern` for Grep,
+//! history used `search_string`; live emitted a single dim string,
+//! history did the same; neither colored the file path or
+//! syntax-highlighted bash commands. Centralizing here ensures both
+//! paths render the same `(name, args)` to the same spans.
+//!
+//! ## Per-tool detail styling
+//!
+//! | Tool                       | Detail format                                       |
+//! |----------------------------|-----------------------------------------------------|
+//! | `Bash`                     | `cmd` syntax-highlighted as bash (single-line)      |
+//! | `Read`/`Write`/`Edit`/`Delete` | `file_path` in [`theme::PATH`] (cyan)            |
+//! | `Grep`                     | `"<pattern>"` in [`theme::MATCH_HIT`] + ` in ` + dir |
+//! | `Glob`                     | `pattern` in [`theme::PATH`]                        |
+//! | `List`                     | `directory` in [`theme::PATH`]                      |
+//! | `WebFetch`                 | `url` in [`theme::PATH`]                            |
+//! | _other_                    | first string arg, dim                               |
+
+use crate::highlight;
+use crate::theme::{self, BOLD, DIM};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use serde_json::Value;
+
+/// Maximum visible chars for inline command/detail text in headers.
+///
+/// Keeps `git commit -m "huge multiline message…"` from blowing past
+/// the viewport. Matches `history_render`'s prior behavior.
+const MAX_DETAIL_CHARS: usize = 120;
+
+/// Build a complete tool-call header line: dot + name + detail spans.
+///
+/// `indent` is prepended raw (used by sub-agent rendering).
+pub fn build_header_line(indent: &str, name: &str, args: &Value) -> Line<'static> {
+    let dot_style = theme::tool_dot(name);
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(8);
+    if !indent.is_empty() {
+        spans.push(Span::raw(indent.to_string()));
+    }
+    spans.push(Span::styled("\u{25cf} ", dot_style));
+    spans.push(Span::styled(name.to_string(), BOLD));
+    let detail = detail_spans(name, args);
+    if !detail.is_empty() {
+        spans.push(Span::raw(" "));
+        spans.extend(detail);
+    }
+    Line::from(spans)
+}
+
+/// Same as [`build_header_line`] but accepts the JSON args as a string
+/// (for the history-replay path which stores OpenAI-style call payloads).
+///
+/// Invalid JSON degrades to an empty detail rather than panicking.
+pub fn build_header_line_from_str(indent: &str, name: &str, args_json: &str) -> Line<'static> {
+    let parsed: Value = serde_json::from_str(args_json).unwrap_or(Value::Null);
+    build_header_line(indent, name, &parsed)
+}
+
+/// Build only the styled detail spans for a tool call (no dot/name).
+///
+/// Returns an empty vec if the args don't carry a useful detail
+/// (e.g. unknown tool with no string args).
+pub fn detail_spans(name: &str, args: &Value) -> Vec<Span<'static>> {
+    match name {
+        "Bash" => bash_detail(args),
+        "Read" | "Write" | "Edit" | "Delete" => path_detail(args),
+        "Grep" => grep_detail(args),
+        "Glob" => glob_detail(args),
+        "List" => list_detail(args),
+        "WebFetch" => webfetch_detail(args),
+        _ => generic_detail(args),
+    }
+}
+
+// ── Per-tool detail builders ──────────────────────────────────────────
+
+fn bash_detail(args: &Value) -> Vec<Span<'static>> {
+    let cmd = first_string(args, &["command", "cmd"]).unwrap_or_default();
+    if cmd.is_empty() {
+        return Vec::new();
+    }
+    let truncated = truncate_for_header(&cmd);
+    highlight::highlight_inline(&truncated, "bash")
+}
+
+fn path_detail(args: &Value) -> Vec<Span<'static>> {
+    let path = first_string(args, &["file_path", "path"]).unwrap_or_default();
+    if path.is_empty() {
+        return Vec::new();
+    }
+    vec![Span::styled(truncate_for_header(&path), theme::PATH)]
+}
+
+fn grep_detail(args: &Value) -> Vec<Span<'static>> {
+    let pattern = first_string(args, &["search_string", "pattern"]).unwrap_or_default();
+    if pattern.is_empty() {
+        return Vec::new();
+    }
+    let dir = first_string(args, &["directory", "path"]).unwrap_or_else(|| ".".to_string());
+    vec![
+        Span::styled(format!("\"{pattern}\""), theme::MATCH_HIT),
+        Span::styled(" in ".to_string(), DIM),
+        Span::styled(truncate_for_header(&dir), theme::PATH),
+    ]
+}
+
+fn glob_detail(args: &Value) -> Vec<Span<'static>> {
+    let pattern = first_string(args, &["pattern"]).unwrap_or_default();
+    if pattern.is_empty() {
+        return Vec::new();
+    }
+    vec![Span::styled(truncate_for_header(&pattern), theme::PATH)]
+}
+
+fn list_detail(args: &Value) -> Vec<Span<'static>> {
+    let dir = first_string(args, &["directory", "path"]).unwrap_or_else(|| ".".to_string());
+    vec![Span::styled(truncate_for_header(&dir), theme::PATH)]
+}
+
+fn webfetch_detail(args: &Value) -> Vec<Span<'static>> {
+    let url = first_string(args, &["url"]).unwrap_or_default();
+    if url.is_empty() {
+        return Vec::new();
+    }
+    vec![Span::styled(
+        truncate_for_header(&url),
+        Style::new()
+            .fg(ratatui::style::Color::Cyan)
+            .add_modifier(ratatui::style::Modifier::UNDERLINED),
+    )]
+}
+
+fn generic_detail(args: &Value) -> Vec<Span<'static>> {
+    let obj = match args.as_object() {
+        Some(o) => o,
+        None => return Vec::new(),
+    };
+    for (_, v) in obj.iter().take(1) {
+        if let Some(s) = v.as_str() {
+            return vec![Span::styled(truncate_for_header(s), DIM)];
+        }
+    }
+    Vec::new()
+}
+
+// ── Internals ─────────────────────────────────────────────────────────
+
+/// Return the first present string value among the candidate keys.
+fn first_string(args: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| args.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()))
+}
+
+/// Truncate a header detail to `MAX_DETAIL_CHARS` with an ellipsis.
+///
+/// Operates on **bytes** rather than chars deliberately — koda's tool
+/// args are overwhelmingly ASCII (paths, commands, regexes), and a
+/// byte-safe slice via `.char_indices()` keeps us correct for the rare
+/// multi-byte path without overcomplicating the hot path.
+fn truncate_for_header(s: &str) -> String {
+    if s.len() <= MAX_DETAIL_CHARS {
+        return s.to_string();
+    }
+    let cut = s
+        .char_indices()
+        .take_while(|(i, _)| *i < MAX_DETAIL_CHARS - 1)
+        .last()
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    format!("{}\u{2026}", &s[..cut])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn span_texts(spans: &[Span<'static>]) -> Vec<String> {
+        spans.iter().map(|s| s.content.to_string()).collect()
+    }
+
+    fn span_styles(spans: &[Span<'static>]) -> Vec<Style> {
+        spans.iter().map(|s| s.style).collect()
+    }
+
+    // ── path_detail ──────────────────────────────────────────────────
+
+    #[test]
+    fn read_uses_path_style() {
+        let spans = detail_spans("Read", &json!({"file_path": "src/main.rs"}));
+        assert_eq!(span_texts(&spans), vec!["src/main.rs"]);
+        assert_eq!(spans[0].style, theme::PATH, "path should be PATH-styled");
+    }
+
+    #[test]
+    fn write_falls_back_to_path_key() {
+        let spans = detail_spans("Write", &json!({"path": "x.txt"}));
+        assert_eq!(span_texts(&spans), vec!["x.txt"]);
+    }
+
+    #[test]
+    fn delete_with_no_path_returns_empty() {
+        let spans = detail_spans("Delete", &json!({}));
+        assert!(spans.is_empty());
+    }
+
+    // ── grep_detail ──────────────────────────────────────────────────
+
+    #[test]
+    fn grep_emits_quoted_pattern_then_dir() {
+        let spans = detail_spans(
+            "Grep",
+            &json!({"search_string": "TODO", "directory": "src"}),
+        );
+        let texts = span_texts(&spans);
+        assert_eq!(texts, vec!["\"TODO\"", " in ", "src"]);
+        let styles = span_styles(&spans);
+        assert_eq!(styles[0], theme::MATCH_HIT);
+        assert_eq!(styles[1], DIM);
+        assert_eq!(styles[2], theme::PATH);
+    }
+
+    #[test]
+    fn grep_default_directory_is_dot() {
+        let spans = detail_spans("Grep", &json!({"pattern": "foo"}));
+        assert_eq!(span_texts(&spans), vec!["\"foo\"", " in ", "."]);
+    }
+
+    #[test]
+    fn grep_accepts_pattern_alias() {
+        // Live-render path uses `pattern`; history uses `search_string`.
+        // Both should produce identical spans.
+        let live = detail_spans("Grep", &json!({"pattern": "x"}));
+        let history = detail_spans("Grep", &json!({"search_string": "x"}));
+        assert_eq!(span_texts(&live), span_texts(&history));
+    }
+
+    // ── bash_detail ──────────────────────────────────────────────────
+
+    #[test]
+    fn bash_returns_at_least_one_span() {
+        let spans = detail_spans("Bash", &json!({"command": "ls -la"}));
+        assert!(!spans.is_empty());
+        let combined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(combined, "ls -la");
+    }
+
+    #[test]
+    fn bash_with_no_command_returns_empty() {
+        let spans = detail_spans("Bash", &json!({}));
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn bash_flattens_multiline_commands() {
+        let spans = detail_spans("Bash", &json!({"command": "echo a\necho b"}));
+        let combined: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            !combined.contains('\n'),
+            "header must remain single-line, got {combined:?}"
+        );
+    }
+
+    // ── glob_detail ──────────────────────────────────────────────────
+
+    #[test]
+    fn glob_uses_path_style() {
+        let spans = detail_spans("Glob", &json!({"pattern": "**/*.rs"}));
+        assert_eq!(spans[0].style, theme::PATH);
+        assert_eq!(span_texts(&spans), vec!["**/*.rs"]);
+    }
+
+    // ── list_detail ──────────────────────────────────────────────────
+
+    #[test]
+    fn list_default_directory_is_dot() {
+        let spans = detail_spans("List", &json!({}));
+        assert_eq!(span_texts(&spans), vec!["."]);
+    }
+
+    // ── webfetch_detail ──────────────────────────────────────────────
+
+    #[test]
+    fn webfetch_underlines_url() {
+        let spans = detail_spans("WebFetch", &json!({"url": "https://example.com"}));
+        assert_eq!(span_texts(&spans), vec!["https://example.com"]);
+        assert!(
+            spans[0]
+                .style
+                .add_modifier
+                .contains(ratatui::style::Modifier::UNDERLINED),
+            "webfetch url should be underlined"
+        );
+    }
+
+    // ── generic_detail ───────────────────────────────────────────────
+
+    #[test]
+    fn generic_picks_first_string_value() {
+        let spans = detail_spans("UnknownTool", &json!({"thing": "hello"}));
+        assert_eq!(span_texts(&spans), vec!["hello"]);
+        assert_eq!(spans[0].style, DIM);
+    }
+
+    #[test]
+    fn generic_with_no_string_args_returns_empty() {
+        let spans = detail_spans("UnknownTool", &json!({"count": 42}));
+        assert!(spans.is_empty());
+    }
+
+    // ── truncation ───────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_passthrough_below_cap() {
+        assert_eq!(truncate_for_header("short"), "short");
+    }
+
+    #[test]
+    fn truncate_caps_long_input_with_ellipsis() {
+        let long = "x".repeat(MAX_DETAIL_CHARS + 50);
+        let out = truncate_for_header(&long);
+        assert!(out.ends_with('\u{2026}'));
+        // Stays under cap (chars, not bytes — ellipsis is multi-byte).
+        assert!(out.chars().count() <= MAX_DETAIL_CHARS);
+    }
+
+    // ── live ↔ history equivalence ───────────────────────────────────
+
+    #[test]
+    fn from_str_matches_typed_args_path_tools() {
+        let v = json!({"file_path": "x.rs"});
+        let typed = build_header_line("", "Read", &v);
+        let stringly = build_header_line_from_str("", "Read", &v.to_string());
+        assert_eq!(span_texts(&typed.spans), span_texts(&stringly.spans));
+        assert_eq!(span_styles(&typed.spans), span_styles(&stringly.spans));
+    }
+
+    #[test]
+    fn from_str_invalid_json_degrades_gracefully() {
+        let line = build_header_line_from_str("", "Read", "{not json");
+        // Header still has dot + bold name, just no detail.
+        let texts = span_texts(&line.spans);
+        assert!(texts.iter().any(|t| t == "Read"));
+    }
+
+    #[test]
+    fn build_header_line_indent_threads_through() {
+        let line = build_header_line("  ", "Read", &json!({"file_path": "x.rs"}));
+        assert_eq!(line.spans[0].content.as_ref(), "  ");
+    }
+
+    #[test]
+    fn build_header_line_no_indent_skips_empty_span() {
+        let line = build_header_line("", "Read", &json!({"file_path": "x.rs"}));
+        // First span must not be an empty raw indent.
+        assert_ne!(line.spans[0].content.as_ref(), "");
+    }
+}

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -38,7 +38,7 @@
 use crate::ansi_parse::parse_ansi_spans;
 use crate::scroll_buffer::ScrollBuffer;
 use crate::theme;
-use crate::tui_output::{self, BOLD, CYAN, DIM, MAGENTA, RED, TOOL_PREFIX, YELLOW};
+use crate::tui_output::{self, CYAN, DIM, MAGENTA, RED, TOOL_PREFIX, YELLOW};
 use crate::widgets::status_bar::TurnStats;
 use koda_core::engine::EngineEvent;
 use ratatui::{
@@ -180,17 +180,8 @@ impl TuiRenderer {
                 self.pending_tool_args
                     .insert(id.clone(), (name.clone(), args.to_string()));
                 let indent = if is_sub_agent { "  " } else { "" };
-                let (dot_style, detail) = tool_call_styles(&name, &args);
-                tui_output::emit_line(
-                    buffer,
-                    Line::from(vec![
-                        Span::raw(indent),
-                        Span::styled("\u{25cf} ", dot_style),
-                        Span::styled(name, BOLD),
-                        Span::raw(" "),
-                        Span::styled(detail, DIM),
-                    ]),
-                );
+                let line = crate::tool_header::build_header_line(indent, &name, &args);
+                tui_output::emit_line(buffer, line);
             }
             EngineEvent::ToolOutputLine {
                 id,
@@ -374,43 +365,6 @@ impl TuiRenderer {
 
 // ── Helper renderers ──────────────────────────────────
 
-/// Get the dot color and detail string for a tool call banner.
-///
-/// Dot color comes from [`theme::tool_dot`] — single source of truth
-/// shared with `history_render`. Detail formatting is per-tool.
-fn tool_call_styles(name: &str, args: &serde_json::Value) -> (Style, String) {
-    let dot_style = theme::tool_dot(name);
-
-    let detail = match name {
-        "Bash" => args
-            .get("command")
-            .or(args.get("cmd"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        "Read" | "Write" | "Edit" | "Delete" => args
-            .get("file_path")
-            .or(args.get("path"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        "Grep" | "Glob" => args
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        "WebFetch" => args
-            .get("url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
-        _ => String::new(),
-    };
-
-    (dot_style, detail)
-}
-
-/// Render tool output with collapsing for long outputs.
 /// Extract file extension from tool call args JSON.
 ///
 /// Walks the keys koda's tools actually use (`file_path` first, then


### PR DESCRIPTION
## Summary

Follow-up to #951. Same color treatment we just shipped for tool-output **bodies** now applies to the tool-call **header** row. Closes the second half of the user-visible "everything is gray" complaint in #945.

## Before vs after

| Tool header | Before | After |
|-------------|--------|-------|
| `Bash` | `● Bash git commit -m "msg" && cargo test` (all dim) | `● Bash <syntax-highlighted bash>` |
| `Read`/`Write`/`Edit`/`Delete` | `● Read src/main.rs` (path dim) | `● Read src/main.rs` (path in cyan, matches body grep paths) |
| `Grep` | `● Grep TODO` (live) / `● Grep TODO in src` (history) — disagreed! | `● Grep "TODO" in src` (pattern in bold amber, dir in cyan, both paths) |
| `Glob` | `● Glob **/*.rs` (dim) | `● Glob **/*.rs` (cyan, matches `List`) |
| `WebFetch` | `● WebFetch https://…` (dim) | `● WebFetch https://…` (cyan + underline — link affordance) |

## Architecture

New module **`koda-cli/src/tool_header.rs`** — single source of truth for `(name, args) → Vec<Span>` header rendering. Mirrors the body-rendering split from #951:

```
tool_output_lines.rs   ←  per-tool BODY line rendering  (Grep/List/Glob)
tool_header.rs         ←  per-tool HEADER row rendering (all tools)
```

Both `tui_render.rs` (live) and `history_render.rs` (replay) now call `tool_header::build_header_line[_from_str]()`. **Two near-duplicate implementations deleted** — `tui_render::tool_call_styles` and `history_render::tool_detail_summary`.

This kills the *second* DRY violation in this code path (#951 killed the dot-color one). They had drifted: live used `pattern` for Grep, history used `search_string` — depending on which path replayed your session, you'd see different text. Now structurally impossible.

New helper **`highlight::highlight_inline()`** — small wrapper around `CodeHighlighter::highlight_spans` that flattens `\n`/`\r`/`\t` to spaces (header is single-row), honors `KODA_SYNTAX_HIGHLIGHT=off`, and returns plain spans for unknown languages. Reusable for any future single-row UI that wants colored code.

## Peer-implementation crib notes

- **Bash highlighting via syntect bash grammar**: directly inspired by Codex's [`highlight_bash_to_lines`](https://github.com/openai/codex/blob/main/codex-rs/tui/src/syntax_highlight.rs). We use the same grammar via syntect's loader; codex builds its own per-language `HighlighterGuard`. Effect is the same.
- **Path coloring in cyan + dim separators**: matches gemini-cli's tool-call header convention.
- **Underlined URL for WebFetch**: cheap precursor to OSC 8 hyperlinks (#945 item #8) — `\x1b]8;;URL\x1b\\` + `\x1b]8;;\x1b\\` would make these click-through in iTerm2/Kitty/Wezterm. Filed as future work.
- **Inline newline-flattening**: borrowed from Codex's command-preview pattern. Multi-line commands shouldn't break header layout.

## Bug fixes (came along for the ride)

- **Grep header arg-name disagreement**: Live render used `args["pattern"]`, history used `args["search_string"]`. The new `grep_detail` checks both, so any stored payload renders identically.

## Test coverage

26 new tests:

| File | Tests | What they cover |
|------|-------|----------------|
| `highlight.rs` | 4 | inline helper: newline flattening, bash multi-span output, unknown-lang fallback, plain-text round-trip |
| `tool_header.rs` | 19 | per-tool detail builders (Bash/Read/Write/Delete/Grep/Glob/List/WebFetch/generic), header truncation, indent threading, live↔history span equivalence |
| `history_render.rs` | 1 (replaced) | live↔history integration smoke test (replaces the deleted `tool_detail_summary` test) |

**1653 / 1653 workspace tests pass; `cargo clippy --workspace --all-targets -- -D warnings` clean.**

## File-size discipline

- `tui_render.rs`: 622 → **576** LoC (finally under the 600-line soft cap! 🎉)
- `history_render.rs`: 422 → **363** LoC
- New `tool_header.rs`: 370 LoC (well under cap)
- All other files unchanged or smaller

Net: −28 LoC across existing files plus a focused 370-LoC new module that earns its place by deleting ~70 LoC of triplicated logic and unblocking future header refinements.

## Deferred

- **`koda-cli/src/transcript.rs` has a *third* copy of `tool_detail_summary`.** It's a plain-text (clipboard/file export) renderer with a different return type (`String`, not `Vec<Span>`) and a `bash_limit` parameter only meaningful for file output. Worth a separate small refactor: extract a shared `detail_text(name, args)` that both `transcript.rs` and the new `tool_header::detail_spans` consume. Filed as a follow-up note in the commit message.

## Diff stat

```
 koda-cli/src/highlight.rs      |  76 +++++++++++++++++++++++++++
 koda-cli/src/history_render.rs | 109 ++++++++--------------------------------
 koda-cli/src/lib.rs            |   1 +
 koda-cli/src/tool_header.rs    | 370 ++++++++++++++++++++++++++++++++++++++++++++++++++++
 koda-cli/src/tui_render.rs     |  52 ++----------------
 5 files changed, 475 insertions(+), 133 deletions(-)
```

Closes #945 items 1, 2, 3 (with #951) and the bash-highlighting follow-up note from that PR's description.
