### PR TITLE
feat(sandbox): FileSystem trait + LocalFileSystem impl (Phase 2b of #934)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "glob",
+ "ignore",
  "insta",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -10,9 +10,16 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+# File globbing for `LocalFileSystem::glob`. Same version as koda-core.
+glob = "0.3"
+# Recursive walk + .gitignore handling for `LocalFileSystem::grep`.
+# Same version as koda-core.
+ignore = "0.4"
+# Regex matching for `LocalFileSystem::grep`. Same version as koda-core.
+regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros"] }
+tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros", "fs"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/koda-sandbox/src/fs/local.rs
+++ b/koda-sandbox/src/fs/local.rs
@@ -1,0 +1,475 @@
+//! [`LocalFileSystem`] — direct, unsandboxed [`FileSystem`] impl
+//! (Phase 2b of #934).
+//!
+//! Uses `tokio::fs` for the IO methods so it stays cooperatively async,
+//! and `spawn_blocking` for the CPU/sync-blocking ones (glob expansion,
+//! recursive walk for grep). No policy enforcement happens here — that's
+//! `SandboxedFileSystem`'s job in Phase 2c. This impl exists for two
+//! callers:
+//!
+//! 1. The `--no-sandbox` debug escape hatch (#934 Phase 2 acceptance).
+//! 2. Unit tests for the file tools (Phase 2d) — much faster than
+//!    spinning up a worker process per test.
+//!
+//! ## Why not just use `std::fs` synchronously?
+//!
+//! The trait has to be `async` for the `SandboxedFileSystem` impl
+//! (which round-trips to a worker over IPC). If `LocalFileSystem` used
+//! sync `std::fs`, the trait would either need two flavors or each call
+//! would block the runtime thread. Using `tokio::fs` keeps both impls
+//! shape-compatible.
+//!
+//! ## Why `spawn_blocking` for glob/grep?
+//!
+//! Neither `glob` nor `ignore` ship async APIs (recursive directory
+//! walks are inherently CPU-bound for large trees anyway), so we
+//! offload them to the runtime's blocking pool. Same shape `tokio::fs`
+//! uses internally.
+
+use crate::fs::{FileSystem, FsError, FsResult, Metadata};
+use crate::ipc::GrepMatch;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use tokio::fs;
+
+/// Unsandboxed, in-process [`FileSystem`].
+///
+/// Construct with `LocalFileSystem::new()` (or `Default`) — there's
+/// nothing to configure. Cheap to clone (zero state).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LocalFileSystem;
+
+impl LocalFileSystem {
+    /// Construct a new [`LocalFileSystem`].
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl FileSystem for LocalFileSystem {
+    async fn read(&self, path: &Path, max_bytes: Option<usize>) -> FsResult<Vec<u8>> {
+        let mut buf = fs::read(path).await?;
+        if let Some(cap) = max_bytes
+            && buf.len() > cap
+        {
+            buf.truncate(cap);
+        }
+        Ok(buf)
+    }
+
+    async fn write(&self, path: &Path, content: &[u8]) -> FsResult<usize> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            // Match the existing Write tool contract — create any
+            // missing parent dirs so the LLM doesn't have to mkdir
+            // before writing. `create_dir_all` is a no-op if it
+            // already exists.
+            fs::create_dir_all(parent).await?;
+        }
+        fs::write(path, content).await?;
+        Ok(content.len())
+    }
+
+    async fn edit(
+        &self,
+        path: &Path,
+        old_string: &str,
+        new_string: &str,
+        all: bool,
+    ) -> FsResult<usize> {
+        let original = fs::read_to_string(path).await?;
+        let (replaced, count) = if all {
+            // matches() doesn't construct intermediate strings — count
+            // first so we know whether to bail before allocating.
+            let n = original.matches(old_string).count();
+            if n == 0 {
+                return Err(FsError::EditNotFound {
+                    path: path.to_path_buf(),
+                });
+            }
+            (original.replace(old_string, new_string), n)
+        } else if original.contains(old_string) {
+            // Replace exactly one occurrence — `replacen` does
+            // exactly this and avoids the second pass `replace` would do.
+            (original.replacen(old_string, new_string, 1), 1)
+        } else {
+            return Err(FsError::EditNotFound {
+                path: path.to_path_buf(),
+            });
+        };
+        // `count` is what we return; bind a no-op ref to the buffer
+        // so future maintainers don't "clean up" the destructure.
+        let _ = &replaced;
+        fs::write(path, replaced.as_bytes()).await?;
+        Ok(count)
+    }
+
+    async fn glob(&self, pattern: &str, root: &Path) -> FsResult<Vec<PathBuf>> {
+        // The `glob` crate is sync and walks the tree itself; offload
+        // to spawn_blocking so we don't park a runtime worker.
+        let pattern = pattern.to_string();
+        let root = root.to_path_buf();
+        tokio::task::spawn_blocking(move || -> FsResult<Vec<PathBuf>> {
+            // Anchor the pattern at `root` unless the caller already
+            // supplied an absolute pattern. Matches the existing
+            // `Glob` tool's expected behavior.
+            let full = if Path::new(&pattern).is_absolute() {
+                pattern.clone()
+            } else {
+                root.join(&pattern).to_string_lossy().into_owned()
+            };
+            let mut out: Vec<PathBuf> = glob::glob(&full)
+                .map_err(|e| FsError::InvalidPattern {
+                    message: format!("glob pattern {pattern:?}: {e}"),
+                })?
+                .filter_map(Result::ok)
+                .collect();
+            // Sorted output = deterministic for snapshot tests + LLM
+            // context stability.
+            out.sort();
+            Ok(out)
+        })
+        .await
+        .map_err(|e| FsError::Transport {
+            message: format!("glob spawn_blocking join error: {e}"),
+        })?
+    }
+
+    async fn grep(
+        &self,
+        pattern: &str,
+        root: &Path,
+        include: Option<&str>,
+    ) -> FsResult<Vec<GrepMatch>> {
+        let pattern = pattern.to_string();
+        let include = include.map(str::to_string);
+        let root = root.to_path_buf();
+        tokio::task::spawn_blocking(move || -> FsResult<Vec<GrepMatch>> {
+            let re = regex::Regex::new(&pattern).map_err(|e| FsError::InvalidPattern {
+                message: format!("grep regex {pattern:?}: {e}"),
+            })?;
+            let include_glob = include
+                .as_ref()
+                .map(|g| {
+                    glob::Pattern::new(g).map_err(|e| FsError::InvalidPattern {
+                        message: format!("grep include {g:?}: {e}"),
+                    })
+                })
+                .transpose()?;
+
+            let mut matches = Vec::new();
+            // `ignore::Walk` honors .gitignore + .ignore by default —
+            // this is exactly what we want for grep so the LLM doesn't
+            // get drowned in node_modules/target/.git matches.
+            for entry in ignore::Walk::new(&root) {
+                let entry = match entry {
+                    Ok(e) => e,
+                    Err(_) => continue, // permission denied on a subdir, etc.
+                };
+                if !entry.file_type().is_some_and(|t| t.is_file()) {
+                    continue;
+                }
+                let path = entry.path();
+                if let Some(g) = &include_glob {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if !g.matches(name) {
+                        continue;
+                    }
+                }
+                // read_to_string fails on binary files (non-UTF8) —
+                // skip them silently. Matches `rg`'s default behavior
+                // and avoids dumping garbage at the LLM.
+                let content = match std::fs::read_to_string(path) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                for (lineno, line) in content.lines().enumerate() {
+                    if re.is_match(line) {
+                        matches.push(GrepMatch {
+                            path: path.to_path_buf(),
+                            line: lineno + 1, // 1-based per the IPC contract
+                            text: line.to_string(),
+                        });
+                    }
+                }
+            }
+            Ok(matches)
+        })
+        .await
+        .map_err(|e| FsError::Transport {
+            message: format!("grep spawn_blocking join error: {e}"),
+        })?
+    }
+
+    async fn stat(&self, path: &Path) -> FsResult<Metadata> {
+        // symlink_metadata = lstat = does NOT follow the final
+        // component. We need this so `is_symlink` is meaningful
+        // (regular `metadata` would always report the target's type).
+        let m = fs::symlink_metadata(path).await?;
+        Ok(Metadata {
+            size: m.len(),
+            is_dir: m.is_dir(),
+            is_symlink: m.file_type().is_symlink(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Cheap helper — every test wants a tempdir + LocalFS pair.
+    fn fixture() -> (TempDir, LocalFileSystem) {
+        (TempDir::new().expect("tempdir"), LocalFileSystem::new())
+    }
+
+    // ── read ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn read_returns_full_contents_when_no_cap() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("hello.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+        let got = fs.read(&path, None).await.unwrap();
+        assert_eq!(got, b"hello world");
+    }
+
+    #[tokio::test]
+    async fn read_truncates_to_max_bytes() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("big.txt");
+        std::fs::write(&path, b"abcdefghij").unwrap();
+        let got = fs.read(&path, Some(4)).await.unwrap();
+        assert_eq!(got, b"abcd");
+    }
+
+    #[tokio::test]
+    async fn read_max_bytes_above_size_returns_full_file() {
+        // Cap higher than file size must NOT pad or error — just
+        // return what's there.
+        let (dir, fs) = fixture();
+        let path = dir.path().join("small.txt");
+        std::fs::write(&path, b"hi").unwrap();
+        let got = fs.read(&path, Some(1024)).await.unwrap();
+        assert_eq!(got, b"hi");
+    }
+
+    #[tokio::test]
+    async fn read_missing_file_returns_io_error() {
+        let (dir, fs) = fixture();
+        let err = fs
+            .read(&dir.path().join("nope"), None)
+            .await
+            .expect_err("missing file must error");
+        assert!(matches!(err, FsError::Io(_)));
+    }
+
+    // ── write ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn write_creates_file_and_returns_byte_count() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("out.txt");
+        let n = fs.write(&path, b"abc").await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(std::fs::read(&path).unwrap(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn write_creates_missing_parent_dirs() {
+        // The Write tool's contract creates parents — LLMs forget to
+        // mkdir before writing constantly, so we accept it.
+        let (dir, fs) = fixture();
+        let path = dir.path().join("a/b/c/deep.txt");
+        let n = fs.write(&path, b"hi").await.unwrap();
+        assert_eq!(n, 2);
+        assert!(path.exists());
+    }
+
+    #[tokio::test]
+    async fn write_overwrites_existing_file() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("over.txt");
+        std::fs::write(&path, b"old contents").unwrap();
+        fs.write(&path, b"new").await.unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+    }
+
+    // ── edit ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn edit_replaces_first_occurrence_when_all_false() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("e.txt");
+        std::fs::write(&path, b"foo bar foo baz foo").unwrap();
+        let n = fs.edit(&path, "foo", "FOO", false).await.unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(std::fs::read(&path).unwrap(), b"FOO bar foo baz foo");
+    }
+
+    #[tokio::test]
+    async fn edit_replaces_all_occurrences_when_all_true() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("e.txt");
+        std::fs::write(&path, b"foo bar foo baz foo").unwrap();
+        let n = fs.edit(&path, "foo", "FOO", true).await.unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(std::fs::read(&path).unwrap(), b"FOO bar FOO baz FOO");
+    }
+
+    #[tokio::test]
+    async fn edit_missing_old_string_returns_edit_not_found() {
+        // Hard fail rather than silent no-op — LLMs are bad at
+        // verifying their own context. Surfacing the mismatch early
+        // gives them a chance to re-read the file.
+        let (dir, fs) = fixture();
+        let path = dir.path().join("e.txt");
+        std::fs::write(&path, b"hello").unwrap();
+        let err = fs
+            .edit(&path, "world", "X", false)
+            .await
+            .expect_err("must fail");
+        assert!(matches!(err, FsError::EditNotFound { .. }));
+        // File must be unchanged.
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+    }
+
+    // ── glob ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn glob_matches_files_relative_to_root() {
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join("a.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("b.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("c.txt"), b"").unwrap();
+        let got = fs.glob("*.rs", dir.path()).await.unwrap();
+        assert_eq!(got.len(), 2);
+        // Sorted ordering contract.
+        assert!(got[0].file_name().unwrap() < got[1].file_name().unwrap());
+    }
+
+    #[tokio::test]
+    async fn glob_recursive_pattern_works() {
+        let (dir, fs) = fixture();
+        std::fs::create_dir(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("top.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("sub/inner.rs"), b"").unwrap();
+        let got = fs.glob("**/*.rs", dir.path()).await.unwrap();
+        assert_eq!(got.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn glob_invalid_pattern_returns_invalid_pattern() {
+        let (dir, fs) = fixture();
+        // `[` opens a character class that's never closed — definitely
+        // invalid in any glob dialect.
+        let err = fs
+            .glob("[abc", dir.path())
+            .await
+            .expect_err("invalid pattern must error");
+        assert!(matches!(err, FsError::InvalidPattern { .. }));
+    }
+
+    // ── grep ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn grep_finds_matches_with_line_numbers() {
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join("a.txt"), b"hello\nworld\nhello again\n").unwrap();
+        let got = fs.grep("hello", dir.path(), None).await.unwrap();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].line, 1);
+        assert_eq!(got[1].line, 3);
+        assert!(got[0].text.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn grep_respects_include_filter() {
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join("a.rs"), b"fn target() {}").unwrap();
+        std::fs::write(dir.path().join("b.txt"), b"fn target() {}").unwrap();
+        let got = fs.grep("target", dir.path(), Some("*.rs")).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert!(got[0].path.extension().unwrap() == "rs");
+    }
+
+    #[tokio::test]
+    async fn grep_skips_binary_files_silently() {
+        // Real-world grepping always trips over binary files — we
+        // skip rather than error so the LLM gets clean text-only
+        // matches.
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join("a.txt"), b"hello text\n").unwrap();
+        // Mixed binary content — has a NUL and high bytes — read_to_string
+        // will fail on the unpaired surrogate.
+        std::fs::write(dir.path().join("b.bin"), b"\x00\xc3\x28hello\x00\xc3\x28").unwrap();
+        let got = fs.grep("hello", dir.path(), None).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].path.extension().unwrap(), "txt");
+    }
+
+    #[tokio::test]
+    async fn grep_invalid_regex_returns_invalid_pattern() {
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join("a.txt"), b"x").unwrap();
+        let err = fs
+            .grep("[unclosed", dir.path(), None)
+            .await
+            .expect_err("invalid regex must error");
+        assert!(matches!(err, FsError::InvalidPattern { .. }));
+    }
+
+    #[tokio::test]
+    async fn grep_honors_ignore_files() {
+        // The `ignore` crate's default walker reads .ignore (and
+        // .gitignore inside a git repo) — that's the whole reason we
+        // picked it over plain walkdir. We use .ignore here because it
+        // works without initializing a git repo in the tempdir.
+        let (dir, fs) = fixture();
+        std::fs::write(dir.path().join(".ignore"), b"ignored.txt\n").unwrap();
+        std::fs::write(dir.path().join("ignored.txt"), b"target line").unwrap();
+        std::fs::write(dir.path().join("kept.txt"), b"target line").unwrap();
+        let got = fs.grep("target", dir.path(), None).await.unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].path.file_name().unwrap(), "kept.txt");
+    }
+
+    // ── stat ────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn stat_reports_file_size_and_type() {
+        let (dir, fs) = fixture();
+        let path = dir.path().join("s.txt");
+        std::fs::write(&path, b"abcdef").unwrap();
+        let m = fs.stat(&path).await.unwrap();
+        assert_eq!(m.size, 6);
+        assert!(!m.is_dir);
+        assert!(!m.is_symlink);
+    }
+
+    #[tokio::test]
+    async fn stat_reports_directory() {
+        let (dir, fs) = fixture();
+        let m = fs.stat(dir.path()).await.unwrap();
+        assert!(m.is_dir);
+        assert!(!m.is_symlink);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stat_reports_symlink_without_following() {
+        // Critical for the symlink-defense work in Phase 2f — we need
+        // to know the path itself is a link, not its target's type.
+        let (dir, fs) = fixture();
+        let target = dir.path().join("real.txt");
+        std::fs::write(&target, b"target").unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let m = fs.stat(&link).await.unwrap();
+        assert!(m.is_symlink);
+        assert!(!m.is_dir);
+    }
+}

--- a/koda-sandbox/src/fs/mod.rs
+++ b/koda-sandbox/src/fs/mod.rs
@@ -1,0 +1,200 @@
+//! Filesystem abstraction trait for sandboxed and unsandboxed file
+//! operations (Phase 2b of #934).
+//!
+//! [`FileSystem`] is the seam between the file tools (Read, Write, Edit,
+//! MultiEdit, Glob, Grep — currently in `koda-core::tools`) and the
+//! actual filesystem they operate on. Two implementations land in this
+//! crate:
+//!
+//! - [`LocalFileSystem`] — direct `tokio::fs`, no policy enforcement.
+//!   Used outside the sandbox (the `--no-sandbox` debug escape hatch
+//!   per #934 §6 Phase 2 acceptance) and as the in-process baseline
+//!   that 2d's tool migration regressions get measured against.
+//! - `SandboxedFileSystem` (Phase 2c) — sends each call to a
+//!   `koda-fs-worker` over IPC; the worker enforces `SandboxPolicy`
+//!   in code on every request.
+//!
+//! Both impls satisfy the same trait, so the migrated tools (Phase 2d)
+//! get dependency-injected with whichever one matches the current
+//! sandbox trust mode.
+//!
+//! ## Why a trait at all?
+//!
+//! 1. **Same tool code, two backends.** Read/Write/Edit don't change
+//!    based on whether they go through the sandbox or not — the only
+//!    thing that changes is the FS object they hold. Without a trait,
+//!    every tool would `if sandbox { … } else { … }` itself.
+//! 2. **Testability.** Tools can be unit-tested against
+//!    [`LocalFileSystem`] backed by a `tempfile::TempDir` without
+//!    spawning a worker process.
+//! 3. **`--no-sandbox` debug mode.** When the user explicitly opts
+//!    out (single-trace debugging, mostly), we hand them
+//!    [`LocalFileSystem`] and the tools work unchanged.
+//!
+//! ## Why not put this in `koda-core::tools`?
+//!
+//! The original #934 sketch suggested koda-core. But koda-core already
+//! depends on koda-sandbox (for the `sandbox::build` shim used by
+//! `tools::shell`), and the natural Phase 2c implementation
+//! (`SandboxedFileSystem`) needs to live next to the worker code in
+//! koda-sandbox. Putting the trait in koda-core would force either
+//! a dep cycle or a third "interface" crate (overkill at this stage).
+//! The trait stays here; koda-core imports it for tool migration in 2d.
+//!
+//! ## Error model
+//!
+//! [`FsError`] is intentionally coarse — fine-grained classification
+//! belongs at the calling tool's level (e.g. "path not found" → user
+//! message vs. "policy denied" → "this path is outside your write
+//! permissions"). The IPC error code wire enum
+//! ([`crate::ipc::ErrorCode`]) maps 1:1 to FsError variants in 2c.
+
+use crate::ipc::GrepMatch;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+pub mod local;
+
+pub use local::LocalFileSystem;
+
+/// Abstraction over filesystem operations needed by the file tools.
+///
+/// All methods are `async` because the `SandboxedFileSystem` impl
+/// (Phase 2c) round-trips each call to a worker process. The
+/// [`LocalFileSystem`] impl uses `tokio::fs` to keep the same
+/// signatures and avoid a sync/async split at the call sites.
+///
+/// `Send + Sync` are required because the file tools are dispatched
+/// by an async runtime that may move the future across threads.
+#[async_trait]
+pub trait FileSystem: Send + Sync {
+    /// Read file contents.
+    ///
+    /// `max_bytes` caps the returned buffer; `None` reads the whole
+    /// file (still bounded by [`crate::ipc::MAX_PAYLOAD_BYTES`] on the
+    /// sandboxed impl). Tools should pass a tighter cap when the LLM
+    /// asks for a head/tail slice.
+    async fn read(&self, path: &Path, max_bytes: Option<usize>) -> FsResult<Vec<u8>>;
+
+    /// Overwrite a file with `content`. Creates parent directories if
+    /// they don't exist (matches the `Write` tool's current contract).
+    /// Returns the number of bytes written.
+    async fn write(&self, path: &Path, content: &[u8]) -> FsResult<usize>;
+
+    /// Replace the first occurrence (or all occurrences if `all = true`)
+    /// of `old_string` with `new_string` in the file. Returns how many
+    /// substitutions happened.
+    ///
+    /// Errors with [`FsError::EditNotFound`] if `old_string` doesn't
+    /// appear in the file — matches the existing `Edit` tool semantics
+    /// in `koda-core::tools::file_tools` (LLMs are surprisingly bad at
+    /// asserting their own context, so a hard fail beats a silent no-op).
+    async fn edit(
+        &self,
+        path: &Path,
+        old_string: &str,
+        new_string: &str,
+        all: bool,
+    ) -> FsResult<usize>;
+
+    /// Expand a glob pattern relative to `root`. Returns matches in
+    /// deterministic (sorted) order.
+    async fn glob(&self, pattern: &str, root: &Path) -> FsResult<Vec<PathBuf>>;
+
+    /// Recursive regex grep starting at `root`. `include` is an
+    /// optional file-glob filter (e.g. `*.rs`).
+    ///
+    /// Honors `.gitignore` / `.ignore` (via the `ignore` crate's
+    /// default walker config) so we don't drown the LLM in matches
+    /// from `node_modules/`.
+    async fn grep(
+        &self,
+        pattern: &str,
+        root: &Path,
+        include: Option<&str>,
+    ) -> FsResult<Vec<GrepMatch>>;
+
+    /// `stat`-like metadata fetch. Follows symlinks (use the
+    /// `is_symlink` field on the result to detect when the original
+    /// path *was* a link).
+    async fn stat(&self, path: &Path) -> FsResult<Metadata>;
+}
+
+/// Subset of `std::fs::Metadata` we care about — small and
+/// serializable so the IPC layer can ship it across the wire
+/// unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Metadata {
+    /// File size in bytes (0 for directories).
+    pub size: u64,
+    /// True if the path is a directory.
+    pub is_dir: bool,
+    /// True if the path itself is a symlink (not its target).
+    pub is_symlink: bool,
+}
+
+/// Result alias used by every [`FileSystem`] method.
+pub type FsResult<T> = Result<T, FsError>;
+
+/// Errors a [`FileSystem`] call can return.
+///
+/// Coarse on purpose — the file tools translate these into user-facing
+/// messages, and richer classification happens in the IPC layer
+/// ([`crate::ipc::ErrorCode`]).
+#[derive(Debug)]
+pub enum FsError {
+    /// Underlying IO error (file not found, permission denied, …).
+    Io(std::io::Error),
+    /// Sandbox policy refused the operation. Only the
+    /// `SandboxedFileSystem` impl (Phase 2c) returns this;
+    /// [`LocalFileSystem`] never does.
+    PolicyDenied {
+        /// Human-readable explanation suitable for showing the LLM.
+        message: String,
+    },
+    /// `Edit` couldn't find `old_string` in the file.
+    EditNotFound {
+        /// Path the substring was looked for in.
+        path: PathBuf,
+    },
+    /// Invalid glob/regex/etc. supplied by the caller.
+    InvalidPattern {
+        /// Human-readable explanation of what was wrong.
+        message: String,
+    },
+    /// Worker process / IPC transport blew up
+    /// (`SandboxedFileSystem` only).
+    Transport {
+        /// Detail describing the transport failure.
+        message: String,
+    },
+}
+
+impl std::fmt::Display for FsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FsError::Io(e) => write!(f, "io error: {e}"),
+            FsError::PolicyDenied { message } => write!(f, "policy denied: {message}"),
+            FsError::EditNotFound { path } => {
+                write!(f, "old_string not found in {}", path.display())
+            }
+            FsError::InvalidPattern { message } => write!(f, "invalid pattern: {message}"),
+            FsError::Transport { message } => write!(f, "fs worker transport: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for FsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            FsError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for FsError {
+    fn from(e: std::io::Error) -> Self {
+        FsError::Io(e)
+    }
+}

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -32,6 +32,7 @@
 #[cfg(target_os = "linux")]
 pub mod bwrap;
 pub mod defaults;
+pub mod fs;
 pub mod ipc;
 pub mod monitor;
 pub mod policy;


### PR DESCRIPTION
## Phase 2b of #934 — `FileSystem` trait + `LocalFileSystem` impl

Second sub-phase of Phase 2 (FS worker + sandboxed file tools). Defines
the `FileSystem` trait that the file tools (Read / Write / Edit /
MultiEdit / Glob / Grep) will dependency-inject in **2d**, plus the
unsandboxed `LocalFileSystem` impl. The sandboxed impl that talks to
the worker lands in **2c**; the actual tool migration lands in **2d**.

Single commit, ~687 LOC, 100% additive — no existing call site touches
this code yet.

### Why a trait at all

Same tool code, two backends. `Read`/`Write`/`Edit` don't change based
on whether they go through the sandbox or not — the only thing that
changes is the FS object they hold. Without a trait every tool would
`if sandbox { … } else { … }` itself. The trait also enables:

- **Unit tests** for tools against a `tempfile::TempDir` without
  spawning a worker process.
- **`--no-sandbox` debug escape hatch** required by #934 §6 Phase 2
  acceptance.

### Why the trait lives in `koda-sandbox` not `koda-core`

The original #934 sketch suggested koda-core. But koda-core already
depends on koda-sandbox (for `sandbox::build` in `tools::shell`), and
the natural Phase 2c implementation (`SandboxedFileSystem`) needs to
live next to the worker code in koda-sandbox. Putting the trait in
koda-core would force either a dep cycle or a third "interface" crate
(overkill at this stage). The trait stays here; koda-core imports it
in 2d.

### What ships

**`koda-sandbox/src/fs/mod.rs`** (~165 LOC):
- `FileSystem` async trait with `read` / `write` / `edit` / `glob` /
  `grep` / `stat`. All `async` because the `SandboxedFileSystem` impl
  (2c) round-trips each call to a worker. `LocalFileSystem` uses
  `tokio::fs` to keep signatures shape-compatible.
- `Metadata { size, is_dir, is_symlink }` — small + serializable so 2c
  can ship it across the IPC wire unchanged. `is_symlink` is critical
  for 2f's symlink-defense work (we need to know the path itself is a
  link, not its target's type).
- `FsError` enum: `Io`, `PolicyDenied`, `EditNotFound`,
  `InvalidPattern`, `Transport`. Coarse on purpose — fine-grained
  classification is the calling tool's job.

**`koda-sandbox/src/fs/local.rs`** (~170 LOC + ~260 LOC of tests):
- `LocalFileSystem` — zero-state, `Copy`, `Default`. Direct `tokio::fs`.
- `read` honors `max_bytes` cap; `write` creates missing parent dirs
  (matches existing `Write` tool contract).
- `edit` returns `FsError::EditNotFound` on missing `old_string` —
  hard fail rather than silent no-op (LLMs are bad at verifying their
  own context, and a hard error gives them a chance to re-read the
  file).
- `glob` and `grep` use `spawn_blocking` (the underlying `glob` and
  `ignore` crates are sync). Glob output is sorted for deterministic
  snapshot tests + stable LLM context.
- `grep` uses `ignore::Walk` so `.gitignore` + `.ignore` are honored
  by default — keeps `node_modules` / `target` / `.git` out of LLM
  context automatically.
- Binary files are skipped silently in grep (matches `rg`'s default).
- `stat` uses `symlink_metadata` (lstat) so symlinks report accurately
  instead of stat-following.

### Workspace plumbing

- `koda-sandbox` deps gain `glob = "0.3"`, `regex = "1"`,
  `ignore = "0.4"` (same pins koda-core uses).
- `koda-sandbox` tokio features add `fs`.

### Tests

- `koda-sandbox`: **97 unit + 3 transform + 2 worker_binary = 102**
  (was 81 in 2a; **+21 new** for Phase 2b).
- 21 new tests cover: read happy / cap / oversize-cap / missing,
  write / parent-creation / overwrite, edit single / all / not-found,
  glob basic / recursive / invalid-pattern, grep matches / include /
  binary-skip / invalid-regex / `.ignore`-honored, stat file / dir /
  symlink (Unix-only, gated on `cfg(unix)`).
- `cargo clippy --workspace --all-targets`: clean.
- `cargo doc -p koda-sandbox --no-deps` with broken-intra-doc-links
  denied: clean.

### What's NOT in this PR

| Sub-phase | Scope | Status |
|---|---|---|
| 2c | `SandboxedFileSystem` impl wrapping a worker + Unix-socket transport for production wiring | next PR |
| 2d | Migrate `Read` / `Write` / `Edit` / `MultiEdit` / `Glob` / `Grep` tools to consume `FileSystem` | stacked |
| 2e | `koda-core::worktree` → `koda-sandbox::GitWorktreeProvider` | stacked |
| 2f | CC defenses (`findSymlinkInPath`, `hasFileAncestor`, `findFirstNonExistentComponent`, `generateMoveBlockingRules`) | stacked |

### Risk

Very low. New module only — no existing imports touch it. Worst case:
the trait + impl are compiled but unused (Phase 2c–2f wire them up).
21 happy-path + edge-case tests prove the impl behaves correctly.

Stacks on `main` (Phase 2a / #986 already merged).

Refs: #934
