### PR TITLE
chore(ci): drop semver-checks job (no real external consumers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ env:
 #   fmt     → formatting
 #   clippy  → lints + compile WITH test-support features (full lint surface)
 #   check   → compile sanity WITHOUT features (what crates.io users see)
-#   semver  → public API stability for koda-core (the only published lib crate)
 #   test    → behaviour, matrix on (ubuntu, macos)
 #   doc     → doc compile + intra-doc links + -Dwarnings
 #   audit   → dependency vulnerabilities
@@ -79,32 +78,6 @@ jobs:
       # Catches cfg-gated items invisible behind feature flags. This is the
       # crates.io consumer build — koda-core ships without test-support.
       - run: cargo check --workspace --all-targets
-
-  semver:
-    name: SemVer (koda-core)
-    runs-on: ubuntu-latest
-    # ADVISORY at first: continue-on-error keeps this from blocking PRs
-    # while we observe its output across a few real changes. Once we've
-    # confirmed it's not flagging false positives on koda-core's API
-    # surface, flip continue-on-error to false and add it to the branch
-    # protection required-checks list.
-    #
-    # Only the published library crate is checked. koda-cli is a binary
-    # (no API contract) and koda-test-utils is unpublished. Adding more
-    # crates later is a one-line change in `package`.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.8.1
-        with:
-          shared-key: semver-Linux
-      # The official action handles tool install, baseline fetch, and the
-      # current==latest edge case (it'll skip the check and report a hint
-      # rather than fail noisily).
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          package: koda-core
 
   test:
     name: Test (${{ matrix.os }})


### PR DESCRIPTION
## Summary

Removes the `SemVer (koda-core)` CI job added in PR #979 (~24 hours ago).

## Why

Reality check on adding SemVer-checks: `koda-core` is published to crates.io but its only real consumer is the `koda-cli` binary in this same workspace. **Nobody externally depends on `koda-core`'s public API surface**, so guarding that surface costs ~90s of CI compute per PR for ~zero value.

The original justification ("5 patch releases in one day → accidental breakage risk") confused two things:
- ✅ True: rapid patches *could* introduce accidental breaking changes
- ❌ Implied: someone *would notice and care* if they did

For an internal-consumer-only crate, the second isn't true — `koda-cli` either compiles or it doesn't, and that's already covered by the existing `Test` jobs.

Zen of Python: ***"If the implementation is hard to explain, it's a bad idea."*** Defending a SemVer gate for a crate with no external consumers IS hard to explain.

## What's removed

```
1 file changed, 27 deletions(-)
```

- The entire `semver` job (~25 lines)
- One topology-comment line referencing it

## What stays

The other 6 jobs from PR #979 — they all earn their keep:

| Job | Catches | Real-world value |
|---|---|---|
| `Format` | whitespace drift | every PR |
| `Clippy` | lint issues | every PR |
| `Check (no features)` | feature-flag misuse | every PR (same workspace `koda-cli` builds w/o test-support too) |
| `Test (ubuntu/macos)` | behavioural regressions | every PR |
| `Docs` | rustdoc errors | every PR |
| `Security Audit` | vulnerable deps | every PR |

## Reversibility

If we ever take on real external consumers of `koda-core` (third-party tools, sister crates, public SDK), reinstating the job is a single `git revert` of this commit. The original implementation in PR #979 used the official `obi1kenobi/cargo-semver-checks-action@v2` and worked on first try.

## Net effect

- **CI wall-clock:** unchanged (was parallel anyway, gated by `Test` matrix)
- **CI compute usage:** -~90s per PR
- **Conceptual surface:** simpler — 6 jobs each with obvious purpose, no "wait, why do we have this?" overhead
