### PR TITLE
koda-core: wire SandboxPolicy::compose into sub-agent dispatch (#934 phase 5 PR-4)

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -210,6 +210,32 @@ pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> 
     });
     policy
 }
+
+/// Compute a sub-agent's effective policy by composing the parent's
+/// active policy with the sub-agent's per-trust derivation.
+///
+/// Phase 5 PR-4 of #934. Convenience wrapper over
+/// [`policy_for_agent`] + [`SandboxPolicy::compose`] so the dispatch
+/// site stays a one-liner and the policy-derivation logic is unit-
+/// testable in isolation (the full async dispatch path is awkward to
+/// drive from a unit test).
+///
+/// Parent-policy passing convention: callers without a meaningful
+/// parent (top-level invocations, bg-spawned agents whose parent has
+/// already returned) pass [`SandboxPolicy::strict_default`] — that's
+/// the algebraic identity for the union/AND/min rules in `compose`,
+/// so it has the effect of "child policy wins".
+///
+/// Returns a policy whose surface is **strictly no more permissive
+/// than the parent**: see `compose` rustdoc for the per-field rules.
+pub fn compose_child_policy(
+    parent: &SandboxPolicy,
+    sub_trust: crate::trust::TrustMode,
+    project_root: &Path,
+) -> SandboxPolicy {
+    let child = policy_for_agent(sub_trust, project_root);
+    SandboxPolicy::compose(parent, &child)
+}
 /// execution on, e.g., Linux without `bwrap` installed — surprising
 /// behavior that the previous `build_inner()` path warned about explicitly.
 fn warn_if_unavailable_once(runtime: &dyn SandboxRuntime) {
@@ -1016,6 +1042,82 @@ mod tests {
         let _ = policy_for_agent(
             crate::trust::TrustMode::Safe,
             std::path::Path::new("/nonexistent/path/that/should/not/exist"),
+        );
+    }
+
+    // ── Phase 5 PR-4 of #934: `compose_child_policy` wiring ──
+    //
+    // PR-3 added `SandboxPolicy::compose` as a pure function with its
+    // own tests in koda-sandbox. PR-4 wires it into sub-agent dispatch
+    // through `compose_child_policy`. These tests pin that the wrapper
+    // *actually calls compose* (not just `policy_for_agent`) and that
+    // the parent's restrictions are honored end-to-end.
+
+    #[test]
+    fn compose_child_policy_with_strict_default_parent_is_just_child_policy() {
+        // Identity case: when there's no meaningful parent (top-level
+        // invocation, bg-spawned agent), `strict_default()` is the
+        // algebraic identity. The composed policy should equal what
+        // `policy_for_agent` would have returned alone.
+        let dir = tempfile::tempdir().unwrap();
+        let parent = SandboxPolicy::strict_default();
+        let composed = compose_child_policy(&parent, crate::trust::TrustMode::Safe, dir.path());
+        let child_alone = policy_for_agent(crate::trust::TrustMode::Safe, dir.path());
+        assert_eq!(
+            composed, child_alone,
+            "strict_default parent must be the identity for compose"
+        );
+    }
+
+    #[test]
+    fn compose_child_policy_inherits_parent_denies() {
+        // Parent restriction that the child doesn't know about must
+        // survive into the composed policy. This is the load-bearing
+        // contract: a parent that bans /etc/secrets can't be widened
+        // by a child that has no opinion on /etc/secrets.
+        let dir = tempfile::tempdir().unwrap();
+        let mut parent = SandboxPolicy::strict_default();
+        parent
+            .fs
+            .deny_read
+            .push(koda_sandbox::PathPattern::new("/etc/secrets"));
+        let composed = compose_child_policy(&parent, crate::trust::TrustMode::Safe, dir.path());
+        assert!(
+            composed
+                .fs
+                .deny_read
+                .contains(&koda_sandbox::PathPattern::new("/etc/secrets")),
+            "parent's deny_read must survive composing with the child"
+        );
+    }
+
+    #[test]
+    fn compose_child_policy_takes_tighter_wall_time() {
+        // When parent has wall_time=10 and child policy_for_agent says
+        // 60, the composed wall_time must be 10 (min). This proves
+        // compose's `min_opt` rule is reachable through the wrapper.
+        let dir = tempfile::tempdir().unwrap();
+        let mut parent = SandboxPolicy::strict_default();
+        parent.limits.wall_time_secs = Some(10);
+        let composed = compose_child_policy(&parent, crate::trust::TrustMode::Safe, dir.path());
+        assert_eq!(
+            composed.limits.wall_time_secs,
+            Some(10),
+            "parent's tighter wall_time must beat the child's looser default"
+        );
+    }
+
+    #[test]
+    fn compose_child_policy_takes_strictest_trust() {
+        // Parent: Forbid (most restrictive). Child: Auto (least). Result: Forbid.
+        let dir = tempfile::tempdir().unwrap();
+        let mut parent = SandboxPolicy::strict_default();
+        parent.trust = koda_sandbox::TrustPreference::Forbid;
+        let composed = compose_child_policy(&parent, crate::trust::TrustMode::Auto, dir.path());
+        assert_eq!(
+            composed.trust,
+            koda_sandbox::TrustPreference::Forbid,
+            "strictest trust wins regardless of which side it came from"
         );
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -64,6 +64,15 @@ async fn run_bg_agent(
         &sub_agent_cache,
         &parent_session,
         &nested_bg,
+        // Phase 5 PR-4 of #934: bg-spawned sub-agents have no live
+        // parent registry to pull a policy from (the spawning agent
+        // already returned). `strict_default()` is the safe choice —
+        // it means "no extra parent restrictions" so the child's own
+        // `policy_for_agent` result wins. If we later make the main
+        // agent registry-policy non-default, we should snapshot it
+        // into the bg-agent task at spawn time so this path inherits
+        // the same restrictions.
+        &koda_sandbox::SandboxPolicy::strict_default(),
     )
     .await;
 
@@ -95,6 +104,12 @@ pub(crate) async fn execute_sub_agent(
     sub_agent_cache: &SubAgentCache,
     parent_session_id: &str,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    // Phase 5 PR-4 of #934: parent's effective sandbox policy. The
+    // child policy is composed onto this so the child can only narrow,
+    // never widen — see [`koda_sandbox::SandboxPolicy::compose`] for
+    // the per-field rules. Pass `&SandboxPolicy::strict_default()`
+    // when there is no meaningful parent (top-level invocation).
+    parent_sandbox_policy: &koda_sandbox::SandboxPolicy,
 ) -> Result<String> {
     let args: serde_json::Value = serde_json::from_str(arguments)?;
     let agent_name = args["agent_name"].as_str().unwrap_or("task");
@@ -309,16 +324,19 @@ pub(crate) async fn execute_sub_agent(
             sub_config.max_context_tokens,
             sub_config.trust,
         );
-        // Phase 5 PR-2 of #934: install the sub-agent's sandbox policy.
-        // Today `policy_for_agent` returns `strict_default()` for every
-        // input so behavior is unchanged — the wiring exists so PR-3 can
-        // start populating the policy with non-default values (e.g.
-        // narrower fs.allow_write for read-only sub-agents) without
-        // touching this dispatch site again.
-        let registry = registry.with_sandbox_policy(crate::sandbox::policy_for_agent(
+        // Phase 5 PR-4 of #934: compose the parent's effective policy
+        // with the child's. Per-field rules in [`SandboxPolicy::compose`]
+        // (denies union, allows parent-wins, limits min, trust strictest)
+        // ensure the child can never widen the parent's surface — only
+        // narrow it. PR-2 installed the child policy verbatim; PR-4
+        // makes the install additive over the parent so chains of
+        // sub-agents accumulate restrictions monotonically.
+        let composed_policy = crate::sandbox::compose_child_policy(
+            parent_sandbox_policy,
             sub_config.trust,
             effective_root_ref,
-        ));
+        );
+        let registry = registry.with_sandbox_policy(composed_policy);
         match parent_cache {
             Some(cache) => registry.with_shared_cache(cache),
             None => registry,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -223,6 +223,9 @@ pub(crate) async fn execute_one_tool(
             sub_agent_cache,
             _session_id,
             bg_agents,
+            // Phase 5 PR-4 of #934: hand the parent's effective policy
+            // to the child so `compose()` can stack restrictions.
+            tools.sandbox_policy(),
         )
         .await
         {


### PR DESCRIPTION
## Summary

Closes the Phase 5 `compose` work that #1015 (PR-3) parked as a pure function. PR-4 is **wiring-only**: every sub-agent's effective policy is now `compose(parent_policy, policy_for_agent(sub.trust))` so chains of sub-agents accumulate restrictions monotonically.

## Series so far

| | What | Status |
|---|---|---|
| #1010 | telemetry hooks | ✅ merged |
| #1012 | PR-1: SandboxPolicy plumbing | ✅ merged |
| #1013 | item 2: Auto requires sandbox | ✅ merged |
| #1014 | PR-2: constructor + threading | ✅ merged |
| #1015 | PR-3: compose() + wall-time defaults | ✅ merged |
| **PR-4** | **wire compose into sub-agent dispatch** | **this** |

## What changed

### 1. `execute_sub_agent` takes a `parent_sandbox_policy` parameter

New trailing arg, documented as: pass `strict_default()` when there is no meaningful parent (top-level invocations / bg-spawned children whose parent has already returned). `strict_default()` is the algebraic identity for the union/AND/min rules in `compose`, so it has the effect of 'child policy wins' in the no-parent case.

### 2. `tool_dispatch::execute_one_tool` passes `tools.sandbox_policy()`

The parent registry already owns the active policy (PR-2 plumbing); PR-4 just reads it and hands it to the dispatch. No churn at any other call site.

### 3. New helper: `koda_core::sandbox::compose_child_policy`

Convenience wrapper: `compose(parent, policy_for_agent(sub_trust, root))`. Lives in `koda-core` (not `koda-sandbox`) because it composes a koda-core-authored child (`policy_for_agent`) with a koda-sandbox-authored `compose`. Keeps the dispatch site a one-liner and the policy derivation logic unit-testable in isolation — the full async dispatch path is awkward to drive from a unit test.

## Behavior change today

**Effectively zero** for the production parent (main agent). The main agent registry still seeds `SandboxPolicy::strict_default()` (no PR has wired the main agent through `policy_for_agent` yet — deferred to a later PR once we have a use case for non-default main-agent restrictions).

`compose(strict_default(), child) = child` for the per-trust defaults #1015 introduced, so sub-agents see the same `wall_time = Some(60)` they saw before. **The wiring matters when:**

- The main agent later gets non-default policy (e.g. a user-supplied per-project policy file). Today's PR-4 means that change ripples through to all sub-agents *automatically*, no dispatch-site churn.
- A sub-agent invokes another sub-agent (compose chains).

## Test pinning

Four unit tests on the new `compose_child_policy` helper:

| Test | Pins |
|---|---|
| `compose_child_policy_with_strict_default_parent_is_just_child_policy` | identity case |
| `compose_child_policy_inherits_parent_denies` | parent restrictions survive (load-bearing security contract) |
| `compose_child_policy_takes_tighter_wall_time` | min-rule from compose is reachable via the wrapper |
| `compose_child_policy_takes_strictest_trust` | strictness rule from compose is reachable via the wrapper |

`compose_child_policy_inherits_parent_denies` is the load-bearing test: any future refactor of the helper that drops parent denies fails this test by name.

## Verification

```
cargo clippy -p koda-core -p koda-sandbox --all-targets -- -D warnings  -> clean
cargo test -p koda-core --lib  -> 1005 passed; 0 failed; 1 ignored
                                  (1001 + 4 new compose_child tests)
```

Diff: **+131 -8** across 3 files. Pure mechanical wiring + tests.

## What's left in Phase 5

- 🟡 `mandatoryDenySearchDepth` config knob (PR-5)
- 🟡 actual enforcement of CPU/RSS/FDs/output limits (PR-6 — currently declared-only)
- 🟡 `koda-sandbox/README.md` threat model + escape hatches (PR-7, docs only)
- 🟢 (later) wire main-agent registry through `policy_for_agent` so non-default main policies actually flow

Refs #934.