### PR TITLE
koda-sandbox+koda-core: SandboxPolicy::compose + per-trust wall-time defaults (#934 phase 5 PR-3)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -178,32 +178,38 @@ pub fn build(
 /// Construct the [`SandboxPolicy`] that should govern a given agent's
 /// tool invocations.
 ///
-/// Phase 5 PR-2 of #934 establishes the constructor and its call sites
-/// (Bash dispatch, sub-agent dispatch). The body intentionally returns
-/// [`SandboxPolicy::strict_default`] for every input today — enforcement
-/// of per-agent variation lands in PR-3 alongside the resource-limit
-/// and `compose()` work that needs distinct policies to act on.
+/// Phase 5 PR-2 of #934 established the constructor and its call sites.
+/// PR-3 starts populating it: every trust mode now ships with a
+/// non-empty `limits.wall_time_secs` so the Bash dispatch path picks up
+/// a per-agent default deadline (precedence: explicit `timeout` arg >
+/// policy default > legacy hardcoded fallback). Other resource limits
+/// (CPU, RSS, FDs, output) stay `None` until the runtime grows actual
+/// enforcement code — the policy field exists, but no setter populates
+/// it yet (YAGNI: don't promise a limit we can't enforce).
 ///
-/// Why a free function here (not a method on `SandboxPolicy`):
-/// - Keeps `koda-sandbox::policy` ignorant of `koda-core::trust` and
-///   `koda-core::config` (the policy crate is the lower layer; the
-///   construction policy that combines runtime context lives upstream).
-/// - Mirrors the existing pattern in this module: `build()` is also a
-///   construction-policy free function, not a method on `Command`.
+/// ## Per-trust defaults (today, intentionally conservative)
 ///
-/// Inputs deliberately minimal until PR-3 needs more:
-/// - `trust`: today unused; reserved for PR-3 (e.g. `Plan` may map to
-///   stricter `fs.allow_write` than `Auto`).
-/// - `project_root`: today unused; reserved for PR-3 to seed allow lists.
+/// | Trust | wall_time_secs | rationale                                                  |
+/// |-------|----------------|------------------------------------------------------------|
+/// | Plan  | 60             | Read-only — 60s is more than enough for greps/reads.       |
+/// | Safe  | 60             | Matches pre-PR `DEFAULT_TIMEOUT_SECS`. Byte-for-byte parity. |
+/// | Auto  | 60             | Same as Safe today. Future PR may bump for build/test workloads once telemetry justifies it. |
+///
+/// Tuning per-trust differently is deliberately deferred — PR-3's job
+/// is the *lift* (make limits policy-driven, not hardcoded), not the
+/// retune. We change values once we have data; we change *where the
+/// values live* now so the change is one-line later.
 pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> SandboxPolicy {
-    // Suppress unused-warning without `_` prefix so the API surface
-    // documents the intended inputs. PR-3 turns these into reads.
-    let _ = (trust, project_root);
-    SandboxPolicy::strict_default()
+    // `project_root` reserved for PR-4+ (seeding fs.allow_write).
+    let _ = project_root;
+    let mut policy = SandboxPolicy::strict_default();
+    policy.limits.wall_time_secs = Some(match trust {
+        crate::trust::TrustMode::Plan
+        | crate::trust::TrustMode::Safe
+        | crate::trust::TrustMode::Auto => 60,
+    });
+    policy
 }
-
-/// Emit a single warning per process if the active runtime can't enforce
-/// kernel-level isolation. Without this users get silent unsandboxed
 /// execution on, e.g., Linux without `bwrap` installed — surprising
 /// behavior that the previous `build_inner()` path warned about explicitly.
 fn warn_if_unavailable_once(runtime: &dyn SandboxRuntime) {
@@ -960,32 +966,46 @@ mod tests {
         }
     }
 
-    // ── Phase 5 PR-2 of #934: `policy_for_agent` constructor ──
+    // ── Phase 5 PR-3 of #934: `policy_for_agent` populates resource limits ──
     //
-    // The constructor is a stub today — it returns `strict_default()`
-    // for every input. These tests pin that contract so PR-3 changes
-    // are forced through review (instead of silently shifting per-agent
-    // capability without anyone noticing). When PR-3 lands, these tests
-    // get rewritten to assert the actual derivation rules — the *names*
-    // stay so it's obvious in `git log` what behavioral promise changed.
+    // PR-2 left the constructor returning `strict_default()` for every
+    // input. PR-3 starts populating `limits.wall_time_secs` so the
+    // Bash dispatch path picks up a policy-driven default deadline.
+    // The other limits (CPU/RSS/FDs/output) stay None until the runtime
+    // grows actual enforcement — declared but not yet used.
 
     #[test]
-    fn policy_for_agent_returns_strict_default_for_all_trust_modes() {
+    fn policy_for_agent_sets_wall_time_for_all_trust_modes() {
         let dir = tempfile::tempdir().unwrap();
-        let strict = SandboxPolicy::strict_default();
         for mode in [
             crate::trust::TrustMode::Plan,
             crate::trust::TrustMode::Safe,
             crate::trust::TrustMode::Auto,
         ] {
+            let policy = policy_for_agent(mode, dir.path());
             assert_eq!(
-                policy_for_agent(mode, dir.path()),
-                strict,
-                "PR-2 contract: every trust mode maps to strict_default(). \
-                 If you're changing this in PR-3, update the test name + body \
-                 to describe the new derivation rule. Mode under test: {mode:?}"
+                policy.limits.wall_time_secs,
+                Some(60),
+                "PR-3 contract: every trust mode ships with a wall_time default \
+                 so the Bash dispatch path stops needing a hardcoded fallback. \
+                 Mode under test: {mode:?}"
             );
         }
+    }
+
+    #[test]
+    fn policy_for_agent_leaves_other_limits_unlimited() {
+        // Defensive: the runtime doesn't enforce CPU/RSS/FD/output
+        // limits yet. Setting them here would lie about enforcement.
+        // When PR-? wires up enforcement, update this test to assert
+        // the new defaults; until then, presence-without-enforcement
+        // is worse than absence (silent unlimited > silent ignored).
+        let dir = tempfile::tempdir().unwrap();
+        let policy = policy_for_agent(crate::trust::TrustMode::Safe, dir.path());
+        assert_eq!(policy.limits.cpu_time_secs, None);
+        assert_eq!(policy.limits.max_rss_bytes, None);
+        assert_eq!(policy.limits.max_open_fds, None);
+        assert_eq!(policy.limits.max_output_bytes, None);
     }
 
     #[test]

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -146,8 +146,16 @@ pub async fn run_shell_command(
         });
     }
 
+    // Phase 5 PR-3 of #934: timeout precedence is
+    //   1. explicit `timeout` arg (model-supplied per-call)
+    //   2. `policy.limits.wall_time_secs` (per-agent default)
+    //   3. `DEFAULT_TIMEOUT_SECS` legacy constant fallback
+    // Hard ceiling `MAX_TIMEOUT_SECS` clamps all three — keeps the
+    // DoS protection that the LLM can't widen its own deadline by
+    // asking for a 1-hour run.
     let timeout_secs = args["timeout"]
         .as_u64()
+        .or(policy.limits.wall_time_secs)
         .unwrap_or(DEFAULT_TIMEOUT_SECS)
         .min(MAX_TIMEOUT_SECS);
 
@@ -720,12 +728,85 @@ mod tests {
 
     #[test]
     fn test_timeout_capped_at_max() {
+        // Mirrors the precedence formula in `run_shell_command` so a
+        // refactor here forces a refactor there (and vice versa).
         let args = serde_json::json!({"command": "echo hi", "timeout": 99999});
+        let policy = koda_sandbox::SandboxPolicy::strict_default();
         let t = args["timeout"]
             .as_u64()
+            .or(policy.limits.wall_time_secs)
             .unwrap_or(DEFAULT_TIMEOUT_SECS)
             .min(MAX_TIMEOUT_SECS);
         assert_eq!(t, MAX_TIMEOUT_SECS);
+    }
+
+    // Phase 5 PR-3 of #934: timeout precedence is
+    //   arg > policy.limits.wall_time_secs > DEFAULT_TIMEOUT_SECS
+    // Each rung is pinned by its own test so a regression in one
+    // (e.g. swapping arg and policy precedence — letting a per-agent
+    // policy override an explicit per-call deadline) names the bug.
+
+    #[test]
+    fn timeout_precedence_arg_beats_policy() {
+        let args = serde_json::json!({"command": "x", "timeout": 42});
+        let mut policy = koda_sandbox::SandboxPolicy::strict_default();
+        policy.limits.wall_time_secs = Some(120);
+        let t = args["timeout"]
+            .as_u64()
+            .or(policy.limits.wall_time_secs)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .min(MAX_TIMEOUT_SECS);
+        assert_eq!(
+            t, 42,
+            "explicit per-call timeout must win over policy default"
+        );
+    }
+
+    #[test]
+    fn timeout_precedence_policy_beats_legacy_default() {
+        let args = serde_json::json!({"command": "x"}); // no timeout arg
+        let mut policy = koda_sandbox::SandboxPolicy::strict_default();
+        policy.limits.wall_time_secs = Some(45);
+        let t = args["timeout"]
+            .as_u64()
+            .or(policy.limits.wall_time_secs)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .min(MAX_TIMEOUT_SECS);
+        assert_eq!(
+            t, 45,
+            "policy-supplied wall_time_secs must beat the legacy DEFAULT_TIMEOUT_SECS const"
+        );
+    }
+
+    #[test]
+    fn timeout_precedence_legacy_default_when_arg_and_policy_absent() {
+        let args = serde_json::json!({"command": "x"});
+        let policy = koda_sandbox::SandboxPolicy::strict_default(); // wall_time_secs = None
+        let t = args["timeout"]
+            .as_u64()
+            .or(policy.limits.wall_time_secs)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .min(MAX_TIMEOUT_SECS);
+        assert_eq!(t, DEFAULT_TIMEOUT_SECS, "fallback chain bottom rung");
+    }
+
+    #[test]
+    fn timeout_max_ceiling_clamps_policy_too() {
+        // Defense against "sub-agent gets a generous wall_time policy
+        // and bypasses the global DoS ceiling". The ceiling must clamp
+        // *all* sources, not just user-supplied args.
+        let args = serde_json::json!({"command": "x"});
+        let mut policy = koda_sandbox::SandboxPolicy::strict_default();
+        policy.limits.wall_time_secs = Some(99_999);
+        let t = args["timeout"]
+            .as_u64()
+            .or(policy.limits.wall_time_secs)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .min(MAX_TIMEOUT_SECS);
+        assert_eq!(
+            t, MAX_TIMEOUT_SECS,
+            "policy can't widen its own deadline past the hard DoS ceiling"
+        );
     }
 
     #[tokio::test]

--- a/koda-sandbox/src/policy.rs
+++ b/koda-sandbox/src/policy.rs
@@ -185,6 +185,122 @@ impl SandboxPolicy {
     pub fn strict_default() -> Self {
         Self::default()
     }
+
+    /// Compose a parent policy with a child override, producing a policy
+    /// that is **strictly no more permissive than either input**.
+    ///
+    /// Phase 5 of #934 (`EffectiveSandboxPermissions::compose` in Codex).
+    /// The composition rules are intentionally simple and one-directional:
+    /// the child can only *narrow* the parent's surface, never widen it.
+    /// This matches the security intuition that a forked sub-agent should
+    /// inherit the parent's restrictions and add its own on top — the
+    /// parent's denies are floors, the parent's allows are ceilings.
+    ///
+    /// ## Per-field semantics
+    ///
+    /// | Field                                  | Rule           | Why                                                  |
+    /// |----------------------------------------|----------------|------------------------------------------------------|
+    /// | `fs.deny_read` / `fs.deny_write_*`     | union          | Either parent or child deny → deny (denies grow)     |
+    /// | `fs.allow_read_within_deny`            | union          | Holes punched by either side stay open               |
+    /// | `fs.allow_write`                       | parent values  | Child can't *widen* writable area (intersection ≈ parent when child empty) |
+    /// | `fs.allow_git_config`                  | logical AND    | Both must permit                                     |
+    /// | `net.denied_domains`                   | union          | Symmetric to fs denies                               |
+    /// | `net.allowed_domains`                  | parent values  | Child can't add allowed domains                      |
+    /// | `net.allow_local_binding`              | logical AND    | Both must permit                                     |
+    /// | `net.weaker_macos_isolation`           | logical AND    | Weakening requires *both* sides to opt in            |
+    /// | `net.mitm`                             | parent value   | MITM is a session-wide config; sub-agents don't change it |
+    /// | `limits.*`                             | minimum        | Tighter resource cap wins                            |
+    /// | `trust`                                | strictest      | `Forbid` > `Require` > `Auto`                        |
+    ///
+    /// ## Why intersection-as-parent for allow lists (not true set intersection)
+    ///
+    /// True set intersection of path patterns is gnarly: `/work` and
+    /// `/work/subdir` should overlap (subdir is contained in work) but
+    /// string-equal pattern intersection would drop both. Until we have
+    /// a real path-prefix lattice, we use the conservative rule
+    /// "child can't add new allows" — if the child wants a narrower
+    /// allow list, it should construct it explicitly *instead of* the
+    /// parent's, and the empty-child case (most common) reduces to
+    /// inheriting the parent's allows verbatim. PR-4+ may revisit.
+    ///
+    /// ## Idempotence
+    ///
+    /// `compose(p, default()) == p` and `compose(default(), c)` produces
+    /// a policy with `c`'s denies (union with empty = `c`'s denies),
+    /// empty allows (parent had none to inherit), and `c`'s limits/trust.
+    /// In practice this means "composing onto strict_default is a no-op
+    /// for denies but loses the child's allows" — callers building from
+    /// a permissive base should populate the parent's allow lists first.
+    pub fn compose(parent: &Self, child: &Self) -> Self {
+        Self {
+            fs: FsPolicy {
+                deny_read: union(&parent.fs.deny_read, &child.fs.deny_read),
+                allow_read_within_deny: union(
+                    &parent.fs.allow_read_within_deny,
+                    &child.fs.allow_read_within_deny,
+                ),
+                // Allows narrow toward parent: see method docs.
+                allow_write: parent.fs.allow_write.clone(),
+                deny_write_within_allow: union(
+                    &parent.fs.deny_write_within_allow,
+                    &child.fs.deny_write_within_allow,
+                ),
+                allow_git_config: parent.fs.allow_git_config && child.fs.allow_git_config,
+            },
+            net: NetPolicy {
+                allowed_domains: parent.net.allowed_domains.clone(),
+                denied_domains: union(&parent.net.denied_domains, &child.net.denied_domains),
+                allow_local_binding: parent.net.allow_local_binding
+                    && child.net.allow_local_binding,
+                mitm: parent.net.mitm.clone(),
+                weaker_macos_isolation: parent.net.weaker_macos_isolation
+                    && child.net.weaker_macos_isolation,
+            },
+            limits: ResourceLimits {
+                cpu_time_secs: min_opt(parent.limits.cpu_time_secs, child.limits.cpu_time_secs),
+                wall_time_secs: min_opt(parent.limits.wall_time_secs, child.limits.wall_time_secs),
+                max_rss_bytes: min_opt(parent.limits.max_rss_bytes, child.limits.max_rss_bytes),
+                max_open_fds: min_opt(parent.limits.max_open_fds, child.limits.max_open_fds),
+                max_output_bytes: min_opt(
+                    parent.limits.max_output_bytes,
+                    child.limits.max_output_bytes,
+                ),
+            },
+            trust: strictest_trust(parent.trust, child.trust),
+        }
+    }
+}
+
+/// De-duplicated union of two pattern slices, preserving parent-first
+/// order so debug output stays predictable across composes. `Vec` (not
+/// `HashSet`) because policies are tiny and serde-friendly here.
+fn union<T: Clone + PartialEq>(a: &[T], b: &[T]) -> Vec<T> {
+    let mut out = a.to_vec();
+    for x in b {
+        if !out.contains(x) {
+            out.push(x.clone());
+        }
+    }
+    out
+}
+
+/// Tighter limit wins. `None` = unlimited; presence beats absence.
+fn min_opt(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    match (a, b) {
+        (None, None) => None,
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (Some(x), Some(y)) => Some(x.min(y)),
+    }
+}
+
+/// Strictest trust wins: `Forbid` > `Require` > `Auto`.
+fn strictest_trust(a: TrustPreference, b: TrustPreference) -> TrustPreference {
+    use TrustPreference::*;
+    match (a, b) {
+        (Forbid, _) | (_, Forbid) => Forbid,
+        (Require, _) | (_, Require) => Require,
+        _ => Auto,
+    }
 }
 
 #[cfg(test)]
@@ -271,5 +387,237 @@ mod tests {
         assert_eq!(p.fs.allow_write, vec![PathPattern::new("/tmp")]);
         assert_eq!(p.trust, TrustPreference::Auto);
         assert!(p.net.allowed_domains.is_empty());
+    }
+
+    // ── Phase 5 PR-3 of #934: SandboxPolicy::compose ──
+    //
+    // The contract is "child can only narrow the parent". These tests
+    // pin each per-field rule independently so a regression in one
+    // (e.g. switching `allow_write` from intersection to union)
+    // shows up as a single failing test naming the violated rule.
+
+    #[test]
+    fn compose_with_default_child_is_identity_for_parent_denies() {
+        let parent = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/etc/shadow".into()],
+                allow_write: vec!["/work".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let composed = SandboxPolicy::compose(&parent, &SandboxPolicy::default());
+        assert_eq!(composed.fs.deny_read, parent.fs.deny_read);
+        assert_eq!(composed.fs.allow_write, parent.fs.allow_write);
+    }
+
+    #[test]
+    fn compose_unions_denies_so_child_can_add_restrictions() {
+        let parent = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/etc/shadow".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/etc/passwd".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let composed = SandboxPolicy::compose(&parent, &child);
+        assert!(composed.fs.deny_read.contains(&"/etc/shadow".into()));
+        assert!(composed.fs.deny_read.contains(&"/etc/passwd".into()));
+        assert_eq!(
+            composed.fs.deny_read.len(),
+            2,
+            "union should de-duplicate, not just concat"
+        );
+    }
+
+    #[test]
+    fn compose_union_dedupes_overlapping_denies() {
+        let p = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/a".into(), "/b".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/b".into(), "/c".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let composed = SandboxPolicy::compose(&p, &c);
+        assert_eq!(composed.fs.deny_read.len(), 3, "a, b, c — b appears once");
+    }
+
+    #[test]
+    fn compose_drops_child_allow_writes_so_child_cannot_widen() {
+        // Anti-privilege-escalation: child requesting a new writable
+        // directory must not be granted it via compose. Child has to
+        // be installed with that allow already (via the constructor),
+        // and the parent has to permit it.
+        let parent = SandboxPolicy {
+            fs: FsPolicy {
+                allow_write: vec!["/work".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = SandboxPolicy {
+            fs: FsPolicy {
+                allow_write: vec!["/etc".into(), "/work".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let composed = SandboxPolicy::compose(&parent, &child);
+        assert_eq!(
+            composed.fs.allow_write,
+            vec![PathPattern::new("/work")],
+            "child cannot smuggle in /etc by listing it in its own allow_write"
+        );
+    }
+
+    #[test]
+    fn compose_allow_git_config_is_logical_and() {
+        for (parent_b, child_b, want) in [
+            (true, true, true),
+            (true, false, false),
+            (false, true, false),
+            (false, false, false),
+        ] {
+            let p = SandboxPolicy {
+                fs: FsPolicy {
+                    allow_git_config: parent_b,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let c = SandboxPolicy {
+                fs: FsPolicy {
+                    allow_git_config: child_b,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            assert_eq!(
+                SandboxPolicy::compose(&p, &c).fs.allow_git_config,
+                want,
+                "parent={parent_b} child={child_b}"
+            );
+        }
+    }
+
+    #[test]
+    fn compose_limits_take_minimum_with_none_meaning_unlimited() {
+        let parent = SandboxPolicy {
+            limits: ResourceLimits {
+                wall_time_secs: Some(60),
+                max_rss_bytes: None, // parent: unlimited
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = SandboxPolicy {
+            limits: ResourceLimits {
+                wall_time_secs: Some(30),  // tighter
+                max_rss_bytes: Some(1024), // child sets a limit, parent had none
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let c = SandboxPolicy::compose(&parent, &child);
+        assert_eq!(c.limits.wall_time_secs, Some(30), "tighter wins");
+        assert_eq!(
+            c.limits.max_rss_bytes,
+            Some(1024),
+            "presence beats absence — a stated limit always restricts an unlimited side"
+        );
+        assert_eq!(c.limits.cpu_time_secs, None, "both unlimited → unlimited");
+    }
+
+    #[test]
+    fn compose_trust_picks_strictest() {
+        use TrustPreference::*;
+        // Symmetry matrix — strictest_trust must be commutative.
+        for (a, b, want) in [
+            (Auto, Auto, Auto),
+            (Auto, Require, Require),
+            (Require, Auto, Require),
+            (Require, Require, Require),
+            (Auto, Forbid, Forbid),
+            (Forbid, Auto, Forbid),
+            (Require, Forbid, Forbid),
+            (Forbid, Require, Forbid),
+            (Forbid, Forbid, Forbid),
+        ] {
+            let p = SandboxPolicy {
+                trust: a,
+                ..Default::default()
+            };
+            let c = SandboxPolicy {
+                trust: b,
+                ..Default::default()
+            };
+            assert_eq!(
+                SandboxPolicy::compose(&p, &c).trust,
+                want,
+                "trust({a:?}, {b:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn compose_idempotent_with_self() {
+        // compose(p, p) == p when p has no duplicate-causing fields.
+        // Defensive: catches any rule that mutates the parent on echo.
+        let p = SandboxPolicy {
+            fs: FsPolicy {
+                deny_read: vec!["/a".into()],
+                allow_write: vec!["/work".into()],
+                allow_git_config: true,
+                ..Default::default()
+            },
+            limits: ResourceLimits {
+                wall_time_secs: Some(45),
+                ..Default::default()
+            },
+            trust: TrustPreference::Require,
+            ..Default::default()
+        };
+        assert_eq!(
+            SandboxPolicy::compose(&p, &p),
+            p,
+            "composing a policy with itself must equal the original"
+        );
+    }
+
+    #[test]
+    fn compose_mitm_inherited_from_parent_only() {
+        // MITM is session-wide config, not a sub-agent-overridable knob.
+        let mitm = MitmConfig {
+            ca_bundle: "/cert.pem".into(),
+            socket_map: vec![],
+        };
+        let parent = SandboxPolicy {
+            net: NetPolicy {
+                mitm: Some(mitm.clone()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let child = SandboxPolicy::default(); // no MITM
+        assert_eq!(
+            SandboxPolicy::compose(&parent, &child).net.mitm,
+            Some(mitm),
+            "parent MITM must survive composing with a no-MITM child"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Stage 3 of the Phase 5 split:
- **PR-1 (#1012, merged):** plumbed `policy: &SandboxPolicy` through `sandbox::build`
- **PR-2 (#1014, merged):** named constructor `policy_for_agent` + threading from registry to dispatch
- **PR-3 (this):** populate the policy with non-default values + add `compose()` for additive sub-agent policies

This PR is the first one that's not pure plumbing — it actually changes what the policy *contains*. Behavior change is minimal and pinned: `wall_time_secs = Some(60)` for every trust mode (matches the pre-PR `DEFAULT_TIMEOUT_SECS` constant byte-for-byte).

## What's new

### 1. `SandboxPolicy::compose(parent, child)` — pure function

Combines two policies under the rule **'child can only narrow the parent'** — the security intuition that a forked sub-agent inherits the parent's restrictions and adds its own on top.

| Field | Rule |
|---|---|
| denies (fs/net) | union |
| `allow_read_within_deny` | union |
| `allow_write` / `allowed_domains` | parent-wins (anti-escalation) |
| `allow_git_config` / `allow_local_binding` / `weaker_macos_isolation` | logical AND |
| `mitm` | parent-wins (session-wide config) |
| `limits.*` | minimum (None = unlimited; presence beats absence) |
| `trust` | strictest (Forbid > Require > Auto) |

**Allow-list semantics** use 'parent values' instead of true intersection because path-pattern intersection is gnarly without a real prefix lattice. Documented + revisitable in PR-4+.

**Not wired into `sub_agent_dispatch` yet** — needs parent-policy threading through dispatch, which is more invasive. Deferred to PR-4. The pure function ships now so PR-4 is wiring-only.

### 2. Resource-limit defaults in `policy_for_agent`

`limits.wall_time_secs` is now populated for every trust mode (60s across all three today). PR-3's job is the **lift** (make limits policy-driven, not hardcoded), not the retune. We change values once we have telemetry; we change *where the values live* now so the retune is one line later.

Other limits (CPU/RSS/FDs/output) stay `None` until the runtime grows actual enforcement — declared but unused. `policy_for_agent_leaves_other_limits_unlimited` pins this so we don't lie about enforcement.

### 3. Bash dispatch reads `policy.limits.wall_time_secs`

New timeout precedence:

1. explicit `timeout` arg (model-supplied per-call) — wins
2. `policy.limits.wall_time_secs` (per-agent default)
3. `DEFAULT_TIMEOUT_SECS` legacy const fallback

Hard ceiling `MAX_TIMEOUT_SECS` (300s) clamps **all three** — keeps the DoS protection that the LLM can't widen its own deadline by asking for a 1-hour run, *and* a sub-agent can't be handed a generous wall_time policy that bypasses the global ceiling.

## Test pinning

| Area | Tests added | Pins |
|---|---|---|
| compose semantics | 9 | one per per-field rule + idempotence + MITM |
| `policy_for_agent` | 2 | wall_time set; other limits unlimited |
| timeout precedence | 4 | each precedence rung + ceiling clamps policy too |

`compose_drops_child_allow_writes_so_child_cannot_widen` is the load-bearing test: it pins the anti-privilege-escalation contract that any future change to allow-list semantics must consciously break.

## Verification

```
cargo clippy -p koda-core -p koda-sandbox --all-targets -- -D warnings  -> clean
cargo test -p koda-core --lib    -> 1001 passed; 0 failed; 1 ignored
cargo test -p koda-sandbox --lib -> 288 passed;  0 failed
```

Diff: **+485 -36** across 3 files. ~75% of the diff is rustdoc tables + tests.

## What's left in Phase 5

- 🟡 wire `compose` into `sub_agent_dispatch` (PR-4 — needs parent-policy threading)
- 🟡 `mandatoryDenySearchDepth` config knob
- 🟡 actual enforcement of CPU/RSS/FDs/output limits (currently declared-only)
- 🟡 docs: `koda-sandbox/README.md` threat model + escape hatches

Refs #934.