### PR TITLE
fix(#1022): B9+B15 bg-agent visibility & headless reject signaling

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -268,6 +268,23 @@ emits `EngineEvent::ApprovalRequest` and awaits
 `EngineCommand::ApprovalResponse` — works identically over in-process
 channels or network transport.
 
+**Decision variants distinguish the source of "no" (#1022 B15)**.
+`ApprovalDecision` has four variants, not three: `Approve`, `Reject`,
+`RejectWithFeedback { feedback }`, `RejectAuto { reason }`. The split
+between `Reject` (interactive: a human said no) and `RejectAuto`
+(structural: no human is in the loop, e.g. headless mode refuses
+destructive ops by policy) matters because the model adapts
+differently to each. A human "no" is a signal to ask or re-plan; an
+auto-reject is a constraint to route around for the rest of the
+session. Pre-fix, headless emitted `Reject` for policy-blocked tools,
+the model saw `"User rejected this action."`, and would loop asking
+the (nonexistent) user for clarification until timeout. Now the model
+sees `[auto-rejected: <reason>]` — the same shape as the bg-agent
+closed-channel auto-reject (B10), so the "no human, here's why"
+signal is uniform across all auto-reject paths. Wire format is
+`{"decision":"reject_auto","reason":"…"}` (snake_case, pinned by
+`test_reject_auto_wire_tag_is_snake_case`).
+
 ### Tool Dispatch: Match Statement, Not Trait Registry (P2)
 
 Tools are dispatched via a `match` statement in `ToolRegistry::execute()`,
@@ -347,7 +364,17 @@ Four execution modes, one mental model:
    transitive offender (generic IPC helpers in `koda-sandbox::ipc`) carry
    matching `Send` bounds on their `R`/`W`/`T` parameters; without them,
    `tokio::sync::MutexGuard<WorkerClient>` held across an `await` was
-   silently non-Send.
+   silently non-Send. **Visibility (#1022 B9)**: bg agents run with
+   `engine::sink::BufferingSink`, not `NullSink`. The buffering sink
+   captures a narrative trace (one short line per `ToolCallStart`,
+   `Info`, auto-rejected approval) capped at 256 lines. The trace
+   ships back over the result oneshot as a `BgPayload = (output,
+   Vec<String>)` and is surfaced to the user as a multi-line `Info`
+   event at result-injection time. `NullSink` is preserved for tests
+   and any future fully-detached path. Streaming text
+   (`TextDelta`/`TextDone`) is intentionally *not* captured — the
+   final output already crosses the oneshot, so capturing would
+   duplicate.
 4. **Forked context** (`agent_name="fork"`) — copies the parent's full
    conversation history into the new session. Fork children cannot spawn
    sub-agents (recursion guard) — same blanket rule that applies to all

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -142,9 +142,21 @@ impl EngineSink for HeadlessSink {
                     eprintln!(
                         "\x1b[31m  ✗ Rejected destructive action: {tool_name} — {detail}\x1b[0m"
                     );
+                    // #1022 B15: use `RejectAuto` so the model can
+                    // distinguish a structural headless-policy block
+                    // from a real human "no". Pre-fix it saw `"User
+                    // rejected this action."` and would loop asking
+                    // the (nonexistent) user for clarification.
+                    let reason = format!(
+                        "destructive action '{tool_name}' auto-rejected (headless mode \
+                         refuses destructive ops by policy; no human is available to \
+                         approve). Adapt your plan: avoid this kind of action for the \
+                         rest of this session, or ask the operator to re-run \
+                         interactively."
+                    );
                     let _ = self.cmd_tx.try_send(EngineCommand::ApprovalResponse {
                         id,
-                        decision: ApprovalDecision::Reject,
+                        decision: ApprovalDecision::RejectAuto { reason },
                     });
                 } else {
                     let _ = self.cmd_tx.try_send(EngineCommand::ApprovalResponse {

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -33,6 +33,20 @@ use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 
+/// Payload sent over the bg-agent oneshot.
+///
+/// Pre-#1022-B9 this was just `String` (the model's final output).
+/// Now also carries the trace lines collected by
+/// [`crate::engine::sink::BufferingSink`] so the inference loop
+/// can surface them to the user when injecting the result.
+///
+/// The `Result<BgPayload, BgPayload>` shape preserves the prior
+/// success/failure discrimination: `Ok` means `execute_sub_agent`
+/// returned text, `Err` means it returned an error (the trace is
+/// useful in *both* cases — the bg agent may have done several
+/// steps before erroring).
+pub type BgPayload = (String, Vec<String>);
+
 /// A completed background agent result.
 #[derive(Debug)]
 pub struct BgAgentResult {
@@ -44,6 +58,15 @@ pub struct BgAgentResult {
     pub output: String,
     /// Whether the agent succeeded.
     pub success: bool,
+    /// **#1022 B9**: narrative trace lines captured by
+    /// [`crate::engine::sink::BufferingSink`] inside the bg agent.
+    /// Pre-fix this was implicitly always empty (bg agents ran with
+    /// `NullSink`). Now populated with one line per significant
+    /// event (tool start, info, auto-rejected approval) so the user
+    /// can see what the bg agent did at result-injection time.
+    /// Empty for the cancelled / panicked case (`output` carries the
+    /// failure detail in those paths).
+    pub events: Vec<String>,
 }
 
 /// Handle returned when a background agent is spawned.
@@ -56,7 +79,7 @@ pub struct BgAgentResult {
 struct BgAgentEntry {
     agent_name: String,
     prompt: String,
-    rx: oneshot::Receiver<Result<String, String>>,
+    rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
     /// Per-task cancel — derived as a `child_token()` of the parent
     /// session's token at spawn time. Firing this token causes the
     /// in-flight bg agent to observe `is_cancelled()` on its next
@@ -98,10 +121,10 @@ pub struct BgAgentReservation {
     pub task_id: u32,
     /// Sender half of the result oneshot. Move into the spawned
     /// future so it can deliver `Ok(output)` / `Err(message)`.
-    pub tx: oneshot::Sender<Result<String, String>>,
+    pub tx: oneshot::Sender<Result<BgPayload, BgPayload>>,
     /// Receiver half. Move back into the registry via [`BgAgentRegistry::attach`]
     /// so `drain_completed()` can poll it.
-    pub rx: oneshot::Receiver<Result<String, String>>,
+    pub rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
     /// Per-task cancel token. Cloned for the spawned future
     /// (`bg_cancel`) and re-stored on the registry entry
     /// (`entry_cancel`); both halves observe parent cancellation
@@ -151,7 +174,7 @@ impl BgAgentRegistry {
         reservation_id: u32,
         agent_name: &str,
         prompt: &str,
-        rx: oneshot::Receiver<Result<String, String>>,
+        rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
         cancel: CancellationToken,
         handle: tokio::task::JoinHandle<()>,
     ) {
@@ -176,7 +199,7 @@ impl BgAgentRegistry {
         &self,
         agent_name: &str,
         prompt: &str,
-    ) -> (u32, oneshot::Sender<Result<String, String>>) {
+    ) -> (u32, oneshot::Sender<Result<BgPayload, BgPayload>>) {
         let (tx, rx) = oneshot::channel();
         let mut id = self.next_id.lock().unwrap();
         let task_id = *id;
@@ -206,35 +229,39 @@ impl BgAgentRegistry {
 
         for (id, entry) in guard.iter_mut() {
             match entry.rx.try_recv() {
-                Ok(Ok(output)) => {
+                Ok(Ok((output, events))) => {
                     done_ids.push(*id);
                     completed.push(BgAgentResult {
                         agent_name: entry.agent_name.clone(),
                         prompt: entry.prompt.clone(),
                         output,
                         success: true,
+                        events,
                     });
                 }
-                Ok(Err(err)) => {
+                Ok(Err((err, events))) => {
                     done_ids.push(*id);
                     completed.push(BgAgentResult {
                         agent_name: entry.agent_name.clone(),
                         prompt: entry.prompt.clone(),
                         output: err,
                         success: false,
+                        events,
                     });
                 }
                 Err(oneshot::error::TryRecvError::Empty) => {
                     // Still running
                 }
                 Err(oneshot::error::TryRecvError::Closed) => {
-                    // Sender dropped without sending — task panicked or was cancelled
+                    // Sender dropped without sending — task panicked or was cancelled.
+                    // No events available (the buffering sink died with the task).
                     done_ids.push(*id);
                     completed.push(BgAgentResult {
                         agent_name: entry.agent_name.clone(),
                         prompt: entry.prompt.clone(),
                         output: "[background agent task was cancelled]".to_string(),
                         success: false,
+                        events: Vec::new(),
                     });
                 }
             }
@@ -307,7 +334,8 @@ mod tests {
         assert!(reg.drain_completed().is_empty());
 
         // Complete it
-        tx.send(Ok("found 42 tests".to_string())).unwrap();
+        tx.send(Ok(("found 42 tests".to_string(), Vec::new())))
+            .unwrap();
         let results = reg.drain_completed();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].agent_name, "explore");
@@ -322,7 +350,7 @@ mod tests {
         let (_id1, tx1) = reg.register_test("task", "build");
         let (_id2, _tx2) = reg.register_test("explore", "search");
 
-        tx1.send(Ok("done".to_string())).unwrap();
+        tx1.send(Ok(("done".to_string(), Vec::new()))).unwrap();
 
         let results = reg.drain_completed();
         assert_eq!(results.len(), 1);
@@ -346,12 +374,80 @@ mod tests {
     async fn error_result() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("verify", "check");
-        tx.send(Err("test failures".to_string())).unwrap();
+        tx.send(Err(("test failures".to_string(), Vec::new())))
+            .unwrap();
 
         let results = reg.drain_completed();
         assert_eq!(results.len(), 1);
         assert!(!results[0].success);
         assert_eq!(results[0].output, "test failures");
+    }
+
+    /// #1022 B9 regression: the narrative trace captured by
+    /// `BufferingSink` inside the bg agent must propagate through
+    /// the oneshot → registry → `BgAgentResult.events`. Pre-fix
+    /// this field didn't exist; bg agents ran with `NullSink` and
+    /// the user only saw spawn + completion lines. The fix is
+    /// useless if the trace gets dropped at any of the three hops,
+    /// so this test pins the round-trip end-to-end.
+    #[tokio::test]
+    async fn events_propagate_through_drain_for_success() {
+        let reg = BgAgentRegistry::new();
+        let (_id, tx) = reg.register_test("explore", "map repo");
+        let trace = vec![
+            "  \u{1f527} Read".to_string(),
+            "  \u{1f527} Grep".to_string(),
+            "  \u{26a1} cache hit".to_string(),
+        ];
+        tx.send(Ok(("map result".to_string(), trace.clone())))
+            .unwrap();
+
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert_eq!(
+            results[0].events, trace,
+            "trace lost between sender and BgAgentResult"
+        );
+    }
+
+    /// #1022 B9 regression: trace must propagate even when the bg
+    /// agent failed. The trace is *most* useful in the failure case
+    /// — "the agent tried Read, Bash, Edit, then errored" is the
+    /// kind of breadcrumb that turns a black-box failure into a
+    /// debuggable one.
+    #[tokio::test]
+    async fn events_propagate_through_drain_for_failure() {
+        let reg = BgAgentRegistry::new();
+        let (_id, tx) = reg.register_test("build", "compile");
+        let trace = vec![
+            "  \u{1f527} Bash".to_string(),
+            "  \u{2398} approval auto-rejected for Delete (no user channel)".to_string(),
+        ];
+        tx.send(Err(("compile failed".to_string(), trace.clone())))
+            .unwrap();
+
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert_eq!(results[0].events, trace);
+    }
+
+    /// #1022 B9 corollary: cancelled / panicked tasks have *no*
+    /// trace available (the buffering sink died with the task), and
+    /// that's an explicitly-empty Vec rather than uninitialized.
+    #[tokio::test]
+    async fn cancelled_task_has_empty_event_trace() {
+        let reg = BgAgentRegistry::new();
+        let (_id, tx) = reg.register_test("flaky", "x");
+        drop(tx); // simulate panic / abort
+        let results = reg.drain_completed();
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(
+            results[0].events.is_empty(),
+            "cancel path must yield empty trace"
+        );
     }
 
     /// Phase 1 of #1022, B3 regression test: dropping the registry
@@ -387,7 +483,7 @@ mod tests {
                     flag.store(true, Ordering::SeqCst);
                 }
             }
-            let _ = tx.send(Ok("done".to_string()));
+            let _ = tx.send(Ok(("done".to_string(), Vec::new())));
         });
         reg.attach(
             task_id,

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -371,12 +371,28 @@ pub struct ImageAttachment {
 pub enum ApprovalDecision {
     /// Approve and execute the action.
     Approve,
-    /// Reject the action.
+    /// Reject the action (interactive: a human said no).
     Reject,
     /// Reject with feedback (tells the LLM what to change).
     RejectWithFeedback {
         /// Feedback explaining why the action was rejected.
         feedback: String,
+    },
+    /// Reject *automatically*, with no human in the loop. Distinct from
+    /// [`ApprovalDecision::Reject`] because the model needs to know **why** it was
+    /// rejected to act intelligently — a human "no" is a signal to
+    /// re-plan or ask, but an auto-reject (e.g. headless mode
+    /// refusing destructive ops by policy) is a structural constraint
+    /// the model should adapt around for the rest of the session.
+    ///
+    /// **#1022 B15**: pre-fix, headless mode emitted `Reject` for
+    /// auto-blocked destructive tools, which the model saw as `"User
+    /// rejected this action."` — indistinguishable from a real human
+    /// reject. The model would then ask the (nonexistent) user how to
+    /// proceed, then time out.
+    RejectAuto {
+        /// Why the action was auto-rejected (surfaced to the model).
+        reason: String,
     },
 }
 
@@ -611,12 +627,34 @@ mod tests {
             ApprovalDecision::RejectWithFeedback {
                 feedback: "try again".into(),
             },
+            // #1022 B15: new variant for headless / no-human-in-loop
+            // auto-rejection. Distinct from `Reject` on the wire so
+            // the model can adapt its plan instead of asking a
+            // nonexistent user.
+            ApprovalDecision::RejectAuto {
+                reason: "destructive op blocked by headless policy".into(),
+            },
         ];
         for d in decisions {
             let json = serde_json::to_string(&d).unwrap();
             let roundtripped: ApprovalDecision = serde_json::from_str(&json).unwrap();
             assert_eq!(d, roundtripped);
         }
+    }
+
+    /// #1022 B15: wire-format guard. The `decision` tag for the new
+    /// `RejectAuto` variant must be `"reject_auto"` (snake_case via
+    /// `#[serde(rename_all = "snake_case")]`). Renaming this would
+    /// break ACP clients silently — they'd see an unknown decision
+    /// and fall through to `Reject`, re-introducing the bug.
+    #[test]
+    fn test_reject_auto_wire_tag_is_snake_case() {
+        let d = ApprovalDecision::RejectAuto { reason: "r".into() };
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(
+            json.contains("\"decision\":\"reject_auto\""),
+            "expected snake_case tag, got: {json}"
+        );
     }
 
     #[test]

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -19,11 +19,122 @@ pub trait EngineSink: Send + Sync {
     fn emit(&self, event: EngineEvent);
 }
 
-/// A no-op sink that discards all events. Used by background sub-agents.
+/// A no-op sink that discards all events.
+///
+/// Used by background sub-agents that don't have a live channel to
+/// the user. **#1022 B9**: superseded for bg-agent use by
+/// [`BufferingSink`], which captures a narrative trace so the user
+/// can see what the bg agent did at result-injection time. `NullSink`
+/// is still useful for tests and for any future fully-detached
+/// execution path.
 pub struct NullSink;
 
 impl EngineSink for NullSink {
     fn emit(&self, _event: EngineEvent) {}
+}
+
+/// A sink that buffers a *narrative trace* of bg-agent activity.
+///
+/// **#1022 B9**: pre-fix, bg agents ran with [`NullSink`] so every
+/// event inside them — tool calls, info lines, approval requests,
+/// errors — was silently dropped. The user only saw two lines: the
+/// spawn message and the completion message. The model only saw the
+/// final output. *What the bg agent actually did* was opaque.
+///
+/// `BufferingSink` records short, human-readable lines for events
+/// that matter for traceability:
+/// - `ToolCallStart` → `"  🔧 ToolName"`
+/// - `Info` → forwarded as-is (sub-agent emits info for things like
+///   nested spawn / cache hit)
+/// - `ApprovalRequest` / `AskUserRequest` → short auto-reject note
+///   (they auto-reject on closed channel — see B10)
+/// - Streaming text (`TextDelta`/`TextDone`) is *not* recorded — the
+///   final output already crosses the result oneshot, so capturing
+///   text here would duplicate it.
+///
+/// Drained at result-injection time and emitted as a multi-line
+/// `Info` event so the user sees `✅ bg agent X completed\n  🔧 Read\n
+/// 🔧 Bash\n  …` instead of just `✅ bg agent X completed`.
+///
+/// Cap is intentionally generous (256 lines): a runaway bg agent
+/// could otherwise grow this unboundedly. After the cap we record a
+/// single `… (trace truncated at N lines)` marker and stop.
+pub struct BufferingSink {
+    lines: std::sync::Mutex<Vec<String>>,
+    cap: usize,
+}
+
+impl BufferingSink {
+    /// Create a buffering sink with the default 256-line cap.
+    pub fn new() -> Self {
+        Self::with_cap(256)
+    }
+
+    /// Create a buffering sink with a custom cap (mainly for tests).
+    pub fn with_cap(cap: usize) -> Self {
+        Self {
+            lines: std::sync::Mutex::new(Vec::new()),
+            cap,
+        }
+    }
+
+    /// Drain and return all buffered lines. The sink is empty after
+    /// this returns.
+    pub fn take_lines(&self) -> Vec<String> {
+        std::mem::take(&mut *self.lines.lock().unwrap())
+    }
+
+    /// Append a line, honoring the cap. Idempotent on the truncation
+    /// marker so a single overflow only produces one marker.
+    fn push_capped(&self, line: String) {
+        let mut guard = self.lines.lock().unwrap();
+        if guard.len() < self.cap {
+            guard.push(line);
+        } else if guard.last().map(|l| !l.starts_with('…')).unwrap_or(true) {
+            // Cap reached — emit one truncation marker and stop.
+            guard.push(format!("… (trace truncated at {} lines)", self.cap));
+        }
+    }
+}
+
+impl Default for BufferingSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineSink for BufferingSink {
+    fn emit(&self, event: EngineEvent) {
+        match event {
+            EngineEvent::ToolCallStart { name, .. } => {
+                self.push_capped(format!("  \u{1f527} {name}"));
+            }
+            EngineEvent::Info { message } => {
+                // Sub-agent already prefixes its own info lines with
+                // two spaces and an emoji — forward as-is so the
+                // visual hierarchy survives.
+                self.push_capped(message);
+            }
+            EngineEvent::ApprovalRequest { tool_name, .. } => {
+                // B10: bg agents have no user channel — these always
+                // auto-reject. Record so the model's apparent
+                // "failure to do X" is debuggable.
+                self.push_capped(format!(
+                    "  \u{2398} approval auto-rejected for {tool_name} (no user channel)"
+                ));
+            }
+            EngineEvent::AskUserRequest { question, .. } => {
+                self.push_capped(format!(
+                    "  \u{2398} ask-user auto-skipped: {}",
+                    question.chars().take(80).collect::<String>()
+                ));
+            }
+            // Everything else (streaming text, thinking, status, etc.)
+            // is intentionally dropped — either redundant with the
+            // result oneshot or noisy without context.
+            _ => {}
+        }
+    }
 }
 
 /// A sink that collects events into a Vec for testing.
@@ -97,5 +208,105 @@ mod tests {
         sink.emit(EngineEvent::Info {
             message: "test".into(),
         });
+    }
+
+    // ── BufferingSink (#1022 B9) ─────────────────────────────────
+
+    #[test]
+    fn buffering_sink_records_tool_calls_and_info() {
+        let sink = BufferingSink::new();
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "t1".into(),
+            name: "Read".into(),
+            args: serde_json::json!({"path": "foo.txt"}),
+            is_sub_agent: false,
+        });
+        sink.emit(EngineEvent::Info {
+            message: "  \u{26a1} cache hit".into(),
+        });
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "t2".into(),
+            name: "Bash".into(),
+            args: serde_json::json!({"command": "ls"}),
+            is_sub_agent: false,
+        });
+
+        let lines = sink.take_lines();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].contains("Read"), "got: {}", lines[0]);
+        assert!(lines[1].contains("cache hit"), "got: {}", lines[1]);
+        assert!(lines[2].contains("Bash"), "got: {}", lines[2]);
+    }
+
+    #[test]
+    fn buffering_sink_drops_streaming_text() {
+        let sink = BufferingSink::new();
+        sink.emit(EngineEvent::TextDelta {
+            text: "hello".into(),
+        });
+        sink.emit(EngineEvent::TextDelta {
+            text: " world".into(),
+        });
+        sink.emit(EngineEvent::TextDone);
+        sink.emit(EngineEvent::ThinkingDelta {
+            text: "reasoning".into(),
+        });
+        // Streaming text crosses the result oneshot already — capturing
+        // it here would duplicate the model's final output in the
+        // user-facing trace.
+        assert!(sink.take_lines().is_empty());
+    }
+
+    #[test]
+    fn buffering_sink_records_auto_reject_for_approval() {
+        let sink = BufferingSink::new();
+        sink.emit(EngineEvent::ApprovalRequest {
+            id: "a1".into(),
+            tool_name: "Delete".into(),
+            detail: "foo.txt".into(),
+            preview: None,
+            effect: crate::tools::ToolEffect::Destructive,
+        });
+        let lines = sink.take_lines();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("Delete"));
+        assert!(
+            lines[0].contains("auto-rejected"),
+            "approval-without-channel must be marked as auto-rejected; got: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn buffering_sink_caps_runaway_traces() {
+        let sink = BufferingSink::with_cap(3);
+        for i in 0..10 {
+            sink.emit(EngineEvent::Info {
+                message: format!("line {i}"),
+            });
+        }
+        let lines = sink.take_lines();
+        // 3 real lines + 1 truncation marker. Marker is idempotent
+        // even though we tried to push 7 more lines.
+        assert_eq!(lines.len(), 4, "got: {lines:?}");
+        assert!(lines.last().unwrap().starts_with('\u{2026}'));
+        assert!(lines.last().unwrap().contains("truncated"));
+    }
+
+    #[test]
+    fn buffering_sink_take_drains() {
+        let sink = BufferingSink::new();
+        sink.emit(EngineEvent::Info {
+            message: "a".into(),
+        });
+        assert_eq!(sink.take_lines().len(), 1);
+        // Second take returns empty — not a snapshot, a drain.
+        assert!(sink.take_lines().is_empty());
+    }
+
+    #[test]
+    fn buffering_sink_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<BufferingSink>();
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -659,12 +659,26 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                  Result:\n{}",
                 bg_result.agent_name, bg_result.prompt, bg_result.output
             );
-            sink.emit(EngineEvent::Info {
-                message: format!(
-                    "  \u{2705} Background agent '{}' {status}",
-                    bg_result.agent_name
-                ),
-            });
+            // #1022 B9: surface the bg agent's narrative trace so the
+            // user can see what it did, not just that it finished.
+            // Pre-fix this was a single-line "✅ X completed" with
+            // *no visibility* into intermediate tool calls (bg agents
+            // ran with NullSink). Now the trace is appended as
+            // bullet-formatted lines under the completion header.
+            // Trace goes to the *user* via Info; the model sees the
+            // result via the injected user message above (which is
+            // intentionally trace-free — the model already chose
+            // those tool calls and doesn't need to re-read its own
+            // history).
+            let mut msg = format!(
+                "  \u{2705} Background agent '{}' {status}",
+                bg_result.agent_name
+            );
+            if !bg_result.events.is_empty() {
+                msg.push('\n');
+                msg.push_str(&bg_result.events.join("\n"));
+            }
+            sink.emit(EngineEvent::Info { message: msg });
             db.insert_message(session_id, &Role::User, Some(&injection), None, None, None)
                 .await?;
         }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -45,7 +45,9 @@ async fn run_bg_agent(
     arguments: String,
     sub_agent_cache: SubAgentCache,
     parent_session: String,
-    tx: tokio::sync::oneshot::Sender<Result<String, String>>,
+    tx: tokio::sync::oneshot::Sender<
+        Result<crate::bg_agent::BgPayload, crate::bg_agent::BgPayload>,
+    >,
     // B2 of #1022: parent's cancel token, threaded as a `child_token()`
     // so a Ctrl-C in the parent loop cancels the bg agent.
     cancel: CancellationToken,
@@ -60,7 +62,15 @@ async fn run_bg_agent(
     parent_sandbox_policy: koda_sandbox::SandboxPolicy,
 ) {
     let (_, mut cmd_rx) = mpsc::channel(1);
-    let null_sink = crate::engine::sink::NullSink;
+    // #1022 B9: bg agents used to run with `NullSink`, so every
+    // event inside them was silently dropped — the user only saw
+    // the spawn line and the eventual completion line. Now we use
+    // `BufferingSink` to capture a narrative trace (tool calls,
+    // info, auto-rejected approvals) that ships back over the
+    // result oneshot and gets surfaced to the user at
+    // result-injection time. See `engine::sink::BufferingSink` for
+    // the capture rules.
+    let buffering_sink = crate::engine::sink::BufferingSink::new();
     let nested_bg = crate::bg_agent::new_shared();
 
     // Override background=false to prevent infinite spawn — a bg agent
@@ -77,7 +87,7 @@ async fn run_bg_agent(
         &db,
         &sync_arguments,
         parent_trust,
-        &null_sink,
+        &buffering_sink,
         cancel,
         &mut cmd_rx,
         None,
@@ -88,9 +98,14 @@ async fn run_bg_agent(
     )
     .await;
 
+    // Drain the buffered trace exactly once. The events ship back
+    // alongside the output (for the success case) or alongside the
+    // error message (for the failure case) so the user can see
+    // *what the bg agent attempted* even when it failed.
+    let events = buffering_sink.take_lines();
     let _ = match result {
-        Ok(output) => tx.send(Ok(output)),
-        Err(e) => tx.send(Err(format!("Error: {e}"))),
+        Ok(output) => tx.send(Ok((output, events))),
+        Err(e) => tx.send(Err((format!("Error: {e}"), events))),
     };
 }
 
@@ -706,6 +721,15 @@ pub(crate) fn execute_sub_agent<'a>(
                                 Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),
                                 Some(ApprovalDecision::RejectWithFeedback { feedback }) => {
                                     format!("[rejected: {feedback}]")
+                                }
+                                Some(ApprovalDecision::RejectAuto { reason }) => {
+                                    // #1022 B15: same shape as the existing
+                                    // sub-agent auto-reject below, so the model
+                                    // sees a uniform "no human, here's why"
+                                    // signal regardless of whether the auto-
+                                    // rejection came from headless policy or
+                                    // from a closed approval channel.
+                                    format!("[auto-rejected: {reason}]")
                                 }
                                 None => {
                                     // #1022 B10: `request_approval` returns `None`

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -745,6 +745,23 @@ pub(crate) async fn execute_tools_sequential(
                         .await?;
                         continue;
                     }
+                    Some(ApprovalDecision::RejectAuto { reason }) => {
+                        // #1022 B15: distinct from Reject so the model knows
+                        // there's no human in the loop — it should adapt its
+                        // plan to the structural constraint, not ask for
+                        // clarification.
+                        let result = format!("[auto-rejected: {reason}]");
+                        db.insert_message(
+                            session_id,
+                            &Role::Tool,
+                            Some(&result),
+                            None,
+                            Some(&tc.id),
+                            None,
+                        )
+                        .await?;
+                        continue;
+                    }
                     None => {
                         // Cancelled
                         return Ok(());


### PR DESCRIPTION
## Provenance

Final P1 phase of the multi-agent execution review (#1022). Two
paired observability/UX fixes — both surface the same failure mode
(model and user can't tell what auto-rejected/auto-ran inside an
agent), so they share a design conversation and one PR.

After this lands, all P1 work in #1022 is done (B1–B15, with B14
already in #1027). Only P2 polish remains.

## What lands

### B9 — Background agent visibility

Pre-fix, bg agents ran with `engine::sink::NullSink` so every
event inside them — tool calls, info, approval requests, errors —
was silently dropped. The user only ever saw:

```
🚀 explorer launched in background (task 1)
…
✅ Background agent 'explorer' completed
```

*What the bg agent actually did* was opaque. No tool trace, no
intermediate status, no breadcrumb on failure. **#1022's whole
point is multi-agent confidence — and "I can't see what my agents
did" is the failure mode that kills it.**

**Fix**: new `engine::sink::BufferingSink` captures a narrative
trace (one short line per `ToolCallStart`, `Info`, auto-rejected
approval). Capped at 256 lines with a single
`… (trace truncated at N lines)` marker. Trace ships back through
the existing oneshot via a new `BgPayload = (output, Vec<String>)`
type alias. `BgAgentResult` gains `events: Vec<String>`. Drain
emits as a multi-line `Info`:

```
✅ Background agent 'explorer' completed
  🔧 Read
  🔧 Grep
  🔧 Bash
  ⎘ approval auto-rejected for Delete (no user channel)
```

What's *intentionally* dropped: streaming text (`TextDelta`,
`TextDone`, `ThinkingDelta`). The final output already crosses the
result oneshot, so capturing here would duplicate the model's
response in the trace.

### B15 — Headless reject indistinguishable from user reject

Pre-fix, `HeadlessSink` auto-rejected destructive tools via
`ApprovalDecision::Reject`. Dispatch formatted that as
`"User rejected this action."` — indistinguishable from a real
human "no". The model would loop asking the (nonexistent) user how
to proceed, then time out.

**Fix**: new `ApprovalDecision::RejectAuto { reason: String }`
variant. Headless sends a richly-worded reason. Dispatch formats
as `[auto-rejected: <reason>]` — the same shape as the bg-agent
closed-channel auto-reject (B10 in #1028). Uniform "no human,
here's why" signal across all auto-reject paths.

## Why grouped

Tightly coupled:

- Both surface the same failure mode: an auto-reject silently
  looking like the user did something.
- Both add a new "auto" channel to an existing
  user-vs-system-rejection split.
- The format `[auto-rejected: <reason>]` is shared between B10
  (bg/sub-agent closed channel), B15 (headless policy), and the
  trace marker for B9 (`approval auto-rejected for X`). One
  vocabulary, three call sites.

## Tests

| Layer | Result |
|---|---|
| Lib tests | **1026** green (was 1016 — **+10 new**) |
| e2e tests | `e2e_test`, `e2e_tools_test`, `e2e_agent_test` green |
| smoke tests | green (headless flow exercised) |
| Clippy | clean |
| Rustdoc | clean |

### New tests (10)

- `test_reject_auto_wire_tag_is_snake_case` — pins `"reject_auto"`
  on the wire so renaming silently breaks ACP clients (which
  would fall through to `Reject` and re-introduce B15)
- `test_approval_decision_variants` extended for `RejectAuto`
  roundtrip
- `BufferingSink` (6): records tool calls + info, drops streaming
  text, records auto-reject for approval, caps runaway, drains on
  take, Send+Sync
- `bg_agent` registry (3): events propagate on success, on
  failure, empty-Vec on cancel/abort

## DESIGN.md

- **Sub-Agent Lifecycle § 3 (Background)** — added "Visibility"
  subsection: `BufferingSink` not `NullSink`, what's captured and
  why, what's dropped and why (oneshot already carries final
  output), the 256-line cap, the `BgPayload` type alias.
- **Async Approval Flow §** — documented the four-variant decision
  split and the `Reject` vs `RejectAuto` distinction with the
  model-adaptation rationale and the wire format pin.

## Files

```
DESIGN.md                           |  29 ++++-
koda-cli/src/headless.rs            |  14 ++-
koda-core/src/bg_agent.rs           | 120 +++++++++++++++++--
koda-core/src/engine/event.rs       |  40 ++++++-
koda-core/src/engine/sink.rs        | 213 +++++++++++++++++++++++++++++++++++-
koda-core/src/inference.rs          |  26 ++++-
koda-core/src/sub_agent_dispatch.rs |  34 +++++-
koda-core/src/tool_dispatch.rs      |  17 +++
8 files changed, 466 insertions(+), 27 deletions(-)
```

## Cancelled / panicked tasks

`BgAgentResult.events` is explicitly `Vec::new()` for the
cancel/abort path (the buffering sink died with the task). Pinned
by `cancelled_task_has_empty_event_trace` so future refactors
can't silently regress.

## Remaining #1022 work

Only P2 polish (B16–B22) — mutex type swap, debug asserts,
transactional file ops, etc. All standalone, none on the critical
path for the multi-agent confidence story this issue was scoped
to.
