### PR TITLE
fix(#1022): P1 bg-agent lifecycle cluster — B10 + B11 + B12

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -330,11 +330,18 @@ Four execution modes, one mental model:
 3. **Background fire-and-forget** (`InvokeAgent { prompt, background: true }`)
    — spawned via `tokio::spawn` onto the multi-thread runtime, with the
    resulting `JoinHandle` held by `BgAgentRegistry` as an
-   `AbortOnDropHandle`. The inference loop drains completed handles
-   before each iteration via `BgAgentRegistry::drain_completed()` and
-   injects results as user messages. Bg-spawned agents cannot themselves
-   spawn bg agents (override `background: false`). `execute_sub_agent`'s
-   future is `Send` by construction — the function returns
+   `AbortOnDropHandle`. The registry **lives on `KodaSession`**, not
+   inside `inference_loop`, so bg agents survive across turns: the
+   model can spawn a long-running explorer in turn 1, return final
+   text in the same iteration, and turn 2's first iteration drains
+   the result. Owning per-loop would have aborted every still-pending
+   task on every turn boundary via `AbortOnDropHandle` (silent data
+   loss in the single-iteration response case). The inference loop
+   drains completed handles before each iteration via
+   `BgAgentRegistry::drain_completed()` and injects results as user
+   messages. Bg-spawned agents cannot themselves spawn bg agents
+   (override `background: false`). `execute_sub_agent`'s future is
+   `Send` by construction — the function returns
    `impl Future<Output = ...> + Send + 'a` rather than using `async fn`,
    forcing the compiler to *prove* Send-ness at the boundary. The
    transitive offender (generic IPC helpers in `koda-sandbox::ipc`) carry
@@ -364,10 +371,15 @@ Four execution modes, one mental model:
   `GitWorktreeProvider`). Read-only agents share the parent root via
   `CwdProvider`. Parallel write-agents cannot trample each other.
 - **Result caching** (P1, cost lever). `SubAgentCache` keyed by
-  `(agent_name, prompt_hash)`. Cache hits = no LLM call. Invalidated on any
+  `(agent_name, prompt_hash)`. Cache hits = no LLM call. Lives on
+  `KodaSession` (sibling of `BgAgentRegistry`) so cross-turn hits
+  work — the natural "explore X / read result / explore X again"
+  follow-up flow doesn't pay LLM cost twice. Invalidated on any
   mutating tool — including mutations performed *inside* a sub-agent
   (sub-agent dispatch routes through `execute_one_tool`, which honors
   `is_mutating_tool` invalidation just like the top-level path).
+  Generation-bumping invalidation makes cross-turn safe: stale entries
+  become misses without needing explicit eviction.
 - **Single tool-dispatch path**. Sub-agent tool execution does *not*
   re-implement approval+execute logic. After the sub-agent's own approval
   check (using its `effective_root` for path-aware decisions), the call
@@ -405,6 +417,17 @@ Four execution modes, one mental model:
   matches Codex / Claude Code / Gemini-CLI's design and avoids the
   multi-sub-agent attribution problem (which sub-agent is asking?) plus
   the bg-agent deadlock problem (no `cmd_rx` reachable from the user).
+  As a defense-in-depth backstop, the dummy `cmd_rx` handed to every
+  sub-agent is constructed with the sender bound to `_` so it drops
+  immediately at construction — if a non-AskUser tool ever hits the
+  `request_approval` path inside a sub-agent (e.g. a Destructive
+  operation under inherited Plan trust), `recv()` returns `None`
+  rather than blocking forever, and the sub-agent loop maps that to a
+  clear `[auto-rejected: '<tool>' requires user confirmation but this
+  sub-agent has no channel to the user]` tool result. The model can
+  reason about and recover from the rejection; the dispatch loop
+  continues. This distinguishes from genuine cancellation (Ctrl+C),
+  which still surfaces as `[cancelled]`.
 
 **What we considered and rejected**:
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -575,6 +575,15 @@ pub struct InferenceContext<'a> {
     pub cmd_rx: &'a mut mpsc::Receiver<EngineCommand>,
     /// File lifecycle tracker for ownership-aware approval (#465).
     pub file_tracker: &'a mut FileTracker,
+    /// Background sub-agent registry (#1022 B12). Owned by [`crate::session::KodaSession`]
+    /// so bg agents survive across turns; this is just a borrow into
+    /// the loop. Drained at the top of every iteration to inject
+    /// completed bg results into the conversation.
+    pub bg_agents: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    /// Cross-turn sub-agent result cache (#1022 B12). Owned by [`crate::session::KodaSession`].
+    /// Generation-based invalidation on mutating tool calls is
+    /// honored uniformly via `crate::tool_dispatch::execute_one_tool`.
+    pub sub_agent_cache: &'a crate::sub_agent_cache::SubAgentCache,
 }
 
 /// Run the inference loop: send messages, stream responses, dispatch tool calls.
@@ -595,6 +604,8 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
         cancel,
         cmd_rx,
         file_tracker,
+        bg_agents,
+        sub_agent_cache,
     } = ctx;
 
     // Hard cap is configurable per-agent; user can extend it interactively.
@@ -603,8 +614,14 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     let mut made_tool_calls = false;
     let mut retried_empty = false;
     let mut loop_detector = LoopDetector::new();
-    let sub_agent_cache = crate::sub_agent_cache::SubAgentCache::new();
-    let bg_agents = crate::bg_agent::new_shared();
+    // #1022 B12: `bg_agents` and `sub_agent_cache` now live on
+    // `KodaSession` and are borrowed in via `InferenceContext`. Local
+    // construction here was the root cause of the cross-turn drop bug:
+    // when this function returned, the `Arc<BgAgentRegistry>` dropped,
+    // every still-pending bg task was aborted by `AbortOnDropHandle`,
+    // and the result was lost. Owning on the session means the
+    // registry survives across turns and the next call drains anything
+    // that completed during the idle gap.
     let mut skill_scope = SkillToolScope::new();
     let mut total_prompt_tokens: i64 = 0;
     let mut total_completion_tokens: i64 = 0;
@@ -1125,9 +1142,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 mode,
                 sink,
                 cancel.clone(),
-                &sub_agent_cache,
+                sub_agent_cache,
                 file_tracker,
-                &bg_agents,
+                bg_agents,
             )
             .await?;
         } else if remaining_tools.len() > 1 {
@@ -1142,9 +1159,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sink,
                 cancel.clone(),
                 cmd_rx,
-                &sub_agent_cache,
+                sub_agent_cache,
                 file_tracker,
-                &bg_agents,
+                bg_agents,
             )
             .await?;
         } else if !remaining_tools.is_empty() {
@@ -1159,9 +1176,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sink,
                 cancel.clone(),
                 cmd_rx,
-                &sub_agent_cache,
+                sub_agent_cache,
                 file_tracker,
-                &bg_agents,
+                bg_agents,
             )
             .await?;
         }

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -23,12 +23,14 @@
 //! (e.g., main REPL + background sub-agents) without shared mutable state.
 
 use crate::agent::KodaAgent;
+use crate::bg_agent::{self, BgAgentRegistry};
 use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference::InferenceContext;
 use crate::providers::{self, ImageData, LlmProvider};
+use crate::sub_agent_cache::SubAgentCache;
 use crate::trust::TrustMode;
 
 use anyhow::Result;
@@ -86,6 +88,46 @@ pub struct KodaSession {
     /// same hostname allowlist as the HTTP proxy by construction —
     /// see [`koda_sandbox::BuiltInSocks5Proxy`].
     pub socks5_proxy: Option<ProxyHandle>,
+
+    /// Background sub-agent registry (#1022 B12).
+    ///
+    /// Lives on the session, not on `inference_loop`, so background
+    /// agents survive across turns. The previous design constructed
+    /// the registry locally inside `inference_loop`; when the loop
+    /// returned (final text, error, hard-stop) the `Arc` dropped and
+    /// every still-pending bg task was aborted via
+    /// [`tokio_util::task::AbortOnDropHandle`] — silently discarding
+    /// any not-yet-completed result. With single-iteration responses
+    /// (`InvokeAgent { background: true }` followed by final text in
+    /// the same turn) this lost the bg result every time.
+    ///
+    /// Owning here means: bg tasks keep running between turns, and the
+    /// next turn's first iteration drains anything that completed
+    /// during the idle gap. Registry abort still happens at
+    /// `Drop` — i.e. when the session itself is dropped — which is
+    /// what users actually mean by "stop".
+    ///
+    /// Wrapped in `Arc` because tool dispatch needs to hand the same
+    /// registry into the recursive `execute_sub_agent` call (so
+    /// nested `InvokeAgent { background: true }` registers in the
+    /// caller-visible slot, not a fresh per-call one).
+    pub bg_agents: Arc<BgAgentRegistry>,
+
+    /// Cross-turn sub-agent result cache (#1022 B12).
+    ///
+    /// Same lifetime motivation as [`Self::bg_agents`]: was previously
+    /// re-created per `inference_loop` invocation, which threw away
+    /// every cache entry on each turn boundary and made the cache
+    /// useless for the natural "ask, follow up, ask again" flow.
+    /// Living on the session means the second turn can hit results
+    /// computed in the first.
+    ///
+    /// Invalidation still happens on every mutating tool call via
+    /// `crate::tool_dispatch::execute_one_tool` — generation bump,
+    /// cached entries with stale generations are treated as misses.
+    /// Cross-turn doesn't change that contract; it just extends the
+    /// window in which a still-fresh entry can be reused.
+    pub sub_agent_cache: SubAgentCache,
 }
 
 impl KodaSession {
@@ -177,6 +219,11 @@ impl KodaSession {
             title_set: false,
             proxy,
             socks5_proxy,
+            // #1022 B12: registry + cache live on the session so bg
+            // agents survive across turns and the cache yields
+            // cross-turn hits.
+            bg_agents: bg_agent::new_shared(),
+            sub_agent_cache: SubAgentCache::new(),
         }
     }
 
@@ -236,6 +283,8 @@ impl KodaSession {
             cancel: self.cancel.clone(),
             cmd_rx,
             file_tracker: &mut self.file_tracker,
+            bg_agents: &self.bg_agents,
+            sub_agent_cache: &self.sub_agent_cache,
         })
         .await;
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -707,7 +707,27 @@ pub(crate) fn execute_sub_agent<'a>(
                                 Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
                                     format!("[rejected: {feedback}]")
                                 }
-                                None => "[cancelled]".to_string(),
+                                None => {
+                                    // #1022 B10: `request_approval` returns `None`
+                                    // when the command channel is closed (sub-agents
+                                    // don't have a live channel to the user) or
+                                    // cancelled. Distinguish the two so the model
+                                    // gets actionable signal instead of a generic
+                                    // "[cancelled]" that looked like the user
+                                    // hit Ctrl+C.
+                                    if cancel.is_cancelled() {
+                                        "[cancelled]".to_string()
+                                    } else {
+                                        format!(
+                                            "[auto-rejected: '{tool}' requires user \
+                                             confirmation but this sub-agent has no \
+                                             channel to the user. The parent agent \
+                                             must pre-approve destructive operations \
+                                             or run the tool itself.]",
+                                            tool = tc.function_name,
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -224,7 +224,17 @@ pub(crate) async fn execute_one_tool(
         // *type* cycle by erasing the future to `Pin<Box<dyn Future>>`.
         // The heap allocation is negligible — we already pay for
         // workspace setup, DB session, and a provider call.
-        let (_dummy_tx, mut dummy_rx) = mpsc::channel(1);
+        //
+        // #1022 B10: bind the sender to `_` (drops immediately) rather
+        // than `_dummy_tx` (lives until end of scope). With the sender
+        // alive a sub-agent that hits `request_approval` would block
+        // forever on `cmd_rx.recv()`. Dropping at construction makes
+        // the channel closed from the receiver's perspective, which
+        // `request_approval` already handles — it returns `None` and
+        // the sub-agent dispatch loop maps that to a clean auto-reject
+        // tool result the model can act on. Sub-agents have no path to
+        // the user's prompt by design.
+        let (_, mut dummy_rx) = mpsc::channel(1);
         let policy = tools.sandbox_policy().clone();
         let read_cache = tools.file_read_cache();
         let fut = sub_agent_dispatch::execute_sub_agent(

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -101,6 +101,8 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         cancel,
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
+        bg_agents: &koda_core::bg_agent::new_shared(),
+        sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -172,6 +172,8 @@ async fn test_provider_error_emits_error_event() {
         cancel: CancellationToken::new(),
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
+        bg_agents: &koda_core::bg_agent::new_shared(),
+        sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;
 
@@ -281,6 +283,8 @@ async fn test_cancel_during_streaming() {
         cancel,
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
+        bg_agents: &koda_core::bg_agent::new_shared(),
+        sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;
 

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -102,6 +102,8 @@ async fn make_session_with_mcp(
         title_set: false,
         proxy: None,
         socks5_proxy: None,
+        bg_agents: koda_core::bg_agent::new_shared(),
+        sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -61,6 +61,8 @@ async fn make_session(
         title_set: false,
         proxy: None,
         socks5_proxy: None,
+        bg_agents: koda_core::bg_agent::new_shared(),
+        sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
     };
     (session, cancel)
 }

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -200,6 +200,11 @@ impl Env {
         let tool_defs = self.tool_defs();
         let mut file_tracker =
             koda_core::file_tracker::FileTracker::new(&self.session_id, self.db.clone()).await;
+        // #1022 B12: registry + cache live on the session in production.
+        // Tests construct fresh per-call versions — same observable
+        // contract for single-turn tests.
+        let bg_agents = koda_core::bg_agent::new_shared();
+        let sub_agent_cache = koda_core::sub_agent_cache::SubAgentCache::new();
 
         let result = inference::inference_loop(InferenceContext {
             project_root: &self.root,
@@ -216,6 +221,8 @@ impl Env {
             cancel,
             cmd_rx: &mut cmd_rx,
             file_tracker: &mut file_tracker,
+            bg_agents: &bg_agents,
+            sub_agent_cache: &sub_agent_cache,
         })
         .await;
 


### PR DESCRIPTION
## Provenance

Phase 2 of the multi-agent execution review (#1022). Phase 1 closed
out the bg-agent **safety** cluster (B1-B5, PRs #1025/#1026). PR-A
closed the **dispatch** cluster (B6/B7/B8/B14, PR #1027). This PR
closes the **bg-agent lifecycle** cluster: three tightly-coupled P1
bugs that all manifest when sub-agents \u2014 background or foreground
\u2014 hit boundary conditions the original design didn't contemplate.

## What lands

| ID | Fix | Where |
|---|---|---|
| **B10** Approval channel | Foreground sub-agent dispatch bound the dummy mpsc sender to `_dummy_tx` (alive for full scope), so `request_approval` would hang forever on `recv()`. Now binds to `_` (dropped immediately) so the channel is closed at construction. The `None` mapping in the loop now discriminates `cancel.is_cancelled()`: cancelled \u2192 `[cancelled]` (existing behavior), closed channel \u2192 `[auto-rejected: '<tool>' requires user confirmation but this sub-agent has no channel to the user]` (model gets actionable signal). | `tool_dispatch.rs`, `sub_agent_dispatch.rs` |
| **B11** Drain race | Was: drain only at top of each iter inside loop. Single-iter responses (final text in iter 1) terminated before bg task completed, registry dropped, no future drain ever ran. Now: registry persists across turns (B12), so next turn's first-iter drain catches it. Drain timing in loop body unchanged. | `session.rs` (lifetime), `inference.rs` (drain unchanged) |
| **B12** Lifecycle | `bg_agents` and `sub_agent_cache` were constructed locally inside `inference_loop`. When the loop returned, the `Arc<BgAgentRegistry>` dropped and `AbortOnDropHandle` (from B3) aborted every still-pending bg task \u2014 silent data loss in the single-iteration case. Same issue for `SubAgentCache` \u2014 cross-turn cache hits never worked. Now both live on `KodaSession`; bg agents survive across turns, cache hits work across turns. Type system enforces correctness (`Arc<BgAgentRegistry>` borrowed into `InferenceContext`, can't be otherwise). | `session.rs`, `inference.rs` |

## Why one PR

The three bugs are tightly coupled \u2014 fixing any one in isolation
either doesn't fully resolve the underlying issue or is wasted work:

- **B11** is essentially a symptom of **B12**. Once the registry
  lives on `KodaSession`, single-iter responses naturally drain
  on the next turn. No new drain logic needed.
- **B10**'s closed-channel signal is what `request_approval`
  already returned for the *bg* path (sender bound to `_`); this
  PR aligns the foreground path with that contract and turns the
  resulting `None` into an *actionable* model error rather than
  the misleading `[cancelled]`.
- **B12**'s registry move forces every `InferenceContext`
  construction site to be touched (one prod call site, several
  tests, the test-utils helper). Doing this once per cluster
  rather than per bug minimizes churn.

## Lifetime semantics now

Three layers, clean ownership:

- `KodaSession` **owns** `Arc<BgAgentRegistry>` and `SubAgentCache`.
- `InferenceContext` **borrows** both as references with the loop's
  lifetime.
- `tool_dispatch` / `sub_agent_dispatch` receive `&Arc<...>` so
  they can clone and hand into spawned tasks.

`AbortOnDropHandle` semantics still hold \u2014 they fire on **session**
drop now (which is what users mean by "stop"), not on every turn
boundary (which was a bug).

## Tests

- All **1015 lib tests** green.
- All **integration test binaries** green (each run individually
  with `--test-threads=1`):
  anthropic_http, bash_safety, builtin_proxy_e2e, cancel,
  e2e_agent (5 tests), e2e_safety, e2e_skills, e2e, e2e_tools,
  file_tools, gemini_http, golden, guarantee_matrix,
  http_client_config, inference_context, inference_edge,
  inference_recovery, mcp_http_transport, mcp_instructions_bootstrap,
  new_tools, openai_compat_http, perf, purge, session,
  snapshot, token_audit, tool_normalize, tool_wiring.
- Workspace tests green: `cargo test --workspace --exclude koda-core`.
- `cargo clippy -p koda-core --tests --features test-support` clean.
- `cargo doc --no-deps -p koda-core` clean (fixed pre-existing
  intra-doc link to `pub(crate) execute_one_tool`).

## Design.md updates

- **Bg lifecycle**: registry lives on `KodaSession`, survives across
  turns. Documents the failure mode (single-iter aborts, silent loss)
  and how owning higher up fixes it.
- **Result caching**: same lifetime story. Cross-turn hits work
  because cache lives on session. Generation-bumping invalidation
  makes it safe.
- **No user interaction from sub-agents**: defense-in-depth backstop
  documented \u2014 dummy `cmd_rx` is closed at construction so
  `request_approval` returns `None` rather than blocking, and the
  loop maps that to a clear actionable error distinguishable from
  user cancellation.

## Files

- `koda-core/src/session.rs`: +49 (two new fields, doc, init)
- `koda-core/src/inference.rs`: +33/-? (context fields, removed local
  construction, dropped `&` from forwarding sites)
- `koda-core/src/sub_agent_dispatch.rs`: +22 (None discrimination)
- `koda-core/src/tool_dispatch.rs`: +12 (`_dummy_tx` \u2192 `_` + comment)
- `Design.md`: +35 (lifetime, cache, backstop)
- Test fixtures (`cancel_test`, `e2e_test`,
  `mcp_instructions_bootstrap_test`, `session_test`,
  `koda-test-utils/env`): add the two new fields.

## Remaining #1022 work

| Priority | Bug | Status |
|---|---|---|
| P1 | B9 (bg visibility \u2014 only spawn+result lines emit) | Not started |
| P1 | B13 (`can_parallelize` uses `check_tool` not `_with_tracker`) | Not started \u2014 small standalone fix |
| P1 | B15 (headless reject indistinguishable from user reject) | Not started |
| P2 | B16-B22 (polish) | Not started |

After this PR ships, B13 is a natural next standalone PR (small,
focused). B9/B15 are observability/UX and can wait.