### PR TITLE
koda-core: SandboxPolicy constructor + sub-agent threading (#934 phase 5 PR-2)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -175,6 +175,33 @@ pub fn build(
     Ok(cmd)
 }
 
+/// Construct the [`SandboxPolicy`] that should govern a given agent's
+/// tool invocations.
+///
+/// Phase 5 PR-2 of #934 establishes the constructor and its call sites
+/// (Bash dispatch, sub-agent dispatch). The body intentionally returns
+/// [`SandboxPolicy::strict_default`] for every input today — enforcement
+/// of per-agent variation lands in PR-3 alongside the resource-limit
+/// and `compose()` work that needs distinct policies to act on.
+///
+/// Why a free function here (not a method on `SandboxPolicy`):
+/// - Keeps `koda-sandbox::policy` ignorant of `koda-core::trust` and
+///   `koda-core::config` (the policy crate is the lower layer; the
+///   construction policy that combines runtime context lives upstream).
+/// - Mirrors the existing pattern in this module: `build()` is also a
+///   construction-policy free function, not a method on `Command`.
+///
+/// Inputs deliberately minimal until PR-3 needs more:
+/// - `trust`: today unused; reserved for PR-3 (e.g. `Plan` may map to
+///   stricter `fs.allow_write` than `Auto`).
+/// - `project_root`: today unused; reserved for PR-3 to seed allow lists.
+pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> SandboxPolicy {
+    // Suppress unused-warning without `_` prefix so the API surface
+    // documents the intended inputs. PR-3 turns these into reads.
+    let _ = (trust, project_root);
+    SandboxPolicy::strict_default()
+}
+
 /// Emit a single warning per process if the active runtime can't enforce
 /// kernel-level isolation. Without this users get silent unsandboxed
 /// execution on, e.g., Linux without `bwrap` installed — surprising
@@ -931,5 +958,44 @@ mod tests {
                 "{mode:?} must succeed when sandbox is available: {result:?}"
             );
         }
+    }
+
+    // ── Phase 5 PR-2 of #934: `policy_for_agent` constructor ──
+    //
+    // The constructor is a stub today — it returns `strict_default()`
+    // for every input. These tests pin that contract so PR-3 changes
+    // are forced through review (instead of silently shifting per-agent
+    // capability without anyone noticing). When PR-3 lands, these tests
+    // get rewritten to assert the actual derivation rules — the *names*
+    // stay so it's obvious in `git log` what behavioral promise changed.
+
+    #[test]
+    fn policy_for_agent_returns_strict_default_for_all_trust_modes() {
+        let dir = tempfile::tempdir().unwrap();
+        let strict = SandboxPolicy::strict_default();
+        for mode in [
+            crate::trust::TrustMode::Plan,
+            crate::trust::TrustMode::Safe,
+            crate::trust::TrustMode::Auto,
+        ] {
+            assert_eq!(
+                policy_for_agent(mode, dir.path()),
+                strict,
+                "PR-2 contract: every trust mode maps to strict_default(). \
+                 If you're changing this in PR-3, update the test name + body \
+                 to describe the new derivation rule. Mode under test: {mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_for_agent_does_not_panic_on_nonexistent_project_root() {
+        // Defensive: the constructor must be safe to call before the
+        // project root is materialized on disk (sub-agent dispatch can
+        // build the policy before its workspace exists).
+        let _ = policy_for_agent(
+            crate::trust::TrustMode::Safe,
+            std::path::Path::new("/nonexistent/path/that/should/not/exist"),
+        );
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -309,6 +309,16 @@ pub(crate) async fn execute_sub_agent(
             sub_config.max_context_tokens,
             sub_config.trust,
         );
+        // Phase 5 PR-2 of #934: install the sub-agent's sandbox policy.
+        // Today `policy_for_agent` returns `strict_default()` for every
+        // input so behavior is unchanged — the wiring exists so PR-3 can
+        // start populating the policy with non-default values (e.g.
+        // narrower fs.allow_write for read-only sub-agents) without
+        // touching this dispatch site again.
+        let registry = registry.with_sandbox_policy(crate::sandbox::policy_for_agent(
+            sub_config.trust,
+            effective_root_ref,
+        ));
         match parent_cache {
             Some(cache) => registry.with_shared_cache(cache),
             None => registry,

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -240,6 +240,12 @@ pub struct ToolRegistry {
     pub bg_registry: bg_process::BgRegistry,
     /// Trust mode — determines sandbox configuration for Bash tool.
     trust: crate::trust::TrustMode,
+    /// Active sandbox policy. Phase 5 PR-2 of #934 wires this through
+    /// the Bash dispatch path so per-agent variation becomes possible.
+    /// Today every constructor seeds it with `SandboxPolicy::strict_default()`
+    /// so behavior is byte-for-byte unchanged — PR-3 starts populating it
+    /// with non-default values via [`crate::sandbox::policy_for_agent`].
+    sandbox_policy: koda_sandbox::SandboxPolicy,
     /// MCP connection manager — owns all MCP server connections (#662).
     /// `None` until attached via `set_mcp_manager()`.
     mcp_manager: std::sync::RwLock<Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>>,
@@ -333,6 +339,10 @@ impl ToolRegistry {
             caps: OutputCaps::for_context(max_context_tokens),
             bg_registry: bg_process::BgRegistry::new(),
             trust,
+            // Phase 5 PR-2 of #934: seed with strict_default(). Callers
+            // can override via [`Self::with_sandbox_policy`] (sub-agent
+            // dispatch does this; the main agent inherits the default).
+            sandbox_policy: koda_sandbox::SandboxPolicy::strict_default(),
             mcp_manager: std::sync::RwLock::new(None),
             proxy_port: std::sync::RwLock::new(None),
             socks5_port: std::sync::RwLock::new(None),
@@ -346,6 +356,26 @@ impl ToolRegistry {
     pub fn with_shared_cache(mut self, cache: FileReadCache) -> Self {
         self.read_cache = cache;
         self
+    }
+
+    /// Override the active sandbox policy.
+    ///
+    /// Phase 5 PR-2 of #934. Builder-style; chains after `with_trust`
+    /// (or `new`). Sub-agent dispatch uses this to install the policy
+    /// produced by [`crate::sandbox::policy_for_agent`] on the child's
+    /// registry. The main agent path doesn't call this and inherits
+    /// the `strict_default()` seed from `with_trust` — byte-for-byte
+    /// unchanged behavior in PR-2.
+    pub fn with_sandbox_policy(mut self, policy: koda_sandbox::SandboxPolicy) -> Self {
+        self.sandbox_policy = policy;
+        self
+    }
+
+    /// Borrow the active sandbox policy. Used by the Bash dispatch
+    /// path to thread the per-registry policy into
+    /// [`crate::sandbox::build`].
+    pub fn sandbox_policy(&self) -> &koda_sandbox::SandboxPolicy {
+        &self.sandbox_policy
     }
 
     /// Inject a custom [`FileSystem`] implementation.
@@ -625,6 +655,7 @@ impl ToolRegistry {
                     &self.bg_registry,
                     sink_for_streaming,
                     &self.trust,
+                    self.sandbox_policy(),
                     self.proxy_port(),
                     self.socks5_port(),
                 )
@@ -1350,5 +1381,54 @@ mod describe_action_tests {
         let registry = ToolRegistry::new(PathBuf::from("/tmp"), 128_000);
         let all = registry.get_definitions(&[], &[]);
         assert!(all.len() > 10, "Should have many tools");
+    }
+
+    // ── Phase 5 PR-2 of #934: SandboxPolicy threading on ToolRegistry ──
+    //
+    // The Bash dispatch path now reads `self.sandbox_policy()` instead
+    // of synthesizing `strict_default()` inline. These tests pin:
+    //   1. The default seed is `strict_default()` so unchanged callers
+    //      preserve byte-for-byte behavior.
+    //   2. `with_sandbox_policy` actually replaces the field (the
+    //      threading is real, not a stub).
+    //   3. The accessor returns the most recent setter's value (no
+    //      caching/aliasing surprises).
+
+    #[test]
+    fn registry_sandbox_policy_defaults_to_strict() {
+        let registry = ToolRegistry::new(PathBuf::from("/tmp"), 128_000);
+        assert_eq!(
+            *registry.sandbox_policy(),
+            koda_sandbox::SandboxPolicy::strict_default(),
+            "PR-2 contract: ToolRegistry::new must seed strict_default() so \
+             pre-PR callers see unchanged behavior"
+        );
+    }
+
+    #[test]
+    fn with_sandbox_policy_overrides_the_default() {
+        // Build a deliberately-non-default policy by mutating one field.
+        // We don't care which field — only that round-tripping through
+        // `with_sandbox_policy` preserves the override and the default
+        // would not match.
+        let mut custom = koda_sandbox::SandboxPolicy::strict_default();
+        custom
+            .fs
+            .allow_write
+            .push(koda_sandbox::PathPattern::new("/pr2-marker"));
+
+        let registry =
+            ToolRegistry::new(PathBuf::from("/tmp"), 128_000).with_sandbox_policy(custom.clone());
+
+        assert_eq!(
+            *registry.sandbox_policy(),
+            custom,
+            "with_sandbox_policy must replace the field, not no-op"
+        );
+        assert_ne!(
+            *registry.sandbox_policy(),
+            koda_sandbox::SandboxPolicy::strict_default(),
+            "sanity: the override is observably different from the default"
+        );
     }
 }

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -116,6 +116,7 @@ pub async fn run_shell_command(
     bg: &BgRegistry,
     sink: Option<(&dyn EngineSink, &str)>,
     trust: &crate::trust::TrustMode,
+    policy: &koda_sandbox::SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
 ) -> Result<ShellOutput> {
@@ -130,7 +131,15 @@ pub async fn run_shell_command(
     );
 
     if background {
-        let msg = spawn_background(project_root, command, bg, trust, proxy_port, socks5_port)?;
+        let msg = spawn_background(
+            project_root,
+            command,
+            bg,
+            trust,
+            policy,
+            proxy_port,
+            socks5_port,
+        )?;
         return Ok(ShellOutput {
             summary: msg,
             full_output: None,
@@ -143,16 +152,16 @@ pub async fn run_shell_command(
         .min(MAX_TIMEOUT_SECS);
 
     // Spawn via sandbox wrapper (enforced for all trust modes).
-    // Phase 5 PR-1 of #934: pass an explicit policy. Today this is
-    // `strict_default()` for byte-for-byte parity with pre-PR
-    // behavior; PR-2 will derive a real policy from trust + agent
-    // config so kernel enforcement actually varies per agent.
-    let policy = koda_sandbox::SandboxPolicy::strict_default();
+    // Phase 5 PR-2 of #934: policy is now threaded in from the
+    // ToolRegistry (set via [`ToolRegistry::with_sandbox_policy`] in
+    // sub-agent dispatch; defaults to `strict_default()` for the main
+    // agent). PR-3 will start populating the policy with non-default
+    // values via [`crate::sandbox::policy_for_agent`].
     let mut child = crate::sandbox::build(
         command,
         project_root,
         trust,
-        &policy,
+        policy,
         proxy_port,
         socks5_port,
     )?
@@ -306,19 +315,19 @@ fn spawn_background(
     command: &str,
     bg: &BgRegistry,
     trust: &crate::trust::TrustMode,
+    policy: &koda_sandbox::SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
 ) -> Result<String> {
     // Spawn via sandbox wrapper (enforced for all trust modes).
     // Detach stdio so the process doesn't block on terminal I/O.
-    // Phase 5 PR-1 of #934: see comment on the foreground call site
-    // above for why `strict_default()` is used today.
-    let policy = koda_sandbox::SandboxPolicy::strict_default();
+    // Phase 5 PR-2 of #934: policy threaded in from the registry
+    // (see comment on `run_shell_command` above for the threading rationale).
     let child = crate::sandbox::build(
         command,
         project_root,
         trust,
-        &policy,
+        policy,
         proxy_port,
         socks5_port,
     )?
@@ -493,6 +502,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -516,6 +526,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -539,6 +550,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -563,6 +575,7 @@ mod tests {
             &registry,
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -593,6 +606,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -686,6 +700,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -745,6 +760,7 @@ mod tests {
             &bg(),
             Some((sink.as_ref(), "test_id")),
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )
@@ -845,6 +861,7 @@ mod tests {
             &bg(),
             None,
             &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
         )


### PR DESCRIPTION
## Summary

Stage 2 of the Phase 5 split:
- **PR-1 (#1012, merged):** plumbed `policy: &SandboxPolicy` through `sandbox::build`
- **PR-2 (this):** named constructor + threading from registry to dispatch
- **PR-3 (next):** populate the policy with non-default values (resource limits, per-agent variation)

This PR is **all wiring, zero behavior change**. Every code path still ends up with `SandboxPolicy::strict_default()` at runtime — the difference is the policy is now produced by a named constructor (`policy_for_agent`) and threaded through the registry, so PR-3 can swap one function body to vary per-agent capability without touching dispatch sites.

## What's plumbed

1. **`koda_core::sandbox::policy_for_agent(trust, project_root) -> SandboxPolicy`** — new constructor. Stub today: returns `strict_default()` for every input. Inputs deliberately minimal (YAGNI).
2. **`ToolRegistry`** gains a `sandbox_policy: SandboxPolicy` field seeded with `strict_default()`, plus:
   - `with_sandbox_policy(policy)` builder — chainable like `with_shared_cache`
   - `sandbox_policy()` accessor
3. **Bash dispatch** (`tools/mod.rs`) now reads `self.sandbox_policy()` instead of synthesizing `strict_default()` inline.
4. **`run_shell_command` + `spawn_background`** take `policy: &SandboxPolicy` and pass it to `sandbox::build`. Removes inline `strict_default()` construction at both call sites.
5. **Sub-agent dispatch** (`sub_agent_dispatch.rs`) chains `.with_sandbox_policy(policy_for_agent(sub_config.trust, effective_root))` on the child registry.

## Why a free function (not a method on SandboxPolicy)

- Keeps `koda-sandbox::policy` ignorant of `koda-core::trust` and `koda-core::config`. The policy crate is the lower layer; the construction policy that combines runtime context lives upstream.
- Mirrors `sandbox::build` — also a free function in this module, not a method on `Command`.

## Test pinning

PR-2 contract tests assert the *current* stub behavior so PR-3 changes get forced through review:

| Test | Pins |
|---|---|
| `policy_for_agent_returns_strict_default_for_all_trust_modes` | constructor identity for all 3 modes |
| `policy_for_agent_does_not_panic_on_nonexistent_project_root` | safe before workspace materialized |
| `registry_sandbox_policy_defaults_to_strict` | seed value preserves pre-PR behavior |
| `with_sandbox_policy_overrides_the_default` | threading is real, not a stub |

Each test docstring says: 'when PR-3 changes this, update the test name + body to describe the new derivation rule.'

## Verification

```
cargo clippy -p koda-core --all-targets -- -D warnings  -> clean
cargo test -p koda-core --lib  -> 996 passed; 0 failed; 1 ignored
cargo test -p koda-core --test bash_safety_test
     --test builtin_proxy_e2e_test --test cancel_test
  -> 28 passed; 0 failed
```

Diff: **+184 -11**, four files. Pure mechanical threading.

Refs #934.