### PR TITLE
Phase 4b+4c: SandboxPool + SandboxSlot lifecycle (#934)

### DIFF
--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -40,6 +40,8 @@ pub mod monitor;
 pub mod path_defense;
 pub mod policy;
 pub mod policy_check;
+#[cfg(unix)]
+pub mod pool;
 pub mod proxy;
 #[cfg(target_os = "macos")]
 pub mod seatbelt;

--- a/koda-sandbox/src/pool.rs
+++ b/koda-sandbox/src/pool.rs
@@ -30,7 +30,8 @@
 //! that would be a privilege-escalation bug, not just a perf miss.
 //!
 //! The bucket key uses **owned** `SandboxPolicy` (not a hash) for the
-//! same security reason as [`crate::seatbelt_cache`]: a hash-only key
+//! same security reason as `seatbelt_cache` (macOS-only sibling): a
+//! hash-only key
 //! could theoretically let two policies share a free-list entry on
 //! collision, silently widening one of them.
 //!

--- a/koda-sandbox/src/pool.rs
+++ b/koda-sandbox/src/pool.rs
@@ -1,0 +1,451 @@
+//! Sandbox pool + slot lifecycle (Phases 4b + 4c of #934).
+//!
+//! ## What this gives you
+//!
+//! [`SandboxPool`] is a per-process LRU-free pool of pre-warmed
+//! [`WorkerClient`]s keyed by `(writable_root, policy, proxy_port)`.
+//! Calling [`SandboxPool::acquire`] returns a [`SandboxSlot`] that
+//! owns one worker plus one provisioned workspace. Drop-ing the slot
+//! returns the worker to the pool (if still healthy) and asynchronously
+//! releases the workspace.
+//!
+//! ## Why the pool exists
+//!
+//! Every sandboxed FS / Bash invocation today spawns a fresh
+//! `koda-fs-worker`: fork + exec + binary startup + readiness
+//! handshake = ~60-250 ms wall clock on a warm laptop. Phase 4 wants
+//! `acquire_slot() < 15 ms p95 warm`, which means we have to amortize
+//! the spawn cost across multiple acquires of the same `(root, policy)`
+//! tuple — exactly the pattern the sub-agent dispatcher hits when it
+//! fans out 30 parallel workers against the same project.
+//!
+//! ## Bucketing
+//!
+//! Workers bind their `writable_root` and `SandboxPolicy` at spawn
+//! time (via `--root` CLI arg + `KODA_FS_WORKER_POLICY` env var). They
+//! **cannot** be re-bound after the fact without a worker-protocol
+//! change, so the pool buckets workers by the full
+//! `(writable_root, policy, proxy)` tuple. A worker spawned with
+//! policy A is never reused for a request that asked for policy B —
+//! that would be a privilege-escalation bug, not just a perf miss.
+//!
+//! The bucket key uses **owned** `SandboxPolicy` (not a hash) for the
+//! same security reason as [`crate::seatbelt_cache`]: a hash-only key
+//! could theoretically let two policies share a free-list entry on
+//! collision, silently widening one of them.
+//!
+//! ## Pre-warming model
+//!
+//! Pre-warming is **opt-in** via [`SandboxPool::warm_bucket`]. The
+//! constructor doesn't pre-warm because it doesn't yet know which
+//! buckets will be hit; the dispatcher does, and it can call
+//! `warm_bucket` before fanning out work. Cold acquires still work —
+//! they just spawn a fresh worker — so callers that don't pre-warm
+//! get correctness without any speedup.
+//!
+//! There is no background fill task. YAGNI for the first cut. Warm
+//! buckets stay warm because finished slots return their workers,
+//! and the steady-state population matches the working-set size.
+//!
+//! ## Drop ordering
+//!
+//! - `SandboxSlot::drop` returns the worker (if clean) and spawns an
+//!   async task to release the workspace. The release runs
+//!   best-effort: if the tokio runtime is gone, we log and skip.
+//! - `SandboxPool::drop` clears all free-list buckets, which drops
+//!   every cached `WorkerClient`, which kills the child processes via
+//!   `WorkerClient::Drop`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, Weak};
+
+use anyhow::Result;
+use tracing::{debug, warn};
+
+use crate::policy::SandboxPolicy;
+use crate::proxy::ProxyHandle;
+use crate::worker_client::WorkerClient;
+use crate::workspace::WorkspaceProvider;
+
+// ── Bucket key ────────────────────────────────────────────────────────────
+
+/// Identifies a free-list bucket. Two acquires with byte-identical
+/// keys can share a worker; otherwise they cannot.
+///
+/// The full `SandboxPolicy` is stored (not a hash) so collisions are
+/// physically impossible — a hash-only key would be a security defect
+/// (see module docs).
+///
+/// `proxy_port` is just the loopback port number, not a `ProxyHandle`,
+/// because two `ProxyHandle`s pointing at the same port are
+/// semantically interchangeable from the worker's perspective.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BucketKey {
+    writable_root: PathBuf,
+    policy: SandboxPolicy,
+    proxy_port: Option<u16>,
+}
+
+// ── Pool ──────────────────────────────────────────────────────────────────
+
+/// Process-wide pool of pre-warmed `WorkerClient`s.
+///
+/// Hand-roll your own per-test or share `Arc<SandboxPool>` across the
+/// whole koda process — both work. The internal mutex guards a small
+/// `HashMap<BucketKey, Vec<WorkerClient>>` so contention is minimal.
+pub struct SandboxPool {
+    target_per_bucket: usize,
+    free: Mutex<HashMap<BucketKey, Vec<WorkerClient>>>,
+}
+
+impl std::fmt::Debug for SandboxPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let n = self.free.lock().map(|m| m.len()).unwrap_or(0);
+        f.debug_struct("SandboxPool")
+            .field("target_per_bucket", &self.target_per_bucket)
+            .field("buckets", &n)
+            .finish()
+    }
+}
+
+impl SandboxPool {
+    /// Construct an empty pool. `target_per_bucket` caps how many
+    /// idle workers any single `(root, policy, proxy)` bucket can
+    /// hold; surplus returns are dropped (= killed).
+    ///
+    /// Reasonable values: 1 for sequential-only flows, 4-8 for the
+    /// usual desktop case, 30+ for the sub-agent dispatcher's
+    /// fan-out demo.
+    pub fn new(target_per_bucket: usize) -> Arc<Self> {
+        assert!(target_per_bucket > 0, "target_per_bucket must be >= 1");
+        Arc::new(Self {
+            target_per_bucket,
+            free: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Eagerly spawn `n` workers into the bucket for
+    /// `(writable_root, policy, proxy)`. Subsequent
+    /// [`acquire`](Self::acquire) calls with the same triple will
+    /// pop from this pre-warmed set.
+    ///
+    /// Caps the bucket at `target_per_bucket`: requesting more is a
+    /// no-op past the cap, not an error. Returning fewer than `n`
+    /// (because the cap was hit) is intentional — the cap exists
+    /// to bound resource usage.
+    ///
+    /// Spawns happen sequentially, not in parallel, because the
+    /// fork+exec syscall already has internal serialization on most
+    /// kernels and parallel spawning gives nearly zero speedup while
+    /// adding error-handling complexity. If this ever shows up on a
+    /// flame graph, switch to `futures::future::try_join_all`.
+    pub async fn warm_bucket(
+        self: &Arc<Self>,
+        writable_root: PathBuf,
+        policy: &SandboxPolicy,
+        proxy: Option<&ProxyHandle>,
+        n: usize,
+    ) -> Result<()> {
+        let key = BucketKey {
+            writable_root: writable_root.clone(),
+            policy: policy.clone(),
+            proxy_port: proxy.map(|p| p.port),
+        };
+
+        let already = {
+            let map = self.free.lock().expect("pool mutex poisoned");
+            map.get(&key).map(|v| v.len()).unwrap_or(0)
+        };
+        let want = n.min(self.target_per_bucket).saturating_sub(already);
+        debug!(
+            "warm_bucket: target={n}, cap={}, already={already}, spawning={want}",
+            self.target_per_bucket
+        );
+
+        for _ in 0..want {
+            let client =
+                WorkerClient::spawn_with_policy_and_proxy(writable_root.clone(), policy, proxy)
+                    .await?;
+            let mut map = self.free.lock().expect("pool mutex poisoned");
+            // Re-check the cap inside the lock — concurrent warm /
+            // return calls might have filled the bucket since we
+            // computed `want`. Drop the surplus instead of leaking.
+            let bucket = map.entry(key.clone()).or_default();
+            if bucket.len() < self.target_per_bucket {
+                bucket.push(client);
+            } else {
+                drop(client); // explicit: kills the worker via WorkerClient::Drop
+            }
+        }
+        Ok(())
+    }
+
+    /// Acquire a slot: pop a warm worker for this bucket if one
+    /// exists, otherwise spawn a fresh one. Provisions the workspace
+    /// via `provider` and bundles everything into a [`SandboxSlot`].
+    ///
+    /// `proxy` is by-reference because `ProxyHandle` is non-`Clone`;
+    /// the slot only needs the port number to identify its bucket.
+    ///
+    /// On error after worker checkout but before slot construction
+    /// (e.g. workspace provisioning fails), the worker is **dropped**
+    /// rather than returned to the pool — we have no way to know if
+    /// the worker is still in a clean state, and the safe default is
+    /// to kill it.
+    pub async fn acquire(
+        self: &Arc<Self>,
+        provider: Arc<dyn WorkspaceProvider>,
+        writable_root: PathBuf,
+        policy: &SandboxPolicy,
+        proxy: Option<&ProxyHandle>,
+        slot_id: String,
+    ) -> Result<SandboxSlot> {
+        let key = BucketKey {
+            writable_root: writable_root.clone(),
+            policy: policy.clone(),
+            proxy_port: proxy.map(|p| p.port),
+        };
+
+        // Try the warm path first.
+        let warm = {
+            let mut map = self.free.lock().expect("pool mutex poisoned");
+            map.get_mut(&key).and_then(|bucket| bucket.pop())
+        };
+        let worker = if let Some(w) = warm {
+            debug!("acquire: warm hit for slot_id={slot_id}");
+            w
+        } else {
+            debug!("acquire: cold spawn for slot_id={slot_id}");
+            WorkerClient::spawn_with_policy_and_proxy(writable_root, policy, proxy).await?
+        };
+
+        // Provision the workspace AFTER we have a worker so a
+        // provisioning failure doesn't leak a freshly-spawned worker
+        // back to the caller as a half-built slot.
+        let workspace_path = match provider.provision(&slot_id).await {
+            Ok(p) => p,
+            Err(e) => {
+                drop(worker); // explicit: don't return half-built worker to pool
+                return Err(e);
+            }
+        };
+
+        Ok(SandboxSlot {
+            worker: Some(worker),
+            pool: Arc::downgrade(self),
+            key,
+            provider: Some(provider),
+            slot_id,
+            workspace_path,
+            dirty: false,
+        })
+    }
+
+    /// Total number of idle workers across all buckets. Test/diag
+    /// helper; production callers don't need this.
+    pub fn idle_count(&self) -> usize {
+        self.free
+            .lock()
+            .expect("pool mutex poisoned")
+            .values()
+            .map(Vec::len)
+            .sum()
+    }
+
+    /// Number of distinct buckets currently tracked. Test/diag
+    /// helper; production callers don't need this.
+    pub fn bucket_count(&self) -> usize {
+        self.free.lock().expect("pool mutex poisoned").len()
+    }
+
+    /// Internal: try to return a worker to its bucket. Called from
+    /// `SandboxSlot::Drop`. Drops the worker (= kills) if the bucket
+    /// is at the cap.
+    fn return_worker(&self, key: BucketKey, worker: WorkerClient) {
+        let mut map = self.free.lock().expect("pool mutex poisoned");
+        let bucket = map.entry(key).or_default();
+        if bucket.len() < self.target_per_bucket {
+            bucket.push(worker);
+        } else {
+            // Surplus: dropping kills the worker.
+            drop(worker);
+        }
+    }
+}
+
+impl Drop for SandboxPool {
+    fn drop(&mut self) {
+        // Explicit clear so the order of effects is obvious in
+        // logs / valgrind output: every cached WorkerClient is
+        // dropped here, which kills its child process.
+        if let Ok(mut map) = self.free.lock() {
+            map.clear();
+        }
+    }
+}
+
+// ── Slot ──────────────────────────────────────────────────────────────────
+
+/// A single in-flight sandbox session: one worker + one workspace.
+///
+/// Move-only (no `Clone`): the slot owns mutable access to its
+/// worker and the right to release its workspace exactly once.
+///
+/// ## Drop semantics
+///
+/// On `drop`:
+/// 1. If the slot is **clean** (no `mark_dirty` called) and the pool
+///    is still alive, the worker is returned to its bucket (capped
+///    at `target_per_bucket`).
+/// 2. If the slot is **dirty** OR the pool is gone, the worker is
+///    dropped, which kills the child process.
+/// 3. The workspace release runs via `tokio::spawn` — best-effort,
+///    requires a live tokio runtime. If the runtime is gone we log
+///    a warning and skip; the next process restart will GC any
+///    leftover state via the provider's own conventions.
+///
+/// Callers that need synchronous, guaranteed workspace cleanup
+/// should call [`SandboxSlot::close`] explicitly before drop. The
+/// `Drop` path is a safety net, not the primary release mechanism
+/// for production code.
+pub struct SandboxSlot {
+    /// `Option` because `Drop` needs to move the worker out. Always
+    /// `Some` between `acquire` and `drop`.
+    worker: Option<WorkerClient>,
+    pool: Weak<SandboxPool>,
+    key: BucketKey,
+    /// Held as `Option` for the same reason as `worker`: `Drop`
+    /// moves it out so the async release task can `await` on it.
+    provider: Option<Arc<dyn WorkspaceProvider>>,
+    slot_id: String,
+    workspace_path: PathBuf,
+    /// Set to `true` to force this worker to be killed on drop
+    /// instead of returned to the pool. Use when an RPC errored or
+    /// the worker is in any uncertain state.
+    dirty: bool,
+}
+
+impl std::fmt::Debug for SandboxSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SandboxSlot")
+            .field("slot_id", &self.slot_id)
+            .field("workspace_path", &self.workspace_path)
+            .field("dirty", &self.dirty)
+            .finish()
+    }
+}
+
+impl SandboxSlot {
+    /// Mutable access to the wrapped worker. `expect` is safe
+    /// because `worker` is only `None` after `Drop` (which consumes
+    /// `self`).
+    pub fn worker(&mut self) -> &mut WorkerClient {
+        self.worker
+            .as_mut()
+            .expect("slot worker accessed after drop")
+    }
+
+    /// The path the slot should treat as its writable root. Returned
+    /// by the workspace provider during `acquire`.
+    pub fn workspace_path(&self) -> &std::path::Path {
+        &self.workspace_path
+    }
+
+    /// The slot's unique id, as supplied to `acquire`. Useful for
+    /// log correlation.
+    pub fn slot_id(&self) -> &str {
+        &self.slot_id
+    }
+
+    /// Mark the worker as not safe to reuse. Call this if the worker
+    /// returned a transport error or the slot otherwise observed
+    /// inconsistent state — the worker will be killed on drop
+    /// instead of returned to the pool.
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    /// Async release path. Returns the worker to the pool (if clean)
+    /// and synchronously awaits the workspace release. Use this when
+    /// you need deterministic cleanup ordering.
+    ///
+    /// Consumes `self` so the `Drop` impl runs without trying to
+    /// re-release.
+    pub async fn close(mut self) -> Result<()> {
+        let worker = self.worker.take().expect("worker present in close()");
+        let provider = self.provider.take().expect("provider present in close()");
+        if !self.dirty {
+            if let Some(pool) = self.pool.upgrade() {
+                pool.return_worker(
+                    std::mem::replace(
+                        &mut self.key,
+                        BucketKey {
+                            writable_root: PathBuf::new(),
+                            policy: SandboxPolicy::default(),
+                            proxy_port: None,
+                        },
+                    ),
+                    worker,
+                );
+            } else {
+                // Pool gone — worker dies here.
+                drop(worker);
+            }
+        } else {
+            drop(worker);
+        }
+        // Synchronous await — caller chose this path explicitly.
+        match provider.release(&self.slot_id, &self.workspace_path).await {
+            Ok(Some(hint)) => {
+                debug!("slot {} released with hint: {hint}", self.slot_id);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!("slot {} release failed: {e}", self.slot_id);
+                return Err(e);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SandboxSlot {
+    fn drop(&mut self) {
+        // 1. Worker disposition.
+        if let Some(worker) = self.worker.take() {
+            if self.dirty {
+                drop(worker);
+            } else if let Some(pool) = self.pool.upgrade() {
+                pool.return_worker(self.key.clone(), worker);
+            } else {
+                drop(worker);
+            }
+        }
+
+        // 2. Workspace release: best-effort async.
+        if let Some(provider) = self.provider.take() {
+            let slot_id = std::mem::take(&mut self.slot_id);
+            let workspace_path = std::mem::take(&mut self.workspace_path);
+            match tokio::runtime::Handle::try_current() {
+                Ok(handle) => {
+                    handle.spawn(async move {
+                        if let Err(e) = provider.release(&slot_id, &workspace_path).await {
+                            warn!("slot {slot_id} async release failed: {e}");
+                        }
+                    });
+                }
+                Err(_) => {
+                    warn!(
+                        "slot {slot_id} dropped outside tokio runtime; \
+                         workspace release skipped — call close() for \
+                         deterministic cleanup"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/koda-sandbox/src/pool/tests.rs
+++ b/koda-sandbox/src/pool/tests.rs
@@ -1,0 +1,525 @@
+//! Pool + slot tests. Split out of `pool.rs` to keep that file under
+//! 600 LOC and to let test helpers live without polluting the public
+//! surface.
+//!
+//! ## Worker spawning in tests
+//!
+//! Tests need `KODA_FS_WORKER_BIN` to point at a real `koda-fs-worker`
+//! binary. Cargo sets `CARGO_BIN_EXE_koda-fs-worker` for integration
+//! tests in the same workspace; unit tests in this module
+//! (`#[cfg(test)]`) get it via the `[[bin]]` declaration in
+//! `koda-sandbox/Cargo.toml`. If you see "koda-fs-worker not found"
+//! while developing, run `cargo build -p koda-fs-worker` first or
+//! set `KODA_FS_WORKER_BIN` to its target/debug/ path.
+
+use super::*;
+
+use async_trait::async_trait;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tempfile::TempDir;
+
+use crate::ipc::Request;
+use crate::policy::SandboxPolicy;
+use crate::workspace::{CwdProvider, WorkspaceProvider};
+
+// ── Mock provider ─────────────────────────────────────────────────────────
+
+/// Counts provision/release calls so tests can assert lifecycle
+/// behavior without a real filesystem provider in the loop.
+#[derive(Debug, Default)]
+struct CountingProvider {
+    project_root: PathBuf,
+    provisioned: AtomicUsize,
+    released: AtomicUsize,
+}
+
+impl CountingProvider {
+    fn new(project_root: PathBuf) -> Arc<Self> {
+        Arc::new(Self {
+            project_root,
+            provisioned: AtomicUsize::new(0),
+            released: AtomicUsize::new(0),
+        })
+    }
+}
+
+#[async_trait]
+impl WorkspaceProvider for CountingProvider {
+    async fn provision(&self, _slot_id: &str) -> Result<PathBuf> {
+        self.provisioned.fetch_add(1, Ordering::SeqCst);
+        Ok(self.project_root.clone())
+    }
+    async fn release(&self, _slot_id: &str, _path: &Path) -> Result<Option<String>> {
+        self.released.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }
+}
+
+/// Provider whose `provision` always errors. Used to prove that an
+/// acquire failure after worker checkout doesn't leak the worker
+/// back into the pool — the worker must be killed because we have
+/// no way to know if it's still in a clean state.
+#[derive(Debug)]
+struct FailingProvider;
+
+#[async_trait]
+impl WorkspaceProvider for FailingProvider {
+    async fn provision(&self, _slot_id: &str) -> Result<PathBuf> {
+        anyhow::bail!("synthetic provision failure for test")
+    }
+    async fn release(&self, _slot_id: &str, _path: &Path) -> Result<Option<String>> {
+        Ok(None)
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/// Make sure the worker binary path is wired up for these tests.
+/// Cargo sets `CARGO_BIN_EXE_koda-fs-worker` for integration tests
+/// but not for `#[cfg(test)]` modules in the lib crate, so we shell
+/// out to find it the same way `worker_client::worker_binary()` does
+/// for production.
+fn ensure_worker_bin() {
+    if std::env::var("KODA_FS_WORKER_BIN").is_ok() {
+        return;
+    }
+    if std::env::var("CARGO_BIN_EXE_koda-fs-worker").is_ok() {
+        return;
+    }
+    // Fall back to the workspace target dir: tests under `cargo test
+    // -p koda-sandbox` rely on `cargo build` having produced this.
+    let mut p = std::env::current_exe().expect("current_exe");
+    while p.pop() {
+        if p.ends_with("debug") || p.ends_with("release") {
+            let bin = p.join("koda-fs-worker");
+            if bin.exists() {
+                // SAFETY: tests here are inherently single-threaded
+                // for env mutation purposes — cargo serializes test
+                // binaries by default and we set this once per
+                // process. Documented in `worker_client::tests` for
+                // the same reason.
+                unsafe {
+                    std::env::set_var("KODA_FS_WORKER_BIN", &bin);
+                }
+                return;
+            }
+        }
+    }
+}
+
+fn pool_dir() -> TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+// ── Construction & basic invariants ───────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "target_per_bucket must be >= 1")]
+fn new_with_zero_capacity_panics() {
+    // Zero-capacity buckets would mean every return-to-pool drops the
+    // worker, defeating the entire purpose of the pool. Better to
+    // catch the misconfiguration loudly at construction than to
+    // silently degrade to fork-per-acquire forever.
+    let _ = SandboxPool::new(0);
+}
+
+#[test]
+fn new_pool_is_empty() {
+    let pool = SandboxPool::new(4);
+    assert_eq!(pool.idle_count(), 0);
+    assert_eq!(pool.bucket_count(), 0);
+}
+
+// ── Acquire & return ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn cold_acquire_spawns_worker_and_calls_provision() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    let slot = pool
+        .acquire(
+            provider.clone(),
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "slot-cold-1".to_string(),
+        )
+        .await
+        .expect("acquire");
+
+    assert_eq!(provider.provisioned.load(Ordering::SeqCst), 1);
+    assert_eq!(slot.slot_id(), "slot-cold-1");
+    assert_eq!(slot.workspace_path(), dir.path());
+    // No worker in the pool yet — it's checked out.
+    assert_eq!(pool.idle_count(), 0);
+}
+
+#[tokio::test]
+async fn drop_returns_clean_worker_to_pool() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    {
+        let _slot = pool
+            .acquire(
+                provider.clone(),
+                dir.path().to_path_buf(),
+                &SandboxPolicy::default(),
+                None,
+                "slot-return-1".to_string(),
+            )
+            .await
+            .expect("acquire");
+    }
+    // Drop is sync — the worker is back in the pool by the time
+    // control returns here.
+    assert_eq!(pool.idle_count(), 1, "clean drop must return worker");
+}
+
+#[tokio::test]
+async fn warm_then_acquire_uses_warm_worker() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    pool.warm_bucket(dir.path().to_path_buf(), &SandboxPolicy::default(), None, 2)
+        .await
+        .expect("warm");
+    assert_eq!(pool.idle_count(), 2);
+
+    let _slot = pool
+        .acquire(
+            provider,
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "slot-warm-1".to_string(),
+        )
+        .await
+        .expect("acquire");
+
+    // One worker should have moved out of the free-list into the
+    // slot; the other stays warm for the next acquire.
+    assert_eq!(
+        pool.idle_count(),
+        1,
+        "acquire must consume from warm bucket"
+    );
+}
+
+#[tokio::test]
+async fn warm_bucket_respects_target_cap() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2); // cap = 2
+    pool.warm_bucket(dir.path().to_path_buf(), &SandboxPolicy::default(), None, 5)
+        .await
+        .expect("warm");
+    assert_eq!(
+        pool.idle_count(),
+        2,
+        "warm_bucket must cap at target_per_bucket regardless of requested n"
+    );
+}
+
+#[tokio::test]
+async fn warm_bucket_is_idempotent_at_cap() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    pool.warm_bucket(dir.path().to_path_buf(), &SandboxPolicy::default(), None, 2)
+        .await
+        .expect("warm 1");
+    pool.warm_bucket(dir.path().to_path_buf(), &SandboxPolicy::default(), None, 2)
+        .await
+        .expect("warm 2");
+    assert_eq!(
+        pool.idle_count(),
+        2,
+        "second warm must NOT spawn extras when bucket is already at cap"
+    );
+}
+
+#[tokio::test]
+async fn return_to_full_bucket_drops_worker() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(1); // tight cap
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    // Two slots out at once → cap=1, so the second drop has nowhere
+    // to land and the worker must be killed instead of stashed.
+    let s1 = pool
+        .acquire(
+            provider.clone(),
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "s1".to_string(),
+        )
+        .await
+        .expect("a1");
+    let s2 = pool
+        .acquire(
+            provider.clone(),
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "s2".to_string(),
+        )
+        .await
+        .expect("a2");
+
+    drop(s1);
+    assert_eq!(pool.idle_count(), 1, "first drop fills the cap");
+    drop(s2);
+    assert_eq!(
+        pool.idle_count(),
+        1,
+        "second drop must be discarded because bucket is at cap"
+    );
+}
+
+#[tokio::test]
+async fn dirty_slot_does_not_return_worker_to_pool() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    {
+        let mut slot = pool
+            .acquire(
+                provider.clone(),
+                dir.path().to_path_buf(),
+                &SandboxPolicy::default(),
+                None,
+                "dirty".to_string(),
+            )
+            .await
+            .expect("acquire");
+        // Simulate "the worker errored mid-RPC and might be in
+        // inconsistent state" — caller flags it as not-reusable.
+        slot.mark_dirty();
+    }
+    assert_eq!(
+        pool.idle_count(),
+        0,
+        "dirty drop must kill the worker, not return it"
+    );
+}
+
+#[tokio::test]
+async fn distinct_policies_do_not_share_bucket() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    // The security invariant: a worker spawned with policy A must
+    // NEVER serve a request that asked for policy B. The pool
+    // enforces this via the bucket key including the full policy.
+    let policy_a = SandboxPolicy::default();
+    let mut policy_b = SandboxPolicy::default();
+    policy_b.fs.allow_git_config = true; // any field difference works
+
+    {
+        let _ = pool
+            .acquire(
+                provider.clone(),
+                dir.path().to_path_buf(),
+                &policy_a,
+                None,
+                "pa".to_string(),
+            )
+            .await
+            .expect("a");
+    }
+    {
+        let _ = pool
+            .acquire(
+                provider.clone(),
+                dir.path().to_path_buf(),
+                &policy_b,
+                None,
+                "pb".to_string(),
+            )
+            .await
+            .expect("b");
+    }
+    assert_eq!(
+        pool.bucket_count(),
+        2,
+        "policies that differ in any field must land in distinct buckets"
+    );
+}
+
+// ── Failure modes ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn provision_failure_does_not_leak_worker_into_pool() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let bad_provider: Arc<dyn WorkspaceProvider> = Arc::new(FailingProvider);
+
+    let res = pool
+        .acquire(
+            bad_provider,
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "leaky".to_string(),
+        )
+        .await;
+    assert!(res.is_err(), "acquire must propagate the provision error");
+    assert_eq!(
+        pool.idle_count(),
+        0,
+        "failed acquire must NOT return the half-built worker to the pool \
+         (we can't prove its state, so kill it)"
+    );
+}
+
+// ── Pool drop ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn pool_drop_releases_warm_workers() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(3);
+    pool.warm_bucket(dir.path().to_path_buf(), &SandboxPolicy::default(), None, 3)
+        .await
+        .expect("warm");
+    assert_eq!(pool.idle_count(), 3);
+
+    // Capture the strong count to prove pool drop happens here.
+    let weak = Arc::downgrade(&pool);
+    drop(pool);
+    assert!(
+        weak.upgrade().is_none(),
+        "pool drop must release its Arc storage so the SandboxPool struct \
+         is destructed (which kills every cached worker via its Drop)"
+    );
+}
+
+#[tokio::test]
+async fn slot_outliving_pool_still_drops_cleanly() {
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = CountingProvider::new(dir.path().to_path_buf());
+
+    let slot = pool
+        .acquire(
+            provider.clone(),
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "orphan".to_string(),
+        )
+        .await
+        .expect("acquire");
+
+    // Pool gone before slot.
+    drop(pool);
+
+    // This drop must NOT panic — the slot uses Weak<Pool> precisely
+    // so the worker can be killed (not returned) when the pool is
+    // already dead.
+    drop(slot);
+
+    // Give the async release task a tick to run.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(
+        provider.released.load(Ordering::SeqCst) >= 1,
+        "release should have been spawned even with pool gone"
+    );
+}
+
+// ── Worker actually works ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn acquired_worker_responds_to_ping() {
+    // Belt-and-suspenders: the slot abstraction is worthless if it
+    // hands you a busted worker. Round-trip a Ping through the
+    // worker we got from acquire.
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = Arc::new(CwdProvider::new(dir.path()));
+
+    let mut slot = pool
+        .acquire(
+            provider,
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "ping".to_string(),
+        )
+        .await
+        .expect("acquire");
+
+    let resp = slot
+        .worker()
+        .request(&Request::Ping)
+        .await
+        .expect("ping ok");
+    assert!(matches!(resp, crate::ipc::Response::Pong));
+}
+
+#[tokio::test]
+async fn warm_acquire_is_faster_than_cold() {
+    // The whole reason the pool exists. A warm acquire should beat
+    // a cold one by the spawn cost (~50-200ms typical). We use a
+    // generous threshold (warm < cold / 2) to avoid flakiness on
+    // slow CI runners — the actual ratio is usually >5x.
+    ensure_worker_bin();
+    let dir = pool_dir();
+    let pool = SandboxPool::new(2);
+    let provider = Arc::new(CwdProvider::new(dir.path()));
+
+    // Cold: time the spawn.
+    let t_cold_start = std::time::Instant::now();
+    let _cold = pool
+        .acquire(
+            provider.clone(),
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "cold".to_string(),
+        )
+        .await
+        .expect("cold");
+    let cold = t_cold_start.elapsed();
+    drop(_cold); // returns worker to pool
+
+    // Warm: now the bucket has 1 worker.
+    let t_warm_start = std::time::Instant::now();
+    let _warm = pool
+        .acquire(
+            provider,
+            dir.path().to_path_buf(),
+            &SandboxPolicy::default(),
+            None,
+            "warm".to_string(),
+        )
+        .await
+        .expect("warm");
+    let warm = t_warm_start.elapsed();
+
+    // Liberal bound to keep CI green; tighter checks live in benches.
+    assert!(
+        warm < cold / 2,
+        "warm acquire ({warm:?}) must beat cold ({cold:?}) by at least 2x; \
+         pool isn't actually amortizing spawn cost"
+    );
+}


### PR DESCRIPTION
The structural foundation slice of Phase 4 from #934. **4a banked the
profile-cache speedup; 4b+4c bank the spawn-cost speedup.** Together
they put us within reach of the Phase 4 acceptance gate
(`acquire_slot() < 15ms p95 warm`).

## What lands

New `pool` module in koda-sandbox:

- **`SandboxPool`** — per-process LRU-free pool of pre-warmed
  `WorkerClient`s keyed by `(writable_root, policy, proxy_port)`
- **`SandboxSlot`** — RAII handle that owns one worker + one
  workspace; on drop returns the worker (if clean) and asynchronously
  releases the workspace

## Why a pool

Every sandboxed FS / Bash invocation today spawns a fresh
`koda-fs-worker`: fork + exec + binary startup + readiness handshake
= **~60-250 ms wall clock** on a warm laptop. The sub-agent
dispatcher fan-out (30 parallel workers against the same project)
currently pays this cost 30 times serially. With the pool, the first
acquire in a bucket pays it once; the next 29 amortize to ~1ms each.

Verified locally: `warm_acquire_is_faster_than_cold` passes with
`warm < cold/2` (typical observed ratio is **5-10x**; we keep the
threshold liberal to avoid CI flakiness — tighter measurements live
in the 4g benches).

## Bucketing model

Workers bind their `writable_root` and `SandboxPolicy` at spawn time
(via `--root` CLI arg + `KODA_FS_WORKER_POLICY` env var). They
**cannot** be re-bound after the fact without a worker-protocol
change, so the pool buckets workers by the full
`(writable_root, policy, proxy_port)` tuple.

A worker spawned with policy A is **never** reused for a request
that asked for policy B — that would be a privilege-escalation bug,
not just a perf miss. The bucket key uses owned `SandboxPolicy`
(not a hash) for the same security reason as 4a's `seatbelt_cache`:
a hash-only key could theoretically let two policies share a
free-list entry on collision, silently widening one of them. The
`distinct_policies_do_not_share_bucket` test pins this down.

## Pre-warming

Opt-in via `SandboxPool::warm_bucket(root, policy, proxy, n)`. The
constructor doesn't pre-warm because it doesn't yet know which
buckets will be hit; the dispatcher does, and it can call
`warm_bucket` before fanning out work. Cold acquires still work —
they just spawn fresh workers — so callers that don't pre-warm get
correctness without any speedup.

No background fill task. YAGNI for the first cut. Warm buckets stay
warm because finished slots return their workers, and the
steady-state population matches the working-set size.

## Slot drop semantics

`SandboxSlot::Drop`:

1. **Worker disposition:**
   - Clean + pool alive → return to bucket (capped at
     `target_per_bucket`; surplus drops = kills)
   - Dirty OR pool gone → drop = kill
2. **Workspace release:** `tokio::spawn(provider.release(...))` —
   best-effort, requires live tokio runtime. If runtime is gone we
   log and skip; next process restart GCs leftover state via the
   provider's own conventions.

Plus an explicit async **`close()`** method for callers that need
synchronous, guaranteed workspace cleanup. Drop is a safety net,
not the primary release mechanism for production code.

`SandboxPool::Drop` clears all free-list buckets, dropping every
cached `WorkerClient` (which kills the child via
`WorkerClient::Drop`). The `pool_drop_releases_warm_workers` test
pins this lifecycle.

## Tests — koda-sandbox: 254 → 269 (+15 new)

**Construction:**

- `new_with_zero_capacity_panics` — zero buckets defeats the
  pool's purpose; catch the misconfiguration loudly
- `new_pool_is_empty` — sanity

**Acquire & return:**

- `cold_acquire_spawns_worker_and_calls_provision`
- `drop_returns_clean_worker_to_pool`
- `warm_then_acquire_uses_warm_worker`
- `warm_bucket_respects_target_cap`
- `warm_bucket_is_idempotent_at_cap`
- `return_to_full_bucket_drops_worker` — the cap enforcement
- `dirty_slot_does_not_return_worker_to_pool` — error recovery
- `distinct_policies_do_not_share_bucket` — the security argument

**Failure modes:**

- `provision_failure_does_not_leak_worker_into_pool` — failed
  acquire kills the half-built worker rather than risk returning a
  worker in unknown state to the pool

**Lifecycle:**

- `pool_drop_releases_warm_workers` — pool drop cleans up
- `slot_outliving_pool_still_drops_cleanly` — `Weak<Pool>` handles
  the orphan case

**End-to-end:**

- `acquired_worker_responds_to_ping` — the slot is worthless if it
  hands you a busted worker; round-trip a real RPC
- `warm_acquire_is_faster_than_cold` — proves the whole point of
  the pool actually works

All 269 koda-sandbox lib tests + 988 koda-core lib tests pass.
Clippy clean. fmt clean. Workspace docs clean.

## Cfg gating

`#[cfg(unix)]` on `pub mod pool` to match `WorkerClient` (which uses
`tokio::net::UnixStream`). The pool is consumed only by Unix-only
code; gating it is a no-op on consumer side and prevents Windows
build breaks if someone ever tries.

## What's next in Phase 4

| Slice | What |
|---|---|
| **4d** | `ClonefileProvider` (macOS APFS `clonefile`) — the big speed win for sub-agents that each get a fresh workspace clone |
| **4e** | `OverlayfsProvider` (Linux overlayfs in bwrap) — Linux equivalent |
| **4f** | Lazy provisioning (defer FS materialization until first `fs_write`) |
| **4g** | Criterion benches + 30-parallel-dispatch demo (the Phase 4 acceptance gate) |
