### PR TITLE
fix(highlight): swap syntect defaults for two-face SyntaxSet (fixes silent TOML/TS coloring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "two-face",
  "unicode-width",
 ]
 
@@ -3975,6 +3976,17 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
 ]
 
 [[package]]

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -35,6 +35,7 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 
 # Syntax highlighting
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "html", "regex-fancy"] }
+two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 once_cell = "1"
 
 # TUI (inline viewport: input + status bar)

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -1,7 +1,8 @@
-//! Syntax highlighting for code blocks using syntect.
+//! Syntax highlighting for code blocks using syntect + two-face.
 //!
 //! Provides terminal-colored syntax highlighting for code in
-//! fenced markdown code blocks. Uses the same engine as `bat`.
+//! fenced markdown code blocks and Read tool output. Uses the same
+//! engine as `bat` and `codex`.
 //!
 //! ## Architecture
 //!
@@ -18,9 +19,14 @@
 //!
 //! ## Language lookup
 //!
-//! Languages are found by name token (`"rust"`, `"python"`) or by file
-//! extension (`"rs"`, `"py"`). Unknown languages fall back to unstyled
-//! passthrough — no panic.
+//! Languages are found by [`find_syntax`] which tries token, exact name,
+//! case-insensitive name, and file extension lookups. Unknown languages
+//! fall back to unstyled passthrough — no panic.
+//!
+//! `SYNTAX_SET` uses [`two_face::syntax::extra_newlines`] (~250 languages,
+//! same as `bat`/`codex`) instead of syntect's slim default bundle.
+//! Fixes silent no-ops for TOML, TypeScript, Kotlin, Swift, Zig, Lua,
+//! Dockerfile, and ~180 other languages that syntect's defaults omit.
 //!
 //! Syntaxes and themes are loaded once at first use via [`once_cell::sync::Lazy`].
 //! Theme: `base16-ocean.dark` (matches popular terminal palettes).
@@ -28,13 +34,60 @@
 use once_cell::sync::Lazy;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
-use syntect::parsing::SyntaxSet;
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 #[cfg(test)]
 use syntect::util::as_24_bit_terminal_escaped;
 
 /// Lazily loaded syntax definitions and theme.
-static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
+///
+/// `two_face::syntax::extra_newlines()` bundles ~250 languages including TOML,
+/// TypeScript, Kotlin, Swift, Zig, Lua, Dockerfile, Protocol Buffers, and
+/// everything else syntect's slim default set omits. Same grammar pack used
+/// by `bat` and `codex`. Loaded once; cloning the SyntaxSet is not needed.
+static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(two_face::syntax::extra_newlines);
 static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+
+/// Resolve a language hint to a syntect `SyntaxReference`.
+///
+/// Tries lookups in priority order:
+/// 1. By token (matches `file_extensions` case-insensitively) — fastest path.
+/// 2. By exact syntax name (e.g. `"Rust"`, `"Python"`).
+/// 3. Case-insensitive syntax name (handles `"rust"` → `"Rust"`).
+/// 4. By file extension (raw input treated as extension).
+///
+/// Common LLM-emitted aliases that two-face doesn’t handle automatically
+/// are patched before the lookup chain:
+/// - `csharp` / `c-sharp` → `c#`
+/// - `golang` → `go`
+/// - `python3` → `python`
+/// - `shell` → `bash`
+///
+/// Returns `None` for unknown languages — callers fall back to plain text.
+fn find_syntax(lang: &str) -> Option<&'static SyntaxReference> {
+    let ss = &*SYNTAX_SET;
+    let patched = match lang {
+        "csharp" | "c-sharp" => "c#",
+        "golang" => "go",
+        "python3" => "python",
+        "shell" => "bash",
+        other => other,
+    };
+    if let Some(s) = ss.find_syntax_by_token(patched) {
+        return Some(s);
+    }
+    if let Some(s) = ss.find_syntax_by_name(patched) {
+        return Some(s);
+    }
+    let lower = patched.to_ascii_lowercase();
+    if let Some(s) = ss
+        .syntaxes()
+        .iter()
+        .find(|s| s.name.to_ascii_lowercase() == lower)
+    {
+        return Some(s);
+    }
+    ss.find_syntax_by_extension(lang)
+}
 
 // Guardrails so a Read of a 50 MB minified bundle doesn't peg syntect.
 // Borrowed from codex's `exceeds_highlight_limits` — same numbers, same
@@ -74,15 +127,10 @@ impl CodeHighlighter {
         if !crate::theme::syntax_highlight_enabled() {
             return Self { state: None };
         }
-        let syntax = SYNTAX_SET
-            .find_syntax_by_token(lang)
-            .or_else(|| SYNTAX_SET.find_syntax_by_extension(lang));
-
-        let state = syntax.map(|syn| {
+        let state = find_syntax(lang).map(|syn| {
             let theme = &THEME_SET.themes["base16-ocean.dark"];
             HighlightLines::new(syn, theme)
         });
-
         Self { state }
     }
 
@@ -356,5 +404,82 @@ mod tests {
         for spans in &lines {
             assert_eq!(spans.len(), 1, "expected plain fallback, got highlighted");
         }
+    }
+
+    // ── two-face regression tests ─────────────────────────────────────────
+    // These assert that languages syntect’s default set silently dropped
+    // now resolve correctly after switching to two_face::syntax::extra_newlines.
+    // If any of these fail, the SYNTAX_SET initialiser was rolled back.
+
+    /// The headline regression: `Cargo.toml` was showing flat white because
+    /// syntect defaults have no TOML grammar. This must never regress.
+    #[test]
+    fn toml_resolves_with_two_face() {
+        assert!(
+            find_syntax("toml").is_some(),
+            "TOML syntax missing — two-face dep may have been removed or downgraded"
+        );
+    }
+
+    #[test]
+    fn typescript_resolves_with_two_face() {
+        assert!(find_syntax("ts").is_some(), "TypeScript (.ts) not found");
+        assert!(find_syntax("tsx").is_some(), "TypeScript (.tsx) not found");
+    }
+
+    #[test]
+    fn common_languages_all_resolve() {
+        // Spot-check a cross-section of commonly-read extensions.
+        // Failure here means two-face was swapped out for a slimmer set.
+        let must_resolve = [
+            ("rs", "Rust"),
+            ("py", "Python"),
+            ("js", "JavaScript"),
+            ("ts", "TypeScript"),
+            ("toml", "TOML"),
+            ("json", "JSON"),
+            ("yaml", "YAML"),
+            ("md", "Markdown"),
+            ("sh", "Bash"),
+            ("go", "Go"),
+            ("html", "HTML"),
+            ("css", "CSS"),
+            ("kt", "Kotlin"),
+            ("swift", "Swift"),
+            ("lua", "Lua"),
+            ("proto", "Protobuf"),
+        ];
+        for (ext, name) in must_resolve {
+            assert!(
+                find_syntax(ext).is_some(),
+                "{name} (.{ext}) not found in SYNTAX_SET — two-face may be misconfigured"
+            );
+        }
+    }
+
+    #[test]
+    fn llm_aliases_resolve_via_patching() {
+        // LLMs commonly emit these non-standard language names in code fences.
+        // The patching in find_syntax() must map them to real syntaxes.
+        assert!(find_syntax("golang").is_some(), "golang alias broken");
+        assert!(find_syntax("python3").is_some(), "python3 alias broken");
+        assert!(find_syntax("shell").is_some(), "shell alias broken");
+        assert!(find_syntax("csharp").is_some(), "csharp alias broken");
+        assert!(find_syntax("c-sharp").is_some(), "c-sharp alias broken");
+    }
+
+    #[test]
+    fn toml_produces_colored_spans() {
+        // End-to-end: TOML input through the full highlighter must emit
+        // multiple styled spans (not a single plain Span::raw).
+        if !crate::theme::syntax_highlight_enabled() {
+            return;
+        }
+        let mut h = CodeHighlighter::new("toml");
+        let spans = h.highlight_spans("[package]\nname = \"koda\"");
+        assert!(
+            spans.len() > 1,
+            "TOML should produce multiple colored spans, got: {spans:?}"
+        );
     }
 }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -524,32 +524,87 @@ fn collapse_blank_lines(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koda_core::engine::event::EngineEvent;
+    use serde_json::json;
 
-    #[test]
-    fn test_collapse_preserves_single_blank() {
-        assert_eq!(collapse_blank_lines("a\n\nb"), "a\n\nb");
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /// Drive `TuiRenderer` with a complete Read tool call and return all
+    /// buffer lines for inspection.
+    fn render_read(file_path: &str, content: &str) -> Vec<ratatui::text::Line<'static>> {
+        let mut renderer = TuiRenderer::new();
+        let mut buffer = ScrollBuffer::new(256);
+        renderer.render_to_buffer(
+            EngineEvent::ToolCallStart {
+                id: "t1".into(),
+                name: "Read".into(),
+                args: json!({ "file_path": file_path }),
+                is_sub_agent: false,
+            },
+            &mut buffer,
+        );
+        renderer.render_to_buffer(
+            EngineEvent::ToolCallResult {
+                id: "t1".into(),
+                name: "Read".into(),
+                output: content.to_string(),
+            },
+            &mut buffer,
+        );
+        buffer.all_lines().cloned().collect()
     }
 
-    #[test]
-    fn test_collapse_many_blanks() {
-        assert_eq!(collapse_blank_lines("a\n\n\n\n\nb"), "a\n\nb");
+    /// Drive `TuiRenderer` with any tool call (List/Glob/Grep/etc) and return
+    /// the full buffer. The `args` value is whatever JSON the tool expects;
+    /// the renderer just forwards it through `extract_file_extension` and the
+    /// per-tool dispatch in `render_tool_output`.
+    fn render_tool(
+        tool_name: &str,
+        args: serde_json::Value,
+        output: &str,
+    ) -> Vec<ratatui::text::Line<'static>> {
+        let mut renderer = TuiRenderer::new();
+        let mut buffer = ScrollBuffer::new(256);
+        renderer.render_to_buffer(
+            EngineEvent::ToolCallStart {
+                id: "t1".into(),
+                name: tool_name.into(),
+                args,
+                is_sub_agent: false,
+            },
+            &mut buffer,
+        );
+        renderer.render_to_buffer(
+            EngineEvent::ToolCallResult {
+                id: "t1".into(),
+                name: tool_name.into(),
+                output: output.to_string(),
+            },
+            &mut buffer,
+        );
+        buffer.all_lines().cloned().collect()
     }
 
-    #[test]
-    fn test_collapse_no_blanks() {
-        assert_eq!(collapse_blank_lines("a\nb\nc"), "a\nb\nc");
+    /// Return all spans from lines whose *joined text* contains `needle`.
+    fn spans_on_lines_containing(
+        lines: &[ratatui::text::Line<'static>],
+        needle: &str,
+    ) -> Vec<ratatui::text::Span<'static>> {
+        lines
+            .iter()
+            .filter(|line| {
+                let joined: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+                joined.contains(needle)
+            })
+            .flat_map(|line| line.spans.iter().cloned())
+            .collect()
     }
 
-    #[test]
-    fn test_collapse_all_blank() {
-        assert_eq!(collapse_blank_lines("\n\n\n\n"), "\n");
-    }
-
-    // ── extract_file_extension ──────────────────────────────────────
+    // ── extract_file_extension ────────────────────────────────────────────────
 
     #[test]
     fn extract_file_extension_handles_file_path_key() {
-        // The bug fix: koda's tools advertise `file_path`, not `path`.
+        // The bug fix: koda’s tools advertise `file_path`, not `path`.
         // Pre-fix, this returned None and silently disabled Read
         // syntax highlighting on every Read call.
         let args = r#"{"file_path": "src/main.rs"}"#;
@@ -572,5 +627,251 @@ mod tests {
     fn extract_file_extension_returns_none_for_extensionless() {
         let args = r#"{"file_path": "Makefile"}"#;
         assert_eq!(extract_file_extension(args), None);
+    }
+
+    // ── Read tool coloring regression tests ───────────────────────────────────
+    // These drive the full TuiRenderer → ScrollBuffer pipeline to confirm that
+    // Read output is actually syntax-highlighted, not rendered flat-white.
+    // Each test seeds a specific extension so a future SyntaxSet regression
+    // fails loudly here rather than silently in the user’s terminal.
+
+    /// Headline regression: Cargo.toml was showing flat white because syntect’s
+    /// default set had no TOML grammar. End-to-end proof it’s now colored.
+    #[test]
+    fn read_toml_produces_multiple_colored_spans() {
+        if !crate::theme::syntax_highlight_enabled() {
+            return;
+        }
+        let lines = render_read(
+            "Cargo.toml",
+            "[package]\nname = \"koda\"\nversion = \"0.2.16\"",
+        );
+        let spans = spans_on_lines_containing(&lines, "[package]");
+        assert!(
+            spans.len() > 2,
+            "[package] line should have multiple colored spans (got {}); \
+             TOML syntax highlighting broken — check two-face dep",
+            spans.len()
+        );
+        // At least one content span must carry a non-default foreground.
+        let colored = spans.iter().any(|s| {
+            s.style
+                .fg
+                .is_some_and(|c| c != ratatui::style::Color::Reset)
+        });
+        assert!(
+            colored,
+            "no colored spans on [package] line — highlighter is a no-op"
+        );
+    }
+
+    /// Rust was working before two-face; ensure the switch didn’t regress it.
+    #[test]
+    fn read_rust_still_produces_colored_spans() {
+        if !crate::theme::syntax_highlight_enabled() {
+            return;
+        }
+        let lines = render_read("src/main.rs", "fn main() {}\nprintln!(\"hello\");");
+        let spans = spans_on_lines_containing(&lines, "fn main");
+        assert!(
+            spans.len() > 2,
+            "`fn main` line should have multiple spans; Rust highlighting broken"
+        );
+    }
+
+    /// TypeScript was silently broken (no grammar in syntect defaults).
+    #[test]
+    fn read_typescript_produces_colored_spans() {
+        if !crate::theme::syntax_highlight_enabled() {
+            return;
+        }
+        let lines = render_read(
+            "index.ts",
+            "interface Foo { bar: string }\nconst x: number = 42;",
+        );
+        let spans = spans_on_lines_containing(&lines, "interface");
+        assert!(
+            spans.len() > 2,
+            "`interface` line should have multiple spans; TypeScript highlighting broken"
+        );
+    }
+
+    /// Unknown extensions must not panic and must render as plain text
+    /// (single content span, not zero spans).
+    #[test]
+    fn read_unknown_extension_falls_back_safely() {
+        let lines = render_read("data.xyz123", "some content here");
+        let spans = spans_on_lines_containing(&lines, "some content");
+        assert!(
+            !spans.is_empty(),
+            "unknown-extension Read must still emit spans (got none)"
+        );
+    }
+
+    /// Extensionless files (Makefile, Dockerfile) must render without panicking.
+    #[test]
+    fn read_extensionless_file_renders_safely() {
+        let lines = render_read("Makefile", ".PHONY: all\nall:\n\techo done");
+        // Just assert we get output lines containing the content.
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            all_text.contains(".PHONY"),
+            "Makefile content missing from output"
+        );
+    }
+
+    // ── Other read-only tools — E2E pipeline coverage ─────────────────────────
+    // List / Glob / Grep have unit tests in tool_output_lines, but those
+    // bypass the dispatch in render_tool_output. These tests catch the
+    // class of bugs where a tool name typo or extension extraction quirk
+    // silently flattens output — same shape as the Read tests above.
+
+    /// List output: directory entries should render with non-default styling
+    /// (bold), proving the dispatch → render_list_line path works end-to-end.
+    #[test]
+    fn list_directory_entries_render_styled() {
+        let lines = render_tool(
+            "List",
+            json!({ "path": "." }),
+            "d src\nd tests\n  Cargo.toml\n  README.md",
+        );
+        // Find the line containing "src" — directory entry.
+        let src_line = lines
+            .iter()
+            .find(|l| l.spans.iter().any(|s| s.content.as_ref() == "src"));
+        let src_line = src_line.expect("src directory entry not in output");
+        let dir_span = src_line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "src")
+            .unwrap();
+        assert!(
+            dir_span
+                .style
+                .add_modifier
+                .contains(ratatui::style::Modifier::BOLD),
+            "directory entry should be bold; render_list_line dispatch broken"
+        );
+    }
+
+    /// List output: file entries get extension-bucket coloring (e.g. .toml → yellow).
+    #[test]
+    fn list_file_entries_colored_by_extension() {
+        let lines = render_tool("List", json!({ "path": "." }), "  Cargo.toml\n  src.rs");
+        let toml_line = lines
+            .iter()
+            .find(|l| l.spans.iter().any(|s| s.content.as_ref() == "Cargo.toml"))
+            .expect("Cargo.toml entry not in output");
+        let toml_span = toml_line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "Cargo.toml")
+            .unwrap();
+        assert_eq!(
+            toml_span.style.fg,
+            Some(ratatui::style::Color::Yellow),
+            ".toml file should be yellow (config bucket); style_for_extension dispatch broken"
+        );
+    }
+
+    /// Glob output: file paths get extension-bucket coloring; meta lines dim.
+    #[test]
+    fn glob_paths_colored_by_extension() {
+        let lines = render_tool(
+            "Glob",
+            json!({ "pattern": "**/*.rs" }),
+            "3 files matched:\nsrc/main.rs\nsrc/lib.rs\ntests/it.rs",
+        );
+        let rs_line = lines
+            .iter()
+            .find(|l| l.spans.iter().any(|s| s.content.as_ref() == "src/main.rs"))
+            .expect("src/main.rs not in Glob output");
+        let rs_span = rs_line
+            .spans
+            .iter()
+            .find(|s| s.content.as_ref() == "src/main.rs")
+            .unwrap();
+        assert_eq!(
+            rs_span.style.fg,
+            Some(ratatui::style::Color::Green),
+            ".rs file should be green (source bucket); render_glob_line dispatch broken"
+        );
+    }
+
+    /// Grep output: matched substrings inside content render with MATCH_HIT style.
+    #[test]
+    fn grep_pattern_hits_styled_with_match_hit() {
+        let lines = render_tool(
+            "Grep",
+            json!({ "pattern": "TODO", "path": "." }),
+            "src/main.rs:42:    // TODO: refactor this",
+        );
+        // The hit span should carry the MATCH_HIT style (amber + bold).
+        let hit_span = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find(|s| s.content.as_ref() == "TODO");
+        let hit_span = hit_span.expect("TODO match span missing; Grep dispatch broken");
+        assert!(
+            hit_span
+                .style
+                .add_modifier
+                .contains(ratatui::style::Modifier::BOLD),
+            "Grep match should be bold (MATCH_HIT); pattern propagation broken"
+        );
+        assert_eq!(
+            hit_span.style.fg,
+            Some(ratatui::style::Color::Rgb(255, 191, 0)),
+            "Grep match should be amber (MATCH_HIT)"
+        );
+    }
+
+    /// Grep without a pattern (e.g. structured query) still renders path/lineno coloring.
+    #[test]
+    fn grep_path_and_lineno_styled_without_pattern() {
+        let lines = render_tool(
+            "Grep",
+            json!({ "path": "." }),
+            "src/main.rs:42:fn main() {}",
+        );
+        // File path span should be present and styled (cyan).
+        let path_span = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .find(|s| s.content.as_ref() == "src/main.rs");
+        assert!(
+            path_span.is_some(),
+            "Grep file path span missing — render_grep_line dispatch broken"
+        );
+        assert!(
+            path_span.unwrap().style.fg.is_some(),
+            "Grep file path should have a foreground color"
+        );
+    }
+
+    // ── collapse_blank_lines ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_collapse_preserves_single_blank() {
+        assert_eq!(collapse_blank_lines("a\n\nb"), "a\n\nb");
+    }
+
+    #[test]
+    fn test_collapse_many_blanks() {
+        assert_eq!(collapse_blank_lines("a\n\n\n\n\nb"), "a\n\nb");
+    }
+
+    #[test]
+    fn test_collapse_no_blanks() {
+        assert_eq!(collapse_blank_lines("a\nb\nc"), "a\nb\nc");
+    }
+
+    #[test]
+    fn test_collapse_all_blank() {
+        assert_eq!(collapse_blank_lines("\n\n\n\n"), "\n");
     }
 }


### PR DESCRIPTION
## Problem

`syntect::parsing::SyntaxSet::load_defaults_newlines()` ships with a slim grammar set that **silently omits TOML, TypeScript, Kotlin, Swift, Zig, Lua, Dockerfile, Protocol Buffers, and ~180 other languages**. Reading any such file through the Read tool no-opped through `CodeHighlighter` — `find_syntax_by_token` and `find_syntax_by_extension` both returned `None` — leaving content rendered as flat default-foreground spans.

Most visible victim: every `Cargo.toml`. v0.2.16's CHANGELOG promises *"syntax-highlighted Read"* — half-true today.

## Competitive landscape

| Agent | Library | TOML support | Languages |
|---|---|---|---|
| claude code | cli-highlight (highlight.js) | ✅ | ~190 |
| gemini-cli | highlight.js v11 | ✅ | ~190 |
| **codex** (Rust) | syntect + **two-face 0.5** | ✅ | **~250** |
| **koda** (today) | syntect defaults | ❌ | ~70 |

Every competitor handles TOML. Codex — the closest peer (also Rust, also syntect) — landed on `two-face`. Industry consensus.

## Fix

Swap `SYNTAX_SET` constructor:
```rust
// before
static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
// after
static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(two_face::syntax::extra_newlines);
```

Add a `find_syntax()` helper (mirroring codex's pattern): tries token → exact name → case-insensitive name → extension. Patches common LLM-emitted aliases (`csharp`, `golang`, `python3`, `shell`) that two-face doesn't resolve directly.

`two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }` — `syntect-fancy` keeps us on the pure-Rust regex engine matching our existing syntect dep config (no `libonig` C dep added).

## Tests

**16 new tests, zero existing tests touched, 1,433 workspace tests green, clippy clean.**

`koda-cli/src/highlight.rs` (5 new):
- `toml_resolves_with_two_face` — headline regression
- `typescript_resolves_with_two_face`
- `common_languages_all_resolve` — Rust, Python, JS, TS, TOML, JSON, YAML, Markdown, Bash, Go, HTML, CSS, Kotlin, Swift, Lua, Protobuf
- `llm_aliases_resolve_via_patching` — golang, python3, shell, csharp, c-sharp
- `toml_produces_colored_spans` — proves multi-span output for TOML input

`koda-cli/src/tui_render.rs` (11 new):
- 5 E2E pipeline tests for **Read** (TOML, Rust, TS, unknown ext, extensionless) — drives `TuiRenderer → ScrollBuffer` and asserts multi-span colored output
- 5 E2E pipeline tests for **List/Glob/Grep** — closes the gap where `tool_output_lines` unit tests bypassed the dispatch in `render_tool_output`. Catches bugs like tool name typos or extension extraction quirks that would silently flatten output

## Out of scope

Six read-only tools (WebFetch, WebSearch, MemoryRead, TodoRead, ListAgents/ListSkills) still render as flat ANSI passthrough. `MemoryRead` (JSON) and `WebFetch` (Markdown) deserve dedicated treatment. Tracked separately.