### PR TITLE
fix(context): meter no longer exceeds 100% on multi-tool-call turns (closes #946)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -960,6 +960,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                     ),
                 });
             }
+            // `last_prompt_tokens` (this iteration's prompt size) drives the
+            // context-window % meter: it reflects current context occupancy.
+            // `total_prompt_tokens` (cumulative across iterations) drives the
+            // Footer billing line. Conflating them caused #946 — see below.
+            let last_prompt_tokens = usage.prompt_tokens;
             total_prompt_tokens += usage.prompt_tokens;
             total_completion_tokens += usage.completion_tokens;
             total_cache_read_tokens += usage.cache_read_tokens;
@@ -988,9 +993,15 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             // underreports for code, tool results, and JSON payloads.
             // This corrective event fires once per completed turn, after all
             // tool calls resolve, so the status bar reflects real usage.
-            crate::context::update(total_prompt_tokens as usize, config.max_context_tokens);
+            //
+            // We use `last_prompt_tokens` (most recent iteration) rather than
+            // `total_prompt_tokens` (cumulative across iterations) because the
+            // meter measures *current context-window occupancy*, not cumulative
+            // billing. Summing iterations would double-count the shared history
+            // and let the meter exceed 100% on multi-tool-call turns (#946).
+            crate::context::update(last_prompt_tokens as usize, config.max_context_tokens);
             sink.emit(EngineEvent::ContextUsage {
-                used: total_prompt_tokens as usize,
+                used: last_prompt_tokens as usize,
                 max: config.max_context_tokens,
             });
 
@@ -1008,7 +1019,11 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             return Ok(());
         }
 
-        // Accumulate token usage across iterations
+        // Accumulate token usage across iterations.
+        // (`last_prompt_tokens` is scoped to the no-tool-calls terminating
+        // branch above — the only reader of it. Each loop iteration creates
+        // its own binding when that branch runs, so there's nothing to update
+        // here for the meter.)
         total_prompt_tokens += usage.prompt_tokens;
         total_completion_tokens += usage.completion_tokens;
         total_cache_read_tokens += usage.cache_read_tokens;

--- a/koda-core/tests/inference_context_test.rs
+++ b/koda-core/tests/inference_context_test.rs
@@ -97,3 +97,80 @@ async fn context_percentage_reflects_actual_tokens_after_turn() {
          Footer.prompt_tokens ({footer_tokens})"
     );
 }
+
+/// Regression test for #946: the context-usage meter must NOT exceed 100%
+/// on multi-iteration turns. Each iteration's `prompt_tokens` reports the
+/// full prompt size (not a delta), so summing across iterations double-counts
+/// the shared history. The corrective `ContextUsage` must reflect the *last*
+/// iteration's `prompt_tokens` (current context-window occupancy), while the
+/// `Footer` keeps the cumulative sum (billing/telemetry).
+///
+/// Three-iteration turn (tool_call → tool_call → text), MockProvider reports
+/// `prompt_tokens: 10` per iteration:
+///   - last_prompt_tokens = 10 — single prompt's footprint  → ContextUsage
+///   - total_prompt_tokens = 30 — cumulative billing for the turn → Footer
+///
+/// Pre-fix bug: ContextUsage.used was 30, exceeding `max_context_tokens = 25`
+/// and rendering as 120% in the status bar. Post-fix: 10/25 = 40%.
+#[tokio::test]
+async fn context_meter_uses_last_iteration_not_sum() {
+    // Tight max so the bug would manifest as a clear >100% overflow.
+    let env = Env::builder().max_context_tokens(25).build().await;
+    env.insert_user_message("do two things then summarise")
+        .await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call("Bash", serde_json::json!({"command": "echo one"})),
+        MockResponse::tool_call("Bash", serde_json::json!({"command": "echo two"})),
+        MockResponse::Text("Both done.".into()),
+    ]);
+    let (result, events) = env.run_inference_result(&provider).await;
+    assert!(result.is_ok(), "inference must succeed: {:?}", result.err());
+
+    let last_context_used = events
+        .iter()
+        .filter_map(|e| match e {
+            EngineEvent::ContextUsage { used, .. } => Some(*used),
+            _ => None,
+        })
+        .next_back()
+        .expect("at least one ContextUsage event required");
+
+    let footer_tokens = events
+        .iter()
+        .find_map(|e| match e {
+            EngineEvent::Footer { prompt_tokens, .. } => Some(*prompt_tokens),
+            _ => None,
+        })
+        .expect("Footer event must be emitted");
+
+    // The corrective meter must reflect the LAST iteration's prompt size.
+    assert_eq!(
+        last_context_used, 10,
+        "ContextUsage.used must be the last iteration's prompt_tokens (10), \
+         not the cumulative sum — got {last_context_used} (#946)"
+    );
+
+    // The Footer must still report the cumulative sum (3 iterations × 10 = 30).
+    assert_eq!(
+        footer_tokens, 30,
+        "Footer.prompt_tokens must remain the cumulative sum across iterations \
+         (3 iterations × 10 = 30), got {footer_tokens}"
+    );
+
+    // The two values MUST diverge for multi-iteration turns — that's the whole
+    // point of the fix. If they're equal, the meter is still summing.
+    assert_ne!(
+        last_context_used as i64, footer_tokens,
+        "ContextUsage.used and Footer.prompt_tokens must diverge on \
+         multi-iteration turns (they're measuring different things)"
+    );
+
+    // The headline regression: meter must never exceed 100% under normal use.
+    // Pre-fix this would be 30/25 = 120%.
+    assert!(
+        last_context_used <= 25,
+        "context meter must never exceed max_context_tokens — \
+         got {last_context_used}/25 (#946 regression)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #946: the context-usage meter in the status bar was exceeding 100% (`139%` in the user repro screenshot) on multi-tool-call turns because `prompt_tokens` was being summed across every iteration of the inference loop, double-counting the shared history.

## Root cause

`koda-core/src/inference.rs` was using `total_prompt_tokens` (the cumulative sum across iterations) for *both* the `Footer` billing line *and* the `ContextUsage` meter event. Each iteration's `prompt_tokens` reports the **full prompt** sent on that call (which includes the bulk of the same history every time), so summing inflates the apparent context occupancy by ~N×.

## Two distinct values were conflated

| Value | Measures | Belongs in |
|---|---|---|
| Sum of `prompt_tokens` across iterations | Cumulative tokens billed for this turn | `Footer.prompt_tokens` (telemetry) |
| Last iteration's `prompt_tokens` | Largest single prompt actually sent = current context occupancy | `ContextUsage.used` (the % meter) |

## Fix

```diff
+let last_prompt_tokens = usage.prompt_tokens;
 total_prompt_tokens += usage.prompt_tokens;
 ...
-crate::context::update(total_prompt_tokens as usize, config.max_context_tokens);
+crate::context::update(last_prompt_tokens as usize, config.max_context_tokens);
 sink.emit(EngineEvent::ContextUsage {
-    used: total_prompt_tokens as usize,
+    used: last_prompt_tokens as usize,
     max: config.max_context_tokens,
 });

 sink.emit(EngineEvent::Footer {
     prompt_tokens: total_prompt_tokens,  // unchanged — billing is cumulative
     ...
 });
```

`last_prompt_tokens` is scoped to the no-tool-calls terminating branch (the only place that emits `ContextUsage`). The made-tool-calls branch doesn't need to touch it — the next iteration overwrites before any read anyway. Scoping the binding makes the data flow obvious and avoids a dead-write clippy warning.

## Behavior

| Scenario | Before fix | After fix |
|---|---|---|
| Single-iteration turn (no tool calls) | meter = 10, footer = 10 ✅ | meter = 10, footer = 10 ✅ (unchanged) |
| 3-iteration turn (tool→tool→text) | meter = **30** ❌ (overflow!) | meter = 10, footer = 30 ✅ |
| Long session, many tool calls | meter > 100% (#946 bug) | meter ≤ 100% always |

## Tests

New regression test: `context_meter_uses_last_iteration_not_sum`.

Three-iteration turn with `max_context_tokens = 25` to make the bug manifest as a clear overflow:

```rust
let provider = MockProvider::new(vec![
    MockResponse::tool_call("Bash", json!({"command": "echo one"})),
    MockResponse::tool_call("Bash", json!({"command": "echo two"})),
    MockResponse::Text("Both done.".into()),
]);
// asserts:
//  - last_context_used == 10  (single iteration's prompt size)
//  - footer_tokens     == 30  (cumulative, 3 iterations × 10)
//  - last_context_used != footer_tokens  (must diverge on multi-iter)
//  - last_context_used <= 25  (the headline regression: never exceeds max)
```

Existing tests (`corrective_context_usage_uses_actual_prompt_tokens`, `context_percentage_reflects_actual_tokens_after_turn`) keep passing — for single-iteration turns `last == total == 10`, so their contracts still hold.

## Verification

- ✅ 3/3 `inference_context_test` pass
- ✅ 995/995 `koda-core` lib tests pass (no regressions)
- ✅ `cargo fmt --all --check` clean
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` clean

## Closes

- Closes #946

## Knock-on effects considered

- `CONTEXT_WARN_THRESHOLD` / `AUTO_COMPACT_THRESHOLD` comparisons in `assemble_context()` are unaffected — that path uses the heuristic estimate, not the cumulative sum. Auto-compact triggered from the **corrected** value at turn-end may now fire less aggressively (which is correct — it was previously firing on inflated values).
- `Footer.prompt_tokens` is unchanged — cumulative is the right value for "tokens billed this turn".
