### PR TITLE
fix(#1024): word-wrap long AskUser questions instead of truncating at the screen edge

### DIFF
--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -56,10 +56,10 @@ pub(crate) fn draw_viewport(
     // Determine menu height (only when active)
     let menu_height = match menu {
         MenuContent::None => 0u16,
-        MenuContent::Approval { .. }
-        | MenuContent::LoopCap
-        | MenuContent::PurgeConfirm { .. }
-        | MenuContent::AskUser { .. } => 2,
+        MenuContent::Approval { .. } | MenuContent::LoopCap | MenuContent::PurgeConfirm { .. } => 2,
+        MenuContent::AskUser {
+            question, options, ..
+        } => ask_user_menu_height(question, options, area.width, area.height),
         MenuContent::WizardTrail(trail) => (trail.len() as u16) + 1,
         MenuContent::Slash(dd) => dd.visible_count() as u16 + 1,
         MenuContent::Model(dd) => dd.visible_count() as u16 + 1,
@@ -390,7 +390,10 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
                     ),
                 ]),
             ];
-            frame.render_widget(Paragraph::new(lines), menu_area);
+            // `Wrap { trim: false }` mirrors the height calculation in
+            // `ask_user_menu_height` so what we draw matches what we
+            // reserved space for. See #1024.
+            frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), menu_area);
         }
         MenuContent::HistorySearch {
             query,
@@ -437,6 +440,67 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
     }
 }
 
+// ── AskUser dynamic height (#1024) ─────────────────────
+
+/// Build the hint text for an AskUser menu, matching the renderer.
+fn build_ask_user_hint(options: &[String]) -> String {
+    if options.is_empty() {
+        "Type your answer and press Enter".to_string()
+    } else {
+        let choices = options
+            .iter()
+            .enumerate()
+            .map(|(i, o)| format!("[{}] {}", i + 1, o))
+            .collect::<Vec<_>>()
+            .join("  ");
+        format!("Choices: {choices}")
+    }
+}
+
+/// Compute the dynamic height for an AskUser menu so the question (and
+/// the hint with options) wraps instead of being truncated at the
+/// screen edge. Capped at half the viewport so the menu can never
+/// crowd out the history panel.
+///
+/// The two rendered lines are:
+/// - `"  ❓ " + question` (prefix is 5 visual cols: 2 spaces + wide
+///   emoji + 1 space).
+/// - `"  " + hint + "  · Esc to skip"` (prefix is 2 visual cols).
+///
+/// We compute the wrap count of each by reusing
+/// [`crate::wrap_util::visual_line_count`] \u2014 the same word-wrap
+/// algorithm ratatui's `Paragraph::wrap(Wrap { trim: false })` uses,
+/// so the rendered height matches the reserved menu_area height
+/// exactly.
+///
+/// Regression coverage for #1024.
+fn ask_user_menu_height(
+    question: &str,
+    options: &[String],
+    viewport_width: u16,
+    viewport_height: u16,
+) -> u16 {
+    use crate::wrap_util::visual_line_count;
+
+    // The Paragraph wraps each `Line` independently, so we measure
+    // each line's full text (prefix + content + suffix) at viewport
+    // width \u2014 not at "width minus prefix". Continuation rows wrap to
+    // column 0 just like ratatui does.
+    let q_text = format!("  \u{2753} {question}");
+    let q_rows = visual_line_count(&q_text, viewport_width as usize);
+
+    let hint = build_ask_user_hint(options);
+    let h_text = format!("  {hint}  \u{00b7} Esc to skip");
+    let h_rows = visual_line_count(&h_text, viewport_width as usize);
+
+    let total = (q_rows + h_rows) as u16;
+
+    // Cap at half the viewport (min 2) so the menu can't eat the
+    // history panel on a tiny terminal or with a giant question.
+    let cap = (viewport_height / 2).max(2);
+    total.clamp(2, cap)
+}
+
 // ── Terminal lifecycle ─────────────────────────────────
 
 /// Initialize the terminal in fullscreen mode (alternate screen buffer).
@@ -472,4 +536,95 @@ pub(crate) fn restore_terminal(terminal: &mut Term) {
         crossterm::terminal::LeaveAlternateScreen,
     );
     let _ = crossterm::terminal::disable_raw_mode();
+}
+
+#[cfg(test)]
+mod ask_user_height_tests {
+    use super::ask_user_menu_height;
+
+    /// Short question fits on one line → 2 rows total (question + hint).
+    /// Same as the legacy hardcoded value, so existing layouts don't shift.
+    #[test]
+    fn short_question_yields_two_rows() {
+        let h = ask_user_menu_height("Continue?", &[], 80, 24);
+        assert_eq!(h, 2);
+    }
+
+    /// Long question wraps to multiple rows. Regression for #1024.
+    /// Without the fix, the question would be truncated at column 80.
+    #[test]
+    fn long_question_wraps_and_grows_menu() {
+        // ~200-char question — must wrap to 3+ rows at width 80.
+        let q = "Should we proceed with the migration of all the legacy \
+                 modules to the new architecture, including the \
+                 deprecated bits and the experimental ones nobody \
+                 remembers writing in the first place?";
+        let h = ask_user_menu_height(q, &[], 80, 24);
+        assert!(
+            h > 2,
+            "long question should grow the menu beyond 2 rows, got {h}"
+        );
+    }
+
+    /// Width 80 with a 200-char question wraps to a known row count.
+    /// Pin a tight bound so regressions in the wrap math get caught.
+    #[test]
+    fn long_question_height_is_bounded_by_wrap_count() {
+        let q = "x".repeat(200);
+        // Question line text = "  \u{2753} " (5 cols: 2 spaces + 2-col emoji
+        // + 1 space) + 200 x's = 205 cols. At width 80 with word-wrap,
+        // the long single-word x-run wraps *before* the word when it
+        // doesn't fit (matching ratatui's `Wrap { trim: false }`):
+        //   Row 1: "  \u{2753} " + 75 x's (cols 0..79)
+        //   Row 2: 80 x's   (chars 76..155)
+        //   Row 3: 80 x's   (chars 156..200, force-break) — actually only 45
+        //   Row 4: trailing — depends on word-wrap re-flow accounting
+        // We don't pin the exact integer here (the algorithm has subtle
+        // word-relocation semantics); we just bound it.
+        let h = ask_user_menu_height(&q, &[], 80, 24);
+        assert!(
+            (4..=6).contains(&h),
+            "expected 4..=6 rows for 200-char question at width 80, got {h}"
+        );
+    }
+
+    /// Many options make the hint line wrap too — both lines contribute
+    /// to the total height.
+    #[test]
+    fn many_options_grow_the_hint_row() {
+        let opts: Vec<String> = (0..12).map(|i| format!("option-{i}")).collect();
+        let h = ask_user_menu_height("Pick one:", &opts, 80, 24);
+        // Hint becomes "Choices: [1] option-0  [2] option-1  …" which is
+        // > 80 chars → at least 2 hint rows + 1 question row.
+        assert!(h >= 3, "many options must wrap the hint row, got {h}");
+    }
+
+    /// Hard cap: menu can never exceed half the viewport height, even
+    /// for absurdly long questions. Protects the history panel.
+    #[test]
+    fn height_is_capped_to_half_viewport() {
+        let q = "x".repeat(10_000);
+        let h = ask_user_menu_height(&q, &[], 80, 20);
+        assert!(h <= 10, "must not exceed half viewport, got {h} > 10");
+    }
+
+    /// Cap floor: even on tiny terminals the menu is at least 2 rows
+    /// (question + hint), matching the legacy minimum.
+    #[test]
+    fn minimum_height_is_two_rows() {
+        let h = ask_user_menu_height("Q", &[], 80, 4);
+        assert_eq!(h, 2);
+    }
+
+    /// Narrow terminal: question with 60 chars at width 30 wraps to
+    /// 2+ rows. Catches off-by-one in the prefix-width accounting.
+    #[test]
+    fn narrow_terminal_wraps_short_question() {
+        let q = "a".repeat(60);
+        let h = ask_user_menu_height(&q, &[], 30, 24);
+        assert!(
+            h >= 3,
+            "60 chars at width 30 should be ≥2 q-rows + 1 hint, got {h}"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1024.

## What was wrong

The `AskUser` menu reserved a hardcoded **2 rows** in the viewport layout and rendered the question as a single ratatui `Line`. Anything longer than the terminal width was silently truncated at column N — so users couldn't read the question they were being asked, and had to either guess or `Esc` out of it.

## Fix

Replace the hardcoded `2` for `MenuContent::AskUser` with a dynamic `ask_user_menu_height(question, options, width, height)` helper that:

1. Measures the actual wrapped row count for both the question line (`"  ❓ " + question`) and the hint/options line (`"  " + hint + "  · Esc to skip"`).
2. Sums them.
3. Caps at `viewport_height / 2` (min 2) so a giant question can't crowd out the history panel.

Then render the menu with `Paragraph::new(...).wrap(Wrap { trim: false })` so the on-screen wrap matches the height we reserved.

## Why the wrap math is reliable

The helper reuses `wrap_util::visual_line_count`, which is already the single source of truth for the word-boundary wrapping algorithm used by `scroll_buffer` and `wrap_input` (extracted in #527 specifically because we kept getting off-by-one bugs from competing implementations). It matches ratatui's `Wrap { trim: false }` behavior, so what we measure and what we render always agree.

The question's prefix (`"  ❓ "`, **5 visual columns** counting the wide emoji `\u{2753}`) is folded into the measured text so the wrap point lands at the actual rendered width — not at `width - prefix`. Continuation rows wrap to column 0, exactly the way ratatui will draw them.

## Why the cap is `viewport_height / 2`

Without a cap, a paragraph-sized question would push the history panel down to a single row, which is worse UX than a scrolled question. Half the viewport feels like a sane upper bound: tall enough for any reasonable clarifying question, small enough to leave the agent's context visible.

If even the cap isn't enough, the question gets truncated by `Paragraph::wrap` clipping — but at that point the user can press `Esc` to skip and ask the agent to ask something shorter. (Could be revisited later with a scrollable AskUser pane, but YAGNI for now.)

## Tests

Seven new regression tests in `tui_viewport::ask_user_height_tests`:

| Test | What it pins |
|---|---|
| `short_question_yields_two_rows` | Single-line question still reserves exactly 2 rows — no layout shift for existing users. |
| `long_question_wraps_and_grows_menu` | Multi-line question grows beyond 2 rows. **The actual #1024 regression.** |
| `long_question_height_is_bounded_by_wrap_count` | Pins the wrap math against a 200-char question at width 80. |
| `many_options_grow_the_hint_row` | Long `Choices: [1] foo [2] bar …` hint also wraps. |
| `height_is_capped_to_half_viewport` | Guards against runaway menus eating the history panel. |
| `minimum_height_is_two_rows` | Floor matches the legacy minimum on tiny terminals. |
| `narrow_terminal_wraps_short_question` | 60 chars at width 30 exercises the prefix accounting. |

`cargo test -p koda-cli --lib` → 473 passing (up from 466). `cargo clippy -p koda-cli --lib --tests` → clean. `cargo fmt --all` → clean.

## Manual verification

1. `cargo install --path koda-cli`
2. `cd` into any repo.
3. Trigger an `AskUser` with a long question — easiest way is to prompt the agent with something deliberately ambiguous so it calls `AskUser` with a multi-sentence clarifying question.
4. **Before:** question is truncated at the terminal edge, mid-word, no wrap.
   **After:** question wraps cleanly across multiple rows, menu grows to fit, history scrolls up but stays visible.

## Risk

Low. The change is localized to `tui_viewport.rs`. `MenuContent::AskUser`'s 2-row layout is preserved exactly for short questions (the most common case), so existing visual flows are unchanged. The new height path only activates when the question or hint would actually overflow.
