### PR TITLE
fix(bash): remove xargs from read-only allowlist (closes #968)

### DIFF
--- a/koda-core/src/bash_safety.rs
+++ b/koda-core/src/bash_safety.rs
@@ -96,7 +96,10 @@ const READ_ONLY_PREFIXES: &[&str] = &[
     "diff ",
     "jq ",
     "yq ",
-    "xargs ",
+    // NOTE: `xargs` deliberately excluded — it's a command-runner, not a
+    // read-only filter. `xargs rm` would auto-approve in Safe mode if listed
+    // here. See #968 for the discovery and #969 for the broader sweep of
+    // bare-command misclassification fixes.
     "dirname ",
     "basename ",
     "realpath ",
@@ -743,7 +746,8 @@ mod tests {
             "echo hi | awk",
             "echo hi | tr",
             "echo hi | jq",
-            "echo hi | xargs",
+            // NOTE: `echo hi | xargs` removed — fixed in #968 to correctly
+            // classify as LocalMutation (xargs runs the inner command).
             "ls | wc",
             "find . | sort | uniq",
         ];
@@ -803,6 +807,61 @@ mod tests {
                 classify_bash_command(cmd),
                 ToolEffect::ReadOnly,
                 "bare `{cmd}` must not be misclassified as ReadOnly",
+            );
+        }
+    }
+
+    // xargs classification (#968)
+
+    /// `xargs <cmd>` runs `<cmd>` as a subprocess. It must NOT auto-approve in
+    /// Safe mode, regardless of which inner command is invoked. Removing
+    /// `xargs` from READ_ONLY_PREFIXES makes any pipeline with an `xargs`
+    /// segment fall through to LocalMutation.
+    #[test]
+    fn test_classify_xargs_with_destructive_inner_not_read_only() {
+        for cmd in [
+            "ls | xargs rm",
+            "find . -name '*.tmp' | xargs rm",
+            "echo file | xargs rm -rf",
+            "ls | xargs mv -t /tmp",
+            "echo a b c | xargs cp -t /backup",
+        ] {
+            assert_ne!(
+                classify_bash_command(cmd),
+                ToolEffect::ReadOnly,
+                "`{cmd}` must NOT be ReadOnly — xargs runs the inner command",
+            );
+        }
+    }
+
+    /// Even `xargs <read-only-cmd>` should not auto-approve. We can't safely
+    /// inspect the inner command without a real parser, so the conservative
+    /// stance is to require approval for *all* xargs invocations.
+    #[test]
+    fn test_classify_xargs_with_read_only_inner_still_not_auto_approved() {
+        for cmd in ["ls | xargs grep foo", "ls | xargs cat", "ls | xargs wc"] {
+            assert_ne!(
+                classify_bash_command(cmd),
+                ToolEffect::ReadOnly,
+                "`{cmd}` should require approval — xargs is opaque to the classifier",
+            );
+        }
+    }
+
+    /// Removing `xargs` from the prefix list must not regress unrelated
+    /// read-only pipelines.
+    #[test]
+    fn test_classify_non_xargs_pipelines_still_read_only() {
+        for cmd in [
+            "ls | grep foo",
+            "cat file | sort | uniq",
+            "find . | head -20",
+            "git log | grep WIP",
+        ] {
+            assert_eq!(
+                classify_bash_command(cmd),
+                ToolEffect::ReadOnly,
+                "`{cmd}` should still be ReadOnly",
             );
         }
     }


### PR DESCRIPTION
## Summary

`xargs` is fundamentally a command-runner, not a read-only filter. Listing it in `READ_ONLY_PREFIXES` made every `<pipeline> | xargs <cmd>` auto-approve in Safe mode — including **`xargs rm`, `xargs mv`**, etc.

## Severity (higher than it looks)

`rm -rf` in raw text is caught by Phase 1 `RAW_DANGER_PATTERNS`, but `xargs rm` **evades** that because the `rm` isn't directly in the command line — it's a token argument to xargs.

A model could compose `find . -name '*.tmp' | xargs rm` and koda would auto-approve it without a confirmation prompt. **This is a real Safe-mode escape hatch.**

## Repro

| Command | Before | After |
|---|---|---|
| `ls \| xargs rm` | `ReadOnly` ❌ | `LocalMutation` ✅ |
| `find . -name '*.tmp' \| xargs rm` | `ReadOnly` ❌ | `LocalMutation` ✅ |
| `echo file \| xargs rm -rf` | `ReadOnly` ❌ | `LocalMutation` ✅ |
| `ls \| xargs grep foo` | `ReadOnly` ❌ | `LocalMutation` ✅ |

## Discovery

Surfaced during PR #969 (fix for #944) when broader test coverage asserted `assert_ne!(classify_bash_command("ls | xargs rm"), ReadOnly)` — the pre-existing classifier failed it. Filed as #968 for focused triage; this is the fix.

## Fix

Single-line change: remove `"xargs "` from `READ_ONLY_PREFIXES`. Replaced with an explanatory comment so future contributors don't add it back.

```diff
     "jq ",
     "yq ",
-    "xargs ",
+    // NOTE: `xargs` deliberately excluded — it's a command-runner, not a
+    // read-only filter. `xargs rm` would auto-approve in Safe mode if listed
+    // here. See #968 for the discovery and #969 for the broader sweep of
+    // bare-command misclassification fixes.
     "dirname ",
```

Conservative stance: even `xargs grep` (read-only inner command) requires approval. The classifier can't safely inspect the inner command without a real parser, and inconsistent treatment would be worse than uniform conservative gating.

## Tests

Added 3 new test cases in `bash_safety::tests`:

- `test_classify_xargs_with_destructive_inner_not_read_only` — primary bug coverage
- `test_classify_xargs_with_read_only_inner_still_not_auto_approved` — conservative-stance documentation
- `test_classify_non_xargs_pipelines_still_read_only` — regression coverage for `grep`/`sort`/`uniq`/etc.

**Also updated `test_classify_bare_pipeline_tail_is_read_only`** (added in #969) to remove the `echo hi | xargs` case — that test was predicated on the bug this PR fixes. Self-correcting test history is OK; it shows the bug class wasn't fully understood until this PR.

**Test results:** 22/22 `bash_safety` tests pass + 34/34 `trust` tests pass. Pre-push clippy clean.

## Out-of-scope follow-up (filed as #970)

Same investigation revealed that `env` has the **identical bug pattern**: `env cargo build` is classified as ReadOnly because `"env"` is in `READ_ONLY_PREFIXES`. `env` runs whatever command follows it.

Filed as **#970** for separate triage. Same fix shape (remove from prefix list), but minor regression to consider (bare `env` listing env vars would now require approval — `printenv` is the cleaner alternative anyway).

## Closes

- Closes #968

## Related

- PR #969 (fix for #944) — the broader pipeline-classification work that exposed this
- #970 — `env` sibling bug, same class