### PR TITLE
fix(#1022): B20 — fork copies parent history in single transaction (3N→N+3 queries, 1 fsync)

### DIFF
--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -268,6 +268,69 @@ impl Persistence for Database {
         Ok(())
     }
 
+    /// **#1022 B20**: atomic batch copy of messages into a session.
+    ///
+    /// Replaces the pre-fix per-row loop (`insert_message` x N times,
+    /// each a separate UPDATE-last_accessed_at + optional
+    /// `mark_message_complete`). All inserts run inside a single sqlx
+    /// transaction — one fsync at COMMIT instead of N — with
+    /// `completed_at` written inline for assistant rows so no follow-up
+    /// UPDATE is needed.
+    ///
+    /// Errors mid-loop bubble up via `?`; the transaction is dropped
+    /// without `commit()`, so the destination session sees no partial
+    /// state. Sqlx rolls back on Drop.
+    async fn copy_messages_into_session(
+        &self,
+        dst_session: &str,
+        messages: &[Message],
+    ) -> Result<()> {
+        // Empty-input shortcut: skip the BEGIN/COMMIT roundtrip
+        // entirely. Cheap branch; matches "do nothing if there's
+        // nothing to do" intent and avoids touching the WAL for
+        // a no-op fork (fresh session has no history).
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.pool.begin().await?;
+
+        for msg in messages {
+            // Inline `completed_at`: assistant rows are born complete
+            // (they've already been delivered to the parent session),
+            // everything else stays NULL. This eliminates the
+            // per-row `mark_message_complete` round-trip from the
+            // pre-fix loop. Mirrors the `completed_at = datetime('now')`
+            // inline pattern already used by the compaction continuation
+            // hint elsewhere in this file.
+            sqlx::query(
+                "INSERT INTO messages (session_id, role, content, tool_calls, tool_call_id, completed_at) \
+                 VALUES (?, ?, ?, ?, ?, \
+                   CASE WHEN ? = 'assistant' THEN datetime('now') ELSE NULL END)",
+            )
+            .bind(dst_session)
+            .bind(msg.role.as_str())
+            .bind(msg.content.as_deref())
+            .bind(msg.tool_calls.as_deref())
+            .bind(msg.tool_call_id.as_deref())
+            .bind(msg.role.as_str()) // bound twice for the CASE; sqlx has no positional reuse
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        // Single last_accessed_at bump for the whole batch. Parent's
+        // per-row pattern updated this N times; the value is
+        // monotonic-by-second so collapsing to one update is
+        // observationally identical.
+        sqlx::query("UPDATE sessions SET last_accessed_at = datetime('now') WHERE id = ?")
+            .bind(dst_session)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// Persist the accumulated thinking/reasoning text for an assistant message.
     ///
     /// Called after `insert_message` so the INSERT signature stays lean —

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1413,3 +1413,182 @@ async fn interrupted_turn_detected_after_incomplete_filtered() {
         "should detect unanswered user prompt; got {interruption:?}"
     );
 }
+
+// ── #1022 B20: copy_messages_into_session ────────────────────────────────
+//
+// Tests the atomic batch-copy method introduced for fork sub-agent
+// dispatch. Covers:
+//
+// - **Empty input is a no-op** (early return; doesn't touch the WAL).
+// - **All roles are copied verbatim** (User/Assistant/Tool).
+// - **Assistant rows are born complete** (`completed_at` set inline,
+//   so `load_context` includes them without a follow-up
+//   `mark_message_complete` round-trip).
+// - **Order is preserved** (load_context returns them in the same
+//   sequence).
+// - **No usage stats leak across sessions** (parent token usage is
+//   not double-counted on the child; matches the pre-fix loop's
+//   `usage = None` policy).
+// - **Tool-call wiring survives the round-trip** (tool_calls JSON
+//   and tool_call_id columns are preserved so the model's
+//   tool_use/tool_result pairs aren't broken in the fork).
+
+#[tokio::test]
+async fn test_copy_messages_empty_is_noop() {
+    let (db, _tmp) = setup().await;
+    let dst = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.copy_messages_into_session(&dst, &[]).await.unwrap();
+
+    let loaded = db.load_context(&dst).await.unwrap();
+    assert!(loaded.is_empty(), "empty copy must leave session empty");
+}
+
+#[tokio::test]
+async fn test_copy_messages_preserves_roles_and_order() {
+    let (db, _tmp) = setup().await;
+    let src = db.create_session("default", _tmp.path()).await.unwrap();
+    let dst = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&src, &Role::User, Some("first"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, Some("second"), None).await;
+    db.insert_message(&src, &Role::User, Some("third"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, Some("fourth"), None).await;
+
+    let history = db.load_context(&src).await.unwrap();
+    assert_eq!(history.len(), 4, "src should have 4 messages");
+
+    db.copy_messages_into_session(&dst, &history).await.unwrap();
+
+    let copied = db.load_context(&dst).await.unwrap();
+    assert_eq!(copied.len(), 4, "dst must contain all 4 messages");
+
+    let texts: Vec<&str> = copied.iter().filter_map(|m| m.content.as_deref()).collect();
+    assert_eq!(
+        texts,
+        vec!["first", "second", "third", "fourth"],
+        "order must be preserved across the batch copy"
+    );
+
+    let roles: Vec<&str> = copied.iter().map(|m| m.role.as_str()).collect();
+    assert_eq!(roles, vec!["user", "assistant", "user", "assistant"]);
+}
+
+#[tokio::test]
+async fn test_copy_messages_assistant_rows_are_born_complete() {
+    // The bug this prevents: pre-fix needed a follow-up
+    // `mark_message_complete` per assistant row, otherwise
+    // `load_context` would filter the copied assistant rows out
+    // (`role != 'assistant' OR completed_at IS NOT NULL`). If the
+    // CASE-based inline `completed_at` ever regresses to NULL, this
+    // test catches it because `load_context` would return only the
+    // user rows.
+    let (db, _tmp) = setup().await;
+    let src = db.create_session("default", _tmp.path()).await.unwrap();
+    let dst = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&src, &Role::User, Some("q1"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, Some("a1"), None).await;
+    db.insert_message(&src, &Role::User, Some("q2"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, Some("a2"), None).await;
+
+    let history = db.load_context(&src).await.unwrap();
+    db.copy_messages_into_session(&dst, &history).await.unwrap();
+
+    let loaded = db.load_context(&dst).await.unwrap();
+    let assistant_count = loaded.iter().filter(|m| m.role == Role::Assistant).count();
+    assert_eq!(
+        assistant_count, 2,
+        "both assistant rows must survive load_context's \
+         `completed_at IS NOT NULL` filter \u{2014} if this is 0, the inline \
+         `completed_at` write regressed and assistant rows are being \
+         persisted as incomplete"
+    );
+}
+
+#[tokio::test]
+async fn test_copy_messages_preserves_tool_call_wiring() {
+    // tool_calls JSON and tool_call_id columns must survive the
+    // copy or the model's tool_use/tool_result pairing in the fork
+    // session would be broken (load_context would prune them via
+    // `prune_mismatched_tool_calls`).
+    let (db, _tmp) = setup().await;
+    let src = db.create_session("default", _tmp.path()).await.unwrap();
+    let dst = db.create_session("default", _tmp.path()).await.unwrap();
+
+    let tool_calls_json = r#"[{"id":"tc_1","function":{"name":"Read","arguments":"{}"}}]"#;
+
+    db.insert_message(&src, &Role::User, Some("read foo.txt"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, None, Some(tool_calls_json)).await;
+    db.insert_message(
+        &src,
+        &Role::Tool,
+        Some("file contents"),
+        None,
+        Some("tc_1"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let history = db.load_context(&src).await.unwrap();
+    db.copy_messages_into_session(&dst, &history).await.unwrap();
+
+    let loaded = db.load_context(&dst).await.unwrap();
+    assert_eq!(loaded.len(), 3, "user + assistant + tool must all survive");
+
+    let assistant = loaded.iter().find(|m| m.role == Role::Assistant).unwrap();
+    assert_eq!(
+        assistant.tool_calls.as_deref(),
+        Some(tool_calls_json),
+        "tool_calls JSON must round-trip unchanged"
+    );
+
+    let tool = loaded.iter().find(|m| m.role == Role::Tool).unwrap();
+    assert_eq!(
+        tool.tool_call_id.as_deref(),
+        Some("tc_1"),
+        "tool_call_id must round-trip unchanged"
+    );
+}
+
+#[tokio::test]
+async fn test_copy_messages_does_not_touch_source_session() {
+    // Copying out of `src` must not mutate `src` \u{2014} sanity check
+    // for the SQL (no accidental DELETE, no role swap).
+    let (db, _tmp) = setup().await;
+    let src = db.create_session("default", _tmp.path()).await.unwrap();
+    let dst = db.create_session("default", _tmp.path()).await.unwrap();
+
+    db.insert_message(&src, &Role::User, Some("hello"), None, None, None)
+        .await
+        .unwrap();
+    insert_complete_assistant(&db, &src, Some("world"), None).await;
+
+    let before = db.load_context(&src).await.unwrap();
+    let history = before.clone();
+    db.copy_messages_into_session(&dst, &history).await.unwrap();
+    let after = db.load_context(&src).await.unwrap();
+
+    assert_eq!(
+        before.len(),
+        after.len(),
+        "source session message count must not change"
+    );
+    let before_texts: Vec<_> = before.iter().filter_map(|m| m.content.as_deref()).collect();
+    let after_texts: Vec<_> = after.iter().filter_map(|m| m.content.as_deref()).collect();
+    assert_eq!(
+        before_texts, after_texts,
+        "source content must be unchanged"
+    );
+}

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -265,6 +265,34 @@ pub trait Persistence: Send + Sync {
     /// A `NULL` `completed_at` means the message is in-progress or was interrupted.
     async fn mark_message_complete(&self, message_id: i64) -> Result<()>;
 
+    /// Atomically copy a slice of pre-loaded messages into a session.
+    ///
+    /// Used by `fork` sub-agent dispatch (#1022 B20). Pre-fix, the fork
+    /// path looped over `Persistence::insert_message` row-by-row — each
+    /// iteration was 2 queries (INSERT + UPDATE last_accessed_at) plus,
+    /// for assistant rows, a separate `mark_message_complete` (1 more
+    /// query). For an N-message parent history that's ~3N round-trips
+    /// to SQLite, each its own commit, on the synchronous fork hot path.
+    ///
+    /// This method:
+    /// - Wraps every INSERT in a single transaction (one fsync at COMMIT
+    ///   instead of N).
+    /// - Sets `completed_at = datetime('now')` inline at INSERT time for
+    ///   `Role::Assistant` rows, eliminating the separate
+    ///   `mark_message_complete` round-trip per row.
+    /// - Updates `last_accessed_at` on the destination session exactly
+    ///   once at the end (not per-row).
+    ///
+    /// Token usage stats are intentionally **not** copied: fork creates a
+    /// new conversation perspective and cost-attributing parent tokens
+    /// to the child would double-count session usage. Same policy as the
+    /// pre-fix loop, which passed `usage = None` for every copied row.
+    async fn copy_messages_into_session(
+        &self,
+        dst_session: &str,
+        messages: &[Message],
+    ) -> Result<()>;
+
     /// Persist thinking/reasoning text for an assistant message.
     ///
     /// Called only for Claude with extended thinking enabled. All other

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -325,27 +325,18 @@ pub(crate) fn execute_sub_agent<'a>(
                 let sid = db
                     .create_session(&sub_config.agent_name, project_root)
                     .await?;
-                // Fork: copy parent conversation history into the new session
+                // Fork: copy parent conversation history into the new session.
+                //
+                // **#1022 B20**: was a per-row loop — N×(`insert_message`
+                // + `mark_message_complete` for assistant rows), each
+                // call its own fsync, on the synchronous fork hot path.
+                // For a 200-message parent that's ~600 round-trips and
+                // hundreds of ms of disk wait. Now a single transaction
+                // via `copy_messages_into_session` (one fsync at COMMIT,
+                // `completed_at` written inline for assistant rows).
                 if is_fork {
                     let parent_history = db.load_context(parent_session_id).await?;
-                    for msg in &parent_history {
-                        let mid = db
-                            .insert_message(
-                                &sid,
-                                &msg.role,
-                                msg.content.as_deref(),
-                                msg.tool_calls.as_deref(),
-                                msg.tool_call_id.as_deref(),
-                                None, // don't duplicate usage stats
-                            )
-                            .await?;
-                        // Copied assistant messages are already complete in the
-                        // parent — mark them complete in the child session so
-                        // load_context includes them (#875).
-                        if msg.role == Role::Assistant {
-                            db.mark_message_complete(mid).await?;
-                        }
-                    }
+                    db.copy_messages_into_session(&sid, &parent_history).await?;
                 }
                 sid
             }


### PR DESCRIPTION
## Provenance

P2 phase of the multi-agent execution review (#1022). Performance
+ correctness on the synchronous fork hot path.

## The bug

`sub_agent_dispatch.rs` fork branch looped row-by-row:

```rust
for msg in &parent_history {
    let mid = db.insert_message(...).await?;        // 2 queries (INSERT + UPDATE)
    if msg.role == Role::Assistant {
        db.mark_message_complete(mid).await?;       // 1 more query
    }
}
```

For an N-message parent that's roughly **3N round-trips** to
SQLite, each its own commit/fsync, on the synchronous fork hot
path the user is waiting on. A 200-message parent = ~600
round-trips, hundreds of ms of disk wait under typical SQLite WAL
fsync timing.

## Fix

New `Persistence::copy_messages_into_session(dst, &[Message])`
method, atomic via single sqlx transaction, with three
optimizations stacked:

1. **Single transaction** — one fsync at COMMIT instead of N.
2. **Inline `completed_at` for assistant rows** —
   `CASE WHEN role = 'assistant' THEN datetime('now') ELSE NULL END`.
   Eliminates the per-row `mark_message_complete` round-trip.
   Mirrors the inline-`completed_at` pattern already used by the
   compaction continuation hint elsewhere in `queries.rs`.
3. **Single `last_accessed_at` bump** — was N times in the loop;
   now once at the end. Value is monotonic-by-second so collapsing
   is observationally identical.

Net query count: **N+3 queries with 1 fsync**, down from ~3N
queries each with their own fsync.

Empty-input shortcut returns `Ok(())` without touching the WAL,
so a fresh-session fork (no parent history) is free.

Errors mid-loop bubble up via `?`; transaction is dropped without
`commit()` so the destination sees no partial state. Sqlx rolls
back on Drop.

### Fork branch refactor

Six lines replaces 18:

```rust
if is_fork {
    let parent_history = db.load_context(parent_session_id).await?;
    db.copy_messages_into_session(&sid, &parent_history).await?;
}
```

`mark_message_complete` is gone — the new method handles
assistant-completeness inline.

## Tests

| Layer | Result |
|---|---|
| Lib tests | **1040** green (+5 new B20 tests) |
| `e2e_agent_test` (fork integration) | 5 green — no regression |
| Clippy / fmt | clean |

### New tests (5) — all in `db::tests`

- `test_copy_messages_empty_is_noop` — empty input returns Ok
  without touching the WAL.
- `test_copy_messages_preserves_roles_and_order` — User/Assistant
  alternation and chronological order survive the batch copy.
- `test_copy_messages_assistant_rows_are_born_complete` — the
  load-bearing test. `load_context` filters
  `role != 'assistant' OR completed_at IS NOT NULL`; if the
  CASE-based inline `completed_at` ever regresses to NULL,
  `load_context` would return only the user rows.
- `test_copy_messages_preserves_tool_call_wiring` — `tool_calls`
  JSON and `tool_call_id` columnsve the copy or
  `prune_mismatched_tool_calls` would prune them in the fork
  session, breaking the model's tool_use/tool_result pairing.
- `test_copy_messages_does_not_touch_source_session` — sanity
  check for the SQL (no accidental DELETE, no role swap on src).

### Why no e2e fork-volume benchmark

A "200 messages, time the fork" benchmark would tell us wall
clock improved, but it'd be flaky on shared CI runners and
wouldn't catch correctness regressions. Structural tests pin the
contract (empty/order/completeness/tool-wiring/source-immutability),
and `e2e_agent_test` catches dispatch-level regressions. Cost/value
ratio doesn't justify a microbench in CI.

## Files

```
koda-core/src/db/queries.rs         |  63 +++++++++++++
koda-core/src/db/tests.rs           | 179 +++++++++++++++++++++++++++++++++
koda-core/src/persistence.rs        |  28 ++++++
koda-core/src/sub_agent_dispatch.rs |  29 ++----
4 files changed, 280 insertions(+), 19 deletions(-)
```

## Remaining #1022 P2 work

After this lands: B21 (macOS `pick_write_provider` fallback
corrupts unisolated workspace).
