### PR TITLE
fix(#1022): B19 — derive_child_trust uses runtime mode (privilege escalation fix)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -382,9 +382,14 @@ Four execution modes, one mental model:
 
 **Invariants** — enforced consistently across all four modes:
 
-- **Trust never widens**. `derive_child_trust(parent, declared) =
-  TrustMode::clamp(parent, declared)` is the *only* way to compute child
-  trust. Same helper for fork, named, and bg paths.
+- **Trust never widens**. `derive_child_trust(parent_runtime, declared)`
+  in `koda_core::trust` is the *only* way to compute child trust. Same
+  helper for fork, named, and bg paths. **Critical**: `parent_runtime`
+  must be the runtime `mode` parameter threaded through dispatch —
+  never `parent_config.trust`, which is the *startup* value and is
+  not updated by `/safe`/`/auto` toggles (#1022 B19). The structural
+  lint test in `koda-cli/tests/regression_test.rs` enforces this at
+  CI time.
 - **Sandbox never widens**. `compose_child_policy(parent_policy, child_trust,
   root)` calls `SandboxPolicy::compose()` (denies = union, allows = intersect,
   limits = min). Bg agents snapshot the parent's effective policy at spawn

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -335,3 +335,82 @@ mod hardcoded_trust_mode_at_session_creation {
         assert_no_hardcoded_auto_in_session_new("koda-cli/src/tui_context/mod.rs");
     }
 }
+
+/// **#1022 B19** \u{2014} sub-agent dispatch must clamp child trust against
+/// the **runtime** trust mode (the `mode` parameter), not the
+/// **stale startup** value `parent_config.trust`.
+///
+/// `cycle_trust` and `set_trust` mutate the `SharedTrustMode` atomic
+/// but never the `KodaConfig.trust` field. Pre-fix, sub_agent_dispatch
+/// passed `parent_config.trust` as the parent side of the clamp, so a
+/// user who started in Auto and hit `/safe` would still get sub-agents
+/// clamped against Auto \u{2014} the child could run with broader privileges
+/// than the parent's *current* mode. Real escalation.
+///
+/// The fix routes all three dispatch paths (fork/named/bg) through
+/// `derive_child_trust(mode, declared)`. This test scans
+/// `sub_agent_dispatch.rs` for the antipatterns
+/// (`clamp(parent_config.trust,` or `derive_child_trust(parent_config.trust,`)
+/// and fails with a clear pointer if either reappears.
+///
+/// Why structural and not e2e: an e2e test would need to (1) toggle
+/// trust mid-session, (2) dispatch a sub-agent, (3) introspect the
+/// child's effective trust. That's a heavy harness for a one-line
+/// regression. The structural test catches the only way the bug
+/// reintroduces.
+mod sub_agent_dispatch_uses_runtime_trust_not_stale_config {
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn no_clamp_or_derive_against_parent_config_trust() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let path = manifest_dir
+            .join("..")
+            .join("koda-core/src/sub_agent_dispatch.rs");
+        let src =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+
+        // Strip rustdoc + line comments before scanning so the
+        // "antipattern this helper exists to prevent" prose in
+        // doc comments doesn't trip the lint. Cheap pass: drop
+        // anything from `//` to end of line. Block comments are
+        // unused in this file but `///` is a `//` so it falls out
+        // naturally.
+        let code: String = src
+            .lines()
+            .map(|line| {
+                if let Some(idx) = line.find("//") {
+                    &line[..idx]
+                } else {
+                    line
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for needle in [
+            "clamp(parent_config.trust",
+            "derive_child_trust(parent_config.trust",
+        ] {
+            assert!(
+                !code.contains(needle),
+                "sub_agent_dispatch.rs uses `{needle}` \u{2014} this is the \
+                 #1022 B19 antipattern. `parent_config.trust` is the \
+                 stale startup value; runtime trust toggles never \
+                 update it. Pass the runtime `mode` parameter instead. \
+                 See `derive_child_trust` doc in `koda-core/src/trust.rs`."
+            );
+        }
+
+        // Positive assertion: the helper *is* called somewhere.
+        // Catches a refactor that drops trust derivation entirely.
+        assert!(
+            code.contains("derive_child_trust("),
+            "sub_agent_dispatch.rs no longer calls `derive_child_trust` \
+             at all \u{2014} child trust derivation has been bypassed. \
+             Every fork/named/bg path must derive child trust through \
+             this helper."
+        );
+    }
+}

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -18,7 +18,7 @@ use crate::providers::{ChatMessage, ToolCall};
 use crate::sub_agent_cache::SubAgentCache;
 use crate::tool_dispatch::execute_one_tool;
 use crate::tools::{self, ToolRegistry};
-use crate::trust::{self, ToolApproval, TrustMode};
+use crate::trust::{self, ToolApproval, TrustMode, derive_child_trust};
 
 use anyhow::{Context, Result};
 use koda_sandbox::{CwdProvider, GitWorktreeProvider, WorkspaceProvider};
@@ -261,9 +261,9 @@ pub(crate) fn execute_sub_agent<'a>(
         //   Anthropic), so if the agent has its own provider we leave the model
         //   resolved from that provider's defaults.
         let sub_config = if is_fork {
-            // Fork inherits the parent config verbatim — including
-            // trust mode. The clone preserves trust; no clamping
-            // needed since fork == exact copy.
+            // Fork inherits the parent config verbatim, *except* for
+            // trust — which must come from the **runtime** mode
+            // (see `derive_child_trust` doc).
             //
             // **#1022 B17**: was `debug_assert!`, which is *compiled
             // out* in release builds. The fork-trust invariant is a
@@ -272,10 +272,25 @@ pub(crate) fn execute_sub_agent<'a>(
             // and use would silently ship). Promoted to `assert!`
             // — the runtime cost is a single enum equality check, so
             // there's no reason to weaken the guarantee for release.
-            let cfg = parent_config.clone();
+            //
+            // **#1022 B19**: pre-fix asserted `cfg.trust ==
+            // parent_config.trust` after a clone, which checked the
+            // wrong thing — `parent_config.trust` is the *startup*
+            // value of the trust mode and ignores `/safe`/`/auto`
+            // toggles. The actual invariant is "fork runs at the
+            // parent's *runtime* trust", and the runtime mode is
+            // `mode`. Now we explicitly write `cfg.trust` from
+            // `derive_child_trust(mode, mode)` (= `mode`) and
+            // assert against `mode`. The clone-then-overwrite
+            // pattern is intentional: keeps the rest of
+            // `parent_config` (model, base_url, system prompt
+            // overrides, ...) verbatim while making the trust
+            // derivation explicit and uniform with the named path.
+            let mut cfg = parent_config.clone();
+            cfg.trust = derive_child_trust(mode, mode);
             assert!(
-                cfg.trust == parent_config.trust,
-                "fork must inherit parent trust exactly"
+                cfg.trust == mode,
+                "fork must inherit parent's runtime trust mode exactly"
             );
             cfg
         } else {
@@ -301,15 +316,29 @@ pub(crate) fn execute_sub_agent<'a>(
             // else: agent opted into its own provider — use its resolved config
             // as-is. The agent JSON is responsible for any model it needs.
 
-            // Inherit trust: child can never exceed parent's trust (#845).
-            // Same pattern as Codex's `apply_spawn_agent_runtime_overrides()`
-            // which copies the parent's runtime sandbox_policy onto the child.
+            // Inherit trust: child can never exceed parent's *runtime*
+            // trust (#845, #1022 B19). Same pattern as Codex's
+            // `apply_spawn_agent_runtime_overrides()` which copies the
+            // parent's runtime sandbox_policy onto the child.
+            //
+            // **#1022 B19**: pre-fix used `parent_config.trust` as the
+            // ceiling. That field is the *startup* trust value;
+            // `cycle_trust`/`set_trust` mutate the SharedTrustMode
+            // atomic but never the config field. So a user who
+            // started in Auto and hit `/safe` would get sub-agents
+            // clamped against the stale Auto, allowing the child to
+            // run with broader privileges than the parent's *current*
+            // mode. Real escalation. The runtime mode is `mode`,
+            // threaded through `execute_one_tool` from the inference
+            // loop — that's the only authoritative value. The helper
+            // `derive_child_trust` exists to make this antipattern
+            // greppable (see its doc).
             let child_trust = cfg.trust;
-            cfg.trust = TrustMode::clamp(parent_config.trust, cfg.trust);
+            cfg.trust = derive_child_trust(mode, cfg.trust);
             if cfg.trust != child_trust {
                 tracing::info!(
                     agent = agent_name,
-                    parent = %parent_config.trust,
+                    parent = %mode,
                     child = %child_trust,
                     effective = %cfg.trust,
                     "sub-agent trust clamped to match parent",

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -122,6 +122,76 @@ impl TrustMode {
     }
 }
 
+// ── Child trust derivation (#1022 B19) ─────────────────────────────────
+
+/// The single, authoritative way to compute a child agent's trust mode.
+///
+/// **Per DESIGN.md § "Trust never widens"**: this helper is the *only*
+/// way fork, named, and bg sub-agent dispatch paths derive child
+/// trust. Three call sites converging on one function ensures the
+/// invariant cannot drift between paths.
+///
+/// # `parent_runtime` MUST be the runtime mode
+///
+/// **#1022 B19**: pre-fix, `sub_agent_dispatch` clamped against
+/// `parent_config.trust` — the *startup* value of the trust mode.
+/// `cycle_trust`/`set_trust` mutate the `SharedTrustMode` atomic but
+/// **never** the `KodaConfig.trust` field. So a user who started in
+/// `Auto` and hit `/safe` would still get sub-agents clamped against
+/// the stale `Auto`, allowing the child to run with broader
+/// privileges than the parent's *current* mode. Real escalation.
+///
+/// The runtime trust mode is the `mode: TrustMode` parameter
+/// threaded through `execute_one_tool` → `execute_sub_agent`. That
+/// value is read from the `SharedTrustMode` atomic at the start of
+/// each turn and is the only source of truth for "what trust level
+/// is this turn running at".
+///
+/// Passing `parent_config.trust` here is the antipattern this helper
+/// exists to prevent.
+///
+/// # `declared` is the child's own declaration
+///
+/// For named sub-agents this is `cfg.trust` loaded from the agent's
+/// JSON. For `fork` (which has no separate declaration) the call
+/// site passes `parent_runtime` again — the helper then collapses
+/// to identity, but the symmetry across all three paths is what
+/// makes the invariant easy to audit.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::trust::{derive_child_trust, TrustMode};
+///
+/// // Named child declares Auto, parent runtime is Safe → child
+/// // clamps down to Safe (declared narrows toward parent).
+/// assert_eq!(
+///     derive_child_trust(TrustMode::Safe, TrustMode::Auto),
+///     TrustMode::Safe,
+/// );
+///
+/// // Named child declares Plan, parent runtime is Auto → child
+/// // stays Plan (declared is already stricter).
+/// assert_eq!(
+///     derive_child_trust(TrustMode::Auto, TrustMode::Plan),
+///     TrustMode::Plan,
+/// );
+///
+/// // Fork case: declared = parent_runtime → identity.
+/// assert_eq!(
+///     derive_child_trust(TrustMode::Safe, TrustMode::Safe),
+///     TrustMode::Safe,
+/// );
+/// ```
+pub fn derive_child_trust(parent_runtime: TrustMode, declared: TrustMode) -> TrustMode {
+    // Implementation is `clamp` — the named function exists to make
+    // "trust derivation" greppable and to carry the documentation
+    // about which `parent` to pass. **Do not inline back into
+    // `TrustMode::clamp` at call sites** — that re-opens the door
+    // for `parent_config.trust` to creep back in.
+    TrustMode::clamp(parent_runtime, declared)
+}
+
 impl From<u8> for TrustMode {
     fn from(v: u8) -> Self {
         match v {
@@ -421,6 +491,91 @@ mod tests {
             TrustMode::clamp(TrustMode::Auto, TrustMode::Auto),
             TrustMode::Auto
         );
+    }
+
+    // ── #1022 B19: derive_child_trust contract ──
+    //
+    // The helper *is* `clamp` underneath, so the matrix duplicates
+    // the `test_clamp` cases. That duplication is intentional:
+    //
+    // - `test_clamp` pins the math.
+    // - These tests pin the **named contract** — if a future refactor
+    //   inlines `clamp` back into call sites, these tests still pass
+    //   (clamp didn't break) but the structural lint test in
+    //   `koda-cli/tests/regression_test.rs` catches the call-site
+    //   regression. Tests target different layers; both must hold.
+    //
+    // The naming (`fork_identity`, `named_clamps_down`,
+    // `child_already_stricter_passes_through`) documents the
+    // architectural cases each call site exercises.
+
+    #[test]
+    fn derive_child_trust_fork_identity() {
+        // Fork passes (mode, mode) — helper collapses to identity.
+        // Documents that the symmetry is preserved.
+        for parent in [TrustMode::Plan, TrustMode::Safe, TrustMode::Auto] {
+            assert_eq!(
+                derive_child_trust(parent, parent),
+                parent,
+                "fork (parent==declared) must return parent verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn derive_child_trust_named_clamps_down() {
+        // Named child declares Auto; parent runtime is Safe →
+        // child must clamp down to Safe. This is the load-bearing
+        // case — a child that wanted broader privileges than its
+        // parent's runtime mode is forcibly narrowed.
+        assert_eq!(
+            derive_child_trust(TrustMode::Safe, TrustMode::Auto),
+            TrustMode::Safe
+        );
+        assert_eq!(
+            derive_child_trust(TrustMode::Plan, TrustMode::Auto),
+            TrustMode::Plan
+        );
+        assert_eq!(
+            derive_child_trust(TrustMode::Plan, TrustMode::Safe),
+            TrustMode::Plan
+        );
+    }
+
+    #[test]
+    fn derive_child_trust_child_already_stricter_passes_through() {
+        // Named child declares Plan with parent Auto → child stays
+        // Plan. Clamp never *widens*, only narrows.
+        assert_eq!(
+            derive_child_trust(TrustMode::Auto, TrustMode::Plan),
+            TrustMode::Plan
+        );
+        assert_eq!(
+            derive_child_trust(TrustMode::Auto, TrustMode::Safe),
+            TrustMode::Safe
+        );
+        assert_eq!(
+            derive_child_trust(TrustMode::Safe, TrustMode::Plan),
+            TrustMode::Plan
+        );
+    }
+
+    #[test]
+    fn derive_child_trust_is_commutative_in_min_but_not_in_meaning() {
+        // Math is symmetric: min(a, b) == min(b, a).
+        // But the *contract* is asymmetric: arg 1 is parent runtime,
+        // arg 2 is declared. This test pins that the math is
+        // commutative (so no path is order-sensitive in result),
+        // while the function name and docstring make the semantic
+        // asymmetry explicit. Catches a refactor that introduces
+        // *non-commutative* behavior (e.g. "if declared is Plan
+        // unconditionally allow it") which would silently change
+        // dispatch semantics.
+        for a in [TrustMode::Plan, TrustMode::Safe, TrustMode::Auto] {
+            for b in [TrustMode::Plan, TrustMode::Safe, TrustMode::Auto] {
+                assert_eq!(derive_child_trust(a, b), derive_child_trust(b, a));
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Provenance

P2 phase of the multi-agent execution review (#1022). **Real
privilege escalation**, not just a DRY refactor.

## The bug

`sub_agent_dispatch::execute_sub_agent` clamped child trust against
`parent_config.trust`. That field is the **startup** value;
`cycle_trust`/`set_trust` (the implementation of `/safe`/`/auto`)
mutate the `SharedTrustMode` atomic but **never** the
`KodaConfig.trust` field. `grep` for `config.trust =` returns zero
hits in the runtime path.

A user who:

1. Started in Auto (config.trust = Auto, runtime mode = Auto).
2. Hit `/safe` mid-session (runtime mode = Safe; **config.trust still Auto**).
3. Dispatched a sub-agent declared with `trust: "auto"` in its JSON.

…would get `clamp(parent_config.trust=Auto, declared=Auto) = Auto`.
**Sub-agent runs in Auto despite parent being in Safe.** Auto
auto-approves all destructive ops the user explicitly declined to
auto-approve when they typed `/safe`.

Same defect on `fork`, which `parent_config.clone()`d the stale
trust. Affects all three dispatch modes (fork, named, background)
because they all funnel through this function.

## Fix

Three pieces:

### 1. New helper `koda_core::trust::derive_child_trust`

```rust
pub fn derive_child_trust(parent_runtime: TrustMode, declared: TrustMode) -> TrustMode {
    TrustMode::clamp(parent_runtime, declared)
}
```

Implementation is `clamp` underneath. The named function makes
trust derivation **greppable**, carries the rustdoc warning that
`parent_runtime` MUST be the runtime `mode` parameter (never
`parent_config.trust`), and matches DESIGN.md notation word-for-word.

### 2. Wire the helper into all three dispatch paths

| Path | Before | After |
|---|---|---|
| Fork | `cfg = parent_config.clone()` (stale trust inherited) | `cfg.trust = derive_child_trust(mode, mode)` |
| Named | `cfg.trust = clamp(parent_config.trust, cfg.trust)` | `cfg.trust = derive_child_trust(mode, cfg.trust)` |
| Bg | already passes `mode` correctly | unchanged (recursive call routes through fork/named) |

`assert!(cfg.trust == mode)` (not `debug_assert!`) preserved from
B17 — trust assertions are security-relevant and must hold in
release.

### 3. Structural lint test

`koda-cli/tests/regression_test.rs` gains a scan modeled on the
existing `#982 hardcoded-trust` test. Strips `//`-comments (so doc
prose about the antipattern doesn't trip the lint) then asserts:

- `clamp(parent_config.trust` — the original B19 antipattern — absent.
- `derive_child_trust(parent_config.trust` — lazy-renamed variant — absent.
- `derive_child_trust(` appears at least once — catches a refactor
  that drops trust derivation entirely.

Why structural and not e2e: an e2e test would need to (1) toggle
trust mid-session via the SharedTrustMode atomic, (2) dispatch a
sub-agent, (3) introspect the child's effective trust. Heavy
harness for a one-line regression. Structural test catches the
only way the bug reintroduces.

### 4. DESIGN.md updated

"Trust never widens" invariant now spells out the `parent_runtime`
vs `parent_config.trust` distinction, references #1022 B19, and
points at the structural lint test.

## Tests

| Layer | Result |
|---|---|
| Lib tests | **1033** green (+4 derive_child_trust contract) |
| CLI regression tests | **20** green (+1 structural lint) |
| Clippy / fmt | clean |

### New unit tests on `derive_child_trust` (4)

- `derive_child_trust_fork_identity` — `(mode, mode) → mode` for
  all three modes. Pins fork's identity contract.
- `derive_child_trust_named_clamps_down` — load-bearing case: a
  child wanting broader privileges than parent runtime is forcibly
  narrowed.
- `derive_child_trust_child_already_stricter_passes_through` —
  inverse: clamp never widens.
- `derive_child_trust_is_commutative_in_min_but_not_in_meaning` —
  catches a refactor that introduces *non-commutative* behavior
  (e.g. "if declared is Plan unconditionally allow it") which
  would silently change dispatch semantics.

Duplication with `test_clamp` is intentional: `test_clamp` pins
the math, `derive_child_trust_*` pins the **named contract**. If
a future refactor inlines `clamp` back into call sites, the unit
tests still pass (clamp didn't break) but the structural lint
catches the call-site regression. Different layers, both must hold.

## Files

```
DESIGN.md                              |  9 +++--
koda-cli/tests/regression_test.rs      | 76 +++++++++++++++++++++++
koda-core/src/sub_agent_dispatch.rs    | 51 +++++++++++++---
koda-core/src/trust.rs                 | 95 +++++++++++++++++++++++++++-
4 files changed, 215 insertions(+), 16 deletions(-)
```

## Remaining #1022 P2 work

After this lands: B20 (fork copies history row-by-row),
B21 (macOS `pick_write_provider` fallback corrupts unisolated
workspace).
