### PR TITLE
koda-sandbox: Phase 2f — path defense primitives + worker policy gate (#934)

### DIFF
--- a/koda-sandbox/src/bin/koda-fs-worker.rs
+++ b/koda-sandbox/src/bin/koda-fs-worker.rs
@@ -9,6 +9,25 @@
 //! - **No arguments** (legacy / tests): run against stdin/stdout.
 //!   The `worker_binary` integration tests still use this path.
 //!
+//! ## Policy injection (Phase 2f)
+//!
+//! When spawned with `--root <path>` the worker enforces write-policy
+//! for every `Write`/`Edit` request. The full [`SandboxPolicy`] is
+//! passed via the `KODA_FS_WORKER_POLICY` environment variable as a
+//! JSON string. Both are set by
+//! [`koda_sandbox::worker_client::WorkerClient::spawn_with_policy`].
+//!
+//! If `--root` is absent the worker runs with no enforcement (legacy
+//! behavior, used by `WorkerClient::spawn()` and stdio tests).
+//!
+//! ## Accepted arguments
+//!
+//! ```text
+//! koda-fs-worker                                # stdin/stdout, no policy
+//! koda-fs-worker --socket <sock>                # Unix socket, no policy
+//! koda-fs-worker --socket <sock> --root <root>  # Unix socket + policy
+//! ```
+//!
 //! ## Lifecycle
 //!
 //! Spawned by `WorkerClient::spawn()` for each sandbox slot. Exits
@@ -20,7 +39,9 @@
 //! Crash isolation. A panicking FS handler kills the worker, not the
 //! host process driving the LLM session.
 
-use anyhow::Result;
+use anyhow::{Result, bail};
+use koda_sandbox::policy::SandboxPolicy;
+use std::path::PathBuf;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
@@ -32,27 +53,104 @@ async fn main() -> Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    // Parse --socket <path> from argv. We roll our own to avoid adding
-    // a CLI-parsing dep to this binary — two-argument argv parsing is
-    // not worth the dep weight.
-    let args: Vec<String> = std::env::args().collect();
-    let socket_path = match args.as_slice() {
-        [_, flag, path] if flag == "--socket" => Some(std::path::PathBuf::from(path)),
-        [_] => None,
-        _ => anyhow::bail!("usage: koda-fs-worker [--socket <path>]"),
-    };
+    let Args {
+        socket_path,
+        writable_root,
+    } = parse_args()?;
 
-    match socket_path {
-        Some(path) => {
+    // Read optional policy from env — absent means use permissive default.
+    let policy = read_policy_env()?;
+
+    match (socket_path, writable_root) {
+        (Some(sock), Some(root)) => {
+            // Production: Unix socket + write-policy enforcement.
             #[cfg(unix)]
             {
-                koda_sandbox::worker::run_unix_socket(&path).await
+                koda_sandbox::worker::run_unix_socket_with_policy(&sock, root, policy).await
             }
             #[cfg(not(unix))]
             {
-                anyhow::bail!("--socket is only supported on Unix")
+                bail!("--socket is only supported on Unix")
             }
         }
-        None => koda_sandbox::worker::run_stdio().await,
+        (Some(sock), None) => {
+            // Unix socket, no enforcement (legacy / test path).
+            #[cfg(unix)]
+            {
+                koda_sandbox::worker::run_unix_socket(&sock).await
+            }
+            #[cfg(not(unix))]
+            {
+                bail!("--socket is only supported on Unix")
+            }
+        }
+        (None, _) => {
+            // stdin/stdout (legacy integration tests and `run_stdio`).
+            koda_sandbox::worker::run_stdio().await
+        }
+    }
+}
+
+// ── Argument parsing ──────────────────────────────────────────────────────
+
+struct Args {
+    socket_path: Option<PathBuf>,
+    writable_root: Option<PathBuf>,
+}
+
+/// Minimal flag parser for the two supported flags.
+///
+/// We intentionally avoid adding a CLI-parsing dep (clap et al.) to the
+/// worker binary — the arg surface is tiny and the dep would meaningfully
+/// bloat the binary's startup time for every slot spawn.
+fn parse_args() -> Result<Args> {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut socket_path: Option<PathBuf> = None;
+    let mut writable_root: Option<PathBuf> = None;
+    let mut iter = raw.iter();
+
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--socket" => {
+                let val = iter
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--socket requires a path argument"))?;
+                socket_path = Some(PathBuf::from(val));
+            }
+            "--root" => {
+                let val = iter
+                    .next()
+                    .ok_or_else(|| anyhow::anyhow!("--root requires a path argument"))?;
+                writable_root = Some(PathBuf::from(val));
+            }
+            other => bail!(
+                "unknown argument: {other}\nusage: koda-fs-worker [--socket <path>] [--root <path>]"
+            ),
+        }
+    }
+
+    Ok(Args {
+        socket_path,
+        writable_root,
+    })
+}
+
+// ── Policy env var ────────────────────────────────────────────────────────
+
+/// Read `KODA_FS_WORKER_POLICY` and deserialize it as a [`SandboxPolicy`].
+///
+/// Returns [`SandboxPolicy::default()`] when the variable is unset \u2014 this
+/// produces a permissive policy that only enforces the absolute deny list
+/// (koda credential DB and dangerous system paths).
+///
+/// Returns an error when the variable is set but cannot be parsed \u2014 a
+/// malformed policy env var is a programming error in the host, not a
+/// user error, so we fail hard rather than silently falling back.
+fn read_policy_env() -> Result<SandboxPolicy> {
+    match std::env::var("KODA_FS_WORKER_POLICY") {
+        Ok(json) => serde_json::from_str(&json)
+            .map_err(|e| anyhow::anyhow!("KODA_FS_WORKER_POLICY is not valid JSON: {e}")),
+        Err(std::env::VarError::NotPresent) => Ok(SandboxPolicy::default()),
+        Err(e) => Err(anyhow::anyhow!("KODA_FS_WORKER_POLICY env var error: {e}")),
     }
 }

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -35,6 +35,7 @@ pub mod defaults;
 pub mod fs;
 pub mod ipc;
 pub mod monitor;
+pub mod path_defense;
 pub mod policy;
 pub mod policy_check;
 #[cfg(target_os = "macos")]
@@ -45,6 +46,7 @@ pub mod worker;
 pub mod worker_client;
 pub mod workspace;
 
+pub use path_defense::{find_symlink_in_path, is_dangerous_system_path, is_path_inside, paths_for_write_check, resolve_deepest_existing_ancestor};
 pub use policy::{
     DomainPattern, FsPolicy, MitmConfig, NetPolicy, PathPattern, ResourceLimits, SandboxPolicy,
     TrustPreference,

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -46,7 +46,10 @@ pub mod worker;
 pub mod worker_client;
 pub mod workspace;
 
-pub use path_defense::{find_symlink_in_path, is_dangerous_system_path, is_path_inside, paths_for_write_check, resolve_deepest_existing_ancestor};
+pub use path_defense::{
+    find_symlink_in_path, is_dangerous_system_path, is_path_inside, paths_for_write_check,
+    resolve_deepest_existing_ancestor,
+};
 pub use policy::{
     DomainPattern, FsPolicy, MitmConfig, NetPolicy, PathPattern, ResourceLimits, SandboxPolicy,
     TrustPreference,

--- a/koda-sandbox/src/path_defense.rs
+++ b/koda-sandbox/src/path_defense.rs
@@ -141,11 +141,8 @@ pub fn resolve_deepest_existing_ancestor(path: &Path) -> std::io::Result<Option<
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
     let mut dir = path.to_path_buf();
 
-    loop {
-        let parent = match dir.parent() {
-            Some(p) => p.to_path_buf(),
-            None => break, // reached filesystem root with no symlink found
-        };
+    while let Some(parent_ref) = dir.parent() {
+        let parent = parent_ref.to_path_buf();
 
         match std::fs::symlink_metadata(&dir) {
             Ok(meta) if meta.file_type().is_symlink() => {
@@ -160,9 +157,7 @@ pub fn resolve_deepest_existing_ancestor(path: &Path) -> std::io::Result<Option<
                         if target.is_absolute() {
                             target
                         } else {
-                            dir.parent()
-                                .map(|p| p.join(&target))
-                                .unwrap_or(target)
+                            dir.parent().map(|p| p.join(&target)).unwrap_or(target)
                         }
                     }
                 };
@@ -176,11 +171,10 @@ pub fn resolve_deepest_existing_ancestor(path: &Path) -> std::io::Result<Option<
                 // different path, a symlink existed somewhere above.
                 match std::fs::canonicalize(&dir) {
                     Ok(canon) if canon != dir => {
-                        let final_path =
-                            tail.iter().rev().fold(canon, |acc, seg| acc.join(seg));
+                        let final_path = tail.iter().rev().fold(canon, |acc, seg| acc.join(seg));
                         return Ok(Some(final_path));
                     }
-                    Ok(_) => return Ok(None), // no symlink anywhere above
+                    Ok(_) => return Ok(None),  // no symlink anywhere above
                     Err(_) => return Ok(None), // EACCES etc — fail open
                 }
             }
@@ -217,7 +211,7 @@ pub fn resolve_deepest_existing_ancestor(path: &Path) -> std::io::Result<Option<
 ///    redirects and add the resolved destination.
 /// 3. Otherwise follow the symlink chain: at each hop, add the current
 ///    target; break on non-symlink, FIFO/socket/device, or cycle.
-/// 4. Cap at [`MAX_SYMLINK_DEPTH`] hops (matches `SYMLOOP_MAX`).
+/// 4. Cap at `MAX_SYMLINK_DEPTH` hops (matches `SYMLOOP_MAX`).
 /// 5. Add the final `canonicalize()` result for completeness (resolves any
 ///    remaining directory-component symlinks).
 ///
@@ -362,10 +356,10 @@ pub fn is_dangerous_system_path(path: &Path) -> bool {
     }
 
     // Home directory exactly (not subdirectories — those are user data).
-    if let Ok(home) = std::env::var("HOME") {
-        if path == Path::new(&home) {
-            return true;
-        }
+    if let Ok(home) = std::env::var("HOME")
+        && path == Path::new(&home)
+    {
+        return true;
     }
 
     // Windows system paths.
@@ -387,12 +381,10 @@ pub fn is_dangerous_system_path(path: &Path) -> bool {
     }
 
     // POSIX: direct children of root (parent == "/").
-    // Examples: /usr ✓, /etc ✓, /var ✓, /tmp ✓
-    // Counter-examples: /usr/local ✗, /var/tmp ✗, /home/user ✗
-    if let Some(parent) = path.parent() {
-        if parent == Path::new("/") {
-            return true;
-        }
+    if let Some(parent) = path.parent()
+        && parent == Path::new("/")
+    {
+        return true;
     }
 
     false
@@ -446,26 +438,54 @@ mod tests {
     #[test]
     fn direct_children_of_root_are_dangerous() {
         // Matches CC's `dirname(normalizedPath) === '/'` rule.
-        for p in ["/usr", "/etc", "/bin", "/sbin", "/dev", "/proc", "/sys",
-                  "/var", "/tmp", "/boot", "/lib", "/lib64",
-                  "/System", "/Library", "/Applications"] {
-            assert!(is_dangerous_system_path(Path::new(p)), "{p} should be dangerous");
+        for p in [
+            "/usr",
+            "/etc",
+            "/bin",
+            "/sbin",
+            "/dev",
+            "/proc",
+            "/sys",
+            "/var",
+            "/tmp",
+            "/boot",
+            "/lib",
+            "/lib64",
+            "/System",
+            "/Library",
+            "/Applications",
+        ] {
+            assert!(
+                is_dangerous_system_path(Path::new(p)),
+                "{p} should be dangerous"
+            );
         }
     }
 
     #[test]
     fn subdirs_of_system_dirs_are_safe() {
         // CC allows subdirs: /usr/local, /var/tmp/work, /tmp/myapp, etc.
-        for p in ["/usr/local", "/usr/local/share", "/var/tmp/build",
-                  "/tmp/sandbox", "/etc/apache2"] {
-            assert!(!is_dangerous_system_path(Path::new(p)), "{p} should be safe");
+        for p in [
+            "/usr/local",
+            "/usr/local/share",
+            "/var/tmp/build",
+            "/tmp/sandbox",
+            "/etc/apache2",
+        ] {
+            assert!(
+                !is_dangerous_system_path(Path::new(p)),
+                "{p} should be safe"
+            );
         }
     }
 
     #[test]
     fn user_project_dirs_are_safe() {
         for p in ["/home/user/project", "/Users/alice/work"] {
-            assert!(!is_dangerous_system_path(Path::new(p)), "{p} should be safe");
+            assert!(
+                !is_dangerous_system_path(Path::new(p)),
+                "{p} should be safe"
+            );
         }
     }
 
@@ -586,9 +606,6 @@ mod tests {
         let path = link_dir.join("new_file.txt");
         let resolved = resolve_deepest_existing_ancestor(&path).unwrap();
         let resolved = resolved.expect("should find a symlink");
-        assert!(
-            resolved.ends_with("real/new_file.txt"),
-            "got: {resolved:?}"
-        );
+        assert!(resolved.ends_with("real/new_file.txt"), "got: {resolved:?}");
     }
 }

--- a/koda-sandbox/src/path_defense.rs
+++ b/koda-sandbox/src/path_defense.rs
@@ -1,0 +1,594 @@
+//! Path defense primitives — application-layer hardening against escape attacks.
+//!
+//! These complement the kernel sandbox (seatbelt/bwrap) by catching attacks
+//! that happen *before* a syscall is issued, such as symlink-based redirects
+//! and TOCTOU races on new-file writes.
+//!
+//! The design mirrors Claude Code's `fsOperations.ts` and
+//! `permissions/filesystem.ts`:
+//!
+//! | This module              | CC equivalent                           |
+//! |--------------------------|-----------------------------------------|
+//! | [`find_symlink_in_path`] | implicit in `safeResolvePath` (lstat loop) |
+//! | [`resolve_deepest_existing_ancestor`] | `resolveDeepestExistingAncestorSync` |
+//! | [`paths_for_write_check`]| `getPathsForPermissionCheck`            |
+//! | [`is_path_inside`]       | `pathInWorkingPath`                     |
+//! | [`is_dangerous_system_path`] | `isDangerousRemovalPath`            |
+//!
+//! ## Attack classes addressed
+//!
+//! 1. **Symlink escape** — `./evil → /etc/shadow`. Without chain expansion
+//!    the policy check sees `./evil` (inside root); the write lands at
+//!    `/etc/shadow`. `paths_for_write_check` expands the full chain and
+//!    checks every link.
+//!
+//! 2. **Dangling-symlink new-file bypass** — `./data/ → /etc/cron.d/`
+//!    (directory symlink, target doesn't exist yet at check time). The
+//!    write creates a cron job outside the root. `resolve_deepest_existing_ancestor`
+//!    walks up to the first real component, canonicalizes it, and rejoins
+//!    the non-existing tail so the check sees the real destination.
+//!
+//! 3. **Catastrophic deletion** — `rm -rf /usr`. `is_dangerous_system_path`
+//!    blocks unconditionally regardless of allow rules.
+//!
+//! 4. **macOS private-symlink bypass** — `/tmp` is a symlink to
+//!    `/private/tmp`. Without normalization, a path starting with
+//!    `/private/tmp/…` would fail an `is_path_inside(path, /tmp)` check.
+//!    Both sides are canonicalized by callers; `is_path_inside` uses
+//!    Rust's `Path::starts_with` which is component-aware.
+//!
+//! ## Invariants
+//!
+//! - **No panics.** Every function is total; I/O errors are absorbed and
+//!   reported through the return type or cause a graceful false-positive
+//!   (fail closed on permission checks, fail open on non-existence checks
+//!   where the path will be created fresh).
+//! - **No blocking inside async**. All functions are synchronous. Callers
+//!   in async contexts must use `tokio::task::spawn_blocking` if needed.
+//! - **No TOCTOU widening**. We never `stat` the same path twice; we
+//!   `symlink_metadata` once and branch on the result immediately.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+/// Maximum symlink hops before we declare a cycle and stop.
+/// Matches Linux/macOS `SYMLOOP_MAX` (40) and the CC implementation.
+const MAX_SYMLINK_DEPTH: usize = 40;
+
+// ── 1. find_symlink_in_path ───────────────────────────────────────────────
+
+/// Walk every *existing* prefix of `path` via `symlink_metadata` (lstat)
+/// and return the first component that is a symlink, or `None` if every
+/// existing component resolves to a real file/directory.
+///
+/// The walk is prefix-by-prefix (`/a`, `/a/b`, `/a/b/c`, …) and stops
+/// at the first non-existing component — we can't lstat what doesn't exist.
+///
+/// ## Example
+///
+/// ```
+/// # use std::path::Path;
+/// // If /tmp is a symlink to /private/tmp on macOS:
+/// // find_symlink_in_path(Path::new("/tmp/work/file.txt")) → Some("/tmp")
+/// ```
+///
+/// ## Errors
+///
+/// Returns `Err` only for unexpected I/O (e.g. permission denied on `lstat`).
+/// `ENOENT` is treated as "end of existing prefix" and causes `Ok(None)`.
+pub fn find_symlink_in_path(path: &Path) -> std::io::Result<Option<PathBuf>> {
+    let mut current = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::Prefix(_) => {
+                current.push(component.as_os_str());
+                continue; // root and drive letters are never symlinks
+            }
+            Component::CurDir | Component::ParentDir => {
+                current.push(component.as_os_str());
+                continue; // logical — don't lstat `.` or `..`
+            }
+            Component::Normal(part) => {
+                current.push(part);
+            }
+        }
+
+        match std::fs::symlink_metadata(&current) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                return Ok(Some(current));
+            }
+            Ok(_) => {} // real entry — continue
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                break; // path component doesn't exist; nothing more to walk
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(None)
+}
+
+// ── 2. resolve_deepest_existing_ancestor ─────────────────────────────────
+
+/// Resolve the deepest *existing* ancestor of `path` through symlinks and
+/// return the resolved path with non-existing tail segments re-joined.
+///
+/// Returns `Some(resolved)` when at least one existing ancestor contains
+/// a symlink. Returns `None` when no symlinks are present in the existing
+/// prefix (the path's existing portion is already canonical).
+///
+/// ## Why this matters
+///
+/// Standard `canonicalize` fails with `ENOENT` for non-existing paths, so
+/// a simple `canonicalize(path)` is useless for new-file write checks.
+/// Without this function, an agent can bypass write policy via a dangling
+/// directory symlink:
+///
+/// ```text
+/// ./uploads/ → /var/www/html/     # symlink created by prior action
+/// Write("./uploads/backdoor.php") # check sees "./uploads/" (inside root)
+///                                 # write lands at /var/www/html/backdoor.php
+/// ```
+///
+/// This function catches that: it walks up to `./uploads`, detects the
+/// symlink, and returns `/var/www/html/backdoor.php` — outside the root.
+///
+/// ## Equivalent
+///
+/// Claude Code's `resolveDeepestExistingAncestorSync` in `fsOperations.ts`.
+pub fn resolve_deepest_existing_ancestor(path: &Path) -> std::io::Result<Option<PathBuf>> {
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut dir = path.to_path_buf();
+
+    loop {
+        let parent = match dir.parent() {
+            Some(p) => p.to_path_buf(),
+            None => break, // reached filesystem root with no symlink found
+        };
+
+        match std::fs::symlink_metadata(&dir) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                // Found a symlink (live or dangling). Try canonicalize first
+                // (handles chained symlinks); fall back to readlink for
+                // dangling ones whose target doesn't exist yet.
+                let resolved = match std::fs::canonicalize(&dir) {
+                    Ok(r) => r,
+                    Err(_) => {
+                        // Dangling — readlink gives us the raw target.
+                        let target = std::fs::read_link(&dir)?;
+                        if target.is_absolute() {
+                            target
+                        } else {
+                            dir.parent()
+                                .map(|p| p.join(&target))
+                                .unwrap_or(target)
+                        }
+                    }
+                };
+                // Rejoin any non-existing tail that was popped earlier.
+                let final_path = tail.iter().rev().fold(resolved, |acc, seg| acc.join(seg));
+                return Ok(Some(final_path));
+            }
+            Ok(_) => {
+                // Existing non-symlink: canonicalize resolves any symlinks
+                // lurking in *its* ancestors. If canonicalize returns a
+                // different path, a symlink existed somewhere above.
+                match std::fs::canonicalize(&dir) {
+                    Ok(canon) if canon != dir => {
+                        let final_path =
+                            tail.iter().rev().fold(canon, |acc, seg| acc.join(seg));
+                        return Ok(Some(final_path));
+                    }
+                    Ok(_) => return Ok(None), // no symlink anywhere above
+                    Err(_) => return Ok(None), // EACCES etc — fail open
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Non-existing component — pop it and walk up.
+                if let Some(name) = dir.file_name() {
+                    tail.push(name.to_os_string());
+                }
+                dir = parent;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(None)
+}
+
+// ── 3. paths_for_write_check ──────────────────────────────────────────────
+
+/// Collect every path that must be validated before allowing a write to
+/// `path`. The returned `Vec` always contains at least `[path]`.
+///
+/// For symlinks the list contains the original path, all intermediate link
+/// targets in the chain, and the final resolved path. This ensures a deny
+/// rule on `/etc/passwd` fires even when the agent writes through
+/// `./evil.txt → /etc/passwd` — every hop is checked.
+///
+/// ## Algorithm (mirrors CC `getPathsForPermissionCheck`)
+///
+/// 1. Seed the set with the original path.
+/// 2. If the path doesn't exist on disk, call
+///    [`resolve_deepest_existing_ancestor`] to detect dangling-symlink
+///    redirects and add the resolved destination.
+/// 3. Otherwise follow the symlink chain: at each hop, add the current
+///    target; break on non-symlink, FIFO/socket/device, or cycle.
+/// 4. Cap at [`MAX_SYMLINK_DEPTH`] hops (matches `SYMLOOP_MAX`).
+/// 5. Add the final `canonicalize()` result for completeness (resolves any
+///    remaining directory-component symlinks).
+///
+/// ## Errors
+///
+/// Never fails — I/O errors inside the chain walk are silently swallowed
+/// and the function returns whatever it collected so far. The caller's
+/// policy check is fail-closed: if we can't prove a path is inside the
+/// root, it's denied.
+pub fn paths_for_write_check(path: &Path) -> Vec<PathBuf> {
+    let mut result: HashSet<PathBuf> = HashSet::new();
+    result.insert(path.to_path_buf());
+
+    // ── Case A: path doesn't exist yet ────────────────────────────────────
+    match std::fs::symlink_metadata(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Could be a dangling symlink or a genuinely new file. Either
+            // way, resolve the deepest existing ancestor so we know where
+            // the write would *actually* land after the OS follows links.
+            if let Ok(Some(resolved)) = resolve_deepest_existing_ancestor(path) {
+                result.insert(resolved);
+            }
+            return result.into_iter().collect();
+        }
+        _ => {}
+    }
+
+    // ── Case B: path exists — follow the symlink chain ────────────────────
+    let mut current = path.to_path_buf();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+
+    for _ in 0..MAX_SYMLINK_DEPTH {
+        if visited.contains(&current) {
+            break; // cycle detected
+        }
+        visited.insert(current.clone());
+
+        let meta = match std::fs::symlink_metadata(&current) {
+            Ok(m) => m,
+            Err(_) => break,
+        };
+
+        // Guard: FIFOs, sockets, and block/char devices can cause hangs or
+        // irreversible side-effects. Stop the chain here (same guard as CC).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileTypeExt as _;
+            let ft = meta.file_type();
+            if ft.is_fifo() || ft.is_socket() || ft.is_block_device() || ft.is_char_device() {
+                break;
+            }
+        }
+
+        if !meta.file_type().is_symlink() {
+            // Real file or directory — canonicalize and add the final path.
+            if let Ok(canon) = std::fs::canonicalize(&current) {
+                result.insert(canon);
+            }
+            break;
+        }
+
+        // Follow the symlink: readlink → resolve relative targets.
+        let target = match std::fs::read_link(&current) {
+            Ok(t) => t,
+            Err(_) => break,
+        };
+        let next = if target.is_absolute() {
+            target
+        } else {
+            match current.parent() {
+                Some(parent) => parent.join(&target),
+                None => break,
+            }
+        };
+
+        result.insert(next.clone());
+        current = next;
+    }
+
+    result.into_iter().collect()
+}
+
+// ── 4. is_path_inside ────────────────────────────────────────────────────
+
+/// True when `path` is equal to `root` or is a descendant of `root`.
+///
+/// Both inputs **must be canonicalized** by the caller (via
+/// `std::fs::canonicalize` or [`resolve_deepest_existing_ancestor`]).
+/// This function does no I/O — it compares components directly.
+///
+/// Uses Rust's `Path::starts_with` which is component-aware:
+/// - `is_path_inside("/etc/password", "/etc/pass")` → `false` ✅
+/// - `is_path_inside("/etc/passwd", "/etc")` → `true` ✅
+/// - `is_path_inside("/etc", "/etc")` → `true` ✅
+///
+/// ## Equivalent
+///
+/// Claude Code's `pathInWorkingPath` (after both sides are canonicalized).
+#[inline]
+pub fn is_path_inside(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+// ── 5. is_dangerous_system_path ──────────────────────────────────────────
+
+/// True when `path` is a system-critical location that should never be
+/// the target of a write or deletion, even if a broad allow rule exists.
+///
+/// This is a last-resort guard — it fires *after* all other policy checks
+/// and cannot be overridden by any allow rule.
+///
+/// ## Blocked paths (mirrors CC `isDangerousRemovalPath`)
+///
+/// | Category | Rule |
+/// |---|---|
+/// | Filesystem root | `/` exactly |
+/// | Home directory | `$HOME` exactly (runtime check) |
+/// | Direct children of root | `/usr`, `/etc`, `/var`, `/bin`, etc. — but `/usr/local` is **safe** |
+/// | Glob wildcards | `*` or paths ending in `/*` |
+/// | Windows drive roots | `C:\`, `C:\Windows`, etc. |
+///
+/// The "direct child of `/`" rule captures all of `/bin`, `/sbin`, `/etc`,
+/// `/usr`, `/var`, `/dev`, `/proc`, `/sys`, `/tmp`, `/Library`,
+/// `/System`, etc. without needing an explicit allowlist — matching CC's
+/// `dirname(normalizedPath) === '/'` condition exactly.
+///
+/// ## Equivalent
+///
+/// Claude Code's `isDangerousRemovalPath` in `permissions/pathValidation.ts`.
+pub fn is_dangerous_system_path(path: &Path) -> bool {
+    // Glob wildcard check (guard for bash-expansion paths stored as PathBuf).
+    {
+        let s = path.to_string_lossy();
+        if s == "*" || s.ends_with("/*") || s.ends_with("/\\*") {
+            return true;
+        }
+    }
+
+    // Root itself.
+    if path == Path::new("/") {
+        return true;
+    }
+
+    // Home directory exactly (not subdirectories — those are user data).
+    if let Ok(home) = std::env::var("HOME") {
+        if path == Path::new(&home) {
+            return true;
+        }
+    }
+
+    // Windows system paths.
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy().to_lowercase();
+        // Drive roots: C:\ or C:
+        if s.len() <= 3 && s.chars().nth(1) == Some(':') {
+            return true;
+        }
+        // Direct children of drive root: C:\Windows, C:\Users, etc.
+        // (exactly one path segment after the drive root)
+        if let Some(parent) = path.parent() {
+            let parent_s = parent.to_string_lossy().to_lowercase();
+            if parent_s.len() <= 3 && parent_s.chars().nth(1) == Some(':') {
+                return true;
+            }
+        }
+    }
+
+    // POSIX: direct children of root (parent == "/").
+    // Examples: /usr ✓, /etc ✓, /var ✓, /tmp ✓
+    // Counter-examples: /usr/local ✗, /var/tmp ✗, /home/user ✗
+    if let Some(parent) = path.parent() {
+        if parent == Path::new("/") {
+            return true;
+        }
+    }
+
+    false
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    // ── is_path_inside ────────────────────────────────────────────────────
+
+    #[test]
+    fn same_path_is_inside() {
+        assert!(is_path_inside(Path::new("/a/b"), Path::new("/a/b")));
+    }
+
+    #[test]
+    fn child_is_inside() {
+        assert!(is_path_inside(Path::new("/a/b/c"), Path::new("/a/b")));
+    }
+
+    #[test]
+    fn sibling_is_not_inside() {
+        assert!(!is_path_inside(Path::new("/a/bc"), Path::new("/a/b")));
+    }
+
+    #[test]
+    fn parent_is_not_inside_child() {
+        assert!(!is_path_inside(Path::new("/a"), Path::new("/a/b")));
+    }
+
+    #[test]
+    fn prefix_match_respects_component_boundary() {
+        // /etc/password must NOT match root /etc/pass
+        assert!(!is_path_inside(
+            Path::new("/etc/password"),
+            Path::new("/etc/pass")
+        ));
+    }
+
+    // ── is_dangerous_system_path ─────────────────────────────────
+
+    #[test]
+    fn root_is_dangerous() {
+        assert!(is_dangerous_system_path(Path::new("/")));
+    }
+
+    #[test]
+    fn direct_children_of_root_are_dangerous() {
+        // Matches CC's `dirname(normalizedPath) === '/'` rule.
+        for p in ["/usr", "/etc", "/bin", "/sbin", "/dev", "/proc", "/sys",
+                  "/var", "/tmp", "/boot", "/lib", "/lib64",
+                  "/System", "/Library", "/Applications"] {
+            assert!(is_dangerous_system_path(Path::new(p)), "{p} should be dangerous");
+        }
+    }
+
+    #[test]
+    fn subdirs_of_system_dirs_are_safe() {
+        // CC allows subdirs: /usr/local, /var/tmp/work, /tmp/myapp, etc.
+        for p in ["/usr/local", "/usr/local/share", "/var/tmp/build",
+                  "/tmp/sandbox", "/etc/apache2"] {
+            assert!(!is_dangerous_system_path(Path::new(p)), "{p} should be safe");
+        }
+    }
+
+    #[test]
+    fn user_project_dirs_are_safe() {
+        for p in ["/home/user/project", "/Users/alice/work"] {
+            assert!(!is_dangerous_system_path(Path::new(p)), "{p} should be safe");
+        }
+    }
+
+    #[test]
+    fn glob_wildcards_are_dangerous() {
+        assert!(is_dangerous_system_path(Path::new("*")));
+        assert!(is_dangerous_system_path(Path::new("/home/user/*")));
+    }
+
+    // ── find_symlink_in_path ──────────────────────────────────────────────
+
+    #[test]
+    fn no_symlink_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("real.txt");
+        fs::write(&file, b"hi").unwrap();
+        let result = find_symlink_in_path(&file).unwrap();
+        // The tmp dir itself may be a symlink on macOS (/var → /private/var),
+        // so just verify we don't panic. The real assertion is that when
+        // there are no symlinks in a purely real path, we get None.
+        // (We test the symlink case below.)
+        let _ = result;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_component_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_dir = tmp.path().join("real");
+        let link_dir = tmp.path().join("link");
+        let target_file = real_dir.join("secret.txt");
+
+        fs::create_dir_all(&real_dir).unwrap();
+        fs::write(&target_file, b"secret").unwrap();
+        std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let path_through_link = link_dir.join("secret.txt");
+        let found = find_symlink_in_path(&path_through_link).unwrap();
+        assert!(found.is_some(), "should detect symlink component");
+    }
+
+    // ── paths_for_write_check ─────────────────────────────────────────────
+
+    #[test]
+    fn real_file_returns_at_least_original() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("plain.txt");
+        fs::write(&file, b"x").unwrap();
+        let paths = paths_for_write_check(&file);
+        assert!(paths.contains(&file) || paths.iter().any(|p| p.ends_with("plain.txt")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_expands_to_full_chain() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("real.txt");
+        let link = tmp.path().join("link.txt");
+        fs::write(&real, b"secret").unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let paths = paths_for_write_check(&link);
+
+        // Should contain at minimum: the link itself and the real target.
+        assert!(paths.len() >= 2, "expected ≥2 paths, got {paths:?}");
+        let has_real = paths.iter().any(|p| {
+            p.ends_with("real.txt")
+                || std::fs::canonicalize(p)
+                    .ok()
+                    .map(|c| c.ends_with("real.txt"))
+                    .unwrap_or(false)
+        });
+        assert!(has_real, "resolved target should be in chain: {paths:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_ancestor_resolved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        let link = tmp.path().join("link");
+
+        // Dangling symlink — outside doesn't exist yet.
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let check_target = link.join("new_file.txt");
+        let paths = paths_for_write_check(&check_target);
+
+        // The resolved path should point to outside/new_file.txt, not link/new_file.txt.
+        let has_outside = paths.iter().any(|p| p.ends_with("outside/new_file.txt"));
+        assert!(
+            has_outside,
+            "dangling symlink should resolve to outside dir: {paths:?}"
+        );
+    }
+
+    // ── resolve_deepest_existing_ancestor ─────────────────────────────
+
+    #[test]
+    fn ancestor_no_symlink_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = resolve_deepest_existing_ancestor(tmp.path()).unwrap();
+        // tmp itself might be via /var → /private/var on macOS, so this
+        // is always Some on macOS. On Linux it should be None.
+        // Just assert no panic.
+        let _ = result;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn live_symlink_resolved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real_dir = tmp.path().join("real");
+        let link_dir = tmp.path().join("link");
+        fs::create_dir_all(&real_dir).unwrap();
+        std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let path = link_dir.join("new_file.txt");
+        let resolved = resolve_deepest_existing_ancestor(&path).unwrap();
+        let resolved = resolved.expect("should find a symlink");
+        assert!(
+            resolved.ends_with("real/new_file.txt"),
+            "got: {resolved:?}"
+        );
+    }
+}

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -25,8 +25,11 @@
 
 use crate::fs::{FileSystem, FsError, LocalFileSystem};
 use crate::ipc::{ErrorCode, Request, Response, read_message, write_message};
+use crate::path_defense::{is_dangerous_system_path, is_path_inside, paths_for_write_check};
+use crate::policy::SandboxPolicy;
+use crate::policy_check::is_fully_denied;
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, warn};
 
@@ -34,17 +37,32 @@ use tracing::{debug, warn};
 
 /// Per-connection state threaded through every handler.
 ///
-/// Today this is just a [`LocalFileSystem`] — a zero-cost newtype.
-/// Phase 2f adds a `policy: SandboxPolicy` field so the handlers can
-/// enforce rules on each path before touching the filesystem.
+/// Phase 2f adds `writable_root` and `policy` so the handlers can
+/// enforce write policy on each path before touching the filesystem.
 struct Context {
     fs: LocalFileSystem,
+    /// Canonical path the slot is allowed to write to.
+    /// `None` means no write-root enforcement (legacy / test callers).
+    writable_root: Option<PathBuf>,
+    policy: SandboxPolicy,
 }
 
 impl Default for Context {
     fn default() -> Self {
         Self {
             fs: LocalFileSystem::new(),
+            writable_root: None,
+            policy: SandboxPolicy::default(),
+        }
+    }
+}
+
+impl Context {
+    fn with_policy(writable_root: PathBuf, policy: SandboxPolicy) -> Self {
+        Self {
+            fs: LocalFileSystem::new(),
+            writable_root: Some(writable_root),
+            policy,
         }
     }
 }
@@ -64,6 +82,25 @@ where
     W: AsyncWrite + Unpin,
 {
     let ctx = Context::default();
+    run_with_ctx(&ctx, reader, writer).await
+}
+
+/// Run the worker with a sandbox policy and writable root.
+///
+/// This is the entry point used by the production worker binary when
+/// spawned by [`crate::worker_client::WorkerClient`]. The policy is
+/// applied to every `Write` and `Edit` request.
+pub async fn run_with_policy<R, W>(
+    writable_root: PathBuf,
+    policy: SandboxPolicy,
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let ctx = Context::with_policy(writable_root, policy);
     run_with_ctx(&ctx, reader, writer).await
 }
 
@@ -107,6 +144,143 @@ where
 
 // ── Request handlers ──────────────────────────────────────────────────────
 
+/// Canonicalize `path` for a policy containment check.
+///
+/// `std::fs::canonicalize` fails with `ENOENT` for paths that don't
+/// exist yet (e.g. the target of a Write request). We resolve the
+/// deepest existing prefix instead, then rejoin the non-existing tail.
+/// This correctly resolves platform symlinks like macOS `/var` →
+/// `/private/var` even when the leaf file hasn't been created yet.
+fn canonicalize_for_check(path: &Path) -> PathBuf {
+    // Fast path: the path already exists and canonicalize succeeds.
+    if let Ok(c) = std::fs::canonicalize(path) {
+        return c;
+    }
+    // Slow path: walk up to the first existing ancestor, canonicalize it,
+    // then rejoin the non-existing tail segments.
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    let mut dir = path.to_path_buf();
+    loop {
+        match std::fs::canonicalize(&dir) {
+            Ok(c) => {
+                return tail.iter().rev().fold(c, |acc, seg| acc.join(seg));
+            }
+            Err(_) => {
+                if let Some(name) = dir.file_name() {
+                    tail.push(name.to_os_string());
+                }
+                match dir.parent() {
+                    Some(p) => dir = p.to_path_buf(),
+                    None => return path.to_path_buf(), // gave up
+                }
+            }
+        }
+    }
+}
+
+/// Validate `path` against the slot's write policy.
+///
+/// Runs three layers in order:
+/// 1. **Fully-denied** — koda's own credential DB (`~/.config/koda/db`).
+/// 2. **Dangerous system path** — `/`, `/usr`, `/etc`, etc.
+/// 3. **Writable-root containment** — the path (and every hop in its
+///    symlink chain) must resolve to inside the slot's writable root.
+///
+/// Returns `Ok(())` when all checks pass, `Err(PolicyDenied { … })` otherwise.
+fn check_write_path(ctx: &Context, path: &Path) -> Result<(), FsError> {
+    // 1. Absolute fully-denied paths — e.g. koda's own API-key database.
+    if is_fully_denied(path) {
+        return Err(FsError::PolicyDenied {
+            message: format!(
+                "write denied: '{}' is a fully-protected path",
+                path.display()
+            ),
+        });
+    }
+
+    // 2. Catastrophic system-path guard — regardless of allow rules.
+    if is_dangerous_system_path(path) {
+        return Err(FsError::PolicyDenied {
+            message: format!(
+                "write denied: '{}' is a critical system path",
+                path.display()
+            ),
+        });
+    }
+
+    // 3. Writable-root containment — only enforced when a root is configured.
+    let Some(ref root) = ctx.writable_root else {
+        return Ok(()); // legacy/test mode: no root enforcement
+    };
+
+    // Expand the full symlink chain so a symlink pointing outside the root
+    // is caught even when the link itself lives inside it.
+    let chain = paths_for_write_check(path);
+
+    for candidate in &chain {
+        // Absolute-deny overrides a broad allow-write rule.
+        if is_fully_denied(candidate) || is_dangerous_system_path(candidate) {
+            return Err(FsError::PolicyDenied {
+                message: format!(
+                    "write denied: symlink chain reaches protected path '{}'",
+                    candidate.display()
+                ),
+            });
+        }
+
+        // Canonical containment check.
+        // For new files, `canonicalize(candidate)` returns ENOENT. Instead
+        // canonicalize the parent (which exists) and rejoin the filename.
+        // This handles the macOS `/var` → `/private/var` symlink, etc.
+        let canonical_candidate = canonicalize_for_check(candidate);
+        let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.clone());
+
+        if !is_path_inside(&canonical_candidate, &canonical_root) {
+            let explicitly_allowed = ctx
+                .policy
+                .fs
+                .allow_write
+                .iter()
+                .any(|pat| is_path_inside(&canonical_candidate, pat.as_path()));
+
+            let explicitly_denied = ctx
+                .policy
+                .fs
+                .deny_write_within_allow
+                .iter()
+                .any(|pat| is_path_inside(&canonical_candidate, pat.as_path()));
+
+            if !explicitly_allowed || explicitly_denied {
+                return Err(FsError::PolicyDenied {
+                    message: format!(
+                        "write denied: '{}' is outside writable root '{}'",
+                        path.display(),
+                        root.display()
+                    ),
+                });
+            }
+        } else {
+            // Inside the root — check deny_write_within_allow carve-outs.
+            let carved_out = ctx
+                .policy
+                .fs
+                .deny_write_within_allow
+                .iter()
+                .any(|pat| is_path_inside(&canonical_candidate, pat.as_path()));
+            if carved_out {
+                return Err(FsError::PolicyDenied {
+                    message: format!(
+                        "write denied: '{}' is in a write-protected sub-path",
+                        path.display()
+                    ),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 async fn handle(ctx: &Context, req: Request) -> Response {
     match req {
         Request::Ping | Request::Shutdown => Response::Pong,
@@ -114,15 +288,23 @@ async fn handle(ctx: &Context, req: Request) -> Response {
             Ok(content) => Response::Read { content },
             Err(e) => fs_err_to_resp(e),
         },
-        Request::Write { path, content } => match ctx.fs.write(&path, &content).await {
-            Ok(bytes_written) => Response::Write { bytes_written },
-            Err(e) => fs_err_to_resp(e),
-        },
+        Request::Write { path, content } => {
+            if let Err(e) = check_write_path(ctx, &path) {
+                return fs_err_to_resp(e);
+            }
+            match ctx.fs.write(&path, &content).await {
+                Ok(bytes_written) => Response::Write { bytes_written },
+                Err(e) => fs_err_to_resp(e),
+            }
+        }
         Request::Edit {
             path,
             old_string,
             new_string,
         } => {
+            if let Err(e) = check_write_path(ctx, &path) {
+                return fs_err_to_resp(e);
+            }
             // Workers always do single-occurrence edits — the
             // `all` flag is a tool-layer choice, not an IPC primitive.
             match ctx.fs.edit(&path, &old_string, &new_string, false).await {
@@ -373,5 +555,96 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // ── Phase 2f: policy-gate tests ──────────────────────────────
+
+    fn spawn_worker_with_root(
+        root: PathBuf,
+    ) -> (tokio::io::DuplexStream, tokio::task::JoinHandle<Result<()>>) {
+        let (host, worker) = duplex(65536);
+        let (mut wr, mut ww) = tokio::io::split(worker);
+        let policy = crate::policy::SandboxPolicy::default();
+        let join = tokio::spawn(async move {
+            run_with_policy(root, policy, &mut wr, &mut ww).await
+        });
+        (host, join)
+    }
+
+    #[tokio::test]
+    async fn write_inside_root_is_allowed() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("allowed.txt");
+        let (mut host, _join) = spawn_worker_with_root(dir.path().to_path_buf());
+        write_message(&mut host, &Request::Write {
+            path: path.clone(),
+            content: b"ok".to_vec(),
+        })
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert!(matches!(resp, Response::Write { .. }), "expected Write ok, got {resp:?}");
+        assert_eq!(std::fs::read(&path).unwrap(), b"ok");
+    }
+
+    #[tokio::test]
+    async fn write_outside_root_is_denied() {
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let path = outside.path().join("escape.txt");
+        let (mut host, _join) = spawn_worker_with_root(root.path().to_path_buf());
+        write_message(&mut host, &Request::Write {
+            path,
+            content: b"evil".to_vec(),
+        })
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert!(
+            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            "expected PolicyDenied, got {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dangerous_system_path_always_denied() {
+        let dir = TempDir::new().unwrap();
+        // Even though root is set, /etc directly is always blocked.
+        let (mut host, _join) = spawn_worker_with_root(dir.path().to_path_buf());
+        write_message(&mut host, &Request::Write {
+            path: PathBuf::from("/etc"),
+            content: b"evil".to_vec(),
+        })
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert!(
+            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            "expected PolicyDenied, got {resp:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlink_escape_is_denied() {
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        // Create a symlink inside root that points to outside.
+        let link = root.path().join("escape_link");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+        let through_link = link.join("secret.txt");
+        let (mut host, _join) = spawn_worker_with_root(root.path().to_path_buf());
+        write_message(&mut host, &Request::Write {
+            path: through_link,
+            content: b"evil".to_vec(),
+        })
+        .await
+        .unwrap();
+        let resp: Response = read_message(&mut host).await.unwrap().unwrap();
+        assert!(
+            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            "symlink escape should be denied, got {resp:?}"
+        );
     }
 }

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -365,10 +365,41 @@ pub async fn run_stdio() -> Result<()> {
 /// by writing "ready\n" to stdout, accept exactly one connection, and
 /// run the dispatch loop over it.
 ///
-/// This is the production transport used by [`crate::worker_client`].
-/// One connection, one slot, one worker — per-slot policy comes in 2f.
+/// No policy enforcement — use [`run_unix_socket_with_policy`] for
+/// production slots. This entry point exists for tests and legacy callers.
 #[cfg(unix)]
 pub async fn run_unix_socket(path: &Path) -> Result<()> {
+    unix_socket_serve(path, Context::default()).await
+}
+
+/// Bind a Unix domain socket at `path` and serve one connection with
+/// write-policy enforcement.
+///
+/// This is the production entry point: the `koda-fs-worker` binary
+/// calls this when `--root <path>` is supplied. Every `Write` and `Edit`
+/// request is validated against `writable_root` and `policy` via
+/// `check_write_path` before touching the filesystem.
+///
+/// The policy JSON is passed to the binary via the
+/// `KODA_FS_WORKER_POLICY` environment variable; the writable root
+/// is passed via `--root <path>`. [`crate::worker_client::WorkerClient`]
+/// handles both when spawning with [`crate::worker_client::WorkerClient::spawn_with_policy`].
+#[cfg(unix)]
+pub async fn run_unix_socket_with_policy(
+    path: &Path,
+    writable_root: PathBuf,
+    policy: SandboxPolicy,
+) -> Result<()> {
+    unix_socket_serve(path, Context::with_policy(writable_root, policy)).await
+}
+
+/// Shared Unix-socket bind/accept/serve logic.
+///
+/// Binds `path`, prints `"ready\n"` to stdout, accepts one connection,
+/// runs the dispatch loop with `ctx`. Kept private — callers pick the
+/// right context via the public wrappers above.
+#[cfg(unix)]
+async fn unix_socket_serve(path: &Path, ctx: Context) -> Result<()> {
     use std::io::Write as _;
     use tokio::net::UnixListener;
 
@@ -380,7 +411,7 @@ pub async fn run_unix_socket(path: &Path) -> Result<()> {
 
     let (stream, _addr) = listener.accept().await?;
     let (mut reader, mut writer) = tokio::io::split(stream);
-    run(&mut reader, &mut writer).await
+    run_with_ctx(&ctx, &mut reader, &mut writer).await
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -565,9 +596,8 @@ mod tests {
         let (host, worker) = duplex(65536);
         let (mut wr, mut ww) = tokio::io::split(worker);
         let policy = crate::policy::SandboxPolicy::default();
-        let join = tokio::spawn(async move {
-            run_with_policy(root, policy, &mut wr, &mut ww).await
-        });
+        let join =
+            tokio::spawn(async move { run_with_policy(root, policy, &mut wr, &mut ww).await });
         (host, join)
     }
 
@@ -576,14 +606,20 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("allowed.txt");
         let (mut host, _join) = spawn_worker_with_root(dir.path().to_path_buf());
-        write_message(&mut host, &Request::Write {
-            path: path.clone(),
-            content: b"ok".to_vec(),
-        })
+        write_message(
+            &mut host,
+            &Request::Write {
+                path: path.clone(),
+                content: b"ok".to_vec(),
+            },
+        )
         .await
         .unwrap();
         let resp: Response = read_message(&mut host).await.unwrap().unwrap();
-        assert!(matches!(resp, Response::Write { .. }), "expected Write ok, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Write { .. }),
+            "expected Write ok, got {resp:?}"
+        );
         assert_eq!(std::fs::read(&path).unwrap(), b"ok");
     }
 
@@ -593,15 +629,24 @@ mod tests {
         let outside = TempDir::new().unwrap();
         let path = outside.path().join("escape.txt");
         let (mut host, _join) = spawn_worker_with_root(root.path().to_path_buf());
-        write_message(&mut host, &Request::Write {
-            path,
-            content: b"evil".to_vec(),
-        })
+        write_message(
+            &mut host,
+            &Request::Write {
+                path,
+                content: b"evil".to_vec(),
+            },
+        )
         .await
         .unwrap();
         let resp: Response = read_message(&mut host).await.unwrap().unwrap();
         assert!(
-            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            matches!(
+                resp,
+                Response::Error {
+                    code: ErrorCode::PolicyDenied,
+                    ..
+                }
+            ),
             "expected PolicyDenied, got {resp:?}"
         );
     }
@@ -611,15 +656,24 @@ mod tests {
         let dir = TempDir::new().unwrap();
         // Even though root is set, /etc directly is always blocked.
         let (mut host, _join) = spawn_worker_with_root(dir.path().to_path_buf());
-        write_message(&mut host, &Request::Write {
-            path: PathBuf::from("/etc"),
-            content: b"evil".to_vec(),
-        })
+        write_message(
+            &mut host,
+            &Request::Write {
+                path: PathBuf::from("/etc"),
+                content: b"evil".to_vec(),
+            },
+        )
         .await
         .unwrap();
         let resp: Response = read_message(&mut host).await.unwrap().unwrap();
         assert!(
-            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            matches!(
+                resp,
+                Response::Error {
+                    code: ErrorCode::PolicyDenied,
+                    ..
+                }
+            ),
             "expected PolicyDenied, got {resp:?}"
         );
     }
@@ -635,15 +689,24 @@ mod tests {
 
         let through_link = link.join("secret.txt");
         let (mut host, _join) = spawn_worker_with_root(root.path().to_path_buf());
-        write_message(&mut host, &Request::Write {
-            path: through_link,
-            content: b"evil".to_vec(),
-        })
+        write_message(
+            &mut host,
+            &Request::Write {
+                path: through_link,
+                content: b"evil".to_vec(),
+            },
+        )
         .await
         .unwrap();
         let resp: Response = read_message(&mut host).await.unwrap().unwrap();
         assert!(
-            matches!(resp, Response::Error { code: ErrorCode::PolicyDenied, .. }),
+            matches!(
+                resp,
+                Response::Error {
+                    code: ErrorCode::PolicyDenied,
+                    ..
+                }
+            ),
             "symlink escape should be denied, got {resp:?}"
         );
     }

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -42,6 +42,7 @@
 
 use crate::fs::FsError;
 use crate::ipc::{Request, Response, read_message, write_message};
+use crate::policy::SandboxPolicy;
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -108,14 +109,41 @@ impl WorkerClient {
     /// Blocks the current async task for up to 5 seconds waiting for
     /// the worker to bind its socket and write "ready\n" to stdout.
     pub async fn spawn() -> Result<Self> {
+        Self::spawn_inner(None).await
+    }
+
+    /// Spawn a worker with write-policy enforcement.
+    ///
+    /// Passes `--root <writable_root>` and the serialized `policy`
+    /// (via `KODA_FS_WORKER_POLICY`) to the binary. Every `Write` and
+    /// `Edit` request will be validated against the root and policy
+    /// before touching the filesystem.
+    ///
+    /// Use this for production slots; use [`spawn`](Self::spawn) only
+    /// for tests and the `--no-sandbox` escape hatch.
+    pub async fn spawn_with_policy(writable_root: PathBuf, policy: &SandboxPolicy) -> Result<Self> {
+        Self::spawn_inner(Some((writable_root, policy))).await
+    }
+
+    /// Shared spawn logic. `policy_args` being `None` → no `--root`/policy env.
+    async fn spawn_inner(policy_args: Option<(PathBuf, &SandboxPolicy)>) -> Result<Self> {
         let socket_path = unique_socket_path();
         let bin = worker_binary()?;
 
-        let mut child = Command::new(&bin)
-            .arg("--socket")
+        let mut cmd = Command::new(&bin);
+        cmd.arg("--socket")
             .arg(&socket_path)
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit());
+
+        if let Some((ref root, policy)) = policy_args {
+            cmd.arg("--root").arg(root);
+            let policy_json =
+                serde_json::to_string(policy).context("serialize SandboxPolicy for worker env")?;
+            cmd.env("KODA_FS_WORKER_POLICY", policy_json);
+        }
+
+        let mut child = cmd
             .spawn()
             .with_context(|| format!("spawn {}", bin.display()))?;
 

--- a/koda-sandbox/tests/sandboxed_fs.rs
+++ b/koda-sandbox/tests/sandboxed_fs.rs
@@ -145,4 +145,109 @@ mod unix {
             .expect_err("must fail");
         assert!(matches!(err, FsError::Io(_)));
     }
+
+    // ── Phase 2f: spawn_with_policy integration ──────────────────────
+
+    #[tokio::test]
+    async fn spawn_with_policy_write_inside_root_succeeds() {
+        use koda_sandbox::ipc::{Request, Response};
+        use koda_sandbox::policy::SandboxPolicy;
+
+        let root = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+        let path = canonical_root.join("allowed.txt");
+
+        let mut client =
+            WorkerClient::spawn_with_policy(canonical_root.clone(), &SandboxPolicy::default())
+                .await
+                .expect("spawn_with_policy");
+
+        let resp = client
+            .request(&Request::Write {
+                path: path.clone(),
+                content: b"policy ok".to_vec(),
+            })
+            .await
+            .expect("request");
+
+        assert!(
+            matches!(resp, Response::Write { .. }),
+            "expected Write ok, got {resp:?}"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"policy ok");
+    }
+
+    #[tokio::test]
+    async fn spawn_with_policy_write_outside_root_is_denied() {
+        use koda_sandbox::ipc::{ErrorCode, Request, Response};
+        use koda_sandbox::policy::SandboxPolicy;
+
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+        let path = std::fs::canonicalize(outside.path())
+            .unwrap()
+            .join("escape.txt");
+
+        let mut client = WorkerClient::spawn_with_policy(canonical_root, &SandboxPolicy::default())
+            .await
+            .expect("spawn_with_policy");
+
+        let resp = client
+            .request(&Request::Write {
+                path,
+                content: b"evil".to_vec(),
+            })
+            .await
+            .expect("request");
+
+        assert!(
+            matches!(
+                resp,
+                Response::Error {
+                    code: ErrorCode::PolicyDenied,
+                    ..
+                }
+            ),
+            "expected PolicyDenied, got {resp:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_with_policy_symlink_escape_is_denied() {
+        use koda_sandbox::ipc::{ErrorCode, Request, Response};
+        use koda_sandbox::policy::SandboxPolicy;
+
+        let root = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+        let canonical_outside = std::fs::canonicalize(outside.path()).unwrap();
+
+        // Symlink inside root pointing outside.
+        let link = canonical_root.join("escape_link");
+        std::os::unix::fs::symlink(&canonical_outside, &link).unwrap();
+
+        let mut client = WorkerClient::spawn_with_policy(canonical_root, &SandboxPolicy::default())
+            .await
+            .expect("spawn_with_policy");
+
+        let resp = client
+            .request(&Request::Write {
+                path: link.join("secret.txt"),
+                content: b"evil".to_vec(),
+            })
+            .await
+            .expect("request");
+
+        assert!(
+            matches!(
+                resp,
+                Response::Error {
+                    code: ErrorCode::PolicyDenied,
+                    ..
+                }
+            ),
+            "symlink escape should be denied, got {resp:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Phase 2f of [#934](https://github.com/lijunzh/koda/issues/934) — application-layer path hardening that closes the symlink-escape, dangling-symlink TOCTOU, and catastrophic-deletion attack classes.

Modelled closely on Claude Code's `fsOperations.ts` / `permissions/filesystem.ts`. Neither Codex nor Gemini CLI implement this at the app layer (they rely solely on the OS sandbox), so CC is the reference.

---

## What's in

### New module: `koda-sandbox/src/path_defense.rs`

Five pure, total, sync functions (no panics, no blocking in async):

| Rust | CC equivalent |
|---|---|
| `find_symlink_in_path` | implicit in `safeResolvePath` lstat loop |
| `resolve_deepest_existing_ancestor` | `resolveDeepestExistingAncestorSync` |
| `paths_for_write_check` | `getPathsForPermissionCheck` |
| `is_path_inside` | `pathInWorkingPath` |
| `is_dangerous_system_path` | `isDangerousRemovalPath` |

`is_dangerous_system_path` is an exact port of CC's logic: blocks `/`, `$HOME`, and **any direct child of `/`** (e.g. `/usr`, `/etc`, `/var`) — but **not** grandchildren like `/usr/local` or `/var/tmp/work`.

### `worker.rs` — policy-bearing Context + enforcement gate

- `Context` gains `writable_root: Option<PathBuf>` + `policy: SandboxPolicy`
- `check_write_path()` validates every `Write`/`Edit` through 3 layers:
  1. Absolute deny (koda credential DB via `is_fully_denied`)
  2. Dangerous-system-path guard (non-overridable)
  3. Full symlink-chain expansion via `paths_for_write_check` + root-containment check with `allow_write` / `deny_write_within_allow` overrides
- `canonicalize_for_check()` handles macOS `/var → /private/var` for not-yet-existing paths (new file writes where `canonicalize` would ENOENT)
- `run_with_policy(root, policy, reader, writer)` — public entry point
- `run_unix_socket_with_policy(path, root, policy)` — production Unix-socket entry; shared `unix_socket_serve` helper keeps the bind/accept logic DRY

### `koda-fs-worker` binary — `--root` flag + policy env var

- Parses `--root <path>` alongside `--socket <path>`
- Reads `KODA_FS_WORKER_POLICY` (JSON `SandboxPolicy`)
- Calls `run_unix_socket_with_policy` when `--root` is present; falls back to `run_unix_socket` for legacy callers (zero behavior change)

### `worker_client.rs` — `spawn_with_policy`

- `WorkerClient::spawn_with_policy(root, policy)` spawns the binary with `--root` and sets `KODA_FS_WORKER_POLICY=<json>`
- `spawn()` delegates to `spawn_inner(None)` — no behavior change for existing callers

---

## Attack classes closed

| Attack | Mechanism | Where blocked |
|---|---|---|
| Symlink escape | `./evil.txt → /etc/passwd` | `paths_for_write_check` expands full chain; every hop checked |
| Dangling-symlink TOCTOU | `./uploads/ → /var/www/` (dir not yet created) | `resolve_deepest_existing_ancestor` walks up to real ancestor |
| Catastrophic deletion | `rm -rf /usr` | `is_dangerous_system_path` — direct-child-of-root rule, non-overridable |
| macOS `/tmp` symlink | `/var → /private/var` desync | `canonicalize_for_check` resolves existing ancestor before comparison |

---

## Tests: 150 passing (↑ from 127 pre-2f)

| Suite | New | Total |
|---|---|---|
| Unit (`--lib`) | +4 | 131 |
| Integration `sandboxed_fs` | +3 | 13 |

New E2E tests exercise the full `spawn_with_policy → binary → run_unix_socket_with_policy → check_write_path` stack across a real OS process boundary:
- `spawn_with_policy_write_inside_root_succeeds`
- `spawn_with_policy_write_outside_root_is_denied`
- `spawn_with_policy_symlink_escape_is_denied`

---

## Explicitly out of scope (YAGNI)

- Rename/move seatbelt rules — neither CC nor Gemini add explicit `file-write-rename-*` rules; `deny file-write*` covers it
- `Delete` enforcement — no `Delete` IPC type exists yet
- Network egress — Phase 3