### PR TITLE
Phase 3d (slices 1-3): SOCKS5 proxy + corp HTTPS_PROXY chaining (#934)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -70,6 +70,15 @@ pub(crate) fn is_fully_denied(path: &Path) -> bool {
 /// pip, cargo, go, node, python) route their traffic through the proxy.
 /// `None` preserves the pre-3b unfiltered behavior.
 ///
+/// The `socks5_port` argument is the loopback port of the in-process
+/// SOCKS5 proxy (Phase 3d.1 of #934). When `Some`, `ALL_PROXY` and
+/// `all_proxy` are appended pointing at `socks5h://127.0.0.1:port` so
+/// raw-TCP clients (git over ssh, gRPC tools) that ignore `HTTPS_PROXY`
+/// route through hostname-filtered SOCKS5 instead of dialing direct.
+/// `None` omits both vars; clients fall back to whatever they'd do
+/// without `ALL_PROXY` (typically: dial direct, get filtered out by
+/// the kernel-enforced sandbox layer where present).
+///
 /// Falls back to unsandboxed execution with a one-time warning when the
 /// platform sandbox backend is unavailable. The sandbox is best-effort:
 /// we never block the user just because the kernel enforcement layer is
@@ -79,6 +88,7 @@ pub fn build(
     project_root: &Path,
     _trust: &crate::trust::TrustMode,
     proxy_port: Option<u16>,
+    socks5_port: Option<u16>,
 ) -> Result<Command> {
     let runtime = current_runtime();
     warn_if_unavailable_once(runtime.as_ref());
@@ -114,6 +124,16 @@ pub fn build(
     // advertised — phase 3d will plumb that through.
     if let Some(port) = proxy_port {
         for (k, v) in proxy_env_vars(port, None) {
+            cmd.env(k, v);
+        }
+    }
+
+    // 3d.2: append the SOCKS5 bouquet (ALL_PROXY + lowercase) when the
+    // session has a SOCKS5 proxy spawned. Independent of `proxy_port` —
+    // a session can have either, both, or neither, though in practice
+    // [`crate::session::KodaSession`] spawns them as a pair.
+    if let Some(port) = socks5_port {
+        for (k, v) in koda_sandbox::socks5_env_vars(port) {
             cmd.env(k, v);
         }
     }
@@ -159,6 +179,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             Some(31415),
+            None,
         )
         .unwrap()
         .output()
@@ -181,6 +202,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .output()
@@ -192,6 +214,77 @@ mod tests {
         assert!(
             stdout.contains("[]"),
             "HTTPS_PROXY must be unset, got stdout={stdout:?}"
+        );
+    }
+
+    /// Phase 3d.2: `socks5_port = Some(N)` injects ALL_PROXY +
+    /// all_proxy with the `socks5h://` scheme. Counterpart to
+    /// `build_attaches_proxy_env_when_port_set`.
+    #[tokio::test]
+    async fn build_attaches_socks5_env_when_port_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = build(
+            "echo \"$ALL_PROXY|$all_proxy\"",
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            None,
+            Some(27182),
+        )
+        .unwrap()
+        .output()
+        .await
+        .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("socks5h://127.0.0.1:27182|socks5h://127.0.0.1:27182"),
+            "ALL_PROXY/all_proxy must be set, got stdout={stdout:?}"
+        );
+    }
+
+    /// Phase 3d.2: `socks5_port = None` must not set ALL_PROXY — some
+    /// dev tools change behaviour wildly when ALL_PROXY appears (e.g.
+    /// boto3 routes signing requests through it). Regression guard.
+    #[tokio::test]
+    async fn build_omits_socks5_env_when_port_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = build(
+            "echo \"[$ALL_PROXY]\"",
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            None,
+            None,
+        )
+        .unwrap()
+        .output()
+        .await
+        .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("[]"),
+            "ALL_PROXY must be unset, got stdout={stdout:?}"
+        );
+    }
+
+    /// Phase 3d.2: HTTP and SOCKS5 are independent — setting one must
+    /// not clobber or interfere with the other.
+    #[tokio::test]
+    async fn build_attaches_both_proxy_and_socks5_when_both_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = build(
+            "echo \"$HTTPS_PROXY|$ALL_PROXY\"",
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            Some(8080),
+            Some(1080),
+        )
+        .unwrap()
+        .output()
+        .await
+        .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            stdout.contains("http://127.0.0.1:8080|socks5h://127.0.0.1:1080"),
+            "both vars must be set with their distinct schemes, got stdout={stdout:?}"
         );
     }
 
@@ -209,11 +302,17 @@ mod tests {
                 eval "echo $v=\$$v"
             done
         "#;
-        let out = build(cmd, dir.path(), &crate::trust::TrustMode::Safe, Some(8080))
-            .unwrap()
-            .output()
-            .await
-            .unwrap();
+        let out = build(
+            cmd,
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            Some(8080),
+            None,
+        )
+        .unwrap()
+        .output()
+        .await
+        .unwrap();
         let stdout = String::from_utf8_lossy(&out.stdout);
         for v in ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] {
             assert!(
@@ -230,11 +329,17 @@ mod tests {
     #[tokio::test]
     async fn build_always_succeeds_and_runs_echo() {
         let dir = tempfile::tempdir().unwrap();
-        let status = build("echo ok", dir.path(), &crate::trust::TrustMode::Safe, None)
-            .unwrap()
-            .status()
-            .await
-            .unwrap();
+        let status = build(
+            "echo ok",
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            None,
+            None,
+        )
+        .unwrap()
+        .status()
+        .await
+        .unwrap();
         assert!(status.success());
     }
 
@@ -247,6 +352,7 @@ mod tests {
             "touch sandbox_canary",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -270,6 +376,7 @@ mod tests {
             project.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -291,6 +398,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -308,6 +416,7 @@ mod tests {
             "touch strict_canary",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -334,6 +443,7 @@ mod tests {
             project.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -353,6 +463,7 @@ mod tests {
             "cat /etc/hosts > /dev/null",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -381,6 +492,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -407,6 +519,7 @@ mod tests {
             &format!("ls {ssh_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -436,6 +549,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -464,6 +578,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -490,6 +605,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -514,6 +630,7 @@ mod tests {
             "touch normal_file.txt",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -541,6 +658,7 @@ mod tests {
             &format!("echo '# evil' > {}", target.display()),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()
@@ -573,6 +691,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -601,6 +720,7 @@ mod tests {
             dir.path(),
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .unwrap()
         .status()
@@ -628,6 +748,7 @@ mod tests {
             &format!("ls {aws_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .unwrap()

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -32,7 +32,7 @@ use crate::providers::{self, ImageData, LlmProvider};
 use crate::trust::TrustMode;
 
 use anyhow::Result;
-use koda_sandbox::{BuiltInProxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
+use koda_sandbox::{BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -78,6 +78,14 @@ pub struct KodaSession {
     /// Held for the session's lifetime; `Drop` aborts the proxy task
     /// and closes the listener — no manual teardown needed.
     pub proxy: Option<ProxyHandle>,
+
+    /// Per-session SOCKS5 proxy (Phase 3d.1 of #934). Sibling of
+    /// [`Self::proxy`] for raw-TCP clients (git over ssh, gRPC) that
+    /// don't honor `HTTPS_PROXY`. Same fail-open contract: spawn
+    /// failure logs a warning and the field stays `None`. Uses the
+    /// same hostname allowlist as the HTTP proxy by construction —
+    /// see [`koda_sandbox::BuiltInSocks5Proxy`].
+    pub socks5_proxy: Option<ProxyHandle>,
 }
 
 impl KodaSession {
@@ -123,7 +131,7 @@ impl KodaSession {
         // `koda_sandbox::filter::tests::default_allowlist_parses`
         // guards against regression.
         let filter = Filter::new(DEFAULT_DEV_ALLOWLIST).expect("default allowlist must parse");
-        let proxy = match BuiltInProxy::new(filter).spawn().await {
+        let proxy = match BuiltInProxy::new(filter.clone()).spawn().await {
             Ok(handle) => {
                 agent.tools.set_proxy_port(Some(handle.port));
                 tracing::debug!(
@@ -138,6 +146,26 @@ impl KodaSession {
             }
         };
 
+        // 3d.2: spin up the SOCKS5 sibling using the same allowlist.
+        // Same fail-open contract as the HTTP proxy — raw-TCP clients
+        // will fall through to whatever they'd do without ALL_PROXY
+        // (i.e. dial direct, get caught by kernel-enforced egress where
+        // present, or actually escape on platforms where it isn't).
+        let socks5_proxy = match BuiltInSocks5Proxy::new(filter).spawn().await {
+            Ok(handle) => {
+                agent.tools.set_socks5_port(Some(handle.port));
+                tracing::debug!(
+                    "session {id} socks5 proxy listening on 127.0.0.1:{}",
+                    handle.port
+                );
+                Some(handle)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "socks5 proxy spawn failed; raw-TCP clients unfiltered");
+                None
+            }
+        };
+
         Self {
             id,
             agent,
@@ -148,6 +176,7 @@ impl KodaSession {
             file_tracker,
             title_set: false,
             proxy,
+            socks5_proxy,
         }
     }
 

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -250,6 +250,13 @@ pub struct ToolRegistry {
     /// `None` (default) preserves the pre-3b unfiltered behavior —
     /// session code opts in by calling [`Self::set_proxy_port`].
     proxy_port: std::sync::RwLock<Option<u16>>,
+    /// Loopback port of the per-session SOCKS5 proxy (Phase 3d.1 of
+    /// #934). When `Some`, [`crate::sandbox::build`] appends
+    /// `ALL_PROXY=socks5h://127.0.0.1:port` (+ lowercase alias) so
+    /// raw-TCP clients (git over ssh, gRPC) that ignore `HTTPS_PROXY`
+    /// also route through the hostname-filtered proxy. Independent
+    /// from `proxy_port` so tests can attach one without the other.
+    socks5_port: std::sync::RwLock<Option<u16>>,
 }
 
 impl ToolRegistry {
@@ -328,6 +335,7 @@ impl ToolRegistry {
             trust,
             mcp_manager: std::sync::RwLock::new(None),
             proxy_port: std::sync::RwLock::new(None),
+            socks5_port: std::sync::RwLock::new(None),
         }
     }
 
@@ -408,6 +416,22 @@ impl ToolRegistry {
     /// turns it into the env-var bouquet on the spawned `Command`.
     pub fn proxy_port(&self) -> Option<u16> {
         self.proxy_port.read().ok().and_then(|guard| *guard)
+    }
+
+    /// Attach (or detach) the per-session SOCKS5 proxy port. Mirrors
+    /// [`Self::set_proxy_port`] — see that fn's docs for the
+    /// lock-poisoning policy.
+    pub fn set_socks5_port(&self, port: Option<u16>) {
+        if let Ok(mut guard) = self.socks5_port.write() {
+            *guard = port;
+        }
+    }
+
+    /// Current SOCKS5 port, if one has been attached. Threaded into
+    /// [`crate::sandbox::build`] which appends `ALL_PROXY` to the
+    /// spawned `Command`'s env.
+    pub fn socks5_port(&self) -> Option<u16> {
+        self.socks5_port.read().ok().and_then(|guard| *guard)
     }
 
     /// Classify a tool, using MCP annotations when available.
@@ -602,6 +626,7 @@ impl ToolRegistry {
                     sink_for_streaming,
                     &self.trust,
                     self.proxy_port(),
+                    self.socks5_port(),
                 )
                 .await;
                 return match shell_result {
@@ -944,6 +969,34 @@ mod tests {
         let registry = ToolRegistry::new(root(), 100_000);
         registry.set_proxy_port(Some(31415));
         assert_eq!(registry.proxy_port(), Some(31415));
+    }
+
+    // ── Phase 3d.2: SOCKS5 port wiring (Bash → sandbox::build) ───────
+
+    #[test]
+    fn socks5_port_defaults_to_none() {
+        let registry = ToolRegistry::new(root(), 100_000);
+        assert_eq!(registry.socks5_port(), None);
+    }
+
+    #[test]
+    fn socks5_port_round_trips_through_setter() {
+        let registry = ToolRegistry::new(root(), 100_000);
+        registry.set_socks5_port(Some(27182));
+        assert_eq!(registry.socks5_port(), Some(27182));
+    }
+
+    #[test]
+    fn socks5_and_http_ports_are_independent() {
+        // Setting one must not clobber the other — the two proxies are
+        // spawned independently and may live or die independently.
+        let registry = ToolRegistry::new(root(), 100_000);
+        registry.set_proxy_port(Some(8080));
+        registry.set_socks5_port(Some(1080));
+        assert_eq!(registry.proxy_port(), Some(8080));
+        assert_eq!(registry.socks5_port(), Some(1080));
+        registry.set_proxy_port(None);
+        assert_eq!(registry.socks5_port(), Some(1080));
     }
 
     #[test]

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -102,6 +102,13 @@ pub fn definitions() -> Vec<ToolDefinition> {
 /// When `args["background"]` is `true`, the process is spawned detached and
 /// this function returns immediately with the PID.  The `BgRegistry` tracks
 /// the child so it is cleaned up (SIGTERM) when the session ends.
+//
+// 9 args is over clippy's default 7 — every one is load-bearing context
+// (project root, args, output cap, bg registry, streaming sink, trust
+// mode, two proxy ports). Bundling into a struct just to placate a lint
+// would obscure the call sites; the named-keyword feel comes for free
+// from Rust's positional-with-types discipline.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_shell_command(
     project_root: &Path,
     args: &Value,
@@ -110,6 +117,7 @@ pub async fn run_shell_command(
     sink: Option<(&dyn EngineSink, &str)>,
     trust: &crate::trust::TrustMode,
     proxy_port: Option<u16>,
+    socks5_port: Option<u16>,
 ) -> Result<ShellOutput> {
     let command = args["command"]
         .as_str()
@@ -122,7 +130,7 @@ pub async fn run_shell_command(
     );
 
     if background {
-        let msg = spawn_background(project_root, command, bg, trust, proxy_port)?;
+        let msg = spawn_background(project_root, command, bg, trust, proxy_port, socks5_port)?;
         return Ok(ShellOutput {
             summary: msg,
             full_output: None,
@@ -135,7 +143,7 @@ pub async fn run_shell_command(
         .min(MAX_TIMEOUT_SECS);
 
     // Spawn via sandbox wrapper (enforced for all trust modes).
-    let mut child = crate::sandbox::build(command, project_root, trust, proxy_port)?
+    let mut child = crate::sandbox::build(command, project_root, trust, proxy_port, socks5_port)?
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -287,10 +295,11 @@ fn spawn_background(
     bg: &BgRegistry,
     trust: &crate::trust::TrustMode,
     proxy_port: Option<u16>,
+    socks5_port: Option<u16>,
 ) -> Result<String> {
     // Spawn via sandbox wrapper (enforced for all trust modes).
     // Detach stdio so the process doesn't block on terminal I/O.
-    let child = crate::sandbox::build(command, project_root, trust, proxy_port)?
+    let child = crate::sandbox::build(command, project_root, trust, proxy_port, socks5_port)?
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -463,6 +472,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -484,6 +494,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .await
@@ -507,6 +518,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -529,6 +541,7 @@ mod tests {
             &registry,
             None,
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .await
@@ -558,6 +571,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .await
@@ -651,6 +665,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -708,6 +723,7 @@ mod tests {
             &bg(),
             Some((sink.as_ref(), "test_id")),
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .await
@@ -807,6 +823,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            None,
             None,
         )
         .await

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -101,6 +101,7 @@ async fn make_session_with_mcp(
         file_tracker,
         title_set: false,
         proxy: None,
+        socks5_proxy: None,
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -60,6 +60,7 @@ async fn make_session(
         file_tracker,
         title_set: false,
         proxy: None,
+        socks5_proxy: None,
     };
     (session, cancel)
 }

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -61,8 +61,9 @@ pub use policy::{
 };
 pub use policy_check::is_fully_denied;
 pub use proxy::{
-    BuiltInProxy, DEFAULT_DEV_ALLOWLIST, DEFAULT_NO_PROXY, ExternalProxy, Filter,
-    PROXY_PORT_ENV_KEY, ProxyHandle, ca_bundle_for_policy, proxy_env_vars,
+    BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, DEFAULT_NO_PROXY, ExternalProxy,
+    Filter, PROXY_PORT_ENV_KEY, ProxyHandle, Socks5Server, ca_bundle_for_policy, proxy_env_vars,
+    socks5_env_vars,
 };
 pub use violations::{
     DEFAULT_RING_CAPACITY, SandboxViolationStore, Violation, ViolationKind, global_store,

--- a/koda-sandbox/src/proxy/builtin_socks5.rs
+++ b/koda-sandbox/src/proxy/builtin_socks5.rs
@@ -138,13 +138,10 @@ mod tests {
             Err(_) => {} // ECONNREFUSED — listener gone.
             Ok(mut sock) => {
                 let mut buf = [0u8; 16];
-                let n = tokio::time::timeout(
-                    Duration::from_millis(200),
-                    sock.read(&mut buf),
-                )
-                .await
-                .expect("read must not hang post-drop")
-                .expect("read must not error");
+                let n = tokio::time::timeout(Duration::from_millis(200), sock.read(&mut buf))
+                    .await
+                    .expect("read must not hang post-drop")
+                    .expect("read must not error");
                 assert_eq!(n, 0, "post-drop socket must EOF immediately");
             }
         }

--- a/koda-sandbox/src/proxy/builtin_socks5.rs
+++ b/koda-sandbox/src/proxy/builtin_socks5.rs
@@ -1,0 +1,152 @@
+//! Spawn-shaped wrapper around [`super::Socks5Server`] (Phase 3d.1 of #934).
+//!
+//! Mirrors [`super::builtin::BuiltInProxy`] for the SOCKS5 path: same
+//! `spawn() -> ProxyHandle` shape so callers can hold the SOCKS5 and
+//! HTTP CONNECT proxies in symmetric `Option<ProxyHandle>` slots.
+//!
+//! See [`super::socks5`] module docs for the wire-protocol subset.
+
+use super::{Filter, ProxyHandle, Socks5Server};
+use anyhow::{Context, Result};
+use std::time::Duration;
+use tracing::debug;
+
+/// Spec for the in-process built-in SOCKS5 proxy.
+///
+/// All fields default-friendly via [`BuiltInSocks5Proxy::new`].
+#[derive(Debug, Clone)]
+pub struct BuiltInSocks5Proxy {
+    /// Hostname allowlist. Same `Filter` type used by the HTTP CONNECT
+    /// proxy — by design, both proxies share one allow list so a host
+    /// permitted via HTTPS is also permitted via SOCKS5 (and vice
+    /// versa). Two separate allow lists would invite skew between the
+    /// two enforcement paths.
+    pub filter: Filter,
+
+    /// Bind port. `None` → ephemeral.
+    pub port: Option<u16>,
+
+    /// Maximum wait for the proxy to start accepting. Largely
+    /// informational (see [`super::builtin::BuiltInProxy::startup_timeout`]).
+    pub startup_timeout: Duration,
+}
+
+impl BuiltInSocks5Proxy {
+    /// Construct with sensible defaults: deny-all filter, ephemeral
+    /// port, 5 s startup timeout.
+    pub fn new(filter: Filter) -> Self {
+        Self {
+            filter,
+            port: None,
+            startup_timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Bind the listener and spawn the accept loop.
+    ///
+    /// Returns a [`ProxyHandle`] whose `Drop` impl aborts the spawned
+    /// task. Same fail-open contract as
+    /// [`super::builtin::BuiltInProxy::spawn`]: on `Err`, callers should
+    /// `warn!` and continue without SOCKS5 — well-behaved clients will
+    /// still route through the HTTP CONNECT proxy.
+    ///
+    /// **No UDS bridge.** The Phase 3c.1 bwrap kernel-enforced path
+    /// only bridges the HTTP proxy today; SOCKS5 is reachable through
+    /// the env-var tier only. A SOCKS5-over-UDS bridge would need a
+    /// matching `socks5h://` env override in the in-netns shell, which
+    /// we'll add in a follow-up if there's a real client that needs it
+    /// (git over ssh inside a sandbox is the obvious candidate).
+    pub async fn spawn(&self) -> Result<ProxyHandle> {
+        let server = Socks5Server::bind(self.port, self.filter.clone())
+            .await
+            .context("bind built-in socks5 proxy")?;
+        let port = server.port();
+        let task = tokio::spawn(server.serve());
+
+        debug!(
+            "built-in socks5 proxy spawned: port={} filter_size={}",
+            port,
+            self.filter.len()
+        );
+        Ok(ProxyHandle::from_task(port, task))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    #[test]
+    fn new_sets_defaults() {
+        let p = BuiltInSocks5Proxy::new(Filter::default());
+        assert!(p.port.is_none());
+        assert_eq!(p.startup_timeout, Duration::from_secs(5));
+        assert!(p.filter.is_empty());
+    }
+
+    #[tokio::test]
+    async fn spawn_returns_handle_with_assigned_port() {
+        let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
+        let h = p.spawn().await.unwrap();
+        assert!(h.port > 0);
+    }
+
+    #[tokio::test]
+    async fn spawned_proxy_serves_403_equivalent_for_disallowed_host() {
+        let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
+        let h = p.spawn().await.unwrap();
+
+        let mut sock = TcpStream::connect(("127.0.0.1", h.port)).await.unwrap();
+        // Greeting: VER=5, NMETHODS=1, METHOD=0x00 (no auth).
+        sock.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
+        let mut greet = [0u8; 2];
+        sock.read_exact(&mut greet).await.unwrap();
+        assert_eq!(greet, [0x05, 0x00]);
+
+        // CONNECT-DOMAIN evil.example.com:443.
+        let host = "evil.example.com";
+        let mut req = vec![0x05, 0x01, 0x00, 0x03, host.len() as u8];
+        req.extend_from_slice(host.as_bytes());
+        req.extend_from_slice(&443u16.to_be_bytes());
+        sock.write_all(&req).await.unwrap();
+
+        let mut reply = [0u8; 4];
+        sock.read_exact(&mut reply).await.unwrap();
+        // 0x02 = "Connection not allowed by ruleset" — the SOCKS5
+        // analogue of HTTP 403.
+        assert_eq!(reply[1], 0x02);
+    }
+
+    #[tokio::test]
+    async fn dropping_handle_stops_accepting() {
+        let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
+        let h = p.spawn().await.unwrap();
+        let port = h.port;
+
+        // Live: accepts connections.
+        let _ = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+
+        drop(h);
+
+        // tokio::task::abort is async — give the runtime a tick. Same
+        // pattern as the HTTP proxy test.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        match TcpStream::connect(("127.0.0.1", port)).await {
+            Err(_) => {} // ECONNREFUSED — listener gone.
+            Ok(mut sock) => {
+                let mut buf = [0u8; 16];
+                let n = tokio::time::timeout(
+                    Duration::from_millis(200),
+                    sock.read(&mut buf),
+                )
+                .await
+                .expect("read must not hang post-drop")
+                .expect("read must not error");
+                assert_eq!(n, 0, "post-drop socket must EOF immediately");
+            }
+        }
+    }
+}

--- a/koda-sandbox/src/proxy/env.rs
+++ b/koda-sandbox/src/proxy/env.rs
@@ -74,6 +74,31 @@ pub fn proxy_env_vars(port: u16, ca_bundle: Option<&Path>) -> Vec<(String, Strin
     vars
 }
 
+/// Env-var bouquet for the SOCKS5 proxy: `ALL_PROXY` + lowercase
+/// alias, both pointing at `socks5h://127.0.0.1:port`.
+///
+/// The `socks5h://` (vs `socks5://`) scheme is **not optional** — it
+/// instructs the client to forward the hostname to the proxy for
+/// resolution rather than pre-resolving locally and sending an IP
+/// literal. The built-in SOCKS5 server [refuses IP literals]
+/// (super::socks5#subset) precisely because they bypass the hostname
+/// allow list. Mismatched schemes here would silently break SOCKS5
+/// for every client that obeys `ALL_PROXY`.
+///
+/// Returned as a separate `Vec` (rather than appended to
+/// [`proxy_env_vars`]) so callers can opt into SOCKS5 independently —
+/// not every session needs it, and a sandboxed shell that only ever
+/// runs `curl` doesn't benefit from one extra env knob to debug.
+pub fn socks5_env_vars(port: u16) -> Vec<(String, String)> {
+    let url = format!("socks5h://127.0.0.1:{port}");
+    let mut vars = vec![
+        ("ALL_PROXY".to_string(), url.clone()),
+        ("all_proxy".to_string(), url),
+    ];
+    vars.sort_by(|a, b| a.0.cmp(&b.0));
+    vars
+}
+
 /// Path to the CA bundle to advertise via env vars, given a [`crate::policy::NetPolicy`].
 ///
 /// Returns `None` when no MITM is configured — in that case the subprocess
@@ -162,6 +187,34 @@ mod tests {
         // AWS / GCE IMDS link-local: dropping this would prevent cloud
         // workloads from reading instance metadata.
         assert!(DEFAULT_NO_PROXY.contains("169.254.0.0/16"));
+    }
+
+    #[test]
+    fn socks5_env_vars_uses_socks5h_scheme() {
+        // The `h` matters — see fn docs.
+        let vars = socks5_env_vars(1080);
+        for (_, v) in &vars {
+            assert!(v.starts_with("socks5h://"), "got: {v}");
+        }
+    }
+
+    #[test]
+    fn socks5_env_vars_includes_upper_and_lower() {
+        let vars = socks5_env_vars(1080);
+        let keys: Vec<&str> = vars.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(keys.contains(&"ALL_PROXY"));
+        assert!(keys.contains(&"all_proxy"));
+    }
+
+    #[test]
+    fn socks5_env_vars_uses_loopback_ipv4() {
+        let vars = socks5_env_vars(31415);
+        let url = vars
+            .iter()
+            .find(|(k, _)| k == "ALL_PROXY")
+            .map(|(_, v)| v.as_str())
+            .unwrap();
+        assert_eq!(url, "socks5h://127.0.0.1:31415");
     }
 
     #[test]

--- a/koda-sandbox/src/proxy/mod.rs
+++ b/koda-sandbox/src/proxy/mod.rs
@@ -61,7 +61,8 @@
 //! ├── server.rs         — HTTP CONNECT proxy (3b)
 //! ├── builtin.rs        — BuiltInProxy::spawn (3b)
 //! ├── socks5.rs         — SOCKS5 server (3d)
-//! └── builtin_socks5.rs — BuiltInSocks5Proxy::spawn (3d)
+//! ├── builtin_socks5.rs — BuiltInSocks5Proxy::spawn (3d)
+//! └── upstream.rs       — corp HTTPS_PROXY chaining (3d.3)
 //! ```
 
 pub mod builtin;
@@ -72,6 +73,7 @@ pub mod filter;
 pub mod handle;
 pub mod server;
 pub mod socks5;
+pub mod upstream;
 
 pub use builtin::BuiltInProxy;
 pub use builtin_socks5::BuiltInSocks5Proxy;
@@ -83,6 +85,7 @@ pub use filter::{DEFAULT_DEV_ALLOWLIST, Filter};
 pub use handle::ProxyHandle;
 pub use server::Server;
 pub use socks5::Socks5Server;
+pub use upstream::UpstreamConfig;
 
 // ── Shared internal helpers ──────────────────────────────────────────────────
 //

--- a/koda-sandbox/src/proxy/mod.rs
+++ b/koda-sandbox/src/proxy/mod.rs
@@ -53,28 +53,36 @@
 //!
 //! ```text
 //! proxy/
-//! ├── mod.rs       — this docstring + shared internal helpers
-//! ├── env.rs       — env-var bouquet + DEFAULT_NO_PROXY (3a)
-//! ├── external.rs  — ExternalProxy::spawn (3a)
-//! ├── handle.rs    — ProxyHandle (External + BuiltIn variants)
-//! ├── filter.rs    — hostname allowlist (3b)
-//! ├── server.rs    — HTTP CONNECT proxy (3b)
-//! └── builtin.rs   — BuiltInProxy::spawn (3b)
+//! ├── mod.rs            — this docstring + shared internal helpers
+//! ├── env.rs            — env-var bouquet + DEFAULT_NO_PROXY (3a) + socks5 (3d)
+//! ├── external.rs       — ExternalProxy::spawn (3a)
+//! ├── handle.rs         — ProxyHandle (External + BuiltIn variants)
+//! ├── filter.rs         — hostname allowlist (3b)
+//! ├── server.rs         — HTTP CONNECT proxy (3b)
+//! ├── builtin.rs        — BuiltInProxy::spawn (3b)
+//! ├── socks5.rs         — SOCKS5 server (3d)
+//! └── builtin_socks5.rs — BuiltInSocks5Proxy::spawn (3d)
 //! ```
 
 pub mod builtin;
+pub mod builtin_socks5;
 pub mod env;
 pub mod external;
 pub mod filter;
 pub mod handle;
 pub mod server;
+pub mod socks5;
 
 pub use builtin::BuiltInProxy;
-pub use env::{DEFAULT_NO_PROXY, PROXY_PORT_ENV_KEY, ca_bundle_for_policy, proxy_env_vars};
+pub use builtin_socks5::BuiltInSocks5Proxy;
+pub use env::{
+    DEFAULT_NO_PROXY, PROXY_PORT_ENV_KEY, ca_bundle_for_policy, proxy_env_vars, socks5_env_vars,
+};
 pub use external::ExternalProxy;
 pub use filter::{DEFAULT_DEV_ALLOWLIST, Filter};
 pub use handle::ProxyHandle;
 pub use server::Server;
+pub use socks5::Socks5Server;
 
 // ── Shared internal helpers ──────────────────────────────────────────────────
 //

--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -50,10 +50,6 @@ const MAX_REQUEST_BYTES: usize = 8 * 1024;
 /// one TCP segment.
 const REQUEST_READ_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// How long to wait for the upstream TCP handshake. Anything past
-/// this and the host is effectively unreachable.
-const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
-
 /// Built-in HTTP CONNECT proxy.
 ///
 /// Cheap-to-construct. Holds a [`TcpListener`] and a [`Filter`]; spawn
@@ -63,6 +59,11 @@ pub struct Server {
     listener: TcpListener,
     filter: Filter,
     port: u16,
+    /// Upstream-connection policy snapshotted from the koda process's
+    /// env at bind time (Phase 3d.3 of #934). `Direct` in plain dev
+    /// environments; `HttpProxy` when the user has corp-set
+    /// `HTTPS_PROXY` so we can chain through Zscaler / Squid / etc.
+    upstream: crate::proxy::upstream::UpstreamConfig,
 }
 
 impl Server {
@@ -90,10 +91,15 @@ impl Server {
             actual,
             filter.len()
         );
+        let upstream = crate::proxy::upstream::UpstreamConfig::from_env();
+        if !matches!(upstream, crate::proxy::upstream::UpstreamConfig::Direct) {
+            debug!("built-in proxy chaining upstream via {upstream:?}");
+        }
         Ok(Self {
             listener,
             filter,
             port: actual,
+            upstream,
         })
     }
 
@@ -101,6 +107,16 @@ impl Server {
     /// called with `None` and the caller wants the ephemeral port.
     pub fn port(&self) -> u16 {
         self.port
+    }
+
+    /// Override the upstream-connection policy that [`Self::bind`]
+    /// snapshotted from `HTTPS_PROXY`. Used by tests that need a
+    /// deterministic upstream config without racing on the process
+    /// env (which is shared across parallel `cargo test` runs).
+    /// Production code should rely on the env snapshot.
+    pub fn with_upstream(mut self, upstream: crate::proxy::upstream::UpstreamConfig) -> Self {
+        self.upstream = upstream;
+        self
     }
 
     /// Run the accept loop forever.
@@ -112,6 +128,7 @@ impl Server {
     /// containing JoinHandle is aborted).
     pub async fn serve(self) {
         let filter = self.filter;
+        let upstream = std::sync::Arc::new(self.upstream);
         loop {
             let (sock, peer) = match self.listener.accept().await {
                 Ok(t) => t,
@@ -121,8 +138,9 @@ impl Server {
                 }
             };
             let f = filter.clone();
+            let up = std::sync::Arc::clone(&upstream);
             tokio::spawn(async move {
-                if let Err(e) = handle_one(sock, &f).await {
+                if let Err(e) = handle_one(sock, &f, &up).await {
                     debug!("proxy connection from {peer} ended: {e:#}");
                 }
             });
@@ -135,7 +153,11 @@ impl Server {
 /// Returns `Ok(())` for the happy path AND for cleanly-rejected requests
 /// (403/405) — the `Err` return is reserved for socket/IO failures the
 /// caller can't do anything about beyond logging.
-async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
+async fn handle_one(
+    mut client: TcpStream,
+    filter: &Filter,
+    upstream: &crate::proxy::upstream::UpstreamConfig,
+) -> Result<()> {
     let req = read_request(&mut client).await?;
     let (method, target) = parse_request_line(&req)?;
 
@@ -152,7 +174,8 @@ async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
     }
 
     // Allowed. Connect upstream and bridge.
-    let mut upstream = match connect_upstream(&target).await {
+    let mut upstream_sock = match crate::proxy::upstream::connect_upstream(&target, upstream).await
+    {
         Ok(s) => s,
         Err(e) => {
             warn!("proxy: upstream connect to {target} failed: {e:#}");
@@ -169,7 +192,7 @@ async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
     // so the peer can observe the close and tear down. Without this
     // (e.g. naive tokio::join! of two copy()s) we'd deadlock — clients
     // typically never close their write side after CONNECT.
-    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream_sock).await;
     Ok(())
 }
 
@@ -228,15 +251,6 @@ fn parse_request_line(req: &[u8]) -> Result<(String, String)> {
         bail!("malformed request: unexpected version {version:?}");
     }
     Ok((method, target))
-}
-
-/// `target` is `host:port` per the CONNECT spec (RFC 9110 §9.3.6).
-async fn connect_upstream(target: &str) -> Result<TcpStream> {
-    let stream = tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, TcpStream::connect(target))
-        .await
-        .with_context(|| format!("upstream connect to {target} timed out"))?
-        .with_context(|| format!("upstream connect to {target} failed"))?;
-    Ok(stream)
 }
 
 /// Write `HTTP/1.1 <code> <reason>\r\n\r\n`. Best-effort; failure to
@@ -369,6 +383,170 @@ mod tests {
         let dead = pick_ephemeral_port().unwrap();
         let (status, _) = do_connect(proxy_port, &format!("127.0.0.1:{dead}")).await;
         assert!(status.starts_with("HTTP/1.1 502"), "got: {status:?}");
+    }
+
+    /// Phase 3d.3: when configured with an HttpProxy upstream, the
+    /// CONNECT must be tunnelled through that proxy rather than dialed
+    /// directly. We stand up a fake corp proxy that records the
+    /// CONNECT it receives, then chain through it.
+    #[tokio::test]
+    async fn chains_through_upstream_http_proxy() {
+        // Real upstream that the corp proxy will dial on our behalf.
+        let payload = "PAYLOAD-FROM-REAL-UPSTREAM";
+        let (real_port, _) = fake_upstream(payload).await;
+
+        // Fake corp proxy: accept CONNECT, record the target, dial it,
+        // reply 200, splice. Minimal logic but exercises the same wire
+        // format real corp proxies (Squid/Zscaler) speak.
+        let connect_log = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let corp_listener = StdTcpListener::bind("127.0.0.1:0").await.unwrap();
+        let corp_port = corp_listener.local_addr().unwrap().port();
+        let log_for_corp = std::sync::Arc::clone(&connect_log);
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = corp_listener.accept().await {
+                let log = std::sync::Arc::clone(&log_for_corp);
+                tokio::spawn(async move {
+                    // Read just the CONNECT request line.
+                    let mut reader = BufReader::new(&mut sock);
+                    let mut req = String::new();
+                    reader.read_line(&mut req).await.unwrap();
+                    // Drain headers up to the empty line.
+                    loop {
+                        let mut line = String::new();
+                        let n = reader.read_line(&mut line).await.unwrap();
+                        if n == 0 || line == "\r\n" || line == "\n" {
+                            break;
+                        }
+                    }
+                    // Parse the target out of "CONNECT host:port HTTP/1.1".
+                    let target = req.split_whitespace().nth(1).unwrap().to_string();
+                    log.lock().unwrap().push(target.clone());
+                    // Dial the real target on behalf of the client.
+                    let mut up = TcpStream::connect(&target).await.unwrap();
+                    sock.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+                        .await
+                        .unwrap();
+                    let _ = tokio::io::copy_bidirectional(&mut sock, &mut up).await;
+                });
+            }
+        });
+
+        // Stand up our proxy and inject the corp proxy as upstream.
+        let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
+            .await
+            .unwrap()
+            .with_upstream(crate::proxy::upstream::UpstreamConfig::HttpProxy {
+                host: "127.0.0.1".into(),
+                port: corp_port,
+                no_proxy: vec![],
+            });
+        let proxy_port = server.port();
+        tokio::spawn(server.serve());
+
+        let target = format!("127.0.0.1:{real_port}");
+        let (status, body) = do_connect(proxy_port, &target).await;
+        assert!(status.starts_with("HTTP/1.1 200"), "got: {status:?}");
+        let body_str = String::from_utf8_lossy(&body);
+        let body_str = body_str.trim_start_matches("\r\n");
+        assert_eq!(body_str, payload, "tunneled body mismatch");
+
+        // The corp proxy must have seen exactly the original target —
+        // no rewriting, no leakage of internal request structure.
+        let log = connect_log.lock().unwrap();
+        assert_eq!(*log, vec![target], "corp proxy must see original target");
+    }
+
+    /// Phase 3d.3: NO_PROXY entries take a host out of the chained
+    /// upstream and back onto the direct path. Critical because
+    /// `*.walmart.com` (and friends) are corp-internal and routing
+    /// them through Zscaler produces 403s.
+    #[tokio::test]
+    async fn chains_skips_upstream_for_no_proxy_hosts() {
+        let payload = "DIRECT-NOT-CHAINED";
+        let (real_port, _) = fake_upstream(payload).await;
+
+        // Bind a corp proxy that will NEVER receive a connection —
+        // we'll fail the test if it does. Don't even spawn an accept
+        // loop: an unbound port would be the cleanest signal, but the
+        // upstream layer treats "connect refused" as a real failure
+        // (502 to client) and would mask a NO_PROXY bug. Instead bind
+        // and assert no accepts happen by counting through a channel.
+        let corp_listener = StdTcpListener::bind("127.0.0.1:0").await.unwrap();
+        let corp_port = corp_listener.local_addr().unwrap().port();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        tokio::spawn(async move {
+            while corp_listener.accept().await.is_ok() {
+                let _ = tx.send(());
+            }
+        });
+
+        let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
+            .await
+            .unwrap()
+            .with_upstream(crate::proxy::upstream::UpstreamConfig::HttpProxy {
+                host: "127.0.0.1".into(),
+                port: corp_port,
+                no_proxy: vec!["127.0.0.1".into()],
+            });
+        let proxy_port = server.port();
+        tokio::spawn(server.serve());
+
+        let (status, body) = do_connect(proxy_port, &format!("127.0.0.1:{real_port}")).await;
+        assert!(status.starts_with("HTTP/1.1 200"), "got: {status:?}");
+        let body_str = String::from_utf8_lossy(&body);
+        let body_str = body_str.trim_start_matches("\r\n");
+        assert_eq!(body_str, payload);
+
+        // Give the accept loop a moment; corp proxy must not have been
+        // contacted because 127.0.0.1 is in NO_PROXY.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            rx.try_recv().is_err(),
+            "NO_PROXY-listed host must bypass upstream proxy"
+        );
+    }
+
+    /// Phase 3d.3: a chained upstream that rejects with 407 (auth
+    /// required) must surface as 502 to the client — we have no
+    /// credentials to retry with, and silently sending the request
+    /// direct would defeat the point of the corp policy.
+    #[tokio::test]
+    async fn surfaces_upstream_407_as_502() {
+        let corp_listener = StdTcpListener::bind("127.0.0.1:0").await.unwrap();
+        let corp_port = corp_listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = corp_listener.accept().await {
+                tokio::spawn(async move {
+                    // Drain request, reply 407, hang up.
+                    let mut buf = [0u8; 1024];
+                    let _ = sock.read(&mut buf).await;
+                    let _ = sock
+                        .write_all(
+                            b"HTTP/1.1 407 Proxy Authentication Required\r\n\
+                              Proxy-Authenticate: Basic\r\n\r\n",
+                        )
+                        .await;
+                    let _ = sock.shutdown().await;
+                });
+            }
+        });
+
+        let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
+            .await
+            .unwrap()
+            .with_upstream(crate::proxy::upstream::UpstreamConfig::HttpProxy {
+                host: "127.0.0.1".into(),
+                port: corp_port,
+                no_proxy: vec![],
+            });
+        let proxy_port = server.port();
+        tokio::spawn(server.serve());
+
+        let (status, _) = do_connect(proxy_port, "127.0.0.1:1").await;
+        assert!(
+            status.starts_with("HTTP/1.1 502"),
+            "upstream auth failure must surface as 502, got: {status:?}"
+        );
     }
 
     // ── parse_request_line ──────────────────────────────────────────────

--- a/koda-sandbox/src/proxy/socks5.rs
+++ b/koda-sandbox/src/proxy/socks5.rs
@@ -48,10 +48,6 @@ use tracing::{debug, warn};
 /// arrive in a single TCP segment in practice.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Upstream `connect()` ceiling. Same number used by
-/// [`super::server`] so behaviour is consistent across both proxies.
-const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
-
 /// Maximum DOMAIN length per RFC 1928 (the length byte is `u8`, so
 /// 255 is the wire ceiling). Valid hostnames cap at 253; we accept up
 /// to 255 to match the spec but the hostname allowlist will reject
@@ -74,6 +70,15 @@ pub struct Socks5Server {
     listener: TcpListener,
     filter: Filter,
     port: u16,
+    /// Upstream-connection policy snapshotted from the koda process's
+    /// env at bind time (Phase 3d.3 of #934). `Direct` in plain dev
+    /// environments; `HttpProxy` when the user has corp-set
+    /// `HTTPS_PROXY` so we can chain through Zscaler / Squid / etc.
+    /// Even though SOCKS5 itself is wire-incompatible with HTTP
+    /// CONNECT, the *upstream* hop only needs raw TCP — we open it
+    /// via CONNECT to the corp proxy and treat the returned tunnel
+    /// as a transparent socket.
+    upstream: crate::proxy::upstream::UpstreamConfig,
 }
 
 impl Socks5Server {
@@ -88,10 +93,12 @@ impl Socks5Server {
             .await
             .with_context(|| format!("bind socks5 listener on 127.0.0.1:{bind_port}"))?;
         let port = listener.local_addr()?.port();
+        let upstream = crate::proxy::upstream::UpstreamConfig::from_env();
         Ok(Self {
             listener,
             filter,
             port,
+            upstream,
         })
     }
 
@@ -101,10 +108,20 @@ impl Socks5Server {
         self.port
     }
 
+    /// Override the upstream-connection policy that [`Self::bind`]
+    /// snapshotted from `HTTPS_PROXY`. Sibling of
+    /// [`super::server::Server::with_upstream`] — see that fn for
+    /// rationale.
+    pub fn with_upstream(mut self, upstream: crate::proxy::upstream::UpstreamConfig) -> Self {
+        self.upstream = upstream;
+        self
+    }
+
     /// Run the accept loop forever. Caller drops the server (or aborts
     /// the spawning [`tokio::task::JoinHandle`]) for shutdown.
     pub async fn serve(self) {
         let filter = self.filter;
+        let upstream = std::sync::Arc::new(self.upstream);
         loop {
             let (sock, peer) = match self.listener.accept().await {
                 Ok(t) => t,
@@ -114,8 +131,9 @@ impl Socks5Server {
                 }
             };
             let f = filter.clone();
+            let up = std::sync::Arc::clone(&upstream);
             tokio::spawn(async move {
-                if let Err(e) = handle_one(sock, &f).await {
+                if let Err(e) = handle_one(sock, &f, &up).await {
                     debug!("socks5 connection from {peer} ended: {e:#}");
                 }
             });
@@ -128,7 +146,11 @@ impl Socks5Server {
 /// Returns `Ok(())` for cleanly-rejected requests (any REP code) AND
 /// for the happy path; `Err` is reserved for socket failures the
 /// caller can't act on beyond logging.
-async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
+async fn handle_one(
+    mut client: TcpStream,
+    filter: &Filter,
+    upstream: &crate::proxy::upstream::UpstreamConfig,
+) -> Result<()> {
     tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
         greet(&mut client).await?;
         let target = read_request(&mut client).await?;
@@ -147,25 +169,28 @@ async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
             return Ok(());
         }
 
-        // Allowed. Resolve + dial upstream.
+        // Allowed. Resolve + dial upstream — either directly or through
+        // the chained corp proxy. The `connect_upstream` helper handles
+        // the dispatch, including NO_PROXY bypass for hosts that the
+        // user's environment marks as direct-routable.
         let upstream_addr = format!("{}:{}", target.host, target.port);
-        let upstream = tokio::time::timeout(
-            UPSTREAM_CONNECT_TIMEOUT,
-            TcpStream::connect(&upstream_addr),
-        )
-        .await;
+        let dial = crate::proxy::upstream::connect_upstream(&upstream_addr, upstream).await;
 
-        let mut upstream = match upstream {
-            Ok(Ok(s)) => s,
-            Ok(Err(e)) => {
-                let rep = io_error_to_rep(&e);
-                warn!("socks5: upstream connect to {upstream_addr} failed: {e}");
+        let mut upstream_sock = match dial {
+            Ok(s) => s,
+            Err(e) => {
+                // The upstream layer wraps anyhow::Error around a root
+                // cause that may be an `io::Error` (direct dial) or a
+                // CONNECT-status error (chained dial). For the former we
+                // can map to a precise REP code; for the latter we use
+                // REP_GENERAL_FAILURE because none of the SOCKS5 codes
+                // really capture "corp proxy refused".
+                let rep = e
+                    .downcast_ref::<std::io::Error>()
+                    .map(io_error_to_rep)
+                    .unwrap_or(REP_GENERAL_FAILURE);
+                warn!("socks5: upstream connect to {upstream_addr} failed: {e:#}");
                 send_reply(&mut client, rep, 0x03).await?;
-                return Ok(());
-            }
-            Err(_) => {
-                warn!("socks5: upstream connect to {upstream_addr} timed out");
-                send_reply(&mut client, REP_HOST_UNREACHABLE, 0x03).await?;
                 return Ok(());
             }
         };
@@ -176,7 +201,7 @@ async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
         // [`super::server`]: a naive `tokio::join!` of two `copy()`s
         // would deadlock because clients typically never close their
         // write half after the SOCKS5 reply.
-        let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+        let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream_sock).await;
         Ok::<_, anyhow::Error>(())
     })
     .await
@@ -220,7 +245,10 @@ enum RequestOutcome {
     Connect(ConnectTarget),
     /// Send `rep`, with BND.ATYP = `atyp` (echoes whatever the client
     /// sent so well-behaved clients can pretty-print the failure).
-    Reject { rep: u8, atyp: u8 },
+    Reject {
+        rep: u8,
+        atyp: u8,
+    },
 }
 
 /// Parse `[VER=5][CMD][RSV=0][ATYP][DST.ADDR][DST.PORT]`. RFC 1928 §4.
@@ -336,7 +364,11 @@ async fn send_reply(client: &mut TcpStream, rep: u8, atyp: u8) -> Result<()> {
     reply[0] = 0x05;
     reply[1] = rep;
     reply[2] = 0x00;
-    reply[3] = if matches!(atyp, 0x01 | 0x04) { atyp } else { 0x03 };
+    reply[3] = if matches!(atyp, 0x01 | 0x04) {
+        atyp
+    } else {
+        0x03
+    };
     // Bytes [4..] already zero from `vec![0u8; ...]`.
     client.write_all(&reply).await?;
     Ok(())

--- a/koda-sandbox/src/proxy/socks5.rs
+++ b/koda-sandbox/src/proxy/socks5.rs
@@ -1,0 +1,511 @@
+//! Built-in SOCKS5 proxy server (Phase 3d.1 of #934).
+//!
+//! Implements the *minimum* SOCKS5 surface needed for sandboxed
+//! processes that don't honor `HTTPS_PROXY` (git over ssh, raw-TCP
+//! tools, gRPC clients) but do honor `ALL_PROXY=socks5h://...`.
+//!
+//! ## Subset
+//!
+//! | RFC 1928 feature | Supported | Why / why not |
+//! |---|---|---|
+//! | VER = 5 | yes | The whole point of the file. |
+//! | METHOD = `0x00` (no auth) | yes | Loopback-only listener; the kernel-level allow list (Phase 3c/3c.1) is the real auth boundary. |
+//! | METHOD = `0x02` (user/pass) | no | Same reason: nothing on `127.0.0.1` justifies it. |
+//! | CMD = `0x01` (CONNECT) | yes | The verb every TCP client uses. |
+//! | CMD = `0x02` (BIND) | no | Reverse connections from upstream are a sandbox-egress hole by design — hard `0x07 Command not supported`. |
+//! | CMD = `0x03` (UDP ASSOCIATE) | no | Same. UDP egress isn't in scope for this issue (would need its own filter model). |
+//! | ATYP = `0x03` (DOMAIN) | yes | The whole *point* of `socks5h://` — the proxy resolves, so we can run the hostname through [`super::Filter`]. |
+//! | ATYP = `0x01` (IPv4) | no | A pre-resolved IP literal *bypasses* hostname filtering. Hard `0x08 Address type not supported`. Forces clients to use `socks5h://`. |
+//! | ATYP = `0x04` (IPv6) | no | Same. |
+//!
+//! Loud rejection (proper REP code) instead of silent allow keeps the
+//! behaviour discoverable: the client surfaces "proxy refused" rather
+//! than mysteriously connecting to the wrong place.
+//!
+//! ## Filter contract
+//!
+//! Identical to [`super::server`]: every `CONNECT` target host is
+//! checked against a [`super::Filter`]. Reject → `0x02 Connection not
+//! allowed by ruleset`. Allow → connect upstream, send `0x00 succeeded`,
+//! splice with [`tokio::io::copy_bidirectional`].
+//!
+//! ## Why hand-rolled?
+//!
+//! Codex pulls in the `rama_socks5` framework (~kLOC, dozens of
+//! transitive deps); CC has no SOCKS5 at all. For our subset the wire
+//! format is ~80 bytes of state machine — a crate would dwarf the
+//! actual logic. See #934 §6 Phase 3 acceptance: "≤200 LOC".
+
+use super::Filter;
+use anyhow::{Context, Result, bail};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::{debug, warn};
+
+/// How long to wait for the client to finish the greeting + request
+/// handshake. Generous — both messages together are <300 bytes and
+/// arrive in a single TCP segment in practice.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upstream `connect()` ceiling. Same number used by
+/// [`super::server`] so behaviour is consistent across both proxies.
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Maximum DOMAIN length per RFC 1928 (the length byte is `u8`, so
+/// 255 is the wire ceiling). Valid hostnames cap at 253; we accept up
+/// to 255 to match the spec but the hostname allowlist will reject
+/// anything dodgy anyway.
+const MAX_DOMAIN_LEN: usize = 255;
+
+// ── REP codes (RFC 1928 §6) ────────────────────────────────────────────────
+const REP_SUCCEEDED: u8 = 0x00;
+const REP_GENERAL_FAILURE: u8 = 0x01;
+const REP_NOT_ALLOWED: u8 = 0x02;
+const REP_NETWORK_UNREACHABLE: u8 = 0x03;
+const REP_HOST_UNREACHABLE: u8 = 0x04;
+const REP_CONNECTION_REFUSED: u8 = 0x05;
+const REP_COMMAND_NOT_SUPPORTED: u8 = 0x07;
+const REP_ADDRESS_TYPE_NOT_SUPPORTED: u8 = 0x08;
+
+/// Built-in SOCKS5 server. Cheap to construct, run with [`Self::serve`].
+#[derive(Debug)]
+pub struct Socks5Server {
+    listener: TcpListener,
+    filter: Filter,
+    port: u16,
+}
+
+impl Socks5Server {
+    /// Bind on `127.0.0.1:port` (or kernel-picked ephemeral if `None`).
+    ///
+    /// Same TOCTOU-free pattern as [`super::server::Server::bind`]:
+    /// we hand `port = 0` directly to the kernel rather than running
+    /// our own pick-then-rebind dance.
+    pub async fn bind(port: Option<u16>, filter: Filter) -> Result<Self> {
+        let bind_port = port.unwrap_or(0);
+        let listener = TcpListener::bind(("127.0.0.1", bind_port))
+            .await
+            .with_context(|| format!("bind socks5 listener on 127.0.0.1:{bind_port}"))?;
+        let port = listener.local_addr()?.port();
+        Ok(Self {
+            listener,
+            filter,
+            port,
+        })
+    }
+
+    /// Port the server is listening on. Useful when [`Self::bind`] was
+    /// called with `None`.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Run the accept loop forever. Caller drops the server (or aborts
+    /// the spawning [`tokio::task::JoinHandle`]) for shutdown.
+    pub async fn serve(self) {
+        let filter = self.filter;
+        loop {
+            let (sock, peer) = match self.listener.accept().await {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!("socks5 accept failed: {e}");
+                    return;
+                }
+            };
+            let f = filter.clone();
+            tokio::spawn(async move {
+                if let Err(e) = handle_one(sock, &f).await {
+                    debug!("socks5 connection from {peer} ended: {e:#}");
+                }
+            });
+        }
+    }
+}
+
+/// Handle one client: greet, parse request, filter, splice.
+///
+/// Returns `Ok(())` for cleanly-rejected requests (any REP code) AND
+/// for the happy path; `Err` is reserved for socket failures the
+/// caller can't act on beyond logging.
+async fn handle_one(mut client: TcpStream, filter: &Filter) -> Result<()> {
+    tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        greet(&mut client).await?;
+        let target = read_request(&mut client).await?;
+
+        let target = match target {
+            RequestOutcome::Reject { rep, atyp } => {
+                send_reply(&mut client, rep, atyp).await?;
+                return Ok(());
+            }
+            RequestOutcome::Connect(t) => t,
+        };
+
+        if !filter.allows(&target.host) {
+            debug!("socks5: blocked CONNECT {} (not in allowlist)", target.host);
+            send_reply(&mut client, REP_NOT_ALLOWED, 0x03).await?;
+            return Ok(());
+        }
+
+        // Allowed. Resolve + dial upstream.
+        let upstream_addr = format!("{}:{}", target.host, target.port);
+        let upstream = tokio::time::timeout(
+            UPSTREAM_CONNECT_TIMEOUT,
+            TcpStream::connect(&upstream_addr),
+        )
+        .await;
+
+        let mut upstream = match upstream {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => {
+                let rep = io_error_to_rep(&e);
+                warn!("socks5: upstream connect to {upstream_addr} failed: {e}");
+                send_reply(&mut client, rep, 0x03).await?;
+                return Ok(());
+            }
+            Err(_) => {
+                warn!("socks5: upstream connect to {upstream_addr} timed out");
+                send_reply(&mut client, REP_HOST_UNREACHABLE, 0x03).await?;
+                return Ok(());
+            }
+        };
+
+        send_reply(&mut client, REP_SUCCEEDED, 0x03).await?;
+
+        // Bidirectional copy with proper half-close. Same rationale as
+        // [`super::server`]: a naive `tokio::join!` of two `copy()`s
+        // would deadlock because clients typically never close their
+        // write half after the SOCKS5 reply.
+        let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+        Ok::<_, anyhow::Error>(())
+    })
+    .await
+    .context("socks5 handshake timed out")??;
+    Ok(())
+}
+
+/// SOCKS5 greeting. Reads `[VER][NMETHODS][METHODS...]` and replies
+/// `[VER=5][METHOD=0x00]` if no-auth was offered, else `[VER=5][0xFF]`
+/// and bails. RFC 1928 §3.
+async fn greet(client: &mut TcpStream) -> Result<()> {
+    let mut header = [0u8; 2];
+    client.read_exact(&mut header).await?;
+    if header[0] != 0x05 {
+        bail!("not a socks5 client (VER={:#x})", header[0]);
+    }
+    let nmethods = header[1] as usize;
+    let mut methods = vec![0u8; nmethods];
+    if nmethods > 0 {
+        client.read_exact(&mut methods).await?;
+    }
+    if !methods.contains(&0x00) {
+        client.write_all(&[0x05, 0xFF]).await?;
+        bail!("client offered no acceptable auth methods");
+    }
+    client.write_all(&[0x05, 0x00]).await?;
+    Ok(())
+}
+
+/// Parsed CONNECT target.
+#[derive(Debug)]
+struct ConnectTarget {
+    host: String,
+    port: u16,
+}
+
+/// Outcome of [`read_request`]: either a host to connect to, or the
+/// REP code we should send back unconditionally.
+#[derive(Debug)]
+enum RequestOutcome {
+    Connect(ConnectTarget),
+    /// Send `rep`, with BND.ATYP = `atyp` (echoes whatever the client
+    /// sent so well-behaved clients can pretty-print the failure).
+    Reject { rep: u8, atyp: u8 },
+}
+
+/// Parse `[VER=5][CMD][RSV=0][ATYP][DST.ADDR][DST.PORT]`. RFC 1928 §4.
+async fn read_request(client: &mut TcpStream) -> Result<RequestOutcome> {
+    let mut header = [0u8; 4];
+    client.read_exact(&mut header).await?;
+    let [ver, cmd, _rsv, atyp] = header;
+    if ver != 0x05 {
+        bail!("bad request version {ver:#x}");
+    }
+    if cmd != 0x01 {
+        // BIND or UDP ASSOCIATE — see module docstring.
+        // Drain whatever address is coming so we send a clean reply.
+        drain_addr_port(client, atyp).await?;
+        return Ok(RequestOutcome::Reject {
+            rep: REP_COMMAND_NOT_SUPPORTED,
+            atyp,
+        });
+    }
+
+    let host = match atyp {
+        0x03 => {
+            // DOMAIN: 1-byte length + N bytes.
+            let mut len_buf = [0u8; 1];
+            client.read_exact(&mut len_buf).await?;
+            let len = len_buf[0] as usize;
+            if len == 0 || len > MAX_DOMAIN_LEN {
+                drain_port(client).await?;
+                return Ok(RequestOutcome::Reject {
+                    rep: REP_GENERAL_FAILURE,
+                    atyp,
+                });
+            }
+            let mut buf = vec![0u8; len];
+            client.read_exact(&mut buf).await?;
+            match String::from_utf8(buf) {
+                Ok(s) => s,
+                Err(_) => {
+                    drain_port(client).await?;
+                    return Ok(RequestOutcome::Reject {
+                        rep: REP_GENERAL_FAILURE,
+                        atyp,
+                    });
+                }
+            }
+        }
+        0x01 | 0x04 => {
+            // IPv4 / IPv6 literal — see module docstring on why we refuse.
+            drain_addr_port(client, atyp).await?;
+            return Ok(RequestOutcome::Reject {
+                rep: REP_ADDRESS_TYPE_NOT_SUPPORTED,
+                atyp,
+            });
+        }
+        other => {
+            // Drain unknown — but we have no idea how long, so just bail.
+            bail!("unknown ATYP {other:#x}");
+        }
+    };
+
+    let mut port_buf = [0u8; 2];
+    client.read_exact(&mut port_buf).await?;
+    let port = u16::from_be_bytes(port_buf);
+
+    Ok(RequestOutcome::Connect(ConnectTarget { host, port }))
+}
+
+/// Skip `addr + port` bytes for a known ATYP. Used after we've decided
+/// to reject so the client gets a clean reply instead of a half-read
+/// socket.
+async fn drain_addr_port(client: &mut TcpStream, atyp: u8) -> Result<()> {
+    match atyp {
+        0x01 => {
+            let mut buf = [0u8; 4 + 2];
+            client.read_exact(&mut buf).await?;
+        }
+        0x03 => {
+            let mut len = [0u8; 1];
+            client.read_exact(&mut len).await?;
+            let mut buf = vec![0u8; len[0] as usize + 2];
+            client.read_exact(&mut buf).await?;
+        }
+        0x04 => {
+            let mut buf = [0u8; 16 + 2];
+            client.read_exact(&mut buf).await?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Drain just the trailing 2-byte port. Used when we already consumed
+/// the address but want a clean reply.
+async fn drain_port(client: &mut TcpStream) -> Result<()> {
+    let mut port_buf = [0u8; 2];
+    client.read_exact(&mut port_buf).await?;
+    Ok(())
+}
+
+/// Send a SOCKS5 reply. BND.ADDR/BND.PORT are zeroed — we don't need
+/// to echo a real bound address for CONNECT, and zeroing matches what
+/// most permissive clients expect when the server isn't in BIND mode.
+async fn send_reply(client: &mut TcpStream, rep: u8, atyp: u8) -> Result<()> {
+    // [VER=5][REP][RSV=0][ATYP][zeros for addr][zeros for port]
+    let addr_len = match atyp {
+        0x01 => 4,
+        0x04 => 16,
+        // For DOMAIN we send a 1-byte length of 0 + 0 bytes of addr,
+        // which is the cheapest legal encoding.
+        _ => 1,
+    };
+    let mut reply = vec![0u8; 4 + addr_len + 2];
+    reply[0] = 0x05;
+    reply[1] = rep;
+    reply[2] = 0x00;
+    reply[3] = if matches!(atyp, 0x01 | 0x04) { atyp } else { 0x03 };
+    // Bytes [4..] already zero from `vec![0u8; ...]`.
+    client.write_all(&reply).await?;
+    Ok(())
+}
+
+/// Map a `tokio::io::Error` from `TcpStream::connect` to the closest
+/// SOCKS5 REP code so well-behaved clients can render a helpful error.
+fn io_error_to_rep(e: &std::io::Error) -> u8 {
+    use std::io::ErrorKind::*;
+    match e.kind() {
+        ConnectionRefused => REP_CONNECTION_REFUSED,
+        // `NetworkUnreachable` and `HostUnreachable` only stabilised in
+        // 1.83; gate on the kind via a string match to stay on stable
+        // MSRV without a version dance.
+        _ => {
+            let s = e.to_string().to_ascii_lowercase();
+            if s.contains("network is unreachable") {
+                REP_NETWORK_UNREACHABLE
+            } else if s.contains("no route to host") || s.contains("host is unreachable") {
+                REP_HOST_UNREACHABLE
+            } else {
+                REP_GENERAL_FAILURE
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spawn a server on an ephemeral port and return its port.
+    async fn spawn(filter: Filter) -> (u16, tokio::task::JoinHandle<()>) {
+        let server = Socks5Server::bind(None, filter).await.unwrap();
+        let port = server.port();
+        let task = tokio::spawn(server.serve());
+        (port, task)
+    }
+
+    /// Greet and read the server's method-selection reply.
+    async fn greet_noauth(sock: &mut TcpStream) -> [u8; 2] {
+        sock.write_all(&[0x05, 0x01, 0x00]).await.unwrap();
+        let mut reply = [0u8; 2];
+        sock.read_exact(&mut reply).await.unwrap();
+        reply
+    }
+
+    /// Send a CONNECT-DOMAIN request and read back the 4-byte reply
+    /// header (VER, REP, RSV, BND.ATYP).
+    async fn connect_domain(sock: &mut TcpStream, host: &str, port: u16) -> [u8; 4] {
+        let mut req = vec![0x05, 0x01, 0x00, 0x03, host.len() as u8];
+        req.extend_from_slice(host.as_bytes());
+        req.extend_from_slice(&port.to_be_bytes());
+        sock.write_all(&req).await.unwrap();
+        let mut reply = [0u8; 4];
+        sock.read_exact(&mut reply).await.unwrap();
+        reply
+    }
+
+    #[tokio::test]
+    async fn greeting_accepts_noauth() {
+        let (port, _task) = spawn(Filter::default()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        assert_eq!(greet_noauth(&mut sock).await, [0x05, 0x00]);
+    }
+
+    #[tokio::test]
+    async fn greeting_rejects_no_acceptable_auth() {
+        let (port, _task) = spawn(Filter::default()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        // Offer only username/password (0x02) — we only support 0x00.
+        sock.write_all(&[0x05, 0x01, 0x02]).await.unwrap();
+        let mut reply = [0u8; 2];
+        sock.read_exact(&mut reply).await.unwrap();
+        assert_eq!(reply, [0x05, 0xFF]);
+    }
+
+    #[tokio::test]
+    async fn connect_domain_blocked_by_filter() {
+        let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let _ = greet_noauth(&mut sock).await;
+        let reply = connect_domain(&mut sock, "evil.example.com", 443).await;
+        assert_eq!(reply[0], 0x05);
+        assert_eq!(reply[1], REP_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn ipv4_literal_rejected_with_atyp_unsupported() {
+        // IP literal bypasses hostname filter, so we hard-refuse.
+        let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let _ = greet_noauth(&mut sock).await;
+        // CONNECT 1.2.3.4:443 with ATYP=0x01.
+        sock.write_all(&[0x05, 0x01, 0x00, 0x01, 1, 2, 3, 4, 0x01, 0xBB])
+            .await
+            .unwrap();
+        let mut reply = [0u8; 4];
+        sock.read_exact(&mut reply).await.unwrap();
+        assert_eq!(reply[0], 0x05);
+        assert_eq!(reply[1], REP_ADDRESS_TYPE_NOT_SUPPORTED);
+    }
+
+    #[tokio::test]
+    async fn ipv6_literal_rejected_with_atyp_unsupported() {
+        let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let _ = greet_noauth(&mut sock).await;
+        let mut req = vec![0x05, 0x01, 0x00, 0x04];
+        req.extend_from_slice(&[0u8; 16]);
+        req.extend_from_slice(&443u16.to_be_bytes());
+        sock.write_all(&req).await.unwrap();
+        let mut reply = [0u8; 4];
+        sock.read_exact(&mut reply).await.unwrap();
+        assert_eq!(reply[1], REP_ADDRESS_TYPE_NOT_SUPPORTED);
+    }
+
+    #[tokio::test]
+    async fn bind_command_refused() {
+        let (port, _task) = spawn(Filter::default()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let _ = greet_noauth(&mut sock).await;
+        // CMD=0x02 (BIND), ATYP=0x03 (DOMAIN), 1-byte name "x", port 80.
+        sock.write_all(&[0x05, 0x02, 0x00, 0x03, 0x01, b'x', 0x00, 0x50])
+            .await
+            .unwrap();
+        let mut reply = [0u8; 4];
+        sock.read_exact(&mut reply).await.unwrap();
+        assert_eq!(reply[1], REP_COMMAND_NOT_SUPPORTED);
+    }
+
+    #[tokio::test]
+    async fn allowed_domain_succeeds_then_relays() {
+        // Stand up a tiny upstream that echoes one byte.
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_port = upstream.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (mut s, _) = upstream.accept().await.unwrap();
+            let mut byte = [0u8; 1];
+            s.read_exact(&mut byte).await.unwrap();
+            s.write_all(&byte).await.unwrap();
+        });
+
+        // Allow `localhost` so the filter passes for our upstream.
+        let (port, _task) = spawn(Filter::new(["localhost"]).unwrap()).await;
+        let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+        let _ = greet_noauth(&mut sock).await;
+        let reply = connect_domain(&mut sock, "localhost", upstream_port).await;
+        assert_eq!(reply[1], REP_SUCCEEDED);
+
+        // Skip BND.ADDR + BND.PORT (we send DOMAIN with len=0, so 1 + 2).
+        let mut tail = [0u8; 3];
+        sock.read_exact(&mut tail).await.unwrap();
+
+        sock.write_all(&[0x42]).await.unwrap();
+        let mut echo = [0u8; 1];
+        sock.read_exact(&mut echo).await.unwrap();
+        assert_eq!(echo[0], 0x42);
+    }
+
+    #[test]
+    fn io_error_mapping_picks_sensible_codes() {
+        let refused = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        assert_eq!(io_error_to_rep(&refused), REP_CONNECTION_REFUSED);
+
+        let other = std::io::Error::other("network is unreachable");
+        assert_eq!(io_error_to_rep(&other), REP_NETWORK_UNREACHABLE);
+
+        let mystery = std::io::Error::other("kaboom");
+        assert_eq!(io_error_to_rep(&mystery), REP_GENERAL_FAILURE);
+    }
+}

--- a/koda-sandbox/src/proxy/upstream.rs
+++ b/koda-sandbox/src/proxy/upstream.rs
@@ -1,0 +1,430 @@
+//! Upstream-connection layer for the built-in proxies (Phase 3d.3 of #934).
+//!
+//! Both [`crate::proxy::server::Server`] (HTTP CONNECT) and
+//! [`crate::proxy::socks5::Socks5Server`] need to reach a target host
+//! on behalf of a sandboxed client. In a plain home/dev environment
+//! that's a direct `TcpStream::connect`; in a corp environment
+//! (Walmart's Zscaler, Bluecoat, MS Defender, etc.) outbound 443 from
+//! arbitrary processes is firewalled and the only path out is the
+//! corporate HTTPS_PROXY.
+//!
+//! This module centralises the dispatch:
+//!
+//! - [`UpstreamConfig::from_env`] snapshots the user's `HTTPS_PROXY` /
+//!   `NO_PROXY` env at proxy spawn time. We snapshot once (not per-
+//!   request) because the koda process's env is stable for its lifetime
+//!   and re-reading it on every CONNECT would just be syscall churn.
+//! - [`connect_upstream`] dispatches: `Direct` → raw `TcpStream`;
+//!   `HttpProxy` → dial the proxy and send our own CONNECT (no auth,
+//!   no MITM — we're acting as a transparent HTTP-tunnel intermediary).
+//! - [`bypasses_proxy`] applies the NO_PROXY suffix rules so requests
+//!   to e.g. `pypi.ci.artifacts.walmart.com` skip the chained proxy
+//!   when NO_PROXY matches.
+//!
+//! What's deliberately out of scope:
+//! - Proxy authentication (Basic / NTLM / Negotiate). Corp proxies that
+//!   require this are unreachable from koda — same as today. Adding it
+//!   would mean shipping (and securing!) credential storage which is a
+//!   much bigger feature.
+//! - SOCKS5 upstream proxies. Most corp setups use HTTP, and chaining
+//!   SOCKS5 → SOCKS5 is unusual. Easy to add later if a user asks.
+//! - HTTPS to the proxy itself. We always speak plain HTTP/1.1 to the
+//!   proxy (TLS happens *inside* the CONNECT tunnel from the client to
+//!   the real target). Most corp proxies accept both; some only accept
+//!   HTTP on a dedicated port. The `https://` scheme in HTTPS_PROXY is
+//!   accepted but treated identically to `http://`.
+
+use anyhow::{Context, Result, anyhow};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tracing::warn;
+
+/// Snapshot of HTTPS_PROXY / NO_PROXY at proxy spawn time. Cheap to
+/// `clone` (small `String` + small `Vec<String>`).
+///
+/// `Direct` is the default when no proxy is configured or the
+/// configured value can't be parsed — fail-open keeps users productive
+/// when the env is misconfigured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpstreamConfig {
+    /// No upstream chaining — dial targets directly.
+    Direct,
+    /// Tunnel through an HTTP CONNECT proxy. `no_proxy` is a list of
+    /// host suffixes (and the literal `*`) that bypass the proxy.
+    HttpProxy {
+        /// Hostname or IP literal of the upstream proxy (e.g.
+        /// `"sysproxy.wal-mart.com"`). Always dialled in the clear —
+        /// the inner CONNECT tunnel carries the client's TLS
+        /// end-to-end so we don't need to wrap this in TLS ourselves.
+        host: String,
+        /// TCP port the proxy listens on. Conventionally 8080 or 3128.
+        port: u16,
+        /// Suffix-match list from `NO_PROXY` (or `no_proxy`). The
+        /// literal `*` means "bypass the proxy for everything" — a
+        /// kill switch that effectively reverts to `Direct` per-request.
+        no_proxy: Vec<String>,
+    },
+}
+
+impl UpstreamConfig {
+    /// Read the env once and decide which mode applies.
+    ///
+    /// Lookup order matches `curl`/`requests`/`pip` convention:
+    /// `HTTPS_PROXY` first, then `https_proxy`. We only honour the
+    /// HTTPS variant because every target we care about (api.openai.com,
+    /// api.anthropic.com, registry.npmjs.org, …) speaks TLS — there's
+    /// no practical difference between HTTPS_PROXY and ALL_PROXY for
+    /// our workload, and HTTP_PROXY is conventionally for plaintext
+    /// HTTP only (which we don't generate).
+    pub fn from_env() -> Self {
+        let raw = std::env::var("HTTPS_PROXY")
+            .ok()
+            .or_else(|| std::env::var("https_proxy").ok());
+        let Some(raw) = raw else {
+            return Self::Direct;
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Self::Direct;
+        }
+        match parse_proxy_url(trimmed) {
+            Some((host, port)) => Self::HttpProxy {
+                host,
+                port,
+                no_proxy: parse_no_proxy(),
+            },
+            None => {
+                warn!(
+                    "HTTPS_PROXY={raw:?} is not parseable (expected http://host:port, no auth) — \
+                     falling back to direct upstream"
+                );
+                Self::Direct
+            }
+        }
+    }
+}
+
+/// Parse `[scheme://]host:port[/]` into `(host, port)`. Returns `None`
+/// for any of: missing port, embedded `@` (auth), non-numeric port,
+/// hostname containing whitespace.
+///
+/// We accept both `http://` and `https://` schemes as input but ignore
+/// them — the connection to the proxy itself is always plain HTTP/1.1
+/// CONNECT, and the inner tunnel carries the client's TLS end-to-end.
+pub fn parse_proxy_url(s: &str) -> Option<(String, u16)> {
+    let s = s.strip_suffix('/').unwrap_or(s);
+    let s = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))
+        .unwrap_or(s);
+
+    if s.contains('@') || s.contains(char::is_whitespace) || s.contains('/') {
+        // `@` means user:pass auth (unsupported); whitespace / `/` mean
+        // a path component or a malformed URL — refuse rather than
+        // guess.
+        return None;
+    }
+
+    let (host, port_str) = s.rsplit_once(':')?;
+    if host.is_empty() {
+        return None;
+    }
+    let port: u16 = port_str.parse().ok()?;
+    if port == 0 {
+        return None;
+    }
+    Some((host.to_string(), port))
+}
+
+/// Read `NO_PROXY` (then `no_proxy`) and split on commas, trimming
+/// whitespace and leading dots. Empty entries are dropped. The literal
+/// `*` is preserved as-is and handled by [`bypasses_proxy`].
+pub fn parse_no_proxy() -> Vec<String> {
+    let raw = std::env::var("NO_PROXY")
+        .ok()
+        .or_else(|| std::env::var("no_proxy").ok())
+        .unwrap_or_default();
+    raw.split(',')
+        .map(|e| e.trim().trim_start_matches('.').to_string())
+        .filter(|e| !e.is_empty())
+        .collect()
+}
+
+/// Suffix-match NO_PROXY semantics. `*` matches everything; otherwise
+/// `target_host` (already host-only, no port) bypasses the proxy when
+/// it equals or is a subdomain of any entry.
+///
+/// We deliberately don't support CIDR or wildcard-prefix entries —
+/// they're rare in practice and fancy parsing here would dwarf the
+/// 30-line dispatch logic. Users who need CIDRs can add the matching
+/// hostnames explicitly to NO_PROXY.
+pub fn bypasses_proxy(target_host: &str, no_proxy: &[String]) -> bool {
+    no_proxy
+        .iter()
+        .any(|e| e == "*" || target_host == e || target_host.ends_with(&format!(".{e}")))
+}
+
+/// Hard cap on the upstream-proxy CONNECT handshake. Same value the
+/// outer proxy uses for direct connects so a slow corp proxy times out
+/// in roughly the same window as an unreachable target.
+const UPSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Dispatch a connection to `target` (`host:port` form, per RFC 9110
+/// §9.3.6) according to `cfg`.
+///
+/// Returns a `TcpStream` wired straight to `target`'s server endpoint
+/// — callers can copy bytes through it without further protocol on
+/// either side. In `HttpProxy` mode the stream is the post-CONNECT
+/// tunnel; in `Direct` mode it's the raw socket to `target`.
+pub async fn connect_upstream(target: &str, cfg: &UpstreamConfig) -> Result<TcpStream> {
+    match cfg {
+        UpstreamConfig::Direct => connect_direct(target).await,
+        UpstreamConfig::HttpProxy {
+            host,
+            port,
+            no_proxy,
+        } => {
+            let target_host = target.rsplit_once(':').map(|(h, _)| h).unwrap_or(target);
+            if bypasses_proxy(target_host, no_proxy) {
+                return connect_direct(target).await;
+            }
+            connect_via_http_proxy(target, host, *port).await
+        }
+    }
+}
+
+async fn connect_direct(target: &str) -> Result<TcpStream> {
+    let stream = tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, TcpStream::connect(target))
+        .await
+        .with_context(|| format!("upstream connect to {target} timed out"))?
+        .with_context(|| format!("upstream connect to {target} failed"))?;
+    Ok(stream)
+}
+
+/// Dial the corp proxy and send `CONNECT target HTTP/1.1\r\n\r\n`,
+/// returning the raw stream once we get back a 2xx. Any other status
+/// (407 auth required, 403 corp-blocked, 502, …) is surfaced as an
+/// `Err` so the outer proxy turns it into the appropriate client-side
+/// response (502 for HTTP CONNECT, REP=0x05 for SOCKS5).
+async fn connect_via_http_proxy(
+    target: &str,
+    proxy_host: &str,
+    proxy_port: u16,
+) -> Result<TcpStream> {
+    let proxy_addr = format!("{proxy_host}:{proxy_port}");
+    let mut stream =
+        tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, TcpStream::connect(&proxy_addr))
+            .await
+            .with_context(|| format!("dial upstream proxy {proxy_addr} timed out"))?
+            .with_context(|| format!("dial upstream proxy {proxy_addr} failed"))?;
+
+    // Conventional CONNECT request. We send a Host header because
+    // some corp proxies (Squid in particular) require it even though
+    // RFC 9110 only mandates it for non-CONNECT methods. User-Agent
+    // is omitted intentionally — proxies that fingerprint by UA can
+    // be tricked into a different policy and we want to look like a
+    // generic tunnel client.
+    let req = format!(
+        "CONNECT {target} HTTP/1.1\r\nHost: {target}\r\nProxy-Connection: keep-alive\r\n\r\n"
+    );
+    tokio::time::timeout(UPSTREAM_CONNECT_TIMEOUT, stream.write_all(req.as_bytes()))
+        .await
+        .with_context(|| format!("send CONNECT to upstream proxy {proxy_addr} timed out"))?
+        .with_context(|| format!("send CONNECT to upstream proxy {proxy_addr} failed"))?;
+
+    // Read the status line + headers. We can't use copy_bidirectional
+    // yet because we need to consume (and discard) the proxy's headers
+    // before handing the raw tunnel back to the caller.
+    let (status, _headers) = read_proxy_response(&mut stream)
+        .await
+        .with_context(|| format!("read CONNECT response from upstream proxy {proxy_addr}"))?;
+    if !(200..300).contains(&status) {
+        return Err(anyhow!(
+            "upstream proxy {proxy_addr} refused CONNECT to {target} with status {status}"
+        ));
+    }
+
+    Ok(stream)
+}
+
+/// Read the response status line + headers up to the first blank line
+/// without using a buffered reader. Buffered reads risk consuming
+/// post-header tunnel bytes (the proxy can pipeline the CONNECT
+/// response with the first tunnelled bytes from the upstream peer);
+/// since we hand the bare stream back to the caller for splicing,
+/// losing those bytes would silently corrupt every TLS handshake. So
+/// we read one byte at a time — wasteful, but CONNECT responses are
+/// ~50 bytes long and only happen once per tunnel.
+///
+/// Bounded at 8 KiB total so a misbehaving proxy can't blow our
+/// memory or stall us forever.
+async fn read_proxy_response(stream: &mut TcpStream) -> Result<(u16, Vec<u8>)> {
+    const MAX_RESPONSE: usize = 8192;
+    let mut buf = Vec::with_capacity(256);
+    let deadline = tokio::time::Instant::now() + UPSTREAM_CONNECT_TIMEOUT;
+    loop {
+        if buf.len() >= MAX_RESPONSE {
+            return Err(anyhow!(
+                "proxy response exceeded {MAX_RESPONSE} bytes before CRLF CRLF"
+            ));
+        }
+        let mut byte = [0u8; 1];
+        let n = tokio::time::timeout_at(deadline, stream.read(&mut byte))
+            .await
+            .context("read proxy response timed out")?
+            .context("read proxy response failed")?;
+        if n == 0 {
+            return Err(anyhow!("proxy closed connection mid-response"));
+        }
+        buf.push(byte[0]);
+        // End of headers: \r\n\r\n. Tolerate bare \n\n too (some
+        // proxies are sloppy) by also checking for that pattern.
+        if buf.ends_with(b"\r\n\r\n") || buf.ends_with(b"\n\n") {
+            break;
+        }
+    }
+
+    // Status line is everything up to the first \r\n (or \n).
+    let line_end = buf
+        .iter()
+        .position(|&b| b == b'\n')
+        .ok_or_else(|| anyhow!("proxy response missing newline after status line"))?;
+    let status_line = std::str::from_utf8(&buf[..line_end])
+        .context("proxy status line is not UTF-8")?
+        .trim_end_matches('\r');
+    let mut parts = status_line.split_whitespace();
+    let _version = parts
+        .next()
+        .context("missing HTTP version in status line")?;
+    let code_str = parts.next().context("missing status code in status line")?;
+    let code: u16 = code_str
+        .parse()
+        .with_context(|| format!("non-numeric status code {code_str:?}"))?;
+    Ok((code, buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_proxy_url ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_bare_host_port() {
+        assert_eq!(
+            parse_proxy_url("proxy.corp:8080"),
+            Some(("proxy.corp".into(), 8080))
+        );
+    }
+
+    #[test]
+    fn parse_strips_http_scheme() {
+        assert_eq!(
+            parse_proxy_url("http://proxy.corp:8080"),
+            Some(("proxy.corp".into(), 8080))
+        );
+    }
+
+    #[test]
+    fn parse_strips_https_scheme() {
+        // We accept https:// in input (some users / corp docs write it)
+        // but treat the proxy connection as plain HTTP — the inner
+        // tunnel carries the client's TLS end-to-end.
+        assert_eq!(
+            parse_proxy_url("https://proxy.corp:8080"),
+            Some(("proxy.corp".into(), 8080))
+        );
+    }
+
+    #[test]
+    fn parse_strips_trailing_slash() {
+        assert_eq!(
+            parse_proxy_url("http://proxy.corp:8080/"),
+            Some(("proxy.corp".into(), 8080))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_auth() {
+        // user:pass@host — we don't ship credential storage. Reject so
+        // we fall back to Direct rather than silently sending requests
+        // without auth (corp proxy would 407 every one).
+        assert_eq!(parse_proxy_url("http://user:pass@proxy.corp:8080"), None);
+    }
+
+    #[test]
+    fn parse_rejects_missing_port() {
+        assert_eq!(parse_proxy_url("proxy.corp"), None);
+        assert_eq!(parse_proxy_url("http://proxy.corp"), None);
+    }
+
+    #[test]
+    fn parse_rejects_zero_port() {
+        // Port 0 is meaningless for CONNECT; treating it as Direct is
+        // safer than producing an unusable HttpProxy config.
+        assert_eq!(parse_proxy_url("proxy.corp:0"), None);
+    }
+
+    #[test]
+    fn parse_rejects_non_numeric_port() {
+        assert_eq!(parse_proxy_url("proxy.corp:eight"), None);
+    }
+
+    #[test]
+    fn parse_rejects_path_component() {
+        assert_eq!(parse_proxy_url("http://proxy.corp:8080/some/path"), None);
+    }
+
+    // ── bypasses_proxy ──────────────────────────────────────────────────
+
+    #[test]
+    fn no_proxy_exact_match() {
+        let no_proxy = vec!["localhost".into(), "internal.corp".into()];
+        assert!(bypasses_proxy("localhost", &no_proxy));
+        assert!(bypasses_proxy("internal.corp", &no_proxy));
+        assert!(!bypasses_proxy("example.com", &no_proxy));
+    }
+
+    #[test]
+    fn no_proxy_subdomain_match() {
+        let no_proxy = vec!["walmart.com".into()];
+        assert!(bypasses_proxy("pypi.ci.artifacts.walmart.com", &no_proxy));
+        assert!(bypasses_proxy("walmart.com", &no_proxy));
+        // Substring match must NOT count — "evilwalmart.com" is a
+        // different domain from "walmart.com" and routing it through
+        // bypass would be a security hole (someone registers it,
+        // suddenly traffic skips the corp proxy).
+        assert!(!bypasses_proxy("evilwalmart.com", &no_proxy));
+    }
+
+    #[test]
+    fn no_proxy_star_matches_everything() {
+        let no_proxy = vec!["*".into()];
+        assert!(bypasses_proxy("api.openai.com", &no_proxy));
+        assert!(bypasses_proxy("anything.at.all", &no_proxy));
+    }
+
+    #[test]
+    fn no_proxy_empty_list_bypasses_nothing() {
+        assert!(!bypasses_proxy("localhost", &[]));
+    }
+
+    // ── parse_no_proxy ──────────────────────────────────────────────────
+
+    #[test]
+    fn parse_no_proxy_strips_dots_and_whitespace() {
+        // We stash NO_PROXY into a temp env var and parse() reads it.
+        // Tests use a serial mutex because env mutations race across
+        // parallel cargo tests in the same process. Simplest approach:
+        // build the list manually and rely on the unit tests above for
+        // matching, while smoke-testing the splitter inline here.
+        let raw = " .example.com, internal.corp ,, *";
+        let parsed: Vec<String> = raw
+            .split(',')
+            .map(|e| e.trim().trim_start_matches('.').to_string())
+            .filter(|e| !e.is_empty())
+            .collect();
+        assert_eq!(parsed, vec!["example.com", "internal.corp", "*"]);
+    }
+}


### PR DESCRIPTION
Phase 3d of #934, first three slices. Sets up the network-egress
infrastructure for clients that don't honor `HTTPS_PROXY` (raw-TCP,
git-over-ssh, gRPC) and for users behind a corp proxy (Walmart Zscaler,
Bluecoat, MS Defender).

MITM (TLS interception) and per-request timeouts will land in a
separate PR — this one's already three sizeable slices and stops at a
coherent boundary.

## Slices

### 3d.1 — Built-in SOCKS5 proxy server
`koda-sandbox/src/proxy/socks5.rs` + `builtin_socks5.rs` + `socks5_env_vars` helper

Hand-rolled RFC 1928 subset (~350 LOC):
- VER=5, METHOD=0x00 (no auth) supported
- CMD=0x01 CONNECT supported; BIND / UDP ASSOCIATE refused
- ATYP=0x03 DOMAIN supported; **IPv4/IPv6 literals refused** — this
  is the security-critical bit. Pre-resolved IP literals would bypass
  the hostname allowlist; refusing them forces clients to use the
  `socks5h://` scheme so the proxy resolves and runs the hostname
  through the same `Filter` the HTTP CONNECT proxy uses.

Why hand-rolled: Codex's network-proxy crate pulls in rama (~kLOC +
many deps); CC has no SOCKS5. The subset above is ~80 bytes of state
machine — a crate would dwarf the logic. Honors #934 G7 (zero new
runtime deps on macOS).

### 3d.2 — Wire SOCKS5 into koda-core
- `KodaSession::new` spawns `BuiltInSocks5Proxy` alongside
  `BuiltInProxy` using the **same** `DEFAULT_DEV_ALLOWLIST` filter
  (one allowlist, two enforcement paths — no skew possible by
  construction)
- `ToolRegistry` gains `socks5_port: RwLock<Option<u16>>` mirroring
  the existing `proxy_port`
- `sandbox::build` appends `ALL_PROXY=socks5h://127.0.0.1:port` (+
  `all_proxy` lowercase alias) to every Bash invocation when set

Same fail-open contract as the HTTP proxy — SOCKS5 spawn failure logs
a warning and the session keeps going.

### 3d.3 — Upstream HTTPS_PROXY chaining (the corp unblocker)
`koda-sandbox/src/proxy/upstream.rs` (~340 LOC + tests)

Both built-in proxies now route through a corp HTTPS_PROXY when the
koda process has one in its env:
- `UpstreamConfig::from_env` snapshots `HTTPS_PROXY` + `NO_PROXY` once
  at proxy spawn time
- `parse_proxy_url` accepts `http://`, `https://`, or bare
  `host:port`; rejects auth (`user@host`) and path components
- `bypasses_proxy` does suffix-match `NO_PROXY` semantics including
  the `*` kill switch; subdomain match guards against the
  `evilwalmart.com` substring-match security hole
- `connect_upstream` dispatches direct vs CONNECT-to-corp-proxy with
  a bounded byte-by-byte response read (BufReader would lose tunnel
  bytes pipelined after the headers — silently corrupted TLS
  handshakes are the worst possible failure mode)

Both `Server` (HTTP CONNECT) and `Socks5Server` get an `upstream`
field + `with_upstream(cfg)` builder for tests.

## Tests

- 234 koda-sandbox lib tests pass (was 217 → +17 new)
- 988 koda-core lib tests pass (+5 new)
- New highlights:
  - `chains_through_upstream_http_proxy` — end-to-end CONNECT chain
    via a fake corp proxy + assertion that the corp proxy received
    the *original* target (no rewriting)
  - `chains_skips_upstream_for_no_proxy_hosts` — confirms NO_PROXY
    bypass actually skips the corp hop
  - `surfaces_upstream_407_as_502` — corp auth-required must surface
    as 502, not silently dial direct (which would defeat the policy)
  - `socks5_and_http_ports_are_independent` — setting one port
    doesn't clobber the other
  - `build_attaches_both_proxy_and_socks5_when_both_set` — env-var
    bouquet shape end-to-end

## Out of scope (future PRs)
- TLS MITM (CA gen + leaf cert minting + rustls integration)
- Per-request idle/read/write/total timeouts
- Proxy authentication (Basic/NTLM/Negotiate)
- SOCKS5 upstream chaining (HTTP covers every corp setup we've seen)
