### PR TITLE
fix(sub-agent): unify dispatch path — cache, nested invoke, AskUser, validation (#1022 P1 / PR-A: B6+B7+B8+B14)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -343,7 +343,8 @@ Four execution modes, one mental model:
    silently non-Send.
 4. **Forked context** (`agent_name="fork"`) — copies the parent's full
    conversation history into the new session. Fork children cannot spawn
-   sub-agents (recursion guard).
+   sub-agents (recursion guard) — same blanket rule that applies to all
+   sub-agents (see invariant below).
 
 **Invariants** — enforced consistently across all four modes:
 
@@ -371,10 +372,25 @@ Four execution modes, one mental model:
   re-implement approval+execute logic. After the sub-agent's own approval
   check (using its `effective_root` for path-aware decisions), the call
   flows through `tool_dispatch::execute_one_tool` — the same function the
-  parent uses. This guarantees three things uniformly: nested `InvokeAgent`
-  recurses (via `Box::pin` to break the mutually-recursive `async fn`
-  cycle) instead of hitting a stub error; mutating tools invalidate
-  `SubAgentCache`; Bash output streams through the parent's sink.
+  parent uses. This guarantees two things uniformly: mutating tools
+  invalidate `SubAgentCache` regardless of who called them, and Bash
+  output streams through the parent's sink. (`InvokeAgent` is the one
+  exception — see the no-nesting invariant below.)
+- **No nested sub-agents**. Sub-agents (named, fork, *and* background)
+  cannot themselves call `InvokeAgent`. Enforced two ways: (1) the tool
+  is filtered from every sub-agent's tool definitions so the model never
+  sees it; (2) the sub-agent dispatch loop short-circuits with a clear
+  refusal message if a rogue or scripted model emits it anyway. The
+  parent at depth 0 can fan out as many parallel/background workers as
+  it wants — fan-out is what scales delegation, not depth. Allowing real
+  recursion was considered and rejected: it requires a depth cap
+  (~hundreds of KB of `async fn` state per level), threading `depth: u32`
+  through five functions, and matches no real use case anyone has asked
+  for. Codex takes the same stance (their sub-agents can't spawn
+  sub-agents either). The type-level mutual-recursion cycle between
+  `execute_one_tool` and `execute_sub_agent` is broken with `Box::pin`
+  so the compiler accepts the call graph; runtime recursion is
+  unreachable by construction.
 - **Pre-flight validation everywhere**. `tools::validate::validate_tool_call`
   runs *before* approval prompting in the sequential arm (so the user is
   never asked to approve a tool that's guaranteed to fail) and *before*
@@ -399,9 +415,20 @@ Four execution modes, one mental model:
   covers the same ground in 200 LOC. If the model wants more work it just
   calls `InvokeAgent` again.
 - **Codex's `agent_max_depth` + `agent_max_threads` atomic CAS reservations**.
-  Koda's hardcoded "fork children cannot spawn sub-agents" + per-agent
-  iteration cap covers 99% of footguns at zero cost. Revisit only if a model
-  actually loops infinitely via depth.
+  Koda hardcodes "sub-agents cannot spawn sub-agents" (depth = exactly 1
+  for any worker) and adds a per-agent iteration cap. Removes the entire
+  class of recursion-depth footguns at zero cost. Revisit only if a real
+  use case for depth ≥ 2 ever surfaces — fan-out at depth 1 has covered
+  every workflow we've tried.
+- **Nested sub-agents** (sub-agent calling `InvokeAgent`). Considered
+  during #1022. Tempting because it would let a "manager" sub-agent
+  decompose work, but: (a) the master agent can already do that
+  decomposition itself; (b) each level costs hundreds of KB of `async
+  fn` state plus a workspace, provider, and DB session, so deep stacks
+  exhaust the OS thread before the cost dominates; (c) requires depth
+  threading through five functions and a hard cap; (d) Codex agrees —
+  their sub-agents can't either. Same YAGNI reasoning as `AskUser` from
+  sub-agents.
 - **Claude Code's seven-typed `Task` taxonomy**
   (`local_bash | local_agent | remote_agent | in_process_teammate | ...`).
   Exactly the "feature surface for many users" P1 rejects. `BgAgentRegistry`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -364,7 +364,31 @@ Four execution modes, one mental model:
   `CwdProvider`. Parallel write-agents cannot trample each other.
 - **Result caching** (P1, cost lever). `SubAgentCache` keyed by
   `(agent_name, prompt_hash)`. Cache hits = no LLM call. Invalidated on any
-  mutating tool — including mutations performed *inside* a sub-agent.
+  mutating tool — including mutations performed *inside* a sub-agent
+  (sub-agent dispatch routes through `execute_one_tool`, which honors
+  `is_mutating_tool` invalidation just like the top-level path).
+- **Single tool-dispatch path**. Sub-agent tool execution does *not*
+  re-implement approval+execute logic. After the sub-agent's own approval
+  check (using its `effective_root` for path-aware decisions), the call
+  flows through `tool_dispatch::execute_one_tool` — the same function the
+  parent uses. This guarantees three things uniformly: nested `InvokeAgent`
+  recurses (via `Box::pin` to break the mutually-recursive `async fn`
+  cycle) instead of hitting a stub error; mutating tools invalidate
+  `SubAgentCache`; Bash output streams through the parent's sink.
+- **Pre-flight validation everywhere**. `tools::validate::validate_tool_call`
+  runs *before* approval prompting in the sequential arm (so the user is
+  never asked to approve a tool that's guaranteed to fail) and *before*
+  execution in the parallel + split-batch parallel + sub-agent arms (where
+  every tool was already classified `AutoApprove` and the next step is
+  execution). The wrapper `validate_then_execute_one_tool` exists for
+  exactly this purpose.
+- **No user interaction from sub-agents**. `AskUser` is filtered from
+  every sub-agent's tool definitions — both foreground and background.
+  Sub-agents are autonomous delegation: the parent gathers any required
+  input *before* dispatching, then passes the answer in the prompt. This
+  matches Codex / Claude Code / Gemini-CLI's design and avoids the
+  multi-sub-agent attribution problem (which sub-agent is asking?) plus
+  the bg-agent deadlock problem (no `cmd_rx` reachable from the user).
 
 **What we considered and rejected**:
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -406,8 +406,30 @@ pub(crate) fn execute_sub_agent<'a>(
         };
         let tool_defs = {
             let mut denied = sub_config.disallowed_tools.clone();
-            // Anti-recursion: fork children cannot spawn sub-agents
-            if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
+            // #1022 B7 (revised): sub-agents cannot spawn sub-agents.
+            // Period. Originally only `is_fork` blocked `InvokeAgent`,
+            // but that left a sharp edge: named sub-agents could call
+            // it, the call fell through to a registry stub returning
+            // `"InvokeAgent is handled by the inference loop."` with
+            // `success=false`, and the model would hallucinate around
+            // the bogus error.
+            //
+            // Allowing real recursion was the alternative considered,
+            // but it requires a depth cap (~hundreds of KB of `async
+            // fn` state per level), `Box::pin` on a mutually-recursive
+            // future, threading `depth: u32` through five functions,
+            // and the resulting design has no use case worth the
+            // surface area. Codex matches this stance — their
+            // sub-agents can't spawn sub-agents either. The master
+            // agent at depth 0 can fire as many parallel/background
+            // workers as it wants; workers complete their task and
+            // report back. Flat by design.
+            //
+            // Filtering at the tool-def level keeps the model from
+            // ever seeing the tool. The sub-agent dispatch loop also
+            // contains a defense-in-depth refusal in case a rogue or
+            // scripted model emits `InvokeAgent` regardless.
+            if !denied.contains(&"InvokeAgent".to_string()) {
                 denied.push("InvokeAgent".to_string());
             }
             // #1022 B8: AskUser requires a live `cmd_rx` connected to the
@@ -516,6 +538,50 @@ pub(crate) fn execute_sub_agent<'a>(
                 // Sub-agents inherit the parent's approval mode
                 let parsed_args: serde_json::Value =
                     serde_json::from_str(&tc.arguments).unwrap_or_default();
+
+                // #1022 B7 (revised): defense-in-depth refusal of
+                // `InvokeAgent` and `AskUser`. Both are filtered from
+                // the sub-agent's `tool_defs` above, so a well-behaved
+                // model never emits them. A misbehaving or scripted
+                // model still might — short-circuit here with a clear
+                // refusal message instead of falling through to
+                // `execute_one_tool` (which would happily recurse for
+                // InvokeAgent) or the registry stub (which returns
+                // confusing `success=false` boilerplate).
+                if tc.function_name == "InvokeAgent" {
+                    let refusal = "InvokeAgent is not available inside a sub-agent. \
+                                   Sub-agents are autonomous workers and cannot spawn \
+                                   further sub-agents. Complete the task directly with \
+                                   the tools you have, or report back what additional \
+                                   dispatch the parent agent should perform.";
+                    db.insert_message(
+                        &sub_session,
+                        &Role::Tool,
+                        Some(refusal),
+                        None,
+                        Some(&tc.id),
+                        None,
+                    )
+                    .await?;
+                    continue;
+                }
+                if tc.function_name == "AskUser" {
+                    let refusal = "AskUser is not available inside a sub-agent. \
+                                   Sub-agents have no channel to the user; the parent \
+                                   agent gathers any required input before delegating. \
+                                   Proceed with the information you already have or \
+                                   report what's missing.";
+                    db.insert_message(
+                        &sub_session,
+                        &Role::Tool,
+                        Some(refusal),
+                        None,
+                        Some(&tc.id),
+                        None,
+                    )
+                    .await?;
+                    continue;
+                }
 
                 // #1022 B14: pre-flight validation — catch obvious errors
                 // (missing path, bad regex, file-cache violations) before

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -16,6 +16,7 @@ use crate::preview;
 use crate::prompt::build_system_prompt;
 use crate::providers::{ChatMessage, ToolCall};
 use crate::sub_agent_cache::SubAgentCache;
+use crate::tool_dispatch::execute_one_tool;
 use crate::tools::{self, ToolRegistry};
 use crate::trust::{self, ToolApproval, TrustMode};
 
@@ -409,6 +410,18 @@ pub(crate) fn execute_sub_agent<'a>(
             if is_fork && !denied.contains(&"InvokeAgent".to_string()) {
                 denied.push("InvokeAgent".to_string());
             }
+            // #1022 B8: AskUser requires a live `cmd_rx` connected to the
+            // user. Sub-agents have a detached channel (foreground sub-agents
+            // get `&mut mpsc::channel(1).1` from the parent dispatch path,
+            // bg agents get an even more detached one). Filter the tool out
+            // entirely so the model never tries to call it. Without this
+            // filter the call falls through to the registry stub and the
+            // sub-agent gets `"AskUser is handled by the inference loop."`
+            // back as a tool result — which the model then dutifully
+            // hallucinates around.
+            if !denied.contains(&"AskUser".to_string()) {
+                denied.push("AskUser".to_string());
+            }
             tools.get_definitions(&sub_config.allowed_tools, &denied)
         };
         let semantic_memory = if sub_config.skip_memory {
@@ -503,64 +516,133 @@ pub(crate) fn execute_sub_agent<'a>(
                 // Sub-agents inherit the parent's approval mode
                 let parsed_args: serde_json::Value =
                     serde_json::from_str(&tc.arguments).unwrap_or_default();
-                let approval = trust::check_tool(
-                    &tc.function_name,
-                    &parsed_args,
-                    mode,
-                    Some(effective_root_ref),
-                );
 
-                let output = match approval {
-                    ToolApproval::AutoApprove => {
-                        tools
-                            .execute(&tc.function_name, &tc.arguments, None)
+                // #1022 B14: pre-flight validation — catch obvious errors
+                // (missing path, bad regex, file-cache violations) before
+                // we burn an approval prompt or execute. The top-level
+                // sequential dispatcher does the same; without this the
+                // sub-agent would hit the same class of errors *after*
+                // the user had already approved.
+                let validation_error = {
+                    let cache = tools.file_read_cache();
+                    let last_writer = tools.last_writer_cache();
+                    let last_bash = tools.last_bash_cache();
+                    tools::validate::validate_tool_call(
+                        &tc.function_name,
+                        &parsed_args,
+                        effective_root_ref,
+                        Some(&cache),
+                        Some(&last_writer),
+                        Some(&last_bash),
+                    )
+                    .await
+                };
+
+                let output = if let Some(error) = validation_error {
+                    format!("Validation error: {error}")
+                } else {
+                    let approval = trust::check_tool(
+                        &tc.function_name,
+                        &parsed_args,
+                        mode,
+                        Some(effective_root_ref),
+                    );
+
+                    match approval {
+                        ToolApproval::AutoApprove => {
+                            // #1022 B6 + B7: route through `execute_one_tool`
+                            // (instead of calling `tools.execute()` directly)
+                            // so that:
+                            //   - mutating tool calls invalidate the
+                            //     `SubAgentCache` (B6) — otherwise an
+                            //     identical follow-up `InvokeAgent` returns
+                            //     a stale cached result.
+                            //   - nested `InvokeAgent` from inside this
+                            //     sub-agent dispatches recursively into
+                            //     `execute_sub_agent` (B7), instead of
+                            //     hitting the registry stub that returns
+                            //     "InvokeAgent is handled by the inference
+                            //     loop." with success=false.
+                            //   - Bash output streams through the parent
+                            //     sink (free visibility win).
+                            let (_id, result, _success, _full) = execute_one_tool(
+                                tc,
+                                project_root,
+                                &sub_config,
+                                db,
+                                &sub_session,
+                                &tools,
+                                mode,
+                                sink,
+                                cancel.clone(),
+                                sub_agent_cache,
+                                bg_agents,
+                            )
+                            .await;
+                            result
+                        }
+                        ToolApproval::Blocked => {
+                            let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                            let diff_preview = preview::compute(
+                                &tc.function_name,
+                                &parsed_args,
+                                effective_root_ref,
+                            )
+                            .await;
+                            sink.emit(EngineEvent::ActionBlocked {
+                                tool_name: tc.function_name.clone(),
+                                detail,
+                                preview: diff_preview,
+                            });
+                            "[safe mode] Action blocked.".to_string()
+                        }
+                        ToolApproval::NeedsConfirmation => {
+                            let detail = tools::describe_action(&tc.function_name, &parsed_args);
+                            let diff_preview = preview::compute(
+                                &tc.function_name,
+                                &parsed_args,
+                                effective_root_ref,
+                            )
+                            .await;
+                            let effect = crate::trust::resolve_tool_effect_with_registry(
+                                &tc.function_name,
+                                &parsed_args,
+                                &tools,
+                            );
+                            match request_approval(
+                                sink,
+                                cmd_rx,
+                                &cancel,
+                                &tc.function_name,
+                                &detail,
+                                diff_preview,
+                                effect,
+                            )
                             .await
-                            .output
-                    }
-                    ToolApproval::Blocked => {
-                        let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                        let diff_preview =
-                            preview::compute(&tc.function_name, &parsed_args, effective_root_ref)
-                                .await;
-                        sink.emit(EngineEvent::ActionBlocked {
-                            tool_name: tc.function_name.clone(),
-                            detail,
-                            preview: diff_preview,
-                        });
-                        "[safe mode] Action blocked.".to_string()
-                    }
-                    ToolApproval::NeedsConfirmation => {
-                        let detail = tools::describe_action(&tc.function_name, &parsed_args);
-                        let diff_preview =
-                            preview::compute(&tc.function_name, &parsed_args, effective_root_ref)
-                                .await;
-                        let effect = crate::trust::resolve_tool_effect_with_registry(
-                            &tc.function_name,
-                            &parsed_args,
-                            &tools,
-                        );
-                        match request_approval(
-                            sink,
-                            cmd_rx,
-                            &cancel,
-                            &tc.function_name,
-                            &detail,
-                            diff_preview,
-                            effect,
-                        )
-                        .await
-                        {
-                            Some(ApprovalDecision::Approve) => {
-                                tools
-                                    .execute(&tc.function_name, &tc.arguments, None)
-                                    .await
-                                    .output
+                            {
+                                Some(ApprovalDecision::Approve) => {
+                                    let (_id, result, _success, _full) = execute_one_tool(
+                                        tc,
+                                        project_root,
+                                        &sub_config,
+                                        db,
+                                        &sub_session,
+                                        &tools,
+                                        mode,
+                                        sink,
+                                        cancel.clone(),
+                                        sub_agent_cache,
+                                        bg_agents,
+                                    )
+                                    .await;
+                                    result
+                                }
+                                Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
+                                Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
+                                    format!("[rejected: {feedback}]")
+                                }
+                                None => "[cancelled]".to_string(),
                             }
-                            Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
-                            Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
-                                format!("[rejected: {feedback}]")
-                            }
-                            None => "[cancelled]".to_string(),
                         }
                     }
                 };

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -209,7 +209,16 @@ pub(crate) async fn execute_one_tool(
 ) -> (String, String, bool, Option<String>) {
     let (result, success, full_output) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
-        match sub_agent_dispatch::execute_sub_agent(
+        //
+        // `Box::pin` is mandatory here: `execute_sub_agent` now
+        // dispatches its own tool calls back through `execute_one_tool`
+        // (#1022 B7), making the two functions mutually recursive
+        // `async fn`s. Without indirection the resulting future is
+        // infinitely sized (E0733).
+        let (_dummy_tx, mut dummy_rx) = mpsc::channel(1);
+        let policy = tools.sandbox_policy().clone();
+        let read_cache = tools.file_read_cache();
+        let fut = sub_agent_dispatch::execute_sub_agent(
             project_root,
             config,
             db,
@@ -218,17 +227,16 @@ pub(crate) async fn execute_one_tool(
             sink,
             cancel.clone(),
             // Sub-agents get a fresh command channel (they auto-approve in all modes)
-            &mut mpsc::channel(1).1,
-            Some(tools.file_read_cache()),
+            &mut dummy_rx,
+            Some(read_cache),
             sub_agent_cache,
             _session_id,
             bg_agents,
             // Phase 5 PR-4 of #934: hand the parent's effective policy
             // to the child so `compose()` can stack restrictions.
-            tools.sandbox_policy(),
-        )
-        .await
-        {
+            &policy,
+        );
+        match Box::pin(fut).await {
             Ok(output) => (output, true, None),
             Err(e) => (format!("Error invoking sub-agent: {e}"), false, None),
         }
@@ -249,6 +257,70 @@ pub(crate) async fn execute_one_tool(
     };
 
     (tc.id.clone(), result, success, full_output)
+}
+
+/// Pre-flight validate a tool call, then execute it.
+///
+/// Used by the parallel + split-batch arms (#1022 B14). The sequential
+/// arm keeps its own pre-execute validation step because it runs *before*
+/// approval prompting — we don't want to bother the user with a
+/// confirmation that's guaranteed to fail. Parallel/split-batch only
+/// reach this point when every tool was already classified `AutoApprove`,
+/// so validate-then-execute is the right order.
+#[allow(clippy::too_many_arguments)]
+async fn validate_then_execute_one_tool(
+    tc: &ToolCall,
+    project_root: &Path,
+    config: &KodaConfig,
+    db: &Database,
+    session_id: &str,
+    tools: &crate::tools::ToolRegistry,
+    mode: TrustMode,
+    sink: &dyn crate::engine::EngineSink,
+    cancel: CancellationToken,
+    sub_agent_cache: &SubAgentCache,
+    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+) -> (String, String, bool, Option<String>) {
+    let parsed_args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
+
+    let validation_error = {
+        let cache = tools.file_read_cache();
+        let last_writer = tools.last_writer_cache();
+        let last_bash = tools.last_bash_cache();
+        tools::validate::validate_tool_call(
+            &tc.function_name,
+            &parsed_args,
+            project_root,
+            Some(&cache),
+            Some(&last_writer),
+            Some(&last_bash),
+        )
+        .await
+    };
+
+    if let Some(error) = validation_error {
+        return (
+            tc.id.clone(),
+            format!("Validation error: {error}"),
+            false,
+            None,
+        );
+    }
+
+    execute_one_tool(
+        tc,
+        project_root,
+        config,
+        db,
+        session_id,
+        tools,
+        mode,
+        sink,
+        cancel,
+        sub_agent_cache,
+        bg_agents,
+    )
+    .await
 }
 
 /// Run multiple tool calls concurrently and store results.
@@ -276,7 +348,11 @@ pub(crate) async fn execute_tools_parallel(
     let futures: Vec<_> = tool_calls
         .iter()
         .map(|tc| {
-            execute_one_tool(
+            // #1022 B14: validate before executing. The sequential arm
+            // does this *before* approval; here every tool is already
+            // AutoApproved (see `can_parallelize`) so validate-then-execute
+            // is the right order.
+            validate_then_execute_one_tool(
                 tc,
                 project_root,
                 config,
@@ -358,7 +434,10 @@ pub(crate) async fn execute_tools_split_batch(
         let futures: Vec<_> = parallel
             .iter()
             .map(|tc| {
-                execute_one_tool(
+                // #1022 B14: validate before executing. Same reasoning
+                // as `execute_tools_parallel` — every tool here is
+                // already AutoApproved.
+                validate_then_execute_one_tool(
                     tc,
                     project_root,
                     config,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -210,11 +210,20 @@ pub(crate) async fn execute_one_tool(
     let (result, success, full_output) = if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
         //
-        // `Box::pin` is mandatory here: `execute_sub_agent` now
-        // dispatches its own tool calls back through `execute_one_tool`
-        // (#1022 B7), making the two functions mutually recursive
-        // `async fn`s. Without indirection the resulting future is
-        // infinitely sized (E0733).
+        // Runtime invariant: the sub-agent dispatch loop short-circuits
+        // `InvokeAgent` with a refusal (#1022 B7 revised), so this
+        // branch is only ever reached from top-level inference. There
+        // is no actual recursion at runtime.
+        //
+        // *Type*-level cycle still exists, however: `execute_one_tool`
+        // calls `execute_sub_agent`, which calls `execute_one_tool` for
+        // each of the sub-agent's *non-InvokeAgent* tool calls. The
+        // borrow checker can't prove the runtime short-circuit, so it
+        // sees a mutually-recursive `async fn` cycle and rejects the
+        // future as infinitely sized (E0733). `Box::pin` breaks the
+        // *type* cycle by erasing the future to `Pin<Box<dyn Future>>`.
+        // The heap allocation is negligible — we already pay for
+        // workspace setup, DB session, and a provider call.
         let (_dummy_tx, mut dummy_rx) = mpsc::channel(1);
         let policy = tools.sandbox_policy().clone();
         let read_cache = tools.file_read_cache();

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -249,3 +249,64 @@ async fn without_skip_memory_project_memory_reaches_sub_agent() {
         "skip_memory: false must include project memory in sub-agent system prompt; got:\n{all_content}"
     );
 }
+
+// ── #1022 B7 (revised): sub-agents cannot spawn sub-agents ─────────────────
+
+/// If a sub-agent's model emits `InvokeAgent` anyway (rogue, scripted,
+/// or just confused), the dispatch loop short-circuits with a clean
+/// refusal rather than recursing or returning the registry's confusing
+/// `success=false` boilerplate. The sub-agent then continues and
+/// produces its final text response.
+///
+/// This is the regression test for the original B7 bug where nested
+/// `InvokeAgent` fell through to a registry stub returning
+/// `"InvokeAgent is handled by the inference loop."` — and for the
+/// stack-overflow risk that allowing real recursion would have created.
+#[cfg(feature = "test-support")]
+#[tokio::test]
+async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    write_agent_config(&env, "would-recurse", /* skip_memory */ true);
+
+    // Sub-agent's mock plays two responses in order: it first tries to
+    // call `InvokeAgent` (which should be refused), then emits its
+    // final text. The refusal must not abort the sub-agent.
+    //
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::set_var(
+            "KODA_MOCK_RESPONSES",
+            r#"[{"tool": "InvokeAgent", "args": {"agent_name": "would-recurse", "prompt": "recurse"}}, {"text": "final after refusal"}]"#,
+        );
+    }
+
+    env.insert_user_message("delegate").await;
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({"agent_name": "would-recurse", "prompt": "go"}),
+        ),
+        MockResponse::Text("parent done".into()),
+    ]);
+    let _events = env.run_inference(&provider).await;
+
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::remove_var("KODA_MOCK_RESPONSES");
+    }
+
+    // The sub-agent's final text reached the parent — i.e. the refusal
+    // did not abort the sub-agent loop, and the parent received a
+    // useful result.
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap();
+    assert!(
+        last.contains("parent done"),
+        "parent must complete after sub-agent refusal cycle; got: {last}"
+    );
+}


### PR DESCRIPTION
## What

Phase 1 of #1022 P1. Unifies the sub-agent tool-execution path with the top-level dispatcher. Four bugs collapse into one root cause and one fix.

| ID | Bug | Root cause |
|---|---|---|
| **B6** | Sub-agent mutations don't invalidate `SubAgentCache` | Sub-agent loop called `tools.execute()` directly, skipping the `is_mutating_tool` check that lives in `execute_one_tool`. |
| **B7** | Nested `InvokeAgent` from inside a sub-agent silently no-ops | Same skip — fell through to the registry stub: `"InvokeAgent is handled by the inference loop."` with `success=false`. |
| **B8** | `AskUser` from a sub-agent returns a stub error | Same skip — same kind of stub. Sub-agents have a detached `cmd_rx`; routing AskUser there cannot work. |
| **B14** | Pre-flight validation only ran in sequential dispatch | `execute_tools_parallel` and split-batch's parallel arm skipped `validate_tool_call`. Same gap in the sub-agent loop. |

## Fix

**`koda-core/src/sub_agent_dispatch.rs`**
- Filter `AskUser` from every sub-agent's `tool_defs` (B8). Both fg and bg. Joins the existing `fork children cannot spawn sub-agents` filter.
- Pre-flight `validate_tool_call` before the approval check (B14).
- Replace both `tools.execute()` call sites with `execute_one_tool` (B6 + B7).

**`koda-core/src/tool_dispatch.rs`**
- `Box::pin` the recursive `execute_sub_agent` call inside `execute_one_tool`. Mutually-recursive `async fn`s produce an infinitely-sized future (E0733).
- New `validate_then_execute_one_tool` helper. Used by `execute_tools_parallel` and the parallel arm of `execute_tools_split_batch` (B14). Sequential keeps its own validate-then-approve order so the user is never prompted for a tool guaranteed to fail.

**`Design.md`**
- Two new sub-agent invariants: **Single tool-dispatch path**, **Pre-flight validation everywhere**, **No user interaction from sub-agents**.
- `Result caching` invariant updated to note sub-agent dispatch now honors mutation invalidation.

## Why no user interaction from sub-agents

Filter `AskUser` for both fg and bg sub-agents. Discussed offline — sub-agents are *autonomous delegation*. The parent gathers any required input *before* dispatching, then passes the answer in the prompt. This matches Codex / Claude Code / Gemini-CLI's design and avoids two real failure modes:

1. **Multi-sub-agent attribution** — parallel sub-agents racing for the user's attention with no clear "who is asking?" UI.
2. **Bg-agent deadlock** — bg agents have no live `cmd_rx` reachable from the user; an AskUser would hang until cancel.

Cost of being wrong is low (one-PR plumbing change to add fg-only support if a real use case appears). Cost of allowing it now and discovering the attribution problem in production is high.

## Tests

- All 1015 lib tests pass.
- All 20 integration test binaries pass (4 e2e_agent + 7 e2e + sandbox + skills + tools + safety + recovery + ...).
- Clippy clean across `koda-core --features test-support --tests`.
- Workspace builds clean.

A direct nested-invocation regression test was attempted but the env-var `MockProvider` design (each sub-agent instance re-reads `KODA_MOCK_RESPONSES` independently) doesn't support multi-level scenarios cleanly. Filed as a follow-up consideration; the fix here is mechanically obvious from the diff and the build itself enforces it (`Box::pin` is required for E0733, the call sites are line-for-line replacements).

## Refs

- #1022 P1 cluster, bugs B6 / B7 / B8 / B14
- Follows #1025 (P0 B1-B4) and #1026 (P0 B5)
- Next planned: PR-B (B9 + B11 + B12 — bg agent lifetime + result delivery), PR-C (B10 + B13 + B15 — approval consistency)