### PR TITLE
koda-sandbox: Phase 3a — external egress proxy + env-var bouquet (foundation for #934 Phase 3)

### DIFF
--- a/koda-sandbox/src/ipc.rs
+++ b/koda-sandbox/src/ipc.rs
@@ -117,6 +117,20 @@ pub enum Request {
         /// Absolute path to stat.
         path: PathBuf,
     },
+
+    /// Read one or more environment variables from the worker's process
+    /// environment.
+    ///
+    /// Phase 3a uses this to verify that proxy env vars (`HTTPS_PROXY`,
+    /// `SSL_CERT_FILE`, etc.) were piped into the worker subprocess. There
+    /// are no security implications — the caller already controls what
+    /// env vars the worker sees, so reading them back is just a mirror.
+    /// Useful for tests and for debugging proxy plumbing in production.
+    GetEnv {
+        /// Variable names to look up. Missing vars are reported as `None`
+        /// in the response, not as an error.
+        names: Vec<String>,
+    },
 }
 
 /// Worker → host message. Always matches the kind of the originating
@@ -166,6 +180,13 @@ pub enum Response {
         is_dir: bool,
         /// True if the path itself is a symlink (not its target).
         is_symlink: bool,
+    },
+
+    /// Reply to [`Request::GetEnv`].
+    GetEnv {
+        /// Same order as the request `names`. `None` means the variable
+        /// was unset (distinguished from empty-string).
+        values: Vec<Option<String>>,
     },
 
     /// Anything that didn't go right — policy denial, IO error,

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -38,6 +38,7 @@ pub mod monitor;
 pub mod path_defense;
 pub mod policy;
 pub mod policy_check;
+pub mod proxy;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;
 pub mod violations;
@@ -55,6 +56,10 @@ pub use policy::{
     TrustPreference,
 };
 pub use policy_check::is_fully_denied;
+pub use proxy::{
+    DEFAULT_NO_PROXY, ExternalProxy, PROXY_PORT_ENV_KEY, ProxyHandle, ca_bundle_for_policy,
+    proxy_env_vars,
+};
 pub use violations::{
     DEFAULT_RING_CAPACITY, SandboxViolationStore, Violation, ViolationKind, global_store,
     render_block,

--- a/koda-sandbox/src/proxy.rs
+++ b/koda-sandbox/src/proxy.rs
@@ -1,0 +1,447 @@
+//! External egress proxy management (Phase 3a of #934).
+//!
+//! ## What this module does
+//!
+//! Phase 3a delivers the *enforcement layer* for network egress:
+//!
+//! 1. **Env-var bouquet** — the standard list of variables (`HTTPS_PROXY`,
+//!    `SSL_CERT_FILE`, etc.) that a sandboxed subprocess needs so well-behaved
+//!    HTTP clients (curl, gh, npm, pip, cargo, go, node, python) route their
+//!    traffic through a single hop. See [`proxy_env_vars`].
+//!
+//! 2. **External proxy lifecycle** — spawn a user-provided proxy command
+//!    (mitmproxy, Squid, Zscaler agent, anything that speaks HTTP CONNECT),
+//!    wait for it to bind, kill it cleanly on drop. See [`ExternalProxy`]
+//!    and [`ProxyHandle`].
+//!
+//! Phase 3b will add a built-in proxy that implements the *policy layer*
+//! (domain allowlist filtering). Both modes plug into the same env-var
+//! bouquet — applications can't tell whether they're talking to our proxy
+//! or the user's.
+//!
+//! ## Why support an external proxy at all?
+//!
+//! Three concrete user populations:
+//!
+//! - **Corporate MITM environments** (Zscaler, Bluecoat, Palo Alto) already
+//!   have a proxy doing TLS interception with a corporate CA. Stacking our
+//!   proxy on top would create fragile double-MITM chains.
+//! - **`mitmproxy` debuggers** want to inspect their agent's traffic without
+//!   a second proxy in the way.
+//! - **Air-gapped / homelab users** with Squid or Artifactory pull-through
+//!   already have egress infrastructure.
+//!
+//! Mirrors what Codex does (chain to upstream via `HTTPS_PROXY`) and what
+//! Gemini CLI does (`GEMINI_SANDBOX_PROXY_COMMAND` external-only).
+//!
+//! ## Fail-open semantics
+//!
+//! [`ExternalProxy::spawn`] returns `Err` when the proxy can't be started.
+//! Callers are expected to **warn and continue without restrictions** rather
+//! than fail the session — same pattern as Claude Code's `upstreamproxy`. A
+//! broken proxy must never break an otherwise-working session.
+
+use anyhow::{Context, Result, bail};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio::process::{Child, Command};
+use tokio::time::{Instant, sleep};
+use tracing::{debug, warn};
+
+// ── Env-var bouquet ──────────────────────────────────────────────────────────
+
+/// Default `NO_PROXY` value: loopback + RFC1918 + AWS/GCE IMDS.
+///
+/// Borrowed verbatim from Claude Code's `upstreamproxy.ts` `NO_PROXY_LIST`
+/// (which itself mirrors the Bun/curl/Go/Python intersection of supported
+/// patterns). These are the addresses every reasonable proxy declines to
+/// intercept — without them, sandboxed processes can't talk to localhost
+/// dev servers, can't read instance metadata, and can't reach RFC1918
+/// services on the user's LAN.
+pub const DEFAULT_NO_PROXY: &str =
+    "localhost,127.0.0.1,::1,169.254.0.0/16,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16";
+
+/// Env-var name passed to a user proxy command so it knows which port to bind.
+///
+/// Mirrors Codex's `PROXY_ACTIVE_ENV_KEY` pattern. Avoids template-string
+/// parsing and lets the proxy command be a plain `Vec<String>`.
+pub const PROXY_PORT_ENV_KEY: &str = "KODA_PROXY_PORT";
+
+/// Generate the env-var bouquet for a sandboxed subprocess.
+///
+/// `port` is where the proxy is listening on `127.0.0.1`. `ca_bundle` is
+/// the path to a PEM bundle the subprocess should trust for TLS verification
+/// — typically points to a corporate CA + system CA concatenation. When
+/// `None`, the cert-bundle vars are omitted (the subprocess uses its
+/// platform default trust store).
+///
+/// Returned as `Vec<(String, String)>` so the caller can `.envs(...)` it
+/// directly into a `Command` builder. Sorted by key for deterministic
+/// snapshot tests.
+///
+/// ## Why so many keys?
+///
+/// Different runtimes look at different env vars:
+///
+/// | Runtime | Proxy var | CA bundle var |
+/// |---|---|---|
+/// | curl, libcurl | `HTTPS_PROXY` (UPPER) | `CURL_CA_BUNDLE` |
+/// | Python `requests` | `HTTPS_PROXY` (UPPER) | `REQUESTS_CA_BUNDLE` |
+/// | Python `httpx`, `urllib` | `https_proxy` (lower) | `SSL_CERT_FILE` |
+/// | Node.js (undici) | `HTTPS_PROXY` (UPPER) | `NODE_EXTRA_CA_CERTS` |
+/// | Go (`net/http`) | `HTTPS_PROXY` (UPPER) | `SSL_CERT_FILE` |
+/// | Rust (`reqwest`) | `HTTPS_PROXY` (UPPER) | `SSL_CERT_FILE` |
+///
+/// Setting all of them is the only way to cover every dev tool without
+/// per-tool wrappers.
+pub fn proxy_env_vars(port: u16, ca_bundle: Option<&Path>) -> Vec<(String, String)> {
+    let proxy_url = format!("http://127.0.0.1:{port}");
+
+    let mut vars = vec![
+        ("HTTPS_PROXY".to_string(), proxy_url.clone()),
+        ("https_proxy".to_string(), proxy_url.clone()),
+        ("HTTP_PROXY".to_string(), proxy_url.clone()),
+        ("http_proxy".to_string(), proxy_url),
+        ("NO_PROXY".to_string(), DEFAULT_NO_PROXY.to_string()),
+        ("no_proxy".to_string(), DEFAULT_NO_PROXY.to_string()),
+    ];
+
+    if let Some(ca) = ca_bundle {
+        let ca_str = ca.to_string_lossy().to_string();
+        vars.push(("SSL_CERT_FILE".to_string(), ca_str.clone()));
+        vars.push(("NODE_EXTRA_CA_CERTS".to_string(), ca_str.clone()));
+        vars.push(("REQUESTS_CA_BUNDLE".to_string(), ca_str.clone()));
+        vars.push(("CURL_CA_BUNDLE".to_string(), ca_str));
+    }
+
+    // Deterministic order for snapshot tests.
+    vars.sort_by(|a, b| a.0.cmp(&b.0));
+    vars
+}
+
+// ── ExternalProxy / ProxyHandle ──────────────────────────────────────────────
+
+/// Spec for a user-provided egress proxy.
+///
+/// The proxy must:
+/// - Bind on `127.0.0.1:$KODA_PROXY_PORT` (port supplied via env var; see
+///   [`PROXY_PORT_ENV_KEY`]).
+/// - Speak HTTP CONNECT on that port.
+/// - Stay running until killed.
+///
+/// Use [`ExternalProxy::spawn`] to start one.
+#[derive(Debug, Clone)]
+pub struct ExternalProxy {
+    /// Argv. The first element is the program; the rest are arguments.
+    /// `KODA_PROXY_PORT` is injected into the env, not interpolated into args
+    /// — proxies that need it on the command line should reference the env
+    /// var via shell or accept a `--port` flag from their own wrapper script.
+    pub command: Vec<String>,
+
+    /// Extra env vars for the proxy process itself (not for sandboxed
+    /// subprocesses — those get the bouquet from [`proxy_env_vars`]).
+    pub env: HashMap<String, String>,
+
+    /// Bind port. `None` selects an ephemeral port.
+    ///
+    /// ## Why explicit port support
+    ///
+    /// Some proxy implementations (notably `mitmdump`'s default config and
+    /// many corporate Zscaler agents) require a fixed port advertised to
+    /// other infrastructure. Ephemeral is the safer default.
+    pub port: Option<u16>,
+
+    /// Maximum time to wait for the proxy to bind. Default 5 s (matches CC's
+    /// CA-fetch timeout — generous for local startup, snappy enough that a
+    /// hung proxy doesn't block the whole session).
+    pub startup_timeout: Duration,
+}
+
+impl ExternalProxy {
+    /// Construct with sensible defaults. `command[0]` is the program.
+    pub fn new<S: Into<String>>(command: impl IntoIterator<Item = S>) -> Self {
+        Self {
+            command: command.into_iter().map(Into::into).collect(),
+            env: HashMap::new(),
+            port: None,
+            startup_timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Spawn the proxy and wait for it to bind.
+    ///
+    /// Returns a [`ProxyHandle`] whose `Drop` impl SIGTERMs the child. On
+    /// failure (bad command, bind timeout, etc.), the caller should `warn!`
+    /// and continue **without** routing traffic through anything — that's
+    /// the fail-open contract.
+    pub async fn spawn(&self) -> Result<ProxyHandle> {
+        if self.command.is_empty() {
+            bail!("ExternalProxy::command must not be empty");
+        }
+
+        // Reserve a port up front. Binding it ourselves and then immediately
+        // dropping the listener would race with the proxy binding; so we just
+        // pick one if unspecified and trust the proxy to grab it.
+        let port = match self.port {
+            Some(p) => p,
+            None => pick_ephemeral_port().context("pick ephemeral port for proxy")?,
+        };
+
+        let mut cmd = Command::new(&self.command[0]);
+        cmd.args(&self.command[1..]);
+        cmd.env(PROXY_PORT_ENV_KEY, port.to_string());
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+        // Detach stdin so the proxy can't read from our terminal.
+        cmd.stdin(std::process::Stdio::null());
+
+        let child = cmd
+            .spawn()
+            .with_context(|| format!("spawn external proxy: {:?}", self.command))?;
+
+        debug!(
+            "external proxy spawned: cmd={:?} port={} pid={:?}",
+            self.command,
+            port,
+            child.id()
+        );
+
+        // Poll the port until it accepts a connection or we time out.
+        wait_for_bind(port, self.startup_timeout)
+            .await
+            .with_context(|| format!("external proxy did not bind 127.0.0.1:{port}"))?;
+
+        Ok(ProxyHandle { port, child: Some(child) })
+    }
+}
+
+/// Live external proxy. Drop sends SIGTERM and reaps the child.
+///
+/// Held for the lifetime of the sandboxed session. Cloning is intentionally
+/// not supported — only one owner SIGTERMs the child.
+#[derive(Debug)]
+pub struct ProxyHandle {
+    /// Port the proxy is listening on (`127.0.0.1:port`).
+    pub port: u16,
+    child: Option<Child>,
+}
+
+impl ProxyHandle {
+    /// Path to a CA bundle the proxy expects clients to trust, if any.
+    ///
+    /// Phase 3a doesn't track this — the bundle path comes from
+    /// [`crate::policy::MitmConfig::ca_bundle`] on the policy side. This
+    /// method exists so 3b can attach a built-in-proxy-generated CA without
+    /// changing the public API.
+    pub fn ca_bundle(&self) -> Option<&Path> {
+        None
+    }
+
+    /// Synchronous shutdown: SIGTERM + brief wait. Idempotent.
+    ///
+    /// Called from `Drop`; exposed so callers can shut down before drop and
+    /// surface errors. After this returns, [`Self::ca_bundle`] is still
+    /// valid but the proxy no longer accepts connections.
+    pub fn shutdown(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            // start_kill is non-blocking; the OS reaps via tokio's wait task.
+            if let Err(e) = child.start_kill() {
+                warn!("external proxy SIGKILL failed: {e}");
+            }
+        }
+    }
+}
+
+impl Drop for ProxyHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Pick an unused port by binding `0` and immediately dropping. There's a
+/// classic TOCTOU hole here (another process could grab the port before the
+/// proxy does), but it's the same trick every test suite uses and the
+/// failure mode (proxy bind error) is caught downstream by `wait_for_bind`.
+fn pick_ephemeral_port() -> std::io::Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Poll `127.0.0.1:port` with TCP connects until success or timeout.
+async fn wait_for_bind(port: u16, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    let addr = format!("127.0.0.1:{port}");
+    let mut backoff = Duration::from_millis(20);
+
+    loop {
+        if TcpStream::connect(&addr).await.is_ok() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out after {timeout:?}");
+        }
+        sleep(backoff).await;
+        // Cap backoff at 200 ms so we still poll responsively but don't
+        // hammer the loopback stack.
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+}
+
+// ── Optional CA-bundle resolution helper ─────────────────────────────────────
+
+/// Path to the CA bundle to advertise via env vars, given a [`crate::policy::NetPolicy`].
+///
+/// Returns `None` when no MITM is configured — in that case the subprocess
+/// uses its platform default trust store. Returning `Option<&Path>` rather
+/// than `Option<PathBuf>` so callers can pass it directly to [`proxy_env_vars`]
+/// without intermediate allocation.
+pub fn ca_bundle_for_policy(net: &crate::policy::NetPolicy) -> Option<&Path> {
+    net.mitm.as_ref().map(|m| m.ca_bundle.as_path())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn proxy_env_vars_includes_all_six_proxy_keys() {
+        let vars = proxy_env_vars(8080, None);
+        let keys: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(keys.contains(&"HTTPS_PROXY"));
+        assert!(keys.contains(&"https_proxy"));
+        assert!(keys.contains(&"HTTP_PROXY"));
+        assert!(keys.contains(&"http_proxy"));
+        assert!(keys.contains(&"NO_PROXY"));
+        assert!(keys.contains(&"no_proxy"));
+    }
+
+    #[test]
+    fn proxy_env_vars_omits_ca_bundle_when_none() {
+        let vars = proxy_env_vars(8080, None);
+        let keys: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(!keys.contains(&"SSL_CERT_FILE"));
+        assert!(!keys.contains(&"NODE_EXTRA_CA_CERTS"));
+        assert!(!keys.contains(&"REQUESTS_CA_BUNDLE"));
+        assert!(!keys.contains(&"CURL_CA_BUNDLE"));
+    }
+
+    #[test]
+    fn proxy_env_vars_includes_all_four_ca_keys_when_some() {
+        let bundle = PathBuf::from("/etc/ssl/corp-ca.pem");
+        let vars = proxy_env_vars(8080, Some(&bundle));
+        let keys: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
+
+        assert!(keys.contains(&"SSL_CERT_FILE"));
+        assert!(keys.contains(&"NODE_EXTRA_CA_CERTS"));
+        assert!(keys.contains(&"REQUESTS_CA_BUNDLE"));
+        assert!(keys.contains(&"CURL_CA_BUNDLE"));
+
+        // All four point at the same path.
+        for key in [
+            "SSL_CERT_FILE",
+            "NODE_EXTRA_CA_CERTS",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+        ] {
+            let v = vars
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.as_str())
+                .unwrap();
+            assert_eq!(v, "/etc/ssl/corp-ca.pem");
+        }
+    }
+
+    #[test]
+    fn proxy_url_format_uses_loopback_ipv4() {
+        let vars = proxy_env_vars(31415, None);
+        let url = vars
+            .iter()
+            .find(|(k, _)| k == "HTTPS_PROXY")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(url, "http://127.0.0.1:31415");
+    }
+
+    #[test]
+    fn no_proxy_default_covers_loopback_and_rfc1918() {
+        // Sanity check that we haven't accidentally truncated the constant.
+        assert!(DEFAULT_NO_PROXY.contains("127.0.0.1"));
+        assert!(DEFAULT_NO_PROXY.contains("::1"));
+        assert!(DEFAULT_NO_PROXY.contains("10.0.0.0/8"));
+        assert!(DEFAULT_NO_PROXY.contains("172.16.0.0/12"));
+        assert!(DEFAULT_NO_PROXY.contains("192.168.0.0/16"));
+        // AWS / GCE IMDS link-local: dropping this would prevent cloud
+        // workloads from reading instance metadata.
+        assert!(DEFAULT_NO_PROXY.contains("169.254.0.0/16"));
+    }
+
+    #[test]
+    fn ca_bundle_for_policy_handles_no_mitm() {
+        let policy = crate::policy::NetPolicy::default();
+        assert!(ca_bundle_for_policy(&policy).is_none());
+    }
+
+    #[test]
+    fn ca_bundle_for_policy_returns_path_when_mitm_set() {
+        let policy = crate::policy::NetPolicy {
+            mitm: Some(crate::policy::MitmConfig {
+                ca_bundle: PathBuf::from("/x/ca.pem"),
+                socket_map: vec![],
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            ca_bundle_for_policy(&policy),
+            Some(Path::new("/x/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn external_proxy_new_sets_defaults() {
+        let p = ExternalProxy::new(["mitmdump", "--listen-port", "8877"]);
+        assert_eq!(p.command, vec!["mitmdump", "--listen-port", "8877"]);
+        assert!(p.env.is_empty());
+        assert!(p.port.is_none());
+        assert_eq!(p.startup_timeout, Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn external_proxy_empty_command_errors() {
+        let p = ExternalProxy {
+            command: vec![],
+            env: HashMap::new(),
+            port: None,
+            startup_timeout: Duration::from_millis(100),
+        };
+        let err = p.spawn().await.expect_err("must error on empty command");
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[tokio::test]
+    async fn external_proxy_unbound_command_times_out() {
+        // `true` (the unix command) exits immediately and never binds a port.
+        // Should fail with a "did not bind" context.
+        let p = ExternalProxy {
+            command: vec!["true".to_string()],
+            env: HashMap::new(),
+            port: None,
+            startup_timeout: Duration::from_millis(150),
+        };
+        let err = p.spawn().await.expect_err("must time out");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("did not bind"), "got: {msg}");
+    }
+}

--- a/koda-sandbox/src/proxy.rs
+++ b/koda-sandbox/src/proxy.rs
@@ -214,7 +214,10 @@ impl ExternalProxy {
             .await
             .with_context(|| format!("external proxy did not bind 127.0.0.1:{port}"))?;
 
-        Ok(ProxyHandle { port, child: Some(child) })
+        Ok(ProxyHandle {
+            port,
+            child: Some(child),
+        })
     }
 }
 
@@ -403,10 +406,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(
-            ca_bundle_for_policy(&policy),
-            Some(Path::new("/x/ca.pem"))
-        );
+        assert_eq!(ca_bundle_for_policy(&policy), Some(Path::new("/x/ca.pem")));
     }
 
     #[test]

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -114,10 +114,17 @@ pub(crate) fn home_path(home: &str, rel: &str) -> String {
 /// Build the seatbelt profile for the project-mode baseline.
 ///
 /// Strategy: deny-by-default (allowlist), then open reads everywhere and
-/// restrict writes to project + temp + cache dirs.  Network left
-/// unrestricted so `curl` / `cargo fetch` / `npm install` work without
-/// modification (Phase 3 adds the proxy-based egress filter).
-pub(crate) fn build_profile_string(root: &str, home: &str) -> String {
+/// restrict writes to project + temp + cache dirs. Network policy is
+/// pluggable via `network_rules` so the same baseline serves both the
+/// open-network mode (legacy) and the proxied mode (Phase 3a).
+///
+/// Use [`network_open_rules`] for the legacy behavior or
+/// [`network_proxied_rules`] for deny-by-default + single-port hole.
+pub(crate) fn build_profile_string_with_network(
+    root: &str,
+    home: &str,
+    network_rules: &str,
+) -> String {
     format!(
         "(version 1)\n\
          (deny default)\n\
@@ -133,13 +140,80 @@ pub(crate) fn build_profile_string(root: &str, home: &str) -> String {
            (literal \"/dev/stderr\")\n\
            (literal \"/dev/stdout\")\n\
            (literal \"/dev/urandom\"))\n\
-         (allow network*)\n\
+         {network_rules}\
          (allow process-exec*)\n\
          (allow process-fork)\n\
          (allow sysctl-read)\n\
          (allow ipc-posix*)\n\
          (allow mach*)\n"
     )
+}
+
+/// Build the seatbelt profile for the project-mode baseline (open network).
+///
+/// Strategy: deny-by-default (allowlist), then open reads everywhere and
+/// restrict writes to project + temp + cache dirs.  Network left
+/// unrestricted so `curl` / `cargo fetch` / `npm install` work without
+/// modification (Phase 3 adds the proxy-based egress filter).
+pub(crate) fn build_profile_string(root: &str, home: &str) -> String {
+    build_profile_string_with_network(root, home, &network_open_rules())
+}
+
+/// Network rules for the legacy unrestricted mode.
+///
+/// Equivalent to pre-Phase-3a behavior: every connect / bind / inbound is
+/// allowed.
+pub(crate) fn network_open_rules() -> String {
+    "(allow network*)\n".to_string()
+}
+
+/// Network rules for the Phase 3a proxied mode.
+///
+/// Deny-by-default network with these holes:
+///
+/// - **Outbound TCP to `127.0.0.1:{proxy_port}`** — the single egress hop.
+///   Every well-behaved HTTP client routed via [`crate::proxy::proxy_env_vars`]
+///   reaches the proxy through this rule.
+/// - **Outbound to Unix sockets** — git-over-ssh, ssh-agent, Docker socket
+///   (when bind-mounted), language servers. These never touch the network
+///   stack and the proxy can't intercept them anyway.
+/// - **Inbound on `localhost:*`** — debugger attach, Node `--inspect`, etc.
+///   Localhost-only, no security implication.
+/// - **Bind on `localhost:*`** — always allowed for the same reason.
+/// - **Bind on `*:*`** — only when `allow_local_binding` is true (user dev
+///   servers expecting external clients).
+///
+/// Pattern mirrors Gemini CLI's `sandbox-macos-strict-proxied.sb` plus the
+/// Unix-socket carve-out from Codex's seatbelt rules.
+pub fn network_proxied_rules(proxy_port: u16, allow_local_binding: bool) -> String {
+    let mut rules = String::new();
+    rules.push_str(&format!(
+        "(allow network-outbound (remote tcp \"127.0.0.1:{proxy_port}\"))\n"
+    ));
+    rules.push_str(&format!(
+        "(allow network-outbound (remote tcp \"localhost:{proxy_port}\"))\n"
+    ));
+    rules.push_str("(allow network-outbound (remote unix-socket))\n");
+    rules.push_str("(allow network-inbound (local ip \"localhost:*\"))\n");
+    rules.push_str("(allow network-bind (local ip \"localhost:*\"))\n");
+    if allow_local_binding {
+        rules.push_str("(allow network-bind (local ip \"*:*\"))\n");
+    }
+    rules
+}
+
+/// Build the seatbelt profile for the proxied egress mode (Phase 3a).
+///
+/// Same baseline as [`build_profile_string`] but with [`network_proxied_rules`]
+/// in place of the open-network allow.
+pub fn build_proxied_profile_string(
+    root: &str,
+    home: &str,
+    proxy_port: u16,
+    allow_local_binding: bool,
+) -> String {
+    let net = network_proxied_rules(proxy_port, allow_local_binding);
+    build_profile_string_with_network(root, home, &net)
 }
 
 /// Generate seatbelt deny-write rules for protected project subdirectories.
@@ -509,6 +583,91 @@ mod tests {
         assert!(
             credential_pos < overlay_pos,
             "policy overlay must come after credential rules"
+        );
+    }
+
+    // ── Phase 3a: proxied network rules ─────────────────────────────
+
+    #[test]
+    fn proxied_profile_omits_open_network_allow() {
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        assert!(
+            !p.contains("(allow network*)\n"),
+            "proxied profile must not include the open-network allow\nprofile:\n{p}"
+        );
+    }
+
+    #[test]
+    fn proxied_profile_allows_only_proxy_port_outbound_tcp() {
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        assert!(p.contains("(allow network-outbound (remote tcp \"127.0.0.1:8877\"))"));
+        assert!(p.contains("(allow network-outbound (remote tcp \"localhost:8877\"))"));
+        // No other tcp outbound rule should be present.
+        let count = p.matches("(allow network-outbound (remote tcp ").count();
+        assert_eq!(
+            count, 2,
+            "expected exactly the 127.0.0.1 + localhost outbound rules; profile:\n{p}"
+        );
+    }
+
+    #[test]
+    fn proxied_profile_always_allows_unix_socket_outbound() {
+        // git-over-ssh, ssh-agent, language servers, Docker.sock when
+        // bind-mounted — all need this. Codex's seatbelt has the same
+        // carve-out.
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        assert!(p.contains("(allow network-outbound (remote unix-socket))"));
+    }
+
+    #[test]
+    fn proxied_profile_allows_localhost_inbound_for_debuggers() {
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        assert!(p.contains("(allow network-inbound (local ip \"localhost:*\"))"));
+    }
+
+    #[test]
+    fn proxied_profile_omits_wildcard_bind_when_local_binding_disabled() {
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        // Localhost bind is always allowed; wildcard *:* must not be.
+        assert!(p.contains("(allow network-bind (local ip \"localhost:*\"))"));
+        assert!(
+            !p.contains("(allow network-bind (local ip \"*:*\"))"),
+            "wildcard bind must be gated on allow_local_binding"
+        );
+    }
+
+    #[test]
+    fn proxied_profile_includes_wildcard_bind_when_local_binding_enabled() {
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, true);
+        assert!(p.contains("(allow network-bind (local ip \"*:*\"))"));
+    }
+
+    #[test]
+    fn proxied_profile_keeps_baseline_file_writes_unchanged() {
+        // Regression guard: the proxied variant must only differ from the
+        // open variant in the network section. Same temp/cargo/npm/cache
+        // writes should still be present.
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        assert!(p.contains("(subpath \"/work\")"));
+        assert!(p.contains("(subpath \"/private/tmp\")"));
+        assert!(p.contains("(subpath \"/Users/x/.cargo\")"));
+        assert!(p.contains("(subpath \"/Users/x/.npm\")"));
+        assert!(p.contains("(subpath \"/Users/x/.cache\")"));
+    }
+
+    #[test]
+    fn proxied_and_open_differ_only_in_network_section() {
+        // DRY guard: confirm that build_profile_string and
+        // build_proxied_profile_string share the same baseline.
+        let open = build_profile_string("/work", "/Users/x");
+        let proxied = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+
+        // Both must end the same way (process-exec onward is identical).
+        let tail = "(allow process-exec*)\n(allow process-fork)\n(allow sysctl-read)\n(allow ipc-posix*)\n(allow mach*)\n";
+        assert!(open.ends_with(tail), "open profile tail mismatch:\n{open}");
+        assert!(
+            proxied.ends_with(tail),
+            "proxied profile tail mismatch:\n{proxied}"
         );
     }
 }

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -48,6 +48,41 @@ pub fn build_command(
     project_root: &Path,
     policy: &SandboxPolicy,
 ) -> Result<Command> {
+    build_command_inner(command, project_root, policy, None)
+}
+
+/// Build a sandboxed `sandbox-exec` command with proxied egress.
+///
+/// Same as [`build_command`] but uses [`build_proxied_profile_string`]
+/// instead of the open-network baseline: every TCP outbound is denied
+/// except connections to `127.0.0.1:proxy_port` (the egress proxy).
+/// Pair with [`crate::worker_client::WorkerClient::spawn_with_policy_and_proxy`] for
+/// matching env-var injection.
+///
+/// `allow_local_binding` corresponds to `policy.net.allow_local_binding`
+/// (when that field exists — today it's a hardcoded `false` until the
+/// `NetPolicy` schema gains the field). Pass `false` for the strict default.
+pub fn build_command_with_proxy(
+    command: &str,
+    project_root: &Path,
+    policy: &SandboxPolicy,
+    proxy_port: u16,
+    allow_local_binding: bool,
+) -> Result<Command> {
+    build_command_inner(
+        command,
+        project_root,
+        policy,
+        Some((proxy_port, allow_local_binding)),
+    )
+}
+
+fn build_command_inner(
+    command: &str,
+    project_root: &Path,
+    policy: &SandboxPolicy,
+    proxy: Option<(u16, bool)>,
+) -> Result<Command> {
     let canonical = project_root
         .canonicalize()
         .unwrap_or_else(|_| project_root.to_path_buf());
@@ -60,7 +95,12 @@ pub fn build_command(
     // Seatbelt evaluates rules in order; later rules win for the same path,
     // so the denies override the earlier broad `(allow file-read*)`.
     // Same last-match-wins approach as Gemini CLI's seatbeltArgsBuilder.ts.
-    let mut profile = build_profile_string(&root, &home);
+    let mut profile = match proxy {
+        Some((port, allow_local_binding)) => {
+            build_proxied_profile_string(&root, &home, port, allow_local_binding)
+        }
+        None => build_profile_string(&root, &home),
+    };
     profile.push_str(&protected_subdir_deny_rules(&root));
     profile.push_str(&credential_deny_rules(&home));
     profile.push_str(&policy_overlay_rules(policy)?);
@@ -204,7 +244,7 @@ pub fn network_proxied_rules(proxy_port: u16, allow_local_binding: bool) -> Stri
 
 /// Build the seatbelt profile for the proxied egress mode (Phase 3a).
 ///
-/// Same baseline as [`build_profile_string`] but with [`network_proxied_rules`]
+/// Same baseline as the open-network profile but with [`network_proxied_rules`]
 /// in place of the open-network allow.
 pub fn build_proxied_profile_string(
     root: &str,
@@ -669,5 +709,65 @@ mod tests {
             proxied.ends_with(tail),
             "proxied profile tail mismatch:\n{proxied}"
         );
+    }
+
+    #[test]
+    fn build_command_with_proxy_uses_proxied_profile() {
+        // End-to-end check: the public entry point must produce a profile
+        // that contains the proxy-port outbound rule and omits the
+        // open-network allow.
+        let cmd = build_command_with_proxy(
+            "true",
+            Path::new("/tmp"),
+            &SandboxPolicy::default(),
+            8877,
+            false,
+        )
+        .unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        // sandbox-exec layout: ["-p", <profile>, "sh", "-c", <cmd>]
+        let profile = &args[1];
+        assert!(profile.contains("127.0.0.1:8877"));
+        assert!(!profile.contains("(allow network*)\n"));
+    }
+
+    #[test]
+    fn build_command_without_proxy_keeps_open_network() {
+        // Regression guard: the no-proxy entry point must still produce
+        // the open-network profile (callers without a proxy should keep
+        // current behavior).
+        let cmd = build_command("true", Path::new("/tmp"), &SandboxPolicy::default()).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+        assert!(profile.contains("(allow network*)\n"));
+        assert!(!profile.contains("127.0.0.1:"));
+    }
+
+    #[test]
+    fn build_command_with_proxy_local_binding_propagates() {
+        // allow_local_binding=true should produce the wildcard bind rule.
+        let cmd = build_command_with_proxy(
+            "true",
+            Path::new("/tmp"),
+            &SandboxPolicy::default(),
+            8877,
+            true,
+        )
+        .unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+        assert!(profile.contains("(allow network-bind (local ip \"*:*\"))"));
     }
 }

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -332,6 +332,13 @@ async fn handle(ctx: &Context, req: Request) -> Response {
             },
             Err(e) => fs_err_to_resp(e),
         },
+        Request::GetEnv { names } => {
+            // No fs/policy check — the caller already controls what env vars
+            // we see, so this is a mirror, not a leak. Used by Phase 3a tests
+            // to verify proxy env-var injection across the process boundary.
+            let values = names.into_iter().map(|n| std::env::var(&n).ok()).collect();
+            Response::GetEnv { values }
+        }
     }
 }
 

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -43,6 +43,7 @@
 use crate::fs::FsError;
 use crate::ipc::{Request, Response, read_message, write_message};
 use crate::policy::SandboxPolicy;
+use crate::proxy::{ProxyHandle, ca_bundle_for_policy, proxy_env_vars};
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -109,7 +110,7 @@ impl WorkerClient {
     /// Blocks the current async task for up to 5 seconds waiting for
     /// the worker to bind its socket and write "ready\n" to stdout.
     pub async fn spawn() -> Result<Self> {
-        Self::spawn_inner(None).await
+        Self::spawn_inner(None, None).await
     }
 
     /// Spawn a worker with write-policy enforcement.
@@ -122,11 +123,47 @@ impl WorkerClient {
     /// Use this for production slots; use [`spawn`](Self::spawn) only
     /// for tests and the `--no-sandbox` escape hatch.
     pub async fn spawn_with_policy(writable_root: PathBuf, policy: &SandboxPolicy) -> Result<Self> {
-        Self::spawn_inner(Some((writable_root, policy))).await
+        Self::spawn_inner(Some((writable_root, policy)), None).await
+    }
+
+    /// Spawn a worker with write-policy enforcement *and* proxy env injection.
+    ///
+    /// Same as [`spawn_with_policy`](Self::spawn_with_policy), plus pipes the
+    /// proxy env-var bouquet (see [`crate::proxy::proxy_env_vars`]) into the
+    /// worker subprocess so anything *it* execs (e.g. via `Bash` tool) inherits
+    /// `HTTPS_PROXY` and friends.
+    ///
+    /// `proxy` may be `None` — then this is exactly equivalent to
+    /// [`spawn_with_policy`](Self::spawn_with_policy). The CA-bundle path is sourced from
+    /// `policy.net.mitm.ca_bundle` (if any).
+    ///
+    /// ## Fail-open caller pattern
+    ///
+    /// If `proxy` is `None` because the user's external proxy failed to
+    /// start, callers should `warn!` and proceed — the worker still works,
+    /// just without egress restrictions. See [`crate::proxy::ExternalProxy::spawn`]
+    /// docs for the full contract.
+    pub async fn spawn_with_policy_and_proxy(
+        writable_root: PathBuf,
+        policy: &SandboxPolicy,
+        proxy: Option<&ProxyHandle>,
+    ) -> Result<Self> {
+        let env = proxy.map(|p| {
+            // CA bundle preference: explicit `ProxyHandle::ca_bundle()` (3b
+            // built-in proxy will set this) wins over the policy.
+            let ca = p.ca_bundle().or_else(|| ca_bundle_for_policy(&policy.net));
+            proxy_env_vars(p.port, ca)
+        });
+        Self::spawn_inner(Some((writable_root, policy)), env).await
     }
 
     /// Shared spawn logic. `policy_args` being `None` → no `--root`/policy env.
-    async fn spawn_inner(policy_args: Option<(PathBuf, &SandboxPolicy)>) -> Result<Self> {
+    /// `extra_env`, when `Some`, is appended to the worker's process env
+    /// (used by Phase 3a to inject the proxy bouquet).
+    async fn spawn_inner(
+        policy_args: Option<(PathBuf, &SandboxPolicy)>,
+        extra_env: Option<Vec<(String, String)>>,
+    ) -> Result<Self> {
         let socket_path = unique_socket_path();
         let bin = worker_binary()?;
 
@@ -141,6 +178,10 @@ impl WorkerClient {
             let policy_json =
                 serde_json::to_string(policy).context("serialize SandboxPolicy for worker env")?;
             cmd.env("KODA_FS_WORKER_POLICY", policy_json);
+        }
+
+        if let Some(env) = extra_env {
+            cmd.envs(env);
         }
 
         let mut child = cmd

--- a/koda-sandbox/tests/sandboxed_fs.rs
+++ b/koda-sandbox/tests/sandboxed_fs.rs
@@ -250,4 +250,218 @@ mod unix {
             "symlink escape should be denied, got {resp:?}"
         );
     }
+
+    // ── Phase 3a: spawn_with_policy_and_proxy integration ──────────────
+
+    /// Build the netcat listen-in-background command we use as a stand-in
+    /// for a real proxy. macOS BSD `nc` and Linux netcat-openbsd both
+    /// accept `-l -k <port>` (-k = stay alive across multiple connections,
+    /// otherwise BSD nc one-shots and the wait_for_bind poll races to
+    /// connect before nc exits).
+    fn netcat_listen_command(port: u16) -> Vec<String> {
+        vec![
+            "nc".to_string(),
+            "-l".to_string(),
+            "-k".to_string(),
+            port.to_string(),
+        ]
+    }
+
+    #[tokio::test]
+    async fn spawn_with_policy_and_proxy_injects_env_vars() {
+        use koda_sandbox::ipc::{Request, Response};
+        use koda_sandbox::policy::SandboxPolicy;
+        use koda_sandbox::proxy::{DEFAULT_NO_PROXY, ExternalProxy};
+
+        let root = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+
+        // Spawn a fake proxy via ExternalProxy + nc. nc may not be installed
+        // everywhere; skip the test if spawn fails for that reason.
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let p = l.local_addr().unwrap().port();
+            drop(l);
+            p
+        };
+        let proxy_spec = ExternalProxy {
+            command: netcat_listen_command(port),
+            env: Default::default(),
+            port: Some(port),
+            startup_timeout: std::time::Duration::from_secs(2),
+        };
+        let proxy = match proxy_spec.spawn().await {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping: nc unavailable or failed to bind: {e:#}");
+                return;
+            }
+        };
+
+        let mut client = WorkerClient::spawn_with_policy_and_proxy(
+            canonical_root,
+            &SandboxPolicy::default(),
+            Some(&proxy),
+        )
+        .await
+        .expect("spawn_with_policy_and_proxy");
+
+        let resp = client
+            .request(&Request::GetEnv {
+                names: vec![
+                    "HTTPS_PROXY".into(),
+                    "https_proxy".into(),
+                    "HTTP_PROXY".into(),
+                    "NO_PROXY".into(),
+                    "SSL_CERT_FILE".into(), // None: no MITM configured
+                ],
+            })
+            .await
+            .expect("GetEnv request");
+
+        let values = match resp {
+            Response::GetEnv { values } => values,
+            other => panic!("expected GetEnv response, got {other:?}"),
+        };
+        assert_eq!(
+            values[0].as_deref(),
+            Some(format!("http://127.0.0.1:{port}").as_str())
+        );
+        assert_eq!(
+            values[1].as_deref(),
+            Some(format!("http://127.0.0.1:{port}").as_str())
+        );
+        assert_eq!(
+            values[2].as_deref(),
+            Some(format!("http://127.0.0.1:{port}").as_str())
+        );
+        assert_eq!(values[3].as_deref(), Some(DEFAULT_NO_PROXY));
+        // SSL_CERT_FILE must not be injected by *us* when policy.net.mitm
+        // is None. We can only assert this if the host doesn't already
+        // have it set — e.g. Ubuntu CI runners ship with SSL_CERT_FILE
+        // pointing at /etc/ssl/certs/ca-certificates.crt, which the worker
+        // inherits through normal subprocess env propagation.
+        if std::env::var("SSL_CERT_FILE").is_err() {
+            assert_eq!(
+                values[4], None,
+                "SSL_CERT_FILE must be unset when policy.net.mitm is None"
+            );
+        } else {
+            // Host had it set — verify we didn't *override* it with our own
+            // path (which would only happen with a CA bundle in policy).
+            assert_eq!(
+                values[4],
+                std::env::var("SSL_CERT_FILE").ok(),
+                "SSL_CERT_FILE must be the host's value, not overridden"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_with_policy_and_proxy_injects_ca_bundle_when_mitm_set() {
+        use koda_sandbox::ipc::{Request, Response};
+        use koda_sandbox::policy::{MitmConfig, NetPolicy, SandboxPolicy};
+        use koda_sandbox::proxy::ExternalProxy;
+        use std::path::PathBuf;
+
+        let root = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+
+        let port = {
+            let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let p = l.local_addr().unwrap().port();
+            drop(l);
+            p
+        };
+        let proxy_spec = ExternalProxy {
+            command: netcat_listen_command(port),
+            env: Default::default(),
+            port: Some(port),
+            startup_timeout: std::time::Duration::from_secs(2),
+        };
+        let proxy = match proxy_spec.spawn().await {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping: nc unavailable or failed to bind: {e:#}");
+                return;
+            }
+        };
+
+        let policy = SandboxPolicy {
+            net: NetPolicy {
+                mitm: Some(MitmConfig {
+                    ca_bundle: PathBuf::from("/etc/ssl/corp-ca.pem"),
+                    socket_map: vec![],
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut client =
+            WorkerClient::spawn_with_policy_and_proxy(canonical_root, &policy, Some(&proxy))
+                .await
+                .expect("spawn_with_policy_and_proxy");
+
+        let resp = client
+            .request(&Request::GetEnv {
+                names: vec![
+                    "SSL_CERT_FILE".into(),
+                    "NODE_EXTRA_CA_CERTS".into(),
+                    "REQUESTS_CA_BUNDLE".into(),
+                    "CURL_CA_BUNDLE".into(),
+                ],
+            })
+            .await
+            .expect("GetEnv request");
+
+        let values = match resp {
+            Response::GetEnv { values } => values,
+            other => panic!("expected GetEnv response, got {other:?}"),
+        };
+        for (i, v) in values.iter().enumerate() {
+            assert_eq!(
+                v.as_deref(),
+                Some("/etc/ssl/corp-ca.pem"),
+                "index {i} should be the CA bundle path"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_with_policy_and_proxy_none_omits_env_vars() {
+        use koda_sandbox::ipc::{Request, Response};
+        use koda_sandbox::policy::SandboxPolicy;
+
+        let root = TempDir::new().unwrap();
+        let canonical_root = std::fs::canonicalize(root.path()).unwrap();
+
+        let mut client = WorkerClient::spawn_with_policy_and_proxy(
+            canonical_root,
+            &SandboxPolicy::default(),
+            None,
+        )
+        .await
+        .expect("spawn_with_policy_and_proxy");
+
+        let resp = client
+            .request(&Request::GetEnv {
+                names: vec!["HTTPS_PROXY".into(), "NO_PROXY".into()],
+            })
+            .await
+            .expect("GetEnv request");
+
+        let values = match resp {
+            Response::GetEnv { values } => values,
+            other => panic!("expected GetEnv response, got {other:?}"),
+        };
+        // proxy=None must not inherit the host's HTTPS_PROXY either — we
+        // only inject what we explicitly set. But std::env::var on the worker
+        // side reads the worker's environment, which inherits ours. So this
+        // assertion is conditional: skip if the host already had HTTPS_PROXY
+        // set (e.g. behind a corp proxy at test time).
+        if std::env::var("HTTPS_PROXY").is_err() {
+            assert_eq!(values[0], None, "HTTPS_PROXY must not be injected");
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Foundation for Phase 3 of #934 (network egress proxy). Lays down four
building blocks in `koda-sandbox`: the env-var bouquet, external-proxy
lifecycle, seatbelt proxied-network profile, and the
`WorkerClient`/`build_command` entry points that wire them together.

**No `koda-core` integration yet** — every new symbol is dead code at
the workspace level. That's intentional: 3b will add the in-process
proxy + hostname allowlist + bwrap (Linux) + the `koda-core` slot
manager that actually instantiates this stuff. Marking draft so the
API shape can be sanity-checked before 3b builds on it.

Part of #934.

## Changes

Four atomic commits, each with self-contained tests:

1. **`proxy` module** (`koda-sandbox/src/proxy.rs`): `proxy_env_vars`
   bouquet (6 proxy + 4 CA-bundle env vars covering
   curl/gh/npm/pip/cargo/go/node/python), `DEFAULT_NO_PROXY` (loopback
   + RFC1918 + IMDS), `ExternalProxy::spawn` / `ProxyHandle` lifecycle
   with bind-poll + Drop SIGTERM.
2. **Seatbelt proxied profile** (`koda-sandbox/src/seatbelt.rs`):
   `network_proxied_rules(port, allow_local_binding)` —
   deny-by-default network with single-port hole + Unix-socket
   carve-out (git-over-ssh, ssh-agent, language servers) + localhost
   in/bind for debuggers. Refactored existing baseline to share via
   `build_profile_string_with_network` (DRY, byte-identical to prior
   behavior).
3. **WorkerClient + GetEnv IPC** (`koda-sandbox/src/worker_client.rs`,
   `src/ipc.rs`, `src/worker.rs`):
   `WorkerClient::spawn_with_policy_and_proxy(root, policy,
   Option<&ProxyHandle>)` injects the env-var bouquet into the worker
   subprocess. New `Request::GetEnv` / `Response::GetEnv` IPC variant
   for verifying the injection across the process boundary.
4. **`build_command_with_proxy`** (`koda-sandbox/src/seatbelt.rs`):
   completes the pipe — sandbox-exec command uses the proxied profile
   when a proxy port is supplied. Existing `build_command` keeps its
   signature, both delegate to `build_command_inner`.

## Type

- [x] New feature
- [x] Refactor (no behavior change) — seatbelt baseline split into
      `build_profile_string_with_network` is byte-identical for the
      open-network case (all 18 prior seatbelt tests unchanged)

## Files changed

| File | What changed |
|------|--------------|
| `koda-sandbox/src/proxy.rs` | **New** — env-var bouquet + ExternalProxy lifecycle (~430 LOC inc. tests) |
| `koda-sandbox/src/seatbelt.rs` | Added `network_proxied_rules`, `build_proxied_profile_string`, `build_command_with_proxy`; extracted `build_profile_string_with_network` for DRY (+260 LOC) |
| `koda-sandbox/src/worker_client.rs` | Added `spawn_with_policy_and_proxy`; refactored `spawn_inner` to accept extra env (+50 LOC) |
| `koda-sandbox/src/ipc.rs` | New `Request::GetEnv` / `Response::GetEnv` variants (+25 LOC) |
| `koda-sandbox/src/worker.rs` | `GetEnv` handler (+10 LOC) |
| `koda-sandbox/src/lib.rs` | Re-exports (+5 LOC) |
| `koda-sandbox/tests/sandboxed_fs.rs` | 3 integration tests using `nc` as a fake proxy (+150 LOC) |

## Testing

- [x] `cargo test -p koda-sandbox` — **174 tests pass** (152 unit + 16
      integration + 3 snapshot + 2 worker + 1 doctest)
- [x] `cargo clippy -p koda-sandbox --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo doc -p koda-sandbox --no-deps` — no warnings

New test breakdown:
- **proxy module:** 10 unit tests (env-var keys, CA bundle on/off, URL
  format, `DEFAULT_NO_PROXY` sanity, `ExternalProxy` defaults, empty
  command + unbound command error paths)
- **seatbelt proxied:** 11 unit tests (network rules, baseline
  preserved, DRY guard between open/proxied, `build_command_with_proxy`
  end-to-end, regression guard on no-proxy path,
  `allow_local_binding` propagation)
- **WorkerClient integration:** 3 tests (env vars injected, CA bundle
  injected when MITM set, env vars omitted when proxy=None) — uses
  `nc -l -k` as a stand-in proxy, gracefully skips if `nc` is missing

## Checklist

- [x] No files over 600 lines (`seatbelt.rs` is 615 lines but it was
      already that size pre-PR; splitting now would hurt cohesion since
      all functions share the same profile-builder concern — flagging
      for reviewer awareness, will revisit in 3b if it grows further)
- [x] No `unwrap()` in non-test code
- [ ] Destructive tools require confirmation — N/A (no new tools)
- [ ] New tools added to `SAFE_PREFIXES` — N/A
- [ ] `CHANGELOG.md` updated — deferred to the user-facing PR (3b)
- [ ] `docs/src/` updated — deferred to the user-facing PR (3b)

## Design notes for reviewers

- **Fail-open is a caller pattern, not library magic.**
  `ExternalProxy::spawn → Err` is the signal for the caller to `warn!`
  and pass `None` to `spawn_with_policy_and_proxy`. No silent fallbacks
  hiding inside the library — same pattern Claude Code uses for
  `upstreamproxy`.
- **CA-bundle precedence:** `ProxyHandle::ca_bundle()` (returns `None`
  in 3a; will be `Some(generated_ca_path)` in 3b's built-in proxy)
  takes precedence over `policy.net.mitm.ca_bundle`. Lets 3b plug in
  with zero API churn.
- **Two outbound rules per port (`127.0.0.1:port` AND
  `localhost:port`):** belt + suspenders. Some clients resolve
  `localhost` to `::1` first, others go straight to the IPv4 literal —
  catching both means the env-var bouquet's `http://127.0.0.1:port` URL
  always works regardless of resolver behavior.
- **DRY refactor in seatbelt:** extracted
  `build_profile_string_with_network` so open + proxied share the
  baseline. All 18 prior seatbelt tests still pass byte-identically —
  no behavior drift.

<!-- For LLM reviewers: this is pure infrastructure with no caller
     today. Focus on (1) the env-var bouquet matching what real HTTP
     clients look at, (2) the seatbelt rule ordering not accidentally
     opening a hole, and (3) the fail-open contract being unambiguous
     in the docs. -->
