### PR TITLE
koda-sandbox: shield proxy tests from ambient HTTPS_PROXY (closes #1008)

### DIFF
--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -360,9 +360,17 @@ mod tests {
         // Allowlist the upstream's loopback "host". 127.0.0.1 is an exact
         // match in the filter — works because the filter is just doing
         // string matching on the host part of "host:port".
+        //
+        // `.with_upstream(Direct)` shields the test from any ambient
+        // `HTTPS_PROXY` in the dev's shell (e.g. corp-network setups).
+        // Without it, `Server::bind` snapshots the env var and the
+        // proxy under test tries to chain its 127.0.0.1 connection
+        // through the corp proxy, returning 502. See the doc comment
+        // on `Self::with_upstream`.
         let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
             .await
-            .unwrap();
+            .unwrap()
+            .with_upstream(crate::proxy::upstream::UpstreamConfig::Direct);
         let proxy_port = server.port();
         tokio::spawn(server.serve());
 

--- a/koda-sandbox/src/proxy/socks5.rs
+++ b/koda-sandbox/src/proxy/socks5.rs
@@ -409,8 +409,21 @@ mod tests {
     use super::*;
 
     /// Spawn a server on an ephemeral port and return its port.
+    ///
+    /// Always pins the upstream to `Direct` so the test is immune to
+    /// any ambient `HTTPS_PROXY` in the dev's shell (e.g. corp-network
+    /// setups). Without this, `Socks5Server::bind` would snapshot the
+    /// env var and chain 127.0.0.1 connections through the corp proxy,
+    /// returning failures that look like product bugs but aren't. See
+    /// the doc comment on [`Socks5Server::with_upstream`]. Any future
+    /// socks5 test that needs a non-`Direct` upstream should call
+    /// `Socks5Server::bind(...).with_upstream(...)` directly instead
+    /// of this helper.
     async fn spawn(filter: Filter) -> (u16, tokio::task::JoinHandle<()>) {
-        let server = Socks5Server::bind(None, filter).await.unwrap();
+        let server = Socks5Server::bind(None, filter)
+            .await
+            .unwrap()
+            .with_upstream(crate::proxy::upstream::UpstreamConfig::Direct);
         let port = server.port();
         let task = tokio::spawn(server.serve());
         (port, task)


### PR DESCRIPTION
## Closes #1008 — proxy tests fail when `HTTPS_PROXY` is set in env

Two `koda-sandbox` proxy tests fail for contributors whose shell has `HTTPS_PROXY` set (e.g. corp-network setups), even though both use only loopback `127.0.0.1` addresses. Full root-cause analysis on #1008.

### TL;DR

`Server::bind()` and `Socks5Server::bind()` call `UpstreamConfig::from_env()` internally. With `HTTPS_PROXY` set, the proxy under test tries to chain its 127.0.0.1 connection through the corp proxy → 502. Tests need to call `.with_upstream(UpstreamConfig::Direct)` to shield themselves — `with_upstream`'s doc comment literally says it exists for this. The two failing tests just forgot to.

### The fix

```diff
- proxy::server::tests::allows_listed_host_and_tunnels_payload
   let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
       .await
-      .unwrap();
+      .unwrap()
+      .with_upstream(UpstreamConfig::Direct);

- proxy::socks5::tests::spawn() helper (shields all current + future socks5 tests)
   let server = Socks5Server::bind(None, filter)
       .await
-      .unwrap();
+      .unwrap()
+      .with_upstream(UpstreamConfig::Direct);
```

Plus comments on each fix explaining *why* — so the next contributor doesn't undo it during a refactor.

### Where the fix landed (and where it didn't)

| File | Change | Why |
|---|---|---|
| `server.rs` | One test (`allows_listed_host_and_tunnels_payload`) | Other server.rs tests either explicitly set `HttpProxy` upstream (intentional) or assert on errors that happen anyway (accidentally pass). Surgical fix. |
| `socks5.rs` | Shared `spawn()` test helper | All socks5 tests use it; fixing the helper future-proofs the whole module in one place. |

### Verified

```
HTTPS_PROXY=http://sysproxy.wal-mart.com:8080 cargo test -p koda-sandbox --lib proxy::
→ 95 passed, 0 failed   (was: 93 passed, 2 failed)

cargo test -p koda-sandbox --lib proxy::
→ 95 passed, 0 failed   (unchanged)
```

Plus `cargo clippy -p koda-sandbox --tests -- -D warnings` clean.

### Severity & impact

- **Low severity.** Doesn't affect CI, doesn't affect non-corp devs, doesn't affect production.
- **Real DX win for Walmart contributors.** Saves the ~20 minutes of "wait, why is this localhost test 502'ing" debugging the next person would have done.

### Backstory

Discovered while validating Phase 4 of #934. I initially mis-diagnosed it as "pre-existing fragility around real network access" in the validation comment. Deeper investigation showed the tests are pure-loopback and the failure was self-inflicted by my own `HTTPS_PROXY=...` invocation. Worth a 2-line defensive fix so the next contributor doesn't trip on the same false trail I did.
