### PR TITLE
feat(sandbox): FS worker IPC skeleton (Phase 2a of #934)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 tokio = { version = "1" }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Dev-only deps shared across crates.
 insta = { version = "1", features = ["yaml", "redactions"] }

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -55,7 +55,7 @@ regex = "1"
 
 # Logging (subscriber for CLI configuration)
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { workspace = true }
 tracing-appender = "0.2"
 
 # Error handling

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -12,10 +12,15 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["process", "rt"] }
+tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros"] }
 tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
+
+[[bin]]
+name = "koda-fs-worker"
+path = "src/bin/koda-fs-worker.rs"

--- a/koda-sandbox/src/bin/koda-fs-worker.rs
+++ b/koda-sandbox/src/bin/koda-fs-worker.rs
@@ -1,0 +1,41 @@
+//! `koda-fs-worker` — long-lived FS worker process spawned by the
+//! sandbox shim (Phase 2a of #934).
+//!
+//! Runs the [`koda_sandbox::worker::run_stdio`] dispatch loop against
+//! process stdin/stdout. Phase 2c will add a Unix-socket variant for
+//! the production per-slot wiring; stdio is what the integration tests
+//! use today.
+//!
+//! ## Lifecycle
+//!
+//! Spawned by `koda_sandbox::worker_client` (Phase 2c) for each
+//! sandbox slot. Exits when:
+//! - The host closes stdin (EOF) — normal "slot retired" path.
+//! - The host sends [`koda_sandbox::ipc::Request::Shutdown`] — graceful
+//!   shutdown with ack.
+//! - A transport-level IO error occurs — exit 1, host respawns.
+//!
+//! ## Why a binary not a library function?
+//!
+//! Crash isolation. A panicking FS handler kills the worker, not the
+//! host process driving the LLM session. The host wraps respawn logic
+//! in Phase 2c.
+
+use anyhow::Result;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    // Single-threaded runtime: this binary is one process per sandbox
+    // slot serving one host. No need for the multi-threaded scheduler's
+    // overhead — every request is handled sequentially anyway (the
+    // host serializes them by waiting for each response).
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_env("KODA_FS_WORKER_LOG")
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    koda_sandbox::worker::run_stdio().await
+}

--- a/koda-sandbox/src/ipc.rs
+++ b/koda-sandbox/src/ipc.rs
@@ -1,0 +1,445 @@
+//! Length-prefixed JSON IPC for the FS worker (Phase 2a of #934).
+//!
+//! The host process and `koda-fs-worker` exchange messages over a duplex
+//! transport (stdin/stdout in unit tests, Unix domain socket in
+//! production — see Phase 2c). The wire format is intentionally boring:
+//!
+//! ```text
+//! ┌──────────────────┬──────────────────────────────────┐
+//! │  u32 BE length   │       JSON-serialized payload    │
+//! └──────────────────┴──────────────────────────────────┘
+//! ```
+//!
+//! The 4-byte length prefix tells the reader exactly how many JSON bytes
+//! to consume — no streaming-parser ambiguity, no newline-delimited
+//! foot-guns when payloads embed `\n`. The format was chosen per #934 §8
+//! decision 1 ("JSON, length-prefixed. Debuggable, easy, zero new deps.")
+//! over msgpack; revisit only if benchmarks show >5% overhead.
+//!
+//! ## Why not just `serde_json::to_writer` over a pipe?
+//!
+//! `serde_json::to_writer` doesn't write a separator, so `from_reader`
+//! on the receiving end has no idea where one message ends and the next
+//! begins. Length prefix is the simplest fix that doesn't constrain
+//! payload contents.
+//!
+//! ## Message envelope
+//!
+//! - [`Request`] — host → worker. New variants get added in Phase 2c
+//!   (Read/Write/Edit/Glob/Grep). Today only `Ping` and `Shutdown` are
+//!   implemented; the rest are reserved variants that return
+//!   `Response::Error { code: Unimplemented }`.
+//! - [`Response`] — worker → host. Always either the variant matching
+//!   the request kind or `Response::Error`.
+//!
+//! ## Versioning
+//!
+//! Wire compatibility is **not** a goal — host + worker ship in the
+//! same binary release and re-spawn together. We don't carry a protocol
+//! version field; if the request shape changes between releases, the
+//! worker that gets spawned matches the host. Cross-version IPC would
+//! be a concrete bug, not a feature.
+
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::PathBuf;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Maximum size of a single IPC payload (1 MiB).
+///
+/// Above this we fail the request rather than allocate unbounded —
+/// a hostile or buggy peer must not be able to OOM us by sending a
+/// length prefix of `u32::MAX`. File reads larger than this should be
+/// chunked at a higher layer (the file tools already cap output).
+pub const MAX_PAYLOAD_BYTES: usize = 1 << 20;
+
+/// Host → worker message.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Request {
+    /// Liveness probe. Worker replies [`Response::Pong`] immediately.
+    Ping,
+
+    /// Graceful shutdown. Worker drains its current handler then exits 0.
+    /// Used by `SandboxSlot::Drop` to retire workers cleanly without
+    /// leaving zombie processes. Phase 2c wires this up.
+    Shutdown,
+
+    // ── Phase 2c reserved variants (handlers stubbed today) ──────────
+    /// Read file contents. Phase 2c implements; today returns
+    /// `Response::Error { Unimplemented }`.
+    Read {
+        /// Absolute path to read.
+        path: PathBuf,
+        /// Cap on bytes returned (`None` = read whole file up to
+        /// [`MAX_PAYLOAD_BYTES`]). Tools pre-cap at a smaller value.
+        max_bytes: Option<usize>,
+    },
+
+    /// Write file contents. Phase 2c implements.
+    Write {
+        /// Absolute path to write.
+        path: PathBuf,
+        /// Bytes to write (overwrites existing file).
+        content: Vec<u8>,
+    },
+
+    /// In-place string replacement. Phase 2c implements.
+    Edit {
+        /// Absolute path of the file to edit.
+        path: PathBuf,
+        /// Substring to find.
+        old_string: String,
+        /// Replacement substring.
+        new_string: String,
+    },
+
+    /// Glob expansion. Phase 2c implements.
+    Glob {
+        /// Glob pattern, e.g. `**/*.rs`.
+        pattern: String,
+        /// Directory to anchor the glob expansion.
+        root: PathBuf,
+    },
+
+    /// Recursive grep. Phase 2c implements.
+    Grep {
+        /// Regex pattern to search for.
+        pattern: String,
+        /// Directory to recurse into.
+        root: PathBuf,
+        /// Optional file glob to filter what gets grepped (e.g. `*.rs`).
+        include: Option<String>,
+    },
+
+    /// `stat`-like metadata fetch. Phase 2c implements.
+    Stat {
+        /// Absolute path to stat.
+        path: PathBuf,
+    },
+}
+
+/// Worker → host message. Always matches the kind of the originating
+/// request, or `Error` on any failure (policy denial, IO error,
+/// unimplemented variant, etc.).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Response {
+    /// Reply to [`Request::Ping`] (and the ack for [`Request::Shutdown`]).
+    Pong,
+
+    /// Reply to [`Request::Read`].
+    Read {
+        /// File contents (possibly truncated to `max_bytes`).
+        content: Vec<u8>,
+    },
+
+    /// Reply to [`Request::Write`].
+    Write {
+        /// Bytes successfully written to disk.
+        bytes_written: usize,
+    },
+
+    /// Reply to [`Request::Edit`].
+    Edit {
+        /// How many occurrences of `old_string` were replaced.
+        replacements: usize,
+    },
+
+    /// Reply to [`Request::Glob`].
+    Glob {
+        /// Matching paths in deterministic order (sorted).
+        paths: Vec<PathBuf>,
+    },
+
+    /// Reply to [`Request::Grep`].
+    Grep {
+        /// Hits in document order.
+        matches: Vec<GrepMatch>,
+    },
+
+    /// Reply to [`Request::Stat`].
+    Stat {
+        /// File size in bytes (0 for directories).
+        size: u64,
+        /// True if the path is a directory.
+        is_dir: bool,
+        /// True if the path itself is a symlink (not its target).
+        is_symlink: bool,
+    },
+
+    /// Anything that didn't go right — policy denial, IO error,
+    /// unimplemented request kind, malformed input, etc. The host turns
+    /// this into a Rust `Err` and the calling tool decides what to do.
+    Error {
+        /// Coarse classification (see [`ErrorCode`]).
+        code: ErrorCode,
+        /// Human-readable detail (logged + surfaced to the LLM).
+        message: String,
+    },
+}
+
+/// Error taxonomy for `Response::Error`. Coarse on purpose — fine-grained
+/// classification belongs at the calling tool's level, not the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// Worker doesn't implement this variant yet (Phase 2c will).
+    Unimplemented,
+    /// Sandbox policy refused the operation.
+    PolicyDenied,
+    /// `std::io::Error` flavor (file not found, permission denied, …).
+    Io,
+    /// Payload exceeded [`MAX_PAYLOAD_BYTES`] or otherwise malformed.
+    Protocol,
+    /// Internal worker bug / panic guard. Should never appear in prod.
+    Internal,
+}
+
+/// One ripgrep-style hit in a `Grep` response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrepMatch {
+    /// File the hit lives in.
+    pub path: PathBuf,
+    /// 1-based line number (matches `rg`/`grep` convention).
+    pub line: usize,
+    /// The full matching line, with no trailing newline.
+    pub text: String,
+}
+
+// ── Framing ──────────────────────────────────────────────────────────────
+
+/// Read a single length-prefixed JSON message from `reader`.
+///
+/// Returns `Ok(None)` on clean EOF before any bytes are read — the
+/// peer closed the transport without sending anything, which the host
+/// uses to detect worker death and the worker uses to detect parent
+/// hangup.
+///
+/// # Errors
+///
+/// - `io::ErrorKind::UnexpectedEof` if EOF arrives mid-frame
+///   (length-prefix partial, or payload shorter than declared).
+/// - `io::ErrorKind::InvalidData` if the declared length exceeds
+///   [`MAX_PAYLOAD_BYTES`] or the payload is not valid JSON-of-`T`.
+pub async fn read_message<R, T>(reader: &mut R) -> io::Result<Option<T>>
+where
+    R: AsyncRead + Unpin,
+    T: serde::de::DeserializeOwned,
+{
+    // Read the 4-byte length prefix manually so we can distinguish the
+    // two flavors of EOF: clean (0 bytes read — peer hung up between
+    // messages) versus mid-prefix truncation (1–3 bytes — protocol error).
+    let mut len_buf = [0u8; 4];
+    let mut read_so_far = 0usize;
+    while read_so_far < 4 {
+        let n = reader.read(&mut len_buf[read_so_far..]).await?;
+        if n == 0 {
+            return if read_so_far == 0 {
+                Ok(None) // clean peer close — not an error
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("EOF after {read_so_far} of 4 length-prefix bytes"),
+                ))
+            };
+        }
+        read_so_far += n;
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > MAX_PAYLOAD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("payload size {len} exceeds max {MAX_PAYLOAD_BYTES}"),
+        ));
+    }
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    let parsed = serde_json::from_slice::<T>(&payload).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("malformed JSON payload: {e}"),
+        )
+    })?;
+    Ok(Some(parsed))
+}
+
+/// Write a length-prefixed JSON message to `writer`.
+///
+/// # Errors
+///
+/// - `io::ErrorKind::InvalidData` if the serialized payload exceeds
+///   [`MAX_PAYLOAD_BYTES`] (host-side bug — refuse to send so the peer
+///   doesn't have to defend against it).
+/// - Any IO error from the underlying transport.
+pub async fn write_message<W, T>(writer: &mut W, msg: &T) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: serde::Serialize,
+{
+    let payload = serde_json::to_vec(msg)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("serialize: {e}")))?;
+    if payload.len() > MAX_PAYLOAD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "outgoing payload size {} exceeds max {}",
+                payload.len(),
+                MAX_PAYLOAD_BYTES
+            ),
+        ));
+    }
+    let len = (payload.len() as u32).to_be_bytes();
+    writer.write_all(&len).await?;
+    writer.write_all(&payload).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tokio::io::duplex;
+
+    // ── Roundtrip: every message kind must serialize and parse back ──
+
+    #[tokio::test]
+    async fn ping_roundtrips_through_framing() {
+        let (mut a, mut b) = duplex(64);
+        write_message(&mut a, &Request::Ping).await.unwrap();
+        let got: Request = read_message(&mut b).await.unwrap().unwrap();
+        assert_eq!(got, Request::Ping);
+    }
+
+    #[tokio::test]
+    async fn pong_roundtrips_through_framing() {
+        let (mut a, mut b) = duplex(64);
+        write_message(&mut a, &Response::Pong).await.unwrap();
+        let got: Response = read_message(&mut b).await.unwrap().unwrap();
+        assert_eq!(got, Response::Pong);
+    }
+
+    #[tokio::test]
+    async fn error_response_roundtrips() {
+        let (mut a, mut b) = duplex(256);
+        let msg = Response::Error {
+            code: ErrorCode::PolicyDenied,
+            message: "deny file-write* /etc/passwd".into(),
+        };
+        write_message(&mut a, &msg).await.unwrap();
+        let got: Response = read_message(&mut b).await.unwrap().unwrap();
+        assert_eq!(got, msg);
+    }
+
+    #[tokio::test]
+    async fn complex_request_roundtrips() {
+        // Edit carries a path + two strings — common worst case for
+        // serde-tagging bugs. If this works, simpler variants will too.
+        let (mut a, mut b) = duplex(512);
+        let req = Request::Edit {
+            path: PathBuf::from("/work/src/main.rs"),
+            old_string: "let x = 1;\nlet y = 2;".into(),
+            new_string: "let x = 42;".into(),
+        };
+        write_message(&mut a, &req).await.unwrap();
+        let got: Request = read_message(&mut b).await.unwrap().unwrap();
+        assert_eq!(got, req);
+    }
+
+    #[tokio::test]
+    async fn multiple_messages_back_to_back_parse_correctly() {
+        // Length-prefix correctness: two messages on the wire must not
+        // bleed into each other. Streaming JSON parsers fail this test.
+        let (mut a, mut b) = duplex(1024);
+        write_message(&mut a, &Request::Ping).await.unwrap();
+        write_message(
+            &mut a,
+            &Request::Read {
+                path: "/a".into(),
+                max_bytes: Some(1024),
+            },
+        )
+        .await
+        .unwrap();
+        let m1: Request = read_message(&mut b).await.unwrap().unwrap();
+        let m2: Request = read_message(&mut b).await.unwrap().unwrap();
+        assert_eq!(m1, Request::Ping);
+        assert_eq!(
+            m2,
+            Request::Read {
+                path: "/a".into(),
+                max_bytes: Some(1024)
+            }
+        );
+    }
+
+    // ── EOF / error paths ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn clean_eof_before_any_bytes_returns_none() {
+        // The peer dropped the transport without sending. Host uses
+        // this to detect worker exit; worker uses it to detect parent
+        // hangup. Must NOT be an error.
+        let mut empty = Cursor::new(Vec::<u8>::new());
+        let got: Option<Request> = read_message(&mut empty).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn eof_mid_length_prefix_is_unexpected_eof() {
+        // 2 bytes of length, then EOF. Must error, not silently truncate.
+        let mut partial = Cursor::new(vec![0u8, 0u8]);
+        let err = read_message::<_, Request>(&mut partial).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn eof_mid_payload_is_unexpected_eof() {
+        // Length says 100 bytes, transport has 4. Must error.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&100u32.to_be_bytes());
+        buf.extend_from_slice(b"abcd");
+        let mut cur = Cursor::new(buf);
+        let err = read_message::<_, Request>(&mut cur).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[tokio::test]
+    async fn payload_size_above_cap_is_rejected() {
+        // Hostile peer claiming a huge length must not let us allocate
+        // unbounded. We reject *before* the malloc.
+        let oversize = (MAX_PAYLOAD_BYTES as u32 + 1).to_be_bytes();
+        let mut cur = Cursor::new(oversize.to_vec());
+        let err = read_message::<_, Request>(&mut cur).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds max"));
+    }
+
+    #[tokio::test]
+    async fn malformed_json_payload_is_invalid_data() {
+        let mut buf = Vec::new();
+        let body = b"this is not json";
+        buf.extend_from_slice(&(body.len() as u32).to_be_bytes());
+        buf.extend_from_slice(body);
+        let mut cur = Cursor::new(buf);
+        let err = read_message::<_, Request>(&mut cur).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("malformed JSON"));
+    }
+
+    #[tokio::test]
+    async fn write_rejects_oversize_payload_locally() {
+        // We refuse to *send* something the peer would refuse to *read*
+        // — symmetric defense, fail fast in this process so the bug
+        // doesn't show up as a confusing remote error.
+        let huge = "x".repeat(MAX_PAYLOAD_BYTES + 100);
+        let req = Request::Write {
+            path: "/a".into(),
+            content: huge.into_bytes(),
+        };
+        let (mut a, _b) = duplex(MAX_PAYLOAD_BYTES * 2);
+        let err = write_message(&mut a, &req).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -32,12 +32,14 @@
 #[cfg(target_os = "linux")]
 pub mod bwrap;
 pub mod defaults;
+pub mod ipc;
 pub mod monitor;
 pub mod policy;
 pub mod policy_check;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;
 pub mod violations;
+pub mod worker;
 pub mod workspace;
 
 pub use policy::{

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -1,0 +1,217 @@
+//! FS worker dispatch loop (Phase 2a of #934).
+//!
+//! The worker is a tiny event loop:
+//!
+//! ```text
+//! loop {
+//!     read_message(transport) -> Request
+//!     handle(request)         -> Response
+//!     write_message(transport, response)
+//! }
+//! ```
+//!
+//! It exits when:
+//! - The peer closes the transport (clean EOF on `read_message`).
+//! - It receives [`Request::Shutdown`] (sends `Pong`-equivalent ack
+//!   then breaks the loop).
+//! - An IO error occurs (logs and exits non-zero).
+//!
+//! Phase 2a only implements `Ping` and `Shutdown`. Every other request
+//! kind returns `Response::Error { code: Unimplemented }`. The handlers
+//! land in Phase 2c when the [`crate::ipc::Request::Read`] et al.
+//! variants get real implementations against an enforced policy.
+//!
+//! ## Why a separate process at all?
+//!
+//! In-tree file-tool code runs in the same process as the LLM client
+//! and the agent loop. That process is *the* trusted supervisor —
+//! the kernel sandbox enforces nothing on it. Putting the FS code in a
+//! worker process means we can:
+//!
+//! 1. **Run the worker outside the kernel sandbox** (it needs to
+//!    actually do FS work), but still **enforce the policy in code**
+//!    for every request. Matches CC's `SandboxedFileSystem` shape.
+//! 2. **Bind the worker's lifecycle to a sub-agent slot** (Phase 4).
+//!    Per-slot policy = per-slot worker = no cross-talk.
+//! 3. **Crash isolation** — a panicking file handler kills the worker,
+//!    not the host. The host can respawn.
+//!
+//! See #934 §4.5 for the full motivation.
+
+use crate::ipc::{ErrorCode, Request, Response, read_message, write_message};
+use anyhow::Result;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, warn};
+
+/// Run the worker dispatch loop against an arbitrary duplex transport.
+///
+/// Production callers ([`run_stdio`] today, Unix socket spawner in
+/// Phase 2c) wrap their transport and call this. Tests pass an
+/// in-memory `tokio::io::duplex` half.
+///
+/// Returns `Ok(())` on clean shutdown (peer EOF or `Request::Shutdown`).
+/// Returns `Err(...)` only for genuine transport errors — malformed
+/// requests are reported back as `Response::Error` and the loop
+/// continues.
+pub async fn run<R, W>(reader: &mut R, writer: &mut W) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    loop {
+        let req = match read_message::<R, Request>(reader).await {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                debug!("worker: peer closed transport, exiting cleanly");
+                return Ok(());
+            }
+            Err(e) => {
+                warn!("worker: transport read error: {e}");
+                // Try to tell the peer it sent garbage before bailing.
+                let _ = write_message(
+                    writer,
+                    &Response::Error {
+                        code: ErrorCode::Protocol,
+                        message: format!("read error: {e}"),
+                    },
+                )
+                .await;
+                return Err(e.into());
+            }
+        };
+
+        let is_shutdown = matches!(req, Request::Shutdown);
+        let resp = handle(req).await;
+        write_message(writer, &resp).await?;
+
+        if is_shutdown {
+            debug!("worker: shutdown requested, exiting cleanly");
+            return Ok(());
+        }
+    }
+}
+
+/// Handle a single request. Pure function of input → output (no shared
+/// state today; that comes when handlers need a policy reference).
+async fn handle(req: Request) -> Response {
+    match req {
+        Request::Ping => Response::Pong,
+        // Shutdown's response is just a Pong-style ack so the host knows
+        // the worker received the request before exiting. Any non-Error
+        // variant would do; Pong is the obvious one.
+        Request::Shutdown => Response::Pong,
+        // ── Phase 2c stubs ─────────────────────────────────────────────
+        Request::Read { .. }
+        | Request::Write { .. }
+        | Request::Edit { .. }
+        | Request::Glob { .. }
+        | Request::Grep { .. }
+        | Request::Stat { .. } => Response::Error {
+            code: ErrorCode::Unimplemented,
+            message: "FS request handlers land in Phase 2c of #934".into(),
+        },
+    }
+}
+
+/// Convenience entry point: run the dispatch loop against process
+/// stdin/stdout. This is what the `koda-fs-worker` binary calls.
+///
+/// Phase 2c will add `run_unix_socket(path)` for the production
+/// per-slot wiring; stdio is what the unit tests use today.
+pub async fn run_stdio() -> Result<()> {
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    run(&mut stdin, &mut stdout).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipc::{ErrorCode, Request, Response};
+    use std::path::PathBuf;
+    use tokio::io::duplex;
+
+    /// Spawn the worker against one half of a duplex pair, return the
+    /// other half for the test to drive. The worker task is spawned on
+    /// the runtime so the test can interleave reads and writes against
+    /// it like a real peer.
+    fn spawn_worker() -> (tokio::io::DuplexStream, tokio::task::JoinHandle<Result<()>>) {
+        let (host, worker) = duplex(4096);
+        let (mut wr, mut ww) = tokio::io::split(worker);
+        let join = tokio::spawn(async move { run(&mut wr, &mut ww).await });
+        (host, join)
+    }
+
+    #[tokio::test]
+    async fn ping_returns_pong() {
+        let (mut host, _join) = spawn_worker();
+        write_message(&mut host, &Request::Ping).await.unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(resp, Response::Pong);
+    }
+
+    #[tokio::test]
+    async fn shutdown_acks_then_worker_exits() {
+        let (mut host, join) = spawn_worker();
+        write_message(&mut host, &Request::Shutdown).await.unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(resp, Response::Pong);
+        // Drop our end so the worker sees clean EOF if it didn't exit yet.
+        drop(host);
+        tokio::time::timeout(std::time::Duration::from_secs(2), join)
+            .await
+            .expect("worker must exit within 2s of Shutdown")
+            .expect("worker join error")
+            .expect("worker returned Err");
+    }
+
+    #[tokio::test]
+    async fn unimplemented_request_returns_error_response() {
+        // Phase 2c will replace this assertion. Until then, every
+        // FS-flavored variant must surface as Unimplemented so callers
+        // get a clear signal instead of silent success.
+        let (mut host, _join) = spawn_worker();
+        write_message(
+            &mut host,
+            &Request::Read {
+                path: PathBuf::from("/etc/passwd"),
+                max_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        match resp {
+            Response::Error {
+                code: ErrorCode::Unimplemented,
+                ..
+            } => {}
+            other => panic!("expected Unimplemented error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_loops_for_multiple_requests() {
+        // Pipelining sanity check: the loop must process N requests
+        // back-to-back without losing framing or returning early.
+        let (mut host, _join) = spawn_worker();
+        for _ in 0..5 {
+            write_message(&mut host, &Request::Ping).await.unwrap();
+            let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+            assert_eq!(resp, Response::Pong);
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_eof_exits_loop_cleanly() {
+        // Drop the host end immediately. The worker must see EOF on
+        // its next read and return Ok(()) — not panic, not block forever.
+        let (host, join) = spawn_worker();
+        drop(host);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), join)
+            .await
+            .expect("worker must exit within 2s of EOF")
+            .expect("worker join error");
+        assert!(result.is_ok(), "expected clean exit, got {result:?}");
+    }
+}

--- a/koda-sandbox/tests/worker_binary.rs
+++ b/koda-sandbox/tests/worker_binary.rs
@@ -1,0 +1,111 @@
+//! End-to-end integration test for the `koda-fs-worker` binary
+//! (Phase 2a of #934).
+//!
+//! Spawns the real binary as a subprocess, talks to it over stdin/stdout
+//! using the [`koda_sandbox::ipc`] framing, and asserts the contract
+//! holds across the OS process boundary. The unit tests in
+//! `koda-sandbox::worker::tests` exercise the same code path through
+//! an in-memory `tokio::io::duplex`; this test is what catches issues
+//! the in-memory transport hides (binary discoverability, child stderr,
+//! tokio runtime setup, env-var tracing init).
+
+use koda_sandbox::ipc::{ErrorCode, Request, Response, read_message, write_message};
+use std::path::PathBuf;
+use std::process::Stdio;
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+/// Cargo writes binaries to `$CARGO_MANIFEST_DIR/../target/<profile>/`.
+/// In integration tests, `CARGO_BIN_EXE_<name>` is the canonical way to
+/// find them.
+fn worker_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_koda-fs-worker"))
+}
+
+#[tokio::test]
+async fn worker_binary_responds_to_ping() {
+    let mut child = Command::new(worker_binary())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn koda-fs-worker");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+    write_message(&mut stdin, &Request::Ping)
+        .await
+        .expect("write ping");
+    let resp: Response = read_message(&mut stdout)
+        .await
+        .expect("read response")
+        .expect("response not None");
+    assert_eq!(resp, Response::Pong);
+
+    // Tell the worker to exit and wait for clean shutdown.
+    write_message(&mut stdin, &Request::Shutdown)
+        .await
+        .expect("write shutdown");
+    let _ack: Response = read_message(&mut stdout)
+        .await
+        .expect("read shutdown ack")
+        .expect("ack not None");
+    stdin.shutdown().await.ok();
+    drop(stdin);
+
+    let status = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+        .await
+        .expect("worker must exit within 5s")
+        .expect("wait failed");
+    assert!(
+        status.success(),
+        "worker exited non-zero after Shutdown: {status:?}"
+    );
+}
+
+#[tokio::test]
+async fn worker_binary_returns_unimplemented_for_phase2c_variants() {
+    let mut child = Command::new(worker_binary())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn koda-fs-worker");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+
+    write_message(
+        &mut stdin,
+        &Request::Read {
+            path: PathBuf::from("/etc/passwd"),
+            max_bytes: None,
+        },
+    )
+    .await
+    .expect("write read");
+    let resp: Response = read_message(&mut stdout)
+        .await
+        .expect("read response")
+        .expect("response not None");
+    match resp {
+        Response::Error {
+            code: ErrorCode::Unimplemented,
+            ..
+        } => {}
+        other => panic!("expected Unimplemented, got {other:?}"),
+    }
+
+    // Drop stdin to trigger clean EOF shutdown — exercises the
+    // "peer hung up" exit path of the dispatch loop in the real binary.
+    drop(stdin);
+    let status = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+        .await
+        .expect("worker must exit within 5s of EOF")
+        .expect("wait failed");
+    assert!(
+        status.success(),
+        "worker should exit cleanly on EOF, got {status:?}"
+    );
+}


### PR DESCRIPTION
## Phase 2a of #934 — FS worker IPC skeleton

First sub-phase of the **big** Phase 2 work (FS worker + sandboxed file
tools). Lands the IPC protocol + a long-lived `koda-fs-worker` binary.
The binary doesn't do anything useful yet — file handlers land in 2c,
trait + tool migration in 2b/2d, WorkspaceProvider in 2e, defenses in
2f.

This PR is intentionally tiny (~825 LOC, single commit) so the wire
format + lifecycle gets reviewed in isolation before the file-handler
PRs stack on top of it.

### Why a separate process at all

In-tree file tools currently run in the same process as the LLM client
and agent loop — the *trusted supervisor*. Putting FS code in a worker
process means we can run it **outside** the kernel sandbox (it needs to
actually do FS work) but still **enforce policy in code** for every
request (lands in 2c). Same shape as Claude Code's
`SandboxedFileSystem` and Codex's FS worker. See #934 §4.5.

### What ships

**`koda-sandbox/src/ipc.rs`** (~420 LOC):
- Length-prefixed JSON wire format: `[u32 BE length][JSON payload]`.
  Picked over msgpack per #934 §8 decision 1 (debuggable, easy, zero
  new deps).
- `Request` enum: `Ping`, `Shutdown` today; `Read`/`Write`/`Edit`/
  `Glob`/`Grep`/`Stat` reserved for Phase 2c (return Unimplemented).
- `Response` enum: `Pong`, the matching reply variants, `Error`.
- `MAX_PAYLOAD_BYTES = 1 MiB` — caps reads + sends so a hostile peer
  can't OOM us with a huge length prefix.
- `read_message`/`write_message` framing primitives. `read_message`
  distinguishes clean peer-close (returns `Ok(None)`) from mid-frame
  truncation (returns `Err(UnexpectedEof)`) — critical for the host
  to detect worker death vs protocol bugs.

**`koda-sandbox/src/worker.rs`** (~150 LOC):
- Generic `run<R, W>(reader, writer)` dispatch loop — works against
  any `AsyncRead+AsyncWrite` pair. Tests use `tokio::io::duplex`;
  production binary uses stdin/stdout (Unix socket transport lands
  in 2c).
- `handle()` — pure async fn `Request → Response`. Today returns
  Pong for Ping/Shutdown, Unimplemented for everything else.

**`koda-sandbox/src/bin/koda-fs-worker.rs`** (~25 LOC):
- `tokio::main(flavor = "current_thread")` — single-threaded scheduler
  is enough; one worker per slot serves one host serially.
- Tracing init via `KODA_FS_WORKER_LOG` env var (defaults to `warn`).

**`koda-sandbox/tests/worker_binary.rs`** (~110 LOC):
- Spawns the actual binary as a subprocess via `CARGO_BIN_EXE_*` and
  talks to it over real stdin/stdout pipes. Catches issues the
  in-memory tests hide (binary discoverability, child stderr,
  tokio runtime setup).

### Workspace plumbing

- Hoisted `tracing-subscriber` to `[workspace.dependencies]` (was a
  one-off pin in `koda-cli`); the new binary uses it.
- `koda-sandbox` tokio features: added `io-util`, `io-std`, `net`,
  `macros`.

### Tests

- `koda-sandbox`: **76 unit + 3 transform snapshots + 2 worker_binary
  integration** (was 60+3, +18 new for Phase 2a).
- `cargo clippy --workspace --all-targets`: clean.
- `cargo doc --workspace --no-deps` with `broken-intra-doc-links`
  denied: clean.

### What's NOT in this PR

| Sub-phase | Scope | Status |
|---|---|---|
| 2b | `tools::FileSystem` trait + `LocalFileSystem` impl | next PR |
| 2c | Real handlers for `Read`/`Write`/`Edit`/`Glob`/`Grep`/`Stat` enforced against `SandboxPolicy` + Unix-socket transport for production wiring | stacked |
| 2d | Migrate `Read`/`Write`/`Edit`/`MultiEdit`/`Glob`/`Grep` tools to use the trait | stacked |
| 2e | Move `koda-core::worktree` → `koda-sandbox::GitWorktreeProvider`; wire `SubAgentDispatch` through `WorkspaceProvider` | stacked |
| 2f | CC defenses: `findSymlinkInPath`, `hasFileAncestor`, `findFirstNonExistentComponent`, `generateMoveBlockingRules` | stacked |

### Risk

Very low. New module, new binary, no existing call site touches it.
Worst case: the binary is built but unused (Phase 2c–2f wire it up).
The two integration tests prove the binary runs correctly across the
real OS process boundary today.

Refs: #934
