### PR TITLE
koda-core: wire ClonefileProvider on macOS + document divergence (#934)

### DIFF
--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -136,3 +136,64 @@ even if the agent JSON specifies `"mode": "auto"`.
 If the platform backend is unavailable (e.g. `bwrap` not installed on
 Linux), Koda falls back to unsandboxed execution with a warning logged
 via `tracing::warn!`. Install the backend for full protection.
+
+## Workspace providers
+
+The **sandbox backend** (above) restricts what syscalls a sub-agent can
+make. The **workspace provider** is a separate layer that decides where
+those syscalls write — it materializes an isolated copy of your project
+for each write-capable sub-agent so concurrent fan-out doesn't trample
+shared files.
+
+Isolation guarantees are **identical across platforms**. Only how the
+isolated workspace is materialized — and therefore how fast it is —
+differs:
+
+| Platform | Provider (write-capable agents) | Backing primitive | Typical provision time |
+|----------|---------------------------------|-------------------|------------------------|
+| macOS | `ClonefileProvider` | APFS `clonefile(2)` | ~0.4 s for 30-parallel |
+| Linux | `GitWorktreeProvider` | `git worktree add` | ~1.6 s for 30-parallel |
+| Windows | Not supported | — | — |
+
+*Numbers from the `parallel_dispatch` bench (`cargo bench --bench
+parallel_dispatch -p koda-sandbox`) on a fixture project; exact figures
+vary by hardware and project size.*
+
+**Read-only sub-agents** (no `Write` or `Edit` tools) skip the workspace
+provider entirely on every platform — they share the parent project
+root for free, no provisioning cost.
+
+### Why the platforms differ
+
+macOS exposes a kernel primitive (`clonefile(2)`) that creates a
+copy-on-write snapshot of an entire directory tree in a single syscall.
+Linux has no equivalent that's both unprivileged *and* available out of
+the box across distros — `reflink` requires an FS that supports it
+(XFS, Btrfs, some ext4 configs), `overlayfs` typically requires
+`CAP_SYS_ADMIN`, and `fuse-overlayfs` is a userspace dep. Until
+production usage shows Linux fan-out is meaningfully bottlenecked by
+the `git worktree` cost, Koda uses git worktrees there for portability.
+
+### Practical implications
+
+- **macOS sub-agent fan-out is faster than Linux** by a constant factor
+  (~3-4× in the workspace-provision phase). For typical interactive
+  use (a few sub-agents per task) the difference is sub-second and not
+  noticeable. For heavy parallel fan-out (dozens of sub-agents) it
+  shows up.
+- **The 30-parallel acceptance gate is met on both platforms.** Even
+  the slower Linux path runs in single-digit seconds for 30 concurrent
+  write-capable sub-agents.
+- **Falling back gracefully:** if `ClonefileProvider` can't be
+  constructed on macOS (e.g. `$HOME` unset, project path can't
+  canonicalize), Koda automatically falls back to `GitWorktreeProvider`
+  with a `tracing::warn!`. If the actual `clonefile(2)` syscall fails
+  at runtime (rare — happens on non-APFS volumes), the dispatcher
+  falls back to running unisolated against the shared project root
+  with a warning.
+- **Closing the gap:** a Linux CoW backend is on the roadmap but
+  parked until production telemetry justifies it (tracked in
+  [#934](https://github.com/lijunzh/koda/issues/934)). If you run
+  large parallel fan-out workloads on Linux and feel the slowness,
+  please open an issue — that's exactly the signal that would
+  un-defer the work.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -21,6 +21,9 @@ use crate::trust::{self, ToolApproval, TrustMode};
 
 use anyhow::{Context, Result};
 use koda_sandbox::{CwdProvider, GitWorktreeProvider, WorkspaceProvider};
+
+#[cfg(target_os = "macos")]
+use koda_sandbox::ClonefileProvider;
 use std::path::Path;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -259,14 +262,28 @@ pub(crate) async fn execute_sub_agent(
         .await?;
 
     let provider = crate::providers::create_provider(&sub_config);
-    // Select workspace provider. Write-capable agents get a git worktree for
-    // isolation when available; read-only agents share the parent root.
+    // Select workspace provider. Write-capable agents get an isolated
+    // workspace; read-only agents share the parent root for free.
+    //
+    // Per-platform write-isolation choice:
+    //
+    // - **macOS:** `ClonefileProvider` (APFS clonefile(2)) is
+    //   preferred for its ~3-4× provision speedup over git worktree
+    //   (Phase 4d / #934). Falls back to git worktree if construction
+    //   fails (e.g. `$HOME` unset, project path can't canonicalize).
+    // - **Linux + others:** `GitWorktreeProvider`. The Linux CoW
+    //   equivalent (4e in #934) is deferred until production
+    //   telemetry shows it's worth building.
+    //
+    // **Documented platform divergence** — see `docs/src/sandbox.md`
+    // → "Workspace providers". Both backends provide the same
+    // isolation guarantees; only provision speed differs.
     let has_write_tools = !sub_config
         .disallowed_tools
         .iter()
         .any(|t| t == "Write" || t == "Edit");
     let workspace: Box<dyn WorkspaceProvider> = if has_write_tools {
-        Box::new(GitWorktreeProvider::new(project_root, agent_name))
+        pick_write_provider(project_root, agent_name)
     } else {
         Box::new(CwdProvider::new(project_root))
     };
@@ -482,4 +499,53 @@ pub(crate) async fn execute_sub_agent(
         });
     }
     Ok("(sub-agent reached maximum iterations)".to_string())
+}
+
+// ── Workspace provider selection ────────────────────────────────────────────
+//
+// Two cfg-gated definitions of `pick_write_provider` rather than
+// inline `cfg!()` branches because:
+//
+//  * `ClonefileProvider` is itself `cfg(target_os = "macos")` in
+//    koda-sandbox; inline branches would still need cfg gating to
+//    avoid "unresolved import" on Linux.
+//  * Each platform's selection logic is small but distinct (macOS
+//    has a fallback path, Linux doesn't), and side-by-side cfg
+//    bodies read more honestly than a tangled inline form.
+//
+// Behavior is documented for users in `docs/src/sandbox.md`
+// → "Workspace providers".
+
+#[cfg(target_os = "macos")]
+fn pick_write_provider(
+    project_root: &std::path::Path,
+    agent_name: &str,
+) -> Box<dyn WorkspaceProvider> {
+    // Try `ClonefileProvider` first — its 3-4× provision speedup
+    // (Phase 4d / #934 bench) is durable and the implementation is
+    // a thin wrapper over the OS primitive designed for this.
+    //
+    // Fall back to `GitWorktreeProvider` only if construction itself
+    // fails (e.g. `$HOME` unset, project path can't canonicalize).
+    // Runtime `clonefile(2)` failures (non-APFS volume etc.) surface
+    // through the existing `provision()` error path which already
+    // falls back to the unisolated project root with a warning.
+    match ClonefileProvider::new(project_root) {
+        Ok(p) => Box::new(p),
+        Err(e) => {
+            tracing::warn!("ClonefileProvider unavailable, falling back to git worktree: {e}");
+            Box::new(GitWorktreeProvider::new(project_root, agent_name))
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn pick_write_provider(
+    project_root: &std::path::Path,
+    agent_name: &str,
+) -> Box<dyn WorkspaceProvider> {
+    // Linux + others: GitWorktreeProvider. The Linux CoW equivalent
+    // (4e in #934) is parked until production telemetry shows it's
+    // worth building — see #934 deferral comments.
+    Box::new(GitWorktreeProvider::new(project_root, agent_name))
 }

--- a/koda-sandbox/src/lib.rs
+++ b/koda-sandbox/src/lib.rs
@@ -75,6 +75,12 @@ pub use violations::{
 };
 pub use workspace::{CwdProvider, GitWorktreeProvider, WorkspaceProvider};
 
+// macOS-only: APFS clonefile-backed workspace provider. Re-exported
+// at the crate root so consumers (notably `koda-core::sub_agent_dispatch`)
+// don't have to repeat the cfg gate at the import site.
+#[cfg(target_os = "macos")]
+pub use workspace::ClonefileProvider;
+
 use anyhow::Result;
 use std::path::Path;
 use tokio::process::Command;


### PR DESCRIPTION
## Phase 5a of #934 — wire ClonefileProvider on macOS + document divergence

Two changes:

### 1. Wire `ClonefileProvider` into `sub_agent_dispatch` on macOS

Until now, `ClonefileProvider` (added in #1005) was **dead code** from the dispatcher's perspective — both macOS and Linux went through `GitWorktreeProvider` unconditionally. This PR flips macOS to use `ClonefileProvider` with a graceful fallback.

```rust
#[cfg(target_os = "macos")]
fn pick_write_provider(...) -> Box<dyn WorkspaceProvider> {
    match ClonefileProvider::new(project_root) {
        Ok(p) => Box::new(p),
        Err(e) => {
            tracing::warn!("ClonefileProvider unavailable, falling back to git worktree: {e}");
            Box::new(GitWorktreeProvider::new(project_root, agent_name))
        }
    }
}

#[cfg(not(target_os = "macos"))]
fn pick_write_provider(...) -> Box<dyn WorkspaceProvider> {
    Box::new(GitWorktreeProvider::new(project_root, agent_name))
}
```

**Two cfg-gated definitions instead of inline `cfg!()` branches** because `ClonefileProvider` is itself `cfg(target_os = "macos")` in koda-sandbox — inline branches would still need cfg gating to avoid "unresolved import" on Linux. Side-by-side cfg bodies read more honestly than a tangled inline form.

**Fallback chain:**

| Failure | Recovery |
|---|---|
| `ClonefileProvider::new()` fails (no `$HOME`, can't canonicalize) | → `GitWorktreeProvider` with `tracing::warn!` |
| `clonefile(2)` syscall fails at runtime (rare; non-APFS volume) | → unisolated project root with warning *(existing dispatcher behavior)* |

Same graceful-degradation pattern as today's worktree-failure path. No new error surface for users.

### 2. Document the platform divergence

Per the discussion on #934: shipping platform-divergent perf without docs would surprise users. Added a new **"Workspace providers"** section to `docs/src/sandbox.md` that:

- **Distinguishes the two layers** (sandbox backend = syscall restriction; workspace provider = where writes land). Easy to conflate; needed to call out separately.
- **Names what each platform uses** with concrete bench numbers (~0.4 s vs ~1.6 s for 30-parallel from `cargo bench --bench parallel_dispatch`).
- **Explains WHY** they diverge: macOS has `clonefile(2)` as a designed-for-this primitive; Linux has nothing equivalent that's both unprivileged AND portable across distros.
- **Documents the fallback chain** explicitly so support questions have a paper trail.
- **Calls out the deferred Linux CoW backend** (4e in #934) and **invites users hitting the gap to file an issue** — that's exactly the production telemetry signal that would un-defer the work.

The docs are framed honestly: isolation guarantees are **identical across platforms**, only provision speed differs.

### Why this matters for #934 acceptance

Without this PR, `ClonefileProvider` is dead code — built but unused. That would be the worst of both worlds (maintenance cost without user benefit). This PR makes the Phase 4d work actually pay off in production.

### Verification

- `cargo build -p koda-core`: ✅ clean
- `cargo clippy -p koda-core -p koda-sandbox --all-targets -- -D warnings`: ✅ clean
- `cargo test -p koda-core --lib sub_agent`: ✅ 11 passed
- `mdbook build`: ✅ clean (only pre-existing `mcp.md` warning, unrelated)

### Phase 5 context

This is **Phase 5a** of the #934 close-out. Remaining Phase 5 work after this lands: the default-on flip (turning the sandbox runtime on by default for new sessions) + any final docs polish.

Refs #934. Stacks logically on #1006 (which is independent — both can land in either order).
