### PR TITLE
fix(trust): honor `--mode` flag at session creation (closes #982)

### DIFF
--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -17,7 +17,6 @@ use koda_core::db::{Database, Role};
 use koda_core::engine::{ApprovalDecision, EngineCommand, EngineEvent, EngineSink};
 use koda_core::persistence::Persistence;
 use koda_core::session::KodaSession;
-use koda_core::trust::TrustMode;
 
 use anyhow::Result;
 use std::io::Write;
@@ -44,7 +43,7 @@ pub async fn run_headless(
     agent.rebuild_system_prompt(&config, &[]);
     let agent = Arc::new(agent);
     let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::channel::<koda_core::engine::EngineCommand>(32);
-    let mut session = KodaSession::new(session_id, agent, db, &config, TrustMode::Auto).await;
+    let mut session = KodaSession::new(session_id, agent, db, &config, config.trust).await;
 
     // Process @file references and images
     let processed = input::process_input(&prompt, &project_root);

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -47,7 +47,6 @@ use koda_core::db::{Database, Role};
 use koda_core::engine::EngineCommand;
 use koda_core::persistence::Persistence;
 use koda_core::session::KodaSession;
-use koda_core::trust::TrustMode;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI64;
@@ -327,7 +326,7 @@ async fn handle_new_session(
         state.agent.clone(),
         state.db.clone(),
         &state.config,
-        TrustMode::Auto,
+        state.config.trust,
     )
     .await;
 

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -113,6 +113,24 @@ pub(crate) enum CommandOutcome {
     Quit,
 }
 
+/// Resolve the initial trust mode for a session, given any persisted mode
+/// string and a fallback to use when nothing valid is persisted.
+///
+/// Resume semantics (#590): a previously-stored mode wins over the CLI/config
+/// value, so users don't lose their per-session preference on `/resume`.
+///
+/// Fallback semantics (#982): when there's no persisted mode (fresh session)
+/// OR the persisted string is unparseable (corruption / older format), fall
+/// back to the user's current `config.trust` — **never** to a hardcoded
+/// constant. Hardcoding `Auto` here was the original bug: it silently
+/// overrode `--mode safe`, defeating the whole point of the flag.
+pub(crate) fn resolve_initial_trust_mode(
+    persisted: Option<&str>,
+    fallback: TrustMode,
+) -> TrustMode {
+    persisted.and_then(TrustMode::parse).unwrap_or(fallback)
+}
+
 impl TuiContext {
     /// Initialize all TUI state. Call before entering the event loop.
     ///
@@ -189,24 +207,24 @@ impl TuiContext {
         agent.rebuild_system_prompt(&config, &commands);
         let agent = Arc::new(agent);
 
-        let mut session = KodaSession::new(
-            session_id,
-            agent.clone(),
-            db.clone(),
-            &config,
-            TrustMode::Auto,
-        )
-        .await;
+        let mut session =
+            KodaSession::new(session_id, agent.clone(), db.clone(), &config, config.trust).await;
 
         crate::startup::purge_nudge(&db, &mut startup_lines).await;
 
-        // Restore persisted approval mode on resume (#590)
+        // Restore persisted approval mode on resume (#590).
+        // Fallback to the user's current CLI/config trust mode (not a hardcoded
+        // constant) so `--mode safe` is honored on first run when there's no
+        // persisted mode yet. Fixes #982.
         let initial_mode = {
             use koda_core::persistence::Persistence;
-            match session.db.get_session_mode(&session.id).await {
-                Ok(Some(mode_str)) => TrustMode::parse(&mode_str).unwrap_or(TrustMode::Auto),
-                _ => TrustMode::Auto,
-            }
+            let persisted = session
+                .db
+                .get_session_mode(&session.id)
+                .await
+                .ok()
+                .flatten();
+            resolve_initial_trust_mode(persisted.as_deref(), config.trust)
         };
         let shared_mode = trust::new_shared_trust(initial_mode);
 
@@ -659,4 +677,84 @@ impl TuiContext {
     // ═══════════════════════════════════════════════════════════
     // Idle-mode event handling (keyboard, paste, menu, wizard, history)
     // ═══════════════════════════════════════════════════════════
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression tests for #982: `--mode safe` was silently overridden by a
+    //! hardcoded `TrustMode::Auto` at session-creation time. The fix routes
+    //! `config.trust` through both fresh-session and resume-fallback paths.
+    //!
+    //! These tests pin the resolution semantics so a future refactor can't
+    //! reintroduce a hardcoded constant without turning the build red.
+
+    use super::resolve_initial_trust_mode;
+    use koda_core::trust::TrustMode;
+
+    #[test]
+    fn fresh_session_no_persisted_mode_uses_config_trust() {
+        // The exact bug: fresh session, no persisted mode, user passed `--mode safe`.
+        // Pre-fix this returned hardcoded `Auto`, ignoring the user's choice.
+        assert_eq!(
+            resolve_initial_trust_mode(None, TrustMode::Safe),
+            TrustMode::Safe,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(None, TrustMode::Plan),
+            TrustMode::Plan,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(None, TrustMode::Auto),
+            TrustMode::Auto,
+        );
+    }
+
+    #[test]
+    fn persisted_mode_wins_over_config_trust_on_resume() {
+        // Resume semantics from #590: a stored mode beats the CLI fallback.
+        assert_eq!(
+            resolve_initial_trust_mode(Some("plan"), TrustMode::Auto),
+            TrustMode::Plan,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some("safe"), TrustMode::Auto),
+            TrustMode::Safe,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some("auto"), TrustMode::Safe),
+            TrustMode::Auto,
+        );
+    }
+
+    #[test]
+    fn unparseable_persisted_mode_falls_back_to_config_trust_not_auto() {
+        // The other half of the bug: corrupt/unknown persisted strings used
+        // to fall through to a hardcoded `Auto`. Now they honor config.trust.
+        assert_eq!(
+            resolve_initial_trust_mode(Some("bogus"), TrustMode::Safe),
+            TrustMode::Safe,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some(""), TrustMode::Plan),
+            TrustMode::Plan,
+        );
+    }
+
+    #[test]
+    fn parse_accepts_legacy_aliases_for_persisted_strings() {
+        // `TrustMode::parse` accepts aliases like "yolo", "strict", etc.
+        // Make sure resume of older sessions stored under those names still works.
+        assert_eq!(
+            resolve_initial_trust_mode(Some("yolo"), TrustMode::Safe),
+            TrustMode::Auto,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some("strict"), TrustMode::Auto),
+            TrustMode::Safe,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some("readonly"), TrustMode::Auto),
+            TrustMode::Plan,
+        );
+    }
 }

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -276,3 +276,62 @@ mod provider_key_flow {
         assert!(!should_prompt);
     }
 }
+
+/// Regression test for #982: `--mode safe` was silently overridden by a
+/// hardcoded `TrustMode::Auto` at every `KodaSession::new` call site.
+///
+/// We can't cheaply unit-test the headless / server / TUI bootstrap paths
+/// without a real provider, terminal, and database. Instead, this is a
+/// structural test: scan the source files that previously held the hardcoded
+/// `TrustMode::Auto` literal as the 5th argument to `KodaSession::new` and
+/// assert it's gone. The fix should pass `config.trust` (or `state.config.trust`)
+/// instead.
+///
+/// If a future refactor reintroduces the hardcode, this test fails with a
+/// clear diagnostic pointing at the file.
+mod hardcoded_trust_mode_at_session_creation {
+    use std::fs;
+    use std::path::Path;
+
+    fn assert_no_hardcoded_auto_in_session_new(path: &str) {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        // Tests run with CWD = workspace member dir; resolve from there.
+        let full_path = manifest_dir.join("..").join(path);
+        let src = fs::read_to_string(&full_path)
+            .unwrap_or_else(|e| panic!("read {}: {}", full_path.display(), e));
+
+        // Look for `KodaSession::new(...)` blocks containing `TrustMode::Auto`
+        // as one of the args. Multi-line, so scan window-by-window between
+        // the call's `(` and its matching `)` (heuristic: until next bare `)`).
+        let mut idx = 0;
+        while let Some(start) = src[idx..].find("KodaSession::new(") {
+            let abs_start = idx + start;
+            // crude end: first ").await" or ")\n .await" within next 600 chars
+            let window_end = (abs_start + 600).min(src.len());
+            let window = &src[abs_start..window_end];
+            assert!(
+                !window.contains("TrustMode::Auto"),
+                "{}: KodaSession::new(...) call still passes hardcoded TrustMode::Auto. \
+                 Pass `config.trust` (or equivalent) instead. See #982.\n\nWindow:\n{}",
+                path,
+                window
+            );
+            idx = abs_start + "KodaSession::new(".len();
+        }
+    }
+
+    #[test]
+    fn headless_path_does_not_hardcode_auto() {
+        assert_no_hardcoded_auto_in_session_new("koda-cli/src/headless.rs");
+    }
+
+    #[test]
+    fn acp_server_path_does_not_hardcode_auto() {
+        assert_no_hardcoded_auto_in_session_new("koda-cli/src/server.rs");
+    }
+
+    #[test]
+    fn tui_context_path_does_not_hardcode_auto() {
+        assert_no_hardcoded_auto_in_session_new("koda-cli/src/tui_context/mod.rs");
+    }
+}

--- a/koda-cli/tests/smoke_test.rs
+++ b/koda-cli/tests/smoke_test.rs
@@ -19,22 +19,28 @@ fn koda_bin() -> String {
 }
 
 fn run_mock(prompt: &str, responses: &str) -> (String, String, bool) {
+    run_mock_with_mode(prompt, responses, None)
+}
+
+fn run_mock_with_mode(prompt: &str, responses: &str, mode: Option<&str>) -> (String, String, bool) {
     let tmp = tempfile::tempdir().unwrap();
-    let output = Command::new(koda_bin())
-        .args([
-            "-p",
-            prompt,
-            "--provider",
-            "mock",
-            "--output-format",
-            "json",
-            "--project-root",
-        ])
-        .arg(tmp.path())
-        .env("XDG_CONFIG_HOME", tmp.path())
-        .env("KODA_MOCK_RESPONSES", responses)
-        .output()
-        .expect("Failed to run koda");
+    let mut cmd = Command::new(koda_bin());
+    cmd.args([
+        "-p",
+        prompt,
+        "--provider",
+        "mock",
+        "--output-format",
+        "json",
+        "--project-root",
+    ])
+    .arg(tmp.path())
+    .env("XDG_CONFIG_HOME", tmp.path())
+    .env("KODA_MOCK_RESPONSES", responses);
+    if let Some(m) = mode {
+        cmd.args(["--mode", m]);
+    }
+    let output = cmd.output().expect("Failed to run koda");
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -69,15 +75,20 @@ fn mock_text_response_returns_json() {
 
 #[test]
 fn mock_destructive_bash_auto_approved_in_headless() {
-    // Model tries to run `rm -rf /tmp/nonexistent_test_dir` — headless (Auto mode)
-    // now auto-approves all actions within the project sandbox (#855).
+    // Model tries to run `rm -rf /tmp/nonexistent_test_dir` — with `--mode auto`,
+    // headless auto-approves all actions within the project sandbox (#855).
     // The sandbox kernel enforcement is the safety boundary, not the approval prompt.
+    //
+    // Note: pre-#982 this test passed without `--mode auto` because headless
+    // hardcoded `TrustMode::Auto` regardless of the flag. Post-fix, the flag
+    // must be passed explicitly — which is the entire point of having a flag.
     let responses = r#"[
         {"tool":"Bash","args":{"command":"rm -rf /tmp/nonexistent_test_dir"}},
         {"text":"Done."}
     ]"#;
 
-    let (_stdout, stderr, success) = run_mock("delete everything", responses);
+    let (_stdout, stderr, success) =
+        run_mock_with_mode("delete everything", responses, Some("auto"));
     assert!(
         success,
         "Process should succeed (Auto mode approves within sandbox).\nstderr: {stderr}"
@@ -87,6 +98,31 @@ fn mock_destructive_bash_auto_approved_in_headless() {
         !stderr.contains("Rejected destructive action"),
         "Should not reject destructive action in Auto mode.\nstderr: {stderr}"
     );
+}
+
+#[test]
+fn mock_destructive_bash_rejected_in_safe_mode_in_headless() {
+    // End-to-end regression test for #982. Pre-fix, headless hardcoded
+    // `TrustMode::Auto`, so `--mode safe` was silently ignored and destructive
+    // actions ran without confirmation. Post-fix, `--mode safe` is honored
+    // and the same destructive Bash invocation is rejected by the trust layer.
+    //
+    // We test BOTH: explicit `--mode safe` AND default (no flag, since CLI
+    // default_value = "safe"). Both must reject.
+    let responses = r#"[
+        {"tool":"Bash","args":{"command":"rm -rf /tmp/nonexistent_test_dir"}},
+        {"text":"Done."}
+    ]"#;
+
+    for mode in [Some("safe"), None] {
+        let label = mode.unwrap_or("<default>");
+        let (_stdout, stderr, _success) = run_mock_with_mode("delete everything", responses, mode);
+        assert!(
+            stderr.contains("Rejected destructive action"),
+            "[mode={label}] Safe mode (or default) MUST reject destructive Bash. \
+             If this fails, #982 has regressed.\nstderr: {stderr}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #982. Three downstream session-creation sites hardcoded `TrustMode::Auto`, silently overriding the parsed `--mode` CLI flag. Users who passed `--mode safe` (or relied on the documented default) got auto-approval of all destructive actions despite explicitly opting into supervised mode.

**Worst case:** headless mode (`koda -p "..."`) literally could not be made safe — the `--mode` flag had no effect there because `headless.rs` ignored it entirely.

## Origin

Introduced by **#857** (`refactor: unify ApprovalMode × SandboxMode into TrustMode`). The unification refactor replaced the original "honor user's mode flag" wiring with literal `TrustMode::Auto` constants at each session-creation site. Compiled cleanly because `TrustMode`'s `#[default]` is `Safe` (so `unwrap_or_default()` in `app.rs` *looked* correct), and no test asserted `session.mode == config.trust`.

## Changes

| File | Change |
|---|---|
| `koda-cli/src/headless.rs` | `TrustMode::Auto` → `config.trust` (drop now-unused import) |
| `koda-cli/src/server.rs` | `TrustMode::Auto` → `state.config.trust` (drop now-unused import) |
| `koda-cli/src/tui_context/mod.rs` | Initial session: `Auto` → `config.trust`. Resume fallback: extract pure helper `resolve_initial_trust_mode(persisted, fallback) → TrustMode` with `config.trust` as fallback (was `Auto`). Resume semantics from #590 preserved (persisted mode still wins when valid). |

## Tests added

**4 unit tests in `tui_context::tests`** pinning resolution semantics:
- `fresh_session_no_persisted_mode_uses_config_trust` — the exact bug
- `persisted_mode_wins_over_config_trust_on_resume` — preserves #590 semantics
- `unparseable_persisted_mode_falls_back_to_config_trust_not_auto` — corruption case
- `parse_accepts_legacy_aliases_for_persisted_strings` — backward compat for old persisted strings (`yolo`, `strict`, `readonly`)

**3 structural tests in `regression_test.rs`** that scan the three fixed source files for any `KodaSession::new(...)` window containing literal `TrustMode::Auto`. Fails loudly if a future refactor reintroduces the hardcode. The cheap unit-test option for the TUI / headless / ACP bootstrap paths isn't viable (they need real provider, terminal, DB) — this structural test is the strongest cheap guard.

**Manually verified the structural test catches regression** by temporarily reverting `headless.rs` to `TrustMode::Auto` — the test failed with a clear diagnostic. Restored.

## Verification

```
cargo test -p koda-cli --lib tui_context::tests        # 4 passed
cargo test -p koda-cli --test regression_test          # 19 passed (3 new + 16 existing)
cargo clippy -p koda-cli --tests -- -D warnings        # clean
cargo fmt --check                                      # clean
```

## Non-goals (parking)

- Not changing the `#[default]` of the enum (still `Safe`, which is correct).
- Not changing the CLI flag default (still `"safe"`, which is correct).
- Not touching `sub_agent_dispatch.rs:55`'s `TrustMode::Auto` — that's a sub-agent default governed by `TrustMode::clamp` against parent (separate concern).

Closes #982.
