### PR TITLE
fix(#1022): B16+B17+B22 P2 robustness cluster (parking_lot, assert!, OnceLock)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "insta",
  "koda-sandbox",
  "koda-test-utils",
+ "parking_lot",
  "path-clean",
  "regex",
  "reqwest",

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -59,6 +59,12 @@ sha2 = "0.10"
 # POSIX shell tokenization (bash safety classification — replaces substring matching, #807)
 shlex = "1"
 
+# Sync mutex without poisoning (#1022 B16: BgAgentRegistry needs
+# a non-poisoning sync mutex to survive a panic-while-held without
+# bricking every subsequent drain. parking_lot is also faster on
+# contention and has a cleaner non-`Result` API).
+parking_lot = "0.12"
+
 # HTTP client (for LLM API)
 reqwest = { version = "0.13", features = ["json", "stream"] }
 

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -28,7 +28,22 @@
 //! inference loop and the background task spawner.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+// **#1022 B16**: was `std::sync::Mutex`. Switched to `parking_lot::Mutex`
+// for three reasons:
+//   1. **No poisoning** — if a thread panics while holding the lock,
+//      subsequent calls don't get a `PoisonError`. The bg registry
+//      is shared between the main inference loop and N spawned tasks;
+//      a panic in one critical section bricking every subsequent
+//      drain would be a particularly bad failure mode.
+//   2. **Faster on contention** — no atomic check for poison flag,
+//      no `Result` allocation. The contention is real: `drain_completed`
+//      runs on every loop iteration.
+//   3. **Cleaner API** — `.lock()` returns a guard directly, no
+//      `.unwrap()` boilerplate at every call site.
+// We deliberately keep this *sync* (not `tokio::sync::Mutex`) because
+// the critical sections are short HashMap ops with no awaits inside.
+use parking_lot::Mutex;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
@@ -151,7 +166,7 @@ impl BgAgentRegistry {
     /// `tx` early; attach binds the handle once it exists.
     pub fn reserve(&self, parent_cancel: &CancellationToken) -> BgAgentReservation {
         let (tx, rx) = oneshot::channel();
-        let mut id = self.next_id.lock().unwrap();
+        let mut id = self.next_id.lock();
         let task_id = *id;
         *id += 1;
         BgAgentReservation {
@@ -178,7 +193,7 @@ impl BgAgentRegistry {
         cancel: CancellationToken,
         handle: tokio::task::JoinHandle<()>,
     ) {
-        self.pending.lock().unwrap().insert(
+        self.pending.lock().insert(
             reservation_id,
             BgAgentEntry {
                 agent_name: agent_name.to_string(),
@@ -201,13 +216,13 @@ impl BgAgentRegistry {
         prompt: &str,
     ) -> (u32, oneshot::Sender<Result<BgPayload, BgPayload>>) {
         let (tx, rx) = oneshot::channel();
-        let mut id = self.next_id.lock().unwrap();
+        let mut id = self.next_id.lock();
         let task_id = *id;
         *id += 1;
         drop(id);
         let cancel = CancellationToken::new();
         let noop = tokio::spawn(async {});
-        self.pending.lock().unwrap().insert(
+        self.pending.lock().insert(
             task_id,
             BgAgentEntry {
                 agent_name: agent_name.to_string(),
@@ -223,7 +238,7 @@ impl BgAgentRegistry {
     /// Drain all completed background agents. Non-blocking — only takes
     /// entries whose oneshot has already resolved.
     pub fn drain_completed(&self) -> Vec<BgAgentResult> {
-        let mut guard = self.pending.lock().unwrap();
+        let mut guard = self.pending.lock();
         let mut completed = Vec::new();
         let mut done_ids = Vec::new();
 
@@ -276,7 +291,7 @@ impl BgAgentRegistry {
 
     /// How many background agents are still running.
     pub fn pending_count(&self) -> usize {
-        self.pending.lock().unwrap().len()
+        self.pending.lock().len()
     }
 }
 
@@ -293,14 +308,14 @@ impl Drop for BgAgentRegistry {
     /// only to make the lifecycle explicit and to give a single
     /// place to add telemetry later.
     fn drop(&mut self) {
-        // Try to lock; if poisoned (a thread panicked while holding
-        // it) we still want to drain the entries so their handles
-        // get dropped. `into_inner` on a poisoned guard surfaces the
-        // map regardless of poison state.
-        let map = match self.pending.get_mut() {
-            Ok(map) => std::mem::take(map),
-            Err(poisoned) => std::mem::take(poisoned.into_inner()),
-        };
+        // **#1022 B16**: simplified post-parking_lot. The pre-fix
+        // version had to handle `PoisonError` (via
+        // `match get_mut() { Ok | Err(into_inner()) }`) because a
+        // panic-while-held would poison `std::sync::Mutex`.
+        // `parking_lot::Mutex` doesn't poison, so the cleanup path
+        // is now the obvious one: take the map, log if non-empty,
+        // let `AbortOnDropHandle::drop` do the actual abort work.
+        let map = std::mem::take(&mut *self.pending.lock());
         if !map.is_empty() {
             tracing::debug!(
                 count = map.len(),

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -35,9 +35,30 @@ use crate::trust::TrustMode;
 
 use anyhow::Result;
 use koda_sandbox::{BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+/// Cached parse of [`DEFAULT_DEV_ALLOWLIST`].
+///
+/// **#1022 B22**: pre-fix, `Filter::new(DEFAULT_DEV_ALLOWLIST).expect(…)`
+/// was called on every session creation. The args are static, the
+/// result is identical, and parsing the regex set isn't free. More
+/// importantly: a bad pattern in `DEFAULT_DEV_ALLOWLIST` would panic
+/// at *every* session creation in production rather than failing
+/// once at startup. The CI test
+/// `koda_sandbox::filter::tests::default_allowlist_parses` already
+/// guards the static, so the `expect` is sound — but hoisting into
+/// a `OnceLock` makes the contract structural: parse once, panic
+/// once if it ever does, clone-cheap (`Filter` is
+/// `#[derive(Clone)]` and holds a `Vec<Pattern>`) for each session.
+static DEV_ALLOWLIST_FILTER: OnceLock<Filter> = OnceLock::new();
+
+/// Get (or initialize) the cached default-allowlist filter.
+fn dev_allowlist_filter() -> &'static Filter {
+    DEV_ALLOWLIST_FILTER
+        .get_or_init(|| Filter::new(DEFAULT_DEV_ALLOWLIST).expect("default allowlist must parse"))
+}
 
 /// A single conversation session with its own state.
 ///
@@ -168,11 +189,10 @@ impl KodaSession {
         // Spawn the per-session HTTP CONNECT proxy with the default dev
         // allowlist. Fail-open: on spawn failure, log + run unfiltered.
         // Always-on — koda is config-free, there's no "disable" knob.
-        // `expect` on `Filter::new` is sound because
-        // `DEFAULT_DEV_ALLOWLIST` is a static known-good list and
-        // `koda_sandbox::filter::tests::default_allowlist_parses`
-        // guards against regression.
-        let filter = Filter::new(DEFAULT_DEV_ALLOWLIST).expect("default allowlist must parse");
+        // **#1022 B22**: parse-once via `OnceLock` instead of
+        // re-parsing the static allowlist on every session creation.
+        // See `dev_allowlist_filter()` above for the rationale.
+        let filter = dev_allowlist_filter().clone();
         let proxy = match BuiltInProxy::new(filter.clone()).spawn().await {
             Ok(handle) => {
                 agent.tools.set_proxy_port(Some(handle.port));
@@ -303,5 +323,49 @@ impl KodaSession {
     /// Replace the provider (e.g., after switching models or providers).
     pub fn update_provider(&mut self, config: &KodaConfig) {
         self.provider = providers::create_provider(config);
+    }
+}
+
+#[cfg(test)]
+mod b22_tests {
+    //! **#1022 B22** regression tests.
+    //!
+    //! These pin the OnceLock semantics: parse exactly once, return
+    //! the same instance across calls, and stay valid across
+    //! threads. Without these, a future "helpful" refactor that
+    //! moves the cache to a thread-local or a `RwLock<Option<...>>`
+    //! would silently re-introduce the per-session reparse cost
+    //! (or, worse, the per-session panic path).
+    use super::dev_allowlist_filter;
+    use koda_sandbox::DEFAULT_DEV_ALLOWLIST;
+
+    #[test]
+    fn dev_allowlist_filter_is_singleton() {
+        let a = dev_allowlist_filter();
+        let b = dev_allowlist_filter();
+        // Same `&'static` reference \u2014 not just equal contents.
+        // OnceLock guarantees this; if someone refactors to a Box
+        // and clones, this fails fast.
+        assert!(
+            std::ptr::eq(a, b),
+            "dev_allowlist_filter must return the same instance across calls"
+        );
+    }
+
+    #[test]
+    fn dev_allowlist_filter_matches_static_size() {
+        let f = dev_allowlist_filter();
+        // Sanity: every pattern in the static parsed and made it
+        // into the filter. If a future patch silently drops
+        // patterns (e.g. a filter with a max-size cap), this catches it.
+        assert_eq!(f.len(), DEFAULT_DEV_ALLOWLIST.len());
+    }
+
+    #[test]
+    fn dev_allowlist_filter_is_send_sync() {
+        // `OnceLock<Filter>` requires `Filter: Send + Sync` to give
+        // out `&'static Filter` across threads. Pin it.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<koda_sandbox::Filter>();
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -261,12 +261,19 @@ pub(crate) fn execute_sub_agent<'a>(
         //   Anthropic), so if the agent has its own provider we leave the model
         //   resolved from that provider's defaults.
         let sub_config = if is_fork {
-            // Fork inherits the parent config verbatim — including trust mode.
-            // The clone preserves trust; no clamping needed since
-            // fork == exact copy.  Assertion guards against future changes
-            // that might add config overrides to the fork path.
+            // Fork inherits the parent config verbatim — including
+            // trust mode. The clone preserves trust; no clamping
+            // needed since fork == exact copy.
+            //
+            // **#1022 B17**: was `debug_assert!`, which is *compiled
+            // out* in release builds. The fork-trust invariant is a
+            // security-relevant property (a future change that
+            // accidentally narrowed/widened trust between the clone
+            // and use would silently ship). Promoted to `assert!`
+            // — the runtime cost is a single enum equality check, so
+            // there's no reason to weaken the guarantee for release.
             let cfg = parent_config.clone();
-            debug_assert!(
+            assert!(
                 cfg.trust == parent_config.trust,
                 "fork must inherit parent trust exactly"
             );


### PR DESCRIPTION
## Provenance

P2 phase of the multi-agent execution review (#1022). Three small
defensive-robustness fixes that share a theme — close
production-only failure modes that pass tests but bite at scale —
not because they touch the same code.

Grouped because each diff alone is too small to justify the PR
overhead. As a cluster they tell one story (defensive robustness
pass).

## What lands

### B16 — `BgAgentRegistry` mutex poisoning + `.unwrap()` boilerplate

`std::sync::Mutex<HashMap<u32, BgAgentEntry>>` poisons on
panic-while-held. The bg registry is shared between the main
inference loop and N spawned tasks; one panic inside a critical
section bricks every subsequent `.lock().unwrap()` for the whole
session. The Drop impl already worked around this with a
`match get_mut() { Ok | Err(into_inner()) }` branch — a clear
smell that the wrong primitive was in use.

**Fix**: switched to `parking_lot::Mutex`. No poisoning, faster
on contention, cleaner API (no `Result`). 6 sites drop
`.unwrap()`; the Drop impl collapses to a one-liner. Kept *sync*
(not `tokio::sync::Mutex`) — critical sections are short HashMap
ops with no awaits.

### B17 — Fork-trust invariant only enforced in debug builds

```rust
let cfg = parent_config.clone();
debug_assert!(
    cfg.trust == parent_config.trust,
    "fork must inherit parent trust exactly"
);
```

`debug_assert!` is *compiled out* in release. The fork-trust
invariant is security-relevant — a future change that
accidentally widened/narrowed trust between clone and use would
silently ship.

**Fix**: promoted to `assert!`. Cost is one enum equality check
per fork; benefit is the guarantee actually holds in production.

### B22 — `Filter::new(DEFAULT_DEV_ALLOWLIST)` re-parsed per session

```rust
let filter = Filter::new(DEFAULT_DEV_ALLOWLIST)
    .expect("default allowlist must parse");
```

Called on every session creation. Args are static, result is
identical, parsing the regex set isn't free. Worse: a bad
pattern would panic at *every* session creation in production
rather than failing once at startup.

**Fix**: hoisted into `static DEV_ALLOWLIST_FILTER: OnceLock<Filter>`.
Per-session sites now call `dev_allowlist_filter().clone()`
(Filter is `#[derive(Clone)]`, cheap). Parse once for the
lifetime of the process; panic once if ever, never N times.

## Tests

| Layer | Result |
|---|---|
| Lib tests | **1029** green (was 1026 — **+3 new**) |
| e2e tests | `e2e_test`, `e2e_tools_test`, `e2e_agent_test` green |
| smoke tests | green |
| Clippy | clean |
| Rustdoc | clean |

### New tests (3) — all pin B22 contract

- `dev_allowlist_filter_is_singleton` — `std::ptr::eq` proves
  `OnceLock` returns the same `&'static` reference, not just
  equal contents. Catches a future "helpful" refactor that moves
  to `Box::leak` or per-call clones.
- `dev_allowlist_filter_matches_static_size` — sanity that every
  pattern parsed (catches a future filter cap silently dropping
  patterns).
- `dev_allowlist_filter_is_send_sync` — pins `Filter: Send + Sync`
  (required for `OnceLock<Filter>` to give out static refs across
  threads).

B16 needs no new tests — the existing 9 `bg_agent::tests` suite
exercises the mutex on every code path; `parking_lot` swap is
detected as a regression by any of them. (All 9 still green.)

B17 needs no new test — promoting `debug_assert!` → `assert!`
doesn't change *test* behavior (tests already run in debug). The
change is observable only in release, where there's no practical
way to test "panic-on-violation" without crafting a deliberate
violation.

## Files

```
Cargo.lock                          |  1 +
koda-core/Cargo.toml                |  6 +++
koda-core/src/bg_agent.rs           | 45 +++++++++++--------
koda-core/src/session.rs            | 76 ++++++++++++++++++++++++++++-
koda-core/src/sub_agent_dispatch.rs | 17 ++++---
5 files changed, 119 insertions(+), 26 deletions(-)
```

## Why grouped

- All three are "tests pass but production is fragile" patterns —
  poison-on-panic, debug-only-asserts, repeated-static-parse.
- All three are touched by the same instinct: "is this primitive
  the obvious choice for this workload?" The answer was no in
  three different ways.
- Each diff alone is too small to justify the PR overhead.

## Remaining #1022 P2 work

After this lands: B18 (sub-agent iteration cap returns
success-shaped result → cache poisoning), B19 (`derive_child_trust`
extraction), B20 (fork copies history row-by-row), B21 (macOS
`pick_write_provider` fallback corrupts unisolated workspace).
