### PR TITLE
chore: P3 cleanup batch from v0.2.16 release review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]    # Catch post-merge config drift on protected branch
   pull_request:
     branches: [main]
   workflow_call:        # Called by other workflows

--- a/koda-cli/src/hyperlink.rs
+++ b/koda-cli/src/hyperlink.rs
@@ -35,6 +35,7 @@
 //! or remove the modifier from [`crate::theme::PATH`], not to ship a
 //! knob.
 
+use crate::theme;
 use ratatui::buffer::{Buffer, Cell};
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier};
@@ -81,13 +82,16 @@ fn link_paths_in_row(buf: &mut Buffer, area: Rect, y: u16, project_root: &Path) 
     }
 }
 
-/// Cell predicate: matches `theme::PATH` exactly (cyan fg + underlined).
+/// Cell predicate: matches the `theme::PATH` style.
 ///
-/// We deliberately match the *style* not the modifier alone so unrelated
-/// underlined text (e.g. markdown emphasis if it ever lands underlined)
-/// doesn't get linkified.
+/// We follow `theme::PATH.fg` (rather than hard-coding `Color::Cyan`) so
+/// future theme changes — dark/light variants, user themes — remain in
+/// sync without anyone having to remember to update this predicate.
+/// The `UNDERLINED` modifier is matched via `contains` so cells that pick
+/// up extra modifiers downstream (e.g. cursor highlight) still linkify.
 fn is_path_cell(cell: &Cell) -> bool {
-    cell.fg == Color::Cyan && cell.modifier.contains(Modifier::UNDERLINED)
+    cell.fg == theme::PATH.fg.unwrap_or(Color::Reset)
+        && cell.modifier.contains(Modifier::UNDERLINED)
 }
 
 /// Resolve the visible text of a path run to a URI suitable for OSC 8.
@@ -134,10 +138,22 @@ fn resolve_uri(text: &str, project_root: &Path) -> Option<String> {
 /// A malicious / malformed upstream value containing `\x1B` or `\x07`
 /// could otherwise break out of the OSC 8 payload and inject arbitrary
 /// terminal control sequences. Same defense codex applies.
+///
+/// Logs at `debug` when stripping happens — these bytes are exotic
+/// (most filesystems disallow them) so any hit is worth seeing in
+/// support traces, even though the runtime defense is silent.
 fn escape_url(raw: &str) -> String {
-    raw.chars()
+    let cleaned: String = raw
+        .chars()
         .filter(|&c| c != '\x1B' && c != '\x07')
-        .collect()
+        .collect();
+    if cleaned.len() != raw.len() {
+        tracing::debug!(
+            stripped = raw.len() - cleaned.len(),
+            "escape_url: stripped ESC/BEL bytes from URI"
+        );
+    }
+    cleaned
 }
 
 /// Replace the symbol of every cell in `[start, end)` of row `y` with

--- a/koda-cli/src/theme.rs
+++ b/koda-cli/src/theme.rs
@@ -206,7 +206,9 @@ pub const WARM_INFO: Style = Style::new().fg(Color::Rgb(198, 165, 106));
 /// (e.g. monochrome themes) — users get a one-flag escape hatch instead
 /// of having to file a bug.
 ///
-/// Checked once at process start (env-var reads aren't free in hot paths).
+/// Memoized after the first call — the env var is read once via a
+/// `OnceLock` so subsequent invocations are a load+branch with zero
+/// allocation. Process restarts pick up env-var changes.
 pub fn syntax_highlight_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();

--- a/koda-cli/src/tool_header.rs
+++ b/koda-cli/src/tool_header.rs
@@ -30,14 +30,25 @@
 
 use crate::highlight;
 use crate::theme::{self, BOLD, DIM};
-use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use serde_json::Value;
 
-/// Maximum visible chars for inline command/detail text in headers.
+/// Maximum visible bytes for inline command/detail text in TUI headers.
 ///
-/// Keeps `git commit -m "huge multiline message…"` from blowing past
-/// the viewport. Matches `history_render`'s prior behavior.
+/// Used by [`truncate_for_header`] which slices on byte boundaries
+/// (cheap, ASCII-correct). Matched in value (not unit) by
+/// [`MAX_DETAIL_CHARS`] which serves the char-based path used by
+/// transcript export. The two constants share a number deliberately
+/// — same visible cap from both rendering paths — but each name
+/// matches the unit its caller actually uses.
+const MAX_DETAIL_BYTES: usize = 120;
+
+/// Maximum visible chars for transcript-export detail text.
+///
+/// Used by [`generic_text`] which truncates via [`truncate_chars`]
+/// (Unicode-correct, slower). Co-equal to [`MAX_DETAIL_BYTES`] in
+/// value so a single tool-arg renders identically in TUI and
+/// transcript exports for the common ASCII case.
 const MAX_DETAIL_CHARS: usize = 120;
 
 /// Build a complete tool-call header line: dot + name + detail spans.
@@ -156,12 +167,7 @@ fn webfetch_detail(args: &Value) -> Vec<Span<'static>> {
     if url.is_empty() {
         return Vec::new();
     }
-    vec![Span::styled(
-        truncate_for_header(&url),
-        Style::new()
-            .fg(ratatui::style::Color::Cyan)
-            .add_modifier(ratatui::style::Modifier::UNDERLINED),
-    )]
+    vec![Span::styled(truncate_for_header(&url), theme::PATH)]
 }
 
 fn generic_detail(args: &Value) -> Vec<Span<'static>> {
@@ -240,19 +246,19 @@ fn first_string(args: &Value, keys: &[&str]) -> Option<String> {
         .find_map(|k| args.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()))
 }
 
-/// Truncate a header detail to `MAX_DETAIL_CHARS` with an ellipsis.
+/// Truncate a header detail to `MAX_DETAIL_BYTES` with an ellipsis.
 ///
 /// Operates on **bytes** rather than chars deliberately — koda's tool
 /// args are overwhelmingly ASCII (paths, commands, regexes), and a
 /// byte-safe slice via `.char_indices()` keeps us correct for the rare
 /// multi-byte path without overcomplicating the hot path.
 fn truncate_for_header(s: &str) -> String {
-    if s.len() <= MAX_DETAIL_CHARS {
+    if s.len() <= MAX_DETAIL_BYTES {
         return s.to_string();
     }
     let cut = s
         .char_indices()
-        .take_while(|(i, _)| *i < MAX_DETAIL_CHARS - 1)
+        .take_while(|(i, _)| *i < MAX_DETAIL_BYTES - 1)
         .last()
         .map(|(i, c)| i + c.len_utf8())
         .unwrap_or(0);
@@ -274,6 +280,7 @@ fn truncate_chars(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::style::Style;
     use serde_json::json;
 
     fn span_texts(spans: &[Span<'static>]) -> Vec<String> {
@@ -418,11 +425,12 @@ mod tests {
 
     #[test]
     fn truncate_caps_long_input_with_ellipsis() {
-        let long = "x".repeat(MAX_DETAIL_CHARS + 50);
+        let long = "x".repeat(MAX_DETAIL_BYTES + 50);
         let out = truncate_for_header(&long);
         assert!(out.ends_with('\u{2026}'));
-        // Stays under cap (chars, not bytes — ellipsis is multi-byte).
-        assert!(out.chars().count() <= MAX_DETAIL_CHARS);
+        // Stays under cap (chars ≤ bytes for ASCII; ellipsis is multi-byte
+        // but the byte-slice cuts strictly below MAX_DETAIL_BYTES first).
+        assert!(out.chars().count() <= MAX_DETAIL_BYTES);
     }
 
     // ── live ↔ history equivalence ───────────────────────────────────

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -13,7 +13,7 @@
 //! - JSON and plain text are returned as-is
 //! - Output is truncated to context-scaled caps
 //! - Follows redirects (up to 10 hops)
-//! - Timeout: 30 seconds
+//! - Timeout: 15 seconds (see [`DEFAULT_TIMEOUT_SECS`])
 
 use crate::providers::ToolDefinition;
 use anyhow::Result;

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -13,7 +13,7 @@
 //! - JSON and plain text are returned as-is
 //! - Output is truncated to context-scaled caps
 //! - Follows redirects (up to 10 hops)
-//! - Timeout: 15 seconds (see [`DEFAULT_TIMEOUT_SECS`])
+//! - Timeout: 15 seconds (see `DEFAULT_TIMEOUT_SECS`)
 
 use crate::providers::ToolDefinition;
 use anyhow::Result;


### PR DESCRIPTION
## Context

Pre-release sub-agent validation for v0.2.16 surfaced 17 findings — 2 P1 (handled in the release commit itself), 2 P2 (also in the release commit), and 13 P3s. This PR knocks out the **7 quick P3s** so the release captain can ship a cleaner tag instead of carrying a long deferred-issues tail.

The remaining 6 P3s are deferred to their own tracking issues because each adds a new dev-dep, workflow, or architectural surface that deserves its own design discussion.

## What's in scope (7 fixes)

| # | Source | Fix |
|---|---|---|
| 1 | code-reviewer P3 | `tool_header::webfetch_detail` reuses `theme::PATH` instead of rebuilding cyan+underlined inline |
| 2 | code-reviewer P3 | Split `MAX_DETAIL_CHARS` (char-based, used by transcript export) from new `MAX_DETAIL_BYTES` (byte-based, used by `truncate_for_header`); both at 120 |
| 3 | code-reviewer P3 | `hyperlink::is_path_cell` follows `theme::PATH.fg` instead of hard-coded `Color::Cyan` |
| 4 | code-reviewer P3 | `hyperlink::escape_url` logs at `tracing::debug` when stripping ESC/BEL bytes |
| 5 | code-reviewer P3 | `theme::syntax_highlight_enabled` rustdoc — corrected to 'memoized via OnceLock' |
| 6 | security-auditor P3-1 | `web_fetch` module rustdoc — '30 seconds' → '15 seconds (see `DEFAULT_TIMEOUT_SECS`)' |
| 7 | qa-expert | `ci.yml` now also triggers on `push` to main, not only `pull_request` |

## What's deferred (6 P3s, each becomes its own tracking issue post-merge)

- `session: revisit MCP manager ownership` — tracked in #662 Phase 2 architectural plan
- `ci: add windows-latest to test matrix` — needs sandbox-test exclusions + bwrap-equivalent strategy
- `testing: visual-regression snapshots (insta)`
- `testing: property-based hyperlink::escape_* tests (proptest)`
- `testing: terminal-emulator (vt100) integration tests`
- `testing: mutation-test theme::content_style_* (cargo mutants)`
- `ci: soft coverage gate for new modules`

## Verification

- `cargo fmt --all --check`: ✅ clean
- `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings`: ✅ clean
- `cargo test --workspace --lib --features koda-core/test-support`: ✅ **1,433 tests pass**, 0 failed
- All 7 fixes are non-functional (refactor, doc, log, CI trigger) except the `is_path_cell` predicate which now follows theme drift correctly — covered by existing `hyperlink::tests`.

## Why before the release tag

These P3s were flagged *during* v0.2.16 review. Two paths were possible:

1. Ship v0.2.16 with deferred issues filed → fixes drift, two release cycles to consolidate
2. Land them now → cleaner v0.2.16, zero drift, ~30 min PR

Per DESIGN.md P1 ("build only what we need") the P3s themselves are debatable, but per DESIGN.md P3 ("frontier libraries") shipping with known doc lie drift is just technical debt. Quick path was clearly cheaper.