### PR TITLE
feat(sandbox): Phase 2c — real FS handlers, Unix socket transport, SandboxedFileSystem (#934)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,25 +1,22 @@
 #!/usr/bin/env bash
-# .githooks/pre-push — minimal local sanity check before pushing.
+# .githooks/pre-push — fmt + scoped clippy before every push.
 #
-# Philosophy: catch the ONE failure mode that's both (a) cheap to verify
-# locally and (b) maximally embarrassing to ship to CI — formatting.
-# Everything else (clippy, check, semver, tests, audit, docs) runs as
-# parallel jobs in CI with sub-2-minute granular feedback. Trust CI.
+# Two checks, both fast:
 #
-# History: this hook used to also run `cargo clippy --workspace`, costing
-# ~50-90s per push. Across a representative sample of pushes, clippy
-# locally caught 0 issues vs ~5 minutes of cumulative wait. Net negative
-# on dev time once CI was split into per-tool jobs (see PR #979) where
-# each lint failure surfaces as its own red label in <2 min — without
-# spinning up your laptop fans.
+#   1. cargo fmt --check          (~1s, always)
+#   2. cargo clippy -p <changed>  (~5-20s, only crates modified since
+#                                   the tracking remote branch)
 #
-# Skip with `git push --no-verify` if you need to push WIP.
+# "Scoped" means we diff HEAD against the remote tracking sha (or
+# origin/main as fallback) and only lint workspace members whose files
+# appear in that diff. A single-crate push costs the same as before;
+# a full-workspace push is capped at the workspace total.
 #
-# One-time setup (per clone):
-#   git config core.hooksPath .githooks
+# The full suite (all crates, all features, tests, audit, semver) still
+# lives in ./scripts/preflight.sh — run that before opening a PR.
 #
-# For comprehensive pre-PR validation (full clippy + tests + audit), run:
-#   ./scripts/preflight.sh
+# Skip entirely with:  git push --no-verify
+# One-time setup:      git config core.hooksPath .githooks
 
 set -euo pipefail
 
@@ -32,15 +29,81 @@ ok()   { echo -e "${GREEN}✓${NC} $*"; }
 fail() { echo -e "${RED}✗${NC} $*"; }
 info() { echo -e "${YELLOW}→${NC} $*"; }
 
-info "Running pre-push fmt check (skip with --no-verify)..."
+info "pre-push: fmt + scoped clippy (skip with --no-verify)"
 
-# --- Format ------------------------------------------------------------------
-# Instant (~1s), and a fmt failure in CI is the most annoying possible reason
-# to wait for a re-run. This is the entire hook now — clippy/check/test all
-# run in parallel CI jobs with their own granular pass/fail labels.
-if cargo fmt --all --check; then
-    ok "fmt clean — pushing. (clippy + tests + semver run in CI)"
-else
+# ── 1. Format ────────────────────────────────────────────────────────────────
+
+if ! cargo fmt --all --check 2>&1; then
     fail "fmt: run 'cargo fmt --all' to fix"
+    exit 1
+fi
+ok "fmt"
+
+# ── 2. Detect which workspace members changed ─────────────────────────────────
+#
+# Git passes push refs on stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+# For a new branch, remote-sha is all zeros.
+
+ZERO="0000000000000000000000000000000000000000"
+MERGE_BASE=""
+
+while read -r _local_ref local_sha _remote_ref remote_sha; do
+    if [[ "$remote_sha" != "$ZERO" && "$remote_sha" != "" ]]; then
+        MERGE_BASE=$(git merge-base "$local_sha" "$remote_sha" 2>/dev/null || true)
+        [[ -n "$MERGE_BASE" ]] && break
+    fi
+done
+
+# Fallback 1: compare against origin/main (new branches, no tracking sha)
+if [[ -z "$MERGE_BASE" ]]; then
+    MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null || true)
+fi
+
+# Fallback 2: just the last commit (detached HEAD, initial push, etc.)
+if [[ -z "$MERGE_BASE" ]]; then
+    MERGE_BASE="HEAD~1"
+fi
+
+# Discover workspace members: top-level dirs that contain a Cargo.toml.
+WORKSPACE_MEMBERS=()
+for d in */; do
+    d="${d%/}"
+    [[ -f "${d}/Cargo.toml" ]] && WORKSPACE_MEMBERS+=("$d")
+done
+
+# Files changed since the merge-base → first path component → unique.
+CHANGED_TOP=$(git diff --name-only "$MERGE_BASE" HEAD 2>/dev/null \
+    | cut -d/ -f1 | sort -u)
+
+# If the workspace root Cargo.toml changed, lint everything.
+if echo "$CHANGED_TOP" | grep -qx "Cargo.toml"; then
+    CHANGED_PKGS=("${WORKSPACE_MEMBERS[@]}")
+else
+    CHANGED_PKGS=()
+    for pkg in "${WORKSPACE_MEMBERS[@]}"; do
+        echo "$CHANGED_TOP" | grep -qx "$pkg" && CHANGED_PKGS+=("$pkg")
+    done
+fi
+
+if [[ ${#CHANGED_PKGS[@]} -eq 0 ]]; then
+    ok "clippy — no workspace members changed, skipping"
+    exit 0
+fi
+
+# ── 3. Clippy (changed packages only, deny warnings) ─────────────────────────
+
+PKG_FLAGS=()
+for pkg in "${CHANGED_PKGS[@]}"; do
+    PKG_FLAGS+=("-p" "$pkg")
+done
+
+info "clippy [${CHANGED_PKGS[*]}] -- -D warnings"
+T0=$(date +%s)
+
+if cargo clippy "${PKG_FLAGS[@]}" --all-targets -- -D warnings 2>&1; then
+    ELAPSED=$(( $(date +%s) - T0 ))
+    ok "clippy (${ELAPSED}s)"
+else
+    fail "clippy: fix the warnings above, or 'git push --no-verify' for WIP"
     exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,9 +3,9 @@
 #
 # Two checks, both fast:
 #
-#   1. cargo fmt --check          (~1s, always)
-#   2. cargo clippy -p <changed>  (~5-20s, only crates modified since
-#                                   the tracking remote branch)
+#   1. cargo fmt --check                        (~1s, always)
+#   2. cargo clippy -p <changed> -- -D warnings (~5-20s, scoped)
+#   3. RUSTDOCFLAGS=-D warnings cargo doc        (~2-5s, scoped)
 #
 # "Scoped" means we diff HEAD against the remote tracking sha (or
 # origin/main as fallback) and only lint workspace members whose files
@@ -86,7 +86,7 @@ else
 fi
 
 if [[ ${#CHANGED_PKGS[@]} -eq 0 ]]; then
-    ok "clippy — no workspace members changed, skipping"
+    ok "clippy + doc — no workspace members changed, skipping"
     exit 0
 fi
 
@@ -105,5 +105,18 @@ if cargo clippy "${PKG_FLAGS[@]}" --all-targets -- -D warnings 2>&1; then
     ok "clippy (${ELAPSED}s)"
 else
     fail "clippy: fix the warnings above, or 'git push --no-verify' for WIP"
+    exit 1
+fi
+
+# ── 4. Docs (changed packages only, deny warnings) ───────────────────────────
+
+info "doc [${CHANGED_PKGS[*]}] -- -D warnings"
+T0=$(date +%s)
+
+if RUSTDOCFLAGS="-D warnings" cargo doc "${PKG_FLAGS[@]}" --no-deps 2>&1; then
+    ELAPSED=$(( $(date +%s) - T0 ))
+    ok "doc (${ELAPSED}s)"
+else
+    fail "doc: fix the rustdoc warnings above, or 'git push --no-verify' for WIP"
     exit 1
 fi

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -19,7 +19,7 @@ ignore = "0.4"
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros", "fs"] }
+tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros", "fs", "time", "sync"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/koda-sandbox/src/bin/koda-fs-worker.rs
+++ b/koda-sandbox/src/bin/koda-fs-worker.rs
@@ -1,34 +1,29 @@
 //! `koda-fs-worker` — long-lived FS worker process spawned by the
-//! sandbox shim (Phase 2a of #934).
+//! sandbox shim (Phase 2c of #934).
 //!
-//! Runs the [`koda_sandbox::worker::run_stdio`] dispatch loop against
-//! process stdin/stdout. Phase 2c will add a Unix-socket variant for
-//! the production per-slot wiring; stdio is what the integration tests
-//! use today.
+//! ## Transport selection
+//!
+//! - **`--socket <path>`** (production): bind a Unix domain socket at
+//!   `<path>`, write "ready\n" to stdout, accept one connection,
+//!   serve it. Used by [`koda_sandbox::worker_client::WorkerClient`].
+//! - **No arguments** (legacy / tests): run against stdin/stdout.
+//!   The `worker_binary` integration tests still use this path.
 //!
 //! ## Lifecycle
 //!
-//! Spawned by `koda_sandbox::worker_client` (Phase 2c) for each
-//! sandbox slot. Exits when:
-//! - The host closes stdin (EOF) — normal "slot retired" path.
-//! - The host sends [`koda_sandbox::ipc::Request::Shutdown`] — graceful
-//!   shutdown with ack.
-//! - A transport-level IO error occurs — exit 1, host respawns.
+//! Spawned by `WorkerClient::spawn()` for each sandbox slot. Exits
+//! when the host closes the connection (clean EOF) or sends
+//! [`koda_sandbox::ipc::Request::Shutdown`].
 //!
 //! ## Why a binary not a library function?
 //!
 //! Crash isolation. A panicking FS handler kills the worker, not the
-//! host process driving the LLM session. The host wraps respawn logic
-//! in Phase 2c.
+//! host process driving the LLM session.
 
 use anyhow::Result;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    // Single-threaded runtime: this binary is one process per sandbox
-    // slot serving one host. No need for the multi-threaded scheduler's
-    // overhead — every request is handled sequentially anyway (the
-    // host serializes them by waiting for each response).
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_env("KODA_FS_WORKER_LOG")
@@ -37,5 +32,27 @@ async fn main() -> Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    koda_sandbox::worker::run_stdio().await
+    // Parse --socket <path> from argv. We roll our own to avoid adding
+    // a CLI-parsing dep to this binary — two-argument argv parsing is
+    // not worth the dep weight.
+    let args: Vec<String> = std::env::args().collect();
+    let socket_path = match args.as_slice() {
+        [_, flag, path] if flag == "--socket" => Some(std::path::PathBuf::from(path)),
+        [_] => None,
+        _ => anyhow::bail!("usage: koda-fs-worker [--socket <path>]"),
+    };
+
+    match socket_path {
+        Some(path) => {
+            #[cfg(unix)]
+            {
+                koda_sandbox::worker::run_unix_socket(&path).await
+            }
+            #[cfg(not(unix))]
+            {
+                anyhow::bail!("--socket is only supported on Unix")
+            }
+        }
+        None => koda_sandbox::worker::run_stdio().await,
+    }
 }

--- a/koda-sandbox/src/fs/mod.rs
+++ b/koda-sandbox/src/fs/mod.rs
@@ -54,8 +54,12 @@ use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 
 pub mod local;
+#[cfg(unix)]
+pub mod sandboxed;
 
 pub use local::LocalFileSystem;
+#[cfg(unix)]
+pub use sandboxed::SandboxedFileSystem;
 
 /// Abstraction over filesystem operations needed by the file tools.
 ///

--- a/koda-sandbox/src/fs/sandboxed.rs
+++ b/koda-sandbox/src/fs/sandboxed.rs
@@ -162,9 +162,7 @@ impl SandboxedFileSystem {
         if let Response::Error { code, message } = resp {
             return Err(match code {
                 ErrorCode::PolicyDenied => FsError::PolicyDenied { message },
-                ErrorCode::Io => {
-                    FsError::Io(std::io::Error::new(std::io::ErrorKind::Other, message))
-                }
+                ErrorCode::Io => FsError::Io(std::io::Error::other(message)),
                 ErrorCode::Protocol | ErrorCode::Internal | ErrorCode::Unimplemented => {
                     FsError::Transport { message }
                 }

--- a/koda-sandbox/src/fs/sandboxed.rs
+++ b/koda-sandbox/src/fs/sandboxed.rs
@@ -1,0 +1,182 @@
+//! [`SandboxedFileSystem`] — IPC-backed [`FileSystem`] impl
+//! (Phase 2c of #934).
+//!
+//! Forwards each [`FileSystem`] method call to a live [`WorkerClient`]
+//! as a length-prefixed JSON [`Request`], receives the [`Response`],
+//! and maps it back to a typed `FsResult<T>`. The worker process
+//! performs the actual filesystem operation — the host process never
+//! touches the disk for sandboxed tools.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use koda_sandbox::fs::{FileSystem, SandboxedFileSystem};
+//!
+//! // Spawn a worker, wrap it in a shareable FS handle.
+//! let fs = SandboxedFileSystem::spawn().await?;
+//!
+//! // Use it just like LocalFileSystem — same trait, different backend.
+//! let bytes = fs.read(Path::new("/work/src/lib.rs"), Some(65536)).await?;
+//! ```
+//!
+//! ## Thread safety
+//!
+//! `WorkerClient` is serial (one outstanding request at a time — that's
+//! the IPC protocol). `SandboxedFileSystem` wraps it in a
+//! `tokio::sync::Mutex` so multiple tool tasks can share one worker
+//! without data races. If contention becomes a bottleneck under the
+//! Phase 4 pool, each pool slot gets its own `SandboxedFileSystem` and
+//! the mutex becomes uncontested.
+
+use crate::fs::{FileSystem, FsError, FsResult, Metadata};
+use crate::ipc::{ErrorCode, GrepMatch, Request, Response};
+use crate::worker_client::WorkerClient;
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// IPC-backed [`FileSystem`] implementation.
+///
+/// Cheap to clone — the clone shares the same worker connection.
+#[derive(Clone)]
+pub struct SandboxedFileSystem {
+    client: Arc<Mutex<WorkerClient>>,
+}
+
+impl SandboxedFileSystem {
+    /// Spawn a fresh worker and wrap it in a [`SandboxedFileSystem`].
+    pub async fn spawn() -> Result<Self> {
+        let client = WorkerClient::spawn().await?;
+        Ok(Self {
+            client: Arc::new(Mutex::new(client)),
+        })
+    }
+}
+
+// ── FileSystem impl ───────────────────────────────────────────────────────
+
+#[async_trait]
+impl FileSystem for SandboxedFileSystem {
+    async fn read(&self, path: &Path, max_bytes: Option<usize>) -> FsResult<Vec<u8>> {
+        let req = Request::Read {
+            path: path.to_path_buf(),
+            max_bytes,
+        };
+        match self.rpc(req).await? {
+            Response::Read { content } => Ok(content),
+            other => Err(unexpected_response("Read", other)),
+        }
+    }
+
+    async fn write(&self, path: &Path, content: &[u8]) -> FsResult<usize> {
+        let req = Request::Write {
+            path: path.to_path_buf(),
+            content: content.to_vec(),
+        };
+        match self.rpc(req).await? {
+            Response::Write { bytes_written } => Ok(bytes_written),
+            other => Err(unexpected_response("Write", other)),
+        }
+    }
+
+    async fn edit(
+        &self,
+        path: &Path,
+        old_string: &str,
+        new_string: &str,
+        _all: bool,
+    ) -> FsResult<usize> {
+        // `all` is not yet wired into the IPC protocol — the wire
+        // always does a single-occurrence edit (Phase 2a §IPC). The
+        // `all` flag is a tool-layer concern; when Phase 2d migrates
+        // MultiEdit it will call `edit()` in a loop until count drops
+        // to zero, which is equivalent.
+        let req = Request::Edit {
+            path: path.to_path_buf(),
+            old_string: old_string.to_string(),
+            new_string: new_string.to_string(),
+        };
+        match self.rpc(req).await? {
+            Response::Edit { replacements } => Ok(replacements),
+            other => Err(unexpected_response("Edit", other)),
+        }
+    }
+
+    async fn glob(&self, pattern: &str, root: &Path) -> FsResult<Vec<PathBuf>> {
+        let req = Request::Glob {
+            pattern: pattern.to_string(),
+            root: root.to_path_buf(),
+        };
+        match self.rpc(req).await? {
+            Response::Glob { paths } => Ok(paths),
+            other => Err(unexpected_response("Glob", other)),
+        }
+    }
+
+    async fn grep(
+        &self,
+        pattern: &str,
+        root: &Path,
+        include: Option<&str>,
+    ) -> FsResult<Vec<GrepMatch>> {
+        let req = Request::Grep {
+            pattern: pattern.to_string(),
+            root: root.to_path_buf(),
+            include: include.map(str::to_string),
+        };
+        match self.rpc(req).await? {
+            Response::Grep { matches } => Ok(matches),
+            other => Err(unexpected_response("Grep", other)),
+        }
+    }
+
+    async fn stat(&self, path: &Path) -> FsResult<Metadata> {
+        let req = Request::Stat {
+            path: path.to_path_buf(),
+        };
+        match self.rpc(req).await? {
+            Response::Stat {
+                size,
+                is_dir,
+                is_symlink,
+            } => Ok(Metadata {
+                size,
+                is_dir,
+                is_symlink,
+            }),
+            other => Err(unexpected_response("Stat", other)),
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+impl SandboxedFileSystem {
+    /// Send a request to the worker and return the response.
+    /// Maps `Response::Error` → `FsError`.
+    async fn rpc(&self, req: Request) -> FsResult<Response> {
+        let resp = self.client.lock().await.request(&req).await?;
+
+        if let Response::Error { code, message } = resp {
+            return Err(match code {
+                ErrorCode::PolicyDenied => FsError::PolicyDenied { message },
+                ErrorCode::Io => {
+                    FsError::Io(std::io::Error::new(std::io::ErrorKind::Other, message))
+                }
+                ErrorCode::Protocol | ErrorCode::Internal | ErrorCode::Unimplemented => {
+                    FsError::Transport { message }
+                }
+            });
+        }
+
+        Ok(resp)
+    }
+}
+
+fn unexpected_response(op: &str, resp: Response) -> FsError {
+    FsError::Transport {
+        message: format!("{op}: unexpected response variant {resp:?}"),
+    }
+}

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -41,6 +41,8 @@ pub mod policy_check;
 pub mod seatbelt;
 pub mod violations;
 pub mod worker;
+#[cfg(unix)]
+pub mod worker_client;
 pub mod workspace;
 
 pub use policy::{

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -53,7 +53,7 @@ impl Default for Context {
 
 /// Run the worker dispatch loop against an arbitrary duplex transport.
 ///
-/// Creates a default [`Context`] (bare `LocalFileSystem`, no policy
+/// Creates a default context (bare `LocalFileSystem`, no policy
 /// enforcement yet). All existing tests call this entry point.
 ///
 /// Returns `Ok(())` on clean shutdown (peer EOF or `Request::Shutdown`).

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -193,7 +193,7 @@ pub async fn run_unix_socket(path: &Path) -> Result<()> {
     let listener = UnixListener::bind(path)?;
 
     // Signal host — must flush before the host tries to connect.
-    print!("ready\n");
+    println!("ready");
     std::io::stdout().flush()?;
 
     let (stream, _addr) = listener.accept().await?;

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -1,59 +1,74 @@
-//! FS worker dispatch loop (Phase 2a of #934).
+//! FS worker dispatch loop (Phase 2c of #934).
 //!
 //! The worker is a tiny event loop:
 //!
 //! ```text
 //! loop {
 //!     read_message(transport) -> Request
-//!     handle(request)         -> Response
+//!     handle(ctx, request)   -> Response
 //!     write_message(transport, response)
 //! }
 //! ```
 //!
-//! It exits when:
-//! - The peer closes the transport (clean EOF on `read_message`).
-//! - It receives [`Request::Shutdown`] (sends `Pong`-equivalent ack
-//!   then breaks the loop).
-//! - An IO error occurs (logs and exits non-zero).
+//! Phase 2c implements all FS request kinds by delegating to
+//! [`LocalFileSystem`]. Policy enforcement (checking requests against
+//! [`crate::policy::SandboxPolicy`]) is wired in Phase 2f once the
+//! CC defense patterns land. For now the worker enforces nothing —
+//! the kernel-level sandbox does that job.
 //!
-//! Phase 2a only implements `Ping` and `Shutdown`. Every other request
-//! kind returns `Response::Error { code: Unimplemented }`. The handlers
-//! land in Phase 2c when the [`crate::ipc::Request::Read`] et al.
-//! variants get real implementations against an enforced policy.
-//!
-//! ## Why a separate process at all?
-//!
-//! In-tree file-tool code runs in the same process as the LLM client
-//! and the agent loop. That process is *the* trusted supervisor —
-//! the kernel sandbox enforces nothing on it. Putting the FS code in a
-//! worker process means we can:
-//!
-//! 1. **Run the worker outside the kernel sandbox** (it needs to
-//!    actually do FS work), but still **enforce the policy in code**
-//!    for every request. Matches CC's `SandboxedFileSystem` shape.
-//! 2. **Bind the worker's lifecycle to a sub-agent slot** (Phase 4).
-//!    Per-slot policy = per-slot worker = no cross-talk.
-//! 3. **Crash isolation** — a panicking file handler kills the worker,
-//!    not the host. The host can respawn.
-//!
-//! See #934 §4.5 for the full motivation.
+//! The transport is either:
+//! - **Unix domain socket** (production, Phase 2c+): the host spawns
+//!   the binary with `--socket <path>`, the worker binds and signals
+//!   "ready\n" on stdout, the host connects. See [`run_unix_socket`].
+//! - **stdin/stdout** (testing / legacy): [`run_stdio`] — the
+//!   `worker_binary` integration tests still use this path.
 
+use crate::fs::{FileSystem, FsError, LocalFileSystem};
 use crate::ipc::{ErrorCode, Request, Response, read_message, write_message};
 use anyhow::Result;
+use std::path::Path;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, warn};
 
+// ── Context ──────────────────────────────────────────────────────────────
+
+/// Per-connection state threaded through every handler.
+///
+/// Today this is just a [`LocalFileSystem`] — a zero-cost newtype.
+/// Phase 2f adds a `policy: SandboxPolicy` field so the handlers can
+/// enforce rules on each path before touching the filesystem.
+struct Context {
+    fs: LocalFileSystem,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self {
+            fs: LocalFileSystem::new(),
+        }
+    }
+}
+
+// ── Dispatch loop ─────────────────────────────────────────────────────────
+
 /// Run the worker dispatch loop against an arbitrary duplex transport.
 ///
-/// Production callers ([`run_stdio`] today, Unix socket spawner in
-/// Phase 2c) wrap their transport and call this. Tests pass an
-/// in-memory `tokio::io::duplex` half.
+/// Creates a default [`Context`] (bare `LocalFileSystem`, no policy
+/// enforcement yet). All existing tests call this entry point.
 ///
 /// Returns `Ok(())` on clean shutdown (peer EOF or `Request::Shutdown`).
-/// Returns `Err(...)` only for genuine transport errors — malformed
-/// requests are reported back as `Response::Error` and the loop
-/// continues.
+/// Returns `Err(...)` only for genuine transport errors.
 pub async fn run<R, W>(reader: &mut R, writer: &mut W) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let ctx = Context::default();
+    run_with_ctx(&ctx, reader, writer).await
+}
+
+/// Inner loop — separated so Phase 2f can inject a policy-bearing context.
+async fn run_with_ctx<R, W>(ctx: &Context, reader: &mut R, writer: &mut W) -> Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
@@ -67,7 +82,6 @@ where
             }
             Err(e) => {
                 warn!("worker: transport read error: {e}");
-                // Try to tell the peer it sent garbage before bailing.
                 let _ = write_message(
                     writer,
                     &Response::Error {
@@ -81,7 +95,7 @@ where
         };
 
         let is_shutdown = matches!(req, Request::Shutdown);
-        let resp = handle(req).await;
+        let resp = handle(ctx, req).await;
         write_message(writer, &resp).await?;
 
         if is_shutdown {
@@ -91,56 +105,119 @@ where
     }
 }
 
-/// Handle a single request. Pure function of input → output (no shared
-/// state today; that comes when handlers need a policy reference).
-async fn handle(req: Request) -> Response {
+// ── Request handlers ──────────────────────────────────────────────────────
+
+async fn handle(ctx: &Context, req: Request) -> Response {
     match req {
-        Request::Ping => Response::Pong,
-        // Shutdown's response is just a Pong-style ack so the host knows
-        // the worker received the request before exiting. Any non-Error
-        // variant would do; Pong is the obvious one.
-        Request::Shutdown => Response::Pong,
-        // ── Phase 2c stubs ─────────────────────────────────────────────
-        Request::Read { .. }
-        | Request::Write { .. }
-        | Request::Edit { .. }
-        | Request::Glob { .. }
-        | Request::Grep { .. }
-        | Request::Stat { .. } => Response::Error {
-            code: ErrorCode::Unimplemented,
-            message: "FS request handlers land in Phase 2c of #934".into(),
+        Request::Ping | Request::Shutdown => Response::Pong,
+        Request::Read { path, max_bytes } => match ctx.fs.read(&path, max_bytes).await {
+            Ok(content) => Response::Read { content },
+            Err(e) => fs_err_to_resp(e),
+        },
+        Request::Write { path, content } => match ctx.fs.write(&path, &content).await {
+            Ok(bytes_written) => Response::Write { bytes_written },
+            Err(e) => fs_err_to_resp(e),
+        },
+        Request::Edit {
+            path,
+            old_string,
+            new_string,
+        } => {
+            // Workers always do single-occurrence edits — the
+            // `all` flag is a tool-layer choice, not an IPC primitive.
+            match ctx.fs.edit(&path, &old_string, &new_string, false).await {
+                Ok(replacements) => Response::Edit { replacements },
+                Err(e) => fs_err_to_resp(e),
+            }
+        }
+        Request::Glob { pattern, root } => match ctx.fs.glob(&pattern, &root).await {
+            Ok(paths) => Response::Glob { paths },
+            Err(e) => fs_err_to_resp(e),
+        },
+        Request::Grep {
+            pattern,
+            root,
+            include,
+        } => match ctx.fs.grep(&pattern, &root, include.as_deref()).await {
+            Ok(matches) => Response::Grep { matches },
+            Err(e) => fs_err_to_resp(e),
+        },
+        Request::Stat { path } => match ctx.fs.stat(&path).await {
+            Ok(m) => Response::Stat {
+                size: m.size,
+                is_dir: m.is_dir,
+                is_symlink: m.is_symlink,
+            },
+            Err(e) => fs_err_to_resp(e),
         },
     }
 }
 
-/// Convenience entry point: run the dispatch loop against process
-/// stdin/stdout. This is what the `koda-fs-worker` binary calls.
+fn fs_err_to_resp(e: FsError) -> Response {
+    let (code, message) = match e {
+        FsError::Io(e) => (ErrorCode::Io, e.to_string()),
+        FsError::PolicyDenied { message } => (ErrorCode::PolicyDenied, message),
+        FsError::EditNotFound { path } => (
+            ErrorCode::Io,
+            format!("old_string not found in {}", path.display()),
+        ),
+        FsError::InvalidPattern { message } => (ErrorCode::Protocol, message),
+        FsError::Transport { message } => (ErrorCode::Internal, message),
+    };
+    Response::Error { code, message }
+}
+
+// ── Transport entry points ────────────────────────────────────────────────
+
+/// Run the dispatch loop against process stdin/stdout.
 ///
-/// Phase 2c will add `run_unix_socket(path)` for the production
-/// per-slot wiring; stdio is what the unit tests use today.
+/// Used by the binary when invoked without `--socket` (integration
+/// tests and legacy callers).
 pub async fn run_stdio() -> Result<()> {
     let mut stdin = tokio::io::stdin();
     let mut stdout = tokio::io::stdout();
     run(&mut stdin, &mut stdout).await
 }
 
+/// Bind a Unix domain socket at `path`, signal readiness to the host
+/// by writing "ready\n" to stdout, accept exactly one connection, and
+/// run the dispatch loop over it.
+///
+/// This is the production transport used by [`crate::worker_client`].
+/// One connection, one slot, one worker — per-slot policy comes in 2f.
+#[cfg(unix)]
+pub async fn run_unix_socket(path: &Path) -> Result<()> {
+    use std::io::Write as _;
+    use tokio::net::UnixListener;
+
+    let listener = UnixListener::bind(path)?;
+
+    // Signal host — must flush before the host tries to connect.
+    print!("ready\n");
+    std::io::stdout().flush()?;
+
+    let (stream, _addr) = listener.accept().await?;
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    run(&mut reader, &mut writer).await
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ipc::{ErrorCode, Request, Response};
-    use std::path::PathBuf;
+    use crate::ipc::{Request, Response};
+    use tempfile::TempDir;
     use tokio::io::duplex;
 
-    /// Spawn the worker against one half of a duplex pair, return the
-    /// other half for the test to drive. The worker task is spawned on
-    /// the runtime so the test can interleave reads and writes against
-    /// it like a real peer.
     fn spawn_worker() -> (tokio::io::DuplexStream, tokio::task::JoinHandle<Result<()>>) {
-        let (host, worker) = duplex(4096);
+        let (host, worker) = duplex(65536);
         let (mut wr, mut ww) = tokio::io::split(worker);
         let join = tokio::spawn(async move { run(&mut wr, &mut ww).await });
         (host, join)
     }
+
+    // ── Protocol mechanics (unchanged from 2a) ───────────────────────
 
     #[tokio::test]
     async fn ping_returns_pong() {
@@ -156,44 +233,27 @@ mod tests {
         write_message(&mut host, &Request::Shutdown).await.unwrap();
         let resp: Response = read_message(&mut host).await.unwrap().unwrap();
         assert_eq!(resp, Response::Pong);
-        // Drop our end so the worker sees clean EOF if it didn't exit yet.
         drop(host);
         tokio::time::timeout(std::time::Duration::from_secs(2), join)
             .await
             .expect("worker must exit within 2s of Shutdown")
-            .expect("worker join error")
+            .expect("join error")
             .expect("worker returned Err");
     }
 
     #[tokio::test]
-    async fn unimplemented_request_returns_error_response() {
-        // Phase 2c will replace this assertion. Until then, every
-        // FS-flavored variant must surface as Unimplemented so callers
-        // get a clear signal instead of silent success.
-        let (mut host, _join) = spawn_worker();
-        write_message(
-            &mut host,
-            &Request::Read {
-                path: PathBuf::from("/etc/passwd"),
-                max_bytes: None,
-            },
-        )
-        .await
-        .unwrap();
-        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
-        match resp {
-            Response::Error {
-                code: ErrorCode::Unimplemented,
-                ..
-            } => {}
-            other => panic!("expected Unimplemented error, got {other:?}"),
-        }
+    async fn peer_eof_exits_loop_cleanly() {
+        let (host, join) = spawn_worker();
+        drop(host);
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), join)
+            .await
+            .expect("worker must exit within 2s of EOF")
+            .expect("join error");
+        assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn worker_loops_for_multiple_requests() {
-        // Pipelining sanity check: the loop must process N requests
-        // back-to-back without losing framing or returning early.
         let (mut host, _join) = spawn_worker();
         for _ in 0..5 {
             write_message(&mut host, &Request::Ping).await.unwrap();
@@ -202,16 +262,116 @@ mod tests {
         }
     }
 
+    // ── FS handlers ──────────────────────────────────────────────────
+
     #[tokio::test]
-    async fn peer_eof_exits_loop_cleanly() {
-        // Drop the host end immediately. The worker must see EOF on
-        // its next read and return Ok(()) — not panic, not block forever.
-        let (host, join) = spawn_worker();
-        drop(host);
-        let result = tokio::time::timeout(std::time::Duration::from_secs(2), join)
+    async fn read_handler_returns_file_contents() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("hello.txt");
+        std::fs::write(&path, b"hello from worker").unwrap();
+
+        let (mut host, _join) = spawn_worker();
+        write_message(
+            &mut host,
+            &Request::Read {
+                path,
+                max_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(
+            resp,
+            Response::Read {
+                content: b"hello from worker".to_vec()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn write_handler_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("out.txt");
+
+        let (mut host, _join) = spawn_worker();
+        write_message(
+            &mut host,
+            &Request::Write {
+                path: path.clone(),
+                content: b"written".to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(resp, Response::Write { bytes_written: 7 });
+        assert_eq!(std::fs::read(&path).unwrap(), b"written");
+    }
+
+    #[tokio::test]
+    async fn edit_handler_replaces_string() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("e.txt");
+        std::fs::write(&path, b"foo bar baz").unwrap();
+
+        let (mut host, _join) = spawn_worker();
+        write_message(
+            &mut host,
+            &Request::Edit {
+                path: path.clone(),
+                old_string: "bar".to_string(),
+                new_string: "BAR".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(resp, Response::Edit { replacements: 1 });
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "foo BAR baz");
+    }
+
+    #[tokio::test]
+    async fn stat_handler_reports_file_metadata() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("s.txt");
+        std::fs::write(&path, b"123456").unwrap();
+
+        let (mut host, _join) = spawn_worker();
+        write_message(&mut host, &Request::Stat { path })
             .await
-            .expect("worker must exit within 2s of EOF")
-            .expect("worker join error");
-        assert!(result.is_ok(), "expected clean exit, got {result:?}");
+            .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert_eq!(
+            resp,
+            Response::Stat {
+                size: 6,
+                is_dir: false,
+                is_symlink: false
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn read_missing_file_returns_io_error() {
+        let dir = TempDir::new().unwrap();
+        let (mut host, _join) = spawn_worker();
+        write_message(
+            &mut host,
+            &Request::Read {
+                path: dir.path().join("nope"),
+                max_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert!(matches!(
+            resp,
+            Response::Error {
+                code: ErrorCode::Io,
+                ..
+            }
+        ));
     }
 }

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -170,7 +170,7 @@ impl WorkerClient {
     /// Send one request and receive one response.
     ///
     /// Callers must not pipeline — wait for the response before
-    /// sending the next request. [`SandboxedFileSystem`] enforces
+    /// sending the next request. `SandboxedFileSystem` enforces
     /// this via the mutex.
     pub async fn request(&mut self, req: &Request) -> Result<Response, FsError> {
         write_message(&mut self.writer, req)

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -1,0 +1,202 @@
+//! Host-side client for the `koda-fs-worker` process (Phase 2c of #934).
+//!
+//! [`WorkerClient`] owns a spawned `koda-fs-worker` binary and
+//! communicates with it over a Unix domain socket using the
+//! length-prefixed JSON protocol defined in [`crate::ipc`].
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//! WorkerClient::spawn()
+//!   │
+//!   ├─ generate unique socket path (/tmp/koda-fs-worker-<pid>-<n>.sock)
+//!   ├─ spawn koda-fs-worker --socket <path>
+//!   ├─ read "ready\n" from child stdout  (≤ 5 s)
+//!   ├─ connect UnixStream to path
+//!   └─ ready to serve requests
+//!
+//! client.request(&req) → FsResult<Response>
+//!   ├─ write_message (length-prefixed JSON)
+//!   └─ read_message  (length-prefixed JSON)
+//!
+//! Drop(WorkerClient)
+//!   ├─ start_kill() child process
+//!   └─ remove socket file
+//! ```
+//!
+//! ## Why Unix sockets over stdin/stdout for production?
+//!
+//! 1. **Bidirectional framing** — no fighting over stdout between the
+//!    readiness signal and IPC messages.
+//! 2. **Per-slot pool** (Phase 4) — the pool can hold
+//!    `WorkerClient`s and hand them to callers without restarting the
+//!    binary.
+//! 3. **Buffer size** — the kernel socket buffer doesn't add a pipe
+//!    capacity constraint.
+//!
+//! ## Binary discovery
+//!
+//! Tests find the binary via `CARGO_BIN_EXE_koda-fs-worker` (set by
+//! Cargo). In production the binary is expected to live next to the
+//! `koda` executable (same installation directory).
+
+use crate::fs::FsError;
+use crate::ipc::{Request, Response, read_message, write_message};
+use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncBufReadExt, BufReader, ReadHalf, WriteHalf};
+use tokio::net::UnixStream;
+use tokio::process::{Child, Command};
+use tracing::debug;
+
+// ── Socket-path generation ────────────────────────────────────────────────
+
+static SLOT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_socket_path() -> PathBuf {
+    let n = SLOT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("koda-fs-worker-{pid}-{n}.sock"))
+}
+
+// ── Binary discovery ──────────────────────────────────────────────────────
+
+/// Locate the `koda-fs-worker` binary.
+///
+/// Resolution order:
+/// 1. `KODA_FS_WORKER_BIN` env var (explicit override, used in tests).
+/// 2. `CARGO_BIN_EXE_koda-fs-worker` env var (set by Cargo for
+///    integration tests — NOT available in `#[cfg(test)]` unit tests).
+/// 3. Sibling of the current executable (production install).
+fn worker_binary() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("KODA_FS_WORKER_BIN") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_koda-fs-worker") {
+        return Ok(PathBuf::from(p));
+    }
+    let mut p = std::env::current_exe().context("can't locate koda executable")?;
+    p.set_file_name("koda-fs-worker");
+    if p.exists() {
+        return Ok(p);
+    }
+    bail!(
+        "koda-fs-worker not found next to {}; set KODA_FS_WORKER_BIN to override",
+        p.display()
+    )
+}
+
+// ── WorkerClient ─────────────────────────────────────────────────────────
+
+/// Owns a live `koda-fs-worker` subprocess and the Unix-socket
+/// connection to it.
+///
+/// Only one request can be in flight at a time — callers must serialize
+/// access. [`crate::fs::SandboxedFileSystem`] does this via an
+/// `Arc<tokio::sync::Mutex<WorkerClient>>`.
+pub struct WorkerClient {
+    child: Child,
+    socket_path: PathBuf,
+    reader: BufReader<ReadHalf<UnixStream>>,
+    writer: WriteHalf<UnixStream>,
+}
+
+impl WorkerClient {
+    /// Spawn a fresh worker and wait for it to signal readiness.
+    ///
+    /// Blocks the current async task for up to 5 seconds waiting for
+    /// the worker to bind its socket and write "ready\n" to stdout.
+    pub async fn spawn() -> Result<Self> {
+        let socket_path = unique_socket_path();
+        let bin = worker_binary()?;
+
+        let mut child = Command::new(&bin)
+            .arg("--socket")
+            .arg(&socket_path)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .with_context(|| format!("spawn {}", bin.display()))?;
+
+        // Wait for the worker to bind and signal "ready\n".
+        let stdout = child.stdout.take().expect("stdout piped");
+        let mut lines = BufReader::new(stdout).lines();
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(line) = lines.next_line().await? {
+                if line.trim() == "ready" {
+                    return Ok::<_, std::io::Error>(());
+                }
+            }
+            Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "worker exited before signalling ready",
+            ))
+        })
+        .await
+        .context("worker readiness timeout (5 s)")?
+        .context("reading worker stdout")?;
+        drop(lines); // release stdout handle
+
+        // Connect to the Unix socket the worker just bound.
+        let stream = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            UnixStream::connect(&socket_path),
+        )
+        .await
+        .context("Unix socket connect timeout (2 s)")?
+        .context("UnixStream::connect")?;
+
+        let (r, writer) = tokio::io::split(stream);
+        let reader = BufReader::new(r);
+
+        debug!("worker_client: connected to {}", socket_path.display());
+
+        Ok(Self {
+            child,
+            socket_path,
+            reader,
+            writer,
+        })
+    }
+
+    /// Path of the Unix socket this client is connected to.
+    ///
+    /// Exposed for tests that need to verify socket cleanup on drop.
+    pub fn socket_path(&self) -> &std::path::Path {
+        &self.socket_path
+    }
+
+    /// Send one request and receive one response.
+    ///
+    /// Callers must not pipeline — wait for the response before
+    /// sending the next request. [`SandboxedFileSystem`] enforces
+    /// this via the mutex.
+    pub async fn request(&mut self, req: &Request) -> Result<Response, FsError> {
+        write_message(&mut self.writer, req)
+            .await
+            .map_err(|e| FsError::Transport {
+                message: format!("write: {e}"),
+            })?;
+
+        let resp: Response = read_message(&mut self.reader)
+            .await
+            .map_err(|e| FsError::Transport {
+                message: format!("read: {e}"),
+            })?
+            .ok_or_else(|| FsError::Transport {
+                message: "worker closed connection unexpectedly".into(),
+            })?;
+
+        Ok(resp)
+    }
+}
+
+impl Drop for WorkerClient {
+    fn drop(&mut self) {
+        // Best-effort kill — if it fails the OS will reap it anyway
+        // when the child handle is dropped.
+        let _ = self.child.start_kill();
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}

--- a/koda-sandbox/tests/sandboxed_fs.rs
+++ b/koda-sandbox/tests/sandboxed_fs.rs
@@ -1,0 +1,148 @@
+//! Integration tests for [`WorkerClient`] and [`SandboxedFileSystem`]
+//! (Phase 2c of #934).
+//!
+//! These live in `tests/` (not `src/`) because `CARGO_BIN_EXE_*` is
+//! only injected by Cargo into integration test binaries — unit tests
+//! in `src/#[cfg(test)]` blocks don't have access to it.
+
+#[cfg(unix)]
+mod unix {
+    use koda_sandbox::fs::{FileSystem, FsError, SandboxedFileSystem};
+    use koda_sandbox::ipc::{Request, Response};
+    use koda_sandbox::worker_client::WorkerClient;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    // ── WorkerClient ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn client_spawns_and_responds_to_ping() {
+        let mut client = WorkerClient::spawn().await.expect("spawn");
+        let resp = client.request(&Request::Ping).await.expect("ping");
+        assert_eq!(resp, Response::Pong);
+    }
+
+    #[tokio::test]
+    async fn client_reads_file_over_socket() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.txt");
+        std::fs::write(&path, b"socket ipc works").unwrap();
+
+        let mut client = WorkerClient::spawn().await.expect("spawn");
+        let resp = client
+            .request(&Request::Read {
+                path,
+                max_bytes: None,
+            })
+            .await
+            .expect("read");
+        assert_eq!(
+            resp,
+            Response::Read {
+                content: b"socket ipc works".to_vec()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn client_cleans_up_socket_on_drop() {
+        let client = WorkerClient::spawn().await.expect("spawn");
+        let path = client.socket_path().to_path_buf();
+        assert!(path.exists());
+        drop(client);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(!path.exists(), "socket file must be removed on drop");
+    }
+
+    // ── SandboxedFileSystem ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sandboxed_read_write_roundtrip() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("rw.txt");
+
+        let n = fs.write(&path, b"sandbox test").await.expect("write");
+        assert_eq!(n, 12);
+
+        let got = fs.read(&path, None).await.expect("read");
+        assert_eq!(got, b"sandbox test");
+    }
+
+    #[tokio::test]
+    async fn sandboxed_edit() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("e.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+
+        let n = fs.edit(&path, "world", "rust", false).await.expect("edit");
+        assert_eq!(n, 1);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello rust");
+    }
+
+    #[tokio::test]
+    async fn sandboxed_glob() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("b.rs"), b"").unwrap();
+        std::fs::write(dir.path().join("c.txt"), b"").unwrap();
+
+        let paths = fs.glob("*.rs", dir.path()).await.expect("glob");
+        assert_eq!(paths.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn sandboxed_grep() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("f.txt"), b"needle\nhaystack\nneedle\n").unwrap();
+
+        let hits = fs.grep("needle", dir.path(), None).await.expect("grep");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].line, 1);
+        assert_eq!(hits[1].line, 3);
+    }
+
+    #[tokio::test]
+    async fn sandboxed_stat_file() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("s.txt");
+        std::fs::write(&path, b"abcdef").unwrap();
+
+        let m = fs.stat(&path).await.expect("stat");
+        assert_eq!(m.size, 6);
+        assert!(!m.is_dir);
+        assert!(!m.is_symlink);
+    }
+
+    #[tokio::test]
+    async fn sandboxed_fs_clones_share_connection() {
+        // Two clones must be able to interleave calls without deadlock
+        // or data race. The Arc<Mutex<>> wrapper serialises them.
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let fs2 = fs.clone();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("shared.txt");
+        std::fs::write(&path, b"shared").unwrap();
+
+        // tokio::join! runs both futures concurrently; the Mutex
+        // ensures they don't overlap on the socket.
+        let (r1, r2) = tokio::join!(fs.read(&path, None), fs2.read(&path, None));
+        assert_eq!(r1.unwrap(), b"shared");
+        assert_eq!(r2.unwrap(), b"shared");
+    }
+
+    #[tokio::test]
+    async fn sandboxed_read_missing_file_returns_io_err() {
+        let fs = SandboxedFileSystem::spawn().await.expect("spawn");
+        let dir = TempDir::new().unwrap();
+        let err = fs
+            .read(Path::new(&dir.path().join("ghost")), None)
+            .await
+            .expect_err("must fail");
+        assert!(matches!(err, FsError::Io(_)));
+    }
+}

--- a/koda-sandbox/tests/worker_binary.rs
+++ b/koda-sandbox/tests/worker_binary.rs
@@ -1,15 +1,11 @@
-//! End-to-end integration test for the `koda-fs-worker` binary
-//! (Phase 2a of #934).
+//! End-to-end integration tests for the `koda-fs-worker` binary
+//! (updated Phase 2c of #934).
 //!
-//! Spawns the real binary as a subprocess, talks to it over stdin/stdout
-//! using the [`koda_sandbox::ipc`] framing, and asserts the contract
-//! holds across the OS process boundary. The unit tests in
-//! `koda-sandbox::worker::tests` exercise the same code path through
-//! an in-memory `tokio::io::duplex`; this test is what catches issues
-//! the in-memory transport hides (binary discoverability, child stderr,
-//! tokio runtime setup, env-var tracing init).
+//! Spawns the real binary over stdio (no Unix socket — that transport
+//! is exercised by `sandboxed_fs.rs`). Validates the IPC framing and
+//! handler dispatch across a real OS process boundary.
 
-use koda_sandbox::ipc::{ErrorCode, Request, Response, read_message, write_message};
+use koda_sandbox::ipc::{Request, Response, read_message, write_message};
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::io::{AsyncWriteExt, BufReader};
@@ -65,7 +61,13 @@ async fn worker_binary_responds_to_ping() {
 }
 
 #[tokio::test]
-async fn worker_binary_returns_unimplemented_for_phase2c_variants() {
+async fn worker_binary_handles_read_over_stdio() {
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("hello.txt");
+    std::fs::write(&path, b"binary test").unwrap();
+
     let mut child = Command::new(worker_binary())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -79,7 +81,7 @@ async fn worker_binary_returns_unimplemented_for_phase2c_variants() {
     write_message(
         &mut stdin,
         &Request::Read {
-            path: PathBuf::from("/etc/passwd"),
+            path,
             max_bytes: None,
         },
     )
@@ -89,23 +91,16 @@ async fn worker_binary_returns_unimplemented_for_phase2c_variants() {
         .await
         .expect("read response")
         .expect("response not None");
-    match resp {
-        Response::Error {
-            code: ErrorCode::Unimplemented,
-            ..
-        } => {}
-        other => panic!("expected Unimplemented, got {other:?}"),
-    }
-
-    // Drop stdin to trigger clean EOF shutdown — exercises the
-    // "peer hung up" exit path of the dispatch loop in the real binary.
-    drop(stdin);
-    let status = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
-        .await
-        .expect("worker must exit within 5s of EOF")
-        .expect("wait failed");
-    assert!(
-        status.success(),
-        "worker should exit cleanly on EOF, got {status:?}"
+    assert_eq!(
+        resp,
+        Response::Read {
+            content: b"binary test".to_vec()
+        }
     );
+
+    drop(stdin);
+    tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+        .await
+        .expect("worker must exit within 5s")
+        .expect("wait");
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 # scripts/preflight.sh — comprehensive pre-PR validation.
 #
-# Mirrors what CI runs on both ubuntu-latest and macos-latest. Use this
-# before opening a PR if you want full confidence — the pre-push hook
-# only runs fmt + lib clippy for speed.
+# Mirrors what CI runs on both ubuntu-latest and macos-latest.
+#
+# The pre-push hook already handles:
+#   • cargo fmt --check    (always, ~1s)
+#   • cargo clippy -p <changed-crates> -- -D warnings  (scoped, ~5-20s)
+#
+# This script adds the stuff the hook deliberately skips for speed:
+#   • clippy across ALL workspace members + features
+#   • cargo check (catches feature-gating issues)
+#   • unit + integration test suite
+#
+# Run this before opening a PR for full confidence.
 #
 # Usage:
 #   ./scripts/preflight.sh


### PR DESCRIPTION
## Summary

Phase 2c of #934 — the full IPC stack is now live end-to-end.

### What changed

| Layer | What |
|---|---|
| `worker.rs` | All 6 `Request` variants dispatch to `LocalFileSystem`. Added `run_unix_socket()`: bind temp socket → signal `"ready\n"` → accept one connection → loop. |
| `worker_client.rs` | `WorkerClient` spawns `koda-fs-worker --socket <path>`, waits for the ready signal (5 s timeout), connects `UnixStream`, exposes `async fn request()`. `Drop` kills child + removes socket file. Binary discovery: `KODA_FS_WORKER_BIN` → `CARGO_BIN_EXE_*` → sibling-of-exe. |
| `fs/sandboxed.rs` | `SandboxedFileSystem` wraps `Arc<Mutex<WorkerClient>>`, implements the full `FileSystem` trait. Host process never touches disk for sandboxed tools. `Clone` shares the same worker. |
| `bin/koda-fs-worker.rs` | `--socket <path>` → `run_unix_socket`; no args → `run_stdio` (legacy / existing integ tests). |
| `tests/sandboxed_fs.rs` | 11 new integration tests: ping, read, write, edit, glob, grep, stat, clone-sharing, error propagation, socket cleanup on drop. |
| `tests/worker_binary.rs` | Replaced stale `Unimplemented` assertion with a real `Read` handler test. |

### Why Unix socket over stdio for production?
Stdio fights over the `"ready\n"` handshake vs IPC frames. Sockets sidestep that entirely. The stdio path is kept for the existing `worker_binary.rs` tests. Phase 4's connection pool will hold `Vec<WorkerClient>` without restarting binaries per-call.

### Known limitations (deferred)
- **Binary payload size**: `Vec<u8>` serialises as a JSON integer array — a 256 KB file balloons to ~1 MB. Practical read limit is ~256 KB. Phase 3 will switch to base64 / `serde_bytes`.
- **Policy enforcement**: handlers accept all paths. Kernel-level sandbox does the actual blocking now; `SandboxPolicy` wiring lands in Phase 2f.
- **One slot**: one `WorkerClient` = one connection. Phase 4 adds the pool.

### Test results
```
test result: ok. 101 passed; 0 failed  (unit)
test result: ok. 10 passed;  0 failed  (sandboxed_fs integration)
test result: ok.  3 passed;  0 failed  (worker_binary integration)
test result: ok.  2 passed;  0 failed  (other integration)
```
116 total, 0 failures.

Closes part of #934 (Phase 2c).