### PR TITLE
feat(tools): Phase 2d — thread FileSystem trait through Read/Write/Edit/Glob/Grep (#934)

### DIFF
--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -26,6 +26,7 @@ use super::resolve_read_path;
 use super::safe_resolve_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
+use koda_sandbox::fs::FileSystem;
 use serde_json::{Value, json};
 use std::path::Path;
 use std::time::SystemTime;
@@ -178,6 +179,7 @@ pub async fn read_file(
     project_root: &Path,
     args: &Value,
     cache: &super::FileReadCache,
+    fs: &dyn FileSystem,
 ) -> Result<String> {
     let path_str = args["file_path"]
         .as_str()
@@ -190,7 +192,9 @@ pub async fn read_file(
     let start_line = args["start_line"].as_u64();
     let num_lines = args["num_lines"].as_u64();
 
-    // Check if the file exists and get its metadata
+    // Use tokio::fs::metadata for the mtime/size cache check — this is a
+    // host-side performance optimization only; actual content reads go through
+    // the FileSystem abstraction so the sandbox can intercept them (Phase 2d).
     let metadata = tokio::fs::metadata(&resolved)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", resolved.display(), e))?;
@@ -221,50 +225,44 @@ pub async fn read_file(
     // staleness detection in edit_file (Gemini CLI strategy).
     let mut content_sha256 = String::new();
 
+    // Read the full file through the FileSystem abstraction (no cap — we truncate
+    // for display below, but hash the raw content for staleness detection).
+    let raw_bytes = fs
+        .read(&resolved, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", resolved.display(), e))?;
+    let raw_content = String::from_utf8_lossy(&raw_bytes).into_owned();
+
     let output = match (start_line, num_lines) {
         (Some(start), Some(count)) => {
-            // Line-range read: use BufReader to avoid loading the entire file
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let file = tokio::fs::File::open(&resolved).await?;
-            let reader = BufReader::new(file);
-            let mut lines = reader.lines();
-
+            // Line-range slice — the file is already in memory from the trait call above.
             let start_idx = (start as usize).saturating_sub(1); // 1-based to 0-based
-            let mut collected = Vec::with_capacity(count as usize);
-            let mut current = 0usize;
-
-            while let Some(line) = lines.next_line().await? {
-                if current >= start_idx {
-                    collected.push(line);
-                    if collected.len() >= count as usize {
-                        break;
-                    }
-                }
-                current += 1;
-            }
-            collected.join("\n")
+            raw_content
+                .lines()
+                .skip(start_idx)
+                .take(count as usize)
+                .collect::<Vec<_>>()
+                .join("\n")
         }
         _ => {
-            // Full read with token safety cap
-            let content = tokio::fs::read_to_string(&resolved).await?;
-
+            // Full read with token safety cap.
             // Hash the raw (un-truncated) content so edit_file can detect if
             // the file changes between this read and the subsequent write.
-            content_sha256 = format!("{:x}", Sha256::digest(content.as_bytes()));
+            content_sha256 = format!("{:x}", Sha256::digest(raw_content.as_bytes()));
 
-            if content.len() > 20_000 {
+            if raw_content.len() > 20_000 {
                 // Snap to char boundary to avoid panic on multi-byte chars
                 let mut end = 20_000;
-                while !content.is_char_boundary(end) {
+                while !raw_content.is_char_boundary(end) {
                     end -= 1;
                 }
                 format!(
                     "{}\n\n... [TRUNCATED: file is {} bytes. Use start_line/num_lines for large files]",
-                    &content[..end],
-                    content.len()
+                    &raw_content[..end],
+                    raw_content.len()
                 )
             } else {
-                content
+                raw_content
             }
         }
     };
@@ -280,7 +278,7 @@ pub async fn read_file(
 
 /// Write content to a file, creating parent directories as needed.
 /// Refuses to overwrite existing files unless `overwrite=true`.
-pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
+pub async fn write_file(project_root: &Path, args: &Value, fs: &dyn FileSystem) -> Result<String> {
     let path_str = args["file_path"]
         .as_str()
         .or_else(|| args["path"].as_str())
@@ -292,8 +290,10 @@ pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
 
     let resolved = safe_resolve_path(project_root, path_str)?;
 
-    // Overwrite protection: refuse to clobber existing files without explicit opt-in
-    if resolved.exists() && !overwrite {
+    // Overwrite protection: refuse to clobber existing files without explicit opt-in.
+    // Use fs.stat() so the check respects the sandbox boundary.
+    let already_exists = fs.stat(&resolved).await.is_ok();
+    if already_exists && !overwrite {
         anyhow::bail!(
             "File '{}' already exists. Set overwrite=true to replace it, \
              or use Edit for targeted changes.",
@@ -301,12 +301,11 @@ pub async fn write_file(project_root: &Path, args: &Value) -> Result<String> {
         );
     }
 
-    // Ensure parent directory exists
-    if let Some(parent) = resolved.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
+    // Delegate write (+ parent-dir creation) to the FileSystem impl.
+    fs.write(&resolved, content.as_bytes())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", resolved.display(), e))?;
 
-    tokio::fs::write(&resolved, content).await?;
     Ok(format!(
         "Written {} bytes to {}",
         content.len(),
@@ -346,6 +345,7 @@ pub async fn edit_file(
     project_root: &Path,
     args: &Value,
     cache: &super::FileReadCache,
+    fs: &dyn FileSystem,
 ) -> Result<String> {
     let path_str = args["file_path"]
         .as_str()
@@ -356,7 +356,14 @@ pub async fn edit_file(
         .ok_or_else(|| anyhow::anyhow!("Missing 'replacements' argument"))?;
 
     let resolved = safe_resolve_path(project_root, path_str)?;
-    let mut content = tokio::fs::read_to_string(&resolved).await?;
+
+    // Read through the FileSystem abstraction so the sandbox can gate it.
+    let raw_bytes = fs
+        .read(&resolved, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", resolved.display(), e))?;
+    let mut content = String::from_utf8(raw_bytes)
+        .map_err(|e| anyhow::anyhow!("File '{}' is not valid UTF-8: {}", path_str, e))?;
 
     // ── Staleness check (SHA-256, Gemini CLI strategy) ────────────────────
     //
@@ -478,7 +485,9 @@ pub async fn edit_file(
         }
     }
 
-    tokio::fs::write(&resolved, &content).await?;
+    fs.write(&resolved, content.as_bytes())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", resolved.display(), e))?;
 
     Ok(format!(
         "Applied {} edit(s) to {}\n{}",
@@ -632,11 +641,16 @@ pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koda_sandbox::fs::LocalFileSystem;
     use std::collections::HashMap;
     use std::sync::Mutex;
 
     fn cache() -> super::super::FileReadCache {
         std::sync::Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    fn fs() -> LocalFileSystem {
+        LocalFileSystem::new()
     }
 
     // ── Read ─────────────────────────────────────────────────────
@@ -648,7 +662,7 @@ mod tests {
         std::fs::write(&f, "line1\nline2\nline3").unwrap();
 
         let args = json!({"file_path": f.to_string_lossy()});
-        let result = read_file(tmp.path(), &args, &cache()).await.unwrap();
+        let result = read_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert!(result.contains("line1"));
         assert!(result.contains("line3"));
     }
@@ -661,7 +675,7 @@ mod tests {
         std::fs::write(&f, &content).unwrap();
 
         let args = json!({"file_path": f.to_string_lossy(), "start_line": 50, "num_lines": 3});
-        let result = read_file(tmp.path(), &args, &cache()).await.unwrap();
+        let result = read_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert!(result.contains("line 50"));
         assert!(result.contains("line 52"));
         assert!(!result.contains("line 53"));
@@ -671,7 +685,7 @@ mod tests {
     async fn read_file_nonexistent_returns_error() {
         let tmp = tempfile::tempdir().unwrap();
         let args = json!({"file_path": "does_not_exist.txt"});
-        let result = read_file(tmp.path(), &args, &cache()).await;
+        let result = read_file(tmp.path(), &args, &cache(), &fs()).await;
         assert!(result.is_err());
     }
 
@@ -685,11 +699,11 @@ mod tests {
         let args = json!({"file_path": f.to_string_lossy()});
 
         // First read — populates cache.
-        let r1 = read_file(tmp.path(), &args, &c).await.unwrap();
+        let r1 = read_file(tmp.path(), &args, &c, &fs()).await.unwrap();
         assert!(r1.contains("original content"));
 
         // Second read — same file, same mtime → stale-read.
-        let r2 = read_file(tmp.path(), &args, &c).await.unwrap();
+        let r2 = read_file(tmp.path(), &args, &c, &fs()).await.unwrap();
         assert!(r2.contains("unchanged"), "expected stale-read: {r2}");
     }
 
@@ -697,7 +711,7 @@ mod tests {
     async fn read_file_missing_path_arg_errors() {
         let tmp = tempfile::tempdir().unwrap();
         let args = json!({});
-        let result = read_file(tmp.path(), &args, &cache()).await;
+        let result = read_file(tmp.path(), &args, &cache(), &fs()).await;
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("file_path"),
@@ -713,7 +727,7 @@ mod tests {
         std::fs::write(&f, &content).unwrap();
 
         let args = json!({"file_path": f.to_string_lossy()});
-        let result = read_file(tmp.path(), &args, &cache()).await.unwrap();
+        let result = read_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert!(result.contains("TRUNCATED"));
         assert!(result.len() < 25_000);
     }
@@ -730,7 +744,7 @@ mod tests {
         std::fs::create_dir_all(&project).unwrap();
 
         let args = json!({"file_path": "../secret.txt"});
-        let result = read_file(&project, &args, &cache()).await;
+        let result = read_file(&project, &args, &cache(), &fs()).await;
         assert!(
             result.is_ok(),
             "read outside project root should succeed; got: {:?}",
@@ -745,7 +759,7 @@ mod tests {
     async fn write_file_creates_new() {
         let tmp = tempfile::tempdir().unwrap();
         let args = json!({"file_path": "new_file.txt", "content": "hello world"});
-        let result = write_file(tmp.path(), &args).await.unwrap();
+        let result = write_file(tmp.path(), &args, &fs()).await.unwrap();
         assert!(result.contains("Written"));
         assert_eq!(
             std::fs::read_to_string(tmp.path().join("new_file.txt")).unwrap(),
@@ -757,7 +771,7 @@ mod tests {
     async fn write_file_creates_parent_dirs() {
         let tmp = tempfile::tempdir().unwrap();
         let args = json!({"file_path": "a/b/c/deep.txt", "content": "nested"});
-        write_file(tmp.path(), &args).await.unwrap();
+        write_file(tmp.path(), &args, &fs()).await.unwrap();
         assert!(tmp.path().join("a/b/c/deep.txt").exists());
     }
 
@@ -768,7 +782,7 @@ mod tests {
         std::fs::write(&f, "original").unwrap();
 
         let args = json!({"file_path": "existing.txt", "content": "replaced"});
-        let result = write_file(tmp.path(), &args).await;
+        let result = write_file(tmp.path(), &args, &fs()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
         // File should be unchanged.
@@ -782,7 +796,7 @@ mod tests {
         std::fs::write(&f, "old").unwrap();
 
         let args = json!({"file_path": "overwrite_me.txt", "content": "new", "overwrite": true});
-        write_file(tmp.path(), &args).await.unwrap();
+        write_file(tmp.path(), &args, &fs()).await.unwrap();
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "new");
     }
 
@@ -798,7 +812,7 @@ mod tests {
             "file_path": "edit_me.txt",
             "replacements": [{"old_str": "foo", "new_str": "baz"}]
         });
-        let result = edit_file(tmp.path(), &args, &cache()).await.unwrap();
+        let result = edit_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert!(result.contains("Applied 1 edit"));
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "hello world\nbaz bar");
     }
@@ -813,7 +827,7 @@ mod tests {
             "file_path": "multi.txt",
             "replacements": [{"old_str": "aaa", "new_str": "zzz", "replace_all": true}]
         });
-        let result = edit_file(tmp.path(), &args, &cache()).await.unwrap();
+        let result = edit_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert!(result.contains("3 occurrences"));
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "zzz bbb zzz ccc zzz");
     }
@@ -830,7 +844,9 @@ mod tests {
             "file_path": "multi_match.txt",
             "replacements": [{"old_str": "aaa", "new_str": "zzz"}]
         });
-        let err = edit_file(tmp.path(), &args, &cache()).await.unwrap_err();
+        let err = edit_file(tmp.path(), &args, &cache(), &fs())
+            .await
+            .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("matches 2 times"), "expected count: {msg}");
         assert!(
@@ -851,7 +867,7 @@ mod tests {
             "file_path": "edit_me.txt",
             "replacements": [{"old_str": "not here", "new_str": "x"}]
         });
-        let result = edit_file(tmp.path(), &args, &cache()).await;
+        let result = edit_file(tmp.path(), &args, &cache(), &fs()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
@@ -866,7 +882,7 @@ mod tests {
             "file_path": "edit.txt",
             "replacements": [{"old_str": "", "new_str": "x"}]
         });
-        let result = edit_file(tmp.path(), &args, &cache()).await;
+        let result = edit_file(tmp.path(), &args, &cache(), &fs()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
     }
@@ -884,7 +900,7 @@ mod tests {
                 {"old_str": "gamma", "new_str": "GAMMA"}
             ]
         });
-        edit_file(tmp.path(), &args, &cache()).await.unwrap();
+        edit_file(tmp.path(), &args, &cache(), &fs()).await.unwrap();
         assert_eq!(std::fs::read_to_string(&f).unwrap(), "ALPHA beta GAMMA");
     }
 
@@ -919,7 +935,7 @@ mod tests {
             "file_path": "staleness.txt",
             "replacements": [{"old_str": "line one", "new_str": "LINE ONE"}]
         });
-        let err = edit_file(tmp.path(), &args, &c).await.unwrap_err();
+        let err = edit_file(tmp.path(), &args, &c, &fs()).await.unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("changed on disk") || msg.contains("SHA-256"),

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -17,6 +17,7 @@
 use super::resolve_read_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
+use koda_sandbox::fs::FileSystem;
 use serde_json::{Value, json};
 use std::path::Path;
 
@@ -48,7 +49,12 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Execute a glob search from the given base directory.
-pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) -> Result<String> {
+pub async fn glob_search(
+    project_root: &Path,
+    args: &Value,
+    max_results: usize,
+    fs: &dyn FileSystem,
+) -> Result<String> {
     let pattern = args["pattern"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?;
@@ -58,42 +64,41 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
         .unwrap_or(".");
     let base = resolve_read_path(project_root, path_str)?;
 
-    // Build full pattern relative to base directory
-    let full_pattern = base.join(pattern);
-    let full_pattern_str = full_pattern
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("Invalid pattern path"))?;
+    // Delegate to the FileSystem abstraction — LocalFileSystem joins the
+    // pattern against `base` and returns sorted absolute paths; SandboxedFileSystem
+    // does the same through the worker (Phase 2d, #934).
+    let all_matches = fs
+        .glob(pattern, &base)
+        .await
+        .map_err(|e| anyhow::anyhow!("Glob error: {e}"))?;
 
-    let mut matches = Vec::new();
-    let glob_results =
-        glob::glob(full_pattern_str).map_err(|e| anyhow::anyhow!("Invalid glob pattern: {e}"))?;
+    let matches: Vec<String> = all_matches
+        .into_iter()
+        .map(|path| {
+            // Return paths relative to the search base; fall back to
+            // absolute if the path is somehow not under base.
+            let relative = path.strip_prefix(&base).unwrap_or(&path);
+            relative.display().to_string()
+        })
+        .take(max_results)
+        .collect();
 
-    for entry in glob_results {
-        match entry {
-            Ok(path) => {
-                // Return paths relative to the search base; fall back to
-                // absolute if the path is somehow not under base.
-                let relative = path.strip_prefix(&base).unwrap_or(&path);
-                matches.push(relative.display().to_string());
-                if matches.len() >= max_results {
-                    break;
-                }
-            }
-            Err(_) => continue, // Skip permission errors
-        }
-    }
+    // Detect whether we hit the cap (collect stopped early).
+    // Re-check against the pre-cap count is expensive; we simply inspect
+    // whether we filled the bucket to the brim.
+    let capped = matches.len() >= max_results;
 
     if matches.is_empty() {
         Ok(format!("No files matched pattern: {pattern}"))
     } else {
         let count = matches.len();
-        let capped = if count >= max_results {
+        let cap_note = if capped {
             format!("\n\n[Capped at {max_results} results]")
         } else {
             String::new()
         };
         Ok(format!(
-            "{count} files matched:\n{}{capped}",
+            "{count} files matched:\n{}{cap_note}",
             matches.join("\n")
         ))
     }
@@ -102,6 +107,7 @@ pub async fn glob_search(project_root: &Path, args: &Value, max_results: usize) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koda_sandbox::fs::LocalFileSystem;
     use tempfile::TempDir;
 
     fn setup() -> TempDir {
@@ -119,7 +125,9 @@ mod tests {
     async fn test_glob_rust_files() {
         let tmp = setup();
         let args = json!({ "pattern": "**/*.rs" });
-        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("main.rs"));
         assert!(result.contains("lib.rs"));
     }
@@ -128,7 +136,9 @@ mod tests {
     async fn test_glob_toml() {
         let tmp = setup();
         let args = json!({ "pattern": "*.toml" });
-        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("Cargo.toml"));
     }
 
@@ -136,7 +146,9 @@ mod tests {
     async fn test_glob_no_match() {
         let tmp = setup();
         let args = json!({ "pattern": "**/*.xyz" });
-        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("No files matched"));
     }
 
@@ -144,7 +156,9 @@ mod tests {
     async fn test_glob_scoped_path() {
         let tmp = setup();
         let args = json!({ "pattern": "*.rs", "path": "src/tools" });
-        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("mod.rs"));
         assert!(!result.contains("main.rs")); // Not in src/tools
     }
@@ -154,7 +168,9 @@ mod tests {
         let tmp = setup();
         // Cap at 2 results — there are 3 .rs files
         let args = json!({ "pattern": "**/*.rs" });
-        let result = glob_search(tmp.path(), &args, 2).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 2, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(
             result.contains("Capped"),
             "should show cap message: {result}"
@@ -165,7 +181,7 @@ mod tests {
     async fn test_glob_missing_pattern_errors() {
         let tmp = setup();
         let args = json!({});
-        let result = glob_search(tmp.path(), &args, 200).await;
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("pattern"));
     }
@@ -174,7 +190,9 @@ mod tests {
     async fn test_glob_specific_filename() {
         let tmp = setup();
         let args = json!({ "pattern": "**/mod.rs" });
-        let result = glob_search(tmp.path(), &args, 200).await.unwrap();
+        let result = glob_search(tmp.path(), &args, 200, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("mod.rs"));
         assert!(!result.contains("main.rs"));
     }

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -1,19 +1,22 @@
 //! Grep tool — recursive text search across files.
 //!
-//! Uses the `ignore` crate to walk directories (respecting `.gitignore`)
-//! and searches for text patterns. Match cap is set by `OutputCaps`
-//! (context-scaled).
+//! Uses the `FileSystem` trait (Phase 2d, #934) to walk directories
+//! (respecting `.gitignore`) and search for text patterns. This lets
+//! `LocalFileSystem` walk the host tree directly, while `SandboxedFileSystem`
+//! routes the same walk through the policy-enforcing worker process.
+//!
+//! Match cap is set by `OutputCaps` (context-scaled).
 //!
 //! ## Parameters
 //!
 //! - **`pattern`** (required) — Text or regex pattern to search for
 //! - **`path`** (optional, default `.`) — Directory or file to search in
-//! - **`include`** (optional) — Glob pattern to filter files (e.g., `"*.rs"`)
+//! - **`case_insensitive`** (optional) — Ignore case (default: false)
 //!
 //! ## Output format
 //!
-//! Returns matches as `file:line: content`, one per line. When matches
-//! exceed the cap, output is truncated with a count of remaining matches.
+//! Returns matches as `file:line:content`, one per line. When matches
+//! exceed the cap, output is truncated with a count note.
 //!
 //! ## When to use Grep vs Bash
 //!
@@ -23,6 +26,7 @@
 use super::resolve_read_path;
 use crate::providers::ToolDefinition;
 use anyhow::Result;
+use koda_sandbox::fs::FileSystem;
 use serde_json::{Value, json};
 use std::path::Path;
 
@@ -58,11 +62,19 @@ pub fn definitions() -> Vec<ToolDefinition> {
 }
 
 /// Search for a text pattern across files in a directory.
-pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Result<String> {
-    let pattern = args["pattern"]
+///
+/// The pattern is treated as a **literal string** (not a regex) and escaped
+/// before being handed to the [`FileSystem`] impl. `case_insensitive=true`
+/// prepends a `(?i)` inline flag so the regex engine handles case folding.
+pub async fn grep(
+    project_root: &Path,
+    args: &Value,
+    max_matches: usize,
+    fs: &dyn FileSystem,
+) -> Result<String> {
+    let raw_pattern = args["pattern"]
         .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?
-        .to_string();
+        .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' argument"))?;
     let path_str = args["file_path"]
         .as_str()
         .or_else(|| args["path"].as_str())
@@ -70,99 +82,65 @@ pub async fn grep(project_root: &Path, args: &Value, max_matches: usize) -> Resu
     let case_insensitive = args["case_insensitive"].as_bool().unwrap_or(false);
 
     let search_root = resolve_read_path(project_root, path_str)?;
-    let project_root = project_root.to_path_buf();
 
-    // Run blocking file I/O off the tokio thread pool
-    tokio::task::spawn_blocking(move || {
-        grep_blocking(
-            &project_root,
-            &search_root,
-            &pattern,
-            case_insensitive,
-            max_matches,
-        )
-    })
-    .await?
-}
-
-/// Blocking grep implementation (runs on a dedicated thread).
-fn grep_blocking(
-    project_root: &Path,
-    search_root: &Path,
-    pattern: &str,
-    case_insensitive: bool,
-    max_matches: usize,
-) -> Result<String> {
-    let regex = if case_insensitive {
-        regex::RegexBuilder::new(&regex::escape(pattern))
-            .case_insensitive(true)
-            .build()?
+    // Treat the user input as a literal string, not a regex — escape specials.
+    // This prevents "fn (" from blowing up the regex engine (#807 family).
+    let escaped = regex::escape(raw_pattern);
+    let regex_pattern = if case_insensitive {
+        format!("(?i){escaped}")
     } else {
-        regex::Regex::new(&regex::escape(pattern))?
+        escaped
     };
 
-    let walker = ignore::WalkBuilder::new(search_root)
-        .hidden(true)
-        .git_ignore(true)
-        .build();
+    let all_matches = fs
+        .grep(&regex_pattern, &search_root, None)
+        .await
+        .map_err(|e| anyhow::anyhow!("Grep error: {e}"))?;
 
-    let mut matches = Vec::new();
-    let mut files_searched = 0u64;
-
-    for entry in walker.flatten() {
-        let path = entry.path();
-        if !path.is_file() {
-            continue;
-        }
-
-        // Skip binary files: read only the first 8KB to check
-        let content = match std::fs::read(path) {
-            Ok(bytes) => match String::from_utf8(bytes) {
-                Ok(s) => s,
-                Err(_) => continue,
-            },
-            Err(_) => continue,
-        };
-
-        files_searched += 1;
-
-        let relative = path.strip_prefix(project_root).unwrap_or(path);
-        for (line_num, line) in content.lines().enumerate() {
-            if regex.is_match(line) {
-                matches.push(format!(
-                    "{}:{}:{}",
-                    relative.display(),
-                    line_num + 1,
-                    truncate_line(line, 200)
-                ));
-
-                if matches.len() >= max_matches {
-                    matches.push(format!(
-                        "\n... [CAPPED at {max_matches} matches. \
-                         Narrow your search pattern.]"
-                    ));
-                    return Ok(format_output(&matches, files_searched));
-                }
-            }
-        }
+    if all_matches.is_empty() {
+        return Ok(format!("No matches found for '{raw_pattern}'"));
     }
 
-    if matches.is_empty() {
-        Ok(format!(
-            "No matches found for \'{pattern}\' (searched {files_searched} files)"
-        ))
-    } else {
-        Ok(format_output(&matches, files_searched))
-    }
-}
+    // Cap the result set and build output lines.
+    let capped = all_matches.len() > max_matches;
+    let shown = &all_matches[..all_matches.len().min(max_matches)];
 
-fn format_output(matches: &[String], files_searched: u64) -> String {
-    format!(
-        "{} matches (searched {} files):\n{}",
-        matches.len(),
-        files_searched,
-        matches.join("\n")
-    )
+    // Count unique matched files for the summary line.
+    let files_with_matches = {
+        let mut seen = std::collections::HashSet::new();
+        for m in shown {
+            seen.insert(&m.path);
+        }
+        seen.len()
+    };
+
+    let mut lines: Vec<String> = shown
+        .iter()
+        .map(|m| {
+            let rel = m.path.strip_prefix(project_root).unwrap_or(&m.path);
+            format!(
+                "{}:{}:{}",
+                rel.display(),
+                m.line,
+                truncate_line(&m.text, 200)
+            )
+        })
+        .collect();
+
+    if capped {
+        lines.push(format!(
+            "\n... [CAPPED at {max_matches} matches. \
+             Narrow your search pattern.]"
+        ));
+    }
+
+    Ok(format!(
+        "{} matches ({} file{}):\n{}",
+        shown.len(),
+        files_with_matches,
+        if files_with_matches == 1 { "" } else { "s" },
+        lines.join("\n")
+    ))
 }
 
 /// Truncate a line to at most `max_bytes` bytes, snapping down to
@@ -187,6 +165,7 @@ fn truncate_line(line: &str, max_bytes: usize) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use koda_sandbox::fs::LocalFileSystem;
     use tempfile::TempDir;
 
     fn setup_test_dir() -> TempDir {
@@ -214,7 +193,9 @@ mod tests {
     async fn test_grep_finds_matches() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "hello" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("hello.rs"));
         assert!(result.contains("lib.rs"));
     }
@@ -223,7 +204,9 @@ mod tests {
     async fn test_grep_no_matches() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "zzzznotfound" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("No matches"));
     }
 
@@ -231,7 +214,9 @@ mod tests {
     async fn test_grep_case_insensitive() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "HELLO", "case_insensitive": true });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("hello.rs"));
     }
 
@@ -270,7 +255,9 @@ mod tests {
     async fn test_grep_scoped_to_subdirectory() {
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "nope", "path": "nested" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("deep.rs"));
     }
 
@@ -284,7 +271,9 @@ mod tests {
         std::fs::write(tmp.path().join("text.rs"), "hello world").unwrap();
 
         let args = json!({ "pattern": "hello" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         // Binary file should be silently skipped; text file should match.
         assert!(result.contains("text.rs"));
         assert!(!result.contains("data.bin"));
@@ -303,7 +292,9 @@ mod tests {
         }
         // Cap at 5 matches.
         let args = json!({ "pattern": "needle" });
-        let result = grep(tmp.path(), &args, 5).await.unwrap();
+        let result = grep(tmp.path(), &args, 5, &LocalFileSystem::new())
+            .await
+            .unwrap();
         // Result should mention truncation when matches exceed the cap.
         assert!(
             result.contains("CAPPED"),
@@ -316,7 +307,9 @@ mod tests {
         // The tool accepts both "path" and "file_path" as the directory param.
         let tmp = setup_test_dir();
         let args = json!({ "pattern": "nope", "file_path": "nested" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(result.contains("deep.rs"));
     }
 
@@ -328,7 +321,9 @@ mod tests {
         // If the pattern were treated as regex, "fn (" would be a parse error.
         // Since we escape it, it should match the literal text.
         let args = json!({ "pattern": "fn (" });
-        let result = grep(tmp.path(), &args, 100).await.unwrap();
+        let result = grep(tmp.path(), &args, 100, &LocalFileSystem::new())
+            .await
+            .unwrap();
         assert!(
             result.contains("code.rs"),
             "literal paren should be matched without regex error"

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -144,6 +144,7 @@ pub mod web_fetch;
 pub mod web_search;
 
 use anyhow::Result;
+use koda_sandbox::fs::{FileSystem, LocalFileSystem};
 use path_clean::PathClean;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -217,6 +218,9 @@ pub struct ToolRegistry {
     project_root: PathBuf,
     definitions: HashMap<String, ToolDefinition>,
     read_cache: FileReadCache,
+    /// Filesystem abstraction — `LocalFileSystem` by default; swap to
+    /// `SandboxedFileSystem` when a sandbox slot is active (Phase 2d, #934).
+    fs: Arc<dyn FileSystem>,
     /// Per-file last-writer tracking for richer staleness errors (#804 item 7).
     last_writer: LastWriterCache,
     /// Most recent Bash invocation for staleness error context (#804 item 7).
@@ -305,6 +309,7 @@ impl ToolRegistry {
             project_root,
             definitions,
             read_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            fs: Arc::new(LocalFileSystem::new()),
             last_writer: Arc::new(std::sync::Mutex::new(HashMap::new())),
             last_bash: Arc::new(std::sync::Mutex::new(None)),
             undo: std::sync::Mutex::new(crate::undo::UndoStack::new()),
@@ -325,6 +330,14 @@ impl ToolRegistry {
     pub fn with_shared_cache(mut self, cache: FileReadCache) -> Self {
         self.read_cache = cache;
         self
+    }
+
+    /// Inject a custom [`FileSystem`] implementation.
+    ///
+    /// Call this after construction to swap `LocalFileSystem` for
+    /// `SandboxedFileSystem` when a sandbox slot is ready (#934).
+    pub fn set_fs(&mut self, fs: Arc<dyn FileSystem>) {
+        self.fs = fs;
     }
 
     /// Get a clone of the `Arc` file-read cache for sharing with sub-agents.
@@ -527,18 +540,25 @@ impl ToolRegistry {
 
         let result = match name {
             // File tools
-            "Read" => file_tools::read_file(&self.project_root, &args, &self.read_cache).await,
-            "Write" => file_tools::write_file(&self.project_root, &args).await,
-            "Edit" => file_tools::edit_file(&self.project_root, &args, &self.read_cache).await,
+            "Read" => {
+                file_tools::read_file(&self.project_root, &args, &self.read_cache, &*self.fs).await
+            }
+            "Write" => file_tools::write_file(&self.project_root, &args, &*self.fs).await,
+            "Edit" => {
+                file_tools::edit_file(&self.project_root, &args, &self.read_cache, &*self.fs).await
+            }
             "Delete" => file_tools::delete_file(&self.project_root, &args).await,
             "List" => {
                 file_tools::list_files(&self.project_root, &args, self.caps.list_entries).await
             }
 
             // Search tools
-            "Grep" => grep::grep(&self.project_root, &args, self.caps.grep_matches).await,
+            "Grep" => {
+                grep::grep(&self.project_root, &args, self.caps.grep_matches, &*self.fs).await
+            }
             "Glob" => {
-                glob_tool::glob_search(&self.project_root, &args, self.caps.glob_results).await
+                glob_tool::glob_search(&self.project_root, &args, self.caps.glob_results, &*self.fs)
+                    .await
             }
 
             // Shell

--- a/koda-core/tests/file_tools_test.rs
+++ b/koda-core/tests/file_tools_test.rs
@@ -5,6 +5,7 @@
 use koda_core::tools::FileReadCache;
 use koda_core::tools::file_tools;
 use koda_core::tools::safe_resolve_path;
+use koda_sandbox::fs::LocalFileSystem;
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::Path;
@@ -14,6 +15,10 @@ use tempfile::TempDir;
 /// Convenience: fresh empty read cache for tests that don't need pre-seeded state.
 fn empty_cache() -> FileReadCache {
     Arc::new(Mutex::new(HashMap::new()))
+}
+
+fn fs() -> LocalFileSystem {
+    LocalFileSystem::new()
 }
 
 #[test]
@@ -58,7 +63,7 @@ async fn test_edit_file_replacement() {
         "path": "example.rs",
         "replacements": [{"old_str": "\"old\"", "new_str": "\"new\""}]
     });
-    file_tools::edit_file(tmp.path(), &args, &empty_cache())
+    file_tools::edit_file(tmp.path(), &args, &empty_cache(), &fs())
         .await
         .unwrap();
     let result = std::fs::read_to_string(tmp.path().join("example.rs")).unwrap();
@@ -78,7 +83,7 @@ async fn test_edit_file_delete_snippet() {
         "path": "with_comment.rs",
         "replacements": [{"old_str": "// TODO: remove this\n", "new_str": ""}]
     });
-    file_tools::edit_file(tmp.path(), &args, &empty_cache())
+    file_tools::edit_file(tmp.path(), &args, &empty_cache(), &fs())
         .await
         .unwrap();
     let result = std::fs::read_to_string(tmp.path().join("with_comment.rs")).unwrap();
@@ -98,7 +103,7 @@ async fn test_edit_replace_all_replaces_every_occurrence() {
         "path": "vars.rs",
         "replacements": [{"old_str": "foo", "new_str": "bar", "replace_all": true}]
     });
-    let result = file_tools::edit_file(tmp.path(), &args, &empty_cache())
+    let result = file_tools::edit_file(tmp.path(), &args, &empty_cache(), &fs())
         .await
         .unwrap();
     let content = std::fs::read_to_string(tmp.path().join("vars.rs")).unwrap();
@@ -120,7 +125,7 @@ async fn test_edit_without_replace_all_errors_on_multi_match() {
         "path": "vars.rs",
         "replacements": [{"old_str": "foo", "new_str": "bar"}]
     });
-    let err = file_tools::edit_file(tmp.path(), &args, &empty_cache())
+    let err = file_tools::edit_file(tmp.path(), &args, &empty_cache(), &fs())
         .await
         .unwrap_err();
     let msg = err.to_string();
@@ -139,7 +144,7 @@ async fn test_edit_replace_all_single_occurrence_no_count_label() {
         "path": "one.rs",
         "replacements": [{"old_str": "old", "new_str": "new", "replace_all": true}]
     });
-    let result = file_tools::edit_file(tmp.path(), &args, &empty_cache())
+    let result = file_tools::edit_file(tmp.path(), &args, &empty_cache(), &fs())
         .await
         .unwrap();
     let content = std::fs::read_to_string(tmp.path().join("one.rs")).unwrap();


### PR DESCRIPTION
## Summary

Phase 2d of #934: migrate the five FS-touching tools off direct `tokio::fs` / `glob` / `ignore` calls and onto the `koda_sandbox::fs::FileSystem` abstraction introduced in Phase 2b (#987).

Once a sandbox slot is active (Phase 3), `ToolRegistry::set_fs()` swaps in `SandboxedFileSystem` and every file op is automatically routed through the policy-enforcing worker — no tool code changes needed.

## Changes

### `koda-core/src/tools/mod.rs`
- Import `koda_sandbox::fs::{FileSystem, LocalFileSystem}`.
- New `fs: Arc<dyn FileSystem>` field on `ToolRegistry`; defaults to `LocalFileSystem::new()` — zero production behaviour change.
- New `set_fs(&mut self, fs: Arc<dyn FileSystem>)` setter for Phase 3 injection.
- Dispatch for **Read / Write / Edit / Glob / Grep** passes `&*self.fs` to the tool function.

### `koda-core/src/tools/file_tools.rs`
- `read_file`: keeps `tokio::fs::metadata()` for the mtime/size stale-read cache check (host-only perf opt); replaces `BufReader` + `read_to_string` with `fs.read()` + in-memory line slicing.
- `write_file`: `resolved.exists()` → `fs.stat().is_ok()`; `create_dir_all` + `write` → `fs.write()` (LocalFileSystem creates parents internally).
- `edit_file`: `read_to_string` / `write` → `fs.read()` / `fs.write()`.
- Tests: `fn fs() -> LocalFileSystem` helper; `&fs()` threaded to every call.

### `koda-core/src/tools/glob_tool.rs`
- `glob_search` accepts `fs: &dyn FileSystem`; replaces `glob::glob()` loop with `fs.glob(pattern, &base).await?` + `take(max_results)`.

### `koda-core/src/tools/grep.rs`
- `grep` accepts `fs: &dyn FileSystem`; removes `spawn_blocking` + entire `grep_blocking` fn.
- Builds escaped literal regex; prepends `(?i)` for case-insensitive; delegates to `fs.grep()`.
- Output: `"N matches (M file(s)):"` (unique matched files replaces total-files-searched, which isn't available without the walker).

### `koda-core/tests/file_tools_test.rs`
- Integration test calls updated to match new `edit_file` arity.

## Why keep `tokio::fs::metadata()` in `read_file`?

The mtime+size stale-read cache is a host-side perf opt that avoids re-sending unchanged files to the LLM. Routingthe sandbox would require adding `mtime` to `koda_sandbox::fs::Metadata` and expanding the IPC wire format with no security benefit (it's read-only metadata). Kept direct for now; Phase 3 can revisit.

## Testing

| Suite | Result |
|---|---|
| `cargo test -p koda-core --lib` | ✅ 983 passed, 0 failed |
| `cargo test -p koda-sandbox --lib` | ✅ 101 passed, 0 failed |
| `cargo clippy -p koda-core -- -D warnings` | ✅ clean |
| `cargo fmt --all` | ✅ no diff |
| `cargo doc -p koda-core -- -D warnings` | ✅ clean |

## Phase checklist

- [x] Phase 0 — extract `koda-sandbox` crate (#984)
- [x] Phase 1 — violation reporting + policy overlay (#985)
- [x] Phase 2a — IPC skeleton (#986)
- [x] Phase 2b — `FileSystem` trait + `LocalFileSystem` (#987)
- [x] Phase 2c — real FS handlers + `SandboxedFileSystem` (#988)
- [x] **Phase 2d — migrate tools to trait (this PR)**
- [ ] Phase 2e — `GitWorktreeProvider` migration; `SubAgentDispatch` rewire
- [ ] Phase 2f — CC defense patterns (symlink, ancestor, component, rename-bypass)
- [ ] Phase 3 — network egress proxy