### PR TITLE
Phase 3 (slices e/f/g): close out network-egress acceptance for #934

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,9 +3004,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -30,7 +30,7 @@
 
 use anyhow::Result;
 use koda_sandbox::{
-    SandboxPolicy, SandboxRuntime, SandboxTransformRequest, current_runtime,
+    SandboxPolicy, SandboxRuntime, SandboxTransformRequest, ca_bundle_for_policy, current_runtime,
     is_available as ks_is_available, proxy_env_vars,
 };
 use std::path::Path;
@@ -118,12 +118,17 @@ pub fn build(
         }
     };
 
-    // Attach the proxy env-var bouquet last so it overrides anything the
-    // sandbox builder set (the builder doesn't touch HTTPS_PROXY, but
-    // belt-and-suspenders). 3b doesn't ship MITM yet so no CA bundle is
-    // advertised — phase 3d will plumb that through.
+    // Attach the proxy env-var bouquet last so it overrides anything
+    // the sandbox builder set (the builder doesn't touch HTTPS_PROXY,
+    // but belt-and-suspenders). The CA bundle, when policy.net.mitm
+    // is configured (Phase 3g of #934), advertises the corp PKI to
+    // sandboxed subprocesses via SSL_CERT_FILE / NODE_EXTRA_CA_CERTS
+    // / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE — see
+    // [`koda_sandbox::proxy::env::proxy_env_vars`] for the full key
+    // matrix and which runtime cares about which key.
     if let Some(port) = proxy_port {
-        for (k, v) in proxy_env_vars(port, None) {
+        let ca = ca_bundle_for_policy(&policy.net);
+        for (k, v) in proxy_env_vars(port, ca) {
             cmd.env(k, v);
         }
     }

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -179,18 +179,21 @@ impl SandboxRuntime for SeatbeltRuntime {
         // proxy port, so even ill-behaved binaries that ignore
         // `HTTPS_PROXY` env vars cannot escape via direct TCP.
         //
-        // `allow_local_binding=false` is hardcoded until
-        // `policy.net.allow_local_binding` exists. Localhost binds
-        // (e.g. dev servers on 127.0.0.1:3000) are still allowed by
-        // [`network_proxied_rules`]; only wildcard `*:*` binds are
-        // gated by this flag.
+        // `allow_local_binding` and `weaker_macos_isolation` come
+        // straight from the policy. Localhost binds (e.g. dev servers
+        // on 127.0.0.1:3000) are still allowed by
+        // [`network_proxied_rules`] regardless; the bind flag only
+        // gates wildcard `*:*`. The trustd flag (Phase 3e of #934) is
+        // off by default and only set by callers that need Go-style
+        // out-of-process TLS validation to work inside the sandbox.
         let command = match req.proxy_port {
             Some(port) => seatbelt::build_command_with_proxy(
                 req.command,
                 req.project_root,
                 req.policy,
                 port,
-                false,
+                req.policy.net.allow_local_binding,
+                req.policy.net.weaker_macos_isolation,
             )?,
             None => seatbelt::build_command(req.command, req.project_root, req.policy)?,
         };

--- a/koda-sandbox/src/proxy/env.rs
+++ b/koda-sandbox/src/proxy/env.rs
@@ -234,4 +234,67 @@ mod tests {
         };
         assert_eq!(ca_bundle_for_policy(&policy), Some(Path::new("/x/ca.pem")));
     }
+
+    /// Phase 3g of #934: full pipeline from a policy with `MitmConfig`
+    /// to the env bouquet that lands in the sandboxed subprocess.
+    /// Composes `ca_bundle_for_policy` and `proxy_env_vars` exactly
+    /// the way `worker_client.rs` and `koda-core/src/sandbox.rs` do
+    /// at runtime — catches a regression where a future refactor
+    /// detaches the two halves and silently sends `None` again.
+    #[test]
+    fn policy_with_mitm_yields_full_ca_bouquet() {
+        let policy = crate::policy::NetPolicy {
+            mitm: Some(crate::policy::MitmConfig {
+                ca_bundle: PathBuf::from("/etc/ssl/corp.pem"),
+                socket_map: vec![],
+            }),
+            ..Default::default()
+        };
+        let ca = ca_bundle_for_policy(&policy);
+        let vars = proxy_env_vars(8080, ca);
+
+        // All four CA-bundle keys must be present and point at the
+        // same path — different runtimes look at different keys (see
+        // the table in `proxy_env_vars` doc), and a partial bouquet
+        // means some tools silently bypass the corp-CA verification.
+        for key in [
+            "SSL_CERT_FILE",
+            "NODE_EXTRA_CA_CERTS",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+        ] {
+            let v = vars
+                .iter()
+                .find(|(k, _)| k == key)
+                .unwrap_or_else(|| panic!("missing {key} in {vars:?}"));
+            assert_eq!(
+                v.1, "/etc/ssl/corp.pem",
+                "{key} must point at the policy's ca_bundle"
+            );
+        }
+    }
+
+    /// Negative companion: the default policy (no MITM configured)
+    /// must NOT inject any CA env vars — doing so would override the
+    /// platform default trust store with an empty path and break
+    /// every TLS handshake. Same composition shape as the positive
+    /// case to make the diff between them obvious.
+    #[test]
+    fn policy_without_mitm_yields_no_ca_bouquet() {
+        let policy = crate::policy::NetPolicy::default();
+        let ca = ca_bundle_for_policy(&policy);
+        let vars = proxy_env_vars(8080, ca);
+
+        for key in [
+            "SSL_CERT_FILE",
+            "NODE_EXTRA_CA_CERTS",
+            "REQUESTS_CA_BUNDLE",
+            "CURL_CA_BUNDLE",
+        ] {
+            assert!(
+                !vars.iter().any(|(k, _)| k == key),
+                "default policy must not advertise {key}; got {vars:?}"
+            );
+        }
+    }
 }

--- a/koda-sandbox/src/proxy/mod.rs
+++ b/koda-sandbox/src/proxy/mod.rs
@@ -71,6 +71,7 @@ pub mod env;
 pub mod external;
 pub mod filter;
 pub mod handle;
+pub mod relay;
 pub mod server;
 pub mod socks5;
 pub mod upstream;

--- a/koda-sandbox/src/proxy/relay.rs
+++ b/koda-sandbox/src/proxy/relay.rs
@@ -1,0 +1,352 @@
+//! Bidirectional TCP relay with idle + total timeouts (Phase 3f of #934).
+//!
+//! ## Why we don't just call [`tokio::io::copy_bidirectional`]
+//!
+//! `copy_bidirectional` is fire-and-forget: it returns when one side
+//! sends EOF or when an I/O error happens. There is **no signal** to
+//! cancel a tunnel that has gone idle (peer wedged, NAT silently
+//! dropped, corp proxy returned 200 then never sent another byte).
+//!
+//! In a corp environment that's the most common pathological state we
+//! see — the kernel's TCP keepalive defaults to 7200 seconds (two
+//! hours!) and most middleboxes don't bother sending RST on idle. So
+//! a wedged tunnel sits in `copy_bidirectional` for hours, holding a
+//! task slot, an FD pair, and (worse) blocking the per-policy file
+//! descriptor budget if a script churns through many such requests.
+//!
+//! ## What this module provides
+//!
+//! [`relay_with_timeouts`] is a drop-in replacement for
+//! `copy_bidirectional` that adds two cancellation signals:
+//!
+//! * **Idle timeout** — if neither direction has produced bytes within
+//!   `idle`, return `io::ErrorKind::TimedOut`. Per-direction; counted
+//!   from the last successful `read()` on that direction.
+//! * **Total cap** — even if both directions are actively pushing
+//!   bytes, the tunnel cannot live longer than `total`. Bounds the
+//!   blast radius of a runaway stream.
+//!
+//! Both default values ([`DEFAULT_IDLE_TIMEOUT`],
+//! [`DEFAULT_TOTAL_TIMEOUT`]) are chosen so well-behaved long-poll
+//! and SSE / gRPC streaming flows aren't disturbed in normal use.
+//!
+//! ## Implementation note
+//!
+//! We split each socket into reader/writer halves with [`tokio::io::split`]
+//! and run two independent `copy_one_direction` tasks via
+//! [`tokio::try_join!`]. The classic `select! { read … sleep … }` pattern
+//! would require holding a `&mut` to both halves, which is what
+//! `copy_bidirectional` already does — and it's why adding idle detection
+//! upstream hasn't happened in tokio for years. Splitting first is the
+//! straightforward way out.
+
+use std::io;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::time::timeout;
+
+/// Default per-direction idle timeout. Five minutes is a deliberate
+/// compromise: long-poll endpoints (Slack RTM, Server-Sent Events
+/// heartbeats) typically ping every 30-60s, so 5 minutes leaves ample
+/// margin while still reaping wedged tunnels well before the kernel
+/// keepalive (default 7200s) would notice.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Default total-tunnel cap. One hour is enough for very large
+/// downloads (a 50 GB tarball at 100 Mbps is ~70 minutes — we'd cut
+/// that off, which is fine; nobody should be pulling 50 GB through a
+/// dev sandbox proxy without thinking twice).
+pub const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(3600);
+
+/// Buffer size per copy direction. 8 KiB matches `tokio::io::copy`'s
+/// internal default and lines up with most NIC MTU * a small handful
+/// of segments. Bigger buffers don't help throughput on loopback;
+/// smaller ones hurt syscall counts.
+const BUF_SIZE: usize = 8 * 1024;
+
+/// Bidirectional TCP relay with per-direction idle + overall total
+/// timeouts.
+///
+/// Returns `Ok((a_to_b_bytes, b_to_a_bytes))` on clean shutdown,
+/// `Err(io::ErrorKind::TimedOut)` on either timeout firing, or any
+/// other I/O error verbatim.
+///
+/// On a timeout, the *opposite* direction may still have unflushed
+/// bytes in its writer's buffer. We `.shutdown()` both halves before
+/// returning so callers can `drop()` the streams without leaking FDs.
+pub async fn relay_with_timeouts<A, B>(
+    a: A,
+    b: B,
+    idle: Duration,
+    total: Duration,
+) -> io::Result<(u64, u64)>
+where
+    A: AsyncRead + AsyncWrite + Unpin,
+    B: AsyncRead + AsyncWrite + Unpin,
+{
+    let (mut ar, mut aw) = tokio::io::split(a);
+    let (mut br, mut bw) = tokio::io::split(b);
+
+    // tokio::try_join! short-circuits on the first error: if a→b
+    // times out, b→a is dropped (its task is cancelled at the next
+    // await point), which closes the reader half — exactly what we
+    // want. No double-close, no half-open zombie.
+    let work = async {
+        tokio::try_join!(
+            copy_one_direction(&mut ar, &mut bw, idle),
+            copy_one_direction(&mut br, &mut aw, idle),
+        )
+    };
+
+    match timeout(total, work).await {
+        Ok(Ok((a_b, b_a))) => Ok((a_b, b_a)),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!("tunnel exceeded total cap of {total:?}"),
+        )),
+    }
+}
+
+/// Copy bytes from `r` to `w`, returning [`io::ErrorKind::TimedOut`]
+/// if no bytes arrive within `idle` between successful reads.
+///
+/// Counts only **successful** reads as resets — a 0-byte EOF returns
+/// `Ok(total)` so the caller's `try_join!` doesn't treat a clean
+/// half-close as a failure. Mirrors the semantics of
+/// [`tokio::io::copy`].
+async fn copy_one_direction<R, W>(r: &mut R, w: &mut W, idle: Duration) -> io::Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0u8; BUF_SIZE];
+    let mut total = 0u64;
+
+    loop {
+        let n = match timeout(idle, r.read(&mut buf)).await {
+            Ok(Ok(0)) => break,
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                // Best-effort flush before reporting the timeout so the
+                // peer that *was* talking sees its last frame land.
+                let _ = w.shutdown().await;
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!("relay idle for {idle:?}"),
+                ));
+            }
+        };
+        w.write_all(&buf[..n]).await?;
+        total = total.saturating_add(n as u64);
+    }
+
+    // Clean half-close: tell the writer half no more bytes are coming
+    // so the peer's read() returns 0 promptly instead of waiting for
+    // the next idle timeout to fire on its side.
+    let _ = w.shutdown().await;
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// Helper: bind a 127.0.0.1:0 listener, return its addr + a future
+    /// that yields the accepted server-side socket.
+    async fn bound_listener() -> (std::net::SocketAddr, TcpListener) {
+        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = l.local_addr().unwrap();
+        (addr, l)
+    }
+
+    #[tokio::test]
+    async fn relays_bytes_in_both_directions_until_eof() {
+        // Topology:
+        //   client ──┐         ┌── server (echo)
+        //            └─ relay ─┘
+        // Client writes "ping", server echoes "pong-ping", client EOFs,
+        // relay returns clean.
+        let (server_addr, server_listener) = bound_listener().await;
+        let server_task = tokio::spawn(async move {
+            let (mut s, _) = server_listener.accept().await.unwrap();
+            let mut buf = [0u8; 4];
+            s.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf, b"ping");
+            s.write_all(b"pong-ping").await.unwrap();
+            s.shutdown().await.unwrap();
+        });
+
+        let (client_addr, client_listener) = bound_listener().await;
+        let relay_task = tokio::spawn(async move {
+            let (client_side, _) = client_listener.accept().await.unwrap();
+            let upstream_side = TcpStream::connect(server_addr).await.unwrap();
+            relay_with_timeouts(
+                client_side,
+                upstream_side,
+                Duration::from_secs(2),
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        let mut client = TcpStream::connect(client_addr).await.unwrap();
+        client.write_all(b"ping").await.unwrap();
+        client.shutdown().await.unwrap();
+        let mut got = Vec::new();
+        client.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"pong-ping");
+
+        let (a_b, b_a) = relay_task.await.unwrap().unwrap();
+        assert_eq!(a_b, 4, "client→server byte count");
+        assert_eq!(b_a, 9, "server→client byte count");
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn idle_timeout_fires_when_both_sides_silent() {
+        // Neither side ever writes after handshake. The idle timeout
+        // is the only thing keeping us from hanging forever.
+        let (server_addr, server_listener) = bound_listener().await;
+        let _server_task = tokio::spawn(async move {
+            // Accept and then sleep — never write anything.
+            let (sock, _) = server_listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            drop(sock);
+        });
+
+        let (client_addr, client_listener) = bound_listener().await;
+        let start = std::time::Instant::now();
+        let relay_task = tokio::spawn(async move {
+            let (client_side, _) = client_listener.accept().await.unwrap();
+            let upstream_side = TcpStream::connect(server_addr).await.unwrap();
+            relay_with_timeouts(
+                client_side,
+                upstream_side,
+                Duration::from_millis(150),
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        let _client = TcpStream::connect(client_addr).await.unwrap();
+        let res = relay_task.await.unwrap();
+        let elapsed = start.elapsed();
+
+        let err = res.expect_err("expected idle timeout error");
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        // Idle is 150 ms; allow generous slack for slow CI but assert
+        // we didn't hang for the full 5 s total cap.
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "idle should fire well before total cap; took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn total_timeout_fires_even_when_traffic_is_active() {
+        // Server keeps trickling bytes forever — idle timeout never
+        // fires because something is always arriving. Only the total
+        // cap saves us.
+        let (server_addr, server_listener) = bound_listener().await;
+        let _server_task = tokio::spawn(async move {
+            let (mut sock, _) = server_listener.accept().await.unwrap();
+            // Tight loop, but with small sleeps so we don't burn CPU.
+            for _ in 0..1000 {
+                if sock.write_all(b".").await.is_err() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        let (client_addr, client_listener) = bound_listener().await;
+        let start = std::time::Instant::now();
+        let relay_task = tokio::spawn(async move {
+            let (client_side, _) = client_listener.accept().await.unwrap();
+            let upstream_side = TcpStream::connect(server_addr).await.unwrap();
+            relay_with_timeouts(
+                client_side,
+                upstream_side,
+                // Idle is generous (1 s) so it can't fire — the
+                // server pushes a byte every 20 ms.
+                Duration::from_secs(1),
+                // Total is tight (300 ms) so it MUST fire.
+                Duration::from_millis(300),
+            )
+            .await
+        });
+
+        // Drain the client side so writes don't backpressure-stall the
+        // server task before the cap fires.
+        let mut client = TcpStream::connect(client_addr).await.unwrap();
+        let drain = tokio::spawn(async move {
+            let mut buf = [0u8; 64];
+            loop {
+                if client.read(&mut buf).await.unwrap_or(0) == 0 {
+                    break;
+                }
+            }
+        });
+
+        let err = relay_task.await.unwrap().expect_err("expected total cap");
+        let elapsed = start.elapsed();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(
+            elapsed >= Duration::from_millis(250) && elapsed < Duration::from_secs(2),
+            "total cap timing out of bounds: {elapsed:?}"
+        );
+        let _ = drain.await;
+    }
+
+    #[tokio::test]
+    async fn clean_half_close_propagates_without_idle_fire() {
+        // Client closes its write half but still wants to read replies.
+        // copy_one_direction client→server returns Ok(0); server→client
+        // direction must not be killed by an idle timeout if the server
+        // is still actively replying.
+        let (server_addr, server_listener) = bound_listener().await;
+        let _server_task = tokio::spawn(async move {
+            let (mut s, _) = server_listener.accept().await.unwrap();
+            let mut buf = Vec::new();
+            // Drain whatever the client sends; respond with a bunch of
+            // bytes spread out over time.
+            let _ = s.read_to_end(&mut buf).await;
+            for _ in 0..5 {
+                if s.write_all(b"chunk").await.is_err() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            let _ = s.shutdown().await;
+        });
+
+        let (client_addr, client_listener) = bound_listener().await;
+        let relay_task = tokio::spawn(async move {
+            let (client_side, _) = client_listener.accept().await.unwrap();
+            let upstream_side = TcpStream::connect(server_addr).await.unwrap();
+            relay_with_timeouts(
+                client_side,
+                upstream_side,
+                Duration::from_secs(2),
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        let mut client = TcpStream::connect(client_addr).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        client.shutdown().await.unwrap();
+        let mut got = Vec::new();
+        client.read_to_end(&mut got).await.unwrap();
+        assert_eq!(got, b"chunkchunkchunkchunkchunk");
+
+        let (a_b, b_a) = relay_task.await.unwrap().unwrap();
+        assert_eq!(a_b, 5);
+        assert_eq!(b_a, 25);
+    }
+}

--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -32,6 +32,7 @@
 //! - **No upload/idle timeouts** — Phase 3d (resource limits).
 
 use super::Filter;
+use super::relay;
 #[cfg(test)]
 use super::pick_ephemeral_port;
 use anyhow::{Context, Result, bail};
@@ -174,7 +175,7 @@ async fn handle_one(
     }
 
     // Allowed. Connect upstream and bridge.
-    let mut upstream_sock = match crate::proxy::upstream::connect_upstream(&target, upstream).await
+    let upstream_sock = match crate::proxy::upstream::connect_upstream(&target, upstream).await
     {
         Ok(s) => s,
         Err(e) => {
@@ -186,13 +187,21 @@ async fn handle_one(
 
     write_status(&mut client, 200, "Connection Established").await?;
 
-    // Bidirectional copy until either side closes. tokio's helper does
-    // the half-close dance correctly: when one direction reports EOF
-    // it shuts down the corresponding write half on the other socket
-    // so the peer can observe the close and tear down. Without this
-    // (e.g. naive tokio::join! of two copy()s) we'd deadlock — clients
-    // typically never close their write side after CONNECT.
-    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream_sock).await;
+    // Bidirectional copy with idle + total timeouts (Phase 3f of
+    // #934). We use [`crate::proxy::relay`] instead of tokio's
+    // copy_bidirectional so a wedged peer (corp middlebox eating
+    // RST, NAT silently dropping) can't pin a task slot for the
+    // kernel keepalive's two-hour default. Errors are intentionally
+    // swallowed: the connection is already torn down by the time we
+    // see them, and surfacing them as proxy-side log spam would just
+    // be noise — clients can't act on it.
+    let _ = relay::relay_with_timeouts(
+        client,
+        upstream_sock,
+        relay::DEFAULT_IDLE_TIMEOUT,
+        relay::DEFAULT_TOTAL_TIMEOUT,
+    )
+    .await;
     Ok(())
 }
 

--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -32,9 +32,9 @@
 //! - **No upload/idle timeouts** — Phase 3d (resource limits).
 
 use super::Filter;
-use super::relay;
 #[cfg(test)]
 use super::pick_ephemeral_port;
+use super::relay;
 use anyhow::{Context, Result, bail};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -175,8 +175,7 @@ async fn handle_one(
     }
 
     // Allowed. Connect upstream and bridge.
-    let upstream_sock = match crate::proxy::upstream::connect_upstream(&target, upstream).await
-    {
+    let upstream_sock = match crate::proxy::upstream::connect_upstream(&target, upstream).await {
         Ok(s) => s,
         Err(e) => {
             warn!("proxy: upstream connect to {target} failed: {e:#}");

--- a/koda-sandbox/src/proxy/socks5.rs
+++ b/koda-sandbox/src/proxy/socks5.rs
@@ -176,7 +176,7 @@ async fn handle_one(
         let upstream_addr = format!("{}:{}", target.host, target.port);
         let dial = crate::proxy::upstream::connect_upstream(&upstream_addr, upstream).await;
 
-        let mut upstream_sock = match dial {
+        let upstream_sock = match dial {
             Ok(s) => s,
             Err(e) => {
                 // The upstream layer wraps anyhow::Error around a root
@@ -197,11 +197,19 @@ async fn handle_one(
 
         send_reply(&mut client, REP_SUCCEEDED, 0x03).await?;
 
-        // Bidirectional copy with proper half-close. Same rationale as
-        // [`super::server`]: a naive `tokio::join!` of two `copy()`s
-        // would deadlock because clients typically never close their
-        // write half after the SOCKS5 reply.
-        let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream_sock).await;
+        // Bidirectional copy with idle + total timeouts (Phase 3f of
+        // #934). Same rationale as [`super::server`]: SOCKS5 clients
+        // (git-over-https, raw TCP) never half-close after the reply,
+        // so without an idle deadline a wedged peer pins the slot for
+        // the kernel keepalive's two-hour default. See
+        // [`super::relay::relay_with_timeouts`] for the design notes.
+        let _ = super::relay::relay_with_timeouts(
+            client,
+            upstream_sock,
+            super::relay::DEFAULT_IDLE_TIMEOUT,
+            super::relay::DEFAULT_TOTAL_TIMEOUT,
+        )
+        .await;
         Ok::<_, anyhow::Error>(())
     })
     .await

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -105,15 +105,13 @@ fn build_command_inner(
     // so the denies override the earlier broad `(allow file-read*)`.
     // Same last-match-wins approach as Gemini CLI's seatbeltArgsBuilder.ts.
     let mut profile = match proxy {
-        Some((port, allow_local_binding, weaker_macos_isolation)) => {
-            build_proxied_profile_string(
-                &root,
-                &home,
-                port,
-                allow_local_binding,
-                weaker_macos_isolation,
-            )
-        }
+        Some((port, allow_local_binding, weaker_macos_isolation)) => build_proxied_profile_string(
+            &root,
+            &home,
+            port,
+            allow_local_binding,
+            weaker_macos_isolation,
+        ),
         None => build_profile_string(&root, &home),
     };
     profile.push_str(&protected_subdir_deny_rules(&root));

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -62,18 +62,27 @@ pub fn build_command(
 /// `allow_local_binding` corresponds to `policy.net.allow_local_binding`
 /// (when that field exists — today it's a hardcoded `false` until the
 /// `NetPolicy` schema gains the field). Pass `false` for the strict default.
+///
+/// `weaker_macos_isolation` (Phase 3e of #934) corresponds to
+/// `policy.net.weaker_macos_isolation`. When `true`, the proxied profile
+/// permits mach-lookups to Apple's `trustd` and `trustd.agent` daemons
+/// so Go-binary TLS handshakes (which validate certs out-of-process via
+/// trustd, bypassing the rustls/openssl in-process path) succeed. Off
+/// by default — leaks a small amount of metadata to Apple's daemons
+/// but doesn't widen the network egress surface.
 pub fn build_command_with_proxy(
     command: &str,
     project_root: &Path,
     policy: &SandboxPolicy,
     proxy_port: u16,
     allow_local_binding: bool,
+    weaker_macos_isolation: bool,
 ) -> Result<Command> {
     build_command_inner(
         command,
         project_root,
         policy,
-        Some((proxy_port, allow_local_binding)),
+        Some((proxy_port, allow_local_binding, weaker_macos_isolation)),
     )
 }
 
@@ -81,7 +90,7 @@ fn build_command_inner(
     command: &str,
     project_root: &Path,
     policy: &SandboxPolicy,
-    proxy: Option<(u16, bool)>,
+    proxy: Option<(u16, bool, bool)>,
 ) -> Result<Command> {
     let canonical = project_root
         .canonicalize()
@@ -96,8 +105,14 @@ fn build_command_inner(
     // so the denies override the earlier broad `(allow file-read*)`.
     // Same last-match-wins approach as Gemini CLI's seatbeltArgsBuilder.ts.
     let mut profile = match proxy {
-        Some((port, allow_local_binding)) => {
-            build_proxied_profile_string(&root, &home, port, allow_local_binding)
+        Some((port, allow_local_binding, weaker_macos_isolation)) => {
+            build_proxied_profile_string(
+                &root,
+                &home,
+                port,
+                allow_local_binding,
+                weaker_macos_isolation,
+            )
         }
         None => build_profile_string(&root, &home),
     };
@@ -223,9 +238,23 @@ pub(crate) fn network_open_rules() -> String {
 /// - **Bind on `*:*`** — only when `allow_local_binding` is true (user dev
 ///   servers expecting external clients).
 ///
+/// When `weaker_macos_isolation` is true (Phase 3e of #934) we additionally
+/// permit mach-lookups to Apple's `trustd` and `trustd.agent` daemons.
+/// Without this, Go's standard library TLS — which validates server certs
+/// by IPC to `trustd` rather than in-process — fails on every handshake
+/// inside the proxied sandbox. Same toggle Claude Code exposes as
+/// `enableWeakerNetworkIsolation`. The trade-off is intentional: trustd
+/// learns the hostnames you're validating against (a metadata leak), but
+/// it has no power to widen the network egress surface, which the kernel
+/// SBPL still enforces independently.
+///
 /// Pattern mirrors Gemini CLI's `sandbox-macos-strict-proxied.sb` plus the
 /// Unix-socket carve-out from Codex's seatbelt rules.
-pub fn network_proxied_rules(proxy_port: u16, allow_local_binding: bool) -> String {
+pub fn network_proxied_rules(
+    proxy_port: u16,
+    allow_local_binding: bool,
+    weaker_macos_isolation: bool,
+) -> String {
     let mut rules = String::new();
     // SBPL gotcha: `(remote tcp "<host>:<port>")` only accepts `*` or
     // `localhost` as the host — a literal `127.0.0.1` causes
@@ -246,6 +275,29 @@ pub fn network_proxied_rules(proxy_port: u16, allow_local_binding: bool) -> Stri
     if allow_local_binding {
         rules.push_str("(allow network-bind (local ip \"*:*\"))\n");
     }
+    if weaker_macos_isolation {
+        rules.push_str(&trustd_mach_lookup_rules());
+    }
+    rules
+}
+
+/// SBPL rules permitting mach-lookups to Apple's `trustd` family.
+///
+/// These two services are the entire reason the `weaker_macos_isolation`
+/// flag exists. Kept as a separate fn so the snapshot tests can
+/// substring-match against the exact wire form without re-deriving it.
+///
+/// Why both names: Apple split `trustd` into `trustd` (system) and
+/// `trustd.agent` (per-user) somewhere around macOS 11; depending on
+/// what the calling binary links against and which user it runs as,
+/// either may be the actual lookup target. Permitting both is the only
+/// way to handle every binary in one rule set.
+fn trustd_mach_lookup_rules() -> String {
+    let mut rules = String::from(
+        "; \u{2500}\u{2500} weaker_macos_isolation: Apple trustd for Go-style out-of-process TLS \u{2500}\u{2500}\n",
+    );
+    rules.push_str("(allow mach-lookup (global-name \"com.apple.trustd\"))\n");
+    rules.push_str("(allow mach-lookup (global-name \"com.apple.trustd.agent\"))\n");
     rules
 }
 
@@ -258,8 +310,9 @@ pub fn build_proxied_profile_string(
     home: &str,
     proxy_port: u16,
     allow_local_binding: bool,
+    weaker_macos_isolation: bool,
 ) -> String {
-    let net = network_proxied_rules(proxy_port, allow_local_binding);
+    let net = network_proxied_rules(proxy_port, allow_local_binding, weaker_macos_isolation);
     build_profile_string_with_network(root, home, &net)
 }
 
@@ -637,7 +690,7 @@ mod tests {
 
     #[test]
     fn proxied_profile_omits_open_network_allow() {
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         assert!(
             !p.contains("(allow network*)\n"),
             "proxied profile must not include the open-network allow\nprofile:\n{p}"
@@ -646,7 +699,7 @@ mod tests {
 
     #[test]
     fn proxied_profile_allows_only_proxy_port_outbound_tcp() {
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         // Phase 3c fix: SBPL only accepts `*` or `localhost` as the
         // host in `(remote tcp ...)`. A literal `127.0.0.1` causes
         // sandbox-exec to reject the entire profile. `localhost`
@@ -673,19 +726,19 @@ mod tests {
         // git-over-ssh, ssh-agent, language servers, Docker.sock when
         // bind-mounted — all need this. Codex's seatbelt has the same
         // carve-out.
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         assert!(p.contains("(allow network-outbound (remote unix-socket))"));
     }
 
     #[test]
     fn proxied_profile_allows_localhost_inbound_for_debuggers() {
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         assert!(p.contains("(allow network-inbound (local ip \"localhost:*\"))"));
     }
 
     #[test]
     fn proxied_profile_omits_wildcard_bind_when_local_binding_disabled() {
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         // Localhost bind is always allowed; wildcard *:* must not be.
         assert!(p.contains("(allow network-bind (local ip \"localhost:*\"))"));
         assert!(
@@ -696,7 +749,7 @@ mod tests {
 
     #[test]
     fn proxied_profile_includes_wildcard_bind_when_local_binding_enabled() {
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, true);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, true, false);
         assert!(p.contains("(allow network-bind (local ip \"*:*\"))"));
     }
 
@@ -705,7 +758,7 @@ mod tests {
         // Regression guard: the proxied variant must only differ from the
         // open variant in the network section. Same temp/cargo/npm/cache
         // writes should still be present.
-        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
         assert!(p.contains("(subpath \"/work\")"));
         assert!(p.contains("(subpath \"/private/tmp\")"));
         assert!(p.contains("(subpath \"/Users/x/.cargo\")"));
@@ -718,7 +771,7 @@ mod tests {
         // DRY guard: confirm that build_profile_string and
         // build_proxied_profile_string share the same baseline.
         let open = build_profile_string("/work", "/Users/x");
-        let proxied = build_proxied_profile_string("/work", "/Users/x", 8877, false);
+        let proxied = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
 
         // Both must end the same way (process-exec onward is identical).
         let tail = "(allow process-exec*)\n(allow process-fork)\n(allow sysctl-read)\n(allow ipc-posix*)\n(allow mach*)\n";
@@ -739,6 +792,7 @@ mod tests {
             Path::new("/tmp"),
             &SandboxPolicy::default(),
             8877,
+            false,
             false,
         )
         .unwrap();
@@ -781,6 +835,7 @@ mod tests {
             &SandboxPolicy::default(),
             8877,
             true,
+            false,
         )
         .unwrap();
         let args: Vec<String> = cmd
@@ -790,5 +845,98 @@ mod tests {
             .collect();
         let profile = &args[1];
         assert!(profile.contains("(allow network-bind (local ip \"*:*\"))"));
+    }
+
+    // ── Phase 3e: weaker_macos_isolation toggle ────────────────────────────
+
+    #[test]
+    fn proxied_profile_omits_trustd_by_default() {
+        // Strict default: no mach-lookup carve-outs. The trustd daemons
+        // are deliberately UNREACHABLE without the explicit opt-in,
+        // mirroring the deny-by-default network posture.
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, false);
+        assert!(
+            !p.contains("com.apple.trustd"),
+            "strict default must not permit trustd lookups; got:\n{p}"
+        );
+        assert!(
+            !p.contains("mach-lookup"),
+            "strict default must not contain any mach-lookup allow; got:\n{p}"
+        );
+    }
+
+    #[test]
+    fn proxied_profile_permits_trustd_when_weaker_isolation_set() {
+        // Opt-in: both trustd names must appear so per-user agent and
+        // system daemon lookups both succeed regardless of binary.
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, true);
+        assert!(
+            p.contains("(allow mach-lookup (global-name \"com.apple.trustd\"))"),
+            "weaker isolation must permit com.apple.trustd; got:\n{p}"
+        );
+        assert!(
+            p.contains("(allow mach-lookup (global-name \"com.apple.trustd.agent\"))"),
+            "weaker isolation must permit com.apple.trustd.agent; got:\n{p}"
+        );
+    }
+
+    #[test]
+    fn weaker_isolation_does_not_widen_network_egress() {
+        // The whole point of the toggle: it relaxes mach-lookup ONLY.
+        // The kernel-enforced TCP egress remains pinned to the loopback
+        // proxy port. Regression guard against a future maintainer
+        // sneaking a `(allow network*)` in alongside the trustd rules.
+        let p = build_proxied_profile_string("/work", "/Users/x", 8877, false, true);
+        assert!(
+            !p.contains("(allow network*)\n"),
+            "weaker isolation must not include the open-network blanket allow; got:\n{p}"
+        );
+        assert!(
+            p.contains("(allow network-outbound (remote tcp \"localhost:8877\"))"),
+            "single-port loopback rule must remain intact; got:\n{p}"
+        );
+    }
+
+    #[test]
+    fn weaker_isolation_propagates_through_build_command_with_proxy() {
+        // End-to-end: the public entry point must thread the bool all
+        // the way to the emitted profile.
+        let cmd = build_command_with_proxy(
+            "true",
+            Path::new("/tmp"),
+            &SandboxPolicy::default(),
+            8877,
+            false,
+            true,
+        )
+        .unwrap();
+        let profile = cmd
+            .as_std()
+            .get_args()
+            .nth(1)
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            profile.contains("com.apple.trustd"),
+            "weaker isolation flag must reach the profile; got:\n{profile}"
+        );
+    }
+
+    #[test]
+    fn trustd_rules_are_idempotent_on_section_header() {
+        // The section header is a comment used as a visual landmark in
+        // log output. If a future refactor changes the header text, the
+        // log/grep tooling that hunts for sandbox events will silently
+        // stop matching. Pin the exact prefix.
+        let rules = trustd_mach_lookup_rules();
+        assert!(
+            rules.starts_with("; "),
+            "trustd block must lead with an SBPL comment; got:\n{rules}"
+        );
+        assert!(
+            rules.contains("weaker_macos_isolation"),
+            "comment must mention the policy field name for grep-ability; got:\n{rules}"
+        );
     }
 }


### PR DESCRIPTION
Closes out Phase 3 of #934. Three tightly-scoped slices that fill the
last three checkboxes on the Phase 3 acceptance list, after which the
issue's Phase-3 gate (`curl github.com works, curl evil.com blocked,
both return correct stderr; works through corporate sysproxy`) is
green on both macOS and Linux.

## Slices

### 3e — `weaker_macos_isolation` SBPL toggle
`koda-sandbox/src/seatbelt.rs` + `lib.rs`

Honors the `policy.net.weaker_macos_isolation` flag that's lived as
inert data on `NetPolicy` since Phase 0. When `true`, the proxied
seatbelt profile permits mach-lookups to **both** `com.apple.trustd`
(system) and `com.apple.trustd.agent` (per-user) so Go-compiled
binaries (gcloud, terraform, kubectl, every modern devops tool)
succeed at TLS handshakes inside the sandbox — Go validates server
certs by mach-IPC to trustd rather than in-process, and the strict
proxied SBPL was denying that lookup.

Trade-off is intentional: trustd learns which hostnames you're
validating against (a metadata leak), but it has no power to widen
the network egress surface, which the kernel SBPL still enforces
independently. New regression test pins this:
`weaker_isolation_does_not_widen_network_egress`.

Also dropped two stale hardcoded `false` values for
`allow_local_binding` in `SeatbeltRuntime::transform` — the field has
existed on `NetPolicy` for a while; the hardcode predated the field.
Now reads both flags directly from `req.policy.net`.

### 3f — Per-direction idle + total tunnel timeouts
`koda-sandbox/src/proxy/relay.rs` (~310 LOC + tests) + `server.rs` + `socks5.rs`

Both built-in proxies have used `tokio::io::copy_bidirectional` for
the relay phase since 3b/3d.1. That's fire-and-forget: there's NO
signal to cancel a tunnel that has gone idle (peer wedged, NAT
silently dropped, corp middlebox returned 200 then never sent another
byte) — which in a corp environment is the most common pathological
state. The kernel's TCP keepalive defaults to **two hours**, so a
wedged tunnel sits in `copy_bidirectional` for hours.

New `relay_with_timeouts` is a drop-in replacement that adds two
cancellation signals:

- **Per-direction idle** (default 5 min) — long enough that
  long-poll/SSE heartbeats (typically every 30-60s) aren't disturbed,
  short enough to reap wedged tunnels well before kernel keepalive.
  Implemented via `tokio::io::split` + `try_join!` of two custom-copy
  loops (the trick that's blocked tokio from adding idle detection
  upstream for years).
- **Overall total cap** (default 1 h) — bounds runaway streams even
  with active traffic. A 50 GB tarball at 100 Mbps takes ~70 min;
  we'd cut that off, which is fine.

No env knobs. YAGNI; if defaults bite, tune in a follow-up.

### 3g — MITM CA bundle env injection
`koda-core/src/sandbox.rs`

Plumbing existed since Phase 0 (`MitmConfig` on NetPolicy,
`ca_bundle_for_policy` helper, `proxy_env_vars` accepting
`Option<&Path>` and emitting all four runtime keys: `SSL_CERT_FILE`,
`NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`). But
`koda-core::sandbox::build` was hardcoding `None`, leaving the
CA-bundle keys forever unset.

Why this matters separately from 3d.3's HTTPS_PROXY chaining: when
the koda proxy chains through a corp HTTPS_PROXY (Zscaler etc.), the
corp proxy presents a Zscaler-signed leaf for every endpoint.
Sandboxed clients that trust only the public PKI see those certs as
INVALID and abort the handshake. The CA bundle env vars override the
default trust store with the corp PKI bundle. Without this, every
TLS request through a chained corp proxy fails with `unable to verify
the first certificate` even though the routing is perfect.

`worker_client.rs` already wired this correctly — this slice closes
the gap on the Bash-via-`build()` flow.

## Tests

- 245 koda-sandbox lib tests (was 234 → +11 new)
- 988 koda-core lib tests (unchanged)
- All green. Clippy clean. fmt clean. rustdoc clean.

New highlights:
- `proxied_profile_omits_trustd_by_default` — strict default leaves
  trustd unreachable
- `proxied_profile_permits_trustd_when_weaker_isolation_set` — both
  daemon names appear (binary-agnostic)
- `weaker_isolation_does_not_widen_network_egress` — regression
  guard against a future maintainer accidentally smuggling
  `(allow network*)` in alongside the trustd rules
- `idle_timeout_fires_when_both_sides_silent` — wall-clock-bounded
  to distinguish idle-fire from total-fire (both return TimedOut)
- `total_timeout_fires_even_when_traffic_is_active` — server pushes
  byte every 20 ms; only the cap saves us
- `clean_half_close_propagates_without_idle_fire` — active direction
  must NOT be killed when the dormant one returns Ok(0)
- `policy_with_mitm_yields_full_ca_bouquet` — composes
  `ca_bundle_for_policy` and `proxy_env_vars` exactly the way
  runtime callers do; catches a regression where a future refactor
  detaches the two halves

## What's left in #934

Phase 3 is **closed** with this PR. Remaining issue scope:

- Phase 4 — `SandboxPool` + CoW workspace providers (the speed phase)
- Phase 5 — Resource limits, telemetry, threat-model docs

Both are big standalone efforts. Out of scope here.
