### PR TITLE
koda-core: plumb SandboxPolicy through sandbox::build (#934 phase 5 PR-1/3, no-op refactor)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -87,17 +87,23 @@ pub fn build(
     command: &str,
     project_root: &Path,
     _trust: &crate::trust::TrustMode,
+    policy: &SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
 ) -> Result<Command> {
     let runtime = current_runtime();
     warn_if_unavailable_once(runtime.as_ref());
 
-    let policy = SandboxPolicy::strict_default();
+    // Phase 5 of #934 (PR-1): policy is now plumbed in from the caller
+    // instead of synthesized here as `strict_default()`. This is the
+    // first step in making per-agent / per-tool capability variation
+    // possible. Today every caller still passes `strict_default()` so
+    // behavior is byte-for-byte unchanged — PR-2 introduces real
+    // construction logic; PR-3 adds resource-limit + compose() callers.
     let req = SandboxTransformRequest {
         command,
         project_root,
-        policy: &policy,
+        policy,
         // Phase 3c: thread the proxy port into the kernel sandbox so
         // the seatbelt SBPL denies any TCP outbound that doesn't
         // target 127.0.0.1:proxy_port. Belt-and-suspenders alongside
@@ -183,6 +189,7 @@ mod tests {
             "echo \"$HTTPS_PROXY\"",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             Some(31415),
             None,
         )
@@ -206,6 +213,7 @@ mod tests {
             "echo \"[$HTTPS_PROXY]\"",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -232,6 +240,7 @@ mod tests {
             "echo \"$ALL_PROXY|$all_proxy\"",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             Some(27182),
         )
@@ -256,6 +265,7 @@ mod tests {
             "echo \"[$ALL_PROXY]\"",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -279,6 +289,7 @@ mod tests {
             "echo \"$HTTPS_PROXY|$ALL_PROXY\"",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             Some(8080),
             Some(1080),
         )
@@ -311,6 +322,7 @@ mod tests {
             cmd,
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             Some(8080),
             None,
         )
@@ -338,6 +350,7 @@ mod tests {
             "echo ok",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -357,6 +370,7 @@ mod tests {
             "touch sandbox_canary",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -380,6 +394,7 @@ mod tests {
             &format!("echo pwned > {}", target.display()),
             project.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -402,6 +417,7 @@ mod tests {
             "cat /etc/hosts > /dev/null",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -421,6 +437,7 @@ mod tests {
             "touch strict_canary",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -447,6 +464,7 @@ mod tests {
             &format!("echo pwned > {}", target.display()),
             project.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -468,6 +486,7 @@ mod tests {
             "cat /etc/hosts > /dev/null",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -496,6 +515,7 @@ mod tests {
             &format!("ls {db_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -524,6 +544,7 @@ mod tests {
             &format!("ls {ssh_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -553,6 +574,7 @@ mod tests {
             &format!("touch {canary}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -582,6 +604,7 @@ mod tests {
             &format!("echo '{{}}' > {}", target.display()),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -609,6 +632,7 @@ mod tests {
             &format!("echo '{{}}' > {}", target.display()),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -635,6 +659,7 @@ mod tests {
             "touch normal_file.txt",
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -663,6 +688,7 @@ mod tests {
             &format!("echo '# evil' > {}", target.display()),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -695,6 +721,7 @@ mod tests {
             &format!("ls {ssh_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -724,6 +751,7 @@ mod tests {
             &format!("touch {canary}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -753,6 +781,7 @@ mod tests {
             &format!("ls {aws_dir}"),
             dir.path(),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -143,11 +143,23 @@ pub async fn run_shell_command(
         .min(MAX_TIMEOUT_SECS);
 
     // Spawn via sandbox wrapper (enforced for all trust modes).
-    let mut child = crate::sandbox::build(command, project_root, trust, proxy_port, socks5_port)?
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to execute command: {e}"))?;
+    // Phase 5 PR-1 of #934: pass an explicit policy. Today this is
+    // `strict_default()` for byte-for-byte parity with pre-PR
+    // behavior; PR-2 will derive a real policy from trust + agent
+    // config so kernel enforcement actually varies per agent.
+    let policy = koda_sandbox::SandboxPolicy::strict_default();
+    let mut child = crate::sandbox::build(
+        command,
+        project_root,
+        trust,
+        &policy,
+        proxy_port,
+        socks5_port,
+    )?
+    .stdout(std::process::Stdio::piped())
+    .stderr(std::process::Stdio::piped())
+    .spawn()
+    .map_err(|e| anyhow::anyhow!("Failed to execute command: {e}"))?;
 
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
@@ -299,12 +311,22 @@ fn spawn_background(
 ) -> Result<String> {
     // Spawn via sandbox wrapper (enforced for all trust modes).
     // Detach stdio so the process doesn't block on terminal I/O.
-    let child = crate::sandbox::build(command, project_root, trust, proxy_port, socks5_port)?
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| anyhow::anyhow!("Failed to spawn background command: {e}"))?;
+    // Phase 5 PR-1 of #934: see comment on the foreground call site
+    // above for why `strict_default()` is used today.
+    let policy = koda_sandbox::SandboxPolicy::strict_default();
+    let child = crate::sandbox::build(
+        command,
+        project_root,
+        trust,
+        &policy,
+        proxy_port,
+        socks5_port,
+    )?
+    .stdin(std::process::Stdio::null())
+    .stdout(std::process::Stdio::null())
+    .stderr(std::process::Stdio::null())
+    .spawn()
+    .map_err(|e| anyhow::anyhow!("Failed to spawn background command: {e}"))?;
 
     let pid = child
         .id()


### PR DESCRIPTION
## Phase 5 of #934 — PR-1 of three: SandboxPolicy plumbing (no-op refactor)

Phase 5 of #934 calls for items 3 (resource limits) and 4 (`EffectiveSandboxPermissions::compose`) that **depend on per-call SandboxPolicy variation**.

Investigation revealed a **precondition gap**: today every `sandbox::build` call hardcodes `SandboxPolicy::strict_default()` *inside* the function rather than accepting one from the caller. That makes downstream features (resource limits, compose) impossible to wire up without also re-plumbing the call chain.

This is **PR-1 of three** for the re-plumb work.

| PR | What | Behavior change |
|---|---|---|
| **PR-1 (this)** | Add `policy: &SandboxPolicy` parameter; all callers pass `strict_default()` | **None** — pure refactor |
| **PR-2** | `SandboxPolicy::from_trust_and_agent()` constructor + wire into `tools/shell.rs` and `sub_agent_dispatch` | Sub-agents start getting actual policies |
| **PR-3** | Items 3 + 4 of Phase 5 (resource limit enforcement + `compose()`) | Now with real callers from PR-2 |

## What this PR changes

- `sandbox::build()` signature gains `policy: &SandboxPolicy` between `&TrustMode` and `proxy_port`. The internal `let policy = SandboxPolicy::strict_default()` is removed in favor of the passed-in reference.

- Two production call sites in `tools/shell.rs` (foreground + background bash spawn) updated to pass `&SandboxPolicy::strict_default()`, with comments pointing at PR-2 for where real construction lives.

- 23 test callers in `sandbox.rs` updated mechanically to pass the same `strict_default()`. Done with a regex pass; visually verified the diff has no semantic changes.

## Why no behavior change

Every caller passes `strict_default()`. The runtime sees the same empty policy it always saw. Kernel sandbox enforcement stays identical. The only thing that changes is *where the empty policy gets constructed* — caller side instead of callee side.

This is the safest possible refactor for the type-plumbing step. Future PRs swap out `strict_default()` for real constructors at specific call sites.

## Verification

```sh
env -u HTTPS_PROXY -u HTTP_PROXY cargo test -p koda-core --lib
→ 988 passed; 0 failed; 1 ignored

cargo clippy -p koda-core --all-targets -- -D warnings
→ clean
```

## Pre-existing test fragility (not introduced here)

`sandbox::tests::build_omits_proxy_env_when_port_none` fails when the dev's shell has `HTTPS_PROXY` set, even though the assertion is just *"subprocess saw no `HTTPS_PROXY`"*. The test inherits the parent shell's env. **Same class of bug as #1008.** Not introduced by this PR — the test was already fragile this way; my refactor just touched its surrounding lines so the failure surfaced when running with `HTTPS_PROXY` exported (Walmart corp shell). Will file as a follow-up issue.

## Stack

- ✅ #1010 (telemetry, item 5) — merged
- 🔄 **THIS PR** (PR-1)
- ⏭ Next: item 2 (failIfUnavailable, ~30 LOC, independent)
- ⏭ Then: PR-2 (constructor + sub-agent threading)
- ⏭ Then: PR-3 (items 3 + 4)
- ⏭ Then: docs rework (slim README + rustdoc-lift, fixes the fabricated resource-limits claim from #1011)

Refs #934.
