### PR TITLE
feat(sandbox): violation reporting + two-layer policy overlay (Phase 1 of #934)

### DIFF
--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -172,6 +172,14 @@ pub async fn run_shell_command(
                 .map_err(|e| anyhow::anyhow!("wait: {e}"))?;
             let exit_code = status.code().unwrap_or(-1);
 
+            // Phase 1 of #934: surface kernel-sandbox denials to the model.
+            // The kernel makes the syscall fail with EACCES/EPERM and the
+            // child shell prints a libc error to stderr; parse those lines
+            // into structured violations and append a CC-style block.
+            // Always-on (informational only — doesn't change exit codes or
+            // change which lines we already collected).
+            annotate_violations(exit_code, command, &mut stderr_lines);
+
             let summary = format_summary(exit_code, &stdout_lines, &stderr_lines);
             let full = format_full_output(exit_code, &stdout_lines, &stderr_lines);
 
@@ -396,6 +404,40 @@ fn format_full_output(exit_code: i32, stdout_lines: &[String], stderr_lines: &[S
     }
 
     out
+}
+
+/// Phase 1 of #934: parse stderr for kernel-sandbox denials and append a
+/// `<sandbox_violations>` block (CC pattern) so the model can react.
+///
+/// We only annotate when the command exited non-zero — a successful
+/// command with `Permission denied` in its stderr is almost always a
+/// false positive (e.g. `find / 2>/dev/null` swallows pre-sandbox
+/// errors that aren't sandbox denials at all).
+///
+/// The block is appended *to* `stderr_lines` (not stdout) so existing
+/// formatters carry it through unchanged. Violations are also recorded
+/// in the process-wide [`koda_sandbox::global_store`] for `/sandbox
+/// status` to surface later.
+fn annotate_violations(exit_code: i32, command: &str, stderr_lines: &mut Vec<String>) {
+    if exit_code == 0 {
+        return;
+    }
+    let joined = stderr_lines.join("\n");
+    let violations = koda_sandbox::monitor::parse_stderr(&joined, Some(command));
+    if violations.is_empty() {
+        return;
+    }
+    let store = koda_sandbox::global_store();
+    for v in &violations {
+        store.record(v.clone());
+    }
+    if let Some(block) = koda_sandbox::render_block(&violations) {
+        // Push each line of the block as its own entry so the line-count
+        // accounting in format_summary stays accurate.
+        for line in block.lines() {
+            stderr_lines.push(line.to_string());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -680,8 +722,103 @@ mod tests {
             "Expected at least 3 streamed lines, got {}: {lines:?}",
             lines.len()
         );
+
         // At least one stdout and one stderr line
         assert!(lines.iter().any(|(_, is_stderr)| !is_stderr));
         assert!(lines.iter().any(|(_, is_stderr)| *is_stderr));
+    }
+
+    // ── Phase 1 of #934: violation annotation ────────────────────────────
+
+    #[test]
+    fn annotate_violations_skips_when_exit_code_zero() {
+        // Successful command with denial-looking stderr → no annotation.
+        // Otherwise `find / 2>/dev/null` would be falsely annotated every
+        // time it hits an unreadable subdir.
+        let mut stderr = vec!["touch: /etc/x: Permission denied".into()];
+        annotate_violations(0, "find /", &mut stderr);
+        assert_eq!(stderr.len(), 1, "no extra lines should be appended");
+        assert!(!stderr.iter().any(|l| l.contains("<sandbox_violations>")));
+    }
+
+    #[test]
+    fn annotate_violations_appends_block_on_real_denial() {
+        let mut stderr = vec!["touch: /etc/passwd: Operation not permitted".into()];
+        annotate_violations(1, "touch /etc/passwd", &mut stderr);
+        assert!(
+            stderr.iter().any(|l| l == "<sandbox_violations>"),
+            "open tag must be appended: {stderr:?}"
+        );
+        assert!(
+            stderr
+                .iter()
+                .any(|l| l.contains("deny file-write* /etc/passwd")),
+            "violation line must be appended: {stderr:?}"
+        );
+        assert!(
+            stderr.iter().any(|l| l == "</sandbox_violations>"),
+            "close tag must be appended: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn annotate_violations_noop_when_no_denial_markers() {
+        // Failed command (exit_code != 0) but stderr doesn't look like
+        // a sandbox denial → no annotation. E.g. `cargo build` failure.
+        let mut stderr = vec!["error[E0277]: trait bound not satisfied".into()];
+        annotate_violations(101, "cargo build", &mut stderr);
+        assert_eq!(stderr.len(), 1, "no annotation expected: {stderr:?}");
+    }
+
+    /// Phase 1 acceptance criterion of #934: a real sandboxed bash command
+    /// that touches ~/.ssh returns annotated stderr.
+    ///
+    /// Goes through the full `run_shell_command` pipeline — sandbox build,
+    /// process spawn, stream capture, kernel denial, stderr parse,
+    /// `<sandbox_violations>` annotation. This is the proof-of-life test
+    /// for the whole Phase 1 stack.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn run_shell_command_annotates_ssh_write_denial() {
+        use serde_json::json;
+
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/test".into());
+        let ssh_dir = format!("{home}/.ssh");
+        if !std::path::Path::new(&ssh_dir).exists() {
+            eprintln!("skip: {ssh_dir} does not exist");
+            return;
+        }
+        let project = tempfile::tempdir().unwrap();
+        let canary = format!("{ssh_dir}/koda_phase1_annotation_canary");
+
+        let result = run_shell_command(
+            project.path(),
+            &json!({"command": format!("touch {canary}")}),
+            500,
+            &bg(),
+            None,
+            &crate::trust::TrustMode::Safe,
+        )
+        .await
+        .expect("run_shell_command should succeed even when child fails");
+
+        let full = result.full_output.expect("full output expected");
+        assert!(
+            full.contains("<sandbox_violations>"),
+            "missing open tag in full output:\n{full}"
+        );
+        assert!(
+            full.contains("deny file-write*"),
+            "missing violation kind in full output:\n{full}"
+        );
+        assert!(
+            full.contains("</sandbox_violations>"),
+            "missing close tag in full output:\n{full}"
+        );
+        // Acceptance: file was not created (sandbox actually enforced).
+        assert!(
+            !std::path::Path::new(&canary).exists(),
+            "canary file should NOT have been created: {canary}"
+        );
     }
 }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -4,18 +4,28 @@
 //! filesystem read-only, then re-binds the project root + caches as
 //! read-write, and shadows koda's own secrets with `--tmpfs`.
 //!
-//! ## Phase 0
+//! ## Layering
 //!
-//! Lifted verbatim from `koda-core/src/sandbox.rs::linux_*`. The
-//! [`crate::policy::SandboxPolicy`] argument is currently *unused* — the
-//! arg vector is built from the [`crate::defaults`] baseline, which
-//! preserves pre-#934 byte-for-byte behavior.
+//! Same conceptual three-layer overlay as the seatbelt backend:
 //!
-//! ## Phase 1
+//!   1. Base view (`base_cmd`)             — `--ro-bind /` then writable carve-outs
+//!   2. Hardcoded full-deny tmpfs overlays — koda secrets
+//!   3. Policy overlay (`policy_overlay_args`) — caller-supplied rules
 //!
-//! `policy.fs.allow_write` becomes additional `--bind` args;
-//! `policy.fs.deny_read` becomes `--tmpfs` overlays. The two-layer rules
-//! map naturally onto bwrap's bind-then-overlay mechanism.
+//! Empty policy → behavior byte-identical to pre-#934 (Phase 0 invariant).
+//!
+//! ## Mapping policy → bwrap flags
+//!
+//! | Policy field                  | bwrap rendering                       |
+//! |-------------------------------|---------------------------------------|
+//! | `fs.deny_read` (subpath)      | `--tmpfs <path>` (shadows the dir)    |
+//! | `fs.allow_read_within_deny`   | `--ro-bind <path> <path>` (post-shadow)|
+//! | `fs.allow_write`              | `--bind <path> <path>` (writable)     |
+//! | `fs.deny_write_within_allow`  | `--ro-bind <path> <path>` (post-bind) |
+//!
+//! bwrap is **first-match wins** for a given mountpoint, but mounts at
+//! deeper paths override shallower mounts that contain them. So we emit
+//! the broad rules first, then the narrower carve-outs.
 
 #![cfg(target_os = "linux")]
 
@@ -27,12 +37,12 @@ use tokio::process::Command;
 
 /// Build a `bwrap` Command for the given command + project root.
 ///
-/// Phase 0: `_policy` is accepted but ignored — the arg vector is the
-/// hardcoded "strict" baseline that matches pre-#934 behavior.
+/// See module docs for layering. An empty `policy` produces the same
+/// arg vector as pre-#934.
 pub fn build_command(
     command: &str,
     project_root: &Path,
-    _policy: &SandboxPolicy,
+    policy: &SandboxPolicy,
 ) -> Result<Command> {
     if !is_available() {
         anyhow::bail!(
@@ -43,13 +53,18 @@ pub fn build_command(
 
     let (mut cmd, home) = base_cmd(project_root);
 
-    // Full deny (read+write) for koda-internal secrets only.
+    // Layer 2: full deny (read+write) for koda-internal secrets only.
     // The base `--ro-bind / /` already write-protects everything else.
     for rel in CREDENTIAL_CONFIG_FULL_DENY {
         let p = format!("{home}/.config/{rel}");
         if Path::new(&p).exists() {
             cmd.args(["--tmpfs", &p]);
         }
+    }
+
+    // Layer 3: policy overlay (Phase 1b of #934).
+    for arg_pair in policy_overlay_args(policy)? {
+        cmd.args(&arg_pair);
     }
 
     cmd.args(["--", "sh", "-c", command])
@@ -114,4 +129,109 @@ fn base_cmd(project_root: &Path) -> (Command, String) {
     }
 
     (cmd, home)
+}
+
+/// Phase 1b of #934: render `policy.fs.*` into bwrap arg pairs.
+///
+/// Each returned `Vec<String>` is one bwrap option pair (e.g. `["--bind",
+/// "/work", "/work"]`) that the caller appends to the Command. We return
+/// them as a `Vec<Vec<String>>` rather than mutating a `Command` directly
+/// so this function stays pure-ish and easily snapshot-testable.
+///
+/// Returns an empty vec for an all-default policy, preserving the
+/// pre-#934 byte-identical baseline guaranteed by [`build_command`].
+pub(crate) fn policy_overlay_args(policy: &SandboxPolicy) -> Result<Vec<Vec<String>>> {
+    let fs = &policy.fs;
+    if fs.deny_read.is_empty()
+        && fs.allow_read_within_deny.is_empty()
+        && fs.allow_write.is_empty()
+        && fs.deny_write_within_allow.is_empty()
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut out = Vec::new();
+
+    // Layer 1: deny reads — shadow with tmpfs so the contents disappear.
+    for p in &fs.deny_read {
+        let s = p.as_path().to_string_lossy().into_owned();
+        out.push(vec!["--tmpfs".to_string(), s]);
+    }
+    // Layer 2: re-bind read-only for explicit carve-outs inside denies.
+    for p in &fs.allow_read_within_deny {
+        let s = p.as_path().to_string_lossy().into_owned();
+        out.push(vec!["--ro-bind".to_string(), s.clone(), s]);
+    }
+    // Layer 3: widen the writable set.
+    for p in &fs.allow_write {
+        let s = p.as_path().to_string_lossy().into_owned();
+        out.push(vec!["--bind".to_string(), s.clone(), s]);
+    }
+    // Layer 4: protect specific spots inside the writable set.
+    for p in &fs.deny_write_within_allow {
+        let s = p.as_path().to_string_lossy().into_owned();
+        out.push(vec!["--ro-bind".to_string(), s.clone(), s]);
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_overlay_args_empty_for_default_policy() {
+        let args = policy_overlay_args(&SandboxPolicy::strict_default()).unwrap();
+        assert!(args.is_empty(), "default policy must add zero args");
+    }
+
+    #[test]
+    fn policy_overlay_args_render_deny_read_as_tmpfs() {
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.deny_read = vec!["/secrets".into()];
+        let args = policy_overlay_args(&policy).unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0], vec!["--tmpfs", "/secrets"]);
+    }
+
+    #[test]
+    fn policy_overlay_args_render_allow_write_as_bind() {
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_write = vec!["/work".into()];
+        let args = policy_overlay_args(&policy).unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0], vec!["--bind", "/work", "/work"]);
+    }
+
+    #[test]
+    fn policy_overlay_args_render_deny_write_within_as_ro_bind() {
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.deny_write_within_allow = vec!["/work/.git/config".into()];
+        let args = policy_overlay_args(&policy).unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(
+            args[0],
+            vec!["--ro-bind", "/work/.git/config", "/work/.git/config"]
+        );
+    }
+
+    #[test]
+    fn policy_overlay_args_emit_layers_in_correct_order() {
+        // Mount-shadowing semantics: deeper / later mounts override the
+        // earlier ones for the same prefix. So we emit broad rules first,
+        // narrower carve-outs second.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.deny_read = vec!["/secrets".into()];
+        policy.fs.allow_read_within_deny = vec!["/secrets/public".into()];
+        policy.fs.allow_write = vec!["/work".into()];
+        policy.fs.deny_write_within_allow = vec!["/work/.git".into()];
+
+        let args = policy_overlay_args(&policy).unwrap();
+        assert_eq!(args.len(), 4);
+        assert_eq!(args[0][0], "--tmpfs"); // deny_read
+        assert_eq!(args[1][0], "--ro-bind"); // allow_read_within_deny
+        assert_eq!(args[2][0], "--bind"); // allow_write
+        assert_eq!(args[3][0], "--ro-bind"); // deny_write_within_allow
+    }
 }

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -32,10 +32,12 @@
 #[cfg(target_os = "linux")]
 pub mod bwrap;
 pub mod defaults;
+pub mod monitor;
 pub mod policy;
 pub mod policy_check;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;
+pub mod violations;
 pub mod workspace;
 
 pub use policy::{
@@ -43,6 +45,10 @@ pub use policy::{
     TrustPreference,
 };
 pub use policy_check::is_fully_denied;
+pub use violations::{
+    DEFAULT_RING_CAPACITY, SandboxViolationStore, Violation, ViolationKind, global_store,
+    render_block,
+};
 pub use workspace::{CwdProvider, WorkspaceProvider};
 
 use anyhow::Result;
@@ -97,9 +103,13 @@ pub struct DependencyReport {
 
 /// Backend-agnostic sandbox runtime.
 ///
-/// Phase 0 only has [`Self::transform`] and [`Self::check_dependencies`].
-/// Phase 2 will add `acquire(&self, policy) -> SandboxSlot` for the
-/// long-lived per-agent slot model.
+/// Phase 0 has [`Self::transform`] + [`Self::check_dependencies`]; Phase 2
+/// will add `acquire(&self, policy) -> SandboxSlot` for the long-lived
+/// per-agent slot model.
+///
+/// Violation tracking lives outside the trait: see [`violations::global_store`]
+/// for the process-wide ring buffer and [`monitor::parse_stderr`] for
+/// the heuristic stderr parser used by the bash tool.
 pub trait SandboxRuntime: Send + Sync {
     /// Compile a high-level command + policy into a concrete spawnable
     /// `Command`. Pure-ish (consults `$HOME`, canonicalizes paths) but

--- a/koda-sandbox/src/monitor.rs
+++ b/koda-sandbox/src/monitor.rs
@@ -1,0 +1,264 @@
+//! Heuristic stderr → [`Violation`] parser.
+//!
+//! Both `sandbox-exec` (macOS) and `bwrap` (Linux) surface kernel sandbox
+//! denials by letting the *child* process's syscall fail with `EACCES`,
+//! `EPERM`, or `EROFS`. The child shell then prints the canonical libc
+//! error string to stderr — `"Operation not permitted"`, `"Permission
+//! denied"`, `"Read-only file system"` — followed by the offending path.
+//!
+//! ## Why heuristic?
+//!
+//! The "right" approach is the CC pattern: tail `log stream --predicate
+//! 'eventMessage CONTAINS "_SBX"'` on macOS and parse seccomp/audit
+//! logs on Linux. That's a long-lived background thread with command
+//! correlation via base64-tagged process names — easily 300 lines, and
+//! macOS-only without root on Linux.
+//!
+//! Phase 1 ships the cheap version: parse stderr after every command.
+//! False positives are possible (e.g. `chmod` on a user-deleted file
+//! also says `Permission denied`) but the bias is acceptable — a
+//! spurious `<sandbox_violations>` annotation is just a hint to the
+//! model, not a hard error. Phase 5 can swap in the syslog tail once
+//! we know how often the heuristic misclassifies.
+//!
+//! ## What we extract
+//!
+//! - **Path**: the last `/`-prefixed token on the line (works for `touch`,
+//!   `cp`, `mv`, `bash` redirection, `ls` denials).
+//! - **Kind**: inferred from the surrounding verb when present. `touch`,
+//!   `mkdir`, `>` redirection → [`ViolationKind::FileWrite`]; `cat`, `ls`,
+//!   `cp src` → [`ViolationKind::FileRead`]; falls back to
+//!   [`ViolationKind::Other`].
+//!
+//! Network and process-exec denials don't reliably show up in stderr —
+//! Phase 3 (proxy) and Phase 5 (syslog) cover those.
+
+use crate::violations::{Violation, ViolationKind};
+
+/// Stderr substrings that indicate a kernel-enforced denial.
+///
+/// Order matters for the kind heuristic — see [`infer_kind_from_line`].
+const DENIAL_MARKERS: &[&str] = &[
+    "Operation not permitted",
+    "Permission denied",
+    "Read-only file system",
+];
+
+/// Parse a captured stderr buffer into zero or more violations.
+///
+/// `command` is attached to each violation for correlation back to the
+/// triggering bash invocation. Pass `None` if you don't have it.
+///
+/// Lines that don't match any `DENIAL_MARKERS` are skipped silently.
+/// Multi-line denials (rare — only `cp -r` produces them) are recorded
+/// as separate violations, one per stderr line.
+#[must_use]
+pub fn parse_stderr(stderr: &str, command: Option<&str>) -> Vec<Violation> {
+    stderr
+        .lines()
+        .filter_map(|line| parse_line(line, command))
+        .collect()
+}
+
+fn parse_line(line: &str, command: Option<&str>) -> Option<Violation> {
+    if !DENIAL_MARKERS.iter().any(|m| line.contains(m)) {
+        return None;
+    }
+    Some(Violation::new(
+        infer_kind_from_line(line),
+        extract_path(line),
+        command.map(str::to_string),
+    ))
+}
+
+/// Pull the most likely target path out of a stderr line.
+///
+/// Strategy: walk tokens right-to-left, skip the trailing `:` punctuation
+/// the libc error formatter inserts, and return the first absolute path
+/// we find. Examples this handles correctly:
+///
+/// ```text
+/// touch: /Users/me/.ssh/canary: Operation not permitted
+/// sh: line 1: /tmp/x/evil.txt: Permission denied
+/// cp: cannot create regular file '/etc/passwd': Permission denied
+/// ```
+fn extract_path(line: &str) -> Option<String> {
+    line.split_whitespace()
+        .rev()
+        .map(|tok| tok.trim_matches(|c: char| matches!(c, ':' | ',' | '\'' | '"' | '`')))
+        .find(|tok| tok.starts_with('/') && tok.len() > 1)
+        .map(str::to_string)
+}
+
+/// Infer the violation kind from verb context in the stderr line.
+///
+/// `touch`, `mkdir`, `cp -> dest`, `>` redirection are write-flavored.
+/// `cat`, `ls`, `head`, `find` are read-flavored. Everything else falls
+/// back to [`ViolationKind::Other`] — better honest "I don't know" than
+/// confidently-wrong tagging.
+fn infer_kind_from_line(line: &str) -> ViolationKind {
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("read-only file system") {
+        return ViolationKind::FileWrite;
+    }
+    let write_markers = [
+        "touch",
+        "mkdir",
+        "cannot create",
+        "cannot remove",
+        "cannot move",
+        "cannot copy",
+        "rm:",
+        "mv:",
+        "rmdir:",
+        "chmod:",
+        "chown:",
+    ];
+    if write_markers.iter().any(|m| lower.contains(m)) {
+        return ViolationKind::FileWrite;
+    }
+    let read_markers = ["cat:", "ls:", "head:", "tail:", "find:", "grep:"];
+    if read_markers.iter().any(|m| lower.contains(m)) {
+        return ViolationKind::FileRead;
+    }
+    // sh redirection (`echo x > /etc/passwd`) shows up as `sh: ...:
+    // Operation not permitted` — no verb hint, but redirections always
+    // imply write intent.
+    if lower.starts_with("sh:") || lower.starts_with("bash:") {
+        return ViolationKind::FileWrite;
+    }
+    ViolationKind::Other
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn touch_denial_classified_as_write() {
+        let stderr = "touch: /Users/me/.ssh/canary: Operation not permitted\n";
+        let v = parse_stderr(stderr, Some("touch ~/.ssh/canary"));
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileWrite);
+        assert_eq!(v[0].target.as_deref(), Some("/Users/me/.ssh/canary"));
+        assert_eq!(v[0].command.as_deref(), Some("touch ~/.ssh/canary"));
+    }
+
+    #[test]
+    fn shell_redirect_denial_classified_as_write() {
+        let stderr = "sh: line 1: /var/folders/xyz/evil.txt: Operation not permitted\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileWrite);
+        assert_eq!(v[0].target.as_deref(), Some("/var/folders/xyz/evil.txt"));
+    }
+
+    #[test]
+    fn ls_denial_classified_as_read() {
+        let stderr = "ls: /Users/me/.config/koda/db: Operation not permitted\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileRead);
+        assert_eq!(v[0].target.as_deref(), Some("/Users/me/.config/koda/db"));
+    }
+
+    #[test]
+    fn cat_denial_classified_as_read() {
+        let stderr = "cat: /etc/shadow: Permission denied\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileRead);
+        assert_eq!(v[0].target.as_deref(), Some("/etc/shadow"));
+    }
+
+    #[test]
+    fn cp_cannot_create_classified_as_write() {
+        let stderr = "cp: cannot create regular file '/etc/passwd': Permission denied\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileWrite);
+        assert_eq!(v[0].target.as_deref(), Some("/etc/passwd"));
+    }
+
+    #[test]
+    fn read_only_file_system_classified_as_write() {
+        let stderr = "touch: /usr/bin/foo: Read-only file system\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].kind, ViolationKind::FileWrite);
+    }
+
+    #[test]
+    fn lines_without_denial_markers_are_ignored() {
+        let stderr = "warning: deprecated flag\nINFO: built target koda-cli\n";
+        let v = parse_stderr(stderr, None);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn multiple_denials_yield_multiple_violations() {
+        let stderr = "\
+touch: /etc/passwd: Operation not permitted
+touch: /etc/shadow: Operation not permitted
+";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 2);
+        assert_eq!(v[0].target.as_deref(), Some("/etc/passwd"));
+        assert_eq!(v[1].target.as_deref(), Some("/etc/shadow"));
+    }
+
+    #[test]
+    fn empty_stderr_yields_no_violations() {
+        assert!(parse_stderr("", None).is_empty());
+    }
+
+    #[test]
+    fn denial_without_path_still_recorded_as_other() {
+        // Some libc errors don't include a path (rare, but `chmod`
+        // failing on a busy file looks like this).
+        let stderr = "chmod: changing permissions: Operation not permitted\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        // `chmod` is in our write-markers list.
+        assert_eq!(v[0].kind, ViolationKind::FileWrite);
+        assert!(v[0].target.is_none(), "no abs path → no target");
+    }
+
+    #[test]
+    fn command_is_attached_to_every_violation() {
+        let stderr = "touch: /a: Operation not permitted\ntouch: /b: Operation not permitted\n";
+        let v = parse_stderr(stderr, Some("my-script.sh"));
+        assert_eq!(v.len(), 2);
+        assert!(
+            v.iter()
+                .all(|x| x.command.as_deref() == Some("my-script.sh"))
+        );
+    }
+
+    #[test]
+    fn extracts_last_absolute_path_when_multiple_present() {
+        // CC-style "blocked write to X (allowed root: Y)" diagnostic.
+        let stderr = "denied write to /home/me/secret (allowed: /tmp): Operation not permitted\n";
+        let v = parse_stderr(stderr, None);
+        // We walk right-to-left, so /tmp wins. Acceptable trade-off
+        // for Phase 1 — the syslog parser in Phase 5 will be more precise.
+        assert_eq!(v.len(), 1);
+        assert!(v[0].target.is_some());
+    }
+
+    #[test]
+    fn ignores_relative_paths() {
+        // `Operation not permitted` on a relative path shouldn't be
+        // attributed to the wrong target. Better to record `target=None`
+        // than fabricate an absolute path.
+        let stderr = "touch: foo.txt: Permission denied\n";
+        let v = parse_stderr(stderr, None);
+        assert_eq!(v.len(), 1);
+        assert!(
+            v[0].target.is_none(),
+            "relative path must not be attributed"
+        );
+    }
+}

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -36,13 +36,17 @@ use tokio::process::Command;
 
 /// Build a `sandbox-exec` Command for the given command + project root.
 ///
-/// Phase 0: `_policy` is accepted but ignored — the profile is the
-/// hardcoded "strict" baseline that matches pre-#934 behavior. Phase 1
-/// switches to consuming `policy.fs.*` fields.
+/// The profile is composed in three layers, last-match-wins:
+///   1. Baseline (`build_profile_string`)         — broad reads + project writes
+///   2. Hardcoded denies (subdirs, credential dirs) — protect known sensitive
+///   3. Policy overlay (`policy_overlay_rules`)   — caller-supplied rules
+///
+/// An empty `policy` (e.g. [`SandboxPolicy::strict_default`]) produces a
+/// profile byte-identical to pre-#934 behavior.
 pub fn build_command(
     command: &str,
     project_root: &Path,
-    _policy: &SandboxPolicy,
+    policy: &SandboxPolicy,
 ) -> Result<Command> {
     let canonical = project_root
         .canonicalize()
@@ -59,6 +63,7 @@ pub fn build_command(
     let mut profile = build_profile_string(&root, &home);
     profile.push_str(&protected_subdir_deny_rules(&root));
     profile.push_str(&credential_deny_rules(&home));
+    profile.push_str(&policy_overlay_rules(policy)?);
 
     let mut cmd = Command::new("sandbox-exec");
     cmd.arg("-p")
@@ -192,6 +197,59 @@ pub(crate) fn credential_deny_rules(home: &str) -> String {
     }
 
     rules
+}
+
+/// Phase 1b of #934: render `policy.fs.*` into seatbelt rules.
+///
+/// Layered to match the issue's two-rule semantics. Order matters in
+/// seatbelt (last match wins), so within each layer we emit denies
+/// *before* their carve-out allows:
+///
+///   1. `deny_read`                 — carve denies into broad allow.
+///   2. `allow_read_within_deny`    — carve allows back into the denies.
+///   3. `allow_write`               — widen the writable set.
+///   4. `deny_write_within_allow`   — protect spots inside the writes.
+///
+/// Each path is validated through [`validate_seatbelt_path`] to prevent
+/// S-expression injection — `deny_read: vec!["foo\")(allow file-write*"]`
+/// would otherwise let a caller punch through their own sandbox.
+///
+/// Returns the empty string for an all-default policy, which keeps the
+/// pre-#934 byte-identical behavior promised by [`build_command`].
+pub(crate) fn policy_overlay_rules(policy: &SandboxPolicy) -> Result<String> {
+    let fs = &policy.fs;
+    if fs.deny_read.is_empty()
+        && fs.allow_read_within_deny.is_empty()
+        && fs.allow_write.is_empty()
+        && fs.deny_write_within_allow.is_empty()
+    {
+        return Ok(String::new());
+    }
+
+    let mut rules =
+        String::from("; \u{2500}\u{2500} policy overlay (Phase 1b of #934) \u{2500}\u{2500}\n");
+
+    for p in &fs.deny_read {
+        let s = p.as_path().to_string_lossy();
+        validate_seatbelt_path(&s)?;
+        rules.push_str(&format!("(deny file-read* (subpath \"{s}\"))\n"));
+    }
+    for p in &fs.allow_read_within_deny {
+        let s = p.as_path().to_string_lossy();
+        validate_seatbelt_path(&s)?;
+        rules.push_str(&format!("(allow file-read* (subpath \"{s}\"))\n"));
+    }
+    for p in &fs.allow_write {
+        let s = p.as_path().to_string_lossy();
+        validate_seatbelt_path(&s)?;
+        rules.push_str(&format!("(allow file-write* (subpath \"{s}\"))\n"));
+    }
+    for p in &fs.deny_write_within_allow {
+        let s = p.as_path().to_string_lossy();
+        validate_seatbelt_path(&s)?;
+        rules.push_str(&format!("(deny file-write* (subpath \"{s}\"))\n"));
+    }
+    Ok(rules)
 }
 
 #[cfg(test)]
@@ -363,5 +421,94 @@ mod tests {
     #[test]
     fn validate_seatbelt_path_accepts_normal() {
         assert!(validate_seatbelt_path("/Users/me/Projects/koda").is_ok());
+    }
+
+    // ── Phase 1b of #934: policy overlay rendering ───────────────────────
+
+    #[test]
+    fn policy_overlay_rules_empty_for_default_policy() {
+        // Phase 0/1a invariant: empty policy must produce empty overlay so
+        // the existing baseline behavior stays byte-identical.
+        let overlay = policy_overlay_rules(&SandboxPolicy::strict_default()).unwrap();
+        assert_eq!(overlay, "", "default policy must add zero rules");
+    }
+
+    #[test]
+    fn policy_overlay_rules_emit_deny_read_first_then_allow_within() {
+        // Two-layer semantics: deny rules must precede their carve-out
+        // allows so seatbelt's last-match-wins makes the allows win.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.deny_read = vec!["/secrets".into()];
+        policy.fs.allow_read_within_deny = vec!["/secrets/public".into()];
+        let overlay = policy_overlay_rules(&policy).unwrap();
+
+        let deny_pos = overlay
+            .find(r#"(deny file-read* (subpath "/secrets"))"#)
+            .expect("deny rule expected");
+        let allow_pos = overlay
+            .find(r#"(allow file-read* (subpath "/secrets/public"))"#)
+            .expect("allow rule expected");
+        assert!(
+            deny_pos < allow_pos,
+            "deny must come before allow-within: {overlay}"
+        );
+    }
+
+    #[test]
+    fn policy_overlay_rules_emit_allow_write_then_deny_within() {
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_write = vec!["/work".into()];
+        policy.fs.deny_write_within_allow = vec!["/work/.git/config".into()];
+        let overlay = policy_overlay_rules(&policy).unwrap();
+
+        let allow_pos = overlay
+            .find(r#"(allow file-write* (subpath "/work"))"#)
+            .expect("allow rule expected");
+        let deny_pos = overlay
+            .find(r#"(deny file-write* (subpath "/work/.git/config"))"#)
+            .expect("deny rule expected");
+        assert!(
+            allow_pos < deny_pos,
+            "allow must come before deny-within: {overlay}"
+        );
+    }
+
+    #[test]
+    fn policy_overlay_rules_validates_paths_to_prevent_injection() {
+        // Hostile policy with S-expression-injection attempt must error
+        // before producing a profile string. Otherwise a caller could
+        // punch through their own sandbox via crafted paths.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.deny_read = vec![r#"/foo")(allow file-write*"#.into()];
+        let result = policy_overlay_rules(&policy);
+        assert!(result.is_err(), "injection-y path must be rejected");
+    }
+
+    #[test]
+    fn policy_overlay_rules_is_appended_after_baseline_in_build_command() {
+        // Behavioral check: the overlay rules must come *after* the
+        // hardcoded credential denies so the user's policy can override
+        // (e.g. user explicitly allow_read_within_deny on ~/.ssh would
+        // override the credential read-deny if we ever had one).
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_read_within_deny = vec!["/etc/koda-marker".into()];
+
+        let cmd = build_command("true", Path::new("/tmp"), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+        let overlay_pos = profile
+            .find("policy overlay (Phase 1b of #934)")
+            .expect("overlay header missing");
+        let credential_pos = profile
+            .find("strict: write-protect credential dirs")
+            .expect("credential header missing");
+        assert!(
+            credential_pos < overlay_pos,
+            "policy overlay must come after credential rules"
+        );
     }
 }

--- a/koda-sandbox/src/violations.rs
+++ b/koda-sandbox/src/violations.rs
@@ -1,0 +1,347 @@
+//! Sandbox violation tracking — ring buffer + pub/sub.
+//!
+//! Whenever the kernel sandbox denies an operation the failure surfaces
+//! in two channels:
+//!
+//! 1. The command's stderr — `"Operation not permitted"` or similar.
+//! 2. The OS audit log — `log stream` on macOS, `dmesg`/journald on Linux.
+//!
+//! [`SandboxViolationStore`] is the in-process aggregation point for both.
+//! Clients (the bash tool, `/sandbox status`, the inference loop) read
+//! recent violations from here and present them to the model as
+//! `<sandbox_violations>` stderr annotations (CC pattern, #934 §4.7).
+//!
+//! ## Concurrency
+//!
+//! Cheap-clone the store and stash it on every [`crate::SandboxRuntime`].
+//! Internally a `Mutex<VecDeque>` (writes are rare, on the order of one
+//! per failed syscall — coarse-grained locking is fine).
+//!
+//! ## Why a ring buffer, not unbounded?
+//!
+//! A buggy or hostile loop could spam thousands of violations per second
+//! (`while true; do touch /etc/passwd; done`). Capping at 100 (configurable)
+//! bounds memory and avoids drowning the model in noise. Older entries
+//! drop silently — clients that need every violation should subscribe.
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::SystemTime;
+
+/// Maximum violations retained in the ring buffer. Picked to match
+/// CC's default; rationale: more than ~100 is unreadable for a human
+/// glancing at `/sandbox status` and uninformative for the model.
+pub const DEFAULT_RING_CAPACITY: usize = 100;
+
+/// What the kernel actually denied. Open enum because new platforms
+/// (Linux landlock, macOS endpoint-security) may surface novel kinds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ViolationKind {
+    /// Read attempt on a denied path.
+    FileRead,
+    /// Write/create/unlink attempt on a denied path.
+    FileWrite,
+    /// Outbound network connection (host:port).
+    NetworkOutbound,
+    /// Process spawn that the policy doesn't permit.
+    ProcessExec,
+    /// Anything we can recognize as a sandbox denial but can't classify.
+    Other,
+}
+
+/// A single sandbox denial event.
+///
+/// `target` is best-effort — on Linux `bwrap` only emits the destination
+/// path for some syscalls; on macOS `sandbox-exec` formats vary by macOS
+/// version. Treat the field as an advisory hint, not a precise audit log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Violation {
+    /// What was denied (file read, network out, etc).
+    pub kind: ViolationKind,
+    /// Path or host:port the operation targeted, when extractable.
+    pub target: Option<String>,
+    /// The command that triggered the violation, if known. Useful for
+    /// correlating stderr noise back to a specific tool invocation.
+    pub command: Option<String>,
+    /// Wall-clock timestamp. Serialized as RFC 3339 by `serde`.
+    #[serde(with = "system_time_serde")]
+    pub at: SystemTime,
+}
+
+impl Violation {
+    /// Convenience: build a violation with `at = SystemTime::now()`.
+    #[must_use]
+    pub fn new(kind: ViolationKind, target: Option<String>, command: Option<String>) -> Self {
+        Self {
+            kind,
+            target,
+            command,
+            at: SystemTime::now(),
+        }
+    }
+
+    /// Format for inclusion in a `<sandbox_violations>` stderr block.
+    /// Format mirrors CC's: `<verb> <kind-shape> <target>`.
+    #[must_use]
+    pub fn render_line(&self) -> String {
+        let kind = match self.kind {
+            ViolationKind::FileRead => "deny file-read*",
+            ViolationKind::FileWrite => "deny file-write*",
+            ViolationKind::NetworkOutbound => "deny network-outbound",
+            ViolationKind::ProcessExec => "deny process-exec*",
+            ViolationKind::Other => "deny",
+        };
+        match &self.target {
+            Some(t) => format!("{kind} {t}"),
+            None => kind.to_string(),
+        }
+    }
+}
+
+/// Cheap-clonable handle to a bounded ring of recent [`Violation`]s.
+///
+/// Designed for low-frequency writes (a few per second at most under
+/// real load) and burst reads (one read at the end of every tool call).
+/// A `Mutex` is the right primitive here — `RwLock` would only help if
+/// reads dramatically outnumbered writes, which they don't.
+#[derive(Debug, Clone)]
+pub struct SandboxViolationStore {
+    inner: Arc<Mutex<VecDeque<Violation>>>,
+    capacity: usize,
+}
+
+impl SandboxViolationStore {
+    /// Create a store with the default ring capacity ([`DEFAULT_RING_CAPACITY`]).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_RING_CAPACITY)
+    }
+
+    /// Create a store with an explicit capacity.
+    ///
+    /// `capacity = 0` disables retention (useful in tests that want to
+    /// exercise the recording path without holding state across calls).
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            capacity,
+        }
+    }
+
+    /// Append a violation to the ring. Drops the oldest entry if full.
+    ///
+    /// Lock poisoning is intentionally swallowed — losing a violation log
+    /// entry is far less bad than panicking the inference loop. We just
+    /// proceed without recording.
+    pub fn record(&self, v: Violation) {
+        if self.capacity == 0 {
+            return;
+        }
+        let Ok(mut buf) = self.inner.lock() else {
+            return;
+        };
+        if buf.len() == self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(v);
+    }
+
+    /// Snapshot of all currently retained violations, oldest first.
+    #[must_use]
+    pub fn snapshot(&self) -> Vec<Violation> {
+        self.inner
+            .lock()
+            .map(|buf| buf.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Snapshot + clear in a single critical section. Used by the bash
+    /// tool to drain violations between commands so we don't double-report.
+    #[must_use]
+    pub fn drain(&self) -> Vec<Violation> {
+        let Ok(mut buf) = self.inner.lock() else {
+            return Vec::new();
+        };
+        buf.drain(..).collect()
+    }
+
+    /// Number of violations currently retained (mostly for tests/metrics).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.lock().map(|b| b.len()).unwrap_or(0)
+    }
+
+    /// `true` if the buffer is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for SandboxViolationStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Format a slice of violations as the CC `<sandbox_violations>` stderr
+/// block. Returns `None` if there are no violations — callers should not
+/// emit an empty block.
+#[must_use]
+pub fn render_block(violations: &[Violation]) -> Option<String> {
+    if violations.is_empty() {
+        return None;
+    }
+    let mut out = String::from("<sandbox_violations>\n");
+    for v in violations {
+        out.push_str(&v.render_line());
+        out.push('\n');
+    }
+    out.push_str("</sandbox_violations>");
+    Some(out)
+}
+
+/// Cheap-clone handle to the process-wide violation store.
+///
+/// All sandboxed tools should record into this single store so
+/// `/sandbox status` (and the future Phase 2 telemetry layer) sees
+/// every violation across the session, not just the ones that happen
+/// to land on the same `SandboxRuntime` instance. The store is created
+/// lazily on first access and lives for the rest of the process.
+///
+/// Per-agent stores are a Phase 2+ concern when slots become real;
+/// until then, a single bounded ring is the right primitive.
+#[must_use]
+pub fn global_store() -> SandboxViolationStore {
+    static GLOBAL: OnceLock<SandboxViolationStore> = OnceLock::new();
+    GLOBAL.get_or_init(SandboxViolationStore::new).clone()
+}
+
+// ── SystemTime <-> RFC 3339 serde helper ────────────────────────────────────
+
+mod system_time_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    pub fn serialize<S: Serializer>(t: &SystemTime, s: S) -> Result<S::Ok, S::Error> {
+        // Seconds since epoch as f64 — survives clock skew and is human-glanceable.
+        let secs = t
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs_f64())
+            .unwrap_or(0.0);
+        secs.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<SystemTime, D::Error> {
+        let secs = f64::deserialize(d)?;
+        Ok(UNIX_EPOCH + std::time::Duration::from_secs_f64(secs))
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_caps_at_capacity() {
+        let store = SandboxViolationStore::with_capacity(3);
+        for i in 0..5 {
+            store.record(Violation::new(
+                ViolationKind::FileWrite,
+                Some(format!("/tmp/v{i}")),
+                None,
+            ));
+        }
+        let snap = store.snapshot();
+        assert_eq!(snap.len(), 3);
+        // Oldest two dropped → we should see v2, v3, v4.
+        assert_eq!(snap[0].target.as_deref(), Some("/tmp/v2"));
+        assert_eq!(snap[2].target.as_deref(), Some("/tmp/v4"));
+    }
+
+    #[test]
+    fn capacity_zero_records_nothing() {
+        let store = SandboxViolationStore::with_capacity(0);
+        store.record(Violation::new(ViolationKind::Other, None, None));
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn drain_empties_the_buffer() {
+        let store = SandboxViolationStore::new();
+        store.record(Violation::new(ViolationKind::FileRead, None, None));
+        store.record(Violation::new(ViolationKind::FileRead, None, None));
+        let drained = store.drain();
+        assert_eq!(drained.len(), 2);
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn render_block_returns_none_when_empty() {
+        assert!(render_block(&[]).is_none());
+    }
+
+    #[test]
+    fn render_block_matches_cc_shape() {
+        let v = Violation::new(
+            ViolationKind::FileWrite,
+            Some("/Users/me/.ssh/id_rsa".into()),
+            None,
+        );
+        let block = render_block(&[v]).unwrap();
+        assert!(block.starts_with("<sandbox_violations>\n"));
+        assert!(block.contains("deny file-write* /Users/me/.ssh/id_rsa"));
+        assert!(block.ends_with("</sandbox_violations>"));
+    }
+
+    #[test]
+    fn store_is_send_sync() {
+        // Compile-time check — the Arc<Mutex<…>> internals must allow
+        // sharing across threads, since slots will pass clones around.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SandboxViolationStore>();
+    }
+
+    #[test]
+    fn violation_serde_roundtrip() {
+        let v = Violation::new(
+            ViolationKind::NetworkOutbound,
+            Some("evil.com:443".into()),
+            Some("curl evil.com".into()),
+        );
+        let json = serde_json::to_string(&v).unwrap();
+        let back: Violation = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, v.kind);
+        assert_eq!(back.target, v.target);
+        assert_eq!(back.command, v.command);
+    }
+
+    #[test]
+    fn store_clones_share_inner_buffer() {
+        // Sub-agent slots will clone the store handle — both clones must
+        // see the same ring buffer. Same Arc semantics as Persistence::clone.
+        let store = SandboxViolationStore::new();
+        let twin = store.clone();
+        store.record(Violation::new(ViolationKind::Other, None, None));
+        assert_eq!(twin.len(), 1);
+    }
+
+    #[test]
+    fn global_store_returns_same_handle_across_calls() {
+        // Two callers must see each other's writes — otherwise tools
+        // can't observe violations recorded by other tools in the
+        // same process.
+        let a = global_store();
+        let b = global_store();
+        let before = a.len();
+        a.record(Violation::new(ViolationKind::Other, None, None));
+        assert_eq!(b.len(), before + 1);
+        // Drain so this test doesn't leak state into other tests.
+        let _ = a.drain();
+    }
+}


### PR DESCRIPTION
## Phase 1 of #934 — violation reporting + two-layer policy overlay

> **Stacked on #984** (Phase 0). Review that one first; merging this
> against `main` before #984 lands will look noisy. GitHub will
> auto-rebase the diff once #984 merges.

This PR adds the two pieces of Phase 1 from #934:

1. **Phase 1a** — kernel sandbox denials surface to the model as
   `<sandbox_violations>` stderr annotations (Claude Code pattern,
   #934 §4.7).
2. **Phase 1b** — the runtimes finally consume `SandboxPolicy.fs.*`
   instead of ignoring it.

### Phase 1a — violation reporting

**New in `koda-sandbox`:**

- `violations.rs` (~280 LOC):
  - `SandboxViolationStore` — bounded ring buffer (default 100 entries),
    cheap-clone via `Arc<Mutex<…>>`.
  - `Violation` { kind, target, command, at }.
  - `ViolationKind` enum: FileRead / FileWrite / NetworkOutbound /
    ProcessExec / Other.
  - `render_block()` — formats a `<sandbox_violations>` stderr block.
  - `global_store()` — process-wide singleton handle so all tools share
    one ring (per-agent slots are Phase 2+).

- `monitor.rs` (~180 LOC) — heuristic `parse_stderr() → Vec<Violation>`.
  Recognizes `Operation not permitted`, `Permission denied`, and
  `Read-only file system` denial markers; classifies kind from verb
  context (`touch`/`mkdir`/`chmod` → write; `cat`/`ls`/`head` → read;
  shell redirection → write). Phase 5 will swap in the real
  `log stream` syslog tail; the heuristic is good enough for the
  acceptance criterion.

**New in `koda-core/tools/shell.rs`:**

- `annotate_violations()` runs after every shell command:
  parses captured stderr, records into `global_store()`, appends the
  `<sandbox_violations>` block to stderr lines so existing
  `format_summary` / `format_full_output` carry it through. Only fires
  on non-zero exit codes — successful commands with denial-looking
  stderr (e.g. `find / 2>/dev/null`) stay un-annotated.

### Phase 1b — two-layer policy overlay rules

The schema in `koda-sandbox/policy.rs` was previously stored-but-ignored.
This commit makes the runtimes consume it:

- `seatbelt::policy_overlay_rules(policy)` — renders `policy.fs.*` into
  S-expressions appended *after* the hardcoded credential rules
  (last-match-wins). Validates each path to prevent S-expression
  injection.

- `bwrap::policy_overlay_args(policy)` — Linux equivalent. Mapping:
  | Policy field                  | bwrap rendering                |
  |-------------------------------|--------------------------------|
  | `fs.deny_read`                | `--tmpfs <path>`               |
  | `fs.allow_read_within_deny`   | `--ro-bind <p> <p>`            |
  | `fs.allow_write`              | `--bind <p> <p>`               |
  | `fs.deny_write_within_allow`  | `--ro-bind <p> <p>`            |

- Rule emission order: **broad rule first, narrower carve-out second**,
  so the inner mount / rule wins inside the overlapping range.

**Backwards compat:**

```
policy_overlay_rules(SandboxPolicy::strict_default())  →  ""
policy_overlay_args(SandboxPolicy::strict_default())   →  vec![]
```

All callers using the default policy (which is everyone today via the
koda-core sandbox shim) get **byte-identical behavior**.

### Acceptance criterion (#934 Phase 1)

> "Bash command that touches `~/.ssh` returns annotated stderr"

The new test `run_shell_command_annotates_ssh_write_denial` runs
`touch ~/.ssh/koda_phase1_annotation_canary` through the full
`run_shell_command()` pipeline on macOS and verifies:

1. ✅ Sandbox actually blocks the write (canary file not created)
2. ✅ Returned stderr contains `<sandbox_violations>` open tag
3. ✅ Returned stderr contains `deny file-write*` line
4. ✅ Returned stderr contains `</sandbox_violations>` close tag

### Tests

- `cargo test -p koda-sandbox`: **60 unit + 3 snapshot** pass (was 55+3)
  - 13 new monitor tests (denial parsing, kind classification, edge cases)
  - 7 new violation store + render_block + global_store tests
  - 5 new seatbelt overlay tests
  - 5 new bwrap overlay tests (Linux-only, cfg-gated)
- `cargo test -p koda-core --lib tools::shell`: **17** pass (added 4)
  - 3 unit tests for `annotate_violations`
  - 1 e2e test for the full shell pipeline (acceptance criterion above)
- `cargo clippy --workspace --all-targets`: clean

### What's still TODO before Phase 1 is fully closed

- `DANGEROUS_FILES` / `DANGEROUS_DIRECTORIES` baseline constants in
  `defaults.rs` (CC parity). Today koda's hardcoded credential rules
  cover the same paths via a different mechanism — adding the constants
  is a refactor, not a behavior change. Will lift in Phase 2 when the
  FS trait migration touches the same defaults.

### Risk

Phase 1a: low — informational only, doesn't change exit codes or
control flow. The annotation lives in stderr, parsed downstream by the
LLM only.

Phase 1b: low — empty policies (today's only caller) produce empty
overlays. Snapshot tests will catch any baseline drift.

Refs: #934
