### PR TITLE
fix(bg-agent): enforce parent trust, cancel, sandbox, lifecycle (#1022 B1-B4)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,12 +153,26 @@ Studied four projects:
 - **xi-editor**: Used stdio JSON-RPC. Discontinued. Lesson: protocol becomes
   bottleneck when core and frontend are separate processes.
 - **Zed**: Keeps `agent` (engine) and `agent_ui` (rendering) as separate crates
-  in the same binary. Engine has zero UI imports.
+  in the same binary. Engine has zero UI imports — but it *does* import
+  `gpui`, `project`, `fs`, and `language_model`. Zed's "engine" is a
+  gpui-flavored library; you cannot run `Thread` outside a `gpui::App`.
 - **Goose**: Rust engine + ACP server + multiple frontends (Electron, Ink TUI, CLI).
 - **Neovim**: C core + msgpack-RPC. Terminal TUI is just one client.
 
-**Zed's approach wins**: engine and primary client in the same binary. Server
-mode is optional for external clients.
+**Zed's approach inspires; Koda finishes the job**: engine and primary client
+in the same binary, server mode optional. But Koda goes one step further than
+Zed — `koda-core` has zero IO, all output goes through `EngineSink`, all
+input arrives via `EngineCommand` over `mpsc::Receiver`, and `EngineEvent` is
+`Serialize`. The proof is the ACP server in `koda-cli/src/server.rs` (~430 LOC)
+vs. Zed's equivalent in `zed/crates/agent_servers/src/acp.rs` (~3,467 LOC) —
+Koda's smaller because the engine boundary is a serializable enum, not a
+bridge between gpui's `Entity`/`Task` world and the wire protocol.
+
+**Concrete consequence**: `KodaAgent` (immutable, `Arc`-shared) is separated
+from `KodaSession` (per-conversation, mutable). Zed conflates these into
+`Thread`. The split is what makes parallel sub-agents safe: each sub-agent
+shares the agent definition by `Arc` and has its own session for state. No
+`Arc<RwLock<>>` everywhere.
 
 ### ACP (Agent Client Protocol) (P3)
 
@@ -302,6 +316,93 @@ The biggest cost lever — expensive models think, cheap models grunt. A scout
 on Gemini Flash costs 1/20th of Opus for codebase exploration. The parent's
 Anthropic prompt cache is unaffected because sub-agents make independent API
 calls to potentially different providers.
+
+### Sub-Agent Lifecycle (P2, P3)
+
+Four execution modes, one mental model:
+
+1. **Sequential foreground** (`InvokeAgent { prompt }`) — one sub-agent at a
+   time, blocks the parent loop until done. Default.
+2. **Parallel foreground** (multiple `InvokeAgent` calls in one batch) —
+   `tool_dispatch::execute_tools_parallel` runs them concurrently via
+   `futures_util::future::join_all`. Each gets its own DB session and (if
+   write-capable) its own workspace.
+3. **Background fire-and-forget** (`InvokeAgent { prompt, background: true }`)
+   — spawned via `tokio::task::spawn_blocking` onto a per-task
+   `new_current_thread` runtime, with the resulting `JoinHandle` held
+   by `BgAgentRegistry` as an `AbortOnDropHandle`. The inference loop
+   drains completed handles before each iteration via
+   `BgAgentRegistry::drain_completed()` and injects results as user
+   messages. Bg-spawned agents cannot themselves spawn bg agents
+   (override `background: false`). The current-thread runtime exists
+   only because `execute_sub_agent`'s future is not yet `Send`;
+   collapsing to a plain `tokio::spawn` is tracked separately and
+   does not change the invariants below.
+4. **Forked context** (`agent_name="fork"`) — copies the parent's full
+   conversation history into the new session. Fork children cannot spawn
+   sub-agents (recursion guard).
+
+**Invariants** — enforced consistently across all four modes:
+
+- **Trust never widens**. `derive_child_trust(parent, declared) =
+  TrustMode::clamp(parent, declared)` is the *only* way to compute child
+  trust. Same helper for fork, named, and bg paths.
+- **Sandbox never widens**. `compose_child_policy(parent_policy, child_trust,
+  root)` calls `SandboxPolicy::compose()` (denies = union, allows = intersect,
+  limits = min). Bg agents snapshot the parent's effective policy at spawn
+  time — they do not regress to `strict_default()`.
+- **Cancellation cascades**. Sub-agents receive `parent_cancel.child_token()`
+  via `tokio_util::sync::CancellationToken`. Bg agents are no exception:
+  Ctrl+C in the parent kills in-flight bg work. `tokio::task::JoinSet` (or
+  `AbortOnDropHandle`) ensures registry drop = task abort = workspace release.
+- **Workspace isolation** (P3). Write-capable sub-agents get an isolated
+  worktree (macOS: `ClonefileProvider` ~3-4× faster; Linux:
+  `GitWorktreeProvider`). Read-only agents share the parent root via
+  `CwdProvider`. Parallel write-agents cannot trample each other.
+- **Result caching** (P1, cost lever). `SubAgentCache` keyed by
+  `(agent_name, prompt_hash)`. Cache hits = no LLM call. Invalidated on any
+  mutating tool — including mutations performed *inside* a sub-agent.
+
+**What we considered and rejected**:
+
+- **Codex's collab v2 surface** (`spawn_agent`/`send_input`/`wait_agent`/
+  `close_agent`/`resume_agent`, persistent ThreadId-addressed agents,
+  inter-agent mailboxes). ~3,000 LOC for a workflow that's rare in personal
+  use. P2 says no. The `background: true` + drain-on-next-iter pattern
+  covers the same ground in 200 LOC. If the model wants more work it just
+  calls `InvokeAgent` again.
+- **Codex's `agent_max_depth` + `agent_max_threads` atomic CAS reservations**.
+  Koda's hardcoded "fork children cannot spawn sub-agents" + per-agent
+  iteration cap covers 99% of footguns at zero cost. Revisit only if a model
+  actually loops infinitely via depth.
+- **Claude Code's seven-typed `Task` taxonomy**
+  (`local_bash | local_agent | remote_agent | in_process_teammate | ...`).
+  Exactly the "feature surface for many users" P1 rejects. `BgAgentRegistry`
+  + `BgRegistry` (for bash) cover the "long-running thing with a result"
+  case in 200 lines. Don't grow a `trait Task`.
+- **Gemini CLI's LLM-based loop detection** (asks the model "are you stuck?"
+  every 10–15 turns at extra token cost). Apex form of the anti-pattern P3
+  warns about — "don't scaffold around weakness". Frontier models won't need
+  this in six months.
+- **Code Puppy's plugin system** (`callbacks.py` with 30+ hooks, agent
+  frontmatter that can spawn its own MCP servers). Direct violation of P1
+  "customization over configuration". Per-agent MCP = per-agent trust audit.
+
+**What we deferred** (architecture supports it; we'll add when the bug exists):
+
+- **Per-tool `is_concurrency_safe(args)` predicate** (Gemini CLI). Would let
+  read-only `Bash` (e.g. `ls`, `cat`) join the parallel batch. Today all
+  `Bash` is forced sequential. `bash_safety.rs` already does the analysis
+  — surfacing it as a `ToolRegistry` method is ~80 LOC.
+- **Sibling-cancel on parallel `Bash` failure** (Claude Code). Per-batch
+  child `CancellationToken` + typed `[Cancelled: parallel call X errored]`
+  result. ~30 LOC.
+- **Streaming tool inputs** (Zed `supports_input_streaming`). High-value
+  for `Edit`/`Bash` but requires reworking `ToolRegistry::execute` to take
+  a stream. P1 says wait for the bug.
+- **`FuturesUnordered` instead of `join_all`** for parallel tool execution
+  — emits results as they complete instead of after the slowest. ~20 LOC
+  win, no protocol change.
 
 ---
 
@@ -455,7 +556,10 @@ the [trust module docs](https://docs.rs/koda-core/latest/koda_core/trust/).
 
 **Key design choices**:
 - Sub-agents inherit the parent’s trust mode (clamped via `TrustMode::clamp()`
-  — child can never run with less protection than parent)
+  — child can never run with less protection than parent). The clamp is the
+  *single source of truth* across all four sub-agent modes (sequential,
+  parallel, background, fork) — there is no path that hard-codes a child
+  trust value. Same rule for sandbox policy via `SandboxPolicy::compose()`.
 - **Kernel-level sandboxing** — always active. macOS uses `sandbox-exec`
   (seatbelt); Linux uses `bwrap` (bubblewrap). Credential directories
   are always protected.

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -10,7 +10,17 @@
 //! 2. **Track**: the task handle + metadata are stored in `BgAgentRegistry`
 //! 3. **Poll**: before each inference call, the loop calls `drain_completed()`
 //! 4. **Inject**: completed results are appended as user messages
-//! 5. **Cleanup**: on session end, all pending tasks are cancelled
+//! 5. **Cleanup**: on registry drop, all pending task handles are aborted —
+//!    no orphan futures, no leaked worktrees. (Phase 1 of #1022, B3.)
+//!
+//! ## Cancellation cascade
+//!
+//! Bg-agent tasks receive a `CancellationToken` derived from the parent's
+//! token via `child_token()` (wired in `crate::sub_agent_dispatch`). When
+//! the parent is cancelled, every bg child sees it; when the registry
+//! drops without cancellation, [`tokio_util::task::AbortOnDropHandle`]
+//! still aborts the futures so we never leak. Both paths are covered.
+//! (Phase 1 of #1022, B2+B3.)
 //!
 //! ## Thread safety
 //!
@@ -20,6 +30,8 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::AbortOnDropHandle;
 
 /// A completed background agent result.
 #[derive(Debug)]
@@ -35,10 +47,30 @@ pub struct BgAgentResult {
 }
 
 /// Handle returned when a background agent is spawned.
+///
+/// Holds the task's [`tokio_util::task::AbortOnDropHandle`] so the
+/// future is aborted if the registry is dropped before the task
+/// completes (B3 of #1022). Also holds the per-task
+/// [`CancellationToken`] so future per-task cancel commands
+/// (`/cancel <id>` — see #996) have a hook to fire.
 struct BgAgentEntry {
     agent_name: String,
     prompt: String,
     rx: oneshot::Receiver<Result<String, String>>,
+    /// Per-task cancel — derived as a `child_token()` of the parent
+    /// session's token at spawn time. Firing this token causes the
+    /// in-flight bg agent to observe `is_cancelled()` on its next
+    /// loop iteration. Currently used only for the registry-drop
+    /// path; per-task cancel UX lands in #996.
+    #[allow(dead_code)]
+    cancel: CancellationToken,
+    /// Aborts the spawned task on drop. Today the bg path uses
+    /// `spawn_blocking` (because `execute_sub_agent`'s future is
+    /// not yet `Send` — see #1022 B5). The `JoinHandle` returned
+    /// by `spawn_blocking` is still abortable, though abort is a
+    /// no-op while the inner blocking call is in flight; the
+    /// cancel-token cascade is the primary stop signal.
+    _handle: AbortOnDropHandle<()>,
 }
 
 /// Registry of running background sub-agents.
@@ -50,6 +82,33 @@ pub struct BgAgentRegistry {
     next_id: Mutex<u32>,
 }
 
+/// Reservation slot returned by [`BgAgentRegistry::reserve`].
+///
+/// The two-phase pattern (`reserve` → spawn → `attach`) lets the
+/// dispatcher hand the oneshot sender into the spawned future
+/// *before* the future exists, so the spawned closure can `move` it
+/// without referencing the registry. The `cancel` token is a
+/// `child_token()` of the parent's cancel — fires either when the
+/// parent fires (cascade) or when this slot is individually cancelled
+/// (future per-task `/cancel <id>` UX, #996).
+pub struct BgAgentReservation {
+    /// Monotonically-assigned task ID. Surfaces in user-facing
+    /// messages (`Background agent 'foo' started (task 7)`) and
+    /// will key the future per-task `/cancel <id>` UX (#996).
+    pub task_id: u32,
+    /// Sender half of the result oneshot. Move into the spawned
+    /// future so it can deliver `Ok(output)` / `Err(message)`.
+    pub tx: oneshot::Sender<Result<String, String>>,
+    /// Receiver half. Move back into the registry via [`BgAgentRegistry::attach`]
+    /// so `drain_completed()` can poll it.
+    pub rx: oneshot::Receiver<Result<String, String>>,
+    /// Per-task cancel token. Cloned for the spawned future
+    /// (`bg_cancel`) and re-stored on the registry entry
+    /// (`entry_cancel`); both halves observe parent cancellation
+    /// because this is a `child_token()` of the parent.
+    pub cancel: CancellationToken,
+}
+
 impl BgAgentRegistry {
     /// Create an empty registry.
     pub fn new() -> Self {
@@ -59,9 +118,61 @@ impl BgAgentRegistry {
         }
     }
 
-    /// Register a background agent task. Returns the task ID and a sender
-    /// that the spawned task uses to deliver the result.
-    pub fn register(
+    /// Reserve a task ID and produce a oneshot sender + child cancel
+    /// token for the spawn site to consume. Call [`Self::attach`] with
+    /// the resulting `JoinHandle` to complete registration.
+    ///
+    /// The two-phase shape exists because `tokio::spawn` produces the
+    /// `JoinHandle` *after* the future is built, but the future needs
+    /// to own the `tx` to deliver its result. Reservation gives us
+    /// `tx` early; attach binds the handle once it exists.
+    pub fn reserve(&self, parent_cancel: &CancellationToken) -> BgAgentReservation {
+        let (tx, rx) = oneshot::channel();
+        let mut id = self.next_id.lock().unwrap();
+        let task_id = *id;
+        *id += 1;
+        BgAgentReservation {
+            task_id,
+            tx,
+            rx,
+            cancel: parent_cancel.child_token(),
+        }
+    }
+
+    /// Bind a spawned task's metadata to a previously [`reserve`]d slot.
+    ///
+    /// `rx` must be the receiver paired with the `tx` handed out by
+    /// `reserve`. Holding `handle` as `AbortOnDropHandle` ensures the
+    /// task is aborted on registry drop (B3 of #1022).
+    ///
+    /// [`reserve`]: Self::reserve
+    pub fn attach(
+        &self,
+        reservation_id: u32,
+        agent_name: &str,
+        prompt: &str,
+        rx: oneshot::Receiver<Result<String, String>>,
+        cancel: CancellationToken,
+        handle: tokio::task::JoinHandle<()>,
+    ) {
+        self.pending.lock().unwrap().insert(
+            reservation_id,
+            BgAgentEntry {
+                agent_name: agent_name.to_string(),
+                prompt: prompt.to_string(),
+                rx,
+                cancel,
+                _handle: AbortOnDropHandle::new(handle),
+            },
+        );
+    }
+
+    /// Convenience for tests: register a synthetic entry without a
+    /// real spawned task. The provided `tx` can be used to fire the
+    /// result manually. The handle is a noop spawned task that
+    /// returns immediately, so `_handle` has something to abort.
+    #[cfg(test)]
+    pub fn register_test(
         &self,
         agent_name: &str,
         prompt: &str,
@@ -71,16 +182,18 @@ impl BgAgentRegistry {
         let task_id = *id;
         *id += 1;
         drop(id);
-
+        let cancel = CancellationToken::new();
+        let noop = tokio::spawn(async {});
         self.pending.lock().unwrap().insert(
             task_id,
             BgAgentEntry {
                 agent_name: agent_name.to_string(),
                 prompt: prompt.to_string(),
                 rx,
+                cancel,
+                _handle: AbortOnDropHandle::new(noop),
             },
         );
-
         (task_id, tx)
     }
 
@@ -146,6 +259,32 @@ impl Default for BgAgentRegistry {
     }
 }
 
+impl Drop for BgAgentRegistry {
+    /// Abort every still-pending bg task on registry drop.
+    ///
+    /// `AbortOnDropHandle::drop` does the work — this impl exists
+    /// only to make the lifecycle explicit and to give a single
+    /// place to add telemetry later.
+    fn drop(&mut self) {
+        // Try to lock; if poisoned (a thread panicked while holding
+        // it) we still want to drain the entries so their handles
+        // get dropped. `into_inner` on a poisoned guard surfaces the
+        // map regardless of poison state.
+        let map = match self.pending.get_mut() {
+            Ok(map) => std::mem::take(map),
+            Err(poisoned) => std::mem::take(poisoned.into_inner()),
+        };
+        if !map.is_empty() {
+            tracing::debug!(
+                count = map.len(),
+                "BgAgentRegistry dropped with pending tasks; aborting"
+            );
+        }
+        // Map drops here → each entry's `AbortOnDropHandle` aborts
+        // its task. No orphans. No leaked worktrees.
+    }
+}
+
 /// Wrap in Arc for sharing between inference loop and tool dispatch.
 pub fn new_shared() -> Arc<BgAgentRegistry> {
     Arc::new(BgAgentRegistry::new())
@@ -154,11 +293,13 @@ pub fn new_shared() -> Arc<BgAgentRegistry> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
 
-    #[test]
-    fn register_and_complete() {
+    #[tokio::test]
+    async fn register_and_complete() {
         let reg = BgAgentRegistry::new();
-        let (task_id, tx) = reg.register("explore", "find all tests");
+        let (task_id, tx) = reg.register_test("explore", "find all tests");
         assert_eq!(task_id, 1);
         assert_eq!(reg.pending_count(), 1);
 
@@ -175,11 +316,11 @@ mod tests {
         assert_eq!(reg.pending_count(), 0);
     }
 
-    #[test]
-    fn drain_only_completed() {
+    #[tokio::test]
+    async fn drain_only_completed() {
         let reg = BgAgentRegistry::new();
-        let (_id1, tx1) = reg.register("task", "build");
-        let (_id2, _tx2) = reg.register("explore", "search");
+        let (_id1, tx1) = reg.register_test("task", "build");
+        let (_id2, _tx2) = reg.register_test("explore", "search");
 
         tx1.send(Ok("done".to_string())).unwrap();
 
@@ -189,10 +330,10 @@ mod tests {
         assert_eq!(reg.pending_count(), 1); // explore still pending
     }
 
-    #[test]
-    fn dropped_sender_reports_cancelled() {
+    #[tokio::test]
+    async fn dropped_sender_reports_cancelled() {
         let reg = BgAgentRegistry::new();
-        let (_id, tx) = reg.register("task", "build");
+        let (_id, tx) = reg.register_test("task", "build");
         drop(tx); // simulate task panic/cancel
 
         let results = reg.drain_completed();
@@ -201,15 +342,100 @@ mod tests {
         assert!(results[0].output.contains("cancelled"));
     }
 
-    #[test]
-    fn error_result() {
+    #[tokio::test]
+    async fn error_result() {
         let reg = BgAgentRegistry::new();
-        let (_id, tx) = reg.register("verify", "check");
+        let (_id, tx) = reg.register_test("verify", "check");
         tx.send(Err("test failures".to_string())).unwrap();
 
         let results = reg.drain_completed();
         assert_eq!(results.len(), 1);
         assert!(!results[0].success);
         assert_eq!(results[0].output, "test failures");
+    }
+
+    /// Phase 1 of #1022, B3 regression test: dropping the registry
+    /// must abort still-running spawned tasks. Without
+    /// `AbortOnDropHandle` (or an explicit `JoinHandle::abort` in
+    /// `Drop`), the spawned future would keep running after the
+    /// registry — and any worktrees / API tokens / writes it owns —
+    /// were dropped. That's the leak we're fixing.
+    #[tokio::test]
+    async fn registry_drop_aborts_pending_tasks() {
+        let reg = BgAgentRegistry::new();
+        let parent = CancellationToken::new();
+        let reservation = reg.reserve(&parent);
+        let task_id = reservation.task_id;
+        let cancel_for_task = reservation.cancel.clone();
+        let tx = reservation.tx;
+        let rx = reservation.rx;
+        let cancel_for_entry = reservation.cancel;
+
+        // Use a flag the task sets only if it ever finishes a full
+        // sleep. If abort works, the flag stays false even though
+        // we wait long enough for a non-aborted task to finish.
+        let ran_to_completion = Arc::new(AtomicBool::new(false));
+        let flag = ran_to_completion.clone();
+        let handle = tokio::spawn(async move {
+            // Either the cancel token fires (parent cascade) or we
+            // get aborted (drop cascade). The slow sleep just gives
+            // the test time to drop the registry before we'd
+            // naturally finish.
+            tokio::select! {
+                _ = cancel_for_task.cancelled() => {}
+                _ = tokio::time::sleep(Duration::from_secs(60)) => {
+                    flag.store(true, Ordering::SeqCst);
+                }
+            }
+            let _ = tx.send(Ok("done".to_string()));
+        });
+        reg.attach(
+            task_id,
+            "explore",
+            "long task",
+            rx,
+            cancel_for_entry,
+            handle,
+        );
+
+        // Give the task a tick to start.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(reg.pending_count(), 1);
+
+        // Drop the registry — this must abort the spawned task.
+        drop(reg);
+
+        // Yield long enough for the abort to land; well under the
+        // 60 s sleep the task would have completed otherwise.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !ran_to_completion.load(Ordering::SeqCst),
+            "task slept to completion — AbortOnDropHandle did not abort it"
+        );
+    }
+
+    /// Phase 1 of #1022, B2 regression test: cancelling the parent
+    /// token must cascade to bg-agent child tokens handed out by
+    /// `reserve`.
+    #[tokio::test]
+    async fn parent_cancel_cascades_to_reserved_child() {
+        let reg = BgAgentRegistry::new();
+        let parent = CancellationToken::new();
+        let r1 = reg.reserve(&parent);
+        let r2 = reg.reserve(&parent);
+
+        assert!(!r1.cancel.is_cancelled());
+        assert!(!r2.cancel.is_cancelled());
+
+        parent.cancel();
+
+        assert!(
+            r1.cancel.is_cancelled(),
+            "child 1 token should observe parent cancel"
+        );
+        assert!(
+            r2.cancel.is_cancelled(),
+            "child 2 token should observe parent cancel"
+        );
     }
 }

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -355,7 +355,7 @@ pub trait LlmProvider: Send + Sync {
 use crate::config::{KodaConfig, ProviderType};
 
 /// Create an LLM provider from the given configuration.
-pub fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider> {
+pub fn create_provider(config: &KodaConfig) -> Box<dyn LlmProvider + Send + Sync> {
     let api_key = crate::runtime_env::get(config.provider_type.env_key_name());
     match config.provider_type {
         ProviderType::Anthropic => {

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -30,8 +30,13 @@ use tokio_util::sync::CancellationToken;
 
 /// Run a sub-agent in the background. Owns all data (no borrows).
 ///
-/// This is a standalone async fn so the future is `Send + 'static`,
-/// which `tokio::spawn` requires.
+/// **Phase 1 of #1022 fixes B1–B4:** the parent's cancel token,
+/// trust mode, and sandbox policy are threaded through here — a bg
+/// agent can never widen its parent's surface, and parent
+/// cancellation cascades correctly. The owning `tokio::spawn`
+/// (B5) remains deferred while we audit the transitive `Send`
+/// status of `execute_sub_agent`'s future.
+#[allow(clippy::too_many_arguments)]
 async fn run_bg_agent(
     project_root: std::path::PathBuf,
     parent_config: KodaConfig,
@@ -40,13 +45,27 @@ async fn run_bg_agent(
     sub_agent_cache: SubAgentCache,
     parent_session: String,
     tx: tokio::sync::oneshot::Sender<Result<String, String>>,
+    // B2 of #1022: parent's cancel token, threaded as a `child_token()`
+    // so a Ctrl-C in the parent loop cancels the bg agent.
+    cancel: CancellationToken,
+    // B1 of #1022: parent's trust mode — used both as the approval
+    // mode for tool calls inside the bg agent and (via the recursive
+    // `execute_sub_agent` call) as the clamp ceiling for the
+    // sub-agent's own declared trust.
+    parent_trust: TrustMode,
+    // B4 of #1022: parent's effective sandbox policy at spawn time.
+    // The recursive `execute_sub_agent` composes the child policy
+    // onto this so the bg agent inherits any parent narrowing.
+    parent_sandbox_policy: koda_sandbox::SandboxPolicy,
 ) {
-    let cancel = CancellationToken::new();
     let (_, mut cmd_rx) = mpsc::channel(1);
     let null_sink = crate::engine::sink::NullSink;
     let nested_bg = crate::bg_agent::new_shared();
 
-    // Override background=false to prevent infinite spawn
+    // Override background=false to prevent infinite spawn — a bg agent
+    // that itself emitted `InvokeAgent { background: true }` would
+    // never see its child's result (no inference loop is running
+    // *inside* a bg agent to drain results).
     let mut sync_args: serde_json::Value = serde_json::from_str(&arguments).unwrap_or_default();
     sync_args["background"] = serde_json::Value::Bool(false);
     let sync_arguments = serde_json::to_string(&sync_args).unwrap();
@@ -56,7 +75,7 @@ async fn run_bg_agent(
         &parent_config,
         &db,
         &sync_arguments,
-        TrustMode::Auto,
+        parent_trust,
         &null_sink,
         cancel,
         &mut cmd_rx,
@@ -64,15 +83,7 @@ async fn run_bg_agent(
         &sub_agent_cache,
         &parent_session,
         &nested_bg,
-        // Phase 5 PR-4 of #934: bg-spawned sub-agents have no live
-        // parent registry to pull a policy from (the spawning agent
-        // already returned). `strict_default()` is the safe choice —
-        // it means "no extra parent restrictions" so the child's own
-        // `policy_for_agent` result wins. If we later make the main
-        // agent registry-policy non-default, we should snapshot it
-        // into the bg-agent task at spawn time so this path inherits
-        // the same restrictions.
-        &koda_sandbox::SandboxPolicy::strict_default(),
+        &parent_sandbox_policy,
     )
     .await;
 
@@ -121,36 +132,85 @@ pub(crate) async fn execute_sub_agent(
     let is_fork = agent_name == "fork";
     let background = args["background"].as_bool().unwrap_or(false);
 
-    // Background mode: spawn and return immediately
+    // Background mode: spawn and return immediately.
+    //
+    // Phase 1 of #1022 fixes B1–B4 here:
+    //  * **B1 trust:** the recursive `execute_sub_agent` call below
+    //    receives `mode` (the parent's trust mode) instead of
+    //    hard-coded `TrustMode::Auto`. The clamp inside that call
+    //    then guarantees the bg agent can only narrow, never widen.
+    //  * **B2 cancellation:** the bg task receives a `child_token()`
+    //    of the parent's `cancel`. Ctrl-C in the parent loop now
+    //    cascades into every in-flight bg agent.
+    //  * **B3 lifecycle:** the spawned `JoinHandle` is held by the
+    //    registry as an `AbortOnDropHandle`, so a registry drop
+    //    aborts the task and releases its worktree.
+    //  * **B4 sandbox:** `parent_sandbox_policy.clone()` is captured
+    //    at spawn time, so the recursive call composes the bg
+    //    agent's policy onto the parent's effective policy instead
+    //    of regressing to `strict_default()`.
+    //
+    // **B5 deferred to Phase 2 (#1022):** the inner future built by
+    // `execute_sub_agent` is not `Send` (some `Box<dyn Trait>` /
+    // `Arc<dyn Trait>` in the transitive type graph lacks an
+    // explicit `+ Send` annotation — trait-object auto-traits don't
+    // inherit from supertraits). Until that's audited and fixed,
+    // we keep `spawn_blocking + new_current_thread` so the bg
+    // future runs on a single-threaded runtime where Send isn't
+    // required. The new cancel cascade still works because the
+    // child token is shared by reference (`CancellationToken` is
+    // cheaply cloneable across runtimes), and `AbortOnDropHandle`
+    // still gets the `JoinHandle<()>` from `spawn_blocking`.
     if background {
-        let (task_id, tx) = bg_agents.register(agent_name, prompt);
-        let project_root = project_root.to_path_buf();
-        let parent_config = parent_config.clone();
+        let reservation = bg_agents.reserve(&cancel);
+        let task_id = reservation.task_id;
+        let bg_cancel = reservation.cancel.clone();
+        let bg_tx = reservation.tx;
+        let bg_rx = reservation.rx;
+        let entry_cancel = reservation.cancel;
+
+        let project_root_owned = project_root.to_path_buf();
+        let parent_config_owned = parent_config.clone();
         let agent_name_owned = agent_name.to_string();
-        let arguments = arguments.to_string();
-        let sub_agent_cache = sub_agent_cache.clone();
-        let parent_session = parent_session_id.to_string();
+        let prompt_owned = prompt.to_string();
+        let arguments_owned = arguments.to_string();
+        let sub_agent_cache_owned = sub_agent_cache.clone();
+        let parent_session_owned = parent_session_id.to_string();
         let bg_db = db.clone();
+        let bg_policy = parent_sandbox_policy.clone();
+        let bg_trust = mode;
 
         sink.emit(EngineEvent::Info {
             message: format!("  \u{1f680} {agent_name} launched in background (task {task_id})"),
         });
 
-        tokio::task::spawn_blocking(move || {
+        let handle = tokio::task::spawn_blocking(move || {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("bg agent runtime");
             rt.block_on(run_bg_agent(
-                project_root,
-                parent_config,
+                project_root_owned,
+                parent_config_owned,
                 bg_db,
-                arguments,
-                sub_agent_cache,
-                parent_session,
-                tx,
+                arguments_owned,
+                sub_agent_cache_owned,
+                parent_session_owned,
+                bg_tx,
+                bg_cancel,
+                bg_trust,
+                bg_policy,
             ));
         });
+
+        bg_agents.attach(
+            task_id,
+            &agent_name_owned,
+            &prompt_owned,
+            bg_rx,
+            entry_cancel,
+            handle,
+        );
 
         return Ok(format!(
             "Background agent '{agent_name_owned}' started (task {task_id}). \
@@ -297,7 +357,13 @@ pub(crate) async fn execute_sub_agent(
         .disallowed_tools
         .iter()
         .any(|t| t == "Write" || t == "Edit");
-    let workspace: Box<dyn WorkspaceProvider> = if has_write_tools {
+    // Phase 1 of #1022: explicit `+ Send + Sync` on the trait object.
+    // The supertrait bound `WorkspaceProvider: Send + Sync` constrains
+    // *implementors*, but Rust trait objects don't auto-inherit those
+    // bounds — `Box<dyn WorkspaceProvider>` is `!Send` without the
+    // explicit annotation, which makes the whole `execute_sub_agent`
+    // future `!Send` and unspawnable.
+    let workspace: Box<dyn WorkspaceProvider + Send + Sync> = if has_write_tools {
         pick_write_provider(project_root, agent_name)
     } else {
         Box::new(CwdProvider::new(project_root))
@@ -548,7 +614,7 @@ pub(crate) async fn execute_sub_agent(
 fn pick_write_provider(
     project_root: &std::path::Path,
     agent_name: &str,
-) -> Box<dyn WorkspaceProvider> {
+) -> Box<dyn WorkspaceProvider + Send + Sync> {
     // Try `ClonefileProvider` first — its 3-4× provision speedup
     // (Phase 4d / #934 bench) is durable and the implementation is
     // a thin wrapper over the OS primitive designed for this.
@@ -571,7 +637,7 @@ fn pick_write_provider(
 fn pick_write_provider(
     project_root: &std::path::Path,
     agent_name: &str,
-) -> Box<dyn WorkspaceProvider> {
+) -> Box<dyn WorkspaceProvider + Send + Sync> {
     // Linux + others: GitWorktreeProvider. The Linux CoW equivalent
     // (4e in #934) is parked until production telemetry shows it's
     // worth building — see #934 deferral comments.

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -220,7 +220,11 @@ pub struct ToolRegistry {
     read_cache: FileReadCache,
     /// Filesystem abstraction — `LocalFileSystem` by default; swap to
     /// `SandboxedFileSystem` when a sandbox slot is active (Phase 2d, #934).
-    fs: Arc<dyn FileSystem>,
+    /// Explicit `+ Send + Sync` is required: trait objects don't
+    /// auto-inherit auto-traits from the supertrait, so without these
+    /// bounds `ToolRegistry` becomes `!Send` and any future holding
+    /// it (e.g. `execute_sub_agent`) cannot be `tokio::spawn`'d.
+    fs: Arc<dyn FileSystem + Send + Sync>,
     /// Per-file last-writer tracking for richer staleness errors (#804 item 7).
     last_writer: LastWriterCache,
     /// Most recent Bash invocation for staleness error context (#804 item 7).
@@ -382,7 +386,7 @@ impl ToolRegistry {
     ///
     /// Call this after construction to swap `LocalFileSystem` for
     /// `SandboxedFileSystem` when a sandbox slot is ready (#934).
-    pub fn set_fs(&mut self, fs: Arc<dyn FileSystem>) {
+    pub fn set_fs(&mut self, fs: Arc<dyn FileSystem + Send + Sync>) {
         self.fs = fs;
     }
 

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -39,6 +39,8 @@ pub struct Env {
     pub config: KodaConfig,
     /// Tool registry scoped to the test root.
     pub tools: ToolRegistry,
+    /// Trust mode used by the inference loop (default: `Auto`).
+    pub trust: TrustMode,
 }
 
 /// Builder for [`Env`] — customise provider, context window, agent name, etc.
@@ -54,6 +56,7 @@ pub struct EnvBuilder {
     provider_type: ProviderType,
     agent_name: String,
     max_context_tokens: Option<usize>,
+    trust: TrustMode,
 }
 
 impl Default for EnvBuilder {
@@ -62,6 +65,7 @@ impl Default for EnvBuilder {
             provider_type: ProviderType::LMStudio,
             agent_name: "test-agent".into(),
             max_context_tokens: None,
+            trust: TrustMode::Auto,
         }
     }
 }
@@ -85,6 +89,14 @@ impl EnvBuilder {
         self
     }
 
+    /// Override the trust mode used by the inference loop (default: `Auto`).
+    /// Sets both the inference-loop `mode` and the config trust so
+    /// sub-agent clamping observes the correct parent value.
+    pub fn trust(mut self, trust: TrustMode) -> Self {
+        self.trust = trust;
+        self
+    }
+
     /// Build the environment.  Creates a temp dir, DB, session, and tool registry.
     pub async fn build(self) -> Env {
         let tmp = tempfile::tempdir().unwrap();
@@ -92,11 +104,12 @@ impl EnvBuilder {
         let db = Database::init(&root).await.unwrap();
         let session_id = db.create_session(&self.agent_name, &root).await.unwrap();
         let mut config = KodaConfig::default_for_testing(self.provider_type);
+        config.trust = self.trust;
         if let Some(n) = self.max_context_tokens {
             config.max_context_tokens = n;
             config.model_settings.max_context_tokens = n;
         }
-        let tools = ToolRegistry::new(root.clone(), config.max_context_tokens);
+        let tools = ToolRegistry::with_trust(root.clone(), config.max_context_tokens, self.trust);
         Env {
             _tmp: tmp,
             root,
@@ -104,6 +117,7 @@ impl EnvBuilder {
             session_id,
             config,
             tools,
+            trust: self.trust,
         }
     }
 }
@@ -197,7 +211,7 @@ impl Env {
             tools: &self.tools,
             tool_defs: &tool_defs,
             pending_images: None,
-            mode: TrustMode::Auto,
+            mode: self.trust,
             sink: &sink,
             cancel,
             cmd_rx: &mut cmd_rx,


### PR DESCRIPTION
Phase 1 of #1022. Fixes the four bg-agent security/correctness bugs
surfaced by the multi-agent execution review. **B5** (replace
`spawn_blocking + new_current_thread` with plain `tokio::spawn`)
is intentionally deferred to **#1023** because it requires a
workspace-wide `Send`-bound audit on trait objects with a
different blast radius.

## What changed

| ID | Fix | Where |
|---|---|---|
| **B1** Trust | `run_bg_agent` now takes `parent_trust: TrustMode` and threads it into the recursive `execute_sub_agent` call as the clamp ceiling. Bg agents can no longer widen the parent's trust. (Was hard-coded `TrustMode::Auto`.) | `koda-core/src/sub_agent_dispatch.rs` |
| **B2** Cancellation | `BgAgentRegistry::reserve()` hands out a `parent_cancel.child_token()` that the spawned future observes. Ctrl+C in the parent loop cascades into every in-flight bg agent. | `koda-core/src/bg_agent.rs`, `sub_agent_dispatch.rs` |
| **B3** Lifecycle | `BgAgentRegistry` now holds each task's `JoinHandle` as a `tokio_util::task::AbortOnDropHandle`. Registry drop = task abort = worktree release. | `koda-core/src/bg_agent.rs` |
| **B4** Sandbox | Bg path now snapshots `parent_sandbox_policy.clone()` at spawn time and threads it through. No more silent `strict_default()` regression. | `koda-core/src/sub_agent_dispatch.rs` |

## API additions (all internal)

- `bg_agent::BgAgentReservation { task_id, tx, rx, cancel }` — the
  two-phase reserve/spawn/attach pattern needed to hand the oneshot
  sender into the spawned closure before the `JoinHandle` exists.
- `BgAgentRegistry::reserve(&parent_cancel) -> BgAgentReservation`
- `BgAgentRegistry::attach(id, name, prompt, rx, cancel, handle)`
- `BgAgentRegistry::register_test(...)` — preserved for unit tests
- `EnvBuilder::trust(TrustMode)` in `koda-test-utils` — so future B1
  e2e tests can express the parent-trust dimension. Default `Auto`,
  no consumer impact.

## Side fixes (required to surface and partially-resolve the Send issue)

The bg path was using `spawn_blocking + new_current_thread` to dodge
the fact that `execute_sub_agent`'s future is `!Send`. Investigating
that revealed the well-known Rust footgun: trait-object auto-traits
do **not** inherit from supertraits. Fixed three obvious offenders:

- `Box<dyn WorkspaceProvider>` → `+ Send + Sync`
- `Box<dyn LlmProvider>` (in `create_provider`) → `+ Send + Sync`
- `Arc<dyn FileSystem>` (in `ToolRegistry`) → `+ Send + Sync`

After those fixes the future is **still** `!Send`, so this PR keeps
`spawn_blocking + new_current_thread`. The remaining audit is **#1023**.
That choice is **safe** because all four invariants hold regardless of
spawn primitive:

- `CancellationToken` is shareable across runtimes
- `AbortOnDropHandle` wraps any `JoinHandle<T>`
- Trust + sandbox composition happens at the recursive
  `execute_sub_agent` entry, not at the spawn site

## Tests

- ✅ **6/6** `bg_agent` unit tests (4 existing + 2 **new** regression tests)
  - `registry_drop_aborts_pending_tasks` — spawns a 60s sleep,
    drops the registry, asserts the task was aborted within 100ms (B3)
  - `parent_cancel_cascades_to_reserved_child` — reserves two slots,
    cancels parent, asserts both child tokens observe the cancel (B2)
- ✅ **1015/1015** `koda-core` lib tests
- ✅ **4/4** `e2e_agent_test` integration tests
- ✅ **300/300** `koda-sandbox` lib tests
- ✅ `cargo clippy -p koda-core -- -D warnings` clean
- ✅ `RUSTDOCFLAGS=-D warnings cargo doc -p koda-core --no-deps` clean
- ✅ `cargo fmt --all --check` clean

## Design.md

Updated line 332 to drop the aspirational `tokio::spawn(execute_sub_agent)`
claim while keeping all four invariants intact (trust never widens,
sandbox never widens, cancellation cascades, registry drop = task abort).
The runtime-mechanism caveat will disappear once #1023 lands.

## Reviewer hints

- The diff in `bg_agent.rs` looks large but ~60% is doc comments and
  the new tests; the data structures themselves are small.
- The `reserve → spawn → attach` two-phase API exists because we need
  the `JoinHandle` (only available after `spawn`) and the `oneshot::tx`
  (must be `move`d into the spawned closure) to land in the same
  registry entry.
- The `Drop` impl on `BgAgentRegistry` is technically redundant (each
  `AbortOnDropHandle` already aborts on its own drop), but it's
  explicit about intent and gives us a single hook to add telemetry
  later.

Closes #1022 partially (B1–B4). Sets up #1023 (B5).
