### PR TITLE
chore(release): v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.16] - 2026-04-19
+
+UX-focused release. The TUI now renders syntax highlighting for ~250
+languages (TOML, TypeScript, Kotlin, Swift, Lua, …) instead of falling
+back to flat white, file paths in tool-call output and transcript
+exports are clickable hyperlinks, and the rendering layer is split into
+a dedicated `theme` module so future appearance changes ripple through
+in one place. No `koda-core` API changes — patch-compatible with v0.2.15.
+
 ### Added
 - **Clickable file paths in the live TUI.** Every file path styled with
   `theme::PATH` (cyan + underlined) — tool-call headers, `Grep`/`Glob`/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -51,3 +51,26 @@ priority over global config:
 | `.koda/agents/` | Project-specific agent definitions |
 | `.koda/skills/` | Project-specific skills |
 | `MEMORY.md` | Project memory (also checks `CLAUDE.md`, `AGENTS.md`) |
+
+## Display
+
+Koda's TUI ships ANSI-colored syntax highlighting and OSC 8 hyperlinks by
+default — both have one-flag escape hatches for environments where the
+output looks awful (monochrome themes, non-OSC-8-aware terminals that
+leak escape bytes, etc.).
+
+| Env var | Default | Disable with |
+|---------|---------|--------------|
+| `KODA_SYNTAX_HIGHLIGHT` | on | `off`, `0`, `false`, or `no` |
+| `KODA_TRANSCRIPT_HYPERLINKS` | on | `off`, `0`, `false`, or `no` |
+
+- **`KODA_SYNTAX_HIGHLIGHT`** controls TUI syntax highlighting for
+  `Read`, `Bash` headers, and inline code. Disable for monochrome
+  terminals or terminals where ANSI-RGB output looks washed out.
+  Memoized on first call — restart koda after changing.
+- **`KODA_TRANSCRIPT_HYPERLINKS`** controls markdown-style hyperlinks
+  in `/copy` and `/export` output. Disable if you paste transcripts
+  into a viewer that mangles `[text](file:///abs/path)` syntax.
+
+Both flags accept the same negative values; everything else (including
+empty string and `on`) keeps the feature enabled.

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.15" }
+koda-core = { path = "../koda-core", version = "0.2.16" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -78,6 +78,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3"
-koda-core = { path = "../koda-core", version = "0.2.15", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.16", features = ["test-support"] }
 serde_json = "1"
 

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -176,33 +176,6 @@ impl CodeHighlighter {
     }
 }
 
-/// Pre-highlight an entire file, returning styled spans per line.
-///
-/// Maintains syntect parse state across lines for correct multiline
-/// string / comment / heredoc highlighting. Used by the diff renderer
-/// to look up pre-computed highlights by line number.
-///
-/// Returns one `Vec<Span>` per **source line** (trailing newlines stripped).
-/// Empty input returns an empty vec.
-///
-/// # Example
-///
-/// ```ignore
-/// use koda_cli::highlight::pre_highlight;
-///
-/// // Two Rust lines → two span vecs
-/// let lines = pre_highlight("fn main() {}\nlet x = 42;", "rs");
-/// assert_eq!(lines.len(), 2);
-/// // Each vec contains at least one span
-/// for span_vec in &lines {
-///     assert!(!span_vec.is_empty());
-/// }
-///
-/// // Unknown extension falls back to a single unstyled span per line
-/// let plain = pre_highlight("hello\nworld", "xyz_unknown");
-/// assert_eq!(plain.len(), 2);
-/// assert_eq!(plain[0][0].content.as_ref(), "hello");
-/// ```
 /// Highlight a short snippet inline (no newlines) and return spans.
 ///
 /// Designed for one-row UI surfaces (tool-call headers, status banners)
@@ -279,6 +252,33 @@ mod inline_tests {
     }
 }
 
+/// Pre-highlight an entire file, returning styled spans per line.
+///
+/// Maintains syntect parse state across lines for correct multiline
+/// string / comment / heredoc highlighting. Used by the diff renderer
+/// to look up pre-computed highlights by line number.
+///
+/// Returns one `Vec<Span>` per **source line** (trailing newlines stripped).
+/// Empty input returns an empty vec.
+///
+/// # Example
+///
+/// ```ignore
+/// use koda_cli::highlight::pre_highlight;
+///
+/// // Two Rust lines → two span vecs
+/// let lines = pre_highlight("fn main() {}\nlet x = 42;", "rs");
+/// assert_eq!(lines.len(), 2);
+/// // Each vec contains at least one span
+/// for span_vec in &lines {
+///     assert!(!span_vec.is_empty());
+/// }
+///
+/// // Unknown extension falls back to a single unstyled span per line
+/// let plain = pre_highlight("hello\nworld", "xyz_unknown");
+/// assert_eq!(plain.len(), 2);
+/// assert_eq!(plain[0][0].content.as_ref(), "hello");
+/// ```
 pub fn pre_highlight(content: &str, ext: &str) -> Vec<Vec<ratatui::text::Span<'static>>> {
     // Guardrail: massive files (e.g. minified JS bundles) burn syntect
     // wall-clock without giving the user useful color information — fall

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"


### PR DESCRIPTION
## Release: koda v0.2.16

**Patch bump from v0.2.15.** UX-focused release dominated by TUI rendering improvements (syntax highlighting, OSC 8 hyperlinks, transcript-export markdown links) plus the koda-ast/koda-email crate removals.

`koda-core` is byte-identical to v0.2.15 — no sandbox, path-resolution, or tool-execution code changed. Patch-compatible per semver.

## What's in this PR

### Version bumps
- `koda-core` 0.2.15 → 0.2.16
- `koda-cli` 0.2.15 → 0.2.16 (package + `koda-core` dep + dev-dep pin)
- `Cargo.lock` regenerated
- `koda-test-utils` stays at 0.1.0 (`publish = false`)

### P2 fixes folded in
- **`docs/src/configuration.md`** — new 'Display' section documenting `KODA_SYNTAX_HIGHLIGHT` and `KODA_TRANSCRIPT_HYPERLINKS` (both shipped this release without docs until now)
- **`koda-cli/src/highlight.rs`** — moved orphaned `pre_highlight` rustdoc back where it belongs

## Headline changes since v0.2.15

| PR | What |
|---|---|
| #957 | two-face SyntaxSet: ~250 languages now syntax-highlight in TUI `Read` (TOML, TS, Kotlin, Swift, Lua, ...) |
| #955 | OSC 8 hyperlinks: every path styled `theme::PATH` is Ctrl/Cmd-clickable |
| #953 | Markdown links in `/copy` and `/export` transcripts |
| #952 | Syntax-highlighted bash + path coloring in tool headers |
| #951 | New `theme.rs` module + Glob/Grep/Read color pass |
| #950 | Deleted unused `koda-ast` and `koda-email` crates |
| #958 | 7 P3 quick wins from this release review |

Full notes in [`CHANGELOG.md` § 0.2.16](../blob/release/v0.2.16/CHANGELOG.md#0216---2026-04-19).

## Pre-release verification

| Check | Result |
|---|---|
| `cargo fmt --all --check` | ✅ clean |
| `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` | ✅ clean |
| `cargo test --workspace --lib --features koda-core/test-support` | ✅ **1,433 passed**, 0 failed |
| `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` | ✅ clean |
| `cargo audit` | ✅ 0 vulns (existing `.cargo/audit.toml` ignores stand) |

## Sub-agent review summary

Four agents (code-reviewer, rust-programmer, security-auditor, qa-expert) ran the v0.2.15..HEAD review. 17 findings:

| Bucket | Count | Disposition |
|---|---|---|
| P1 (blocking) | 2 | This commit |
| P2 (in-scope quality) | 2 | This commit |
| P3 quick wins | 7 | Shipped in #958 |
| P3 deferrals | 6 | #959, #960, #961, #962, #963, #964, #965 |

## Manual smoke checks (cannot be automated — human-only)

The qa-expert flagged these as the must-do-before-tag manual verifications. They cover the visual changes that programmatic tests can't see:

- [ ] **M1**: `koda` → `Read Cargo.toml` → confirm syntax coloring (the headline #957 fix)
- [ ] **M2**: ⌘/Ctrl-click a file path in a tool-call header → confirm OSC 8 link works (iTerm2 / Ghostty / VS Code terminal)
- [ ] **M3**: Run a `Grep` with a pattern → confirm match-hit highlighting is legible
- [ ] **M4**: `/copy` a session containing Read+Write+WebFetch → paste into GitHub or Slack → confirm markdown links render
- [ ] **M6**: `KODA_TRANSCRIPT_HYPERLINKS=off` → re-export → confirm plain-text fallback

## After merge

1. Tag `v0.2.16` on the merge commit
2. Push the tag → triggers `.github/workflows/release.yml` → cross-platform binaries + crates.io publish
3. Verify release artifacts at https://github.com/lijunzh/koda/releases/tag/v0.2.16
4. Triage the 6 deferred discussion issues at leisure