### PR TITLE
fix(#1022): B18 — sub-agent iteration cap returns structural failure marker + caches it

### DIFF
--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -781,7 +781,40 @@ pub(crate) fn execute_sub_agent<'a>(
                 message: format!("  \u{1f335} {agent_name}: {hint}"),
             });
         }
-        Ok("(sub-agent reached maximum iterations)".to_string())
+        // **#1022 B18**: pre-fix returned a free-text
+        // `"(sub-agent reached maximum iterations)"` that was visually
+        // success-shaped — indistinguishable from a normal sub-agent
+        // answer. The parent model would treat it as a tool result
+        // and either (a) try to keep working with the meaningless
+        // string, or (b) re-issue the same `InvokeAgent` call,
+        // burning another 20 LLM iterations to fail the same way.
+        //
+        // Two prongs to the fix:
+        //
+        // 1. **Bracketed-marker format** matches the established
+        //    failure-result convention (`[cancelled by parent]`,
+        //    `[cancelled]`, `[Background agent X failed]`). The
+        //    `[ERROR: ...]` prefix is unambiguous to the model:
+        //    "this is not a sub-agent answer, this is structural
+        //    failure metadata." Includes the cap as a number so the
+        //    model can reason about whether the task was decomposable.
+        //    Format extracted to `iteration_cap_marker` so the
+        //    contract can be unit-tested without standing up the
+        //    full sub-agent harness.
+        //
+        // 2. **Cache the result** so a second identical call returns
+        //    the same marker immediately instead of burning another
+        //    20 iterations. Keyed by `(agent_name, prompt_hash)`,
+        //    so a *reformulated* prompt is still attempted (parent
+        //    can adapt). Cache is invalidated on any file mutation
+        //    (see `SubAgentCache::invalidate`) so a write-then-retry
+        //    flow naturally bypasses the marker. This makes the
+        //    iteration-cap behave like every other sub-agent
+        //    result — the cache is the right place to record
+        //    "don't try this again unless something changed."
+        let result = iteration_cap_marker(agent_name, loop_guard::MAX_SUB_AGENT_ITERATIONS);
+        sub_agent_cache.put(agent_name, prompt, &result);
+        Ok(result)
     }
 }
 
@@ -832,4 +865,123 @@ fn pick_write_provider(
     // (4e in #934) is parked until production telemetry shows it's
     // worth building — see #934 deferral comments.
     Box::new(GitWorktreeProvider::new(project_root, agent_name))
+}
+
+// \u2500\u2500 Iteration-cap marker (#1022 B18) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+/// Build the structural-failure marker returned when a sub-agent
+/// exhausts its iteration budget without producing a final answer.
+///
+/// Format follows the established bracketed-marker convention used
+/// throughout the dispatch path (`[cancelled by parent]`,
+/// `[cancelled]`, `[Background agent X failed]`). The `[ERROR:`
+/// prefix is the unambiguous "this is metadata, not content" signal
+/// to the model.
+///
+/// Extracted as a free function so the contract (must contain
+/// `[ERROR:`, the agent name, the cap as a number, and a
+/// re-strategize hint) can be regression-tested without standing up
+/// the full sub-agent harness.
+fn iteration_cap_marker(agent_name: &str, cap: usize) -> String {
+    format!(
+        "[ERROR: sub-agent '{agent_name}' exceeded its iteration cap of {cap} without producing \
+         a final answer. Decompose the task into smaller pieces, or attempt the work \
+         directly without delegating.]"
+    )
+}
+
+#[cfg(test)]
+mod b18_tests {
+    //! **#1022 B18** regression tests for the iteration-cap marker.
+    //!
+    //! These pin the *contract* of the marker string \u2014 not its
+    //! exact wording, but the load-bearing pieces:
+    //!
+    //! - `[ERROR:` prefix so the model treats it as structural
+    //!   failure metadata, not a sub-agent answer (the pre-fix
+    //!   `"(sub-agent reached maximum iterations)"` had no such
+    //!   marker and was indistinguishable from a normal result).
+    //! - The agent name appears so multi-agent flows can identify
+    //!   which sub-agent capped out.
+    //! - The cap appears as a number so the model can reason about
+    //!   decomposability ("did it run out of budget at 20 or 200?").
+    //! - A re-strategize hint appears so the model has a concrete
+    //!   next action instead of just retrying.
+    //!
+    //! The cache integration (`sub_agent_cache.put` two lines above
+    //! the call) is verified by code review \u2014 it's adjacent to the
+    //! marker construction and the call shape is obvious. A full
+    //! e2e cap-and-retry test would require the mock provider to
+    //! issue 21+ tool calls in a row; the cost/value ratio doesn't
+    //! justify it for what's effectively a one-line cache write.
+    use super::iteration_cap_marker;
+    use crate::loop_guard::MAX_SUB_AGENT_ITERATIONS;
+
+    #[test]
+    fn marker_has_error_prefix() {
+        let m = iteration_cap_marker("scout", 20);
+        assert!(
+            m.starts_with("[ERROR:"),
+            "marker must start with `[ERROR:` so the model treats it \
+             as structural failure metadata, not a sub-agent answer; \
+             got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_includes_agent_name() {
+        let m = iteration_cap_marker("scout", 20);
+        assert!(
+            m.contains("'scout'"),
+            "marker must name the capped sub-agent; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_includes_cap_as_number() {
+        let m = iteration_cap_marker("scout", 20);
+        assert!(
+            m.contains("20"),
+            "marker must include the cap as a number so the model can \
+             reason about decomposability; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_includes_restrategize_hint() {
+        let m = iteration_cap_marker("scout", 20);
+        // Either of the two suggested actions is fine \u2014 we just
+        // want the model to see that it has options other than
+        // retrying the same call.
+        assert!(
+            m.to_lowercase().contains("decompose")
+                || m.to_lowercase().contains("attempt the work directly"),
+            "marker must give the model a concrete next action; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_uses_real_cap_constant() {
+        // Sanity: the call site passes `MAX_SUB_AGENT_ITERATIONS`,
+        // not a magic number. If someone refactors the constant to
+        // a different name and forgets to update the call site, the
+        // test wouldn't catch it directly \u2014 but this at least
+        // documents the wired-in expectation.
+        let m = iteration_cap_marker("agent", MAX_SUB_AGENT_ITERATIONS);
+        assert!(m.contains(&MAX_SUB_AGENT_ITERATIONS.to_string()));
+    }
+
+    #[test]
+    fn marker_is_single_line_for_tool_result_clarity() {
+        // Sub-agent results land in `tool_call_id`-keyed message
+        // content. Multi-line markers would format awkwardly in
+        // the user-facing trace; single-line keeps the failure
+        // visible at a glance. This catches a future "helpful"
+        // refactor that spreads the message across lines.
+        let m = iteration_cap_marker("scout", 20);
+        assert!(
+            !m.contains('\n'),
+            "marker must be single-line for clean tool-result formatting; got:\n{m}"
+        );
+    }
 }


### PR DESCRIPTION
## Provenance

P2 phase of the multi-agent execution review (#1022). Single-file
fix from the closeout cluster — sub-agent iteration-cap path
returned a success-shaped string and bypassed the cache, which
let the parent burn 20 fresh LLM iterations on every retry.

## The bug

When a sub-agent hits its 20-iteration hard cap, dispatch returned:

```rust
Ok("(sub-agent reached maximum iterations)".to_string())
```

Two bad properties:

1. **Visually success-shaped**. The parent's tool-result handler
   couldn't distinguish this from a normal sub-agent answer. Model
   would either try to keep working with the meaningless string
   or — worse — re-issue the same `InvokeAgent` call.

2. **Not cached**. The clean-exit path populates
   `sub_agent_cache.put(name, prompt, result)`, but the
   iteration-cap path bypassed it. So an identical re-invocation
   ran the *full* 20-iteration loop again before returning the
   same useless string.

In a multi-agent flow with several sub-agents in parallel, one
capped-out sub-agent could trivially burn 80+ LLM iterations
before the parent realized any of the calls had structurally
failed. Real cost line at frontier-model pricing.

## Fix

Two prongs in the iteration-cap branch of `execute_sub_agent`:

### 1. Bracketed-marker format

```
[ERROR: sub-agent 'scout' exceeded its iteration cap of 20 without producing
 a final answer. Decompose the task into smaller pieces, or attempt the work
 directly without delegating.]
```

`[ERROR: ...]` matches the established failure-marker convention
already used by `[cancelled by parent]`, `[cancelled]`, and
`[Background agent X failed]`. Same vocabulary, three call sites.
Model recognizes the shape as "structural failure metadata, not
sub-agent answer content" and adapts.

### 2. Cache the marker

```rust
let result = iteration_cap_marker(agent_name, MAX_SUB_AGENT_ITERATIONS);
sub_agent_cache.put(agent_name, prompt, &result);
Ok(result)
```

A second identical invocation hits the cache and returns instantly
instead of running another 20-iteration loop. Cache invalidation
already triggers on file mutation, so a write-then-retry naturally
bypasses the marker. A *reformulated* prompt is re-attempted
because the cache key hashes the prompt.

Together: iteration-cap behaves like every other sub-agent result
— distinct content, cached, model-adaptable.

## Why I extracted `iteration_cap_marker`

The format is the load-bearing part of the contract. Inlined,
testing it requires standing up the whole sub-agent harness. As a
free function, the contract is unit-testable in microseconds.
Function is private (`fn`, not `pub fn`) — implementation detail
of dispatch.

## Tests

| Layer | Result |
|---|---|
| Lib tests | **1032** green (was 1026 — **+6 new**) |
| e2e tests | 13 green |
| smoke tests | 13 green |
| Clippy / fmt | clean |

### New tests (6) — all pin the marker contract

- `marker_has_error_prefix` — must start with `[ERROR:` so model
  treats it as metadata, not content.
- `marker_includes_agent_name` — multi-agent flows need to know
  *which* sub-agent capped.
- `marker_includes_cap_as_number` — model can reason about
  decomposability ("ran out at 20 or 200?").
- `marker_includes_restrategize_hint` — model has a concrete next
  action instead of just retrying.
- `marker_uses_real_cap_constant` — sanity that call site passes
  `MAX_SUB_AGENT_ITERATIONS`, not a magic number.
- `marker_is_single_line_for_tool_result_clarity` — multi-line
  markers format awkwardly in user-facing trace; catches a future
  "helpful" refactor that spreads the message across lines.

The cache integration (`sub_agent_cache.put` two lines above the
marker construction) is verified by code review — adjacent to the
call, shape obvious. A full e2e cap-and-retry test would require
the mock provider to issue 21+ tool calls in a row; cost/value
ratio doesn't justify it.

## Files

```
koda-core/src/sub_agent_dispatch.rs | 154 +++++++++++++++++++++++-
1 file changed, 153 insertions(+), 1 deletion(-)
```

## Remaining #1022 P2 work

After this lands: B19 (`derive_child_trust` extraction), B20
(fork copies history row-by-row), B21 (macOS
`pick_write_provider` fallback corrupts unisolated workspace).
