### PR TITLE
docs(#1003): expand InvokeAgent tool description so the model can dispatch the four execution modes correctly

### DIFF
--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -37,6 +37,16 @@ pub fn definitions() -> Vec<ToolDefinition> {
             name: "InvokeAgent".to_string(),
             description: "Delegate a task to a specialized sub-agent.
 
+EXECUTION MODES (pick one per call):
+- Sequential foreground (default): one sub-agent runs, blocks until done.
+- Parallel foreground: emit multiple InvokeAgent tool calls in the same
+  message and they run concurrently. Each write-capable agent gets its own
+  isolated workspace, so parallel write-agents cannot trample each other.
+- Background (background=true): returns immediately. Results inject as a
+  user message on the next iteration. Use for long-running independent work.
+- Forked context (agent_name='fork'): inherits your full conversation
+  history. Useful when the sub-agent needs everything you've already loaded.
+
 Use InvokeAgent when:
 - The task requires exploring many files or running many searches that would pollute your context
 - Work is independent and can run in parallel with your current reasoning
@@ -44,16 +54,17 @@ Use InvokeAgent when:
 
 Do NOT use InvokeAgent when:
 - A single Read, Grep, or Glob would answer the question (overhead > benefit)
-- The task requires real-time back-and-forth with the user (sub-agents can't ask questions)
+- The task requires real-time back-and-forth with the user (sub-agents have no way to ask questions; AskUser is filtered from their tool set)
 - You've already loaded the relevant context (just do the work yourself)
 
 Key rules:
 - Sub-agent results are NOT shown to the user — you must summarize them in your reply
-- You can launch multiple InvokeAgent calls in one message to run agents in parallel
+- Sub-agents CANNOT spawn other sub-agents. Plan all fan-out at this level; the InvokeAgent tool is filtered from every sub-agent's tool set.
+- Identical (agent_name, prompt) calls hit a cache and skip the LLM call. Cheap to retry idempotent tasks; no need to memoize yourself.
+- A result starting with '[ERROR: sub-agent ...]' is a structural failure (e.g. iteration cap, workspace setup), not a model answer. Re-strategize rather than treat as content.
 - Always write a clear, self-contained prompt — the sub-agent hasn't seen your conversation
 - Include specific file paths, function names, and success criteria in your prompt
-- Omit agent_name to use the 'task' worker (full write access)
-- Use agent_name='fork' to give the sub-agent your full conversation context"
+- Omit agent_name to use the 'task' worker (full write access)"
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -73,8 +84,10 @@ Key rules:
                     "background": {
                         "type": "boolean",
                         "description": "Run in background and return immediately (default: false). \
-                            Results are injected when complete. Use for independent tasks \
-                            that don't block your current work."
+                            Results are drained and injected as a user message at the start of \
+                            the next iteration — NOT mid-iteration. The bg agent inherits the \
+                            parent's trust + sandbox at spawn time and is cancelled on Ctrl+C. \
+                            Use for independent long-running tasks that don't block your current work."
                     }
                 },
                 "required": ["prompt"]
@@ -270,6 +283,90 @@ mod tests {
         assert_eq!(defs.len(), 2);
         assert_eq!(defs[0].name, "InvokeAgent");
         assert_eq!(defs[1].name, "ListAgents");
+    }
+
+    /// Pin the load-bearing pieces of the InvokeAgent description so future
+    /// "tighter wording" refactors don't silently drop the bits the model
+    /// needs to dispatch correctly. We don't pin exact wording — just the
+    /// concepts that have engineering meaning behind them.
+    #[test]
+    fn test_invoke_agent_description_documents_all_four_modes() {
+        let defs = definitions();
+        let desc = &defs[0].description;
+        // The four execution modes are the user-facing vocabulary the
+        // engine actually implements (sub_agent_dispatch.rs + bg_agent.rs).
+        assert!(
+            desc.contains("Sequential foreground"),
+            "description must name the sequential foreground mode"
+        );
+        assert!(
+            desc.contains("Parallel foreground"),
+            "description must name the parallel foreground mode"
+        );
+        assert!(
+            desc.contains("Background") && desc.contains("background=true"),
+            "description must explain background dispatch and the parameter"
+        );
+        assert!(
+            desc.contains("Forked context") && desc.contains("agent_name='fork'"),
+            "description must name fork mode and its trigger"
+        );
+    }
+
+    #[test]
+    fn test_invoke_agent_description_warns_about_no_nested_invocation() {
+        // Sub-agents cannot spawn other sub-agents (DESIGN.md invariant).
+        // The model needs to know this so it doesn't try a workaround that
+        // hits the empty-tool refusal at runtime.
+        let defs = definitions();
+        let desc = &defs[0].description;
+        assert!(
+            desc.contains("CANNOT spawn other sub-agents")
+                || desc.contains("cannot spawn"),
+            "description must surface the no-nested-invocation rule"
+        );
+    }
+
+    #[test]
+    fn test_invoke_agent_description_explains_error_marker_convention() {
+        // The [ERROR: ...] marker (B18, B21) is structural failure metadata,
+        // not a model answer. The model needs to know that so it
+        // re-strategizes instead of treating the marker as content.
+        let defs = definitions();
+        let desc = &defs[0].description;
+        assert!(
+            desc.contains("[ERROR: sub-agent"),
+            "description must explain the [ERROR: marker so the model knows to re-strategize"
+        );
+    }
+
+    #[test]
+    fn test_invoke_agent_description_mentions_result_caching() {
+        // SubAgentCache lives on KodaSession and survives across turns.
+        // The model should know calls are memoized so it doesn't build its
+        // own (worse) memoization on top.
+        let defs = definitions();
+        let desc = &defs[0].description;
+        assert!(
+            desc.contains("cache") || desc.contains("memoize"),
+            "description must mention result caching so the model doesn't roll its own"
+        );
+    }
+
+    #[test]
+    fn test_invoke_agent_background_param_documents_drain_semantics() {
+        // The drain-on-next-iteration timing is load-bearing: the model
+        // shouldn't expect mid-iteration results from a bg agent.
+        let defs = definitions();
+        let bg_desc = defs[0]
+            .parameters
+            .pointer("/properties/background/description")
+            .and_then(|v| v.as_str())
+            .expect("background param must have a description");
+        assert!(
+            bg_desc.contains("next iteration"),
+            "background param must explain drain-on-next-iteration timing"
+        );
     }
 
     #[test]

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -321,8 +321,7 @@ mod tests {
         let defs = definitions();
         let desc = &defs[0].description;
         assert!(
-            desc.contains("CANNOT spawn other sub-agents")
-                || desc.contains("cannot spawn"),
+            desc.contains("CANNOT spawn other sub-agents") || desc.contains("cannot spawn"),
             "description must surface the no-nested-invocation rule"
         );
     }


### PR DESCRIPTION
## Summary

Closes #1003.

The original tool description had a `background` parameter and a
single-sentence "you can launch multiple InvokeAgent calls in
one message" hint, but it didn't actually name the four
execution modes the engine implements, didn't document the
no-nested-invocation rule, didn't explain the
`[ERROR: sub-agent ...]` marker convention, and didn't mention
the SubAgentCache.

Net effect: the model could read the description and *not know*
that:

- emitting two InvokeAgent calls in one message gives parallel
  workers with isolated workspaces (parallel foreground)
- bg results inject on the *next* iteration, not mid-iteration
- a sub-agent that calls InvokeAgent itself silently no-ops
  (filtered from its tool set)
- a result string starting with `[ERROR: sub-agent ...]` is
  *structural failure metadata*, not a model answer
- identical (agent_name, prompt) calls hit a cache and skip the
  LLM call

All five facts are load-bearing engine behavior already proven
by unit + integration tests in `sub_agent_dispatch.rs` and
`bg_agent.rs`. They just weren't surfaced to the LLM. This PR
fixes that \u2014 pure documentation, zero engine changes.

## Changes

### `koda-core/src/tools/agent.rs`

**Top-level description** now opens with an explicit
`EXECUTION MODES` section naming all four:

1. **Sequential foreground** (default).
2. **Parallel foreground** \u2014 multiple InvokeAgent calls in the
   same message run concurrently with isolated workspaces.
3. **Background** (`background=true`) \u2014 returns immediately,
   results inject on the next iteration.
4. **Forked context** (`agent_name='fork'`) \u2014 inherits parent
   conversation.

**Key rules** section gains four new bullets pinning the
contracts the engine actually enforces:

- "Sub-agents CANNOT spawn other sub-agents. Plan all fan-out at
  this level; the InvokeAgent tool is filtered from every
  sub-agent's tool set." (DESIGN.md no-nested invariant.)
- "Identical (agent_name, prompt) calls hit a cache and skip the
  LLM call." (SubAgentCache cost lever.)
- "A result starting with `[ERROR: sub-agent ...]` is a
  structural failure (e.g. iteration cap, workspace setup), not
  a model answer. Re-strategize rather than treat as content."
  (B18 + B21 marker convention.)
- "AskUser is filtered from their tool set" \u2014 moved into the
  "Do NOT use" section so the constraint is read alongside the
  use-case advice.

**`background` parameter description** now explains the
drain-on-next-iteration timing explicitly:

> Results are drained and injected as a user message at the
> start of the next iteration \u2014 NOT mid-iteration. The bg agent
> inherits the parent's trust + sandbox at spawn time and is
> cancelled on Ctrl+C.

This is the B11 / B12 contract surfaced to the model.

### Five new contract tests

All sit in the existing `tools::agent::tests` module and pin the
*concepts*, not exact wording, so future "tighten the prose"
refactors get caught when they accidentally drop a load-bearing
piece:

- `test_invoke_agent_description_documents_all_four_modes` \u2014
  pins the four mode names + the trigger syntax for bg/fork.
- `test_invoke_agent_description_warns_about_no_nested_invocation`
  \u2014 pins the "CANNOT spawn other sub-agents" rule.
- `test_invoke_agent_description_explains_error_marker_convention`
  \u2014 pins the `[ERROR: sub-agent` callout (B18/B21 are no-ops to
  the model if it doesn't know what the marker means).
- `test_invoke_agent_description_mentions_result_caching` \u2014
  pins "cache" or "memoize" so the model doesn't roll its own
  (worse) memoization.
- `test_invoke_agent_background_param_documents_drain_semantics`
  \u2014 drills into the background param schema and pins the "next
  iteration" phrase so the drain-on-next-iter timing is
  preserved.

## Why scoped tighter than the original #1003 plan

The #1003 thread proposed eight v1/v2 polish items. After
validating each against `../claude_code_src`, `../codex`,
`../gemini-cli`, and `../zed` (full matrix in the closing
comment on the issue), only this docs item had universal
precedent + non-zero value with zero ongoing maintenance cost.
The other seven items are either reject-outright (no precedent
or wrong-shape precedent \u2014 e.g. `context_files` allowlist, L1
envelope) or defer-until-evidence (single-ref precedent only,
mostly Claude Code-specific patterns like per-agent MEMORY.md).

That validation analysis is in the #1003 close comment so future
us doesn't re-litigate the same ground.

## Validation

```
cargo test -p koda-core --lib agent::tests::
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 1034 filtered out
```

5 new tests, 17 existing tests in the same module \u2014 all green.

## Files

```
koda-core/src/tools/agent.rs | 109 +++++++++++++++++++++++++++++++++++--
1 file changed, 103 insertions(+), 6 deletions(-)
```
