### PR TITLE
Phase 3c.1: kernel-enforced egress proxy on Linux (#934)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,7 @@ dependencies = [
  "glob",
  "ignore",
  "insta",
+ "libc",
  "regex",
  "serde",
  "serde_json",

--- a/koda-core/tests/builtin_proxy_e2e_test.rs
+++ b/koda-core/tests/builtin_proxy_e2e_test.rs
@@ -124,10 +124,25 @@ async fn bash_sees_proxy_env_pointing_at_session_proxy() {
         result.output,
         result.full_output.as_deref().unwrap_or("")
     );
-    let expected = format!("http://127.0.0.1:{port}");
+    // Phase 3c.1 caveat: on Linux with kernel-enforced egress, stage 2
+    // rewrites HTTPS_PROXY to point at the *in-netns* port, not the
+    // host port — so an exact port match would fail there for the
+    // right reason. We just verify the env var has the expected shape
+    // (`http://127.0.0.1:<some-port>`) on both platforms; the exact
+    // port plumbing is covered by `linux_kernel_allows_tcp_to_proxy_port`.
+    let prefix = "http://127.0.0.1:";
+    let url_line = combined
+        .lines()
+        .find(|l| l.starts_with(prefix))
+        .unwrap_or_else(|| panic!("no HTTPS_PROXY url in {combined:?}"));
+    let port_str = &url_line[prefix.len()..];
+    let observed_port: u16 = port_str
+        .trim()
+        .parse()
+        .unwrap_or_else(|_| panic!("HTTPS_PROXY port not parseable: {url_line:?}"));
     assert!(
-        combined.contains(&expected),
-        "child process must see HTTPS_PROXY={expected}; got: {combined:?}"
+        observed_port > 0,
+        "HTTPS_PROXY must contain a non-zero port (host proxy is {port}); got {url_line:?}"
     );
 }
 
@@ -295,6 +310,127 @@ async fn macos_kernel_allows_tcp_to_proxy_port() {
     assert!(
         combined.contains("connected"),
         "kernel-enforced sandbox must permit TCP to the proxy port {proxy_port}; got:\n{combined}"
+    );
+}
+
+// ── Phase 3c.1: kernel-enforced egress on Linux ──────────────────────────
+//
+// Mirrors the macOS pair above. The kernel mechanism is different
+// (bwrap netns + UDS bridge instead of seatbelt SBPL) but the
+// observable contract from inside the sandbox is identical: direct
+// TCP to a non-proxy port must fail; TCP to the proxy port must
+// succeed.
+
+/// Linux equivalent of `macos_kernel_blocks_direct_tcp_to_non_proxy_port`.
+///
+/// Catches regressions in the bwrap `--unshare-net` + stage 2 stack:
+/// if any of the four pieces (UDS bridge, --unshare-net flag,
+/// stage 2 fork, env rewriting) silently degrades, this test will
+/// see a `connected` instead of `blocked` and fail.
+///
+/// Skips when `bwrap` isn't installed (CI may run on a runner without
+/// bubblewrap; we handle that elsewhere with a top-level skip).
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn linux_kernel_blocks_direct_tcp_to_non_proxy_port() {
+    if !koda_sandbox::bwrap::is_available() {
+        eprintln!("bwrap not available; skipping Linux kernel-enforcement test");
+        return;
+    }
+
+    let env = Env::builder()
+        .provider_type(ProviderType::Mock)
+        .build()
+        .await;
+    let session = make_real_session(&env).await;
+    let proxy_port = session.proxy.as_ref().expect("proxy spawned").port;
+
+    // Sanity-check that the kernel-enforced path is actually wired
+    // up for this session. If the UDS bridge didn't spawn (e.g.
+    // /tmp not writable in the test sandbox), the assertions below
+    // would still pass for the wrong reason — the env-var path also
+    // doesn't enable connections to non-allowlisted hosts. So we
+    // assert the kernel path is live before testing it.
+    let uds = koda_sandbox::bwrap_proxy::proxy_uds_path(std::process::id(), proxy_port);
+    assert!(
+        uds.exists(),
+        "Phase 3c.1.b regression: UDS bridge {} should exist for the kernel-enforced \
+         path to activate. Without it, this test would pass spuriously via the \
+         env-var fallback.",
+        uds.display()
+    );
+
+    let target_port = if proxy_port == 1 { 2 } else { 1 };
+
+    // bash's /dev/tcp/host/port performs a connect(2) at libc level
+    // with no proxy honoring — same probe used in the macOS test.
+    // We invoke bash explicitly because Ubuntu's /bin/sh is dash,
+    // which doesn't implement the /dev/tcp magic.
+    let cmd = format!(
+        r#"{{"command":"bash -c 'if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}}"#,
+    );
+    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let combined = format!(
+        "{}\n{}",
+        result.output,
+        result.full_output.as_deref().unwrap_or("")
+    );
+    assert!(
+        combined.contains("blocked"),
+        "kernel-enforced sandbox must refuse direct TCP to non-proxy port \
+         {target_port} (proxy is on {proxy_port}); got:\n{combined}"
+    );
+}
+
+/// Linux equivalent of `macos_kernel_allows_tcp_to_proxy_port`.
+///
+/// In the bwrap+stage2 design, "the proxy port" inside the sandbox is
+/// the *in-netns ephemeral port* stage 2 binds (which then bridges
+/// through the UDS to the real host proxy). The user command sees
+/// `HTTPS_PROXY=http://127.0.0.1:NEW_PORT` because stage 2 rewrote
+/// it. So this test parses the rewritten env var rather than using
+/// the host port directly — that's both more honest and more
+/// regression-resistant (a broken rewriter would surface here).
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn linux_kernel_allows_tcp_to_proxy_port() {
+    if !koda_sandbox::bwrap::is_available() {
+        eprintln!("bwrap not available; skipping Linux kernel-allow test");
+        return;
+    }
+
+    let env = Env::builder()
+        .provider_type(ProviderType::Mock)
+        .build()
+        .await;
+    let session = make_real_session(&env).await;
+    let proxy_port = session.proxy.as_ref().expect("proxy spawned").port;
+
+    let uds = koda_sandbox::bwrap_proxy::proxy_uds_path(std::process::id(), proxy_port);
+    if !uds.exists() {
+        eprintln!(
+            "UDS bridge {} not present — kernel-enforced path inactive; skipping",
+            uds.display()
+        );
+        return;
+    }
+
+    // Read the (stage-2-rewritten) HTTPS_PROXY from inside the
+    // sandbox, extract the port via bash parameter expansion
+    // (`${var##*:}` = strip everything up to the last `:`), then
+    // verify /dev/tcp can reach it. Bash explicitly because
+    // Ubuntu's /bin/sh is dash (no /dev/tcp, no `${var##*:}`).
+    let cmd = r#"{"command":"bash -c 'port=\"${HTTPS_PROXY##*:}\"; if exec 3<>/dev/tcp/127.0.0.1/$port 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}"#;
+    let result = session.agent.tools.execute("Bash", cmd, None).await;
+    let combined = format!(
+        "{}\n{}",
+        result.output,
+        result.full_output.as_deref().unwrap_or("")
+    );
+    assert!(
+        combined.contains("connected"),
+        "kernel-enforced sandbox must permit TCP to the in-netns proxy port \
+         (rewritten by stage 2 from host port {proxy_port}); got:\n{combined}"
     );
 }
 

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -23,6 +23,12 @@ tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "n
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+# Linux-only: stage-2 helper binary uses raw syscalls (ioctl for `lo`,
+# prctl for parent-death, execvp). Tokio's tiny libc dep is not
+# enough — we want the public surface so it's a direct workspace dep.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 insta = { workspace = true }
 tempfile = { workspace = true }
@@ -31,3 +37,12 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 [[bin]]
 name = "koda-fs-worker"
 path = "src/bin/koda-fs-worker.rs"
+
+# Linux-only stage-2 helper for the bwrap kernel-enforced egress proxy
+# (Phase 3c.1 of #934). Spawned by `BwrapRuntime` as the bwrap entry
+# point; sets up the in-netns TCP↔UDS local bridge then `execvp`s into
+# the user's command.
+[[bin]]
+name = "koda-sandbox-stage2"
+path = "src/bin/koda-sandbox-stage2.rs"
+required-features = []

--- a/koda-sandbox/src/bin/koda-sandbox-stage2.rs
+++ b/koda-sandbox/src/bin/koda-sandbox-stage2.rs
@@ -1,0 +1,47 @@
+//! `koda-sandbox-stage2` — in-sandbox helper that runs after
+//! `bwrap --unshare-net` strips host networking, before the user
+//! command (Phase 3c.1.c of #934).
+//!
+//! See `koda_sandbox::stage2` (Linux-only module) for the architecture
+//! diagram and the full lifecycle. This file is just the binary shim.
+//!
+//! ## Why a separate binary, not a flag on the main `koda` binary
+//!
+//! - **Tiny binary.** Stage 2 doesn't link tokio, the LLM client, the
+//!   TUI, MCP, etc. — just std + libc. Faster startup, smaller
+//!   memory, smaller bind-mount footprint.
+//! - **Same precedent as `koda-fs-worker`.** koda-sandbox already
+//!   ships one helper binary and the discovery story (`current_exe`
+//!   sibling lookup, `KODA_FS_WORKER_BIN` override) is a known
+//!   pattern. This is just one more.
+//! - **Test isolation.** Cargo sets `CARGO_BIN_EXE_koda-sandbox-stage2`
+//!   for integration tests, so e2e tests can find the binary without
+//!   knowing the install path.
+
+#[cfg(target_os = "linux")]
+fn main() {
+    // Read argv as raw OsStrings — the user command may contain bytes
+    // that aren't valid UTF-8 (e.g. filenames in unusual encodings).
+    let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
+
+    if let Err(e) = koda_sandbox::stage2::run(argv) {
+        // Stage 2 setup failed before reaching execvp. Emit the error
+        // to stderr so it shows up in the user's tool output — then
+        // exit with a distinctive code so callers can tell setup
+        // failure apart from user-command failure.
+        eprintln!("koda-sandbox-stage2: {e:#}");
+        std::process::exit(koda_sandbox::stage2::STAGE2_SETUP_FAILED_EXIT);
+    }
+    // `koda_sandbox::stage2::run` only returns on Err — success path
+    // ends in `execvp`, which replaces this process.
+    unreachable!("stage2::run returned Ok without exec")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    // Stage 2 is Linux-only — the bwrap kernel-enforced egress proxy
+    // doesn't run anywhere else. We still build a stub on macOS so
+    // `cargo build --workspace` works without per-target plumbing.
+    eprintln!("koda-sandbox-stage2: Linux only (this build target lacks bwrap support).");
+    std::process::exit(1);
+}

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -14,6 +14,24 @@
 //!
 //! Empty policy → behavior byte-identical to pre-#934 (Phase 0 invariant).
 //!
+//! ## Kernel-enforced egress (Phase 3c.1)
+//!
+//! When the caller supplies a proxy port AND a UDS bridge socket
+//! (built by [`crate::bwrap_proxy::spawn_uds_bridge`]) is reachable,
+//! [`build_command`] hands off to [`build_command_with_proxy`] which
+//! adds:
+//!
+//!   - `--unshare-net --unshare-user --unshare-pid` — fresh net/user/pid
+//!     namespaces. The fresh netns has no routes to anywhere except
+//!     its own (initially-down) loopback. **This is the kernel
+//!     enforcement**: direct TCP from the sandbox to anywhere
+//!     fails at `connect()` with ENETUNREACH.
+//!   - `--bind <uds> <uds>` — make the host UDS bridge socket
+//!     reachable inside the sandbox.
+//!   - Replaces `-- sh -c <cmd>` with
+//!     `-- /path/to/koda-sandbox-stage2 sh -c <cmd>` so the in-netns
+//!     `lo`-bring-up + TCP↔UDS bridge runs before the user command.
+//!
 //! ## Mapping policy → bwrap flags
 //!
 //! | Policy field                  | bwrap rendering                       |
@@ -31,9 +49,20 @@
 
 use crate::defaults::{CREDENTIAL_CONFIG_FULL_DENY, PROTECTED_PROJECT_SUBDIRS};
 use crate::policy::SandboxPolicy;
-use anyhow::Result;
-use std::path::Path;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
+
+/// Env-var override for the [`stage2_binary`] discovery (mirrors
+/// `KODA_FS_WORKER_BIN`). Used by the bwrap-runtime e2e tests.
+pub const STAGE2_BIN_ENV_KEY: &str = "KODA_SANDBOX_STAGE2_BIN";
+
+/// Comma-separated list of env vars stage 2 will rewrite in-netns.
+/// Kept in lockstep with [`crate::proxy::env::proxy_env_vars`] — every
+/// `*_PROXY` key that function emits must appear here so stage 2's
+/// rewriter visits all of them.
+const STAGE2_PROXY_REWRITE_KEYS: &str =
+    "HTTPS_PROXY,HTTP_PROXY,ALL_PROXY,https_proxy,http_proxy,all_proxy";
 
 /// Build a `bwrap` Command for the given command + project root.
 ///
@@ -52,24 +81,128 @@ pub fn build_command(
     }
 
     let (mut cmd, home) = base_cmd(project_root);
+    apply_credential_denies(&mut cmd, &home);
+    apply_policy_overlay(&mut cmd, policy)?;
+    cmd.args(["--", "sh", "-c", command])
+        .current_dir(project_root);
+    Ok(cmd)
+}
 
-    // Layer 2: full deny (read+write) for koda-internal secrets only.
-    // The base `--ro-bind / /` already write-protects everything else.
+/// Like [`build_command`] but also wires up the kernel-enforced egress
+/// proxy via the stage 2 helper (Phase 3c.1.d).
+///
+/// `proxy_port` is the host-side TCP port the proxy is listening on
+/// (used purely as a debug breadcrumb in the resulting Command —
+/// stage 2 reads the in-netns ephemeral port from its own listener).
+///
+/// `uds_path` is the UDS bridge socket the host bridge
+/// ([`crate::bwrap_proxy::spawn_uds_bridge`]) is listening on. Must
+/// exist; we bind-mount it into the sandbox so stage 2 can
+/// `connect()` to it.
+///
+/// `stage2_bin` is the absolute path to the `koda-sandbox-stage2`
+/// helper binary (located via [`stage2_binary`]). The host filesystem
+/// is bind-mounted read-only into the sandbox, so the same path is
+/// reachable from inside.
+pub fn build_command_with_proxy(
+    command: &str,
+    project_root: &Path,
+    policy: &SandboxPolicy,
+    proxy_port: u16,
+    uds_path: &Path,
+    stage2_bin: &Path,
+) -> Result<Command> {
+    if !is_available() {
+        anyhow::bail!(
+            "Sandbox requested but bwrap is not installed. \
+             Install with: apt install bubblewrap  /  dnf install bubblewrap"
+        );
+    }
+
+    let (mut cmd, home) = base_cmd(project_root);
+    apply_credential_denies(&mut cmd, &home);
+    apply_policy_overlay(&mut cmd, policy)?;
+
+    // Network isolation. The fresh netns has no routes anywhere
+    // except its own (initially-down) loopback — that's the kernel
+    // enforcement. `--unshare-user` is required for `--unshare-net`
+    // when bwrap runs unprivileged. `--unshare-pid` keeps the bridge
+    // child from leaking PIDs into the host PID space (and gives stage
+    // 2's PR_SET_PDEATHSIG a clean parent to track).
+    cmd.args(["--unshare-net", "--unshare-user", "--unshare-pid"]);
+
+    // Bind-mount the UDS bridge socket so stage 2 can connect() to
+    // it. The base `--bind /tmp /tmp` already covers our default UDS
+    // location, but emit the explicit pair so the dependency is
+    // visible in snapshots and survives future base layout changes.
+    let uds_str = uds_path.to_string_lossy().into_owned();
+    cmd.args(["--bind", &uds_str, &uds_str]);
+
+    // Tell stage 2 (a) where the UDS lives and (b) which env keys to
+    // rewrite. Setting on the parent Command propagates to the child
+    // because bwrap doesn't `--clearenv` by default.
+    cmd.env(crate::bwrap_proxy::STAGE2_UDS_ENV_KEY, &uds_str);
+    cmd.env(
+        crate::bwrap_proxy::STAGE2_REWRITE_KEYS_ENV_KEY,
+        STAGE2_PROXY_REWRITE_KEYS,
+    );
+    // Debug breadcrumb — never read by stage 2 itself.
+    cmd.env("KODA_SANDBOX_PROXY_PORT_DEBUG", proxy_port.to_string());
+
+    // Replace the usual `-- sh -c <cmd>` terminator with the stage 2
+    // helper. Stage 2 sets up the in-netns bridge then execvp's
+    // ["sh", "-c", command].
+    let stage2_str = stage2_bin.to_string_lossy().into_owned();
+    cmd.args(["--", &stage2_str, "sh", "-c", command])
+        .current_dir(project_root);
+    Ok(cmd)
+}
+
+/// Apply the credential full-deny tmpfs overlays (layer 2). Shared
+/// between the proxied and unproxied build paths so they stay in
+/// lockstep.
+fn apply_credential_denies(cmd: &mut Command, home: &str) {
     for rel in CREDENTIAL_CONFIG_FULL_DENY {
         let p = format!("{home}/.config/{rel}");
         if Path::new(&p).exists() {
             cmd.args(["--tmpfs", &p]);
         }
     }
+}
 
-    // Layer 3: policy overlay (Phase 1b of #934).
+/// Apply the policy overlay (layer 3). Shared between the proxied and
+/// unproxied build paths.
+fn apply_policy_overlay(cmd: &mut Command, policy: &SandboxPolicy) -> Result<()> {
     for arg_pair in policy_overlay_args(policy)? {
         cmd.args(&arg_pair);
     }
+    Ok(())
+}
 
-    cmd.args(["--", "sh", "-c", command])
-        .current_dir(project_root);
-    Ok(cmd)
+/// Locate the `koda-sandbox-stage2` helper binary.
+///
+/// Resolution order (mirrors [`crate::worker_client`]'s discovery):
+///
+/// 1. `KODA_SANDBOX_STAGE2_BIN` env var — explicit override (e2e tests).
+/// 2. `CARGO_BIN_EXE_koda-sandbox-stage2` — Cargo sets this for
+///    integration tests.
+/// 3. Sibling of the current executable (production install).
+pub fn stage2_binary() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var(STAGE2_BIN_ENV_KEY) {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(p) = std::env::var("CARGO_BIN_EXE_koda-sandbox-stage2") {
+        return Ok(PathBuf::from(p));
+    }
+    let mut p = std::env::current_exe().context("locate koda executable")?;
+    p.set_file_name("koda-sandbox-stage2");
+    if p.exists() {
+        return Ok(p);
+    }
+    anyhow::bail!(
+        "koda-sandbox-stage2 not found next to {}; set {STAGE2_BIN_ENV_KEY} to override",
+        p.display()
+    )
 }
 
 /// Probe whether the bwrap backend is functional. Cached.
@@ -233,5 +366,152 @@ mod tests {
         assert_eq!(args[1][0], "--ro-bind"); // allow_read_within_deny
         assert_eq!(args[2][0], "--bind"); // allow_write
         assert_eq!(args[3][0], "--ro-bind"); // deny_write_within_allow
+    }
+
+    /// Phase 3c.1.d contract: the proxied build path adds the network
+    /// isolation flags, the UDS bind-mount, and replaces the `sh -c`
+    /// terminator with the stage 2 helper.
+    #[test]
+    fn build_command_with_proxy_adds_unshare_and_stage2() {
+        if !is_available() {
+            eprintln!("bwrap not available; skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("bridge.sock");
+        std::fs::write(&uds, b"placeholder").unwrap();
+        let stage2 = dir.path().join("koda-sandbox-stage2");
+        std::fs::write(&stage2, b"#!/bin/sh\n").unwrap();
+
+        let cmd = build_command_with_proxy(
+            "echo hi",
+            dir.path(),
+            &SandboxPolicy::strict_default(),
+            12345,
+            &uds,
+            &stage2,
+        )
+        .unwrap();
+
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+
+        // Network isolation flags must appear.
+        assert!(
+            args.iter().any(|a| a == "--unshare-net"),
+            "--unshare-net missing"
+        );
+        assert!(
+            args.iter().any(|a| a == "--unshare-user"),
+            "--unshare-user missing"
+        );
+        assert!(
+            args.iter().any(|a| a == "--unshare-pid"),
+            "--unshare-pid missing"
+        );
+
+        // UDS bind-mount must reference the host path on both sides.
+        let uds_str = uds.to_string_lossy().to_string();
+        let bind_idx = args
+            .windows(3)
+            .position(|w| w[0] == "--bind" && w[1] == uds_str && w[2] == uds_str)
+            .expect("--bind <uds> <uds> missing");
+        // Should appear *after* --unshare-net so the path resolves
+        // inside the new mount namespace bwrap creates.
+        let unshare_idx = args.iter().position(|a| a == "--unshare-net").unwrap();
+        assert!(
+            bind_idx > unshare_idx,
+            "--bind UDS must follow --unshare-net (got bind@{bind_idx} unshare@{unshare_idx})"
+        );
+
+        // Terminator: -- <stage2_bin> sh -c "echo hi".
+        let dash_dash = args.iter().rposition(|a| a == "--").expect("-- missing");
+        assert_eq!(args[dash_dash + 1], stage2.to_string_lossy());
+        assert_eq!(args[dash_dash + 2], "sh");
+        assert_eq!(args[dash_dash + 3], "-c");
+        assert_eq!(args[dash_dash + 4], "echo hi");
+    }
+
+    /// Companion: env vars are set on the parent Command so they
+    /// propagate to the bwrap child (and through to stage 2).
+    #[test]
+    fn build_command_with_proxy_sets_stage2_env_vars() {
+        if !is_available() {
+            eprintln!("bwrap not available; skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let uds = dir.path().join("bridge.sock");
+        std::fs::write(&uds, b"placeholder").unwrap();
+        let stage2 = dir.path().join("koda-sandbox-stage2");
+        std::fs::write(&stage2, b"#!/bin/sh\n").unwrap();
+
+        let cmd = build_command_with_proxy(
+            "true",
+            dir.path(),
+            &SandboxPolicy::strict_default(),
+            54321,
+            &uds,
+            &stage2,
+        )
+        .unwrap();
+
+        let envs: std::collections::HashMap<String, String> = cmd
+            .as_std()
+            .get_envs()
+            .filter_map(|(k, v)| {
+                Some((
+                    k.to_string_lossy().to_string(),
+                    v?.to_string_lossy().to_string(),
+                ))
+            })
+            .collect();
+
+        assert_eq!(
+            envs.get(crate::bwrap_proxy::STAGE2_UDS_ENV_KEY),
+            Some(&uds.to_string_lossy().to_string()),
+            "stage 2 must learn the UDS path via env"
+        );
+        let rewrite = envs
+            .get(crate::bwrap_proxy::STAGE2_REWRITE_KEYS_ENV_KEY)
+            .expect("stage 2 rewrite-keys env missing");
+        // All six proxy env keys (upper + lower) must be in the list,
+        // matching what proxy::env::proxy_env_vars emits. Otherwise
+        // stage 2 would leave some keys pointing at the host port.
+        for key in [
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "ALL_PROXY",
+            "https_proxy",
+            "http_proxy",
+            "all_proxy",
+        ] {
+            assert!(
+                rewrite.split(',').any(|k| k == key),
+                "rewrite key {key} missing from {rewrite}"
+            );
+        }
+    }
+
+    /// Pinned: stage 2 binary discovery honors the env override
+    /// before falling back to current_exe sibling lookup. E2E tests
+    /// rely on this.
+    #[test]
+    fn stage2_binary_respects_env_override() {
+        // SAFETY: tests run single-threaded for env mutations; we
+        // restore the original value after the assertion.
+        let original = std::env::var(STAGE2_BIN_ENV_KEY).ok();
+        unsafe { std::env::set_var(STAGE2_BIN_ENV_KEY, "/tmp/fake-stage2") };
+        let p = stage2_binary().unwrap();
+        assert_eq!(p, std::path::PathBuf::from("/tmp/fake-stage2"));
+        unsafe {
+            match original {
+                Some(v) => std::env::set_var(STAGE2_BIN_ENV_KEY, v),
+                None => std::env::remove_var(STAGE2_BIN_ENV_KEY),
+            }
+        }
     }
 }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -181,12 +181,18 @@ fn apply_policy_overlay(cmd: &mut Command, policy: &SandboxPolicy) -> Result<()>
 
 /// Locate the `koda-sandbox-stage2` helper binary.
 ///
-/// Resolution order (mirrors [`crate::worker_client`]'s discovery):
+/// Resolution order (mirrors [`crate::worker_client`]'s discovery,
+/// plus a deps-dir fallback for cargo-test invocations):
 ///
 /// 1. `KODA_SANDBOX_STAGE2_BIN` env var — explicit override (e2e tests).
 /// 2. `CARGO_BIN_EXE_koda-sandbox-stage2` — Cargo sets this for
-///    integration tests.
+///    integration tests *of this same crate*.
 /// 3. Sibling of the current executable (production install).
+/// 4. Parent's sibling — cargo runs test exes from `target/debug/deps/`
+///    while built binaries live one level up at `target/debug/`. This
+///    branch lets cross-crate integration tests (notably the
+///    `koda-core` e2e suite) find the helper without setting an env
+///    var.
 pub fn stage2_binary() -> Result<PathBuf> {
     if let Ok(p) = std::env::var(STAGE2_BIN_ENV_KEY) {
         return Ok(PathBuf::from(p));
@@ -194,14 +200,26 @@ pub fn stage2_binary() -> Result<PathBuf> {
     if let Ok(p) = std::env::var("CARGO_BIN_EXE_koda-sandbox-stage2") {
         return Ok(PathBuf::from(p));
     }
-    let mut p = std::env::current_exe().context("locate koda executable")?;
-    p.set_file_name("koda-sandbox-stage2");
-    if p.exists() {
-        return Ok(p);
+    let exe = std::env::current_exe().context("locate koda executable")?;
+
+    let mut sibling = exe.clone();
+    sibling.set_file_name("koda-sandbox-stage2");
+    if sibling.exists() {
+        return Ok(sibling);
     }
+
+    // Cargo-test fallback: target/debug/deps/<test-bin> →
+    // target/debug/koda-sandbox-stage2.
+    if let Some(parent) = exe.parent().and_then(|p| p.parent()) {
+        let cargo_built = parent.join("koda-sandbox-stage2");
+        if cargo_built.exists() {
+            return Ok(cargo_built);
+        }
+    }
+
     anyhow::bail!(
         "koda-sandbox-stage2 not found next to {}; set {STAGE2_BIN_ENV_KEY} to override",
-        p.display()
+        sibling.display()
     )
 }
 

--- a/koda-sandbox/src/bwrap_proxy.rs
+++ b/koda-sandbox/src/bwrap_proxy.rs
@@ -1,0 +1,370 @@
+//! UDS↔TCP proxy bridge for the bwrap kernel-enforced egress path
+//! (Phase 3c.1 of #934).
+//!
+//! ## Why this exists
+//!
+//! On macOS, seatbelt's SBPL has a built-in
+//! `(allow network-outbound (remote tcp "localhost:PORT"))` rule, so
+//! kernel-enforced "deny all egress except the proxy port" is one
+//! profile line (see `seatbelt::network_proxied_rules`, macOS-only).
+//!
+//! On Linux, bubblewrap's `--unshare-net` can deny ALL networking
+//! including loopback — but it can't selectively allow a single
+//! loopback port. Worse, the host's proxy on `127.0.0.1:PORT` is
+//! unreachable from inside a fresh net namespace because the netns
+//! has its own (initially-down) loopback that doesn't share state
+//! with the host's.
+//!
+//! ## How codex solved this (and we borrowed the pattern)
+//!
+//! **Unix domain sockets cross network namespaces** because they're
+//! filesystem objects, not network objects. So we can:
+//!
+//! 1. Spawn a **host bridge** (this module) that listens on a UDS
+//!    path and forwards each accepted connection to the host's TCP
+//!    proxy port.
+//! 2. Bind-mount that UDS path into the bwrap sandbox via
+//!    `--bind <uds> <uds>`.
+//! 3. Inside the sandbox, after `--unshare-net` strips all networking,
+//!    spawn a **local bridge** ([`crate::stage2`]) that brings up
+//!    `lo`, binds an in-netns TCP listener, and forwards each accepted
+//!    connection to the UDS.
+//! 4. Set `HTTPS_PROXY=http://127.0.0.1:LOCAL_PORT` inside the sandbox
+//!    so well-behaved clients use the in-netns TCP listener.
+//!
+//! Direct TCP from inside the sandbox to anywhere else **fails at
+//! the kernel level** because the netns has no routes to anywhere
+//! except its own loopback. That's the kernel enforcement.
+//!
+//! ## What this module owns
+//!
+//! Only the host-side half: the UDS listener that accepts connections
+//! from inside the sandbox (via the bind-mount) and forwards them to
+//! the host's TCP proxy. Pure tokio, lives as a task in the agent
+//! process, dies when the [`tokio::task::JoinHandle`] is dropped.
+//!
+//! The in-sandbox local bridge lives in [`crate::stage2`] and runs as
+//! a forked child of the `koda-sandbox-stage2` helper binary — it
+//! can't be tokio because stage 2 must be a tiny synchronous helper
+//! (no big runtime, executes before the user command).
+//!
+//! ## Reference
+//!
+//! Adapted from codex's `linux-sandbox/src/proxy_routing.rs`
+//! (see `../../codex` checkout). Codex's version forks for both
+//! bridges because their `linux-sandbox` is a CLI binary that exits
+//! after spawning bwrap; koda's host-side bridge can be a tokio task
+//! because koda's agent process is long-lived and already runs a
+//! tokio runtime for the proxy itself.
+
+#![cfg(target_os = "linux")]
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpStream, UnixListener};
+use tokio::task::JoinHandle;
+use tracing::{debug, trace, warn};
+
+/// Env var the parent process sets in the bwrap-spawned `koda-sandbox-stage2`
+/// child to identify the UDS path it must bridge to.
+///
+/// Stage 2 reads this, opens a TCP listener on the netns loopback,
+/// and bridges accepted connections to the UDS.
+pub const STAGE2_UDS_ENV_KEY: &str = "KODA_SANDBOX_STAGE2_UDS";
+
+/// Env var the parent process sets in the bwrap-spawned `koda-sandbox-stage2`
+/// child listing the comma-separated env keys whose values must be
+/// rewritten to point at the in-netns TCP port that stage 2 binds.
+///
+/// Example value: `HTTP_PROXY,HTTPS_PROXY,ALL_PROXY`.
+pub const STAGE2_REWRITE_KEYS_ENV_KEY: &str = "KODA_SANDBOX_STAGE2_REWRITE_KEYS";
+
+/// Returns the deterministic UDS path for a given proxy port.
+///
+/// The path includes the parent PID + port so concurrent koda
+/// processes don't collide on `/tmp/koda-sandbox-proxy-<pid>-<port>.sock`.
+///
+/// Lives under `/tmp` (bind-mounted into the sandbox by
+/// `bwrap::build_command`'s `--bind /tmp /tmp`), so the
+/// per-session sandbox can `connect()` to it without an extra
+/// `--bind` rule. We also emit an explicit `--bind <uds> <uds>` for
+/// clarity and to survive future bwrap layout changes that might
+/// strip the broad `/tmp` mount.
+pub fn proxy_uds_path(parent_pid: u32, proxy_port: u16) -> PathBuf {
+    std::env::temp_dir().join(format!("koda-sandbox-proxy-{parent_pid}-{proxy_port}.sock"))
+}
+
+/// Spawn a tokio task that listens on `uds_path` and forwards each
+/// accepted connection to `127.0.0.1:tcp_port`.
+///
+/// Returns the [`JoinHandle`] so callers (typically [`crate::proxy::ProxyHandle`])
+/// can `abort()` it on drop. The UDS file is removed before binding
+/// (in case a stale socket is left over from a crashed previous run)
+/// and again best-effort when the task aborts.
+///
+/// ## Failure modes
+///
+/// - `bind` fails: returned `Err`. Likely cause: file exists and
+///   isn't ours, or `/tmp` isn't writable. Caller should warn and
+///   fall back to env-var-only enforcement.
+/// - Per-connection forwarding errors: logged at `trace!` and the
+///   connection is dropped. Doesn't affect other connections.
+pub async fn spawn_uds_bridge(uds_path: PathBuf, tcp_port: u16) -> Result<JoinHandle<()>> {
+    // Remove any stale socket file. Ignored if it doesn't exist.
+    let _ = tokio::fs::remove_file(&uds_path).await;
+
+    let listener = UnixListener::bind(&uds_path)
+        .with_context(|| format!("bind UDS bridge at {}", uds_path.display()))?;
+
+    debug!(
+        "uds bridge listening on {} → 127.0.0.1:{tcp_port}",
+        uds_path.display()
+    );
+
+    // Cleanup-on-drop: when the spawned task is aborted, the destructor
+    // chain doesn't run (tokio just stops polling), so a `Drop` impl on a
+    // guard wouldn't help. We rely on the caller having already removed the
+    // file via `cleanup_uds_path()` after aborting the handle. The struct
+    // that owns the handle (today, `ProxyHandle`) does this in its own
+    // `Drop` impl. Keep `uds_path` here only because the `listener` keeps
+    // the inode bound until aborted, regardless of whether anyone reads it.
+    let _bound_path = uds_path;
+
+    let task = tokio::spawn(async move {
+        loop {
+            let (uds_stream, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    // EBADF after listener drop is the expected shutdown path.
+                    trace!("uds bridge accept error (likely shutdown): {e}");
+                    return;
+                }
+            };
+
+            tokio::spawn(async move {
+                let tcp_stream = match TcpStream::connect(("127.0.0.1", tcp_port)).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        trace!("uds bridge: TCP connect to 127.0.0.1:{tcp_port} failed: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = bridge_streams(uds_stream, tcp_stream).await {
+                    trace!("uds bridge: pipe error: {e}");
+                }
+            });
+        }
+    });
+
+    Ok(task)
+}
+
+/// Best-effort cleanup of a stale UDS path. Called by [`crate::proxy::ProxyHandle::shutdown`]
+/// after aborting the bridge task.
+///
+/// Errors are swallowed — if the file doesn't exist (the common case)
+/// or we lack permissions (shouldn't happen for our own `/tmp` files),
+/// there's nothing actionable.
+pub fn cleanup_uds_path(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        warn!(
+            "uds bridge cleanup: failed to remove {}: {e}",
+            path.display()
+        );
+    }
+}
+
+/// Bidirectional pipe between a Unix socket stream and a TCP stream.
+///
+/// Splits both sides and uses `tokio::io::copy` in each direction,
+/// joining when either half EOFs. Mirrors `proxy_bidirectional` in
+/// codex's `proxy_routing.rs` but tokio-async instead of std-blocking.
+async fn bridge_streams(
+    uds_stream: tokio::net::UnixStream,
+    tcp_stream: TcpStream,
+) -> std::io::Result<()> {
+    let (mut uds_r, mut uds_w) = uds_stream.into_split();
+    let (mut tcp_r, mut tcp_w) = tcp_stream.into_split();
+
+    let uds_to_tcp = async move {
+        let _ = tokio::io::copy(&mut uds_r, &mut tcp_w).await;
+        let _ = tcp_w.shutdown().await;
+    };
+    let tcp_to_uds = async move {
+        let _ = tokio::io::copy(&mut tcp_r, &mut uds_w).await;
+        let _ = uds_w.shutdown().await;
+    };
+    tokio::join!(uds_to_tcp, tcp_to_uds);
+    Ok(())
+}
+
+/// Pure helper: rewrite the port of an `http://host:port` proxy URL.
+///
+/// Used by stage 2 to redirect e.g. `HTTPS_PROXY=http://127.0.0.1:54321`
+/// (host-side port that's now unreachable inside the netns) to
+/// `http://127.0.0.1:NEW_PORT` (the local bridge's in-netns port).
+///
+/// Returns `None` if the URL doesn't parse or doesn't have an authority
+/// section we can replace. The grammar is intentionally narrow — we
+/// only ever generate proxy URLs of the form `http://127.0.0.1:PORT`
+/// in [`crate::proxy::env::proxy_env_vars`], so the corner cases are
+/// few. For broader URL shapes (socks5h, etc.) callers should reach
+/// for the `url` crate.
+pub fn rewrite_proxy_url_port(url: &str, new_port: u16) -> Option<String> {
+    // Accept `http://`, `https://`, `socks5://`, `socks5h://`, etc.
+    let scheme_end = url.find("://")?;
+    let after_scheme = &url[scheme_end + 3..];
+    let authority_end = after_scheme.find('/').unwrap_or(after_scheme.len());
+    let authority = &after_scheme[..authority_end];
+    let rest = &after_scheme[authority_end..];
+
+    // Authority is `[userinfo@]host[:port]`. We only rewrite the port.
+    let (userinfo, host_port) = match authority.rsplit_once('@') {
+        Some((u, hp)) => (Some(u), hp),
+        None => (None, authority),
+    };
+    let host = match host_port.rsplit_once(':') {
+        Some((h, _)) => h,
+        None => host_port,
+    };
+    if host.is_empty() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(url.len() + 6);
+    out.push_str(&url[..scheme_end + 3]);
+    if let Some(u) = userinfo {
+        out.push_str(u);
+        out.push('@');
+    }
+    out.push_str(host);
+    out.push(':');
+    out.push_str(&new_port.to_string());
+    out.push_str(rest);
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, UnixStream};
+
+    #[test]
+    fn proxy_uds_path_includes_pid_and_port() {
+        let p = proxy_uds_path(12345, 54321);
+        let s = p.to_string_lossy();
+        assert!(s.contains("12345"), "pid missing: {s}");
+        assert!(s.contains("54321"), "port missing: {s}");
+        assert!(s.ends_with(".sock"), "extension wrong: {s}");
+        assert!(p.starts_with(std::env::temp_dir()), "not in tmp: {s}");
+    }
+
+    #[test]
+    fn proxy_uds_path_distinct_for_distinct_inputs() {
+        // Sanity: two different ports produce different paths.
+        // Without this, concurrent koda sessions would collide.
+        let a = proxy_uds_path(1, 100);
+        let b = proxy_uds_path(1, 101);
+        assert_ne!(a, b);
+        let c = proxy_uds_path(2, 100);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_handles_basic_http() {
+        let out = rewrite_proxy_url_port("http://127.0.0.1:1234", 9999).unwrap();
+        assert_eq!(out, "http://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_handles_no_existing_port() {
+        // The proxy_env_vars output always has an explicit port, but
+        // be robust to user-provided values that omit it.
+        let out = rewrite_proxy_url_port("http://localhost", 9999).unwrap();
+        assert_eq!(out, "http://localhost:9999");
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_preserves_path() {
+        let out = rewrite_proxy_url_port("http://127.0.0.1:1234/path?q=1", 9999).unwrap();
+        assert_eq!(out, "http://127.0.0.1:9999/path?q=1");
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_preserves_userinfo() {
+        let out = rewrite_proxy_url_port("http://user:pw@127.0.0.1:1234", 9999).unwrap();
+        assert_eq!(out, "http://user:pw@127.0.0.1:9999");
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_handles_socks_scheme() {
+        // We don't generate these but stage 2 should pass them
+        // through if the user provided one in their env.
+        let out = rewrite_proxy_url_port("socks5h://127.0.0.1:1080", 9999).unwrap();
+        assert_eq!(out, "socks5h://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn rewrite_proxy_url_port_returns_none_for_garbage() {
+        assert_eq!(rewrite_proxy_url_port("not a url", 9999), None);
+        assert_eq!(rewrite_proxy_url_port("http://", 9999), None);
+    }
+
+    #[tokio::test]
+    async fn uds_bridge_forwards_bytes_to_tcp_listener() {
+        // End-to-end: spin up a TCP listener, spawn the bridge, write
+        // through the UDS, expect the bytes to arrive at the TCP side.
+        let tcp = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let tcp_port = tcp.local_addr().unwrap().port();
+
+        // Echo server on the TCP side: read N bytes, write them back.
+        tokio::spawn(async move {
+            let (mut sock, _) = tcp.accept().await.unwrap();
+            let mut buf = [0u8; 5];
+            sock.read_exact(&mut buf).await.unwrap();
+            sock.write_all(&buf).await.unwrap();
+        });
+
+        let uds_dir = tempfile::tempdir().unwrap();
+        let uds_path = uds_dir.path().join("bridge.sock");
+        let bridge = spawn_uds_bridge(uds_path.clone(), tcp_port).await.unwrap();
+
+        // Connect via UDS, write 5 bytes, read them back through the bridge.
+        let mut client = UnixStream::connect(&uds_path).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        let mut got = [0u8; 5];
+        tokio::time::timeout(Duration::from_secs(2), client.read_exact(&mut got))
+            .await
+            .expect("must echo within 2s")
+            .unwrap();
+        assert_eq!(&got, b"hello");
+
+        bridge.abort();
+        cleanup_uds_path(&uds_path);
+    }
+
+    #[tokio::test]
+    async fn uds_bridge_removes_stale_socket_file() {
+        // Pre-create a stale file at the UDS path; the bridge must
+        // unlink-and-rebind rather than failing with EADDRINUSE.
+        let uds_dir = tempfile::tempdir().unwrap();
+        let uds_path = uds_dir.path().join("stale.sock");
+        std::fs::write(&uds_path, b"leftover").unwrap();
+        assert!(uds_path.exists());
+
+        // No real TCP backend needed for this test; we just want the
+        // bind to succeed. Use port 1 (definitely-no-listener) so any
+        // stray connection attempt fails fast in the trace logs.
+        let bridge = spawn_uds_bridge(uds_path.clone(), 1).await.unwrap();
+        // bind succeeded → file is now a socket
+        assert!(uds_path.exists());
+
+        bridge.abort();
+        cleanup_uds_path(&uds_path);
+    }
+}

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -43,6 +43,8 @@ pub mod policy_check;
 pub mod proxy;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;
+#[cfg(target_os = "linux")]
+pub mod stage2;
 pub mod violations;
 pub mod worker;
 #[cfg(unix)]

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -31,6 +31,8 @@
 
 #[cfg(target_os = "linux")]
 pub mod bwrap;
+#[cfg(target_os = "linux")]
+pub mod bwrap_proxy;
 pub mod defaults;
 pub mod fs;
 pub mod ipc;

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -226,18 +226,32 @@ pub struct BwrapRuntime;
 #[cfg(target_os = "linux")]
 impl SandboxRuntime for BwrapRuntime {
     fn transform(&self, req: SandboxTransformRequest<'_>) -> Result<SandboxExecRequest> {
-        // Phase 3c gap: bwrap doesn't support port-level egress
-        // filtering (`--unshare-net` cuts ALL networking including
-        // loopback, and bringing `lo` back up needs CAP_NET_ADMIN).
-        // Linux kernel-enforcement is deferred to Phase 3c.1, which
-        // will likely use slirp4netns or rootlesskit. Until then,
-        // Linux relies on the env-var bouquet from
-        // [`crate::proxy::env::proxy_env_vars`] — same enforcement
-        // tier as Phase 3b. Warn once so this gap isn't invisible.
-        if req.proxy_port.is_some() {
-            warn_proxy_unenforced_on_linux_once();
-        }
-        let command = bwrap::build_command(req.command, req.project_root, req.policy)?;
+        // Phase 3c.1.d: try kernel-enforced egress via the stage 2
+        // helper. Falls back to env-var-only if any prerequisite is
+        // missing (no proxy, bridge spawn failed, stage 2 binary
+        // unlocatable). The fallback path is the same enforcement
+        // tier as Phase 3b — well-behaved clients (curl, gh, npm,
+        // pip, cargo, go, node, python) honor HTTPS_PROXY and route
+        // through the proxy; ill-behaved binaries can still reach
+        // the network. Every fallback emits the once-per-process
+        // warning so the gap stays visible.
+        let command = match try_build_kernel_enforced(&req) {
+            Ok(Some(cmd)) => cmd,
+            Ok(None) => {
+                if req.proxy_port.is_some() {
+                    warn_proxy_unenforced_on_linux_once();
+                }
+                bwrap::build_command(req.command, req.project_root, req.policy)?
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "koda-sandbox: kernel-enforced egress setup failed ({e:#}); \
+                     falling back to env-var enforcement."
+                );
+                warn_proxy_unenforced_on_linux_once();
+                bwrap::build_command(req.command, req.project_root, req.policy)?
+            }
+        };
         Ok(SandboxExecRequest { command })
     }
 
@@ -262,10 +276,49 @@ impl SandboxRuntime for BwrapRuntime {
     }
 }
 
+/// Try to build a kernel-enforced (Phase 3c.1) bwrap command.
+///
+/// Returns:
+/// - `Ok(Some(cmd))` — prerequisites met, kernel-enforced path active.
+/// - `Ok(None)` — prerequisites missing (no proxy port, or no UDS
+///   bridge spawned). Caller falls back to env-var-only enforcement.
+/// - `Err(_)` — prerequisites partially met but stage 2 binary
+///   couldn't be located. Caller logs and falls back.
+///
+/// The UDS path is derived deterministically from the proxy port +
+/// our own PID via [`crate::bwrap_proxy::proxy_uds_path`] (same
+/// formula the host bridge uses). No IPC needed to discover it.
+#[cfg(target_os = "linux")]
+fn try_build_kernel_enforced(
+    req: &SandboxTransformRequest<'_>,
+) -> Result<Option<tokio::process::Command>> {
+    use anyhow::Context as _;
+    let Some(port) = req.proxy_port else {
+        return Ok(None);
+    };
+    let uds = bwrap_proxy::proxy_uds_path(std::process::id(), port);
+    if !uds.exists() {
+        // Bridge didn't spawn this session (BuiltInProxy::spawn would
+        // have warned). Fall back silently — no second warning.
+        return Ok(None);
+    }
+    let stage2 = bwrap::stage2_binary().context("locate koda-sandbox-stage2")?;
+    let cmd = bwrap::build_command_with_proxy(
+        req.command,
+        req.project_root,
+        req.policy,
+        port,
+        &uds,
+        &stage2,
+    )?;
+    Ok(Some(cmd))
+}
+
 /// One-time warning when koda-core asks the bwrap backend to enforce a
-/// proxy port but bwrap can't (Phase 3c.1 territory). The env-var
-/// bouquet still routes well-behaved clients through the proxy; only
-/// ill-behaved binaries that ignore `HTTPS_PROXY` escape the filter.
+/// proxy port but bwrap can't kernel-enforce it for this session
+/// (e.g. UDS bridge spawn failed). The env-var bouquet still routes
+/// well-behaved clients through the proxy; only ill-behaved binaries
+/// that ignore `HTTPS_PROXY` escape the filter.
 ///
 /// Lives at module scope (not inside `BwrapRuntime`) because the
 /// `OnceLock` must outlive any single runtime instance — each
@@ -277,11 +330,12 @@ fn warn_proxy_unenforced_on_linux_once() {
     static WARNED: OnceLock<()> = OnceLock::new();
     WARNED.get_or_init(|| {
         tracing::warn!(
-            "koda-sandbox: built-in proxy is active but bwrap cannot kernel-enforce \
-             port-level egress filtering on Linux yet. Well-behaved HTTP clients (curl, \
-             gh, npm, pip, cargo, go, node, python) honor HTTPS_PROXY and route through \
-             the filter; ill-behaved binaries can still reach the network directly. \
-             Linux kernel-enforcement is tracked as #934 Phase 3c.1."
+            "koda-sandbox: built-in proxy is active but the kernel-enforced \
+             egress path didn't activate for this session (UDS bridge or \
+             stage 2 helper unavailable). Well-behaved HTTP clients (curl, \
+             gh, npm, pip, cargo, go, node, python) honor HTTPS_PROXY and \
+             route through the filter; ill-behaved binaries can still reach \
+             the network directly."
         );
     });
 }

--- a/koda-sandbox/src/proxy/builtin.rs
+++ b/koda-sandbox/src/proxy/builtin.rs
@@ -85,7 +85,46 @@ impl BuiltInProxy {
             port,
             self.filter.len()
         );
-        Ok(ProxyHandle::from_task(port, task))
+        let handle = ProxyHandle::from_task(port, task);
+
+        // Linux-only: also bind a UDS bridge that the bwrap
+        // kernel-enforced sandbox (Phase 3c.1) can `connect()` through
+        // after `--unshare-net` cuts host TCP. Bridge failure is not
+        // fatal — the env-var enforcement tier still works for
+        // well-behaved clients on every backend; we just lose the
+        // kernel-enforced tier on Linux for this session.
+        #[cfg(target_os = "linux")]
+        let handle = match attach_uds_bridge(handle, port).await {
+            Ok(h) => h,
+            Err((h, e)) => {
+                tracing::warn!(
+                    "koda-sandbox: UDS bridge spawn failed: {e}. Linux kernel-enforced \
+                     egress unavailable for this session; well-behaved clients still \
+                     route through the env-var tier."
+                );
+                h
+            }
+        };
+
+        Ok(handle)
+    }
+}
+
+/// Attach the Linux UDS bridge to a freshly-spawned `ProxyHandle`.
+///
+/// Returns the (possibly-decorated) handle. On bridge spawn failure,
+/// returns the original handle unchanged together with the error so
+/// the caller can log + degrade rather than fail the whole session.
+#[cfg(target_os = "linux")]
+async fn attach_uds_bridge(
+    handle: ProxyHandle,
+    tcp_port: u16,
+) -> std::result::Result<ProxyHandle, (ProxyHandle, anyhow::Error)> {
+    let pid = std::process::id();
+    let uds_path = crate::bwrap_proxy::proxy_uds_path(pid, tcp_port);
+    match crate::bwrap_proxy::spawn_uds_bridge(uds_path.clone(), tcp_port).await {
+        Ok(task) => Ok(handle.with_uds_bridge(uds_path, task)),
+        Err(e) => Err((handle, e)),
     }
 }
 
@@ -177,5 +216,44 @@ mod tests {
         let p = BuiltInProxy::new(Filter::default());
         let h = p.spawn().await.unwrap();
         assert!(h.ca_bundle().is_none());
+    }
+
+    /// Phase 3c.1.b contract: on Linux, every successful built-in proxy
+    /// spawn also stands up a UDS bridge so the bwrap kernel-enforced
+    /// path has a connectable socket inside the eventual `--unshare-net`
+    /// sandbox.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn linux_spawn_attaches_uds_bridge() {
+        let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
+        let h = p.spawn().await.unwrap();
+        let uds = h
+            .uds_path()
+            .expect("Linux built-in proxy must attach a UDS bridge");
+        assert!(
+            uds.exists(),
+            "UDS path {} should exist after bridge spawn",
+            uds.display()
+        );
+    }
+
+    /// Companion: dropping the handle removes the UDS file so the next
+    /// spawn can re-bind cleanly. Without this, repeated session
+    /// creation in the same process would accumulate stale sockets.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn linux_drop_removes_uds_path() {
+        let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
+        let h = p.spawn().await.unwrap();
+        let uds = h.uds_path().expect("bridge attached").to_owned();
+        assert!(uds.exists());
+        drop(h);
+        // Cleanup is synchronous in `ProxyHandle::shutdown`, so the
+        // file should be gone immediately — no sleep needed.
+        assert!(
+            !uds.exists(),
+            "UDS path {} must be unlinked after drop",
+            uds.display()
+        );
     }
 }

--- a/koda-sandbox/src/proxy/handle.rs
+++ b/koda-sandbox/src/proxy/handle.rs
@@ -15,6 +15,8 @@
 //! See [parent module docs](super) for the broader why.
 
 use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 use tokio::process::Child;
 use tokio::task::JoinHandle;
 use tracing::warn;
@@ -30,6 +32,30 @@ pub struct ProxyHandle {
     pub port: u16,
     /// Backing resource. Boxed-enum so callers don't need to match.
     inner: Inner,
+    /// Linux-only side-channel: the UDS path of a tokio task that
+    /// bridges Unix-socket accepts to the proxy's TCP port. Spawned
+    /// alongside the TCP listener by
+    /// [`crate::proxy::BuiltInProxy::spawn`] so the bwrap kernel-enforced
+    /// egress path (Phase 3c.1) has something the sandbox can
+    /// `connect()` through after `--unshare-net` strips all networking.
+    ///
+    /// `None` on macOS, on Linux when the bridge failed to bind, and
+    /// for [`crate::proxy::ExternalProxy`] (which doesn't need the
+    /// in-process bridge — the user already has a proxy elsewhere).
+    /// `Some` on Linux for the in-process built-in proxy.
+    ///
+    /// `Drop` removes the file (best-effort) and aborts the task.
+    #[cfg(target_os = "linux")]
+    uds_bridge: Option<UdsBridge>,
+}
+
+/// Linux-only bridge bookkeeping. Kept inline (not its own module) since
+/// it's a tiny pair of fields and only used here.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct UdsBridge {
+    path: PathBuf,
+    task: JoinHandle<()>,
 }
 
 #[derive(Debug)]
@@ -49,6 +75,8 @@ impl ProxyHandle {
         Self {
             port,
             inner: Inner::External(Some(child)),
+            #[cfg(target_os = "linux")]
+            uds_bridge: None,
         }
     }
 
@@ -58,7 +86,32 @@ impl ProxyHandle {
         Self {
             port,
             inner: Inner::BuiltIn(Some(task)),
+            #[cfg(target_os = "linux")]
+            uds_bridge: None,
         }
+    }
+
+    /// Attach a Linux-only UDS bridge spawned by
+    /// [`crate::bwrap_proxy::spawn_uds_bridge`]. The handle takes
+    /// ownership of the task + path, abort-and-unlinks them on drop.
+    ///
+    /// Crate-private — only `BuiltInProxy::spawn` is meant to call
+    /// this, immediately after spawning both the TCP listener and the
+    /// bridge.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn with_uds_bridge(mut self, path: PathBuf, task: JoinHandle<()>) -> Self {
+        self.uds_bridge = Some(UdsBridge { path, task });
+        self
+    }
+
+    /// Path of the UDS bridge if one was attached. Used by
+    /// [`crate::BwrapRuntime`] (Phase 3c.1.d) to know what to bind-mount
+    /// into the sandbox.
+    ///
+    /// Returns `None` on macOS and for ExternalProxy.
+    #[cfg(target_os = "linux")]
+    pub fn uds_path(&self) -> Option<&Path> {
+        self.uds_bridge.as_ref().map(|b| b.path.as_path())
     }
 
     /// Path to a CA bundle the proxy expects clients to trust, if any.
@@ -97,6 +150,14 @@ impl ProxyHandle {
                     task.abort();
                 }
             }
+        }
+        // Linux-only: tear down the UDS bridge alongside. Order doesn't
+        // matter — if a sandboxed client is mid-CONNECT through the
+        // bridge, both halves dying simultaneously yields a clean EOF.
+        #[cfg(target_os = "linux")]
+        if let Some(bridge) = self.uds_bridge.take() {
+            bridge.task.abort();
+            crate::bwrap_proxy::cleanup_uds_path(&bridge.path);
         }
     }
 }

--- a/koda-sandbox/src/stage2.rs
+++ b/koda-sandbox/src/stage2.rs
@@ -1,0 +1,343 @@
+//! Stage 2 helper: in-sandbox setup that runs after `bwrap --unshare-net`
+//! cuts host networking, before the user command starts (Phase 3c.1.c
+//! of #934).
+//!
+//! ## Where this runs in the lifecycle
+//!
+//! ```text
+//! koda agent (host, tokio)
+//!   └─> BuiltInProxy::spawn  — binds host TCP + UDS bridge          ┌─── PHASE 3c.1.b
+//!   └─> BwrapRuntime::transform                                      │
+//!         └─> Command::new("bwrap")                                  │
+//!               │    --ro-bind / / --bind /tmp /tmp                    │ PHASE 3c.1.d
+//!               │    --unshare-net --unshare-user --unshare-pid        │ (next commit)
+//!               │    --bind <uds> <uds>                                │
+//!               │    -- /path/to/koda-sandbox-stage2 sh -c "$user_cmd" ┘
+//!               └──> [INSIDE THE NETNS]
+//!                    koda-sandbox-stage2 (THIS MODULE)            ┌─── THIS COMMIT
+//!                    ├─> bring up `lo` (ioctl SIOCSIFFLAGS)        │
+//!                    ├─> bind TCP listener on 127.0.0.1:0          │
+//!                    ├─> fork child: TCP↔UDS bridge thread         │
+//!                    ├─> rewrite HTTPS_PROXY etc to new TCP port   │
+//!                    └─> execvp into ["sh", "-c", user_cmd]         ┘
+//!                          └─> user code runs sandboxed, talks to
+//!                                127.0.0.1:NEW_PORT  →  bridge child
+//!                                →  UDS  →  host TCP  →  proxy filter
+//! ```
+//!
+//! ## Why no tokio
+//!
+//! Stage 2 runs in every sandboxed shell invocation (every Bash tool
+//! call). Pulling in a tokio runtime would add ~5 ms of startup latency
+//! and ~3 MB to the binary. Pure std + libc keeps the helper tiny and
+//! fast — the bridge is just two `std::thread::spawn` blocking copies.
+//!
+//! ## Why fork before execvp
+//!
+//! The TCP listener thread must outlive `execvp` (which replaces the
+//! current process image with the user command). std::thread doesn't
+//! survive `execvp` — the kernel kills all threads except the calling
+//! one. So we `fork()`: the child stays alive running the bridge loop;
+//! the parent execs the user command. Parent-death-signal
+//! (`PR_SET_PDEATHSIG`) ensures the bridge child dies when the user
+//! command exits, even if the user command doesn't reap it.
+//!
+//! ## Failure modes
+//!
+//! Every failure here is fatal to the sandboxed command — if we can't
+//! set up the bridge, the user's command will hit a dead `HTTPS_PROXY`
+//! and timeout. We exit with a distinctive code (88) so callers can
+//! distinguish "sandbox setup failed" from "user command failed".
+
+#![cfg(target_os = "linux")]
+
+use crate::bwrap_proxy::{STAGE2_REWRITE_KEYS_ENV_KEY, STAGE2_UDS_ENV_KEY, rewrite_proxy_url_port};
+use anyhow::{Context, Result, bail};
+use std::ffi::{CString, OsString};
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+
+/// Exit code used when stage 2 fails before reaching execvp.
+///
+/// 88 is arbitrary but distinct from the standard 0/1/2/126/127 plus
+/// the 64–78 sysexits range. Lets callers distinguish "sandbox setup
+/// failed" from "user command failed/not found".
+pub const STAGE2_SETUP_FAILED_EXIT: i32 = 88;
+
+/// Stage 2 entry point. Called from `bin/koda-sandbox-stage2.rs`.
+///
+/// `argv` is the full argument vector the helper was invoked with;
+/// `argv[0]` is the helper binary path (we don't use it), `argv[1..]`
+/// is the user command we'll execvp into.
+///
+/// Never returns on success — it execs the user command. Returns
+/// `Err` only if setup fails before exec.
+pub fn run(argv: Vec<OsString>) -> Result<()> {
+    if argv.len() < 2 {
+        bail!("stage2: missing user command (usage: koda-sandbox-stage2 <cmd> [args...])");
+    }
+
+    let uds_path = std::env::var(STAGE2_UDS_ENV_KEY)
+        .with_context(|| format!("stage2: {STAGE2_UDS_ENV_KEY} env var missing"))?;
+    let uds_path = PathBuf::from(uds_path);
+    if !uds_path.exists() {
+        bail!(
+            "stage2: UDS bridge socket {} not found inside sandbox (was it bind-mounted with --bind?)",
+            uds_path.display()
+        );
+    }
+
+    // Step 1: bring `lo` up. Required because --unshare-net leaves
+    // the new netns's loopback interface DOWN by default.
+    bring_up_loopback().context("stage2: bring up lo")?;
+
+    // Step 2: bind a TCP listener on the in-netns loopback. Port 0 ->
+    // kernel-assigned ephemeral port. We must read the port back
+    // before forking so the parent can rewrite env vars correctly.
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .context("stage2: bind in-netns TCP listener")?;
+    let local_port = listener
+        .local_addr()
+        .context("stage2: read in-netns listener port")?
+        .port();
+
+    // Step 3: fork a bridge child that owns the listener. Parent
+    // continues to env rewriting + execvp. Child loops accept-and-pipe
+    // until killed (by parent-death signal, since the user command
+    // becomes its parent after execvp — same PID).
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        bail!("stage2: fork failed: {}", std::io::Error::last_os_error());
+    }
+    if pid == 0 {
+        // Child: become the bridge.
+        run_bridge_child(listener, uds_path);
+        // Unreachable in normal flow; if it returns we exit cleanly.
+        unsafe { libc::_exit(0) };
+    }
+
+    // Step 4: rewrite proxy env vars. The host-side values point at
+    // 127.0.0.1:HOST_PORT which is unreachable in this netns; we want
+    // them to point at our new in-netns listener.
+    let rewrite_keys = std::env::var(STAGE2_REWRITE_KEYS_ENV_KEY).unwrap_or_default();
+    for key in rewrite_keys.split(',').filter(|k| !k.is_empty()) {
+        let Ok(old) = std::env::var(key) else {
+            continue;
+        };
+        let Some(new) = rewrite_proxy_url_port(&old, local_port) else {
+            // Pass-through if the value isn't a parseable URL —
+            // user-supplied weirdness, not our problem here.
+            continue;
+        };
+        // SAFETY: stage 2 is single-threaded at this point (the
+        // bridge child is in a separate process via fork, not a
+        // thread). std::env::set_var is sound when no other thread
+        // is reading env.
+        unsafe { std::env::set_var(key, new) };
+    }
+
+    // Clean up the stage 2 marker env vars so user commands don't
+    // see (and potentially leak) our internal contract.
+    unsafe {
+        std::env::remove_var(STAGE2_UDS_ENV_KEY);
+        std::env::remove_var(STAGE2_REWRITE_KEYS_ENV_KEY);
+    }
+
+    // Step 5: execvp into the user command. argv[1] is the program;
+    // argv[1..] becomes the new argv.
+    let prog = argv[1].clone();
+    let prog_c = osstring_to_cstring(&prog).context("stage2: convert program name")?;
+    let arg_cs: Vec<CString> = argv[1..]
+        .iter()
+        .map(osstring_to_cstring)
+        .collect::<Result<Vec<_>>>()
+        .context("stage2: convert command args")?;
+    let arg_ptrs: Vec<*const libc::c_char> = arg_cs
+        .iter()
+        .map(|c| c.as_ptr())
+        .chain(std::iter::once(std::ptr::null()))
+        .collect();
+
+    // SAFETY: pointers in `arg_ptrs` are kept alive by `arg_cs` for
+    // the entire syscall duration; null terminator present.
+    unsafe { libc::execvp(prog_c.as_ptr(), arg_ptrs.as_ptr()) };
+
+    // Only reached if execvp failed.
+    let err = std::io::Error::last_os_error();
+    bail!("stage2: execvp({:?}) failed: {err}", prog);
+}
+
+/// Convert an `OsString` to a `CString` for syscall use.
+fn osstring_to_cstring(s: &OsString) -> Result<CString> {
+    CString::new(s.clone().into_vec())
+        .with_context(|| format!("stage2: argv contains NUL byte: {s:?}"))
+}
+
+/// Bring the loopback (`lo`) interface UP via SIOCSIFFLAGS ioctl.
+///
+/// Required because `bwrap --unshare-net` creates a fresh net
+/// namespace whose loopback exists but starts DOWN — attempting to
+/// bind 127.0.0.1 fails with EADDRNOTAVAIL until `lo` is up.
+///
+/// Equivalent to `ip link set lo up` but doesn't require the `ip`
+/// binary to be present in the sandbox.
+fn bring_up_loopback() -> Result<()> {
+    // SOCK_DGRAM is fine for ioctl-on-interface — the socket is just a
+    // handle, never used to send packets.
+    let fd = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0) };
+    if fd < 0 {
+        bail!("socket(AF_INET): {}", std::io::Error::last_os_error());
+    }
+    // Defer fd close.
+    let _close = CloseOnDrop(fd);
+
+    let mut req: libc::ifreq = unsafe { std::mem::zeroed() };
+    // "lo\0" — ifreq.ifr_name is a fixed-size i8 array.
+    let name: &[u8] = b"lo\0";
+    for (i, b) in name.iter().enumerate() {
+        req.ifr_name[i] = *b as libc::c_char;
+    }
+
+    // Read current flags.
+    let r = unsafe { libc::ioctl(fd, libc::SIOCGIFFLAGS as libc::Ioctl, &mut req) };
+    if r < 0 {
+        bail!(
+            "ioctl(SIOCGIFFLAGS, lo): {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // Set IFF_UP (and IFF_RUNNING for good measure — some kernels
+    // require it for loopback to actually carry traffic).
+    let up = (libc::IFF_UP | libc::IFF_RUNNING) as libc::c_short;
+    let cur = unsafe { req.ifr_ifru.ifru_flags };
+    if (cur & up) == up {
+        return Ok(()); // already up
+    }
+    // Write to a Copy union field is safe in current Rust (only
+    // reads need unsafe, since the discriminant isn't tracked).
+    // Wrapping this in `unsafe { }` triggers `unused_unsafe` under
+    // CI's -D warnings.
+    req.ifr_ifru.ifru_flags = cur | up;
+    let r = unsafe { libc::ioctl(fd, libc::SIOCSIFFLAGS as libc::Ioctl, &req) };
+    if r < 0 {
+        bail!(
+            "ioctl(SIOCSIFFLAGS, lo|UP): {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(())
+}
+
+/// RAII guard that closes a fd on drop.
+struct CloseOnDrop(libc::c_int);
+impl Drop for CloseOnDrop {
+    fn drop(&mut self) {
+        unsafe { libc::close(self.0) };
+    }
+}
+
+/// Body of the bridge child process. Runs forever (until killed by
+/// parent-death signal) accepting TCP connections and forwarding each
+/// to a Unix socket connection.
+///
+/// One blocking thread per accepted connection — fine because the
+/// concurrent connection count is bounded by what the user's command
+/// produces, and these threads spend their lives in `read`/`write`
+/// syscalls (cheap).
+fn run_bridge_child(listener: TcpListener, uds_path: PathBuf) {
+    // PR_SET_PDEATHSIG: when our parent (which becomes the user
+    // command after execvp — same PID) exits, send us SIGTERM. Without
+    // this, a forked bridge would orphan into init and survive
+    // forever.
+    unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0) };
+
+    // Race window: the parent may have already exited between fork
+    // and prctl. Check explicitly.
+    if unsafe { libc::getppid() } == 1 {
+        return;
+    }
+
+    loop {
+        let (tcp, _) = match listener.accept() {
+            Ok(p) => p,
+            Err(_) => return, // listener closed
+        };
+        let path = uds_path.clone();
+        std::thread::spawn(move || {
+            let uds = match UnixStream::connect(&path) {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            let _ = bridge_two_streams(tcp, uds);
+        });
+    }
+}
+
+/// Bidirectional copy between a TCP and a Unix stream. Returns when
+/// either direction EOFs.
+fn bridge_two_streams(tcp: TcpStream, uds: UnixStream) -> std::io::Result<()> {
+    let tcp_r = tcp.try_clone()?;
+    let mut tcp_w = tcp;
+    let uds_r = uds.try_clone()?;
+    let mut uds_w = uds;
+
+    let h = std::thread::spawn(move || copy_until_eof(tcp_r, &mut uds_w));
+    let _ = copy_until_eof(uds_r, &mut tcp_w);
+    let _ = h.join();
+    Ok(())
+}
+
+/// `std::io::copy` with a fixed buffer; tolerates `Interrupted` (EINTR).
+fn copy_until_eof<R: Read, W: Write>(mut r: R, w: &mut W) -> std::io::Result<u64> {
+    let mut buf = [0u8; 8 * 1024];
+    let mut total = 0u64;
+    loop {
+        let n = match r.read(&mut buf) {
+            Ok(0) => return Ok(total),
+            Ok(n) => n,
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        w.write_all(&buf[..n])?;
+        total += n as u64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osstring_to_cstring_rejects_nul() {
+        let s = OsString::from_vec(b"foo\0bar".to_vec());
+        assert!(osstring_to_cstring(&s).is_err());
+    }
+
+    #[test]
+    fn osstring_to_cstring_accepts_normal_strings() {
+        let s = OsString::from("sh");
+        let c = osstring_to_cstring(&s).unwrap();
+        assert_eq!(c.to_bytes(), b"sh");
+    }
+
+    #[test]
+    fn copy_until_eof_handles_simple_payload() {
+        // Self-contained pipe roundtrip — no syscalls beyond memory.
+        let mut input = std::io::Cursor::new(b"hello world".to_vec());
+        let mut output: Vec<u8> = Vec::new();
+        let n = copy_until_eof(&mut input, &mut output).unwrap();
+        assert_eq!(n, 11);
+        assert_eq!(&output, b"hello world");
+    }
+
+    #[test]
+    fn stage2_setup_failed_exit_is_88() {
+        // Locked-in API: callers (notably the e2e test in 3c.1.e)
+        // assert on this exit code to distinguish setup failure from
+        // user-command failure. Bumping it is a breaking change.
+        assert_eq!(STAGE2_SETUP_FAILED_EXIT, 88);
+    }
+}


### PR DESCRIPTION
Closes Phase 3c.1 of #934 — Linux now matches the macOS kernel-enforced egress story shipped in #997.

## TL;DR

After this PR, every `koda-core` Bash invocation on Linux runs inside a fresh **network namespace** with no routes to anywhere except a single in-netns TCP listener that bridges through a Unix-domain socket back to the session's built-in proxy. Direct TCP from the sandbox fails at `connect()` with `ENETUNREACH`. Same observable contract as macOS seatbelt SBPL; different kernel mechanism.

## Architecture

```
koda agent (host, tokio)
  ├─> BuiltInProxy::spawn  ─ binds host TCP + UDS bridge       ┌─ 3c.1.b
  └─> BwrapRuntime::transform                                    │
        └─> bwrap                                                │
             │   --ro-bind / / --bind /tmp /tmp                  │ 3c.1.d
             │   --unshare-net --unshare-user --unshare-pid      │
             │   --bind <uds> <uds>                              │
             │   -- /path/to/koda-sandbox-stage2 sh -c "$cmd"   ─┘
             └─> [INSIDE THE NETNS]                              ┌─ 3c.1.c
                  koda-sandbox-stage2                            │
                  ├─> bring up `lo` (ioctl SIOCSIFFLAGS)         │
                  ├─> bind TCP listener on 127.0.0.1:0           │
                  ├─> fork bridge child (PR_SET_PDEATHSIG)       │
                  ├─> rewrite HTTPS_PROXY → in-netns port        │
                  └─> execvp ["sh", "-c", user_cmd]             ─┘
```

The whole UDS-as-netns-crossing-channel trick is borrowed from codex's `linux-sandbox/src/proxy_routing.rs`. UDS is a filesystem object, not a network object, so it crosses netns boundaries cleanly via a `--bind <uds> <uds>`. Direct TCP can't.

## Commits (5 logical slices)

| Slice | What |
|---|---|
| 3c.1.a | Host bridge primitives — `bwrap_proxy` module: deterministic UDS path, tokio bridge task, URL port-rewriter |
| 3c.1.b | Wire bridge into ProxyHandle — Linux `BuiltInProxy::spawn` also spawns UDS bridge; `Drop` aborts + unlinks |
| 3c.1.c | Stage 2 helper — new `koda-sandbox-stage2` binary + `stage2` module: ioctl `lo` up, TCP listen, fork+bridge, env rewrite, execvp |
| 3c.1.d | Wire BwrapRuntime — `try_build_kernel_enforced` activates the new path when prereqs present; falls back gracefully with one-time warning |
| 3c.1.e | E2E tests — Linux mirror of `macos_kernel_{blocks,allows}_*` plus deps-dir fallback in stage 2 binary discovery for cross-crate tests |

Each commit has a fat why-style message — design decisions, fail modes, what's deliberately *not* in that commit.

## Why the design

- **Pure tokio host bridge, no fork.** Koda's agent is long-lived with a tokio runtime already; codex forks because their `linux-sandbox` is a CLI that exits.
- **Pure std + libc stage 2, no tokio.** Stage 2 runs in every sandboxed shell call. Tokio would add ~5ms cold start + ~3MB binary. We need this fast and small.
- **Fork before execvp.** `execvp` kills all threads except the caller. The bridge has to live as a separate process. `PR_SET_PDEATHSIG` ensures it dies with the user command.
- **Deterministic UDS path** (`/tmp/koda-sandbox-proxy-<pid>-<port>.sock`). Both spawning side (`BuiltInProxy::spawn`) and consuming side (`BwrapRuntime::transform`) live in the same koda process and derive the same path. Zero IPC.
- **Graceful fallback.** UDS bridge spawn failure (e.g. `/tmp` not writable) doesn't fail the session — it degrades to env-var-only enforcement (Phase 3b tier) and warns once.

## Tests

- 8 new unit tests (`bwrap_proxy`, `bwrap`, `stage2` modules)
- 2 new Linux-only E2E tests (`linux_kernel_blocks_*`, `linux_kernel_allows_*`) in `koda-core/tests/builtin_proxy_e2e_test.rs`, mirroring the macOS pair
- Existing 202 koda-sandbox lib tests: green on macOS
- Existing 7 builtin_proxy_e2e tests: green on macOS
- `cargo clippy --workspace --all-targets`: clean
- `cargo doc --workspace`: clean

The Linux E2E tests are `#[cfg(target_os = "linux")]` and skip gracefully when bwrap isn't installed (`is_available()` guard, same pattern as the existing `bwrap_runtime_command_snapshot` test).

## API surface added

All cfg-gated `target_os = "linux"` — macOS shape unchanged:

- `koda_sandbox::bwrap_proxy` module (proxy bridge primitives)
- `koda_sandbox::stage2` module (stage 2 setup logic)
- `koda_sandbox::bwrap::build_command_with_proxy()` (proxied bwrap builder)
- `koda_sandbox::bwrap::stage2_binary()` (binary discovery)
- `koda_sandbox::bwrap::STAGE2_BIN_ENV_KEY = "KODA_SANDBOX_STAGE2_BIN"`
- `ProxyHandle::uds_path() -> Option<&Path>`

`SandboxTransformRequest` shape is **unchanged** — the kernel-enforced path activates by inference from the presence of the deterministic UDS file, not by any new caller-supplied field.

## New binary

- `koda-sandbox-stage2` (Linux only; macOS builds a stub that exits 1)
- Discovery mirrors `koda-fs-worker` pattern: env var → `CARGO_BIN_EXE_*` → current_exe sibling → deps-dir fallback for cross-crate tests
