### PR TITLE
chore(mcp): document per-session ownership decision (closes #959)

### DIFF
--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -72,9 +72,15 @@ impl KodaSession {
         // Wire db+session into ToolRegistry for RecallContext
         agent.tools.set_session(Arc::new(db.clone()), id.clone());
 
-        // Start MCP servers from DB config (#662)
-        // TODO(#662 Phase 2): Move MCP manager to app-level ownership so
-        // servers are shared across sessions and not duplicated on resume.
+        // Start MCP servers from DB config (#662).
+        //
+        // Per-session ownership is intentional, not pending refactor (see #959).
+        // Codex (closest peer agent) chose the same shape: per-session
+        // `McpConnectionManager` in `SessionServices`, not app-level. App-level
+        // ownership would complicate config-change semantics and lifecycle
+        // management for an unmeasured startup-cost optimization. Reopen #959
+        // if a real bug surfaces (e.g. multi-session resume becomes slow with
+        // many configured servers).
         match crate::mcp::McpManager::start_from_db(&db).await {
             Ok(manager) => {
                 if !manager.is_empty() {


### PR DESCRIPTION
## Summary

Replace the `TODO(#662 Phase 2)` comment in `koda-core/src/session.rs` with a design-decision note. **Per-session `McpManager` ownership is intentional, not pending refactor.**

## Decision rationale

Triaged during v0.2.16 post-release backlog cleanup. Compared three peer agents on MCP manager ownership:

| Agent | Pattern | Notes |
|---|---|---|
| **codex** (Rust, closest peer) | **Per-session** ← matches koda | `SessionServices { mcp_connection_manager: Arc<RwLock<...>> }`. Their `session.rs` even comments about considering `Option`/`OnceCell` and explicitly chose not to refactor — 'the current setup is straightforward enough and performs well.' |
| gemini-cli (TS) | App-level | `Config.mcpClientManager` singleton. Idiomatic for TS god-object `Config` pattern, not a deliberate perf choice. |
| Claude Code (TS) | App-level | `mcpClients` array constructed in `main.tsx`, propagated through React-style component tree. Same TS-idiom story. |

**Score: 1-1-1 with codex on koda's side.** Codex is the directly comparable Rust agent with much more MCP investment than koda.

## Why not lift to app-level

1. Codex (closest peer) made the same call we did
2. Cost is unmeasured — neither #662 nor the TODO cites a benchmark showing per-session ownership actually hurts
3. App-level ownership complicates config-change semantics: changing `/mcp` config in one session leaves stale state in others
4. App-level needs explicit MCP-server lifecycle management; per-session gets automatic cleanup on session end
5. Single-user, single-session usage is dominant; the duplication scenario (two koda terminals running) is rare enough to not pay architectural complexity for

## What this changes

- `koda-core/src/session.rs`: TODO comment replaced with decision note pointing at #959
- **Zero behavior change** — pure documentation update
- No tests touched

## Test plan

- N/A (comment-only edit)
- CI runs full test suite for safety

## Closes

- Closes #959 (the discussion issue)
- #662 already closed; Phase 1 shipped in #945 + #950; Phase 2 declined per this decision

## Context

Final issue from the v0.2.16 post-release P3 triage. Sibling closures in this batch:
- #960 (vt100 tests), #961 (insta snapshots), #962 (proptest), #963 (cargo-mutants), #964 (coverage gate), #965 (windows CI) — all closed with documented rationale during this same triage round.