### PR TITLE
chore(ci): split lints into parallel jobs + add advisory semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,94 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+# ── Job topology ─────────────────────────────────────────────────────────────
+#
+# Each job has ONE responsibility (Zen of Python: "There should be one — and
+# preferably only one — obvious way to do it.") so PR check labels surface
+# exactly what broke without grepping the log:
+#
+#   fmt     → formatting
+#   clippy  → lints + compile WITH test-support features (full lint surface)
+#   check   → compile sanity WITHOUT features (what crates.io users see)
+#   semver  → public API stability for koda-core (the only published lib crate)
+#   test    → behaviour, matrix on (ubuntu, macos)
+#   doc     → doc compile + intra-doc links + -Dwarnings
+#   audit   → dependency vulnerabilities
+#
+# All jobs run in parallel; wall-clock is gated by the slowest (test ≈ 3min).
+#
+# Why both `clippy` and `check`? They run with different feature sets:
+#   - clippy enables `koda-core/test-support` (covers the full code surface)
+#   - check uses no features (validates the crates.io shape)
+# This works only because koda-core has zero `#[cfg(not(feature = "..."))]`
+# code today. If that changes, clippy will stop covering the no-features
+# path and you'll want a second clippy run with --no-default-features.
+
 jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: rustfmt
+      # No rust-cache — fmt doesn't compile anything. Skipping cache saves
+      # the ~10s setup overhead and keeps the job at ~30s end-to-end.
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
+        with:
+          shared-key: clippy-Linux
+      - run: cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings
+
+  check:
+    name: Check (no features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
+        with:
+          shared-key: check-Linux
+      # Catches cfg-gated items invisible behind feature flags. This is the
+      # crates.io consumer build — koda-core ships without test-support.
+      - run: cargo check --workspace --all-targets
+
+  semver:
+    name: SemVer (koda-core)
+    runs-on: ubuntu-latest
+    # ADVISORY at first: continue-on-error keeps this from blocking PRs
+    # while we observe its output across a few real changes. Once we've
+    # confirmed it's not flagging false positives on koda-core's API
+    # surface, flip continue-on-error to false and add it to the branch
+    # protection required-checks list.
+    #
+    # Only the published library crate is checked. koda-cli is a binary
+    # (no API contract) and koda-test-utils is unpublished. Adding more
+    # crates later is a one-line change in `package`.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
+        with:
+          shared-key: semver-Linux
+      # The official action handles tool install, baseline fetch, and the
+      # current==latest edge case (it'll skip the check and report a hint
+      # rather than fail noisily).
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: koda-core
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -29,24 +116,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
         with:
           shared-key: ci-${{ runner.os }}
-      # Lint steps run only on Linux to avoid duplicate noise.
-      # If macOS-specific code triggers a lint that Linux misses, the
-      # platform-specific clippy/check in release.yml still catches it.
-      - name: Format
-        if: runner.os == 'Linux'
-        run: cargo fmt --all --check
-      - name: Clippy
-        if: runner.os == 'Linux'
-        run: cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings
-      - name: Check (no features)
-        if: runner.os == 'Linux'
-        # Catches cfg-gated items invisible behind feature flags.
-        run: cargo check --workspace --all-targets
       - name: Set up Linux sandbox (bubblewrap)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary

Splits the monolithic `test` job in `ci.yml` into **7 single-responsibility parallel jobs** and adds an advisory `cargo-semver-checks` gate for the published `koda-core` crate.

## Why now

PR #978's CI failure today is the canonical motivator: "Test (ubuntu-latest) ❌" surfaced as the failing label, but it could have been any of fmt / clippy / check / actual tests bundled inside that one job. The user had to ask, I had to dig the log. **Granular check labels eliminate that whole dance.**

## Job topology (after)

| Job | One thing it owns | Approx time |
|---|---|---|
| `Format` | `cargo fmt --all --check` | ~30s |
| `Clippy` | Lints + compile WITH `koda-core/test-support` (full surface) | ~90s |
| `Check (no features)` | Compile sanity WITHOUT features — what crates.io users see | ~60s |
| `SemVer (koda-core)` | Public API stability for the published lib crate (advisory) | ~30s |
| `Test (ubuntu-latest)` | Behaviour | ~3min |
| `Test (macos-latest)` | Behaviour, second platform | ~3min |
| `Docs` | `cargo doc -Dwarnings` (existing) | ~30s |
| `Security Audit` | `cargo audit` (existing) | ~30s |

All run **in parallel**. Wall-clock is gated by the slowest (test ≈ 3min) — same as today, **way better signal**.

## Why both `Clippy` and `Check`?

They run with **different feature sets**:

- `Clippy` enables `koda-core/test-support` → covers the full code surface for lints
- `Check` uses no features → validates the build crates.io consumers actually get

Today `koda-core` has **zero `#[cfg(not(feature = "..."))]`** blocks, so the no-features build is a strict subset of with-features. Clippy on the test-support config already lints all the code; `check` is purely the "downstream consumer compile sanity" gate. The YAML comments call this out explicitly so future-me doesn't quietly add a `cfg(not(feature))` without also splitting clippy in two.

(Considered merging `check` into a second clippy run with `--no-default-features`, but per discussion that'd be doing two jobs in one tool and is ~25% slower for no real gain on a codebase without `cfg(not)` paths. **One tool, one job** wins.)

## Why advisory SemVer at first

`koda-core` is published to crates.io. `cargo-semver-checks` catches accidental breaking changes before release — which matters more, not less, given the recent pace of patch releases (5 in one day on 2026-04-19/20).

**Concrete near-miss:** PR #969 changed how `READ_ONLY_PREFIXES` matched. If that constant had been `pub`, semver-checks would have flagged it. We got lucky.

`continue-on-error: true` means the job runs but doesn't block PRs while we observe its output for a few real changes. **Once it's proven not to false-positive on koda-core's actual API surface, flip the flag to `false` and add `SemVer (koda-core)` to branch protection's required-checks list.**

Uses the official `obi1kenobi/cargo-semver-checks-action@v2` which handles the tool install, baseline fetch from crates.io, and the `current==latest` edge case gracefully.

## Migration safety

- ✅ `release.yml`'s `test` job is independently defined — no cross-references to `ci.yml`'s job structure.
- ✅ Existing required-check names (`Test (ubuntu-latest)`, `Test (macos-latest)`, `Docs`, `Security Audit`) are all **preserved**. Branch protection keeps working.
- ✅ The 4 new jobs (`Format`, `Clippy`, `Check (no features)`, `SemVer (koda-core)`) are additive — admin can opt them into branch protection separately when ready.
- ✅ No breaking changes to `workflow_call` callers (none currently exist anyway).
- ✅ YAML validates (`yaml.safe_load`).

## Verification

This PR itself is the first real test of the new topology — if any of fmt/clippy/check surface real issues we'll know in **30-90 seconds** instead of waiting ~3 min for the bundled test job.

## Follow-ups (not in this PR)

- After ~5 PRs of clean semver runs: flip `continue-on-error: false` and require it in branch protection
- If `koda-core` ever grows a `#[cfg(not(feature = "..."))]` block: split `Clippy` into `Clippy (with-features)` + `Clippy (no-features)` and drop the standalone `Check` job
- Could add `coverage.yml` integration but that's a bigger separate conversation
