### PR TITLE
koda-sandbox: Phase 5 telemetry hooks (refs #934)

### DIFF
--- a/koda-sandbox/src/pool.rs
+++ b/koda-sandbox/src/pool.rs
@@ -202,6 +202,14 @@ impl SandboxPool {
         proxy: Option<&ProxyHandle>,
         slot_id: String,
     ) -> Result<SandboxSlot> {
+        // Phase 5 of #934: emit acquisition latency as a structured
+        // tracing event rather than building an in-process histogram.
+        // Tracing integrates with whatever `KODA_LOG=info` consumer the
+        // user already has, requires zero per-process state, and —
+        // critically — adds zero new runtime config knobs. Aggregators
+        // that want histograms can build them on the event stream.
+        let acquire_start = std::time::Instant::now();
+
         let key = BucketKey {
             writable_root: writable_root.clone(),
             policy: policy.clone(),
@@ -213,6 +221,7 @@ impl SandboxPool {
             let mut map = self.free.lock().expect("pool mutex poisoned");
             map.get_mut(&key).and_then(|bucket| bucket.pop())
         };
+        let was_warm = warm.is_some();
         let worker = if let Some(w) = warm {
             debug!("acquire: warm hit for slot_id={slot_id}");
             w
@@ -231,6 +240,18 @@ impl SandboxPool {
                 return Err(e);
             }
         };
+
+        // Latency event. Microseconds because warm acquires are
+        // sub-millisecond (~1µs p95 measured in benches/acquire_slot.rs);
+        // millisecond resolution would round most values to 0.
+        let latency_us = acquire_start.elapsed().as_micros() as u64;
+        tracing::info!(
+            target: "sandbox.acquire",
+            slot_id = %slot_id,
+            latency_us,
+            warm = was_warm,
+            "sandbox slot acquired",
+        );
 
         Ok(SandboxSlot {
             worker: Some(worker),

--- a/koda-sandbox/src/violations.rs
+++ b/koda-sandbox/src/violations.rs
@@ -36,7 +36,7 @@ pub const DEFAULT_RING_CAPACITY: usize = 100;
 
 /// What the kernel actually denied. Open enum because new platforms
 /// (Linux landlock, macOS endpoint-security) may surface novel kinds.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ViolationKind {
     /// Read attempt on a denied path.
@@ -178,6 +178,28 @@ impl SandboxViolationStore {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    /// Per-kind tally over the current ring contents. Phase 5 of #934
+    /// — the headline "violation counts per session" telemetry. Cheap
+    /// (one lock + one pass over up to `DEFAULT_RING_CAPACITY` entries)
+    /// so callers can read it on every `/sandbox status` invocation
+    /// without worrying about overhead.
+    ///
+    /// Returns counts for the variants present in the buffer; absent
+    /// kinds are simply not in the map. Use `unwrap_or(0)` at the
+    /// read site if you want a zero default.
+    #[must_use]
+    pub fn count_by_kind(&self) -> std::collections::HashMap<ViolationKind, usize> {
+        let buf = match self.inner.lock() {
+            Ok(b) => b,
+            Err(_) => return std::collections::HashMap::new(),
+        };
+        let mut counts = std::collections::HashMap::new();
+        for v in buf.iter() {
+            *counts.entry(v.kind.clone()).or_insert(0) += 1;
+        }
+        counts
     }
 }
 
@@ -343,5 +365,30 @@ mod tests {
         assert_eq!(b.len(), before + 1);
         // Drain so this test doesn't leak state into other tests.
         let _ = a.drain();
+    }
+
+    #[test]
+    fn count_by_kind_tallies_per_variant() {
+        // Phase 5 of #934: prove the new per-kind accessor returns
+        // accurate tallies and is robust against zero/empty cases.
+        let s = SandboxViolationStore::new();
+        assert!(
+            s.count_by_kind().is_empty(),
+            "empty store should yield empty map"
+        );
+
+        s.record(Violation::new(ViolationKind::FileRead, None, None));
+        s.record(Violation::new(ViolationKind::FileRead, None, None));
+        s.record(Violation::new(ViolationKind::FileWrite, None, None));
+        s.record(Violation::new(ViolationKind::NetworkOutbound, None, None));
+
+        let counts = s.count_by_kind();
+        assert_eq!(counts.get(&ViolationKind::FileRead), Some(&2));
+        assert_eq!(counts.get(&ViolationKind::FileWrite), Some(&1));
+        assert_eq!(counts.get(&ViolationKind::NetworkOutbound), Some(&1));
+        // ProcessExec was never recorded — absent from the map by
+        // design (callers `unwrap_or(0)` if they want a zero default).
+        assert!(!counts.contains_key(&ViolationKind::ProcessExec));
+        assert_eq!(counts.values().sum::<usize>(), s.len());
     }
 }


### PR DESCRIPTION
## Phase 5 of #934 — telemetry hooks

Phase 5 of #934 calls for two pieces of observability so the deferred-slice triggers (4e Linux CoW, 4f lazy provisioning) become **data-grounded decisions instead of speculation**.

This PR is **item 5** of the Phase 5 list. Item 6 (README + threat model docs) lands next. Items 1-4 are deferred per the YAGNI discussion (no runtime config knobs unless evidence demands them).

## What it adds

### 1. Slot acquisition latency — `tracing::info!` event

In `pool.acquire()`, on the success path:

```rust
tracing::info!(
    target: "sandbox.acquire",
    slot_id = %slot_id,
    latency_us,
    warm = was_warm,
    "sandbox slot acquired",
);
```

Microsecond resolution because warm acquires are sub-millisecond (`~1.4µs p95` in `benches/acquire_slot.rs`); millisecond would round most values to zero.

**Why tracing events instead of an in-process histogram?**

| Concern | Tracing event | In-process histogram |
|---|---|---|
| Integrates with existing `KODA_LOG=info` consumer | ✅ | ❌ new sink to wire up |
| Per-process state | None | bins, sample reservoir, mutex |
| **New runtime config knobs** | **0** | bin count, reservoir size |
| Aggregator can build a histogram on the stream | ✅ | n/a (it IS the histogram) |

The "zero new runtime config knobs" property was the deciding factor — matches the no-runtime-config preference set in the Phase 5 scoping discussion.

### 2. Per-session violation counts — `SandboxViolationStore::count_by_kind`

The store already had `len()` / `snapshot()` / `drain()`. Added one accessor:

```rust
pub fn count_by_kind(&self) -> HashMap<ViolationKind, usize>
```

One lock + one pass over up to `DEFAULT_RING_CAPACITY` (=100) entries. Cheap enough for `/sandbox status` to call on every invocation.

Required adding `Hash` to `ViolationKind`'s derive list so it can key a HashMap. `ViolationKind` is already `PartialEq + Eq + Clone + serde` so adding `Hash` is a free extension and doesn't affect serialization.

Absent kinds are missing-from-map rather than zero-entries, by design. Callers `unwrap_or(0)` at read time. Matches HashMap's natural shape; avoids initializing a full table for variants that may never appear in a given session.

## Why both, why now

Without this, the deferral decisions for 4e and 4f stay theoretical:

| Question | Answered by |
|---|---|
| "Is workspace provisioning the dominant cost in slot acquisition?" | latency event → mean provision contribution per dispatch → un-defer trigger for **4e** |
| "Do violations actually concentrate on `FileWrite`?" | `count_by_kind` → if yes, lazy provisioning matters → un-defer trigger for **4f** |

With it, they become measurable. This is the audit trail Phase 4's deferral comments referenced.

## Verification

```
cargo test -p koda-sandbox --lib
→ 279 passed, 0 failed   (was 278; +1 for count_by_kind test)

cargo clippy -p koda-sandbox --all-targets -- -D warnings
→ clean

cargo bench --bench acquire_slot
→ acquire_slot_warm p95 = 1.375 µs   (gate: 15 ms — still ~10,000× under)
```

The new test (`count_by_kind_tallies_per_variant`) covers empty / multi-kind / missing-kind cases.

## What it does NOT add

- No runtime config knobs.
- No new dependencies.
- No new public types beyond the one `count_by_kind` method.

## Stack

After this lands, **PR B (item 6: README + threat model)** is the last Phase 5 piece, and #934 becomes closeable.

Refs #934.
