### PR TITLE
koda-core: Auto mode requires kernel sandbox (#934 phase 5 item 2)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -86,13 +86,36 @@ pub(crate) fn is_fully_denied(path: &Path) -> bool {
 pub fn build(
     command: &str,
     project_root: &Path,
-    _trust: &crate::trust::TrustMode,
+    trust: &crate::trust::TrustMode,
     policy: &SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
 ) -> Result<Command> {
     let runtime = current_runtime();
     warn_if_unavailable_once(runtime.as_ref());
+
+    // Phase 5 of #934 (item 2 — `failIfUnavailable`): refuse to run
+    // unsandboxed in Auto mode. Auto's whole value proposition is
+    // "trust the kernel sandbox to contain auto-approved destructive
+    // ops" — silently dropping that boundary at process startup
+    // because `bwrap` happens to be missing is a sharp footgun.
+    // #860's confirmation-prompt downgrade is a UX fallback, not a
+    // security guarantee (the model can still read anywhere on the
+    // FS in unsandboxed Auto).
+    //
+    // Safe and Plan keep the warn-and-fallback path: the user is
+    // already in the approval loop (Safe) or the tool registry filters
+    // writes (Plan), so sandbox is defense-in-depth there, not the
+    // primary boundary. No env-var escape hatch exists by design —
+    // if you don't want fail-if-unavailable, drop to Safe/Plan.
+    if matches!(trust, crate::trust::TrustMode::Auto) && !is_available() {
+        anyhow::bail!(
+            "Kernel sandbox backend unavailable in Auto mode \u{2014} refusing to run \
+             unsandboxed. Install the platform sandbox dependency (e.g. `bwrap` on \
+             Linux) or switch to Safe/Plan mode (which keeps the user in the \
+             approval loop)."
+        );
+    }
 
     // Phase 5 of #934 (PR-1): policy is now plumbed in from the caller
     // instead of synthesized here as `strict_default()`. This is the
@@ -793,5 +816,120 @@ mod tests {
             status.success(),
             "linux strict: reading ~/.aws/ must be allowed (aws CLI needs credentials)"
         );
+    }
+
+    // ── Phase 5 of #934 (item 2): Auto-mode hard-fail when sandbox missing ──
+    //
+    // Behavior matrix is intentionally tiny:
+    //
+    //   TrustMode::Auto  + sandbox unavailable  →  build() returns Err
+    //   TrustMode::Safe  + sandbox unavailable  →  build() returns Ok (warn-and-fallback)
+    //   TrustMode::Plan  + sandbox unavailable  →  build() returns Ok (warn-and-fallback)
+    //   *                + sandbox available    →  build() returns Ok
+    //
+    // No env-var override exists by design: if you don't want
+    // fail-if-unavailable, drop to Safe/Plan. Keeps the surface area
+    // crisp and the security posture predictable across hosts.
+    //
+    // The unavailable-host tests skip on macOS (seatbelt always
+    // present) and Linux-with-bwrap. The available-host test runs
+    // everywhere is_available() is true.
+
+    #[tokio::test]
+    async fn build_errors_in_auto_mode_when_sandbox_unavailable() {
+        if is_available() {
+            eprintln!("skip: kernel sandbox is available on this host");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let result = build(
+            "echo hi",
+            dir.path(),
+            &crate::trust::TrustMode::Auto,
+            &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
+            None,
+        );
+        assert!(
+            result.is_err(),
+            "Auto mode without kernel sandbox must hard-error \u{2014} the whole \
+             point of Auto is the kernel boundary"
+        );
+        let err = format!("{}", result.unwrap_err());
+        assert!(
+            err.contains("Auto"),
+            "error message must name the offending mode so the user knows what to change: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_falls_back_in_safe_mode_when_sandbox_unavailable() {
+        if is_available() {
+            eprintln!("skip: kernel sandbox is available on this host");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let result = build(
+            "echo hi",
+            dir.path(),
+            &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
+            None,
+        );
+        assert!(
+            result.is_ok(),
+            "Safe mode must keep the warn-and-fallback path \u{2014} the user is \
+             already in the approval loop: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_falls_back_in_plan_mode_when_sandbox_unavailable() {
+        if is_available() {
+            eprintln!("skip: kernel sandbox is available on this host");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let result = build(
+            "echo hi",
+            dir.path(),
+            &crate::trust::TrustMode::Plan,
+            &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
+            None,
+        );
+        assert!(
+            result.is_ok(),
+            "Plan mode must keep the warn-and-fallback path \u{2014} the tool registry \
+             filters writes already: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_succeeds_in_all_modes_when_sandbox_available() {
+        if !is_available() {
+            eprintln!("skip: kernel sandbox not available on this host");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        for mode in [
+            crate::trust::TrustMode::Plan,
+            crate::trust::TrustMode::Safe,
+            crate::trust::TrustMode::Auto,
+        ] {
+            let result = build(
+                "echo hi",
+                dir.path(),
+                &mode,
+                &koda_sandbox::SandboxPolicy::strict_default(),
+                None,
+                None,
+            );
+            assert!(
+                result.is_ok(),
+                "{mode:?} must succeed when sandbox is available: {result:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Phase 5 of #934 — item 2: Auto mode requires kernel sandbox

Hard-fail in Auto mode when the kernel sandbox backend is unavailable. Safe and Plan keep the warn-and-fallback path (the user is already in the approval loop / tool registry filters writes).

## Behavior matrix

| TrustMode | sandbox unavailable | sandbox available |
|---|---|---|
| `Auto` | **`build()` returns `Err`** | Ok |
| `Safe` | Ok (warn-and-fallback) | Ok |
| `Plan` | Ok (warn-and-fallback) | Ok |

**No env-var override** — by design. If you don't want fail-if-unavailable, drop to Safe/Plan. That's the only knob.

## Why no env-var escape hatch

Earlier iteration of this PR had `KODA_SANDBOX_FAIL_IF_UNAVAILABLE` as a bidirectional override. Dropped per review feedback because:

- **Smaller surface**: no env var to document, parse, validate, or test for typos. One less knob users can misconfigure.
- **No bypass**: a security flag whose default users can flip to off via env var isn't really a security flag — attackers / curious users / "just make it work" scripts will set it. By making the policy mode-derived with no override, the only way to weaken Auto is to explicitly pick a less-trusting mode (which is the right UX).
- **YAGNI**: nobody has asked for a per-host override, and the motivating use case ("I want to run Auto but my host has no bwrap") is exactly the situation we're trying to prevent.

## Why Auto specifically

| Mode | Risk without kernel sandbox | Why |
|---|---|---|
| `Plan` | Low | Tool registry filters writes; bash escape needs model cooperation |
| `Safe` | Low | User approves every mutation; sandbox is defense-in-depth |
| `Auto` | **HIGH** | Model auto-approves destructive ops; #860's confirmation-prompt downgrade is a UX fallback, not a security guarantee. The model can still read anywhere on the FS in unsandboxed Auto. |

## Who hits the new error?

Only **Linux users without `bwrap` installed** who try to use Auto mode. macOS has seatbelt built-in; Walmart corp shells are mostly macOS. Error message tells them exactly what to do:

> `Kernel sandbox backend unavailable in Auto mode — refusing to run unsandboxed. Install the platform sandbox dependency (e.g. `bwrap` on Linux) or switch to Safe/Plan mode (which keeps the user in the approval loop).`

## Verification

```sh
cargo clippy -p koda-core --all-targets -- -D warnings
→ clean

cargo test -p koda-core --lib sandbox:: -- --test-threads=1
→ 24 passed; 0 failed; 0 ignored
```

Tests skip the unavailable-host branches when running on macOS (seatbelt always present). The "all modes succeed when sandbox is available" test exercises the happy path on macOS.

## Stack

- ✅ #1010 (telemetry, item 5) — merged
- 🔄 #1012 (PR-1: SandboxPolicy plumbing, no-op refactor)
- 🔄 **THIS PR** (item 2 — independent of #1012, mergeable in either order)
- ⏭ Next: PR-2 (`from_trust_and_agent` constructor + sub-agent threading)
- ⏭ Then: PR-3 (items 3 + 4 — resource limits + `compose()`)
- ⏭ Then: docs rework (slim README + rustdoc-lift, fixes the fabricated resource-limits claim from #1011)

Refs #934.
