### PR TITLE
fix(bg-agent): switch to tokio::spawn (#1022 B5 / Phase 2)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -328,16 +328,19 @@ Four execution modes, one mental model:
    `futures_util::future::join_all`. Each gets its own DB session and (if
    write-capable) its own workspace.
 3. **Background fire-and-forget** (`InvokeAgent { prompt, background: true }`)
-   — spawned via `tokio::task::spawn_blocking` onto a per-task
-   `new_current_thread` runtime, with the resulting `JoinHandle` held
-   by `BgAgentRegistry` as an `AbortOnDropHandle`. The inference loop
-   drains completed handles before each iteration via
-   `BgAgentRegistry::drain_completed()` and injects results as user
-   messages. Bg-spawned agents cannot themselves spawn bg agents
-   (override `background: false`). The current-thread runtime exists
-   only because `execute_sub_agent`'s future is not yet `Send`;
-   collapsing to a plain `tokio::spawn` is tracked separately and
-   does not change the invariants below.
+   — spawned via `tokio::spawn` onto the multi-thread runtime, with the
+   resulting `JoinHandle` held by `BgAgentRegistry` as an
+   `AbortOnDropHandle`. The inference loop drains completed handles
+   before each iteration via `BgAgentRegistry::drain_completed()` and
+   injects results as user messages. Bg-spawned agents cannot themselves
+   spawn bg agents (override `background: false`). `execute_sub_agent`'s
+   future is `Send` by construction — the function returns
+   `impl Future<Output = ...> + Send + 'a` rather than using `async fn`,
+   forcing the compiler to *prove* Send-ness at the boundary. The
+   transitive offender (generic IPC helpers in `koda-sandbox::ipc`) carry
+   matching `Send` bounds on their `R`/`W`/`T` parameters; without them,
+   `tokio::sync::MutexGuard<WorkerClient>` held across an `await` was
+   silently non-Send.
 4. **Forked context** (`agent_name="fork"`) — copies the parent's full
    conversation history into the new session. Fork children cannot spawn
    sub-agents (recursion guard).

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -64,12 +64,12 @@ struct BgAgentEntry {
     /// path; per-task cancel UX lands in #996.
     #[allow(dead_code)]
     cancel: CancellationToken,
-    /// Aborts the spawned task on drop. Today the bg path uses
-    /// `spawn_blocking` (because `execute_sub_agent`'s future is
-    /// not yet `Send` — see #1022 B5). The `JoinHandle` returned
-    /// by `spawn_blocking` is still abortable, though abort is a
-    /// no-op while the inner blocking call is in flight; the
-    /// cancel-token cascade is the primary stop signal.
+    /// Aborts the spawned task on drop. The bg path uses
+    /// `tokio::spawn` on the multi-thread runtime (#1022 B5):
+    /// `execute_sub_agent` returns an explicitly `Send`-bounded
+    /// future, so abort works promptly at any await point. The
+    /// cancel-token cascade is still the primary stop signal
+    /// (so the bg task can run any cleanup it owns).
     _handle: AbortOnDropHandle<()>,
 }
 

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -56,7 +56,7 @@ pub struct SseCollector {
 /// background reader and close the HTTP connection (#825).
 pub fn spawn_sse_collector(
     response: reqwest::Response,
-    parser: Box<dyn ChunkParser>,
+    parser: Box<dyn ChunkParser + Send>,
 ) -> SseCollector {
     let (tx, rx) = mpsc::channel(64);
     let handle = tokio::spawn(drive_sse_stream(response, parser, tx));
@@ -78,7 +78,7 @@ pub fn spawn_sse_collector(
 /// is responsible for discarding any partial response — see `collect_stream()`.
 async fn drive_sse_stream(
     response: reqwest::Response,
-    mut parser: Box<dyn ChunkParser>,
+    mut parser: Box<dyn ChunkParser + Send>,
     tx: mpsc::Sender<StreamChunk>,
 ) {
     use futures_util::StreamExt;

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -30,12 +30,12 @@ use tokio_util::sync::CancellationToken;
 
 /// Run a sub-agent in the background. Owns all data (no borrows).
 ///
-/// **Phase 1 of #1022 fixes B1–B4:** the parent's cancel token,
-/// trust mode, and sandbox policy are threaded through here — a bg
-/// agent can never widen its parent's surface, and parent
-/// cancellation cascades correctly. The owning `tokio::spawn`
-/// (B5) remains deferred while we audit the transitive `Send`
-/// status of `execute_sub_agent`'s future.
+/// **Phase 2 of #1022 (B5 complete):** uses the multi-thread runtime
+/// via `tokio::spawn`. This requires `execute_sub_agent`'s future to
+/// be `Send`, which we enforce explicitly via the `+ Send` bound on
+/// its return type — see the function's signature for the bound and
+/// `koda-sandbox/src/ipc.rs` for the matching `Send` bounds on the
+/// generic IPC helpers that previously hid a non-Send transitive.
 #[allow(clippy::too_many_arguments)]
 async fn run_bg_agent(
     project_root: std::path::PathBuf,
@@ -102,94 +102,90 @@ async fn run_bg_agent(
 /// On cache hit, returns immediately without any LLM calls.
 #[tracing::instrument(skip_all, fields(agent_name, cached = false))]
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn execute_sub_agent(
-    project_root: &Path,
-    parent_config: &KodaConfig,
-    db: &Database,
-    arguments: &str,
+pub(crate) fn execute_sub_agent<'a>(
+    project_root: &'a Path,
+    parent_config: &'a KodaConfig,
+    db: &'a Database,
+    arguments: &'a str,
     mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
+    sink: &'a dyn crate::engine::EngineSink,
     cancel: CancellationToken,
-    cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+    cmd_rx: &'a mut mpsc::Receiver<EngineCommand>,
     parent_cache: Option<crate::tools::FileReadCache>,
-    sub_agent_cache: &SubAgentCache,
-    parent_session_id: &str,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    sub_agent_cache: &'a SubAgentCache,
+    parent_session_id: &'a str,
+    bg_agents: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
     // Phase 5 PR-4 of #934: parent's effective sandbox policy. The
     // child policy is composed onto this so the child can only narrow,
     // never widen — see [`koda_sandbox::SandboxPolicy::compose`] for
     // the per-field rules. Pass `&SandboxPolicy::strict_default()`
     // when there is no meaningful parent (top-level invocation).
-    parent_sandbox_policy: &koda_sandbox::SandboxPolicy,
-) -> Result<String> {
-    let args: serde_json::Value = serde_json::from_str(arguments)?;
-    let agent_name = args["agent_name"].as_str().unwrap_or("task");
-    tracing::Span::current().record("agent_name", agent_name);
-    let prompt = args["prompt"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
-    let session_id = args["session_id"].as_str().map(|s| s.to_string());
-    let is_fork = agent_name == "fork";
-    let background = args["background"].as_bool().unwrap_or(false);
+    parent_sandbox_policy: &'a koda_sandbox::SandboxPolicy,
+) -> impl std::future::Future<Output = Result<String>> + Send + 'a {
+    async move {
+        let args: serde_json::Value = serde_json::from_str(arguments)?;
+        let agent_name = args["agent_name"].as_str().unwrap_or("task");
+        tracing::Span::current().record("agent_name", agent_name);
+        let prompt = args["prompt"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
+        let session_id = args["session_id"].as_str().map(|s| s.to_string());
+        let is_fork = agent_name == "fork";
+        let background = args["background"].as_bool().unwrap_or(false);
 
-    // Background mode: spawn and return immediately.
-    //
-    // Phase 1 of #1022 fixes B1–B4 here:
-    //  * **B1 trust:** the recursive `execute_sub_agent` call below
-    //    receives `mode` (the parent's trust mode) instead of
-    //    hard-coded `TrustMode::Auto`. The clamp inside that call
-    //    then guarantees the bg agent can only narrow, never widen.
-    //  * **B2 cancellation:** the bg task receives a `child_token()`
-    //    of the parent's `cancel`. Ctrl-C in the parent loop now
-    //    cascades into every in-flight bg agent.
-    //  * **B3 lifecycle:** the spawned `JoinHandle` is held by the
-    //    registry as an `AbortOnDropHandle`, so a registry drop
-    //    aborts the task and releases its worktree.
-    //  * **B4 sandbox:** `parent_sandbox_policy.clone()` is captured
-    //    at spawn time, so the recursive call composes the bg
-    //    agent's policy onto the parent's effective policy instead
-    //    of regressing to `strict_default()`.
-    //
-    // **B5 deferred to Phase 2 (#1022):** the inner future built by
-    // `execute_sub_agent` is not `Send` (some `Box<dyn Trait>` /
-    // `Arc<dyn Trait>` in the transitive type graph lacks an
-    // explicit `+ Send` annotation — trait-object auto-traits don't
-    // inherit from supertraits). Until that's audited and fixed,
-    // we keep `spawn_blocking + new_current_thread` so the bg
-    // future runs on a single-threaded runtime where Send isn't
-    // required. The new cancel cascade still works because the
-    // child token is shared by reference (`CancellationToken` is
-    // cheaply cloneable across runtimes), and `AbortOnDropHandle`
-    // still gets the `JoinHandle<()>` from `spawn_blocking`.
-    if background {
-        let reservation = bg_agents.reserve(&cancel);
-        let task_id = reservation.task_id;
-        let bg_cancel = reservation.cancel.clone();
-        let bg_tx = reservation.tx;
-        let bg_rx = reservation.rx;
-        let entry_cancel = reservation.cancel;
+        // Background mode: spawn and return immediately.
+        //
+        // Phase 1 of #1022 fixes B1–B4 here:
+        //  * **B1 trust:** the recursive `execute_sub_agent` call below
+        //    receives `mode` (the parent's trust mode) instead of
+        //    hard-coded `TrustMode::Auto`. The clamp inside that call
+        //    then guarantees the bg agent can only narrow, never widen.
+        //  * **B2 cancellation:** the bg task receives a `child_token()`
+        //    of the parent's `cancel`. Ctrl-C in the parent loop now
+        //    cascades into every in-flight bg agent.
+        //  * **B3 lifecycle:** the spawned `JoinHandle` is held by the
+        //    registry as an `AbortOnDropHandle`, so a registry drop
+        //    aborts the task and releases its worktree.
+        //  * **B4 sandbox:** `parent_sandbox_policy.clone()` is captured
+        //    at spawn time, so the recursive call composes the bg
+        //    agent's policy onto the parent's effective policy instead
+        //    of regressing to `strict_default()`.
+        //  * **B5 (Phase 2):** the bg agent now runs on the multi-thread
+        //    runtime via `tokio::spawn`. We enforced `Send` on
+        //    `execute_sub_agent`'s future by switching its signature to
+        //    `fn(...) -> impl Future<Output = ...> + Send + 'a`, which
+        //    forces the compiler to *prove* Send (vs. silently degrading
+        //    when an `async fn` happens to capture a non-Send temporary).
+        //    The transitive offender was `koda-sandbox::ipc::{read,write}_message`
+        //    — those generic helpers had no `Send` bound on `R`/`W`/`T`,
+        //    so MutexGuards held across their awaits weren't Send. Bounds
+        //    have been added there as well.
+        if background {
+            let reservation = bg_agents.reserve(&cancel);
+            let task_id = reservation.task_id;
+            let bg_cancel = reservation.cancel.clone();
+            let bg_tx = reservation.tx;
+            let bg_rx = reservation.rx;
+            let entry_cancel = reservation.cancel;
 
-        let project_root_owned = project_root.to_path_buf();
-        let parent_config_owned = parent_config.clone();
-        let agent_name_owned = agent_name.to_string();
-        let prompt_owned = prompt.to_string();
-        let arguments_owned = arguments.to_string();
-        let sub_agent_cache_owned = sub_agent_cache.clone();
-        let parent_session_owned = parent_session_id.to_string();
-        let bg_db = db.clone();
-        let bg_policy = parent_sandbox_policy.clone();
-        let bg_trust = mode;
+            let project_root_owned = project_root.to_path_buf();
+            let parent_config_owned = parent_config.clone();
+            let agent_name_owned = agent_name.to_string();
+            let prompt_owned = prompt.to_string();
+            let arguments_owned = arguments.to_string();
+            let sub_agent_cache_owned = sub_agent_cache.clone();
+            let parent_session_owned = parent_session_id.to_string();
+            let bg_db = db.clone();
+            let bg_policy = parent_sandbox_policy.clone();
+            let bg_trust = mode;
 
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{1f680} {agent_name} launched in background (task {task_id})"),
-        });
+            sink.emit(EngineEvent::Info {
+                message: format!(
+                    "  \u{1f680} {agent_name} launched in background (task {task_id})"
+                ),
+            });
 
-        let handle = tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("bg agent runtime");
-            rt.block_on(run_bg_agent(
+            let handle = tokio::spawn(run_bg_agent(
                 project_root_owned,
                 parent_config_owned,
                 bg_db,
@@ -201,398 +197,400 @@ pub(crate) async fn execute_sub_agent(
                 bg_trust,
                 bg_policy,
             ));
-        });
 
-        bg_agents.attach(
-            task_id,
-            &agent_name_owned,
-            &prompt_owned,
-            bg_rx,
-            entry_cancel,
-            handle,
-        );
+            bg_agents.attach(
+                task_id,
+                &agent_name_owned,
+                &prompt_owned,
+                bg_rx,
+                entry_cancel,
+                handle,
+            );
 
-        return Ok(format!(
-            "Background agent '{agent_name_owned}' started (task {task_id}). \
+            return Ok(format!(
+                "Background agent '{agent_name_owned}' started (task {task_id}). \
              Results will be injected when complete."
-        ));
-    }
-    // Check result cache (only for stateless calls without a session_id,
-    // since session continuations need fresh execution).
-    if session_id.is_none()
-        && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
-    {
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
-        });
-        tracing::Span::current().record("cached", true);
-        return Ok(cached);
-    }
-
-    sink.emit(EngineEvent::SubAgentStart {
-        agent_name: agent_name.to_string(),
-    });
-
-    // Fork inherits parent config; named agents load their own persona
-    // but fall back to the parent's provider and model for anything not
-    // explicitly set in the agent JSON.
-    //
-    // Inheritance rules (applied only when the agent JSON leaves a field None):
-    //
-    // provider + base_url — inherited from parent when the agent JSON sets
-    //   neither. If the agent sets its own provider or base_url (e.g. a
-    //   test-only "mock" agent or a specialist routed to a different endpoint)
-    //   we respect that and leave it alone.
-    //
-    // model — inherited from parent only when (a) the agent JSON left it
-    //   unset AND (b) we are also inheriting the provider. Cross-provider
-    //   model names are not portable ("gemini-2.0-flash" means nothing on
-    //   Anthropic), so if the agent has its own provider we leave the model
-    //   resolved from that provider's defaults.
-    let sub_config = if is_fork {
-        // Fork inherits the parent config verbatim — including trust mode.
-        // The clone preserves trust; no clamping needed since
-        // fork == exact copy.  Assertion guards against future changes
-        // that might add config overrides to the fork path.
-        let cfg = parent_config.clone();
-        debug_assert!(
-            cfg.trust == parent_config.trust,
-            "fork must inherit parent trust exactly"
-        );
-        cfg
-    } else {
-        // Load the raw JSON first to see what the agent explicitly set.
-        let raw = crate::config::KodaConfig::load_agent_json(project_root, agent_name)
-            .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
-
-        let mut cfg = crate::config::KodaConfig::load(project_root, agent_name)
-            .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
-
-        let agent_has_own_provider = raw.provider.is_some() || raw.base_url.is_some();
-
-        if !agent_has_own_provider {
-            // Inherit parent's provider, base_url, and (if unset) model.
-            // All three travel together: model names are provider-scoped.
-            let model_override = raw.model.is_none().then(|| parent_config.model.clone());
-            cfg = cfg.with_overrides(
-                Some(parent_config.base_url.clone()),
-                model_override,
-                Some(parent_config.provider_type.to_string()),
-            );
+            ));
         }
-        // else: agent opted into its own provider — use its resolved config
-        // as-is. The agent JSON is responsible for any model it needs.
-
-        // Inherit trust: child can never exceed parent's trust (#845).
-        // Same pattern as Codex's `apply_spawn_agent_runtime_overrides()`
-        // which copies the parent's runtime sandbox_policy onto the child.
-        let child_trust = cfg.trust;
-        cfg.trust = TrustMode::clamp(parent_config.trust, cfg.trust);
-        if cfg.trust != child_trust {
-            tracing::info!(
-                agent = agent_name,
-                parent = %parent_config.trust,
-                child = %child_trust,
-                effective = %cfg.trust,
-                "sub-agent trust clamped to match parent",
-            );
-        }
-
-        cfg
-    };
-
-    let sub_session = match session_id {
-        Some(id) => id,
-        None => {
-            let sid = db
-                .create_session(&sub_config.agent_name, project_root)
-                .await?;
-            // Fork: copy parent conversation history into the new session
-            if is_fork {
-                let parent_history = db.load_context(parent_session_id).await?;
-                for msg in &parent_history {
-                    let mid = db
-                        .insert_message(
-                            &sid,
-                            &msg.role,
-                            msg.content.as_deref(),
-                            msg.tool_calls.as_deref(),
-                            msg.tool_call_id.as_deref(),
-                            None, // don't duplicate usage stats
-                        )
-                        .await?;
-                    // Copied assistant messages are already complete in the
-                    // parent — mark them complete in the child session so
-                    // load_context includes them (#875).
-                    if msg.role == Role::Assistant {
-                        db.mark_message_complete(mid).await?;
-                    }
-                }
-            }
-            sid
-        }
-    };
-
-    db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)
-        .await?;
-
-    let provider = crate::providers::create_provider(&sub_config);
-    // Select workspace provider. Write-capable agents get an isolated
-    // workspace; read-only agents share the parent root for free.
-    //
-    // Per-platform write-isolation choice:
-    //
-    // - **macOS:** `ClonefileProvider` (APFS clonefile(2)) is
-    //   preferred for its ~3-4× provision speedup over git worktree
-    //   (Phase 4d / #934). Falls back to git worktree if construction
-    //   fails (e.g. `$HOME` unset, project path can't canonicalize).
-    // - **Linux + others:** `GitWorktreeProvider`. The Linux CoW
-    //   equivalent (4e in #934) is deferred until production
-    //   telemetry shows it's worth building.
-    //
-    // **Documented platform divergence** — see `docs/src/sandbox.md`
-    // → "Workspace providers". Both backends provide the same
-    // isolation guarantees; only provision speed differs.
-    let has_write_tools = !sub_config
-        .disallowed_tools
-        .iter()
-        .any(|t| t == "Write" || t == "Edit");
-    // Phase 1 of #1022: explicit `+ Send + Sync` on the trait object.
-    // The supertrait bound `WorkspaceProvider: Send + Sync` constrains
-    // *implementors*, but Rust trait objects don't auto-inherit those
-    // bounds — `Box<dyn WorkspaceProvider>` is `!Send` without the
-    // explicit annotation, which makes the whole `execute_sub_agent`
-    // future `!Send` and unspawnable.
-    let workspace: Box<dyn WorkspaceProvider + Send + Sync> = if has_write_tools {
-        pick_write_provider(project_root, agent_name)
-    } else {
-        Box::new(CwdProvider::new(project_root))
-    };
-    let effective_root = match workspace.provision(&sub_session).await {
-        Ok(path) => {
-            if path != project_root {
-                sink.emit(EngineEvent::Info {
-                    message: format!("  \u{1f333} {agent_name}: isolated in worktree"),
-                });
-            }
-            path
-        }
-        Err(e) => {
-            tracing::warn!("Workspace provision failed: {e}");
-            project_root.to_path_buf()
-        }
-    };
-    let effective_root_ref = effective_root.as_path();
-
-    let tools = {
-        let registry = ToolRegistry::with_trust(
-            effective_root.clone(),
-            sub_config.max_context_tokens,
-            sub_config.trust,
-        );
-        // Phase 5 PR-4 of #934: compose the parent's effective policy
-        // with the child's. Per-field rules in [`SandboxPolicy::compose`]
-        // (denies union, allows parent-wins, limits min, trust strictest)
-        // ensure the child can never widen the parent's surface — only
-        // narrow it. PR-2 installed the child policy verbatim; PR-4
-        // makes the install additive over the parent so chains of
-        // sub-agents accumulate restrictions monotonically.
-        let composed_policy = crate::sandbox::compose_child_policy(
-            parent_sandbox_policy,
-            sub_config.trust,
-            effective_root_ref,
-        );
-        let registry = registry.with_sandbox_policy(composed_policy);
-        match parent_cache {
-            Some(cache) => registry.with_shared_cache(cache),
-            None => registry,
-        }
-    };
-    let tool_defs = {
-        let mut denied = sub_config.disallowed_tools.clone();
-        // Anti-recursion: fork children cannot spawn sub-agents
-        if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
-            denied.push("InvokeAgent".to_string());
-        }
-        tools.get_definitions(&sub_config.allowed_tools, &denied)
-    };
-    let semantic_memory = if sub_config.skip_memory {
-        String::new()
-    } else {
-        memory::load(project_root)?
-    };
-    let env = crate::prompt::EnvironmentInfo {
-        project_root: effective_root_ref,
-        model: &sub_config.model,
-        platform: std::env::consts::OS,
-    };
-    let system_prompt = build_system_prompt(
-        &sub_config.system_prompt,
-        &semantic_memory,
-        &sub_config.agents_dir,
-        &env,
-        &[], // sub-agents have no REPL commands
-        &tools.skill_registry,
-    );
-
-    for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
-        // Respect parent cancellation (#286)
-        if cancel.is_cancelled() {
-            // Release workspace on cancellation (best-effort, no user hint).
-            let _ = workspace.release(&sub_session, &effective_root).await;
-            return Ok("[cancelled by parent]".to_string());
-        }
-        let history = db.load_context(&sub_session).await?;
-        let mut messages = vec![ChatMessage::text("system", &system_prompt)];
-        for msg in &history {
-            let tool_calls: Option<Vec<ToolCall>> = msg
-                .tool_calls
-                .as_deref()
-                .and_then(|tc| serde_json::from_str(tc).ok());
-            messages.push(ChatMessage {
-                role: msg.role.as_str().to_string(),
-                content: msg.content.clone(),
-                tool_calls,
-                tool_call_id: msg.tool_call_id.clone(),
-                images: None,
+        // Check result cache (only for stateless calls without a session_id,
+        // since session continuations need fresh execution).
+        if session_id.is_none()
+            && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
+        {
+            sink.emit(EngineEvent::Info {
+                message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
             });
+            tracing::Span::current().record("cached", true);
+            return Ok(cached);
         }
 
-        sink.emit(EngineEvent::SpinnerStart {
-            message: format!("  🦥 {agent_name} thinking..."),
+        sink.emit(EngineEvent::SubAgentStart {
+            agent_name: agent_name.to_string(),
         });
-        let response = provider
-            .chat(&messages, &tool_defs, &sub_config.model_settings)
-            .await?;
-        sink.emit(EngineEvent::SpinnerStop);
 
-        let tool_calls_json = if response.tool_calls.is_empty() {
-            None
+        // Fork inherits parent config; named agents load their own persona
+        // but fall back to the parent's provider and model for anything not
+        // explicitly set in the agent JSON.
+        //
+        // Inheritance rules (applied only when the agent JSON leaves a field None):
+        //
+        // provider + base_url — inherited from parent when the agent JSON sets
+        //   neither. If the agent sets its own provider or base_url (e.g. a
+        //   test-only "mock" agent or a specialist routed to a different endpoint)
+        //   we respect that and leave it alone.
+        //
+        // model — inherited from parent only when (a) the agent JSON left it
+        //   unset AND (b) we are also inheriting the provider. Cross-provider
+        //   model names are not portable ("gemini-2.0-flash" means nothing on
+        //   Anthropic), so if the agent has its own provider we leave the model
+        //   resolved from that provider's defaults.
+        let sub_config = if is_fork {
+            // Fork inherits the parent config verbatim — including trust mode.
+            // The clone preserves trust; no clamping needed since
+            // fork == exact copy.  Assertion guards against future changes
+            // that might add config overrides to the fork path.
+            let cfg = parent_config.clone();
+            debug_assert!(
+                cfg.trust == parent_config.trust,
+                "fork must inherit parent trust exactly"
+            );
+            cfg
         } else {
-            Some(serde_json::to_string(&response.tool_calls)?)
+            // Load the raw JSON first to see what the agent explicitly set.
+            let raw = crate::config::KodaConfig::load_agent_json(project_root, agent_name)
+                .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
+
+            let mut cfg = crate::config::KodaConfig::load(project_root, agent_name)
+                .with_context(|| format!("Failed to load sub-agent: {agent_name}"))?;
+
+            let agent_has_own_provider = raw.provider.is_some() || raw.base_url.is_some();
+
+            if !agent_has_own_provider {
+                // Inherit parent's provider, base_url, and (if unset) model.
+                // All three travel together: model names are provider-scoped.
+                let model_override = raw.model.is_none().then(|| parent_config.model.clone());
+                cfg = cfg.with_overrides(
+                    Some(parent_config.base_url.clone()),
+                    model_override,
+                    Some(parent_config.provider_type.to_string()),
+                );
+            }
+            // else: agent opted into its own provider — use its resolved config
+            // as-is. The agent JSON is responsible for any model it needs.
+
+            // Inherit trust: child can never exceed parent's trust (#845).
+            // Same pattern as Codex's `apply_spawn_agent_runtime_overrides()`
+            // which copies the parent's runtime sandbox_policy onto the child.
+            let child_trust = cfg.trust;
+            cfg.trust = TrustMode::clamp(parent_config.trust, cfg.trust);
+            if cfg.trust != child_trust {
+                tracing::info!(
+                    agent = agent_name,
+                    parent = %parent_config.trust,
+                    child = %child_trust,
+                    effective = %cfg.trust,
+                    "sub-agent trust clamped to match parent",
+                );
+            }
+
+            cfg
         };
 
-        db.insert_message(
-            &sub_session,
-            &Role::Assistant,
-            response.content.as_deref(),
-            tool_calls_json.as_deref(),
-            None,
-            Some(&response.usage),
-        )
-        .await?;
-
-        if response.tool_calls.is_empty() {
-            let result = response
-                .content
-                .unwrap_or_else(|| "(no output)".to_string());
-            // Cache the result for future identical calls
-            sub_agent_cache.put(agent_name, prompt, &result);
-            // Release workspace; surface branch hint if agent left changes.
-            if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
-                sink.emit(EngineEvent::Info {
-                    message: format!("  \u{1f335} {agent_name}: {hint}"),
-                });
-            }
-            return Ok(result);
-        }
-
-        for tc in &response.tool_calls {
-            sink.emit(EngineEvent::ToolCallStart {
-                id: tc.id.clone(),
-                name: tc.function_name.clone(),
-                args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
-                is_sub_agent: true,
-            });
-
-            // Sub-agents inherit the parent's approval mode
-            let parsed_args: serde_json::Value =
-                serde_json::from_str(&tc.arguments).unwrap_or_default();
-            let approval = trust::check_tool(
-                &tc.function_name,
-                &parsed_args,
-                mode,
-                Some(effective_root_ref),
-            );
-
-            let output = match approval {
-                ToolApproval::AutoApprove => {
-                    tools
-                        .execute(&tc.function_name, &tc.arguments, None)
-                        .await
-                        .output
-                }
-                ToolApproval::Blocked => {
-                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                    let diff_preview =
-                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
-                    sink.emit(EngineEvent::ActionBlocked {
-                        tool_name: tc.function_name.clone(),
-                        detail,
-                        preview: diff_preview,
-                    });
-                    "[safe mode] Action blocked.".to_string()
-                }
-                ToolApproval::NeedsConfirmation => {
-                    let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                    let diff_preview =
-                        preview::compute(&tc.function_name, &parsed_args, effective_root_ref).await;
-                    let effect = crate::trust::resolve_tool_effect_with_registry(
-                        &tc.function_name,
-                        &parsed_args,
-                        &tools,
-                    );
-                    match request_approval(
-                        sink,
-                        cmd_rx,
-                        &cancel,
-                        &tc.function_name,
-                        &detail,
-                        diff_preview,
-                        effect,
-                    )
-                    .await
-                    {
-                        Some(ApprovalDecision::Approve) => {
-                            tools
-                                .execute(&tc.function_name, &tc.arguments, None)
-                                .await
-                                .output
+        let sub_session = match session_id {
+            Some(id) => id,
+            None => {
+                let sid = db
+                    .create_session(&sub_config.agent_name, project_root)
+                    .await?;
+                // Fork: copy parent conversation history into the new session
+                if is_fork {
+                    let parent_history = db.load_context(parent_session_id).await?;
+                    for msg in &parent_history {
+                        let mid = db
+                            .insert_message(
+                                &sid,
+                                &msg.role,
+                                msg.content.as_deref(),
+                                msg.tool_calls.as_deref(),
+                                msg.tool_call_id.as_deref(),
+                                None, // don't duplicate usage stats
+                            )
+                            .await?;
+                        // Copied assistant messages are already complete in the
+                        // parent — mark them complete in the child session so
+                        // load_context includes them (#875).
+                        if msg.role == Role::Assistant {
+                            db.mark_message_complete(mid).await?;
                         }
-                        Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
-                        Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
-                            format!("[rejected: {feedback}]")
-                        }
-                        None => "[cancelled]".to_string(),
                     }
                 }
+                sid
+            }
+        };
+
+        db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)
+            .await?;
+
+        let provider = crate::providers::create_provider(&sub_config);
+        // Select workspace provider. Write-capable agents get an isolated
+        // workspace; read-only agents share the parent root for free.
+        //
+        // Per-platform write-isolation choice:
+        //
+        // - **macOS:** `ClonefileProvider` (APFS clonefile(2)) is
+        //   preferred for its ~3-4× provision speedup over git worktree
+        //   (Phase 4d / #934). Falls back to git worktree if construction
+        //   fails (e.g. `$HOME` unset, project path can't canonicalize).
+        // - **Linux + others:** `GitWorktreeProvider`. The Linux CoW
+        //   equivalent (4e in #934) is deferred until production
+        //   telemetry shows it's worth building.
+        //
+        // **Documented platform divergence** — see `docs/src/sandbox.md`
+        // → "Workspace providers". Both backends provide the same
+        // isolation guarantees; only provision speed differs.
+        let has_write_tools = !sub_config
+            .disallowed_tools
+            .iter()
+            .any(|t| t == "Write" || t == "Edit");
+        // Phase 1 of #1022: explicit `+ Send + Sync` on the trait object.
+        // The supertrait bound `WorkspaceProvider: Send + Sync` constrains
+        // *implementors*, but Rust trait objects don't auto-inherit those
+        // bounds — `Box<dyn WorkspaceProvider>` is `!Send` without the
+        // explicit annotation, which makes the whole `execute_sub_agent`
+        // future `!Send` and unspawnable.
+        let workspace: Box<dyn WorkspaceProvider + Send + Sync> = if has_write_tools {
+            pick_write_provider(project_root, agent_name)
+        } else {
+            Box::new(CwdProvider::new(project_root))
+        };
+        let effective_root = match workspace.provision(&sub_session).await {
+            Ok(path) => {
+                if path != project_root {
+                    sink.emit(EngineEvent::Info {
+                        message: format!("  \u{1f333} {agent_name}: isolated in worktree"),
+                    });
+                }
+                path
+            }
+            Err(e) => {
+                tracing::warn!("Workspace provision failed: {e}");
+                project_root.to_path_buf()
+            }
+        };
+        let effective_root_ref = effective_root.as_path();
+
+        let tools = {
+            let registry = ToolRegistry::with_trust(
+                effective_root.clone(),
+                sub_config.max_context_tokens,
+                sub_config.trust,
+            );
+            // Phase 5 PR-4 of #934: compose the parent's effective policy
+            // with the child's. Per-field rules in [`SandboxPolicy::compose`]
+            // (denies union, allows parent-wins, limits min, trust strictest)
+            // ensure the child can never widen the parent's surface — only
+            // narrow it. PR-2 installed the child policy verbatim; PR-4
+            // makes the install additive over the parent so chains of
+            // sub-agents accumulate restrictions monotonically.
+            let composed_policy = crate::sandbox::compose_child_policy(
+                parent_sandbox_policy,
+                sub_config.trust,
+                effective_root_ref,
+            );
+            let registry = registry.with_sandbox_policy(composed_policy);
+            match parent_cache {
+                Some(cache) => registry.with_shared_cache(cache),
+                None => registry,
+            }
+        };
+        let tool_defs = {
+            let mut denied = sub_config.disallowed_tools.clone();
+            // Anti-recursion: fork children cannot spawn sub-agents
+            if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
+                denied.push("InvokeAgent".to_string());
+            }
+            tools.get_definitions(&sub_config.allowed_tools, &denied)
+        };
+        let semantic_memory = if sub_config.skip_memory {
+            String::new()
+        } else {
+            memory::load(project_root)?
+        };
+        let env = crate::prompt::EnvironmentInfo {
+            project_root: effective_root_ref,
+            model: &sub_config.model,
+            platform: std::env::consts::OS,
+        };
+        let system_prompt = build_system_prompt(
+            &sub_config.system_prompt,
+            &semantic_memory,
+            &sub_config.agents_dir,
+            &env,
+            &[], // sub-agents have no REPL commands
+            &tools.skill_registry,
+        );
+
+        for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
+            // Respect parent cancellation (#286)
+            if cancel.is_cancelled() {
+                // Release workspace on cancellation (best-effort, no user hint).
+                let _ = workspace.release(&sub_session, &effective_root).await;
+                return Ok("[cancelled by parent]".to_string());
+            }
+            let history = db.load_context(&sub_session).await?;
+            let mut messages = vec![ChatMessage::text("system", &system_prompt)];
+            for msg in &history {
+                let tool_calls: Option<Vec<ToolCall>> = msg
+                    .tool_calls
+                    .as_deref()
+                    .and_then(|tc| serde_json::from_str(tc).ok());
+                messages.push(ChatMessage {
+                    role: msg.role.as_str().to_string(),
+                    content: msg.content.clone(),
+                    tool_calls,
+                    tool_call_id: msg.tool_call_id.clone(),
+                    images: None,
+                });
+            }
+
+            sink.emit(EngineEvent::SpinnerStart {
+                message: format!("  🦥 {agent_name} thinking..."),
+            });
+            let response = provider
+                .chat(&messages, &tool_defs, &sub_config.model_settings)
+                .await?;
+            sink.emit(EngineEvent::SpinnerStop);
+
+            let tool_calls_json = if response.tool_calls.is_empty() {
+                None
+            } else {
+                Some(serde_json::to_string(&response.tool_calls)?)
             };
 
             db.insert_message(
                 &sub_session,
-                &Role::Tool,
-                Some(&output),
+                &Role::Assistant,
+                response.content.as_deref(),
+                tool_calls_json.as_deref(),
                 None,
-                Some(&tc.id),
-                None,
+                Some(&response.usage),
             )
             .await?;
-        }
-    }
 
-    sink.emit(EngineEvent::Warn {
-        message: format!(
-            "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
-            loop_guard::MAX_SUB_AGENT_ITERATIONS
-        ),
-    });
-    // Release workspace on iteration limit exit.
-    if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
-        sink.emit(EngineEvent::Info {
-            message: format!("  \u{1f335} {agent_name}: {hint}"),
+            if response.tool_calls.is_empty() {
+                let result = response
+                    .content
+                    .unwrap_or_else(|| "(no output)".to_string());
+                // Cache the result for future identical calls
+                sub_agent_cache.put(agent_name, prompt, &result);
+                // Release workspace; surface branch hint if agent left changes.
+                if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
+                    sink.emit(EngineEvent::Info {
+                        message: format!("  \u{1f335} {agent_name}: {hint}"),
+                    });
+                }
+                return Ok(result);
+            }
+
+            for tc in &response.tool_calls {
+                sink.emit(EngineEvent::ToolCallStart {
+                    id: tc.id.clone(),
+                    name: tc.function_name.clone(),
+                    args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
+                    is_sub_agent: true,
+                });
+
+                // Sub-agents inherit the parent's approval mode
+                let parsed_args: serde_json::Value =
+                    serde_json::from_str(&tc.arguments).unwrap_or_default();
+                let approval = trust::check_tool(
+                    &tc.function_name,
+                    &parsed_args,
+                    mode,
+                    Some(effective_root_ref),
+                );
+
+                let output = match approval {
+                    ToolApproval::AutoApprove => {
+                        tools
+                            .execute(&tc.function_name, &tc.arguments, None)
+                            .await
+                            .output
+                    }
+                    ToolApproval::Blocked => {
+                        let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                        let diff_preview =
+                            preview::compute(&tc.function_name, &parsed_args, effective_root_ref)
+                                .await;
+                        sink.emit(EngineEvent::ActionBlocked {
+                            tool_name: tc.function_name.clone(),
+                            detail,
+                            preview: diff_preview,
+                        });
+                        "[safe mode] Action blocked.".to_string()
+                    }
+                    ToolApproval::NeedsConfirmation => {
+                        let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                        let diff_preview =
+                            preview::compute(&tc.function_name, &parsed_args, effective_root_ref)
+                                .await;
+                        let effect = crate::trust::resolve_tool_effect_with_registry(
+                            &tc.function_name,
+                            &parsed_args,
+                            &tools,
+                        );
+                        match request_approval(
+                            sink,
+                            cmd_rx,
+                            &cancel,
+                            &tc.function_name,
+                            &detail,
+                            diff_preview,
+                            effect,
+                        )
+                        .await
+                        {
+                            Some(ApprovalDecision::Approve) => {
+                                tools
+                                    .execute(&tc.function_name, &tc.arguments, None)
+                                    .await
+                                    .output
+                            }
+                            Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
+                            Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
+                                format!("[rejected: {feedback}]")
+                            }
+                            None => "[cancelled]".to_string(),
+                        }
+                    }
+                };
+
+                db.insert_message(
+                    &sub_session,
+                    &Role::Tool,
+                    Some(&output),
+                    None,
+                    Some(&tc.id),
+                    None,
+                )
+                .await?;
+            }
+        }
+
+        sink.emit(EngineEvent::Warn {
+            message: format!(
+                "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
+                loop_guard::MAX_SUB_AGENT_ITERATIONS
+            ),
         });
+        // Release workspace on iteration limit exit.
+        if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
+            sink.emit(EngineEvent::Info {
+                message: format!("  \u{1f335} {agent_name}: {hint}"),
+            });
+        }
+        Ok("(sub-agent reached maximum iterations)".to_string())
     }
-    Ok("(sub-agent reached maximum iterations)".to_string())
 }
 
 // ── Workspace provider selection ────────────────────────────────────────────

--- a/koda-sandbox/src/ipc.rs
+++ b/koda-sandbox/src/ipc.rs
@@ -245,8 +245,8 @@ pub struct GrepMatch {
 ///   [`MAX_PAYLOAD_BYTES`] or the payload is not valid JSON-of-`T`.
 pub async fn read_message<R, T>(reader: &mut R) -> io::Result<Option<T>>
 where
-    R: AsyncRead + Unpin,
-    T: serde::de::DeserializeOwned,
+    R: AsyncRead + Unpin + Send,
+    T: serde::de::DeserializeOwned + Send,
 {
     // Read the 4-byte length prefix manually so we can distinguish the
     // two flavors of EOF: clean (0 bytes read — peer hung up between
@@ -295,8 +295,8 @@ where
 /// - Any IO error from the underlying transport.
 pub async fn write_message<W, T>(writer: &mut W, msg: &T) -> io::Result<()>
 where
-    W: AsyncWrite + Unpin,
-    T: serde::Serialize,
+    W: AsyncWrite + Unpin + Send,
+    T: serde::Serialize + Sync,
 {
     let payload = serde_json::to_vec(msg)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("serialize: {e}")))?;

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -78,8 +78,8 @@ impl Context {
 /// Returns `Err(...)` only for genuine transport errors.
 pub async fn run<R, W>(reader: &mut R, writer: &mut W) -> Result<()>
 where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
 {
     let ctx = Context::default();
     run_with_ctx(&ctx, reader, writer).await
@@ -97,8 +97,8 @@ pub async fn run_with_policy<R, W>(
     writer: &mut W,
 ) -> Result<()>
 where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
 {
     let ctx = Context::with_policy(writable_root, policy);
     run_with_ctx(&ctx, reader, writer).await
@@ -107,8 +107,8 @@ where
 /// Inner loop — separated so Phase 2f can inject a policy-bearing context.
 async fn run_with_ctx<R, W>(ctx: &Context, reader: &mut R, writer: &mut W) -> Result<()>
 where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
+    R: AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
 {
     loop {
         let req = match read_message::<R, Request>(reader).await {


### PR DESCRIPTION
Fixes #1023 (Phase 2 of #1022 — the deferred B5).

## What

Background sub-agents now run on the multi-thread tokio runtime via plain `tokio::spawn`, instead of the `spawn_blocking + new_current_thread` workaround we shipped in Phase 1.

## Why this was deferred (and why it's fixable now)

`execute_sub_agent`'s future was non-`Send`, but the actual offender was buried three layers deep in the sandbox IPC stack:

```
execute_sub_agent.await
  └── tools.execute(...).await
        └── SandboxedFileSystem::rpc().await
              └── client.lock().await         ← MutexGuard<WorkerClient> held across await
                    └── client.request(req).await
                          └── ipc::write_message::<W, T>().await   ← W, T had no Send bound
                                └── writer.write_all().await       ← T not Sync ⇒ guard not Send
```

`tokio::sync::MutexGuard<T>` is `Send` only when `T: Send`. `WorkerClient` *was* `Send`, but holding the guard across an await inside a generic `write_message<W, T>` whose `W` and `T` had no `Send` bounds quietly poisoned the whole chain.

`async fn` doesn't help you here — Send-ness is checked at the *use site* (`tokio::spawn`), and the error points at the spawn call rather than the offender. `clippy::future_not_send` was the smoking gun once the compile error stopped masking it.

## Changes

| File | What |
|---|---|
| `koda-sandbox/src/ipc.rs` | `Send` bounds on `read_message<R, T>` / `write_message<W, T>` |
| `koda-sandbox/src/worker.rs` | `Send` bounds on `run` / `run_with_policy` / `run_with_ctx` |
| `koda-core/src/sub_agent_dispatch.rs` | `execute_sub_agent` returns `impl Future<Output = ...> + Send + 'a` (forces compiler to *prove* Send-ness at the boundary); bg path now uses plain `tokio::spawn` |
| `koda-core/src/providers/stream_collector.rs` | `Box<dyn ChunkParser + Send>` (same trait-object auto-trait gotcha for the SSE collector path) |
| `koda-core/src/bg_agent.rs` | doc comment refreshed |
| `DESIGN.md` | P3/P4 invariants now reflect the multi-thread bg path |

## Why `impl Future + Send` instead of `async fn`

`async fn foo() -> T` is sugar for `fn foo() -> impl Future<Output = T>` with the auto-traits *inferred*. When inference says "not Send", you get an opaque error at every spawn site. By writing the bound explicitly:

```rust
pub(crate) fn execute_sub_agent<'a>(...)
    -> impl std::future::Future<Output = Result<String>> + Send + 'a
{
    async move { ... }
}
```

…the compiler now *proves* Send at this function's boundary. If a future regression sneaks a non-Send temp across an await, it errors here, not at every downstream `tokio::spawn`.

## Invariants preserved (all four bg-agent rules from #1022 Phase 1 still hold)

- Trust never widens (`derive_child_trust` clamp)
- Cancel cascades from parent (`child_token()` shared with bg task)
- Sandbox policy composes onto parent's effective policy
- Bg agents cannot themselves spawn bg agents (`background: false` override)

## Tests

All **1781 lib tests pass**. Pre-push hook: fmt ✓, clippy `-D warnings` ✓, doc `-D warnings` ✓.

## Follow-ups (not in this PR)

- Add `clippy::future_not_send` to CI for `koda-core` and `koda-sandbox` so this class of regression can't sneak back in.
- Add an E2E integration test that exercises the bg path end-to-end on the multi-thread runtime (today we only have `BgAgentRegistry` unit tests).

🤖 Generated with [Code Puppy](https://puppy.walmart.com)
