### PR TITLE
Phase 3c: kernel-enforced egress proxy on macOS (#934)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -88,6 +88,14 @@ pub fn build(
         command,
         project_root,
         policy: &policy,
+        // Phase 3c: thread the proxy port into the kernel sandbox so
+        // the seatbelt SBPL denies any TCP outbound that doesn't
+        // target 127.0.0.1:proxy_port. Belt-and-suspenders alongside
+        // the env-var bouquet (which catches well-behaved clients)
+        // so even ill-behaved binaries that ignore `HTTPS_PROXY`
+        // can't escape via direct TCP. On Linux this is a no-op
+        // until 3c.1 ships kernel-enforcement (slirp4netns / similar).
+        proxy_port,
     };
 
     let mut cmd = match runtime.transform(req) {

--- a/koda-core/tests/builtin_proxy_e2e_test.rs
+++ b/koda-core/tests/builtin_proxy_e2e_test.rs
@@ -212,6 +212,92 @@ async fn dropping_session_releases_proxy_port() {
     );
 }
 
+// ── Phase 3c: kernel-enforced egress (macOS only) ─────────────────────────
+
+/// **The Phase 3c headline contract.** Even an ill-behaved binary that
+/// completely ignores `HTTPS_PROXY` and tries to open a raw TCP
+/// connection to a non-proxy port must be denied by the seatbelt
+/// kernel sandbox. This is the security upgrade over Phase 3b: 3b
+/// trusts clients to honor env vars; 3c forces them.
+///
+/// We exercise this with bash's `/dev/tcp/host/port` magic — a
+/// pure-bash TCP open that doesn't honor any proxy env var. If the
+/// kernel denies the connect (as 3c requires), bash prints an error
+/// and the conditional reports `blocked`. If the kernel lets it
+/// through, the connect either succeeds (`connected`) or fails
+/// because nothing is listening on that port (`other-fail`) — either
+/// non-`blocked` outcome means 3c isn't enforcing.
+///
+/// macOS only: the bwrap backend on Linux can't kernel-enforce port
+/// filtering yet (see Phase 3c.1).
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn macos_kernel_blocks_direct_tcp_to_non_proxy_port() {
+    let env = Env::builder()
+        .provider_type(ProviderType::Mock)
+        .build()
+        .await;
+    let session = make_real_session(&env).await;
+    let proxy_port = session.proxy.as_ref().expect("proxy spawned").port;
+
+    // Pick a target port that is definitely NOT the proxy port. We
+    // don't actually need anything listening there — we're testing the
+    // kernel's ability to refuse the syscall, which happens before
+    // userspace observes connection success or failure.
+    let target_port = if proxy_port == 1 { 2 } else { 1 };
+
+    // bash's `/dev/tcp/host/port` performs a connect(2) at the libc
+    // level with no proxy honoring. The redirect uses fd 3 to keep
+    // stdout/stderr clean for our parsing.
+    let cmd = format!(
+        r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
+    );
+    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let combined = format!(
+        "{}\n{}",
+        result.output,
+        result.full_output.as_deref().unwrap_or("")
+    );
+    assert!(
+        combined.contains("blocked"),
+        "kernel-enforced sandbox must refuse direct TCP to non-proxy port \
+         {target_port} (proxy is on {proxy_port}); got:\n{combined}"
+    );
+}
+
+/// Companion to `macos_kernel_blocks_direct_tcp_to_non_proxy_port`:
+/// the kernel sandbox MUST still permit connections to the actual
+/// proxy port, otherwise even well-behaved clients can't reach the
+/// filter. Verifies the SBPL allow-rule actually allows the loopback
+/// proxy port through.
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn macos_kernel_allows_tcp_to_proxy_port() {
+    let env = Env::builder()
+        .provider_type(ProviderType::Mock)
+        .build()
+        .await;
+    let session = make_real_session(&env).await;
+    let proxy_port = session.proxy.as_ref().expect("proxy spawned").port;
+
+    // Connect to the proxy port from inside the sandbox via /dev/tcp.
+    // The proxy is up, so connect(2) should succeed; the sandbox must
+    // not get in the way.
+    let cmd = format!(
+        r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{proxy_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
+    );
+    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let combined = format!(
+        "{}\n{}",
+        result.output,
+        result.full_output.as_deref().unwrap_or("")
+    );
+    assert!(
+        combined.contains("connected"),
+        "kernel-enforced sandbox must permit TCP to the proxy port {proxy_port}; got:\n{combined}"
+    );
+}
+
 // ── Live curl smoke (opt-in via --ignored) ───────────────────────────────
 
 /// End-to-end denial proof: a Bash invocation that asks curl to fetch

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -90,6 +90,23 @@ pub struct SandboxTransformRequest<'a> {
     /// Capability policy. Phase 0 ignores all fields; later phases
     /// progressively enforce them.
     pub policy: &'a SandboxPolicy,
+
+    /// Loopback port of the per-session HTTP CONNECT proxy spawned by
+    /// [`crate::proxy::BuiltInProxy::spawn`].
+    ///
+    /// **Phase 3c semantics:** when `Some(port)`, the runtime is asked
+    /// to **kernel-enforce** that the only TCP outbound permitted is to
+    /// `127.0.0.1:port` (plus loopback inbound for debuggers / dev
+    /// servers). Today the seatbelt backend honors this via
+    /// `seatbelt::build_command_with_proxy` (macOS only); the bwrap
+    /// backend logs a one-time warning and falls back to env-var-only
+    /// enforcement (Phase 3c.1 will design Linux kernel-enforcement
+    /// separately, likely via slirp4netns or rootlesskit).
+    ///
+    /// `None` preserves the pre-3c open-network baseline — used for
+    /// callers that haven't migrated, and as the regression-guard
+    /// fallback.
+    pub proxy_port: Option<u16>,
 }
 
 /// Output of [`SandboxRuntime::transform`].
@@ -151,7 +168,27 @@ pub struct SeatbeltRuntime;
 #[cfg(target_os = "macos")]
 impl SandboxRuntime for SeatbeltRuntime {
     fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
-        let command = seatbelt::build_command(req.command, req.project_root, req.policy)?;
+        // Phase 3c: when a proxy port is supplied, switch to the
+        // kernel-enforced proxied profile (`build_command_with_proxy`).
+        // The seatbelt SBPL denies all TCP outbound except the loopback
+        // proxy port, so even ill-behaved binaries that ignore
+        // `HTTPS_PROXY` env vars cannot escape via direct TCP.
+        //
+        // `allow_local_binding=false` is hardcoded until
+        // `policy.net.allow_local_binding` exists. Localhost binds
+        // (e.g. dev servers on 127.0.0.1:3000) are still allowed by
+        // [`network_proxied_rules`]; only wildcard `*:*` binds are
+        // gated by this flag.
+        let command = match req.proxy_port {
+            Some(port) => seatbelt::build_command_with_proxy(
+                req.command,
+                req.project_root,
+                req.policy,
+                port,
+                false,
+            )?,
+            None => seatbelt::build_command(req.command, req.project_root, req.policy)?,
+        };
         Ok(SandboxExecRequest { command })
     }
 
@@ -185,6 +222,17 @@ pub struct BwrapRuntime;
 #[cfg(target_os = "linux")]
 impl SandboxRuntime for BwrapRuntime {
     fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
+        // Phase 3c gap: bwrap doesn't support port-level egress
+        // filtering (`--unshare-net` cuts ALL networking including
+        // loopback, and bringing `lo` back up needs CAP_NET_ADMIN).
+        // Linux kernel-enforcement is deferred to Phase 3c.1, which
+        // will likely use slirp4netns or rootlesskit. Until then,
+        // Linux relies on the env-var bouquet from
+        // [`crate::proxy::env::proxy_env_vars`] — same enforcement
+        // tier as Phase 3b. Warn once so this gap isn't invisible.
+        if req.proxy_port.is_some() {
+            warn_proxy_unenforced_on_linux_once();
+        }
         let command = bwrap::build_command(req.command, req.project_root, req.policy)?;
         Ok(SandboxExecRequest { command })
     }
@@ -208,6 +256,30 @@ impl SandboxRuntime for BwrapRuntime {
             }
         }
     }
+}
+
+/// One-time warning when koda-core asks the bwrap backend to enforce a
+/// proxy port but bwrap can't (Phase 3c.1 territory). The env-var
+/// bouquet still routes well-behaved clients through the proxy; only
+/// ill-behaved binaries that ignore `HTTPS_PROXY` escape the filter.
+///
+/// Lives at module scope (not inside `BwrapRuntime`) because the
+/// `OnceLock` must outlive any single runtime instance — each
+/// `KodaSession` builds a fresh `BwrapRuntime`, but the gap is the
+/// same on every invocation, so once-per-process is the right cadence.
+#[cfg(target_os = "linux")]
+fn warn_proxy_unenforced_on_linux_once() {
+    use std::sync::OnceLock;
+    static WARNED: OnceLock<()> = OnceLock::new();
+    WARNED.get_or_init(|| {
+        tracing::warn!(
+            "koda-sandbox: built-in proxy is active but bwrap cannot kernel-enforce \
+             port-level egress filtering on Linux yet. Well-behaved HTTP clients (curl, \
+             gh, npm, pip, cargo, go, node, python) honor HTTPS_PROXY and route through \
+             the filter; ill-behaved binaries can still reach the network directly. \
+             Linux kernel-enforcement is tracked as #934 Phase 3c.1."
+        );
+    });
 }
 
 /// Fallback runtime for platforms without a kernel sandbox backend.
@@ -296,6 +368,7 @@ mod tests {
             command: "echo hi",
             project_root: Path::new("/tmp"),
             policy: &policy,
+            proxy_port: None,
         };
         let runtime = UnsandboxedRuntime;
         let result = runtime.transform(req).unwrap();
@@ -319,5 +392,129 @@ mod tests {
         // on the test host.
         let runtime = current_runtime();
         let _report = runtime.check_dependencies(); // doesn't panic
+    }
+
+    /// Phase 3c: when `proxy_port = None`, the request runs through the
+    /// unsandboxed runtime unchanged — same `sh` invocation, no env or
+    /// arg surface added. Regression guard against the request gaining
+    /// hidden side-effects from the `proxy_port` field.
+    #[test]
+    fn unsandboxed_runtime_ignores_proxy_port() {
+        let policy = SandboxPolicy::default();
+        let with = UnsandboxedRuntime
+            .transform(SandboxTransformRequest {
+                command: "true",
+                project_root: Path::new("/tmp"),
+                policy: &policy,
+                proxy_port: Some(8080),
+            })
+            .unwrap();
+        let without = UnsandboxedRuntime
+            .transform(SandboxTransformRequest {
+                command: "true",
+                project_root: Path::new("/tmp"),
+                policy: &policy,
+                proxy_port: None,
+            })
+            .unwrap();
+        // Both should be `sh -c true` — no proxy-related divergence in
+        // the unsandboxed path. The proxy port is the kernel sandbox's
+        // concern, not ours.
+        assert_eq!(with.command.as_std().get_program(), "sh");
+        assert_eq!(without.command.as_std().get_program(), "sh");
+        assert_eq!(
+            with.command.as_std().get_args().collect::<Vec<_>>(),
+            without.command.as_std().get_args().collect::<Vec<_>>(),
+        );
+    }
+
+    /// Phase 3c kernel enforcement: when a proxy port is supplied,
+    /// macOS Seatbelt must inject the `network_proxied_rules` SBPL
+    /// (deny all TCP outbound except `127.0.0.1:proxy_port`). The
+    /// profile string is passed via `-p <profile>` so we can grep the
+    /// arg vector to confirm.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_runtime_emits_proxied_profile_when_port_set() {
+        let policy = SandboxPolicy::strict_default();
+        let req = SandboxTransformRequest {
+            command: "true",
+            project_root: Path::new("/tmp"),
+            policy: &policy,
+            proxy_port: Some(54321),
+        };
+        let cmd = SeatbeltRuntime.transform(req).unwrap().command;
+        let profile = cmd
+            .as_std()
+            .get_args()
+            .nth(1) // "sandbox-exec" "-p" "<profile>" ...
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+        // The proxied profile MUST permit only the proxy port and MUST NOT
+        // contain the open-network blanket allow. SBPL requires the host
+        // to be `localhost` (not literal `127.0.0.1`) — see
+        // [`network_proxied_rules`] for the full rationale (macOS only).
+        assert!(
+            profile.contains("localhost:54321"),
+            "proxied profile must allow loopback proxy port via localhost; got: {profile}"
+        );
+        assert!(
+            !profile.contains("(allow network*)"),
+            "proxied profile must NOT include the open-network allow; got: {profile}"
+        );
+    }
+
+    /// Regression guard: `proxy_port = None` keeps the pre-3c open-network
+    /// profile intact. Catches accidental "always-proxied" wiring that
+    /// would break callers (sub-agents, scripts) that don't have a proxy.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_runtime_keeps_open_network_when_port_none() {
+        let policy = SandboxPolicy::strict_default();
+        let req = SandboxTransformRequest {
+            command: "true",
+            project_root: Path::new("/tmp"),
+            policy: &policy,
+            proxy_port: None,
+        };
+        let cmd = SeatbeltRuntime.transform(req).unwrap().command;
+        let profile = cmd
+            .as_std()
+            .get_args()
+            .nth(1)
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            profile.contains("(allow network*)"),
+            "open-network profile must include the blanket allow; got: {profile}"
+        );
+        assert!(
+            !profile.contains("localhost:") || !profile.contains("network-outbound"),
+            "open-network profile must NOT include the proxied loopback outbound rule; got: {profile}"
+        );
+    }
+
+    /// Phase 3c.1 gap documentation: bwrap accepts `proxy_port = Some`
+    /// and produces a working command (no error), even though it can't
+    /// kernel-enforce the port restriction. The env-var bouquet from
+    /// `koda-core::sandbox::build` does the actual filtering for
+    /// well-behaved clients on Linux. Verifies the warn-once doesn't
+    /// turn into a panic.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn bwrap_runtime_accepts_proxy_port_without_error() {
+        let policy = SandboxPolicy::strict_default();
+        let req = SandboxTransformRequest {
+            command: "true",
+            project_root: Path::new("/tmp"),
+            policy: &policy,
+            proxy_port: Some(54321),
+        };
+        // Construct without spawning. We don't assert anything about the
+        // arg vector — bwrap simply doesn't touch the network namespace
+        // until 3c.1.
+        let _ = BwrapRuntime.transform(req);
     }
 }

--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -31,7 +31,9 @@
 //! - **No SOCKS5** — Phase 3d (separate ≤200-LOC module).
 //! - **No upload/idle timeouts** — Phase 3d (resource limits).
 
-use super::{Filter, pick_ephemeral_port};
+use super::Filter;
+#[cfg(test)]
+use super::pick_ephemeral_port;
 use anyhow::{Context, Result, bail};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -69,13 +71,16 @@ impl Server {
     /// Returns immediately with a configured server. Call [`Self::serve`]
     /// to start accepting connections.
     pub async fn bind(port: Option<u16>, filter: Filter) -> Result<Self> {
-        let port = match port {
-            Some(p) => p,
-            None => pick_ephemeral_port().context("pick ephemeral port for built-in proxy")?,
-        };
-        let listener = TcpListener::bind(("127.0.0.1", port))
+        // Phase 3c drive-by: bind directly with port `0` for the
+        // ephemeral case instead of going through `pick_ephemeral_port`
+        // (which has a TOCTOU race — another process can grab the port
+        // between drop and re-bind, and it intermittently does in CI /
+        // parallel test runs). Letting the kernel pick + keep the port
+        // in one syscall closes the race entirely.
+        let bind_port = port.unwrap_or(0);
+        let listener = TcpListener::bind(("127.0.0.1", bind_port))
             .await
-            .with_context(|| format!("bind built-in proxy on 127.0.0.1:{port}"))?;
+            .with_context(|| format!("bind built-in proxy on 127.0.0.1:{bind_port}"))?;
         let actual = listener
             .local_addr()
             .context("read local_addr from listener")?

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -227,9 +227,16 @@ pub(crate) fn network_open_rules() -> String {
 /// Unix-socket carve-out from Codex's seatbelt rules.
 pub fn network_proxied_rules(proxy_port: u16, allow_local_binding: bool) -> String {
     let mut rules = String::new();
-    rules.push_str(&format!(
-        "(allow network-outbound (remote tcp \"127.0.0.1:{proxy_port}\"))\n"
-    ));
+    // SBPL gotcha: `(remote tcp "<host>:<port>")` only accepts `*` or
+    // `localhost` as the host — a literal `127.0.0.1` causes
+    // sandbox-exec to reject the entire profile with
+    // "host must be * or localhost in network address". `localhost`
+    // covers both 127.0.0.1 and ::1 via the kernel resolver, so a
+    // single rule is correct AND complete. Discovered the hard way
+    // when wiring 3c kernel-enforcement to the koda-core test that
+    // actually invokes sandbox-exec (the unit tests in 3b only
+    // grepped the profile string and never asked the kernel to parse
+    // it). See koda-core/src/sandbox.rs::tests::build_attaches_*.
     rules.push_str(&format!(
         "(allow network-outbound (remote tcp \"localhost:{proxy_port}\"))\n"
     ));
@@ -640,13 +647,24 @@ mod tests {
     #[test]
     fn proxied_profile_allows_only_proxy_port_outbound_tcp() {
         let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
-        assert!(p.contains("(allow network-outbound (remote tcp \"127.0.0.1:8877\"))"));
-        assert!(p.contains("(allow network-outbound (remote tcp \"localhost:8877\"))"));
-        // No other tcp outbound rule should be present.
+        // Phase 3c fix: SBPL only accepts `*` or `localhost` as the
+        // host in `(remote tcp ...)`. A literal `127.0.0.1` causes
+        // sandbox-exec to reject the entire profile. `localhost`
+        // resolves to both 127.0.0.1 and ::1 via the kernel, so a
+        // single rule is correct AND complete.
+        assert!(
+            p.contains("(allow network-outbound (remote tcp \"localhost:8877\"))"),
+            "profile must include the localhost:proxy_port allow; got:\n{p}"
+        );
+        assert!(
+            !p.contains("127.0.0.1:8877"),
+            "profile must NOT include literal 127.0.0.1 — SBPL rejects it; got:\n{p}"
+        );
+        // Exactly one tcp outbound rule should be present.
         let count = p.matches("(allow network-outbound (remote tcp ").count();
         assert_eq!(
-            count, 2,
-            "expected exactly the 127.0.0.1 + localhost outbound rules; profile:\n{p}"
+            count, 1,
+            "expected exactly one (localhost) outbound rule; profile:\n{p}"
         );
     }
 
@@ -731,7 +749,10 @@ mod tests {
             .collect();
         // sandbox-exec layout: ["-p", <profile>, "sh", "-c", <cmd>]
         let profile = &args[1];
-        assert!(profile.contains("127.0.0.1:8877"));
+        // SBPL host syntax: must be `localhost` not `127.0.0.1` (kernel
+        // resolves localhost to both v4 + v6 loopback). See
+        // [`network_proxied_rules`].
+        assert!(profile.contains("localhost:8877"));
         assert!(!profile.contains("(allow network*)\n"));
     }
 

--- a/koda-sandbox/tests/transform_snapshots.rs
+++ b/koda-sandbox/tests/transform_snapshots.rs
@@ -29,6 +29,7 @@ fn unsandboxed_runtime_snapshot() {
         command: "echo hi",
         project_root: Path::new("/tmp/snapshot-project"),
         policy: &policy,
+        proxy_port: None,
     };
     let result = UnsandboxedRuntime.transform(req).unwrap();
     let (program, args, cwd) = deconstruct(result.command.as_std());
@@ -50,6 +51,7 @@ fn seatbelt_runtime_command_snapshot() {
         command: "true",
         project_root: dir.path(),
         policy: &policy,
+        proxy_port: None,
     };
     let result = SeatbeltRuntime.transform(req).unwrap();
     let (program, args, _cwd) = deconstruct(result.command.as_std());
@@ -78,6 +80,7 @@ fn seatbelt_profile_contains_required_rules() {
         command: "true",
         project_root: dir.path(),
         policy: &policy,
+        proxy_port: None,
     };
     let result = SeatbeltRuntime.transform(req).unwrap();
     let args: Vec<String> = result
@@ -127,6 +130,7 @@ fn bwrap_runtime_command_snapshot() {
         command: "true",
         project_root: dir.path(),
         policy: &policy,
+        proxy_port: None,
     };
     let result = BwrapRuntime.transform(req).unwrap();
     let (program, args, _cwd) = deconstruct(result.command.as_std());
@@ -163,6 +167,7 @@ fn bwrap_command_starts_with_ro_bind_root() {
         command: "true",
         project_root: dir.path(),
         policy: &policy,
+        proxy_port: None,
     };
     let result = BwrapRuntime.transform(req).unwrap();
     let args: Vec<String> = result


### PR DESCRIPTION
# Phase 3c \u2014 kernel-enforced egress proxy on macOS

Closes the Phase 3c deliverable on the road to #934 (network sandbox). Builds on PR #994 (Phase 3b).

## What this does

Flips the koda-sandbox kernel transform from open-network (`seatbelt::build_command`) to proxied (`seatbelt::build_command_with_proxy`) whenever a per-session HTTP CONNECT proxy is active. The seatbelt SBPL now denies all TCP outbound except connections to `127.0.0.1:proxy_port`.

This is the security upgrade the whole #934 Phase 3 ladder was building toward. **Phase 3a/3b** shipped the env-var bouquet \u2014 well-behaved clients (curl, gh, npm, pip, cargo, go, python) honor `HTTPS_PROXY` and route through the filtered proxy, ill-behaved binaries that ignore env vars escape via direct TCP. **Phase 3c** forces ALL clients via the kernel: even custom binaries that bypass `HTTPS_PROXY` get refused at the syscall layer.

```
                                3a/3b: env-var only        3c: kernel-enforced
                                \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nWell-behaved clients          \u2705 routes through proxy     \u2705 routes through proxy
(curl, gh, npm, pip, cargo)
Ill-behaved binaries          \u274c can bypass proxy via     \u2705 KERNEL DENIES
(custom syscall direct)          direct connect(2)           direct connect(2)
```

## How

```rust
// koda-sandbox/src/lib.rs
pub struct SandboxTransformRequest<'a> {
    pub command: &'a str,
    pub project_root: &'a Path,
    pub policy: &'a SandboxPolicy,
    pub proxy_port: Option<u16>,   // \u2190 NEW in 3c
}

impl SandboxRuntime for SeatbeltRuntime {
    fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
        let command = match req.proxy_port {
            Some(port) => seatbelt::build_command_with_proxy(
                req.command, req.project_root, req.policy, port, /*allow_local_binding=*/false,
            )?,
            None => seatbelt::build_command(req.command, req.project_root, req.policy)?,
        };
        Ok(SandboxExecRequest { command })
    }
}
```

`koda-core::sandbox::build` populates `proxy_port` from the same value already used to inject the env-var bouquet \u2014 belt-and-suspenders. No new wiring at the call sites; the existing `proxy_port` parameter on `build()` just gets forwarded to one more place.

## The Phase 3c headline test

```rust
#[cfg(target_os = "macos")]
#[tokio::test]
async fn macos_kernel_blocks_direct_tcp_to_non_proxy_port() {
    let session = make_real_session(&env).await;
    let proxy_port = session.proxy.as_ref().unwrap().port;
    let target_port = if proxy_port == 1 { 2 } else { 1 };

    // bash's /dev/tcp/host/port performs a libc-level connect(2) and
    // ignores ALL proxy env vars. If the kernel doesn't enforce, this
    // would print "connected".
    let cmd = format!(
        r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
    );
    let result = session.agent.tools.execute("Bash", &cmd, None).await;
    assert!(result.output.contains("blocked"));  // \u2705 kernel refused
}
```

This single assertion is the proof that 3c works: an ill-behaved process that skips `HTTPS_PROXY` and tries `connect(127.0.0.1, target_port)` gets denied at the kernel.

## Linux gap (Phase 3c.1)

`BwrapRuntime::transform` accepts `proxy_port` but logs a one-time warning and falls back to the pre-3c baseline. **bwrap doesn't support port-level egress filtering**: `--unshare-net` cuts ALL networking including loopback, and bringing `lo` back up requires `CAP_NET_ADMIN` which bubblewrap doesn't grant.

Linux retains Phase 3b's env-var-only enforcement for now \u2014 same as today, no regression. The right Linux fix is a follow-up phase that designs slirp4netns or rootlesskit integration. Documented in the bwrap warn-once message + module docs.

## Two latent bugs squashed along the way

This PR includes two small bug-fix commits that surfaced while wiring 3c \u2014 each is a self-contained fix with its own commit so they're cleanly bisectable.

### `f331652` \u2014 TOCTOU race in built-in proxy bind

`Server::bind(None, ..)` was using `pick_ephemeral_port()` (open temp socket, read port, drop, re-bind), which has a classic race window. Tests intermittently failed with `Address already in use (os error 48)` when another process grabbed the port between drop and re-bind. Fixed by binding directly to port `0` and reading back the kernel-assigned port \u2014 single syscall, no race.

### `54bca70` \u2014 SBPL host syntax bug from PR #994

`network_proxied_rules` was emitting a literal `127.0.0.1` in `(remote tcp ...)`. Seatbelt rejects this with:

```
sandbox-exec: host must be * or localhost in network address
```

The PR #994 unit tests grepped the profile string but never asked the kernel to parse it, so the bug was masked \u2014 PR #994's koda-core integration only used the env-var path which doesn't touch `network_proxied_rules`. Phase 3c flips the kernel sandbox to actually use those rules, which is when the parse error surfaced. The `localhost` rule (which was already there) is correct AND complete because the kernel resolves it to both 127.0.0.1 and ::1 via the loopback resolver. Fixed by removing the literal IPv4 rule.

## Commit-by-commit

```
f331652  TOCTOU race in built-in proxy bind   (drive-by flake fix)
54bca70  SBPL host syntax in proxied rule     (latent #994 bug)
84bda4d  Phase 3c main: SandboxTransformRequest.proxy_port + wiring + tests
```

Each commit builds, tests pass, clippy clean. Bisectable.

## Tests (after this PR)

| Crate | Suite | Count | Delta |
|---|---|---|---|
| koda-sandbox | lib | 202 | +3 |
| koda-sandbox | tests/integration | 16 + 3 + 2 | unchanged |
| koda-core | lib | 982 | unchanged |
| koda-core | builtin_proxy_e2e_test | 7 + 1 ignored | +2 macOS-only |
| koda-core | session_test | 3 | unchanged |

- clippy `-D warnings` clean
- fmt clean

## Demo entry point

```bash
# Phase 3c kernel enforcement (the headline tests)
cargo test -p koda-core --test builtin_proxy_e2e_test macos_kernel

# Full live curl smoke (still works unchanged)
cargo test -p koda-core --test builtin_proxy_e2e_test -- --ignored
```

## What's next

With 3c shipped, Phase 3 of #934 has full kernel enforcement on macOS and env-var enforcement on Linux. Two threads can pick up next:

- **Phase 3c.1 (Linux kernel enforcement)** \u2014 design + ship slirp4netns / rootlesskit integration so Linux gets parity with macOS. Independent work; not blocking other phases.
- **Phase 4 (trust modes + per-mode policies)** \u2014 the existing `_trust: &TrustMode` parameter on `sandbox::build` is currently ignored. Phase 4 makes `Safe` / `Workspace` / `Yolo` actually diverge.
