### PR TITLE
chore(hooks): trim pre-push to fmt-only (CI now handles the rest)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,17 +1,24 @@
 #!/usr/bin/env bash
-# .githooks/pre-push — fast local sanity check before pushing.
+# .githooks/pre-push — minimal local sanity check before pushing.
 #
-# Philosophy: catch trivial mistakes (typos, formatting) that would
-# fail CI in 60+ minutes and block a push for nothing. Everything
-# else — full test suite, feature-gated builds, integration tests —
-# runs in CI on both ubuntu-latest and macos-latest. Trust CI.
+# Philosophy: catch the ONE failure mode that's both (a) cheap to verify
+# locally and (b) maximally embarrassing to ship to CI — formatting.
+# Everything else (clippy, check, semver, tests, audit, docs) runs as
+# parallel jobs in CI with sub-2-minute granular feedback. Trust CI.
+#
+# History: this hook used to also run `cargo clippy --workspace`, costing
+# ~50-90s per push. Across a representative sample of pushes, clippy
+# locally caught 0 issues vs ~5 minutes of cumulative wait. Net negative
+# on dev time once CI was split into per-tool jobs (see PR #979) where
+# each lint failure surfaces as its own red label in <2 min — without
+# spinning up your laptop fans.
 #
 # Skip with `git push --no-verify` if you need to push WIP.
 #
 # One-time setup (per clone):
 #   git config core.hooksPath .githooks
 #
-# For comprehensive pre-PR validation (the old behavior), run:
+# For comprehensive pre-PR validation (full clippy + tests + audit), run:
 #   ./scripts/preflight.sh
 
 set -euo pipefail
@@ -25,31 +32,15 @@ ok()   { echo -e "${GREEN}✓${NC} $*"; }
 fail() { echo -e "${RED}✗${NC} $*"; }
 info() { echo -e "${YELLOW}→${NC} $*"; }
 
-info "Running pre-push checks (skip with --no-verify)..."
-echo
+info "Running pre-push fmt check (skip with --no-verify)..."
 
 # --- Format ------------------------------------------------------------------
-# Instant, and a fmt failure in CI is the most annoying possible reason
-# to wait an hour for a re-run.
-info "cargo fmt --check"
+# Instant (~1s), and a fmt failure in CI is the most annoying possible reason
+# to wait for a re-run. This is the entire hook now — clippy/check/test all
+# run in parallel CI jobs with their own granular pass/fail labels.
 if cargo fmt --all --check; then
-    ok "fmt clean"
+    ok "fmt clean — pushing. (clippy + tests + semver run in CI)"
 else
     fail "fmt: run 'cargo fmt --all' to fix"
     exit 1
 fi
-
-# --- Clippy ------------------------------------------------------------------
-# --all-targets is essentially free on warm cache (~1.5s) thanks to
-# incremental compile, and it covers the user-facing `koda` CLI binary
-# that --lib --tests would skip. Don't be clever about scoping this down.
-info "cargo clippy"
-if cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings; then
-    ok "clippy clean"
-else
-    fail "clippy: fix the warnings above"
-    exit 1
-fi
-
-echo
-ok "Pre-push checks passed. Full test suite runs in CI."


### PR DESCRIPTION
## Summary

Trims the local `pre-push` hook from `fmt + clippy` to `fmt-only`. PR #979 split CI into per-tool parallel jobs with sub-2-min granular feedback, which earns us the right to delegate clippy to CI.

This PR was its own first dogfood: **push wall-clock dropped from ~100s to ~8s** end-to-end (hook + network + GitHub API).

## Realistic timing breakdown

The hook itself is fast, but `git push` wall-clock is what actually matters to humans. Honest numbers:

| Phase | Old hook | New hook |
|---|---|---|
| Hook script (warm cache) | ~50-90s (clippy dominates) | ~0.5-0.7s |
| Hook script (cold cache, after `cargo clean`) | ~3-5 min | ~1-3s (cargo binary load + first source read) |
| Network + GitHub processing | ~5-10s | ~5-10s (unchanged) |
| **Total `git push` wall-clock (warm)** | **~60-100s** | **~6-12s** |
| **Total `git push` wall-clock (cold)** | **~3-5 min** | **~7-15s** |

Caveats:
- Cold cache is rare (only after `cargo clean` or first push of the day)
- Network varies by location/VPN — office vs home WiFi differs
- A very large diff can push fmt closer to ~2s even warm

## Why drop clippy

Per the recent session sample (4 pushes across PRs #978 + #979):

| Push | fmt local | clippy local |
|---|---|---|
| #978 push 1 | clean (~1s) | clean (~70s) |
| #978 push 2 | **caught 1 issue** ✅ | clean (~70s) |
| #978 push 3 | clean (~1s) | clean (~70s) |
| #979 push 1 | clean (~1s) | clean (~50s) |

**fmt locally caught 1 real issue. Clippy locally caught 0.** Cumulative local wait: ~5 minutes for ~1 second of value.

Break-even math: local clippy must catch a real lint issue on >50% of pushes to be net-positive on dev time vs the new CI's ~90s parallel clippy job that runs without spinning up your laptop fans. In practice the catch rate is <10%.

## Why keep fmt

- Sub-second on warm cache, ~3s worst case — small enough to not register as friction
- A fmt failure in CI is the most embarrassing possible reason to wait for a re-run — it's not even a real bug, just whitespace
- Doesn't compile anything, so cache state doesn't matter much

## Consistency win

Pre-fix, the hook trusted CI for `cargo check`, `cargo test`, `cargo audit`, `cargo doc`, `cargo semver-checks` — but not clippy. Arbitrary line. The hook header always said *"Trust CI"*; now we actually do.

## Verification

Local hook timing (warm cache, three back-to-back runs):

```
$ for i in 1 2 3; do time bash .githooks/pre-push; done
real    0m0.682s
real    0m0.470s
real    0m0.464s
```

This PR's own push completed in ~8s end-to-end including network + GitHub API.

## Escape hatches preserved

- `git push --no-verify` still skips for WIP pushes
- `./scripts/preflight.sh` still runs the full pre-PR validation for users wanting belt-and-suspenders before opening a PR

## Diff

```
1 file changed, 18 insertions(+), 27 deletions(-)
```

Net **-9 lines** — simpler hook, better DX.

