### PR TITLE
feat(sandbox): extract koda-sandbox crate (Phase 0 of #934)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,7 @@ dependencies = [
  "http",
  "ignore",
  "insta",
+ "koda-sandbox",
  "koda-test-utils",
  "path-clean",
  "regex",
@@ -1826,6 +1827,20 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "koda-sandbox"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "insta",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["koda-core", "koda-cli", "koda-test-utils"]
+members = ["koda-core", "koda-cli", "koda-test-utils", "koda-sandbox"]
 resolver = "3"
 default-members = ["koda-cli"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,23 @@ members = ["koda-core", "koda-cli", "koda-test-utils"]
 resolver = "3"
 default-members = ["koda-cli"]
 
+# Shared dependency versions — single source of truth (DRY).
+# Per-crate feature sets are layered via `features = [...]` at the
+# consumer site. Add a dep here once it's used by 3+ crates; before
+# that it's premature DRY (YAGNI).
+[workspace.dependencies]
+anyhow = "1"
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1" }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = "0.1"
+
+# Dev-only deps shared across crates.
+insta = { version = "1", features = ["yaml", "redactions"] }
+tempfile = "3"
+
 [profile.release]
 strip = true
 lto = true

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -23,12 +23,12 @@ koda-core = { path = "../koda-core", version = "0.2.16" }
 clap = { version = "4", features = ["derive", "env"] }
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
 
 # Serialization (needed for CLI-level config)
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # TUI / Terminal
 crossterm = { version = "0.29", features = ["event-stream"] }
@@ -54,12 +54,12 @@ ansi-to-tui = "8"
 regex = "1"
 
 # Logging (subscriber for CLI configuration)
-tracing = "0.1"
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 
 # Error handling
-anyhow = "1"
+anyhow = { workspace = true }
 
 # Date/time — already a transitive dep via ratatui; declared directly so
 # callers aren't silently depending on an undeclared transitive.
@@ -77,7 +77,7 @@ name = "render_bench"
 harness = false
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 koda-core = { path = "../koda-core", version = "0.2.16", features = ["test-support"] }
-serde_json = "1"
+serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -17,17 +17,17 @@ path = "src/lib.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 
 # Database
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "macros"] }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # File system (respects .gitignore)
 ignore = "0.4"
@@ -66,7 +66,7 @@ reqwest = { version = "0.13", features = ["json", "stream"] }
 futures-util = "0.3"
 
 # Error handling
-anyhow = "1"
+anyhow = { workspace = true }
 
 # MCP client — connect to external MCP servers (#662)
 rmcp = { version = "1.4", default-features = false, features = [
@@ -82,16 +82,16 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Async trait support
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 # Cancellation tokens
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { workspace = true }
 
 [features]
 test-support = []
 
 [dev-dependencies]
-insta = { version = "1", features = ["yaml", "redactions"] }
+insta = { workspace = true }
 # MCP HTTP integration test: rmcp server-side HTTP transport + axum
 rmcp = { version = "1.4", features = [
     "server",
@@ -103,12 +103,12 @@ rmcp = { version = "1.4", features = [
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "tower-log"] }
 tower = "0.5"
 koda-test-utils = { path = "../koda-test-utils" }
-tempfile = "3"
-tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }
 regex = "1"
 ignore = "0.4"
-anyhow = "1"
-async-trait = "0.1"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 
 # Integration tests that need mock infrastructure.
 # Run with: cargo test -p koda-core --features test-support

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -81,6 +81,9 @@ http = "1"
 
 # First-party workspace libraries (direct calls)
 
+# Sandbox runtime — kernel-level FS/net/exec policies (#934)
+koda-sandbox = { path = "../koda-sandbox" }
+
 # Async trait support
 async-trait = { workspace = true }
 

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -1,1008 +1,120 @@
-//! Process sandboxing for the Bash tool.
+//! Process sandboxing for the Bash tool — thin shim over [`koda_sandbox`].
 //!
-//! Sandboxing is always active and determined by [`crate::trust::TrustMode`].
-//! The `SandboxMode` enum is an internal implementation detail.
+//! Phase 0 of #934 lifted the actual sandbox logic into the standalone
+//! `koda-sandbox` crate. This module preserves the in-tree API so the
+//! existing call sites (`tools/shell.rs`, `tools/mod.rs`, `trust.rs`)
+//! don't have to change.
 //!
-//! ## Platform backends
+//! ## Public API
 //!
-//! | Platform | Backend              | If unavailable              |
-//! |----------|----------------------|-----------------------------|
-//! | macOS    | `sandbox-exec -p`    | falls back to unsandboxed   |
-//! | Linux    | `bwrap` (bubblewrap) | falls back to unsandboxed   |
+//! - [`build`](crate::sandbox::build) — main entry point used by `tools/shell.rs`
+//! - [`is_available`](crate::sandbox::is_available) — used by `trust.rs` to gate Auto → Safe downgrade
+//! - [`is_fully_denied`](crate::sandbox::is_fully_denied) — used by `tools/mod.rs` for in-process Read/Edit
+//!   parity with the kernel sandbox (#882, #898)
 //!
-//! ## Trust → Sandbox mapping
+//! ## Behavior
 //!
-//! - **Plan** → Project sandbox + credential denies + read-only FS
-//! - **Safe** → Project sandbox + credential denies + read-write FS
-//! - **Auto** → Project sandbox + credential denies + read-write FS
+//! All trust modes get the same kernel-enforced "strict" baseline today
+//! (project sandbox + credential write-protection + full deny on
+//! `~/.config/koda/db`). When the platform sandbox backend is missing
+//! (e.g. `bwrap` not installed on Linux, unsupported OS), commands run
+//! unsandboxed with a one-time warning — the sandbox is best-effort and
+//! never blocks the user.
 //!
-//! All modes deny credential paths. The old `SandboxMode::None` is gone.
-//!
-//! ## Usage
-//!
-//! ```rust,ignore
-//! let cmd = sandbox::build("cargo test", project_root, &TrustMode::Safe)?;
-//! let child = cmd.stdout(Stdio::piped()).spawn()?;
-//! ```
+//! Phase 1+ will let trust modes diverge by passing a richer
+//! [`koda_sandbox::SandboxPolicy`] through the shim.
+
+// `is_fully_denied` is intentionally pub(crate) but worth linking from
+// these module docs for any koda-core developer reading them.
+#![allow(rustdoc::private_intra_doc_links)]
 
 use anyhow::Result;
+use koda_sandbox::{
+    SandboxPolicy, SandboxRuntime, SandboxTransformRequest, current_runtime,
+    is_available as ks_is_available,
+};
 use std::path::Path;
+use std::sync::OnceLock;
 use tokio::process::Command;
-
-// ── Mode ─────────────────────────────────────────────────────────────────────
-
-/// Internal sandbox level — derived from [`crate::trust::TrustMode`].
-/// Not exposed publicly; users interact via `TrustMode`.
-#[allow(dead_code)] // Variants used internally for sandbox level dispatch
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) enum SandboxMode {
-    /// No sandbox — commands run with full host access. (default)
-    #[default]
-    None,
-    /// Restrict writes to the project dir + /tmp + cache dirs.
-    /// Reads and network are unrestricted.
-    Project,
-    /// Everything from `Project`, plus read+write denies for sensitive
-    /// credential directories (`~/.ssh`, `~/.aws`, `~/.gnupg`, …).
-    ///
-    /// Inspired by Claude Code's `denyRead[]` and Gemini CLI's
-    /// `forbiddenPaths` — both place explicit deny rules after broad allows so
-    /// that the last-match-wins semantics of the underlying sandbox engine
-    /// (seatbelt on macOS, bwrap `--tmpfs` shadow on Linux) take precedence.
-    Strict,
-}
-
-#[allow(dead_code)] // Methods used by internal sandbox tests
-impl SandboxMode {
-    /// Return a numeric strictness level for comparison.
-    ///
-    /// Higher = stricter.  Used by `stricter()` to enforce the
-    /// "never weaken" invariant when inheriting from a parent.
-    fn level(&self) -> u8 {
-        match self {
-            Self::None => 0,
-            Self::Project => 1,
-            Self::Strict => 2,
-        }
-    }
-
-    /// Return whichever of `self` and `other` is stricter.
-    ///
-    /// Used by sub-agent dispatch to enforce the invariant that a child
-    /// agent can never run with a weaker sandbox than its parent — the same
-    /// pattern as Codex's `apply_spawn_agent_runtime_overrides()` which
-    /// copies the parent's runtime `sandbox_policy` onto the child config.
-    pub fn stricter(&self, other: &Self) -> Self {
-        if self.level() >= other.level() {
-            self.clone()
-        } else {
-            other.clone()
-        }
-    }
-
-    /// Parse from a CLI / env string (case-insensitive).
-    ///
-    /// Unknown values produce a warning and fall back to `None`.
-    pub fn parse(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
-            "project" => Self::Project,
-            "strict" => Self::Strict,
-            "none" | "" => Self::None,
-            other => {
-                tracing::warn!(
-                    "Unknown --sandbox value {:?} — defaulting to none. \
-                     Valid values: none, project, strict",
-                    other
-                );
-                Self::None
-            }
-        }
-    }
-
-    /// `true` when sandboxing is active (i.e. not `None`).
-    pub fn is_active(&self) -> bool {
-        self != &Self::None
-    }
-}
-
-impl std::fmt::Display for SandboxMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => f.write_str("none"),
-            Self::Project => f.write_str("project"),
-            Self::Strict => f.write_str("strict"),
-        }
-    }
-}
-
-// ── Sensitive credential paths (Strict mode) ─────────────────────────────────
-//
-// Two tiers of credential protection:
-//
-// 1. **Write-only deny** (most paths) — CLI tools can *read* their own
-//    credentials (e.g. `gh`, `aws`, `kubectl`, `ssh`) but sandboxed
-//    commands cannot modify them.  This matches Codex's model where the
-//    entire host filesystem is mounted read-only via `--ro-bind / /` and
-//    credential directories receive no special treatment beyond that.
-//
-//    Risk accepted: a sandboxed command *can* read credential material
-//    and could exfiltrate it over the network.  Network-level egress
-//    restriction (Gap 4 in #844) is the proper mitigation — blocking
-//    reads without blocking network is security theater (#855).
-//
-// 2. **Full read+write deny** (`koda/db` only) — koda's own API keys
-//    live in a SQLite DB at `~/.config/koda/db/koda.db`.  The koda
-//    process runs *outside* the sandbox and doesn't need sandboxed-
-//    command access.  Blocking reads here prevents a `sqlite3` one-liner
-//    from dumping every stored API key (#847).
-//
-// Deny rules are placed *after* the broad allow so last-match-wins
-// semantics take effect (seatbelt on macOS, bwrap overlay on Linux).
-
-/// Credential *directories* under `$HOME` that are **write-protected** in
-/// Strict mode.  Reads are allowed so CLI tools can authenticate.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-const CREDENTIAL_SUBDIRS: &[&str] = &[
-    ".ssh",            // SSH private keys, authorized_keys, known_hosts
-    ".aws",            // AWS access key ID, secret key, session tokens
-    ".gnupg",          // GPG private keys and trust database
-    ".kube",           // kubeconfig with cluster tokens and client certs
-    ".azure",          // Azure CLI token cache (msal_token_cache.bin, etc.)
-    ".password-store", // pass(1) GPG-encrypted password store
-    ".terraform.d",    // Terraform cloud tokens and plugin cache
-    ".claude",         // Claude Code settings and session tokens
-    ".android",        // Android SDK debug keystores and signing keys
-];
-
-/// Credential directories under `$HOME/.config/` that are **write-protected**
-/// in Strict mode.  Reads are allowed so CLI tools can authenticate.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-const CREDENTIAL_CONFIG_SUBDIRS: &[&str] = &[
-    "gcloud",  // gcloud CLI credentials and service-account key files
-    "gh",      // GitHub CLI personal access tokens (hosts.yml)
-    "op",      // 1Password CLI session tokens
-    "helm",    // Helm registry auth
-    "netlify", // Netlify CLI access tokens
-    "vercel",  // Vercel CLI credentials
-    "fly",     // Fly.io CLI auth tokens
-    "doppler", // Doppler secrets manager tokens
-    "stripe",  // Stripe CLI API keys
-    "heroku",  // Heroku CLI OAuth tokens
-];
-
-/// Credential directories under `$HOME/.config/` where **both reads and
-/// writes** are denied.  These contain koda's own secrets that sandboxed
-/// commands have no legitimate reason to access.
-const CREDENTIAL_CONFIG_FULL_DENY: &[&str] = &[
-    "koda/db", // SQLite DB with plaintext API keys in kv_store table (#847)
-];
-
-/// Returns `true` when `path` falls inside a fully-denied location.
-///
-/// "Fully denied" means both reads **and** writes are blocked in the
-/// subprocess sandbox (bwrap / Seatbelt).  This function lets in-process
-/// file tools enforce the same policy so the restriction is uniform
-/// regardless of how the model accesses the path (Option A parity, #882).
-///
-/// Currently only `~/.config/koda/db` is fully denied — koda's own SQLite
-/// database containing plaintext API keys.  Ordinary credential directories
-/// (`~/.ssh`, `~/.aws`, …) are **not** included: reads are allowed there,
-/// mirroring the Bash sandbox which only write-protects them.
-///
-/// **Defense in depth (#898):** when `HOME` cannot be resolved (containers,
-/// CI, or `unset HOME` inside a sandboxed Bash command), this used to fail
-/// *open* and return `false`, exposing the koda DB to the in-process Read
-/// tool. We now fail *closed*: try `HOME`, then `USERPROFILE` (Windows),
-/// and finally fall back to a path-component pattern match so any path
-/// whose components contain `.config/koda/db` consecutively still gets
-/// denied even with no home directory at all.
-///
-/// See issue #884 for the long-term plan (Option B: sandboxed worker process)
-/// which will replace this application-layer check with true OS enforcement.
-pub(crate) fn is_fully_denied(path: &Path) -> bool {
-    is_fully_denied_with_home(path, resolve_home_dir().as_deref())
-}
-
-/// Best-effort home directory lookup with cross-platform fallback.
-///
-/// Order: `HOME` (Unix-y, including macOS) → `USERPROFILE` (Windows).
-/// Returns `None` only when *both* are unset, which signals a hostile or
-/// degenerate environment; callers must fail closed.
-fn resolve_home_dir() -> Option<String> {
-    std::env::var("HOME")
-        .ok()
-        .or_else(|| std::env::var("USERPROFILE").ok())
-        .filter(|s| !s.is_empty())
-}
-
-/// Pure helper for [`is_fully_denied`] — takes the home directory as an
-/// argument so the no-home case is unit-testable without racing on env vars.
-fn is_fully_denied_with_home(path: &Path, home: Option<&str>) -> bool {
-    // Primary check: does the path live under `${home}/.config/<rel>` for
-    // any fully-denied relative path? Only runs when home is known.
-    if let Some(home) = home {
-        let home_path = Path::new(home);
-        if CREDENTIAL_CONFIG_FULL_DENY
-            .iter()
-            .any(|rel| path.starts_with(home_path.join(".config").join(rel)))
-        {
-            return true;
-        }
-    }
-
-    // Fallback: pattern-match the path components themselves. Even with
-    // no home, any path whose components contain `.config/<rel>` as a
-    // consecutive sequence is treated as fully denied. This catches the
-    // `unset HOME` bypass and exotic paths like `/proc/self/root/.config/koda/db`
-    // that don't share a prefix with `$HOME`.
-    let components: Vec<&std::ffi::OsStr> = path
-        .components()
-        .filter_map(|c| match c {
-            std::path::Component::Normal(s) => Some(s),
-            _ => None,
-        })
-        .collect();
-
-    CREDENTIAL_CONFIG_FULL_DENY.iter().any(|rel| {
-        // Build the target sequence: [".config", <rel parts split by '/'>...]
-        let mut needle: Vec<&str> = vec![".config"];
-        needle.extend(rel.split('/'));
-        // Sliding window match against the path components.
-        components.windows(needle.len()).any(|window| {
-            window
-                .iter()
-                .zip(needle.iter())
-                .all(|(comp, want)| comp.to_str() == Some(*want))
-        })
-    })
-}
-
-/// Individual credential *files* under `$HOME` that are **write-protected**
-/// in Strict mode.  Reads are allowed so tools like `curl`, `git`, `npm`,
-/// and `docker` can authenticate.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-const CREDENTIAL_FILES: &[&str] = &[
-    ".netrc",              // FTP/HTTP credentials (curl, wget, Netrc crate)
-    ".git-credentials",    // git-credential-store plaintext token file
-    ".npmrc",              // npm registry auth token
-    ".pypirc",             // PyPI upload API token
-    ".docker/config.json", // Docker Hub credentials (auths, credsStore)
-    ".vault-token",        // HashiCorp Vault session token
-    ".env",                // dotenv secrets (common project-level pattern)
-];
-
-// ── Agent-file write protection ──────────────────────────────────────────────
-//
-// Prevent sandboxed commands from modifying koda agent definitions or the
-// project-level system prompt.  Same pattern as Claude Code blocking writes
-// to `.claude/settings.json` and `.claude/agents/` — modifying these files
-// could alter system prompts, tool access, or sandbox policy on next session.
-//
-// These are subdirectories of the project root, denied in *all* sandbox modes
-// (project + strict).  The deny rule is placed *after* the project-root allow
-// so last-match-wins semantics apply.
-
-/// Directories under the project root that are write-protected in all sandbox
-/// modes.  Agent JSON files control system prompts and tool access — a
-/// sandboxed command must not be able to modify them.
-const PROTECTED_PROJECT_SUBDIRS: &[&str] = &[
-    ".koda/agents", // Agent definitions (system prompt, tools, sub-agents)
-    ".koda/skills", // Skill definitions (auto-discovered, full capabilities)
-];
-
-// ── Public entry point ────────────────────────────────────────────────────────────────────────
 
 /// Returns `true` if the platform sandbox backend is available.
 ///
 /// Used by the trust layer to downgrade Auto → Safe when the sandbox
 /// is unavailable, ensuring destructive ops still get a confirmation
-/// prompt (#860).  Cached after first probe.
+/// prompt (#860). Cached after first probe.
 pub fn is_available() -> bool {
-    use std::sync::OnceLock;
-    static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| {
-        build_inner("true", std::path::Path::new("/tmp"), &SandboxMode::Strict).is_ok()
-    })
+    ks_is_available()
+}
+
+/// Re-export of [`koda_sandbox::is_fully_denied`] for in-process file tools.
+///
+/// "Fully denied" means both reads **and** writes are blocked. Currently
+/// only `~/.config/koda/db` is fully denied — see the koda-sandbox docs
+/// for the rationale and the `HOME=unset` defense-in-depth path (#898).
+pub(crate) fn is_fully_denied(path: &Path) -> bool {
+    koda_sandbox::is_fully_denied(path)
 }
 
 /// Build a `tokio::process::Command` that runs `sh -c "{command}"` inside
-/// the appropriate sandbox for the given [`crate::trust::TrustMode`].
+/// the appropriate sandbox.
 ///
-/// All trust modes apply project-scoped sandboxing with credential denies.
-/// The mapping is:
-/// - **Plan** → Strict sandbox (credential denies + project writes)
-/// - **Safe** → Strict sandbox (credential denies + project writes)
-/// - **Auto** → Strict sandbox (credential denies + project writes)
+/// The `_trust` argument is currently unused — all trust modes use the
+/// same strict kernel-enforced baseline. Phase 1 of #934 will diverge
+/// per-mode policies through this entry point.
 ///
-/// Falls back to unsandboxed execution with a warning when the platform
-/// sandbox backend is unavailable (e.g. `bwrap` not installed on Linux,
-/// unsupported OS).  The sandbox is best-effort — we never block the user
-/// just because the kernel enforcement layer is missing.
+/// Falls back to unsandboxed execution with a one-time warning when the
+/// platform sandbox backend is unavailable. The sandbox is best-effort:
+/// we never block the user just because the kernel enforcement layer is
+/// missing.
 pub fn build(
     command: &str,
     project_root: &Path,
     _trust: &crate::trust::TrustMode,
 ) -> Result<Command> {
-    // All modes use strict sandboxing (project + credential denies).
-    // The sandbox is the safety boundary — always on when available.
-    match build_inner(command, project_root, &SandboxMode::Strict) {
-        Ok(cmd) => Ok(cmd),
+    let runtime = current_runtime();
+    warn_if_unavailable_once(runtime.as_ref());
+
+    let policy = SandboxPolicy::strict_default();
+    let req = SandboxTransformRequest {
+        command,
+        project_root,
+        policy: &policy,
+    };
+
+    match runtime.transform(req) {
+        Ok(exec) => Ok(exec.command),
         Err(e) => {
-            tracing::warn!("Sandbox unavailable, running unsandboxed: {e}");
-            Ok(plain_sh(command, project_root))
+            tracing::warn!("Sandbox transform failed, running unsandboxed: {e}");
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(command).current_dir(project_root);
+            Ok(cmd)
         }
     }
 }
 
-/// Internal build dispatcher.
-fn build_inner(command: &str, project_root: &Path, mode: &SandboxMode) -> Result<Command> {
-    match mode {
-        SandboxMode::None => Ok(plain_sh(command, project_root)),
-        SandboxMode::Project => build_project(command, project_root),
-        SandboxMode::Strict => build_strict(command, project_root),
-    }
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-fn plain_sh(command: &str, project_root: &Path) -> Command {
-    let mut cmd = Command::new("sh");
-    cmd.arg("-c").arg(command).current_dir(project_root);
-    cmd
-}
-
-/// Dispatch to the platform-specific "project" sandbox builder.
-fn build_project(command: &str, project_root: &Path) -> Result<Command> {
-    #[cfg(target_os = "macos")]
-    return macos_project(command, project_root);
-
-    #[cfg(target_os = "linux")]
-    return linux_project(command, project_root);
-
-    #[allow(unreachable_code)]
-    Err(anyhow::anyhow!(
-        "Sandbox mode 'project' requested but no sandbox backend available \
-         on this platform. Supported: macOS (sandbox-exec), Linux (bwrap)."
-    ))
-}
-
-/// Dispatch to the platform-specific "strict" sandbox builder.
-fn build_strict(command: &str, project_root: &Path) -> Result<Command> {
-    #[cfg(target_os = "macos")]
-    return macos_strict(command, project_root);
-
-    #[cfg(target_os = "linux")]
-    return linux_strict(command, project_root);
-
-    #[allow(unreachable_code)]
-    Err(anyhow::anyhow!(
-        "Sandbox mode 'strict' requested but no sandbox backend available \
-         on this platform. Supported: macOS (sandbox-exec), Linux (bwrap)."
-    ))
-}
-
-/// Reject paths containing characters that could break seatbelt S-expression
-/// syntax.  A crafted `project_root` with `"` or `(` could inject arbitrary
-/// seatbelt rules into the profile string, completely defeating the sandbox.
-///
-/// We reject rather than escape because legitimate filesystem paths should
-/// never contain these characters, and escaping adds subtle semantic risk.
-#[cfg(target_os = "macos")]
-fn validate_seatbelt_path(s: &str) -> Result<()> {
-    const FORBIDDEN: &[char] = &['"', '\\', '(', ')', '\0'];
-    if let Some(c) = s.chars().find(|c| FORBIDDEN.contains(c)) {
-        anyhow::bail!("Path contains character {c:?} unsafe for seatbelt profile: {s:?}");
-    }
-    Ok(())
-}
-
-/// Canonicalize `{home}/{rel}` if the path exists; otherwise return raw path.
-/// This ensures seatbelt subpath/literal rules match the kernel's view of the
-/// path (e.g. `/var` → `/private/var` on macOS).
-#[cfg(target_os = "macos")]
-fn home_path(home: &str, rel: &str) -> String {
-    let p = Path::new(home).join(rel);
-    p.canonicalize().unwrap_or(p).to_string_lossy().into_owned()
-}
-
-// ── macOS: sandbox-exec -p <profile string> ───────────────────────────────────
-
-/// Build the seatbelt profile for `project` mode.
-///
-/// Strategy: deny-by-default (allowlist), then open reads everywhere and
-/// restrict writes to project + temp + cache dirs.  Network left unrestricted
-/// so `curl` / `cargo fetch` / `npm install` work without modification.
-///
-/// Passing the profile via `-p` (inline) avoids a tempfile and its associated
-/// race window — a lesson from Gemini CLI's earlier implementation which used
-/// `-f <tempfile>` and had to clean up on every command.
-#[cfg(target_os = "macos")]
-fn macos_project_profile(root: &str, home: &str) -> String {
-    format!(
-        "(version 1)\n\
-         (deny default)\n\
-         (allow file-read*)\n\
-         (allow file-write*\n\
-           (subpath \"{root}\")\n\
-           (subpath \"/private/tmp\")\n\
-           (subpath \"/tmp\")\n\
-           (subpath \"{home}/.cargo\")\n\
-           (subpath \"{home}/.npm\")\n\
-           (subpath \"{home}/.cache\")\n\
-           (literal \"/dev/null\")\n\
-           (literal \"/dev/stderr\")\n\
-           (literal \"/dev/stdout\")\n\
-           (literal \"/dev/urandom\"))\n\
-         (allow network*)\n\
-         (allow process-exec*)\n\
-         (allow process-fork)\n\
-         (allow sysctl-read)\n\
-         (allow ipc-posix*)\n\
-         (allow mach*)\n"
-    )
-}
-
-/// Generate seatbelt deny-write rules for protected project subdirectories.
-///
-/// Prevents sandboxed commands from modifying agent definitions or skills
-/// that could alter system prompts or tool access on next session.  Same
-/// pattern as Claude Code blocking writes to `.claude/settings.json` and
-/// `.claude/agents/`.
-#[cfg(target_os = "macos")]
-fn protected_subdir_deny_rules_macos(root: &str) -> String {
-    let mut rules = String::from(
-        "; ── deny writes to protected project subdirs (.koda/agents, .koda/skills) ──\n",
-    );
-    for rel in PROTECTED_PROJECT_SUBDIRS {
-        let p = Path::new(root).join(rel);
-        let canonical = p.canonicalize().unwrap_or(p).to_string_lossy().into_owned();
-        rules.push_str(&format!("(deny file-write* (subpath \"{canonical}\"))\n"));
-    }
-    rules
-}
-
-/// Generate seatbelt deny rules for credential paths (Strict mode).
-///
-/// Two tiers:
-/// - **Write-only deny** for most paths — lets CLI tools read their own
-///   credentials while preventing sandboxed commands from modifying them.
-/// - **Full read+write deny** for `koda/db` only — koda’s own API keys
-///   should never be accessible from inside the sandbox (#847).
-///
-/// Rules are placed *after* the broad `(allow file-read*)` so that
-/// seatbelt’s last-match-wins semantics make them take precedence.
-#[cfg(target_os = "macos")]
-fn credential_deny_rules_macos(home: &str) -> String {
-    let mut rules = String::from("; ── strict: write-protect credential dirs (reads allowed) ──\n");
-
-    // Tier 1 — write-only deny (CLI tools can still read).
-    for rel in CREDENTIAL_SUBDIRS {
-        let p = home_path(home, rel);
-        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
-    }
-    for rel in CREDENTIAL_CONFIG_SUBDIRS {
-        let p = home_path(home, &format!(".config/{rel}"));
-        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
-    }
-    for rel in CREDENTIAL_FILES {
-        let p = home_path(home, rel);
-        rules.push_str(&format!("(deny file-write* (literal \"{p}\"))\n"));
-    }
-
-    // Tier 2 — full read+write deny (koda’s own secrets).
-    rules.push_str("; ── strict: full deny for koda-internal secrets ─────────────\n");
-    for rel in CREDENTIAL_CONFIG_FULL_DENY {
-        let p = home_path(home, &format!(".config/{rel}"));
-        rules.push_str(&format!(
-            "(deny file-read* file-write* (subpath \"{p}\"))\n"
-        ));
-    }
-    rules
-}
-
-#[cfg(target_os = "macos")]
-fn macos_project(command: &str, project_root: &Path) -> Result<Command> {
-    let canonical = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.to_path_buf());
-    let root = canonical.to_string_lossy();
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users".into());
-    validate_seatbelt_path(&root)?;
-    validate_seatbelt_path(&home)?;
-
-    let mut profile = macos_project_profile(&root, &home);
-    // Deny writes to agent/skill files within the project (CC parity #844).
-    profile.push_str(&protected_subdir_deny_rules_macos(&root));
-
-    let mut cmd = Command::new("sandbox-exec");
-    cmd.arg("-p")
-        .arg(profile)
-        .arg("sh")
-        .arg("-c")
-        .arg(command)
-        .current_dir(project_root);
-    Ok(cmd)
-}
-
-#[cfg(target_os = "macos")]
-fn macos_strict(command: &str, project_root: &Path) -> Result<Command> {
-    let canonical = project_root
-        .canonicalize()
-        .unwrap_or_else(|_| project_root.to_path_buf());
-    let root = canonical.to_string_lossy();
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users".into());
-    validate_seatbelt_path(&root)?;
-    validate_seatbelt_path(&home)?;
-
-    // Start from the project profile then append credential deny rules.
-    // Seatbelt evaluates rules in order; later rules win for the same path,
-    // so the denies override the earlier broad `(allow file-read*)`.
-    // Same last-match-wins approach as Gemini CLI's seatbeltArgsBuilder.ts.
-    let mut profile = macos_project_profile(&root, &home);
-    profile.push_str(&protected_subdir_deny_rules_macos(&root));
-    profile.push_str(&credential_deny_rules_macos(&home));
-
-    let mut cmd = Command::new("sandbox-exec");
-    cmd.arg("-p")
-        .arg(profile)
-        .arg("sh")
-        .arg("-c")
-        .arg(command)
-        .current_dir(project_root);
-    Ok(cmd)
-}
-
-// ── Linux: bwrap (bubblewrap) ─────────────────────────────────────────────────
-
-#[cfg(target_os = "linux")]
-fn bwrap_available() -> bool {
-    use std::sync::OnceLock;
-    static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| {
-        // Just checking `bwrap --version` is insufficient: bwrap may be
-        // installed but unable to create sandboxes (e.g. GitHub Actions
-        // runners lack unprivileged user namespaces → "setting up uid map:
-        // Permission denied"). Run a real sandboxed command to verify.
-        std::process::Command::new("bwrap")
-            .args(["--ro-bind", "/", "/", "--", "true"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|s| s.success())
-    })
-}
-
-/// Build a bwrap `Command` with the base project-mode filesystem view.
-///
-/// Returns `(cmd, home)` with everything set up *except* the final
-/// `-- sh -c command` terminator — callers add that (plus any extra mounts for
-/// strict mode) before spawning.
-#[cfg(target_os = "linux")]
-fn linux_base_cmd(project_root: &Path) -> (Command, String) {
-    let root = project_root.to_string_lossy().into_owned();
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
-
-    // Strategy: bind the whole root filesystem read-only, then selectively
-    // add read-write binds for project + temp + common caches.
-    let mut cmd = Command::new("bwrap");
-    cmd.args(["--ro-bind", "/", "/"]);
-    cmd.args(["--bind", &root, &root]);
-    cmd.args(["--bind", "/tmp", "/tmp"]);
-    if Path::new("/var/tmp").exists() {
-        cmd.args(["--bind", "/var/tmp", "/var/tmp"]);
-    }
-    // Common package caches — avoids re-downloading on every invocation.
-    for subdir in &[".cargo", ".npm", ".cache"] {
-        let p = format!("{home}/{subdir}");
-        if Path::new(&p).exists() {
-            cmd.args(["--bind", p.as_str(), p.as_str()]);
+/// Emit a single warning per process if the active runtime can't enforce
+/// kernel-level isolation. Without this users get silent unsandboxed
+/// execution on, e.g., Linux without `bwrap` installed — surprising
+/// behavior that the previous `build_inner()` path warned about explicitly.
+fn warn_if_unavailable_once(runtime: &dyn SandboxRuntime) {
+    static WARNED: OnceLock<()> = OnceLock::new();
+    WARNED.get_or_init(|| {
+        let report = runtime.check_dependencies();
+        if !report.available {
+            tracing::warn!(
+                "Sandbox backend {:?} unavailable — commands run unsandboxed. {}",
+                report.backend,
+                report.reason.as_deref().unwrap_or("")
+            );
         }
-    }
-    cmd.args(["--dev", "/dev"]).args(["--proc", "/proc"]);
-
-    // Deny writes to protected project subdirs (.koda/agents, .koda/skills).
-    // Re-bind as read-only after the project-root writable bind (CC parity #844).
-    // Pre-create if absent so bwrap has a mountpoint — otherwise a sandboxed
-    // command could `mkdir -p` and write agent definitions.
-    for rel in PROTECTED_PROJECT_SUBDIRS {
-        let p = format!("{root}/{rel}");
-        let _ = std::fs::create_dir_all(&p);
-        cmd.args(["--ro-bind", &p, &p]);
-    }
-
-    (cmd, home)
+    });
 }
 
-#[cfg(target_os = "linux")]
-fn linux_project(command: &str, project_root: &Path) -> Result<Command> {
-    if !bwrap_available() {
-        anyhow::bail!(
-            "Sandbox mode 'project' requested but bwrap is not installed. \
-             Install with: apt install bubblewrap  /  dnf install bubblewrap"
-        );
-    }
-
-    let (mut cmd, _home) = linux_base_cmd(project_root);
-    cmd.args(["--", "sh", "-c", command])
-        .current_dir(project_root);
-    Ok(cmd)
-}
-
-/// Strict mode on Linux: project-mode base + credential write-protection
-/// and full deny for koda-internal secrets.
-///
-/// The base command (`linux_base_cmd`) already mounts the entire root
-/// filesystem read-only via `--ro-bind / /`, so credential directories
-/// are inherently write-protected.  No additional rules are needed for
-/// write-deny — CLI tools like `gh`, `aws`, `kubectl` can read their
-/// own config files through the base read-only bind.
-///
-/// The only addition is a `--tmpfs` shadow for `koda/db` to block reads
-/// of koda's own API keys (#847).  All other credential paths remain
-/// readable (Codex-style model — see #855).
-#[cfg(target_os = "linux")]
-fn linux_strict(command: &str, project_root: &Path) -> Result<Command> {
-    if !bwrap_available() {
-        anyhow::bail!(
-            "Sandbox mode 'strict' requested but bwrap is not installed. \
-             Install with: apt install bubblewrap  /  dnf install bubblewrap"
-        );
-    }
-
-    let (mut cmd, home) = linux_base_cmd(project_root);
-
-    // Full deny (read+write) for koda-internal secrets only.
-    // The base `--ro-bind / /` already write-protects everything else.
-    for rel in CREDENTIAL_CONFIG_FULL_DENY {
-        let p = format!("{home}/.config/{rel}");
-        if Path::new(&p).exists() {
-            cmd.args(["--tmpfs", &p]);
-        }
-    }
-
-    cmd.args(["--", "sh", "-c", command])
-        .current_dir(project_root);
-    Ok(cmd)
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // ── Unit: enum behaviour ───────────────────────────────────────────────
-
-    #[test]
-    fn stricter_returns_higher_level() {
-        use SandboxMode::*;
-        // Same mode → returns self
-        assert_eq!(None.stricter(&None), None);
-        assert_eq!(Project.stricter(&Project), Project);
-        assert_eq!(Strict.stricter(&Strict), Strict);
-        // Different modes → returns the stricter one
-        assert_eq!(None.stricter(&Project), Project);
-        assert_eq!(Project.stricter(&None), Project);
-        assert_eq!(None.stricter(&Strict), Strict);
-        assert_eq!(Strict.stricter(&None), Strict);
-        assert_eq!(Project.stricter(&Strict), Strict);
-        assert_eq!(Strict.stricter(&Project), Strict);
-    }
-
-    #[test]
-    fn parse_roundtrip() {
-        assert_eq!(SandboxMode::parse("none"), SandboxMode::None);
-        assert_eq!(SandboxMode::parse("project"), SandboxMode::Project);
-        assert_eq!(SandboxMode::parse("PROJECT"), SandboxMode::Project);
-        assert_eq!(SandboxMode::parse("strict"), SandboxMode::Strict);
-        assert_eq!(SandboxMode::parse("STRICT"), SandboxMode::Strict);
-        assert_eq!(SandboxMode::parse(""), SandboxMode::None);
-        // Unknown value → None (warning is logged, not an error)
-        assert_eq!(SandboxMode::parse("banana"), SandboxMode::None);
-    }
-
-    #[test]
-    fn display_roundtrip() {
-        assert_eq!(SandboxMode::None.to_string(), "none");
-        assert_eq!(SandboxMode::Project.to_string(), "project");
-        assert_eq!(SandboxMode::Strict.to_string(), "strict");
-    }
-
-    #[test]
-    fn default_is_none() {
-        assert_eq!(SandboxMode::default(), SandboxMode::None);
-    }
-
-    #[test]
-    fn is_active() {
-        assert!(!SandboxMode::None.is_active());
-        assert!(SandboxMode::Project.is_active());
-        assert!(SandboxMode::Strict.is_active());
-    }
-
-    // ── Unit: is_fully_denied ──────────────────────────────────────────────
-
-    #[test]
-    fn fully_denied_blocks_koda_db() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
-        let koda_db = Path::new(&home).join(".config/koda/db");
-        assert!(
-            is_fully_denied(&koda_db),
-            "~/.config/koda/db must be fully denied"
-        );
-        // Sub-paths inside it are also denied.
-        assert!(is_fully_denied(&koda_db.join("koda.db")));
-    }
-
-    #[test]
-    fn fully_denied_allows_credential_dirs() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
-        let home = Path::new(&home);
-        // Credential dirs are write-protected but reads are allowed — they
-        // must NOT appear in the fully-denied list.
-        for rel in &[".ssh", ".aws", ".gnupg", ".config/gh", ".config/gcloud"] {
-            assert!(
-                !is_fully_denied(&home.join(rel)),
-                "{rel} must NOT be fully denied (reads allowed)"
-            );
-        }
-    }
-
-    #[test]
-    fn fully_denied_allows_project_and_system_paths() {
-        assert!(!is_fully_denied(Path::new(
-            "/home/user/project/src/main.rs"
-        )));
-        assert!(!is_fully_denied(Path::new("/tmp/scratch.txt")));
-        assert!(!is_fully_denied(Path::new("/etc/hosts")));
-    }
-
-    // ── Regression: HOME-unset bypass (#898) ───────────────────────────────
-    //
-    // Before the fix, an unset HOME caused is_fully_denied() to return false
-    // for every path, opening a hole where `unset HOME` inside a sandboxed
-    // Bash command (or any container with no HOME) could read koda's DB via
-    // the in-process Read tool. The fix uses a path-component fallback so
-    // we still fail closed.
-    //
-    // We test the pure helper (`is_fully_denied_with_home`) with an explicit
-    // `home: None` rather than mutating the process-wide HOME env var, which
-    // would race against parallel tests in the same binary.
-
-    #[test]
-    fn fully_denied_blocks_koda_db_when_home_is_none() {
-        // The historical bypass: tool resolves to a real-looking path but
-        // HOME is unset, so the prefix check can't fire. Path-segment
-        // fallback must still deny it.
-        for path in [
-            "/root/.config/koda/db",
-            "/root/.config/koda/db/koda.db",
-            "/home/runner/.config/koda/db/koda.db",
-            "/proc/self/root/.config/koda/db/koda.db",
-            ".config/koda/db/koda.db", // relative path, no anchor at all
-        ] {
-            assert!(
-                is_fully_denied_with_home(Path::new(path), None),
-                "{path:?} must be denied even with HOME=None"
-            );
-        }
-    }
-
-    #[test]
-    fn fully_denied_no_home_still_allows_normal_paths() {
-        // Defense-in-depth fallback must not over-block ordinary paths.
-        for path in [
-            "/home/user/project/src/main.rs",
-            "/tmp/scratch.txt",
-            "/etc/hosts",
-            "/home/user/.config/git/config", // .config but not koda/db
-            "/home/user/.config/koda/agents/foo.json", // koda but not db
-            "/var/lib/koda-db-backups/2025.tar", // contains 'koda' and 'db'
-                                             // but not the sequence
-                                             // .config/koda/db
-        ] {
-            assert!(
-                !is_fully_denied_with_home(Path::new(path), None),
-                "{path:?} must NOT be denied (no koda secrets)"
-            );
-        }
-    }
-
-    #[test]
-    fn fully_denied_uses_home_when_provided() {
-        // Sanity check that the explicit-home path still works and matches
-        // a non-HOME directory the user passes in.
-        let custom_home = "/srv/koda-runner";
-        assert!(is_fully_denied_with_home(
-            Path::new("/srv/koda-runner/.config/koda/db/koda.db"),
-            Some(custom_home),
-        ));
-        assert!(!is_fully_denied_with_home(
-            Path::new("/srv/koda-runner/notes.md"),
-            Some(custom_home),
-        ));
-    }
-
-    #[test]
-    fn resolve_home_dir_treats_empty_as_unset() {
-        // Empty HOME (`HOME=""`) is just as broken as unset — both should
-        // route through the no-home fallback. The .filter() in
-        // resolve_home_dir() guarantees this; verify via direct call to
-        // the helper since we can't safely mutate env in tests.
-        assert!(is_fully_denied_with_home(
-            Path::new("/anywhere/.config/koda/db/koda.db"),
-            None, // simulating resolve_home_dir() returning None
-        ));
-    }
-
-    // ── Unit: strict profile contains deny rules ───────────────────────────────
-    //
-    // We test the profile *string* rather than kernel enforcement to keep the
-    // test hermetic — the kernel-enforcement tests below verify the enforcement
-    // end-to-end for project mode (same underlying mechanism).
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_ssh_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let ssh = home_path(&home, ".ssh");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{ssh}\"))")),
-            "strict profile must write-protect ~/.ssh"
-        );
-        // Reads should NOT be denied — CLI tools need credential access (#855).
-        assert!(
-            !rules.contains(&format!(
-                "(deny file-read* file-write* (subpath \"{ssh}\"))"
-            )),
-            "strict profile must NOT read-deny ~/.ssh (breaks ssh/git)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_aws_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let aws = home_path(&home, ".aws");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{aws}\"))")),
-            "strict profile must write-protect ~/.aws"
-        );
-        assert!(
-            !rules.contains(&format!(
-                "(deny file-read* file-write* (subpath \"{aws}\"))"
-            )),
-            "strict profile must NOT read-deny ~/.aws (breaks aws CLI)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_gh_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let gh = home_path(&home, ".config/gh");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{gh}\"))")),
-            "strict profile must write-protect ~/.config/gh"
-        );
-        assert!(
-            !rules.contains(&format!("(deny file-read* file-write* (subpath \"{gh}\"))")),
-            "strict profile must NOT read-deny ~/.config/gh (breaks gh CLI, #855)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_claude_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let claude = home_path(&home, ".claude");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{claude}\"))")),
-            "strict profile must write-protect ~/.claude"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_android_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let android = home_path(&home, ".android");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{android}\"))")),
-            "strict profile must write-protect ~/.android"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_netlify_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let netlify = home_path(&home, ".config/netlify");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{netlify}\"))")),
-            "strict profile must write-protect ~/.config/netlify"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_vercel_dir() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let vercel = home_path(&home, ".config/vercel");
-        assert!(
-            rules.contains(&format!("(deny file-write* (subpath \"{vercel}\"))")),
-            "strict profile must write-protect ~/.config/vercel"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_fully_denies_koda_db() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let koda_db = home_path(&home, ".config/koda/db");
-        assert!(
-            rules.contains(&format!(
-                "(deny file-read* file-write* (subpath \"{koda_db}\"))"
-            )),
-            "strict profile must fully deny ~/.config/koda/db (plaintext API keys, #847)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_profile_write_protects_credential_files() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let rules = credential_deny_rules_macos(&home);
-        let netrc = home_path(&home, ".netrc");
-        assert!(
-            rules.contains(&format!("(deny file-write* (literal \"{netrc}\"))")),
-            "strict profile must write-protect ~/.netrc"
-        );
-        assert!(
-            !rules.contains(&format!(
-                "(deny file-read* file-write* (literal \"{netrc}\"))"
-            )),
-            "strict profile must NOT read-deny ~/.netrc (breaks curl/wget)"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn strict_deny_rules_come_after_broad_allow() {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
-        let project = Path::new("/tmp/test-project");
-        let root = project.to_string_lossy().into_owned();
-        let profile = macos_project_profile(&root, &home);
-        let deny_rules = credential_deny_rules_macos(&home);
-        // Simulate what macos_strict does: project profile then deny rules.
-        let full = format!("{profile}{deny_rules}");
-        let allow_pos = full.find("(allow file-read*)").unwrap();
-        // Full deny (koda/db) must come after broad allow.
-        let deny_pos = full.find("(deny file-read* file-write*").unwrap();
-        assert!(
-            deny_pos > allow_pos,
-            "deny rules must appear after the broad allow (last-match-wins)"
-        );
-        // Write-only deny must also come after broad allow.
-        let write_deny_pos = full.find("(deny file-write*").unwrap();
-        assert!(
-            write_deny_pos > allow_pos,
-            "write-deny rules must appear after the broad allow"
-        );
-    }
-
-    // ── Integration: kernel-level enforcement ──────────────────────────────
-    //
-    // Spawn real child processes through the sandbox and verify that the
-    // kernel actually enforces the policy.
 
     /// Sandbox build must always succeed (falls back to unsandboxed if
     /// the platform backend is unavailable, e.g. no `bwrap` on CI Linux).
@@ -1114,11 +226,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(
-            !status.success(),
-            "strict: write outside project must be blocked"
-        );
-        assert!(!target.exists());
+        assert!(!status.success(), "write outside project must be blocked");
+        assert!(!target.exists(), "file must not have been created");
     }
 
     /// Strict mode: reads to non-sensitive paths must still work.
@@ -1142,16 +251,12 @@ mod tests {
     }
 
     /// Strict mode: reading `~/.config/koda/db/` must be blocked (#847).
-    ///
-    /// The koda SQLite DB contains plaintext API keys in the `kv_store` table.
-    /// A sandboxed bash command must not be able to `sqlite3` it.
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn macos_strict_blocks_koda_db_read() {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
         let db_dir = format!("{home}/.config/koda/db");
         if !Path::new(&db_dir).exists() {
-            // DB dir doesn't exist on this machine — skip but don't fail.
             eprintln!("skip: {db_dir} does not exist");
             return;
         }
@@ -1172,9 +277,6 @@ mod tests {
     }
 
     /// Strict mode: reading `~/.ssh/` must now be allowed (#855).
-    ///
-    /// CLI tools like `ssh` and `git` need read access to their own credentials.
-    /// Only koda-internal secrets (`koda/db`) remain fully denied.
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn macos_strict_allows_ssh_read() {
@@ -1236,7 +338,6 @@ mod tests {
     #[tokio::test]
     async fn macos_project_blocks_write_to_koda_agents() {
         let dir = tempfile::tempdir().unwrap();
-        // Create the .koda/agents/ directory so the deny rule kicks in.
         std::fs::create_dir_all(dir.path().join(".koda/agents")).unwrap();
         let target = dir.path().join(".koda/agents/evil.json");
 
@@ -1282,8 +383,7 @@ mod tests {
         assert!(!target.exists());
     }
 
-    /// Project mode: writing to normal project files must still work
-    /// (regression check — don't over-deny).
+    /// Project mode: writing to normal project files must still work.
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn macos_project_allows_normal_writes_with_agents_dir() {
@@ -1308,7 +408,7 @@ mod tests {
     }
 
     /// Project mode: writing to `.koda/skills/` inside the project must be
-    /// blocked (same protection as `.koda/agents/`).
+    /// blocked.
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn macos_project_blocks_write_to_koda_skills() {
@@ -1334,14 +434,8 @@ mod tests {
     }
 
     // ── Integration: Linux bwrap credential enforcement ────────────────────
-    //
-    // Mirror the macOS seatbelt tests for bwrap on Linux.  The base bwrap
-    // command mounts `/ ` read-only, so credential dirs are write-protected
-    // by default.  Reads must still succeed (Codex-style model, #855).
 
-    /// Strict mode on Linux: `cat ~/.ssh/known_hosts` (or any file in ~/.ssh)
-    /// must succeed — bwrap inherits the root filesystem read-only, and the
-    /// SSH directory is included in that read-only view.
+    /// Strict mode on Linux: `cat ~/.ssh/known_hosts` must succeed.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn linux_strict_allows_ssh_read() {
@@ -1367,9 +461,7 @@ mod tests {
         );
     }
 
-    /// Strict mode on Linux: `touch ~/.ssh/canary` must fail — the base
-    /// bwrap `--ro-bind / /` makes the entire root filesystem read-only,
-    /// so writes to credential dirs are blocked without extra rules.
+    /// Strict mode on Linux: `touch ~/.ssh/canary` must fail.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn linux_strict_blocks_ssh_write() {
@@ -1397,8 +489,7 @@ mod tests {
         assert!(!Path::new(&canary).exists());
     }
 
-    /// Strict mode on Linux: `cat ~/.aws/credentials` must succeed —
-    /// the AWS CLI needs to read credentials to authenticate.
+    /// Strict mode on Linux: `cat ~/.aws/credentials` must succeed.
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn linux_strict_allows_aws_read() {
@@ -1422,21 +513,5 @@ mod tests {
             status.success(),
             "linux strict: reading ~/.aws/ must be allowed (aws CLI needs credentials)"
         );
-    }
-
-    /// Seatbelt path validation: reject paths with characters that could
-    /// inject rules into the profile string.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn seatbelt_rejects_path_with_quote() {
-        let result = validate_seatbelt_path("/tmp/evil\")(allow file-write*");
-        assert!(result.is_err(), "path with quote must be rejected");
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn seatbelt_accepts_normal_path() {
-        assert!(validate_seatbelt_path("/Users/test/project").is_ok());
-        assert!(validate_seatbelt_path("/tmp/koda-test-12345").is_ok());
     }
 }

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "koda-sandbox"
+version = "0.1.0"
+edition = "2024"
+description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
+license = "MIT"
+repository = "https://github.com/lijunzh/koda"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["process", "rt"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -1,0 +1,117 @@
+//! Linux bwrap (bubblewrap) backend.
+//!
+//! Generates a `bwrap` command-line invocation that mounts the host
+//! filesystem read-only, then re-binds the project root + caches as
+//! read-write, and shadows koda's own secrets with `--tmpfs`.
+//!
+//! ## Phase 0
+//!
+//! Lifted verbatim from `koda-core/src/sandbox.rs::linux_*`. The
+//! [`crate::policy::SandboxPolicy`] argument is currently *unused* — the
+//! arg vector is built from the [`crate::defaults`] baseline, which
+//! preserves pre-#934 byte-for-byte behavior.
+//!
+//! ## Phase 1
+//!
+//! `policy.fs.allow_write` becomes additional `--bind` args;
+//! `policy.fs.deny_read` becomes `--tmpfs` overlays. The two-layer rules
+//! map naturally onto bwrap's bind-then-overlay mechanism.
+
+#![cfg(target_os = "linux")]
+
+use crate::defaults::{CREDENTIAL_CONFIG_FULL_DENY, PROTECTED_PROJECT_SUBDIRS};
+use crate::policy::SandboxPolicy;
+use anyhow::Result;
+use std::path::Path;
+use tokio::process::Command;
+
+/// Build a `bwrap` Command for the given command + project root.
+///
+/// Phase 0: `_policy` is accepted but ignored — the arg vector is the
+/// hardcoded "strict" baseline that matches pre-#934 behavior.
+pub fn build_command(
+    command: &str,
+    project_root: &Path,
+    _policy: &SandboxPolicy,
+) -> Result<Command> {
+    if !is_available() {
+        anyhow::bail!(
+            "Sandbox requested but bwrap is not installed. \
+             Install with: apt install bubblewrap  /  dnf install bubblewrap"
+        );
+    }
+
+    let (mut cmd, home) = base_cmd(project_root);
+
+    // Full deny (read+write) for koda-internal secrets only.
+    // The base `--ro-bind / /` already write-protects everything else.
+    for rel in CREDENTIAL_CONFIG_FULL_DENY {
+        let p = format!("{home}/.config/{rel}");
+        if Path::new(&p).exists() {
+            cmd.args(["--tmpfs", &p]);
+        }
+    }
+
+    cmd.args(["--", "sh", "-c", command])
+        .current_dir(project_root);
+    Ok(cmd)
+}
+
+/// Probe whether the bwrap backend is functional. Cached.
+///
+/// Just checking `bwrap --version` is insufficient: bwrap may be installed
+/// but unable to create sandboxes (e.g. GitHub Actions runners lack
+/// unprivileged user namespaces → "setting up uid map: Permission denied").
+/// Run a real sandboxed command to verify.
+pub fn is_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        std::process::Command::new("bwrap")
+            .args(["--ro-bind", "/", "/", "--", "true"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
+    })
+}
+
+/// Build a bwrap `Command` with the base project-mode filesystem view.
+///
+/// Returns `(cmd, home)` with everything set up *except* the final
+/// `-- sh -c command` terminator — callers add that (plus any extra mounts
+/// for strict mode) before spawning.
+fn base_cmd(project_root: &Path) -> (Command, String) {
+    let root = project_root.to_string_lossy().into_owned();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+
+    // Strategy: bind the whole root filesystem read-only, then selectively
+    // add read-write binds for project + temp + common caches.
+    let mut cmd = Command::new("bwrap");
+    cmd.args(["--ro-bind", "/", "/"]);
+    cmd.args(["--bind", &root, &root]);
+    cmd.args(["--bind", "/tmp", "/tmp"]);
+    if Path::new("/var/tmp").exists() {
+        cmd.args(["--bind", "/var/tmp", "/var/tmp"]);
+    }
+    // Common package caches — avoids re-downloading on every invocation.
+    for subdir in &[".cargo", ".npm", ".cache"] {
+        let p = format!("{home}/{subdir}");
+        if Path::new(&p).exists() {
+            cmd.args(["--bind", p.as_str(), p.as_str()]);
+        }
+    }
+    cmd.args(["--dev", "/dev"]).args(["--proc", "/proc"]);
+
+    // Deny writes to protected project subdirs (.koda/agents, .koda/skills).
+    // Re-bind as read-only after the project-root writable bind (CC parity #844).
+    // Pre-create if absent so bwrap has a mountpoint — otherwise a sandboxed
+    // command could `mkdir -p` and write agent definitions.
+    for rel in PROTECTED_PROJECT_SUBDIRS {
+        let p = format!("{root}/{rel}");
+        let _ = std::fs::create_dir_all(&p);
+        cmd.args(["--ro-bind", &p, &p]);
+    }
+
+    (cmd, home)
+}

--- a/koda-sandbox/src/defaults.rs
+++ b/koda-sandbox/src/defaults.rs
@@ -1,0 +1,108 @@
+//! Hardcoded baselines: credential paths, protected project subdirs, etc.
+//!
+//! These are the kernel-enforced defaults that apply *regardless* of the
+//! [`crate::policy::SandboxPolicy`] passed in. The policy can *augment*
+//! these baselines (Phase 1+) but cannot weaken them — they're the floor.
+//!
+//! All lists ported verbatim from `koda-core/src/sandbox.rs` to preserve
+//! Phase 0's byte-identical-behavior guarantee.
+
+// ── Sensitive credential paths ───────────────────────────────────────────────
+//
+// Two tiers of credential protection:
+//
+// 1. **Write-only deny** (most paths) — CLI tools can *read* their own
+//    credentials (e.g. `gh`, `aws`, `kubectl`, `ssh`) but sandboxed
+//    commands cannot modify them. Matches Codex's model.
+//
+//    Risk accepted: a sandboxed command *can* read credentials and could
+//    exfiltrate them over the network. Network-level egress restriction
+//    (Phase 3) is the proper mitigation — blocking reads without blocking
+//    network is security theater (#855).
+//
+// 2. **Full read+write deny** (`koda/db` only) — koda's own API keys live
+//    in a SQLite DB at `~/.config/koda/db/koda.db`. The koda process runs
+//    *outside* the sandbox and doesn't need sandboxed-command access.
+//    Blocking reads here prevents a `sqlite3` one-liner from dumping
+//    every stored API key (#847).
+
+/// Credential *directories* under `$HOME` that are **write-protected**.
+/// Reads are allowed so CLI tools can authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const CREDENTIAL_SUBDIRS: &[&str] = &[
+    ".ssh",            // SSH private keys, authorized_keys, known_hosts
+    ".aws",            // AWS access key ID, secret key, session tokens
+    ".gnupg",          // GPG private keys and trust database
+    ".kube",           // kubeconfig with cluster tokens and client certs
+    ".azure",          // Azure CLI token cache (msal_token_cache.bin, etc.)
+    ".password-store", // pass(1) GPG-encrypted password store
+    ".terraform.d",    // Terraform cloud tokens and plugin cache
+    ".claude",         // Claude Code settings and session tokens
+    ".android",        // Android SDK debug keystores and signing keys
+];
+
+/// Credential directories under `$HOME/.config/` that are **write-protected**.
+/// Reads are allowed so CLI tools can authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const CREDENTIAL_CONFIG_SUBDIRS: &[&str] = &[
+    "gcloud",  // gcloud CLI credentials and service-account key files
+    "gh",      // GitHub CLI personal access tokens (hosts.yml)
+    "op",      // 1Password CLI session tokens
+    "helm",    // Helm registry auth
+    "netlify", // Netlify CLI access tokens
+    "vercel",  // Vercel CLI credentials
+    "fly",     // Fly.io CLI auth tokens
+    "doppler", // Doppler secrets manager tokens
+    "stripe",  // Stripe CLI API keys
+    "heroku",  // Heroku CLI OAuth tokens
+];
+
+/// Credential directories under `$HOME/.config/` where **both reads and
+/// writes** are denied. These contain koda's own secrets that sandboxed
+/// commands have no legitimate reason to access.
+pub const CREDENTIAL_CONFIG_FULL_DENY: &[&str] = &[
+    "koda/db", // SQLite DB with plaintext API keys in kv_store table (#847)
+];
+
+/// Individual credential *files* under `$HOME` that are **write-protected**.
+/// Reads are allowed so tools like `curl`, `git`, `npm`, and `docker` can
+/// authenticate.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const CREDENTIAL_FILES: &[&str] = &[
+    ".netrc",              // FTP/HTTP credentials (curl, wget, Netrc crate)
+    ".git-credentials",    // git-credential-store plaintext token file
+    ".npmrc",              // npm registry auth token
+    ".pypirc",             // PyPI upload API token
+    ".docker/config.json", // Docker Hub credentials (auths, credsStore)
+    ".vault-token",        // HashiCorp Vault session token
+    ".env",                // dotenv secrets (common project-level pattern)
+];
+
+// ── Agent-file write protection ──────────────────────────────────────────────
+//
+// Prevent sandboxed commands from modifying koda agent definitions or the
+// project-level system prompt. Same pattern as Claude Code blocking writes
+// to `.claude/settings.json` — modifying these files could alter system
+// prompts, tool access, or sandbox policy on next session.
+
+/// Directories under the project root that are write-protected. Agent JSON
+/// files control system prompts and tool access — a sandboxed command must
+/// not be able to modify them.
+pub const PROTECTED_PROJECT_SUBDIRS: &[&str] = &[
+    ".koda/agents", // Agent definitions (system prompt, tools, sub-agents)
+    ".koda/skills", // Skill definitions (auto-discovered, full capabilities)
+];
+
+// ── Default writable system paths ────────────────────────────────────────────
+
+/// Filesystem locations every sandboxed process may write to regardless of
+/// policy. Phase 0 hardcodes the list; Phase 1 will let `FsPolicy.allow_write`
+/// extend it.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const DEFAULT_WRITE_LITERALS: &[&str] =
+    &["/dev/null", "/dev/stderr", "/dev/stdout", "/dev/urandom"];
+
+/// Subpaths under `$HOME` that are writable by default — common package
+/// caches that would otherwise force re-downloads on every invocation.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub const DEFAULT_WRITE_HOME_SUBDIRS: &[&str] = &[".cargo", ".npm", ".cache"];

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -1,0 +1,298 @@
+//! `koda-sandbox` — capability-aware sandbox layer for Koda.
+//!
+//! Per the design in <https://github.com/lijunzh/koda/issues/934>: this
+//! crate owns *kernel-level* sandbox enforcement (Seatbelt on macOS, bwrap
+//! on Linux), workspace provisioning, and the egress proxy (Phase 3+).
+//!
+//! ## Phase 0 — what's here
+//!
+//! - [`SandboxPolicy`] data types (issue §4.2 schema).
+//! - [`SandboxRuntime`] trait + per-platform impls.
+//! - [`SandboxRuntime::transform`] entry point: pure `(cmd, policy) → SandboxExecRequest`.
+//! - [`WorkspaceProvider`] trait + [`CwdProvider`] impl.
+//!
+//! Phase 0 is a *refactor* — the runtime ignores the policy fields and
+//! reproduces pre-#934 behavior byte-for-byte. Subsequent phases consume
+//! the policy fields incrementally.
+//!
+//! ## Dependency direction
+//!
+//! ```text
+//! koda-cli → koda-core → koda-sandbox
+//!                          │
+//!                          └─ no upward dependency
+//! ```
+//!
+//! `koda-sandbox` knows nothing about `Persistence`, `Provider`,
+//! `ToolRegistry`. Pure infrastructure — testable with
+//! `assert_eq!(transform(cmd, policy), expected)`.
+
+#![deny(missing_docs)]
+
+#[cfg(target_os = "linux")]
+pub mod bwrap;
+pub mod defaults;
+pub mod policy;
+pub mod policy_check;
+#[cfg(target_os = "macos")]
+pub mod seatbelt;
+pub mod workspace;
+
+pub use policy::{
+    DomainPattern, FsPolicy, MitmConfig, NetPolicy, PathPattern, ResourceLimits, SandboxPolicy,
+    TrustPreference,
+};
+pub use policy_check::is_fully_denied;
+pub use workspace::{CwdProvider, WorkspaceProvider};
+
+use anyhow::Result;
+use std::path::Path;
+use tokio::process::Command;
+
+// ── Public API: SandboxRuntime trait ─────────────────────────────────────────
+
+/// Inputs to [`SandboxRuntime::transform`].
+///
+/// Borrowed-only so callers can build a request on the stack without
+/// allocating. The runtime returns a fully-spawnable [`SandboxExecRequest`]
+/// that owns its data.
+#[derive(Debug)]
+pub struct SandboxTransformRequest<'a> {
+    /// The command to run, as `sh -c "{command}"`. Quoting is the
+    /// caller's responsibility.
+    pub command: &'a str,
+
+    /// Working directory + writable-root anchor. Most policy paths are
+    /// resolved relative to this.
+    pub project_root: &'a Path,
+
+    /// Capability policy. Phase 0 ignores all fields; later phases
+    /// progressively enforce them.
+    pub policy: &'a SandboxPolicy,
+}
+
+/// Output of [`SandboxRuntime::transform`].
+///
+/// Wraps a `tokio::process::Command` so callers can attach stdio, piping,
+/// and cancellation tokens before spawning.
+#[derive(Debug)]
+pub struct SandboxExecRequest {
+    /// Spawnable command — `sandbox-exec ...` on macOS, `bwrap ...` on
+    /// Linux, plain `sh -c` on platforms with no backend.
+    pub command: Command,
+}
+
+/// Health/dependency check report. Returned by
+/// [`SandboxRuntime::check_dependencies`] so callers (e.g. `/sandbox status`
+/// CLI command) can surface actionable diagnostics.
+#[derive(Debug, Clone)]
+pub struct DependencyReport {
+    /// Backend identifier — `"seatbelt"`, `"bwrap"`, or `"none"`.
+    pub backend: &'static str,
+    /// Whether the backend is installed and functional.
+    pub available: bool,
+    /// Human-readable reason when `available` is `false`.
+    pub reason: Option<String>,
+}
+
+/// Backend-agnostic sandbox runtime.
+///
+/// Phase 0 only has [`Self::transform`] and [`Self::check_dependencies`].
+/// Phase 2 will add `acquire(&self, policy) -> SandboxSlot` for the
+/// long-lived per-agent slot model.
+pub trait SandboxRuntime: Send + Sync {
+    /// Compile a high-level command + policy into a concrete spawnable
+    /// `Command`. Pure-ish (consults `$HOME`, canonicalizes paths) but
+    /// performs no I/O on the supplied command.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the policy or paths violate runtime invariants
+    /// (e.g. unsafe characters in a path that would break the seatbelt
+    /// profile syntax).
+    fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest>;
+
+    /// Probe whether the backend is functional. Cached after first call.
+    fn check_dependencies(&self) -> DependencyReport;
+}
+
+// ── Per-platform runtime impls ───────────────────────────────────────────────
+
+/// macOS Seatbelt runtime — uses `sandbox-exec` with an inline profile.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Default)]
+pub struct SeatbeltRuntime;
+
+#[cfg(target_os = "macos")]
+impl SandboxRuntime for SeatbeltRuntime {
+    fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
+        let command = seatbelt::build_command(req.command, req.project_root, req.policy)?;
+        Ok(SandboxExecRequest { command })
+    }
+
+    fn check_dependencies(&self) -> DependencyReport {
+        if seatbelt::is_available() {
+            DependencyReport {
+                backend: "seatbelt",
+                available: true,
+                reason: None,
+            }
+        } else {
+            DependencyReport {
+                backend: "seatbelt",
+                available: false,
+                reason: Some(
+                    "sandbox-exec failed to run a probe command. Check macOS \
+                     SIP / TCC restrictions."
+                        .into(),
+                ),
+            }
+        }
+    }
+}
+
+/// Linux bwrap runtime — uses `bwrap` (bubblewrap) with mount namespace
+/// isolation.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default)]
+pub struct BwrapRuntime;
+
+#[cfg(target_os = "linux")]
+impl SandboxRuntime for BwrapRuntime {
+    fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
+        let command = bwrap::build_command(req.command, req.project_root, req.policy)?;
+        Ok(SandboxExecRequest { command })
+    }
+
+    fn check_dependencies(&self) -> DependencyReport {
+        if bwrap::is_available() {
+            DependencyReport {
+                backend: "bwrap",
+                available: true,
+                reason: None,
+            }
+        } else {
+            DependencyReport {
+                backend: "bwrap",
+                available: false,
+                reason: Some(
+                    "bwrap not installed or unable to create user namespaces. \
+                     Install: apt install bubblewrap | dnf install bubblewrap"
+                        .into(),
+                ),
+            }
+        }
+    }
+}
+
+/// Fallback runtime for platforms without a kernel sandbox backend.
+///
+/// `transform()` returns a plain `sh -c` Command. Trips `available: false`
+/// in [`SandboxRuntime::check_dependencies`] so callers can surface a
+/// "running unsandboxed" warning to the user.
+#[derive(Debug, Default)]
+pub struct UnsandboxedRuntime;
+
+impl SandboxRuntime for UnsandboxedRuntime {
+    fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(req.command)
+            .current_dir(req.project_root);
+        Ok(SandboxExecRequest { command })
+    }
+
+    fn check_dependencies(&self) -> DependencyReport {
+        DependencyReport {
+            backend: "none",
+            available: false,
+            reason: Some(
+                "No kernel sandbox backend available on this platform. \
+                 Commands run unsandboxed."
+                    .into(),
+            ),
+        }
+    }
+}
+
+// ── Convenience: pick the right runtime for the host ────────────────────────
+
+/// Returns the platform-appropriate runtime.
+///
+/// On macOS: always returns `SeatbeltRuntime` (sandbox-exec ships with
+/// the OS).
+///
+/// On Linux: returns `BwrapRuntime` when `bwrap` is functional, otherwise
+/// [`UnsandboxedRuntime`] with a tracing warning. The sandbox is best-effort
+/// — we never block the user just because the kernel enforcement layer is
+/// missing.
+///
+/// On other platforms: [`UnsandboxedRuntime`].
+#[must_use]
+pub fn current_runtime() -> Box<dyn SandboxRuntime> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(SeatbeltRuntime)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if bwrap::is_available() {
+            Box::new(BwrapRuntime)
+        } else {
+            Box::new(UnsandboxedRuntime)
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        Box::new(UnsandboxedRuntime)
+    }
+}
+
+/// Returns `true` if the platform sandbox backend is available.
+///
+/// Convenience wrapper around `current_runtime().check_dependencies()`
+/// for callers (like the trust layer) that only need a yes/no.
+#[must_use]
+pub fn is_available() -> bool {
+    current_runtime().check_dependencies().available
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsandboxed_runtime_produces_sh_command() {
+        let policy = SandboxPolicy::default();
+        let req = SandboxTransformRequest {
+            command: "echo hi",
+            project_root: Path::new("/tmp"),
+            policy: &policy,
+        };
+        let runtime = UnsandboxedRuntime;
+        let result = runtime.transform(req).unwrap();
+        // sh -c "echo hi" — verify by inspecting the program.
+        let program = result.command.as_std().get_program();
+        assert_eq!(program, "sh");
+    }
+
+    #[test]
+    fn unsandboxed_runtime_reports_unavailable() {
+        let report = UnsandboxedRuntime.check_dependencies();
+        assert_eq!(report.backend, "none");
+        assert!(!report.available);
+        assert!(report.reason.is_some());
+    }
+
+    #[test]
+    fn current_runtime_is_constructible() {
+        // Smoke test — we just want to confirm there's *some* runtime
+        // returned, not panic on this platform. The actual backend depends
+        // on the test host.
+        let runtime = current_runtime();
+        let _report = runtime.check_dependencies(); // doesn't panic
+    }
+}

--- a/koda-sandbox/src/policy.rs
+++ b/koda-sandbox/src/policy.rs
@@ -1,0 +1,275 @@
+//! Sandbox policy data types — the schema callers use to describe the
+//! capabilities a sandbox slot should have.
+//!
+//! Schema mirrors the design in <https://github.com/lijunzh/koda/issues/934>
+//! §4.2. The *structure* is in place from Phase 0 onward; the *enforcement*
+//! of individual fields lands incrementally across phases:
+//!
+//! | Phase | Fields enforced                                                  |
+//! |-------|------------------------------------------------------------------|
+//! | 0     | (none — seatbelt/bwrap builders use built-in defaults)           |
+//! | 1     | `fs.deny_read`, `fs.allow_write`, `fs.deny_write_within_allow`   |
+//! | 3     | `net.*`                                                          |
+//! | 5     | `limits.*`, `trust`                                              |
+//!
+//! Until a phase lands, the corresponding fields are *parsed and stored*
+//! but ignored by the runtime. This intentional "schema first, enforcement
+//! second" sequencing keeps wire formats stable across phase rollouts.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Path pattern for FS policy rules.
+///
+/// Phase 0–1: plain absolute path, exact-prefix matching.
+/// Phase 2+: may grow glob/regex variants behind an enum once the
+/// requirement is real (YAGNI).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PathPattern(pub PathBuf);
+
+impl PathPattern {
+    /// Construct a new pattern from any path-convertible value.
+    pub fn new(p: impl Into<PathBuf>) -> Self {
+        Self(p.into())
+    }
+
+    /// Borrow the underlying path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl<P: Into<PathBuf>> From<P> for PathPattern {
+    fn from(p: P) -> Self {
+        Self::new(p)
+    }
+}
+
+/// Domain pattern for network policy rules.
+///
+/// Phase 0–2: raw string, exact match.
+/// Phase 3: wildcard support (`*.npmjs.org`) — semantics TBD with the
+/// proxy implementation so the consumer can compile the pattern once.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DomainPattern(pub String);
+
+impl DomainPattern {
+    /// Construct a new pattern from any string-convertible value.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// Filesystem policy. Two-layer rules per Claude Code's pattern: an outer
+/// allow/deny plus a same-direction inner exception list (e.g. allow writes
+/// to `~/work` *except* `~/work/.secrets`).
+///
+/// Phase 0 ignores all fields — the seatbelt/bwrap builders use the
+/// hardcoded defaults from [`crate::defaults`]. Phase 1 wires them in.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FsPolicy {
+    /// Paths whose reads are denied at the kernel layer.
+    pub deny_read: Vec<PathPattern>,
+
+    /// Carve-outs *inside* `deny_read` that remain readable.
+    pub allow_read_within_deny: Vec<PathPattern>,
+
+    /// Paths whose writes are permitted. Anything not in this list is
+    /// write-denied (allowlist semantics — matches Codex `writable_roots`).
+    pub allow_write: Vec<PathPattern>,
+
+    /// Carve-outs *inside* `allow_write` that remain write-denied
+    /// (e.g. `.koda/agents` inside the project root).
+    pub deny_write_within_allow: Vec<PathPattern>,
+
+    /// Whether `git config` writes are permitted. Off by default to
+    /// prevent agents from registering `core.fsmonitor` hooks → RCE.
+    pub allow_git_config: bool,
+}
+
+/// Network egress policy. All fields are Phase-3 territory — the runtime
+/// ignores them in Phase 0–2.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NetPolicy {
+    /// Domain allowlist. Empty + `denied_domains` empty == allow-all
+    /// (Phase 0 behavior). Empty + `denied_domains` nonempty == deny-list
+    /// semantics. Nonempty == allow-list semantics, denies override.
+    pub allowed_domains: Vec<DomainPattern>,
+
+    /// Always-denied domains (overrides `allowed_domains`).
+    pub denied_domains: Vec<DomainPattern>,
+
+    /// Whether sandboxed processes may bind to local ports (e.g. dev servers).
+    pub allow_local_binding: bool,
+
+    /// Optional MITM proxy chaining (corporate CA support). When `Some`,
+    /// outbound TLS is decrypted and re-encrypted via the configured CA.
+    pub mitm: Option<MitmConfig>,
+
+    /// macOS-only: relax network sandboxing to permit Apple `trustd`
+    /// callbacks and Go-binary TLS verification. Off by default.
+    pub weaker_macos_isolation: bool,
+}
+
+/// Corporate MITM proxy configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MitmConfig {
+    /// Path to the trusted CA bundle (Zscaler / corp PKI).
+    pub ca_bundle: PathBuf,
+
+    /// Per-domain Unix socket map: traffic to `domain` is forwarded to
+    /// the specified socket instead of the default proxy.
+    #[serde(default)]
+    pub socket_map: Vec<(String, PathBuf)>,
+}
+
+/// Per-process resource limits. Phase 0 placeholder; enforcement lands in
+/// Phase 5 per the issue's roadmap. Using `Option<u64>` so absent ==
+/// "no limit" without needing a magic sentinel value.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ResourceLimits {
+    /// Max CPU time (seconds). `None` = unlimited.
+    pub cpu_time_secs: Option<u64>,
+    /// Max wall-clock time (seconds). `None` = unlimited.
+    pub wall_time_secs: Option<u64>,
+    /// Max resident set size (bytes). `None` = unlimited.
+    pub max_rss_bytes: Option<u64>,
+    /// Max open file descriptors. `None` = unlimited.
+    pub max_open_fds: Option<u64>,
+    /// Max stdout/stderr bytes per process. `None` = unlimited.
+    pub max_output_bytes: Option<u64>,
+}
+
+/// Codex-style trust preference. Orthogonal to the FS/net policy: this
+/// controls *whether the user is asked*, not *what is allowed*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TrustPreference {
+    /// Auto-approve any tool call the policy permits.
+    #[default]
+    Auto,
+    /// Always require explicit user confirmation, even when allowed.
+    Require,
+    /// Never run; reject regardless of policy verdict.
+    Forbid,
+}
+
+/// Top-level sandbox policy. One per slot; sub-agent slots inherit and
+/// `restrict()` from the parent (Phase 5 — `EffectiveSandboxPermissions::compose`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SandboxPolicy {
+    /// Filesystem rules (read/write deny + allow).
+    pub fs: FsPolicy,
+    /// Network egress rules.
+    pub net: NetPolicy,
+    /// Per-process resource limits.
+    pub limits: ResourceLimits,
+    /// Whether to ask the user before running (Codex pattern).
+    pub trust: TrustPreference,
+}
+
+impl SandboxPolicy {
+    /// Phase 0 sentinel: the policy used by [`crate::current_runtime`]'s
+    /// transform when called via the legacy `koda-core::sandbox::build()`
+    /// shim. All fields empty/default — runtime falls back to the
+    /// hardcoded defaults in [`crate::defaults`], which preserves the
+    /// pre-#934 Strict-mode behavior byte-for-byte.
+    ///
+    /// Phase 1+ callers should construct policies explicitly.
+    pub fn strict_default() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_policy_is_empty_and_auto() {
+        let p = SandboxPolicy::default();
+        assert!(p.fs.deny_read.is_empty());
+        assert!(p.fs.allow_write.is_empty());
+        assert!(p.net.allowed_domains.is_empty());
+        assert_eq!(p.trust, TrustPreference::Auto);
+    }
+
+    #[test]
+    fn strict_default_matches_default() {
+        // Phase 0 invariant: strict_default() is just default(). Future
+        // phases may diverge.
+        assert_eq!(SandboxPolicy::strict_default(), SandboxPolicy::default());
+    }
+
+    #[test]
+    fn path_pattern_serde_is_transparent() {
+        let p = PathPattern::new("/etc/passwd");
+        let json = serde_json::to_string(&p).unwrap();
+        // Transparent serde — serializes as the raw path string, not
+        // a wrapped object. Keeps wire format ergonomic.
+        assert_eq!(json, "\"/etc/passwd\"");
+        let parsed: PathPattern = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn domain_pattern_serde_is_transparent() {
+        let d = DomainPattern::new("github.com");
+        let json = serde_json::to_string(&d).unwrap();
+        assert_eq!(json, "\"github.com\"");
+    }
+
+    #[test]
+    fn trust_preference_lowercase_serde() {
+        assert_eq!(
+            serde_json::to_string(&TrustPreference::Auto).unwrap(),
+            "\"auto\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TrustPreference::Require).unwrap(),
+            "\"require\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TrustPreference::Forbid).unwrap(),
+            "\"forbid\""
+        );
+    }
+
+    #[test]
+    fn policy_round_trips_through_json() {
+        let p = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/etc/shadow".into()],
+                allow_write: vec!["/tmp".into(), "/work".into()],
+                allow_git_config: true,
+                ..Default::default()
+            },
+            net: NetPolicy {
+                allowed_domains: vec![DomainPattern::new("github.com")],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let parsed: SandboxPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn policy_accepts_partial_json_via_serde_default() {
+        // Wire-format stability: callers can omit any subtree and get
+        // sensible defaults. Critical for forward-compat as new fields
+        // are added across phases.
+        let json = r#"{"fs": {"allow_write": ["/tmp"]}}"#;
+        let p: SandboxPolicy = serde_json::from_str(json).unwrap();
+        assert_eq!(p.fs.allow_write, vec![PathPattern::new("/tmp")]);
+        assert_eq!(p.trust, TrustPreference::Auto);
+        assert!(p.net.allowed_domains.is_empty());
+    }
+}

--- a/koda-sandbox/src/policy_check.rs
+++ b/koda-sandbox/src/policy_check.rs
@@ -1,0 +1,191 @@
+//! Application-layer policy checks — companions to the kernel sandbox.
+//!
+//! These let *in-process* file tools enforce the same fully-deny rules
+//! that the kernel sandbox applies to subprocesses (CC parity #882).
+//! Without this, the in-process `Read` tool could bypass the sandbox by
+//! reading paths that the Bash sandbox would block.
+//!
+//! Long-term plan (#884) replaces this with a sandboxed worker process
+//! (Phase 2 of #934).
+
+use crate::defaults::CREDENTIAL_CONFIG_FULL_DENY;
+use std::path::Path;
+
+/// Returns `true` when `path` falls inside a fully-denied location.
+///
+/// "Fully denied" means both reads **and** writes are blocked. Currently
+/// only `~/.config/koda/db` is fully denied — koda's own SQLite database
+/// containing plaintext API keys.
+///
+/// Ordinary credential directories (`~/.ssh`, `~/.aws`, …) are **not**
+/// included: reads are allowed there, mirroring the Bash sandbox which
+/// only write-protects them.
+///
+/// **Defense in depth (#898):** when `HOME` cannot be resolved (containers,
+/// CI, or `unset HOME`), this fails *closed*: tries `HOME`, then
+/// `USERPROFILE` (Windows), and finally falls back to a path-component
+/// pattern match so any path containing `.config/koda/db` consecutively
+/// still gets denied even with no home directory at all.
+pub fn is_fully_denied(path: &Path) -> bool {
+    is_fully_denied_with_home(path, resolve_home_dir().as_deref())
+}
+
+/// Best-effort home directory lookup with cross-platform fallback.
+///
+/// Order: `HOME` (Unix-y, including macOS) → `USERPROFILE` (Windows).
+/// Returns `None` only when *both* are unset; callers must fail closed.
+fn resolve_home_dir() -> Option<String> {
+    std::env::var("HOME")
+        .ok()
+        .or_else(|| std::env::var("USERPROFILE").ok())
+        .filter(|s| !s.is_empty())
+}
+
+/// Pure helper for [`is_fully_denied`] — takes the home directory as an
+/// argument so the no-home case is unit-testable without racing on env vars.
+pub(crate) fn is_fully_denied_with_home(path: &Path, home: Option<&str>) -> bool {
+    // Primary check: does the path live under `${home}/.config/<rel>` for
+    // any fully-denied relative path? Only runs when home is known.
+    if let Some(home) = home {
+        let home_path = Path::new(home);
+        if CREDENTIAL_CONFIG_FULL_DENY
+            .iter()
+            .any(|rel| path.starts_with(home_path.join(".config").join(rel)))
+        {
+            return true;
+        }
+    }
+
+    // Fallback: pattern-match the path components themselves. Even with
+    // no home, any path whose components contain `.config/<rel>` as a
+    // consecutive sequence is treated as fully denied. Catches the
+    // `unset HOME` bypass and exotic paths like
+    // `/proc/self/root/.config/koda/db/koda.db` that don't share a prefix
+    // with `$HOME`.
+    let components: Vec<&std::ffi::OsStr> = path
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+
+    CREDENTIAL_CONFIG_FULL_DENY.iter().any(|rel| {
+        // Build the target sequence: [".config", <rel parts split by '/'>...]
+        let mut needle: Vec<&str> = vec![".config"];
+        needle.extend(rel.split('/'));
+        // Sliding window match against the path components.
+        components.windows(needle.len()).any(|window| {
+            window
+                .iter()
+                .zip(needle.iter())
+                .all(|(comp, want)| comp.to_str() == Some(*want))
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fully_denied_blocks_koda_db() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+        let koda_db = Path::new(&home).join(".config/koda/db");
+        assert!(
+            is_fully_denied(&koda_db),
+            "~/.config/koda/db must be fully denied"
+        );
+        // Sub-paths inside it are also denied.
+        assert!(is_fully_denied(&koda_db.join("koda.db")));
+    }
+
+    #[test]
+    fn fully_denied_allows_credential_dirs() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/user".into());
+        let home = Path::new(&home);
+        // Credential dirs are write-protected but reads are allowed — they
+        // must NOT appear in the fully-denied list.
+        for rel in &[".ssh", ".aws", ".gnupg", ".config/gh", ".config/gcloud"] {
+            assert!(
+                !is_fully_denied(&home.join(rel)),
+                "{rel} must NOT be fully denied (reads allowed)"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_denied_allows_project_and_system_paths() {
+        assert!(!is_fully_denied(Path::new(
+            "/home/user/project/src/main.rs"
+        )));
+        assert!(!is_fully_denied(Path::new("/tmp/scratch.txt")));
+        assert!(!is_fully_denied(Path::new("/etc/hosts")));
+    }
+
+    #[test]
+    fn fully_denied_blocks_koda_db_when_home_is_none() {
+        // Regression test for the historical #898 bypass: tool resolves to
+        // a real-looking path but HOME is unset, so the prefix check can't
+        // fire. Path-segment fallback must still deny it.
+        for path in [
+            "/root/.config/koda/db",
+            "/root/.config/koda/db/koda.db",
+            "/home/runner/.config/koda/db/koda.db",
+            "/proc/self/root/.config/koda/db/koda.db",
+            ".config/koda/db/koda.db", // relative path, no anchor at all
+        ] {
+            assert!(
+                is_fully_denied_with_home(Path::new(path), None),
+                "{path:?} must be denied even with HOME=None"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_denied_no_home_still_allows_normal_paths() {
+        // Defense-in-depth fallback must not over-block ordinary paths.
+        for path in [
+            "/home/user/project/src/main.rs",
+            "/tmp/scratch.txt",
+            "/etc/hosts",
+            "/home/user/.config/git/config", // .config but not koda/db
+            "/home/user/.config/koda/agents/foo.json", // koda but not db
+            "/var/lib/koda-db-backups/2025.tar", // contains 'koda' and 'db'
+                                             // but not the sequence
+                                             // .config/koda/db
+        ] {
+            assert!(
+                !is_fully_denied_with_home(Path::new(path), None),
+                "{path:?} must NOT be denied (no koda secrets)"
+            );
+        }
+    }
+
+    #[test]
+    fn fully_denied_uses_home_when_provided() {
+        // Sanity check that the explicit-home path still works and matches
+        // a non-HOME directory the user passes in.
+        let custom_home = "/srv/koda-runner";
+        assert!(is_fully_denied_with_home(
+            Path::new("/srv/koda-runner/.config/koda/db/koda.db"),
+            Some(custom_home),
+        ));
+        assert!(!is_fully_denied_with_home(
+            Path::new("/srv/koda-runner/notes.md"),
+            Some(custom_home),
+        ));
+    }
+
+    #[test]
+    fn resolve_home_dir_treats_empty_as_unset() {
+        // Empty HOME (`HOME=""`) is just as broken as unset — both should
+        // route through the no-home fallback. The .filter() in
+        // resolve_home_dir() guarantees this; verify via direct call to
+        // the helper since we can't safely mutate env in tests.
+        assert!(is_fully_denied_with_home(
+            Path::new("/anywhere/.config/koda/db/koda.db"),
+            None, // simulating resolve_home_dir() returning None
+        ));
+    }
+}

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -1,0 +1,367 @@
+//! macOS Seatbelt (`sandbox-exec`) backend.
+//!
+//! Generates a Scheme-syntax sandbox profile and spawns commands via
+//! `sandbox-exec -p <profile> sh -c <cmd>`.
+//!
+//! ## Phase 0
+//!
+//! Lifted verbatim from `koda-core/src/sandbox.rs::macos_*`. The
+//! [`crate::policy::SandboxPolicy`] argument is currently *unused* — the
+//! profile is built from the [`crate::defaults`] baseline, which preserves
+//! pre-#934 byte-for-byte behavior.
+//!
+//! ## Phase 1
+//!
+//! The two-layer rule support (deny + allow-within / allow + deny-within)
+//! lands here, plus `<sandbox_violations>` annotations parsed from the
+//! macOS unified log.
+//!
+//! ## Profile-passing strategy
+//!
+//! Passing the profile via `-p` (inline) avoids a tempfile and its
+//! associated race window — a lesson from Gemini CLI's earlier
+//! implementation which used `-f <tempfile>` and had to clean up on every
+//! command.
+
+#![cfg(target_os = "macos")]
+
+use crate::defaults::{
+    CREDENTIAL_CONFIG_FULL_DENY, CREDENTIAL_CONFIG_SUBDIRS, CREDENTIAL_FILES, CREDENTIAL_SUBDIRS,
+    PROTECTED_PROJECT_SUBDIRS,
+};
+use crate::policy::SandboxPolicy;
+use anyhow::Result;
+use std::path::Path;
+use tokio::process::Command;
+
+/// Build a `sandbox-exec` Command for the given command + project root.
+///
+/// Phase 0: `_policy` is accepted but ignored — the profile is the
+/// hardcoded "strict" baseline that matches pre-#934 behavior. Phase 1
+/// switches to consuming `policy.fs.*` fields.
+pub fn build_command(
+    command: &str,
+    project_root: &Path,
+    _policy: &SandboxPolicy,
+) -> Result<Command> {
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let root = canonical.to_string_lossy();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users".into());
+    validate_seatbelt_path(&root)?;
+    validate_seatbelt_path(&home)?;
+
+    // Start from the project profile then append credential deny rules.
+    // Seatbelt evaluates rules in order; later rules win for the same path,
+    // so the denies override the earlier broad `(allow file-read*)`.
+    // Same last-match-wins approach as Gemini CLI's seatbeltArgsBuilder.ts.
+    let mut profile = build_profile_string(&root, &home);
+    profile.push_str(&protected_subdir_deny_rules(&root));
+    profile.push_str(&credential_deny_rules(&home));
+
+    let mut cmd = Command::new("sandbox-exec");
+    cmd.arg("-p")
+        .arg(profile)
+        .arg("sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_root);
+    Ok(cmd)
+}
+
+/// Probe whether the macOS Seatbelt backend is functional. Cached.
+pub fn is_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        build_command(
+            "true",
+            Path::new("/tmp"),
+            &crate::policy::SandboxPolicy::strict_default(),
+        )
+        .is_ok()
+    })
+}
+
+/// Reject paths containing characters that could break seatbelt S-expression
+/// syntax.  A crafted `project_root` with `"` or `(` could inject arbitrary
+/// seatbelt rules into the profile string, completely defeating the sandbox.
+///
+/// We reject rather than escape because legitimate filesystem paths should
+/// never contain these characters, and escaping adds subtle semantic risk.
+fn validate_seatbelt_path(s: &str) -> Result<()> {
+    const FORBIDDEN: &[char] = &['"', '\\', '(', ')', '\0'];
+    if let Some(c) = s.chars().find(|c| FORBIDDEN.contains(c)) {
+        anyhow::bail!("Path contains character {c:?} unsafe for seatbelt profile: {s:?}");
+    }
+    Ok(())
+}
+
+/// Canonicalize `{home}/{rel}` if the path exists; otherwise return raw path.
+/// This ensures seatbelt subpath/literal rules match the kernel's view of the
+/// path (e.g. `/var` → `/private/var` on macOS).
+pub(crate) fn home_path(home: &str, rel: &str) -> String {
+    let p = Path::new(home).join(rel);
+    p.canonicalize().unwrap_or(p).to_string_lossy().into_owned()
+}
+
+/// Build the seatbelt profile for the project-mode baseline.
+///
+/// Strategy: deny-by-default (allowlist), then open reads everywhere and
+/// restrict writes to project + temp + cache dirs.  Network left
+/// unrestricted so `curl` / `cargo fetch` / `npm install` work without
+/// modification (Phase 3 adds the proxy-based egress filter).
+pub(crate) fn build_profile_string(root: &str, home: &str) -> String {
+    format!(
+        "(version 1)\n\
+         (deny default)\n\
+         (allow file-read*)\n\
+         (allow file-write*\n\
+           (subpath \"{root}\")\n\
+           (subpath \"/private/tmp\")\n\
+           (subpath \"/tmp\")\n\
+           (subpath \"{home}/.cargo\")\n\
+           (subpath \"{home}/.npm\")\n\
+           (subpath \"{home}/.cache\")\n\
+           (literal \"/dev/null\")\n\
+           (literal \"/dev/stderr\")\n\
+           (literal \"/dev/stdout\")\n\
+           (literal \"/dev/urandom\"))\n\
+         (allow network*)\n\
+         (allow process-exec*)\n\
+         (allow process-fork)\n\
+         (allow sysctl-read)\n\
+         (allow ipc-posix*)\n\
+         (allow mach*)\n"
+    )
+}
+
+/// Generate seatbelt deny-write rules for protected project subdirectories.
+///
+/// Prevents sandboxed commands from modifying agent definitions or skills
+/// that could alter system prompts or tool access on next session.  Same
+/// pattern as Claude Code blocking writes to `.claude/settings.json` and
+/// `.claude/agents/`.
+pub(crate) fn protected_subdir_deny_rules(root: &str) -> String {
+    let mut rules = String::from(
+        "; ── deny writes to protected project subdirs (.koda/agents, .koda/skills) ──\n",
+    );
+    for rel in PROTECTED_PROJECT_SUBDIRS {
+        let p = Path::new(root).join(rel);
+        let canonical = p.canonicalize().unwrap_or(p).to_string_lossy().into_owned();
+        rules.push_str(&format!("(deny file-write* (subpath \"{canonical}\"))\n"));
+    }
+    rules
+}
+
+/// Generate seatbelt deny rules for credential paths.
+///
+/// Two tiers:
+/// - **Write-only deny** for most paths — lets CLI tools read their own
+///   credentials while preventing sandboxed commands from modifying them.
+/// - **Full read+write deny** for `koda/db` only — koda's own API keys
+///   should never be accessible from inside the sandbox (#847).
+///
+/// Rules are placed *after* the broad `(allow file-read*)` so that
+/// seatbelt's last-match-wins semantics make them take precedence.
+pub(crate) fn credential_deny_rules(home: &str) -> String {
+    let mut rules = String::from("; ── strict: write-protect credential dirs (reads allowed) ──\n");
+
+    // Tier 1 — write-only deny (CLI tools can still read).
+    for rel in CREDENTIAL_SUBDIRS {
+        let p = home_path(home, rel);
+        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
+    }
+    for rel in CREDENTIAL_CONFIG_SUBDIRS {
+        let p = home_path(home, &format!(".config/{rel}"));
+        rules.push_str(&format!("(deny file-write* (subpath \"{p}\"))\n"));
+    }
+    for rel in CREDENTIAL_FILES {
+        let p = home_path(home, rel);
+        rules.push_str(&format!("(deny file-write* (literal \"{p}\"))\n"));
+    }
+
+    // Tier 2 — full read+write deny (koda's own secrets).
+    rules.push_str("; ── strict: full deny for koda-internal secrets ─────────────\n");
+    for rel in CREDENTIAL_CONFIG_FULL_DENY {
+        let p = home_path(home, &format!(".config/{rel}"));
+        rules.push_str(&format!(
+            "(deny file-read* file-write* (subpath \"{p}\"))\n"
+        ));
+    }
+
+    rules
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Profile structure: deny rules present ──────────────────────────────
+
+    #[test]
+    fn strict_profile_write_protects_ssh_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let ssh = home_path(&home, ".ssh");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{ssh}\"))")),
+            "strict profile must write-protect ~/.ssh"
+        );
+        // Reads should NOT be denied — CLI tools need credential access (#855).
+        assert!(
+            !rules.contains(&format!(
+                "(deny file-read* file-write* (subpath \"{ssh}\"))"
+            )),
+            "strict profile must NOT read-deny ~/.ssh (breaks ssh/git)"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_aws_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let aws = home_path(&home, ".aws");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{aws}\"))")),
+            "strict profile must write-protect ~/.aws"
+        );
+        assert!(
+            !rules.contains(&format!(
+                "(deny file-read* file-write* (subpath \"{aws}\"))"
+            )),
+            "strict profile must NOT read-deny ~/.aws (breaks aws CLI)"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_gh_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let gh = home_path(&home, ".config/gh");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{gh}\"))")),
+            "strict profile must write-protect ~/.config/gh"
+        );
+        assert!(
+            !rules.contains(&format!("(deny file-read* file-write* (subpath \"{gh}\"))")),
+            "strict profile must NOT read-deny ~/.config/gh (breaks gh CLI, #855)"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_claude_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let claude = home_path(&home, ".claude");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{claude}\"))")),
+            "strict profile must write-protect ~/.claude"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_android_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let android = home_path(&home, ".android");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{android}\"))")),
+            "strict profile must write-protect ~/.android"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_netlify_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let netlify = home_path(&home, ".config/netlify");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{netlify}\"))")),
+            "strict profile must write-protect ~/.config/netlify"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_vercel_dir() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let vercel = home_path(&home, ".config/vercel");
+        assert!(
+            rules.contains(&format!("(deny file-write* (subpath \"{vercel}\"))")),
+            "strict profile must write-protect ~/.config/vercel"
+        );
+    }
+
+    #[test]
+    fn strict_profile_fully_denies_koda_db() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let koda_db = home_path(&home, ".config/koda/db");
+        assert!(
+            rules.contains(&format!(
+                "(deny file-read* file-write* (subpath \"{koda_db}\"))"
+            )),
+            "strict profile must fully deny ~/.config/koda/db (plaintext API keys, #847)"
+        );
+    }
+
+    #[test]
+    fn strict_profile_write_protects_credential_files() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let rules = credential_deny_rules(&home);
+        let netrc = home_path(&home, ".netrc");
+        assert!(
+            rules.contains(&format!("(deny file-write* (literal \"{netrc}\"))")),
+            "strict profile must write-protect ~/.netrc"
+        );
+        assert!(
+            !rules.contains(&format!(
+                "(deny file-read* file-write* (literal \"{netrc}\"))"
+            )),
+            "strict profile must NOT read-deny ~/.netrc (breaks curl/wget)"
+        );
+    }
+
+    #[test]
+    fn strict_deny_rules_come_after_broad_allow() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let project = Path::new("/tmp/test-project");
+        let root = project.to_string_lossy().into_owned();
+        let profile = build_profile_string(&root, &home);
+        let deny_rules = credential_deny_rules(&home);
+        // Simulate what build_command does: project profile then deny rules.
+        let full = format!("{profile}{deny_rules}");
+        let allow_pos = full.find("(allow file-read*)").unwrap();
+        // Full deny (koda/db) must come after broad allow.
+        let deny_pos = full.find("(deny file-read* file-write*").unwrap();
+        assert!(
+            deny_pos > allow_pos,
+            "deny rules must appear after the broad allow (last-match-wins)"
+        );
+        // Write-only deny must also come after broad allow.
+        let write_deny_pos = full.find("(deny file-write*").unwrap();
+        assert!(
+            write_deny_pos > allow_pos,
+            "write-deny rules must appear after the broad allow"
+        );
+    }
+
+    // ── Path validation ────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_seatbelt_path_rejects_quote() {
+        assert!(validate_seatbelt_path("/tmp/evil\"').rs").is_err());
+    }
+
+    #[test]
+    fn validate_seatbelt_path_rejects_paren() {
+        assert!(validate_seatbelt_path("/tmp/(evil)").is_err());
+    }
+
+    #[test]
+    fn validate_seatbelt_path_accepts_normal() {
+        assert!(validate_seatbelt_path("/Users/me/Projects/koda").is_ok());
+    }
+}

--- a/koda-sandbox/src/workspace.rs
+++ b/koda-sandbox/src/workspace.rs
@@ -1,0 +1,103 @@
+//! Workspace provisioning — separates the "where does the slot write?"
+//! decision from the "what can the slot do?" policy.
+//!
+//! Per #934 §4.6 the sandbox runtime is workspace-agnostic. Provider impls
+//! land across phases:
+//!
+//! | Impl                  | Phase | Backend                              |
+//! |-----------------------|-------|--------------------------------------|
+//! | [`CwdProvider`]       | 0     | Returns `project_root` as-is         |
+//! | `GitWorktreeProvider` | 2     | Wraps existing `koda-core::worktree` |
+//! | `ClonefileProvider`   | 4     | macOS APFS `clonefile(2)`            |
+//! | `OverlayfsProvider`   | 4     | Linux overlayfs inside bwrap         |
+//!
+//! The pool selects which provider to use at slot acquisition time, based
+//! on agent persona + trust mode + git availability.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+/// Workspace lifecycle: provision on slot acquire, release on slot drop.
+///
+/// `slot_id` is supplied by the pool so providers can name their backing
+/// storage deterministically (e.g. `~/.koda/worktrees/<slot_id>`).
+#[async_trait]
+pub trait WorkspaceProvider: Send + Sync {
+    /// Provision a writable view for a new slot. Returns the path the
+    /// slot should treat as its writable root.
+    async fn provision(&self, slot_id: &str) -> Result<PathBuf>;
+
+    /// Release on slot drop. Returns `Some(diff)` when there are unsaved
+    /// changes worth surfacing to the user (Phase 2+ semantics — Phase 0
+    /// always returns `None`).
+    async fn release(&self, slot_id: &str, path: &Path) -> Result<Option<String>>;
+}
+
+/// No-op provider: hands back the project root unchanged. Suitable for:
+///
+/// - Read-only slots (plan/explore/verify personas)
+/// - Trust-mode `Auto` on non-git projects
+/// - Any scenario where copy-on-write isn't worth the latency
+///
+/// This is the *only* provider implemented in Phase 0; it lets the
+/// sandbox layer ship without depending on `koda-core::worktree` yet.
+#[derive(Debug, Clone)]
+pub struct CwdProvider {
+    project_root: PathBuf,
+}
+
+impl CwdProvider {
+    /// Construct a provider rooted at the given project directory.
+    pub fn new(project_root: impl Into<PathBuf>) -> Self {
+        Self {
+            project_root: project_root.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl WorkspaceProvider for CwdProvider {
+    async fn provision(&self, _slot_id: &str) -> Result<PathBuf> {
+        Ok(self.project_root.clone())
+    }
+
+    async fn release(&self, _slot_id: &str, _path: &Path) -> Result<Option<String>> {
+        // Nothing to clean up — we never created anything.
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cwd_provider_returns_root_unchanged() {
+        let root = PathBuf::from("/tmp/some-project");
+        let p = CwdProvider::new(&root);
+        let provisioned = p.provision("slot-1").await.unwrap();
+        assert_eq!(provisioned, root);
+    }
+
+    #[tokio::test]
+    async fn cwd_provider_release_is_noop() {
+        let p = CwdProvider::new("/tmp/x");
+        assert!(
+            p.release("slot-1", Path::new("/tmp/x"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cwd_provider_provision_is_idempotent() {
+        // Provider should be safe to call provision() multiple times for
+        // the same slot — pool reuse pattern in Phase 4.
+        let p = CwdProvider::new("/tmp/x");
+        let a = p.provision("slot-1").await.unwrap();
+        let b = p.provision("slot-1").await.unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/koda-sandbox/tests/snapshots/transform_snapshots__bwrap_runtime_command_shape.snap
+++ b/koda-sandbox/tests/snapshots/transform_snapshots__bwrap_runtime_command_shape.snap
@@ -1,0 +1,9 @@
+---
+source: koda-sandbox/tests/transform_snapshots.rs
+expression: "(program, tail)"
+---
+- bwrap
+- - "--"
+  - sh
+  - "-c"
+  - "true"

--- a/koda-sandbox/tests/snapshots/transform_snapshots__seatbelt_runtime_command_shape.snap
+++ b/koda-sandbox/tests/snapshots/transform_snapshots__seatbelt_runtime_command_shape.snap
@@ -1,0 +1,10 @@
+---
+source: koda-sandbox/tests/transform_snapshots.rs
+assertion_line: 65
+expression: "(program, arg_count, tail)"
+---
+- sandbox-exec
+- 5
+- - sh
+  - "-c"
+  - "true"

--- a/koda-sandbox/tests/snapshots/transform_snapshots__unsandboxed_echo.snap
+++ b/koda-sandbox/tests/snapshots/transform_snapshots__unsandboxed_echo.snap
@@ -1,0 +1,9 @@
+---
+source: koda-sandbox/tests/transform_snapshots.rs
+assertion_line: 38
+expression: "(program, args, cwd)"
+---
+- sh
+- - "-c"
+  - echo hi
+- /tmp/snapshot-project

--- a/koda-sandbox/tests/transform_snapshots.rs
+++ b/koda-sandbox/tests/transform_snapshots.rs
@@ -1,0 +1,178 @@
+//! Phase 0 acceptance: snapshot tests on `transform()` output.
+//!
+//! These assert that `(cmd, policy) → SandboxExecRequest` produces a
+//! deterministic, hash-stable spawn invocation. Insta snapshots make
+//! drift visible: if a future PR accidentally changes the seatbelt
+//! profile or bwrap arg vector, the diff shows up here loudly.
+
+use koda_sandbox::{SandboxPolicy, SandboxRuntime, SandboxTransformRequest, UnsandboxedRuntime};
+use std::path::Path;
+use std::process::Command as StdCommand;
+
+/// Extract `(program, args, cwd)` from a `tokio::Command` for snapshotting.
+fn deconstruct(cmd: &StdCommand) -> (String, Vec<String>, Option<String>) {
+    let program = cmd.get_program().to_string_lossy().to_string();
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    let cwd = cmd
+        .get_current_dir()
+        .map(|p| p.to_string_lossy().to_string());
+    (program, args, cwd)
+}
+
+#[test]
+fn unsandboxed_runtime_snapshot() {
+    let policy = SandboxPolicy::default();
+    let req = SandboxTransformRequest {
+        command: "echo hi",
+        project_root: Path::new("/tmp/snapshot-project"),
+        policy: &policy,
+    };
+    let result = UnsandboxedRuntime.transform(req).unwrap();
+    let (program, args, cwd) = deconstruct(result.command.as_std());
+
+    insta::assert_yaml_snapshot!("unsandboxed_echo", (program, args, cwd));
+}
+
+// ── macOS Seatbelt snapshots ────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_runtime_command_snapshot() {
+    use koda_sandbox::SeatbeltRuntime;
+
+    // Use a temp dir so canonicalize() can succeed deterministically.
+    let dir = tempfile::tempdir().unwrap();
+    let policy = SandboxPolicy::default();
+    let req = SandboxTransformRequest {
+        command: "true",
+        project_root: dir.path(),
+        policy: &policy,
+    };
+    let result = SeatbeltRuntime.transform(req).unwrap();
+    let (program, args, _cwd) = deconstruct(result.command.as_std());
+
+    // Profile string (args[1]) varies by $HOME and tempdir path; snapshot
+    // only the structurally stable parts: program + arg count + the
+    // command-shape tail (last 3 args = "sh" "-c" "true").
+    let arg_count = args.len();
+    let tail: Vec<String> = args.iter().rev().take(3).rev().cloned().collect();
+
+    insta::assert_yaml_snapshot!("seatbelt_runtime_command_shape", (program, arg_count, tail));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn seatbelt_profile_contains_required_rules() {
+    // A "behavioral snapshot": rather than locking the *exact* profile
+    // string (sensitive to $HOME), assert the profile contains the rules
+    // we know must be present. Catches accidental rule deletion in
+    // future refactors without flaking on path differences.
+    use koda_sandbox::SeatbeltRuntime;
+
+    let dir = tempfile::tempdir().unwrap();
+    let policy = SandboxPolicy::default();
+    let req = SandboxTransformRequest {
+        command: "true",
+        project_root: dir.path(),
+        policy: &policy,
+    };
+    let result = SeatbeltRuntime.transform(req).unwrap();
+    let args: Vec<String> = result
+        .command
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+    // sandbox-exec layout: ["-p", <profile>, "sh", "-c", <cmd>]
+    let profile = &args[1];
+
+    // Required allows.
+    assert!(profile.contains("(version 1)"));
+    assert!(profile.contains("(deny default)"));
+    assert!(profile.contains("(allow file-read*)"));
+    assert!(profile.contains("(allow network*)"));
+    assert!(profile.contains("(allow process-exec*)"));
+    assert!(profile.contains("(literal \"/dev/null\")"));
+    assert!(profile.contains("(literal \"/dev/urandom\")"));
+
+    // Required denies (#847 koda-db full deny).
+    assert!(profile.contains("(deny file-read* file-write*"));
+    assert!(profile.contains("koda/db"));
+
+    // Protected project subdirs (#844 agent-write protection).
+    assert!(profile.contains(".koda/agents"));
+    assert!(profile.contains(".koda/skills"));
+}
+
+// ── Linux bwrap snapshots ───────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bwrap_runtime_command_snapshot() {
+    use koda_sandbox::BwrapRuntime;
+
+    // bwrap may not be installed — skip if unavailable. Snapshot tests
+    // shouldn't fail just because the test host lacks the backend.
+    if !koda_sandbox::bwrap::is_available() {
+        eprintln!("bwrap not available; skipping snapshot test");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let policy = SandboxPolicy::default();
+    let req = SandboxTransformRequest {
+        command: "true",
+        project_root: dir.path(),
+        policy: &policy,
+    };
+    let result = BwrapRuntime.transform(req).unwrap();
+    let (program, args, _cwd) = deconstruct(result.command.as_std());
+
+    // Last 4 args are the terminator: "--" "sh" "-c" "true". Stable shape.
+    // arg_count itself is *not* in the snapshot — it varies with the test
+    // host (presence of /var/tmp, ~/.cargo, ~/.npm, ~/.cache shifts the
+    // count by 3 each), and a brittle count just causes flaky CI without
+    // catching real regressions. The first/last few args + the existing
+    // `bwrap_command_starts_with_ro_bind_root` test are what actually
+    // protects against accidental reordering.
+    let tail: Vec<String> = args.iter().rev().take(4).rev().cloned().collect();
+
+    insta::assert_yaml_snapshot!("bwrap_runtime_command_shape", (program, tail));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn bwrap_command_starts_with_ro_bind_root() {
+    // Behavioral snapshot — the bwrap arg vector must start with the
+    // root-fs read-only bind. Catches accidental reordering that would
+    // break the "deny by exclusion" model (everything is read-only by
+    // default; only project + caches get re-bound writable).
+    use koda_sandbox::BwrapRuntime;
+
+    if !koda_sandbox::bwrap::is_available() {
+        eprintln!("bwrap not available; skipping behavioral test");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let policy = SandboxPolicy::default();
+    let req = SandboxTransformRequest {
+        command: "true",
+        project_root: dir.path(),
+        policy: &policy,
+    };
+    let result = BwrapRuntime.transform(req).unwrap();
+    let args: Vec<String> = result
+        .command
+        .as_std()
+        .get_args()
+        .map(|a| a.to_string_lossy().to_string())
+        .collect();
+
+    assert_eq!(args[0], "--ro-bind", "first arg must be --ro-bind");
+    assert_eq!(args[1], "/", "first ro-bind source must be /");
+    assert_eq!(args[2], "/", "first ro-bind dest must be /");
+}

--- a/koda-test-utils/Cargo.toml
+++ b/koda-test-utils/Cargo.toml
@@ -11,13 +11,13 @@ name = "koda_test_utils"
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 koda-core = { path = "../koda-core", features = ["test-support"] }
-serde = { version = "1", features = ["derive"] }
-insta = { version = "1", features = ["yaml", "redactions"] }
-tokio = { version = "1", features = ["full", "test-util"] }
-tokio-util = { version = "0.7", features = ["rt"] }
-tempfile = "3"
-anyhow = "1"
-serde_json = "1"
+serde = { workspace = true }
+insta = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }
+tokio-util = { workspace = true }
+tempfile = { workspace = true }
+anyhow = { workspace = true }
+serde_json = { workspace = true }
 wiremock = "0.6"


### PR DESCRIPTION
## Phase 0 of #934 — extract `koda-sandbox` crate

This PR is the foundation for the rest of #934. It does **zero behavior
change** — purely a refactor that extracts the sandbox layer into its
own crate and stands up the schema we'll fill in over Phases 1-5.

### What's in this PR

**Commit 1: `chore(workspace): hoist shared dep versions`**

Pre-req: moves common dep versions to `[workspace.dependencies]` so the
new `koda-sandbox` crate inherits them via `{ workspace = true }`
instead of pinning its own copies. No version changes. No file outside
`Cargo.toml`s touched.

**Commit 2: `feat(sandbox): extract koda-sandbox crate`**

- New `koda-sandbox/` crate. Modules:
  - `defaults.rs` — `CREDENTIAL_*` & `PROTECTED_PROJECT_SUBDIRS` constants
    lifted from `koda-core/sandbox.rs`.
  - `policy.rs` — `SandboxPolicy` schema (fs / net / trust / proc).
    Two-layer fs rules (`deny_read` + `allow_read_within_deny`,
    `allow_write` + `deny_write_within_allow`) per #934 §4.3.
  - `policy_check.rs` — pure `is_path_writable_under_policy()` helper.
  - `seatbelt.rs` — macOS backend (verbatim from koda-core).
  - `bwrap.rs` — Linux backend (verbatim from koda-core).
  - `workspace.rs` — `mark_protected_project_subdirs_readonly()` helper.
  - `lib.rs` — `SandboxRuntime` trait + `current_runtime()` factory.

- `koda-core/sandbox.rs` becomes a **thin shim** that delegates to
  `koda-sandbox::current_runtime().transform()`. All existing callers
  unchanged.

- Snapshot tests in `koda-sandbox/tests/transform_snapshots.rs`
  pin the seatbelt + bwrap arg shapes so future refactors flag drift.

### What's intentionally NOT in this PR

- The runtimes accept a `SandboxPolicy` but ignore it — the hardcoded
  baseline is preserved byte-for-byte. Phase 1b wires the policy fields
  in additively.
- No violation reporting yet — also Phase 1.
- No FS worker, no per-tool sandboxing — Phase 2.
- No network egress proxy — Phase 3.
- No sub-agent slot lifecycle — Phase 4.

### Tests

- `cargo test -p koda-sandbox`: **55 unit + 3 snapshot** pass
- `cargo test -p koda-core --lib sandbox`: **14** pass (shim delegation)
- `cargo clippy --workspace --all-targets`: clean

### Risk

Low. Pure refactor, zero behavior change. The shim guarantees existing
call sites get the same `tokio::process::Command` they did before.

Refs: #934
