### PR TITLE
fix(#1022): B13 `can_parallelize` uses tracker-aware classification

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1130,8 +1130,14 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
             remaining_tools
         };
 
-        // Execute remaining tool calls — parallelize when possible
-        if remaining_tools.len() > 1 && can_parallelize(&remaining_tools, mode, project_root) {
+        // Execute remaining tool calls — parallelize when possible.
+        // #1022 B13: pass `file_tracker` so the parallelizability check
+        // sees the same Koda-owned-file downgrade the sequential path
+        // sees. Without it, batches containing `Delete owned.tmp` are
+        // spuriously refused parallelization (perf regression).
+        if remaining_tools.len() > 1
+            && can_parallelize(&remaining_tools, mode, project_root, Some(file_tracker))
+        {
             execute_tools_parallel(
                 &remaining_tools,
                 project_root,

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -157,15 +157,45 @@ async fn track_file_lifecycle(
     }
 }
 
+/// Decide whether a batch of tool calls can run in parallel.
+///
+/// A batch is parallel-eligible iff every call in it (a) auto-approves
+/// under the current trust mode and (b) doesn't conflict with another
+/// call in the batch on the same target file.
+///
+/// **#1022 B13**: this used to call [`trust::check_tool`] (no
+/// `FileTracker`), which is *not* the same classification the
+/// sequential dispatch loop uses. Sequential calls
+/// [`trust::check_tool_with_tracker`] so that `Delete` of a
+/// Koda-owned file (created via `Write` earlier this session)
+/// downgrades from `NeedsConfirmation` to `AutoApprove` per #465. The
+/// mismatch meant batches like `[Read other.txt, Delete owned.tmp]`
+/// were spuriously refused parallelization — each tool was eligible
+/// in isolation, but the batch fell into the slower split-batch /
+/// sequential path. Pure perf regression, no correctness impact, but
+/// the kind of invariant violation that grows teeth over time as
+/// other path-aware downgrades get added to the tracker path.
+///
+/// Now takes the same `Option<&FileTracker>` the sequential loop
+/// passes, and forwards it to `check_tool_with_tracker`. Same
+/// classification, same answer. Tests guard the regression below
+/// (`test_can_parallelize_delete_owned_file_uses_tracker`).
 pub(crate) fn can_parallelize(
     tool_calls: &[ToolCall],
     mode: TrustMode,
     project_root: &Path,
+    file_tracker: Option<&crate::file_tracker::FileTracker>,
 ) -> bool {
     let all_approved = !tool_calls.iter().any(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            trust::check_tool(&tc.function_name, &args, mode, Some(project_root)),
+            trust::check_tool_with_tracker(
+                &tc.function_name,
+                &args,
+                mode,
+                Some(project_root),
+                file_tracker,
+            ),
             ToolApproval::NeedsConfirmation | ToolApproval::Blocked
         )
     });
@@ -774,7 +804,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             TrustMode::Safe,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -784,7 +815,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             TrustMode::Safe,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -803,7 +835,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             TrustMode::Safe,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -813,7 +846,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             TrustMode::Safe,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -836,7 +870,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             TrustMode::Auto, // Auto mode would normally allow parallelization
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -859,7 +894,8 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             TrustMode::Auto,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -882,7 +918,8 @@ mod tests {
         assert!(!can_parallelize(
             &calls,
             TrustMode::Safe,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
     }
 
@@ -892,7 +929,74 @@ mod tests {
         assert!(can_parallelize(
             &calls,
             TrustMode::Auto,
-            Path::new("/test/project")
+            Path::new("/test/project"),
+            None,
         ));
+    }
+
+    /// #1022 B13 regression: `can_parallelize` must use the same
+    /// approval classification the sequential dispatch loop uses,
+    /// i.e. `check_tool_with_tracker` not `check_tool`. Without the
+    /// tracker, `Delete owned.tmp` looks like `NeedsConfirmation`
+    /// (because Delete is Destructive in Safe mode); with the tracker
+    /// it auto-approves (#465: Koda created it, Koda removes it). The
+    /// bug spuriously refused parallelization for batches that
+    /// included a Delete of a file Koda created earlier in the
+    /// session — pure perf regression, but the kind of
+    /// classification mismatch that compounds.
+    #[tokio::test]
+    async fn test_can_parallelize_delete_owned_file_uses_tracker() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = crate::db::Database::open(&dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let mut tracker = crate::file_tracker::FileTracker::new("test-sess", db).await;
+        // Canonicalize root so the tracked path matches what
+        // `resolve_file_path_from_args` produces at lookup time — on
+        // macOS, tempdirs live under `/var/folders/...` but
+        // `canonicalize()` resolves to `/private/var/folders/...`.
+        // Production code goes through canonicalization on both write
+        // and lookup, so we mirror that here.
+        let root = dir.path().join("project");
+        std::fs::create_dir_all(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+        let owned_abs = root.join("temp_output.md");
+        std::fs::write(&owned_abs, "").unwrap();
+        tracker
+            .track_created(owned_abs.canonicalize().unwrap())
+            .await;
+
+        // Batch: Read other.txt + Delete owned.tmp. Both auto-approve
+        // when the tracker is consulted; without the tracker the
+        // Delete is misclassified as NeedsConfirmation.
+        let calls = vec![
+            ToolCall {
+                id: "t1".to_string(),
+                function_name: "Read".to_string(),
+                arguments: r#"{"path": "other.txt"}"#.to_string(),
+                thought_signature: None,
+            },
+            ToolCall {
+                id: "t2".to_string(),
+                function_name: "Delete".to_string(),
+                arguments: r#"{"path": "temp_output.md"}"#.to_string(),
+                thought_signature: None,
+            },
+        ];
+
+        // Bug repro: without the tracker, Safe mode refuses
+        // parallelization because Delete → NeedsConfirmation.
+        assert!(
+            !can_parallelize(&calls, TrustMode::Safe, &root, None),
+            "sanity: without tracker, Delete must look like NeedsConfirmation"
+        );
+
+        // Fix proof: with the tracker, Delete of owned file
+        // auto-approves → batch is parallelizable.
+        assert!(
+            can_parallelize(&calls, TrustMode::Safe, &root, Some(&tracker)),
+            "with tracker, Delete of Koda-owned file must be \
+             parallel-eligible (matches sequential path classification)"
+        );
     }
 }


### PR DESCRIPTION
## Provenance

Phase 3 of the multi-agent execution review (#1022). Standalone P1
fix for B13. Phase 2 (#1028, B10+B11+B12) and Phase 1 (#1025/#1026,
B1-B5) are merged. PR-A (#1027, B6+B7+B8+B14) is also merged.

## What lands

`can_parallelize` was using a *different* approval classification
than the sequential dispatch loop:

| Path | Classifier |
|---|---|
| `inference_loop` sequential | `trust::check_tool_with_tracker` |
| `inference_loop` parallel-eligibility check | `trust::check_tool` ❌ |

The mismatch matters for the **#465 carve-out**: `Delete` of a file
Koda created earlier in the session downgrades from
`NeedsConfirmation` to `AutoApprove` — but only when the
`FileTracker` is consulted. Without it, batches like

```
[Read other.txt, Delete owned.tmp]
```

were spuriously refused parallelization: each tool was in fact
eligible, but the missed tracker downgrade made the batch look
mixed-approval, falling back into the slower split-batch /
sequential path.

**No correctness impact** (slower path produced the right answer),
but a pure perf regression and — more importantly — the kind of
classification mismatch that compounds as more path-aware
downgrades get added to the tracker path.

## Fix

- `can_parallelize` now takes `file_tracker: Option<&FileTracker>`.
- Forwards to `check_tool_with_tracker`.
- Caller in `inference.rs` passes `Some(file_tracker)` (the same one
  the sequential path already uses).

Same classification end-to-end. The two paths can no longer diverge.

## Regression test

`test_can_parallelize_delete_owned_file_uses_tracker` proves both
sides of the fix:

- **Bug repro**: with `None` tracker, `[Read, Delete owned.tmp]` in
  Safe mode is *not* parallelizable (Delete misclassified).
- **Fix proof**: with the tracker, the same batch *is* parallelizable
  (Delete correctly auto-approved).

Test setup canonicalizes the root path so the tracked entry matches
what `resolve_file_path_from_args` produces at lookup time — on
macOS, tempdirs live under `/var/folders/...` but `canonicalize()`
resolves to `/private/var/folders/...`. Mirrors how the production
write → lookup pipeline already works. (This was caught by the
test on first run — nice example of the fix's regression test
catching a bonus inconsistency in test setup.)

## Tests

- **1016 lib tests** green (was 1015 — +1 for the new regression).
- **All 9 existing `can_parallelize` tests** updated to pass `None`
  for `file_tracker` (preserving previous semantics where no tracker
  was available).
- e2e tests green: `e2e_test`, `e2e_tools_test`, `e2e_agent_test`.
- Clippy + rustdoc clean.

## Files

- `koda-core/src/tool_dispatch.rs`: function signature + 1 call-site
  (the internal `check_tool` → `check_tool_with_tracker` swap), plus
  expanded doc comment explaining the bug, plus the new regression
  test. +112/-7.
- `koda-core/src/inference.rs`: pass `Some(file_tracker)` at the
  parallelization gate. +9/-4.

## Remaining #1022 work

| Priority | Bug | Status |
|---|---|---|
| P1 | **B9** bg visibility — only spawn+result lines emit | Not started |
| P1 | **B15** headless reject indistinguishable from user reject | Not started |
| P2 | B16-B22 polish (mutex type, asserts, transactions, etc.) | Not started |

After this lands, all 4 P1 bg-agent dispatch/lifecycle/safety bugs
in the cluster (B10/B11/B12/B13) will be resolved. **B9** and
**B15** are observability/UX and the natural next pair.
