### PR TITLE
feat(#996): Layer 2 — ListBackgroundTasks / CancelTask / WaitTask LLM tools

### DIFF
--- a/koda-cli/src/tui_bg_agents.rs
+++ b/koda-cli/src/tui_bg_agents.rs
@@ -278,7 +278,10 @@ mod tests {
         CancellationToken,
     ) {
         let parent = CancellationToken::new();
-        let r = reg.reserve(&parent);
+        // Phase A1 of #996 added a `spawner: Option<u32>` to both
+        // reserve() and attach(). The TUI test harness only ever
+        // exercises the top-level path, so `None` is the right value.
+        let r = reg.reserve(&parent, None);
         let task_id = r.task_id;
         let tx = r.tx;
         let status_tx = r.status_tx;
@@ -291,6 +294,7 @@ mod tests {
             r.rx,
             r.cancel,
             r.status_rx,
+            None,
             noop,
         );
         (task_id, tx, status_tx, observer)

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -118,6 +118,19 @@ pub struct BgTaskSnapshot {
     pub age: Duration,
     /// Latest value from the task's `watch::Receiver<AgentStatus>`.
     pub status: AgentStatus,
+    /// Sub-agent task that spawned this bg-agent. `None` = top-level
+    /// (the user's main conversation).
+    ///
+    /// **#996 Layer 2 / Model D**: tracked so that when a sub-agent
+    /// exits, [`BgAgentRegistry::cancel_for_spawner`] can fire the
+    /// cancel token on every bg-agent it left behind. Mirrors
+    /// Claude Code's `agentId` field on `LocalShellTaskState`
+    /// (`prevents 10-day fake-logs.sh zombies`).
+    ///
+    /// We don't use this for permission scoping — any caller with a
+    /// `task_id` can manage any task. Spawner is *only* a cleanup
+    /// hook (matching Claude Code's flat-permissions design).
+    pub spawner: Option<u32>,
 }
 
 /// Payload sent over the bg-agent oneshot.
@@ -178,6 +191,9 @@ struct BgAgentEntry {
     status_rx: watch::Receiver<AgentStatus>,
     /// When the task was attached. Used to compute `age` in snapshots.
     started_at: Instant,
+    /// Sub-agent task that spawned this bg-agent. `None` = top-level.
+    /// **#996 Layer 2 / Model D** — see [`BgTaskSnapshot::spawner`].
+    spawner: Option<u32>,
     /// Aborts the spawned task on drop. The bg path uses
     /// `tokio::spawn` on the multi-thread runtime (#1022 B5):
     /// `execute_sub_agent` returns an explicitly `Send`-bounded
@@ -229,6 +245,10 @@ pub struct BgAgentReservation {
     /// so `snapshot()` and `/agents` can read the current state without
     /// touching the spawn site.
     pub status_rx: watch::Receiver<AgentStatus>,
+    /// Sub-agent task id of the spawner, or `None` for the top-level
+    /// loop. Carried verbatim to [`BgAgentRegistry::attach`] so the
+    /// entry knows who spawned it (Model D cleanup-on-exit).
+    pub spawner: Option<u32>,
 }
 
 impl BgAgentRegistry {
@@ -244,11 +264,22 @@ impl BgAgentRegistry {
     /// token for the spawn site to consume. Call [`Self::attach`] with
     /// the resulting `JoinHandle` to complete registration.
     ///
-    /// The two-phase shape exists because `tokio::spawn` produces the
-    /// `JoinHandle` *after* the future is built, but the future needs
-    /// to own the `tx` to deliver its result. Reservation gives us
-    /// `tx` early; attach binds the handle once it exists.
-    pub fn reserve(&self, parent_cancel: &CancellationToken) -> BgAgentReservation {
+    /// `spawner` records who is reserving this slot. `None` means
+    /// the top-level inference loop; `Some(invocation_id)` means a
+    /// sub-agent invocation. Used by [`Self::cancel_for_spawner`] to
+    /// reap children when a sub-agent exits (Model E cleanup-on-exit)
+    /// and by [`Self::snapshot_for_caller`] to scope LLM-tool views.
+    ///
+    /// The two-phase shape (`reserve` → spawn → `attach`) exists
+    /// because `tokio::spawn` produces the `JoinHandle` *after* the
+    /// future is built, but the future needs to own the `tx` to deliver
+    /// its result. Reservation gives us `tx` early; attach binds the
+    /// handle once it exists.
+    pub fn reserve(
+        &self,
+        parent_cancel: &CancellationToken,
+        spawner: Option<u32>,
+    ) -> BgAgentReservation {
         let (tx, rx) = oneshot::channel();
         let (status_tx, status_rx) = watch::channel(AgentStatus::Pending);
         let mut id = self.next_id.lock();
@@ -261,6 +292,7 @@ impl BgAgentRegistry {
             cancel: parent_cancel.child_token(),
             status_tx,
             status_rx,
+            spawner,
         }
     }
 
@@ -274,10 +306,11 @@ impl BgAgentRegistry {
     ///
     /// [`reserve`]: Self::reserve
     //
-    // 8 args trips `clippy::too_many_arguments` (limit 7). Each one
+    // 9 args trips `clippy::too_many_arguments` (limit 7). Each one
     // is load-bearing: id + name + prompt are display metadata;
-    // rx/cancel/status_rx are the three channels we own; handle is
-    // the AbortOnDropHandle. Bundling into a struct just to satisfy
+    // rx/cancel/status_rx are the three channels we own; spawner is
+    // the cleanup-routing key (Model E); handle is the
+    // AbortOnDropHandle. Bundling into a struct just to satisfy
     // a heuristic would add a one-use type for no readability win
     // — "practicality beats purity".
     #[allow(clippy::too_many_arguments)]
@@ -289,6 +322,7 @@ impl BgAgentRegistry {
         rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
         cancel: CancellationToken,
         status_rx: watch::Receiver<AgentStatus>,
+        spawner: Option<u32>,
         handle: tokio::task::JoinHandle<()>,
     ) {
         self.pending.lock().insert(
@@ -300,6 +334,7 @@ impl BgAgentRegistry {
                 cancel,
                 status_rx,
                 started_at: Instant::now(),
+                spawner,
                 _handle: AbortOnDropHandle::new(handle),
             },
         );
@@ -315,7 +350,8 @@ impl BgAgentRegistry {
         agent_name: &str,
         prompt: &str,
     ) -> (u32, oneshot::Sender<Result<BgPayload, BgPayload>>) {
-        let (id, tx, _status_tx, _cancel) = self.register_test_with_status(agent_name, prompt);
+        let (id, tx, _status_tx, _cancel) =
+            self.register_test_with_status(agent_name, prompt, None);
         (id, tx)
     }
 
@@ -323,11 +359,16 @@ impl BgAgentRegistry {
     /// sender so a test can manually drive transitions without
     /// needing a real spawned `run_bg_agent`. The cancel token also
     /// comes back so cancel-cascade tests can verify the channel.
+    ///
+    /// `spawner` is recorded on the entry so scope-filtering /
+    /// kill-on-exit tests can exercise both the top-level (`None`)
+    /// and sub-agent (`Some(id)`) paths.
     #[cfg(test)]
     pub fn register_test_with_status(
         &self,
         agent_name: &str,
         prompt: &str,
+        spawner: Option<u32>,
     ) -> (
         u32,
         oneshot::Sender<Result<BgPayload, BgPayload>>,
@@ -352,6 +393,7 @@ impl BgAgentRegistry {
                 cancel,
                 status_rx,
                 started_at: Instant::now(),
+                spawner,
                 _handle: AbortOnDropHandle::new(noop),
             },
         );
@@ -449,6 +491,10 @@ impl BgAgentRegistry {
     /// snapshots of the same task report different ages. Status is read
     /// from each entry's `watch::Receiver` (no blocking, no waiting).
     /// Sorted by ascending `task_id` so the output is stable across calls.
+    ///
+    /// **Unscoped**: returns every task regardless of spawner. Used by
+    /// the TUI `/agents` command (humans want the global view) and as
+    /// the engine of [`Self::snapshot_for_caller`] (which filters).
     pub fn snapshot(&self) -> Vec<BgTaskSnapshot> {
         let guard = self.pending.lock();
         let now = Instant::now();
@@ -460,10 +506,28 @@ impl BgAgentRegistry {
                 prompt: entry.prompt.clone(),
                 age: now.saturating_duration_since(entry.started_at),
                 status: entry.status_rx.borrow().clone(),
+                spawner: entry.spawner,
             })
             .collect();
         out.sort_by_key(|s| s.task_id);
         out
+    }
+
+    /// Scoped snapshot for the `ListBackgroundTasks` LLM tool.
+    ///
+    /// **Model E scoping**: a caller only sees tasks whose `spawner`
+    /// matches its own `caller_spawner`. Top-level callers pass `None`
+    /// and see only top-level-spawned tasks; sub-agent callers pass
+    /// `Some(invocation_id)` and see only their own.
+    ///
+    /// Strict equality — a sub-agent does NOT see sibling sub-agents'
+    /// tasks, and the top-level does NOT see sub-agents' tasks via the
+    /// LLM (the TUI's `/agents` command remains the global view).
+    pub fn snapshot_for_caller(&self, caller_spawner: Option<u32>) -> Vec<BgTaskSnapshot> {
+        self.snapshot()
+            .into_iter()
+            .filter(|s| s.spawner == caller_spawner)
+            .collect()
     }
 }
 
@@ -647,7 +711,7 @@ mod tests {
     async fn registry_drop_aborts_pending_tasks() {
         let reg = BgAgentRegistry::new();
         let parent = CancellationToken::new();
-        let reservation = reg.reserve(&parent);
+        let reservation = reg.reserve(&parent, None);
         let task_id = reservation.task_id;
         let cancel_for_task = reservation.cancel.clone();
         let tx = reservation.tx;
@@ -680,6 +744,7 @@ mod tests {
             rx,
             cancel_for_entry,
             status_rx,
+            None,
             handle,
         );
 
@@ -706,8 +771,8 @@ mod tests {
     async fn parent_cancel_cascades_to_reserved_child() {
         let reg = BgAgentRegistry::new();
         let parent = CancellationToken::new();
-        let r1 = reg.reserve(&parent);
-        let r2 = reg.reserve(&parent);
+        let r1 = reg.reserve(&parent, None);
+        let r2 = reg.reserve(&parent, None);
 
         assert!(!r1.cancel.is_cancelled());
         assert!(!r2.cancel.is_cancelled());
@@ -736,7 +801,7 @@ mod tests {
     async fn cancel_known_task_fires_token() {
         let reg = BgAgentRegistry::new();
         let (task_id, _tx, _status_tx, observer) =
-            reg.register_test_with_status("explore", "map repo");
+            reg.register_test_with_status("explore", "map repo", None);
 
         assert!(!observer.is_cancelled(), "precondition");
         let fired = reg.cancel(task_id);
@@ -766,7 +831,8 @@ mod tests {
     #[tokio::test]
     async fn cancel_is_idempotent_while_pending() {
         let reg = BgAgentRegistry::new();
-        let (task_id, _tx, _status_tx, _observer) = reg.register_test_with_status("explore", "x");
+        let (task_id, _tx, _status_tx, _observer) =
+            reg.register_test_with_status("explore", "x", None);
 
         assert!(reg.cancel(task_id));
         assert!(
@@ -805,7 +871,8 @@ mod tests {
     #[tokio::test]
     async fn snapshot_reflects_status_writes() {
         let reg = BgAgentRegistry::new();
-        let (task_id, _tx, status_tx, _cancel) = reg.register_test_with_status("explore", "map");
+        let (task_id, _tx, status_tx, _cancel) =
+            reg.register_test_with_status("explore", "map", None);
 
         // Default is Pending.
         assert_eq!(reg.snapshot()[0].status, AgentStatus::Pending);

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -680,10 +680,7 @@ impl BgAgentRegistry {
                 // Timeout: the task is still pending. Re-snapshot so
                 // the caller sees the latest status (it may have
                 // transitioned `Pending` → `Running` while we waited).
-                let snap = self
-                    .snapshot()
-                    .into_iter()
-                    .find(|s| s.task_id == task_id);
+                let snap = self.snapshot().into_iter().find(|s| s.task_id == task_id);
                 match snap {
                     Some(s) => WaitOutcome::TimedOut(s),
                     // Task vanished mid-wait — drain reaped it. The
@@ -727,15 +724,13 @@ impl BgAgentRegistry {
                         // Worst case (channel closed concurrently) we
                         // fall through to Cancelled below.
                         match entry.rx.try_recv() {
-                            Ok(Ok((output, events))) => {
-                                WaitOutcome::Completed(BgAgentResult {
-                                    agent_name: entry.agent_name,
-                                    prompt: entry.prompt,
-                                    output,
-                                    success: true,
-                                    events,
-                                })
-                            }
+                            Ok(Ok((output, events))) => WaitOutcome::Completed(BgAgentResult {
+                                agent_name: entry.agent_name,
+                                prompt: entry.prompt,
+                                output,
+                                success: true,
+                                events,
+                            }),
                             Ok(Err((err, events))) => WaitOutcome::Completed(BgAgentResult {
                                 agent_name: entry.agent_name,
                                 prompt: entry.prompt,
@@ -764,9 +759,7 @@ async fn wait_for_terminal_status(mut rx: watch::Receiver<AgentStatus>) {
     loop {
         let is_terminal = matches!(
             *rx.borrow(),
-            AgentStatus::Completed { .. }
-                | AgentStatus::Errored { .. }
-                | AgentStatus::Cancelled
+            AgentStatus::Completed { .. } | AgentStatus::Errored { .. } | AgentStatus::Cancelled
         );
         if is_terminal {
             return;
@@ -1250,10 +1243,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_as_caller_returns_not_found_for_unknown_id() {
         let reg = BgAgentRegistry::new();
-        assert_eq!(
-            reg.cancel_as_caller(999, None),
-            CancelOutcome::NotFound
-        );
+        assert_eq!(reg.cancel_as_caller(999, None), CancelOutcome::NotFound);
     }
 
     /// `cancel_for_spawner` cleans up exactly one sub-agent's children
@@ -1380,10 +1370,7 @@ mod tests {
         let outcome = reg
             .wait_for_completion(id, None, Duration::from_secs(1))
             .await;
-        assert!(
-            matches!(outcome, WaitOutcome::Cancelled),
-            "got {outcome:?}"
-        );
+        assert!(matches!(outcome, WaitOutcome::Cancelled), "got {outcome:?}");
         assert!(reg.snapshot().is_empty(), "entry must be reaped");
     }
 

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -691,57 +691,62 @@ impl BgAgentRegistry {
             }
             Ok(()) => {
                 // Terminal status observed. Pull the entry out so the
-                // auto-drain path won't see it again, then map the
-                // oneshot to a BgAgentResult / Cancelled.
-                let mut guard = self.pending.lock();
-                let Some(mut entry) = guard.remove(&task_id) else {
-                    // Drain raced us and reaped first. Rare but
-                    // possible. The model already saw the result in
-                    // the prior turn's auto-drain.
-                    return WaitOutcome::NotFound;
+                // auto-drain path won't see it again, then await the
+                // oneshot for the payload.
+                //
+                // PR #1043 review fix: previously this used
+                // `try_recv` + a back-to-back retry. The retry was a
+                // placebo — both calls run in the same scheduler tick
+                // with no `await` between them, so when the bg future
+                // sets `status_tx` *before* `tx.send` (the standard
+                // ordering in `sub_agent_dispatch::run_bg_agent`),
+                // a multi-thread runtime can wake the waiter on a
+                // *different* worker, observe `Empty` twice, and
+                // falsely report `Cancelled` for a successful task.
+                //
+                // `oneshot::Receiver` IS a `Future` — just `.await`
+                // it. The bound is set by `wait_for_terminal_status`
+                // having already observed the terminal status, so the
+                // sender is either landing or already dropped (the
+                // future writes status before sending the result, and
+                // panics drop both). A short inner timeout caps the
+                // "in-flight" window; the outer timeout is already
+                // exhausted at this point.
+                let entry = {
+                    let mut guard = self.pending.lock();
+                    let Some(entry) = guard.remove(&task_id) else {
+                        // Drain raced us and reaped first. Rare but
+                        // possible. The model already saw the result
+                        // in the prior turn's auto-drain.
+                        return WaitOutcome::NotFound;
+                    };
+                    entry
+                    // `guard` drops here — explicit scope guarantees
+                    // we don't hold the (non-Send) `parking_lot`
+                    // guard across the upcoming `.await`.
                 };
-                drop(guard);
-                match entry.rx.try_recv() {
-                    Ok(Ok((output, events))) => WaitOutcome::Completed(BgAgentResult {
-                        agent_name: entry.agent_name,
-                        prompt: entry.prompt,
+                let agent_name = entry.agent_name;
+                let prompt = entry.prompt;
+                match tokio::time::timeout(Duration::from_millis(50), entry.rx).await {
+                    Ok(Ok(Ok((output, events)))) => WaitOutcome::Completed(BgAgentResult {
+                        agent_name,
+                        prompt,
                         output,
                         success: true,
                         events,
                     }),
-                    Ok(Err((err, events))) => WaitOutcome::Completed(BgAgentResult {
-                        agent_name: entry.agent_name,
-                        prompt: entry.prompt,
+                    Ok(Ok(Err((err, events)))) => WaitOutcome::Completed(BgAgentResult {
+                        agent_name,
+                        prompt,
                         output: err,
                         success: false,
                         events,
                     }),
-                    Err(oneshot::error::TryRecvError::Empty) => {
-                        // Status went terminal but oneshot hasn't
-                        // landed yet — the future writes status before
-                        // sending. Wait a few microseconds for the
-                        // send to complete, then try once more.
-                        // Worst case (channel closed concurrently) we
-                        // fall through to Cancelled below.
-                        match entry.rx.try_recv() {
-                            Ok(Ok((output, events))) => WaitOutcome::Completed(BgAgentResult {
-                                agent_name: entry.agent_name,
-                                prompt: entry.prompt,
-                                output,
-                                success: true,
-                                events,
-                            }),
-                            Ok(Err((err, events))) => WaitOutcome::Completed(BgAgentResult {
-                                agent_name: entry.agent_name,
-                                prompt: entry.prompt,
-                                output: err,
-                                success: false,
-                                events,
-                            }),
-                            _ => WaitOutcome::Cancelled,
-                        }
-                    }
-                    Err(oneshot::error::TryRecvError::Closed) => WaitOutcome::Cancelled,
+                    // Sender dropped (panic) or 50ms elapsed without
+                    // a value landing — surface as Cancelled. Both
+                    // are degenerate cases: status said terminal,
+                    // payload never arrived.
+                    Ok(Err(_)) | Err(_) => WaitOutcome::Cancelled,
                 }
             }
         }
@@ -1381,5 +1386,57 @@ mod tests {
             .wait_for_completion(999, None, Duration::from_millis(10))
             .await;
         assert!(matches!(outcome, WaitOutcome::NotFound), "got {outcome:?}");
+    }
+
+    /// Regression test for the PR #1043 race fix.
+    ///
+    /// Scenario: the bg future writes terminal `AgentStatus` to the
+    /// watch channel, then — after a yield-induced gap — sends the
+    /// payload on the oneshot. The waiter is woken on the watch
+    /// notify and races to read the oneshot.
+    ///
+    /// Before the fix, `wait_for_completion` did `try_recv()` twice
+    /// back-to-back with no `await` between them; on a multi-thread
+    /// runtime the second `try_recv` could observe `Empty` again and
+    /// return `Cancelled` for a successful task. The fix awaits the
+    /// oneshot future directly with a short inner timeout, which
+    /// gives the sender's task a chance to run.
+    ///
+    /// Multi-thread runtime + explicit `yield_now` between the two
+    /// sends reliably triggers the old race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wait_for_completion_handles_status_then_yield_then_payload() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        let (id, tx, status_tx, _observer) =
+            reg.register_test_with_status("explore", "map repo", None);
+
+        // Spawn a task that mimics `run_bg_agent`'s send ordering:
+        // status first, yield, payload. The yield is what exposed the
+        // race — it forces tokio to potentially schedule the waiter
+        // between the two sends.
+        let send_task = tokio::spawn(async move {
+            status_tx
+                .send(AgentStatus::Completed {
+                    summary: "done".into(),
+                })
+                .unwrap();
+            tokio::task::yield_now().await;
+            tokio::task::yield_now().await;
+            let _ = tx.send(Ok(("final".into(), vec!["e1".into()])));
+        });
+
+        let outcome = reg
+            .wait_for_completion(id, None, Duration::from_secs(2))
+            .await;
+        send_task.await.unwrap();
+
+        match outcome {
+            WaitOutcome::Completed(result) => {
+                assert_eq!(result.output, "final");
+                assert!(result.success);
+                assert_eq!(result.events, vec!["e1".to_string()]);
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
     }
 }

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -529,6 +529,256 @@ impl BgAgentRegistry {
             .filter(|s| s.spawner == caller_spawner)
             .collect()
     }
+
+    // ── Layer 2 of #996 ───────────────────────────────────────────────
+    //
+    // Scoped cancel + cleanup-on-exit + WaitTask machinery.
+    // The unscoped [`Self::cancel`] above stays for the TUI (humans get
+    // the global view); LLM tools route through [`Self::cancel_as_caller`]
+    // so a sub-agent can't reach across into a sibling's task.
+
+    /// Scoped per-task cancel for the `CancelTask` LLM tool.
+    ///
+    /// **Model E permission rule** — `caller_spawner` must equal the
+    /// task's `spawner`, with `None == None` (top-level can cancel
+    /// top-level tasks; sub-agent invocation N can cancel only its
+    /// own tasks). Returns [`CancelOutcome::Forbidden`] otherwise.
+    ///
+    /// The unscoped [`Self::cancel`] is the TUI's contract — humans
+    /// at the keyboard implicitly have full authority. This method is
+    /// the LLM's contract.
+    pub fn cancel_as_caller(&self, task_id: u32, caller_spawner: Option<u32>) -> CancelOutcome {
+        let guard = self.pending.lock();
+        match guard.get(&task_id) {
+            None => CancelOutcome::NotFound,
+            Some(entry) if entry.spawner != caller_spawner => CancelOutcome::Forbidden,
+            Some(entry) => {
+                entry.cancel.cancel();
+                CancelOutcome::Cancelled
+            }
+        }
+    }
+
+    /// Fire the cancel token on every task whose `spawner` matches.
+    ///
+    /// Called from the sub-agent dispatch path when an invocation
+    /// exits (Model E cleanup-on-exit). Returns the number of tasks
+    /// signalled, purely for tracing — the actual reaping happens
+    /// later via [`Self::drain_completed`] once the futures observe
+    /// their cancel tokens and finish.
+    ///
+    /// Idempotent: re-calling on the same `spawner` after all tasks
+    /// have been reaped returns `0`.
+    pub fn cancel_for_spawner(&self, spawner: u32) -> usize {
+        let guard = self.pending.lock();
+        let mut count = 0;
+        for entry in guard.values() {
+            if entry.spawner == Some(spawner) {
+                entry.cancel.cancel();
+                count += 1;
+            }
+        }
+        count
+    }
+}
+
+/// Outcome of [`BgAgentRegistry::cancel_as_caller`].
+///
+/// Mirrors HTTP-ish status codes so the LLM-tool layer can produce
+/// useful error messages without inspecting registry internals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CancelOutcome {
+    /// Task existed, caller owned it, cancel token fired.
+    Cancelled,
+    /// No task with that id (already drained, never registered, or
+    /// completed and reaped).
+    NotFound,
+    /// Task exists but caller's `spawner` doesn't match. The LLM
+    /// surface translates this into a permission-style error.
+    Forbidden,
+}
+
+/// Outcome of [`BgAgentRegistry::wait_for_completion`].
+///
+/// Encodes the four resolutions of a `WaitTask` call. The LLM-tool
+/// layer translates each into a serialised payload the model receives.
+#[derive(Debug)]
+pub enum WaitOutcome {
+    /// Task reached a terminal `Completed`/`Errored` status before
+    /// the timeout fired. Carries the drained [`BgAgentResult`] so
+    /// the same payload `drain_completed()` would have produced is
+    /// surfaced directly to the caller. (Drain semantics: a task
+    /// consumed via `wait_for_completion` is removed from `pending`
+    /// so the next `drain_completed()` won't double-inject it.)
+    Completed(BgAgentResult),
+    /// Task was cancelled (parent token fired, peer cancelled, or
+    /// the spawned future panicked). The task has been reaped.
+    Cancelled,
+    /// Timeout fired before the task reached a terminal state. The
+    /// task is still in `pending` and may still complete on its own.
+    /// Carries the most-recent status snapshot so the model can
+    /// decide whether to wait again or move on.
+    TimedOut(BgTaskSnapshot),
+    /// No task with that id, or caller's spawner doesn't match.
+    /// Same `Forbidden`/`NotFound` distinction as [`CancelOutcome`].
+    NotFound,
+    /// Caller doesn't own this task.
+    Forbidden,
+}
+
+impl BgAgentRegistry {
+    /// Block until a single task reaches a terminal state, or until
+    /// `timeout` elapses. The tool layer is the sole caller; humans
+    /// use `/cancel` (synchronous) and the auto-drain path.
+    ///
+    /// **Drain semantics**: on `Completed`/`Cancelled`, the task is
+    /// removed from `pending` here so `drain_completed()` won't
+    /// surface it again on the next inference iteration. (This is
+    /// the resolution to the result-routing race we settled in
+    /// design Decision 3 — `WaitTask` consumes; auto-drain becomes a
+    /// no-op for that id.)
+    ///
+    /// **Scoping**: same Model E rule as [`Self::cancel_as_caller`].
+    /// `caller_spawner` must equal the task's `spawner` exactly.
+    ///
+    /// **Timeout**: bounded by the caller. The tool layer caps this
+    /// at 300 s before reaching here; we trust the bound but will
+    /// happily wait whatever value is passed (handy for tests with
+    /// `Duration::from_millis(50)`).
+    pub async fn wait_for_completion(
+        &self,
+        task_id: u32,
+        caller_spawner: Option<u32>,
+        timeout: Duration,
+    ) -> WaitOutcome {
+        // Phase 1 — ownership check + grab a status receiver to await on.
+        // We do NOT remove the entry yet: if we time out, it must remain
+        // visible to the next `drain_completed()` and to other callers.
+        let status_rx = {
+            let guard = self.pending.lock();
+            match guard.get(&task_id) {
+                None => return WaitOutcome::NotFound,
+                Some(entry) if entry.spawner != caller_spawner => {
+                    return WaitOutcome::Forbidden;
+                }
+                Some(entry) => entry.status_rx.clone(),
+            }
+        };
+
+        // Phase 2 — wait for terminal status or timeout.
+        // We watch the status channel rather than the oneshot so we
+        // can distinguish Cancelled (terminal, no payload) from
+        // Completed (terminal, payload pending on the oneshot). The
+        // spawned future writes status BEFORE sending the oneshot,
+        // so by the time we observe a terminal status the oneshot is
+        // either ready or about to be (sub-microsecond skew).
+        let wait_fut = wait_for_terminal_status(status_rx);
+        let result = tokio::time::timeout(timeout, wait_fut).await;
+
+        match result {
+            Err(_elapsed) => {
+                // Timeout: the task is still pending. Re-snapshot so
+                // the caller sees the latest status (it may have
+                // transitioned `Pending` → `Running` while we waited).
+                let snap = self
+                    .snapshot()
+                    .into_iter()
+                    .find(|s| s.task_id == task_id);
+                match snap {
+                    Some(s) => WaitOutcome::TimedOut(s),
+                    // Task vanished mid-wait — drain reaped it. The
+                    // result already injected into the conversation;
+                    // tell the caller it's gone.
+                    None => WaitOutcome::NotFound,
+                }
+            }
+            Ok(()) => {
+                // Terminal status observed. Pull the entry out so the
+                // auto-drain path won't see it again, then map the
+                // oneshot to a BgAgentResult / Cancelled.
+                let mut guard = self.pending.lock();
+                let Some(mut entry) = guard.remove(&task_id) else {
+                    // Drain raced us and reaped first. Rare but
+                    // possible. The model already saw the result in
+                    // the prior turn's auto-drain.
+                    return WaitOutcome::NotFound;
+                };
+                drop(guard);
+                match entry.rx.try_recv() {
+                    Ok(Ok((output, events))) => WaitOutcome::Completed(BgAgentResult {
+                        agent_name: entry.agent_name,
+                        prompt: entry.prompt,
+                        output,
+                        success: true,
+                        events,
+                    }),
+                    Ok(Err((err, events))) => WaitOutcome::Completed(BgAgentResult {
+                        agent_name: entry.agent_name,
+                        prompt: entry.prompt,
+                        output: err,
+                        success: false,
+                        events,
+                    }),
+                    Err(oneshot::error::TryRecvError::Empty) => {
+                        // Status went terminal but oneshot hasn't
+                        // landed yet — the future writes status before
+                        // sending. Wait a few microseconds for the
+                        // send to complete, then try once more.
+                        // Worst case (channel closed concurrently) we
+                        // fall through to Cancelled below.
+                        match entry.rx.try_recv() {
+                            Ok(Ok((output, events))) => {
+                                WaitOutcome::Completed(BgAgentResult {
+                                    agent_name: entry.agent_name,
+                                    prompt: entry.prompt,
+                                    output,
+                                    success: true,
+                                    events,
+                                })
+                            }
+                            Ok(Err((err, events))) => WaitOutcome::Completed(BgAgentResult {
+                                agent_name: entry.agent_name,
+                                prompt: entry.prompt,
+                                output: err,
+                                success: false,
+                                events,
+                            }),
+                            _ => WaitOutcome::Cancelled,
+                        }
+                    }
+                    Err(oneshot::error::TryRecvError::Closed) => WaitOutcome::Cancelled,
+                }
+            }
+        }
+    }
+}
+
+/// Wait for a `watch::Receiver<AgentStatus>` to report a terminal
+/// variant (`Completed`, `Errored`, `Cancelled`).
+///
+/// Returns when the current value is already terminal OR after a
+/// `changed()` event lands a terminal value. Yields control on
+/// every iteration so the timeout future in
+/// [`BgAgentRegistry::wait_for_completion`] gets a chance to fire.
+async fn wait_for_terminal_status(mut rx: watch::Receiver<AgentStatus>) {
+    loop {
+        let is_terminal = matches!(
+            *rx.borrow(),
+            AgentStatus::Completed { .. }
+                | AgentStatus::Errored { .. }
+                | AgentStatus::Cancelled
+        );
+        if is_terminal {
+            return;
+        }
+        // `changed()` resolves on the next write to the channel. If
+        // the sender was dropped (task panicked) it returns Err —
+        // treat as terminal so the caller can pull `Cancelled` from
+        // the closed oneshot.
+        if rx.changed().await.is_err() {
+            return;
+        }
+    }
 }
 
 impl Default for BgAgentRegistry {
@@ -944,5 +1194,205 @@ mod tests {
             reg.snapshot().is_empty(),
             "drained tasks must not appear in snapshots"
         );
+    }
+
+    // ── Layer 2 of #996: scoped APIs + WaitOutcome ────────────────────────
+
+    /// `snapshot_for_caller(None)` returns only top-level tasks;
+    /// `snapshot_for_caller(Some(N))` returns only N's tasks. Cross-spawner
+    /// visibility is exactly zero — the Model E isolation guarantee.
+    #[tokio::test]
+    async fn snapshot_for_caller_filters_by_spawner() {
+        let reg = BgAgentRegistry::new();
+        let (top_id, _tx, _, _) = reg.register_test_with_status("a", "top", None);
+        let (sub_a_id, _tx, _, _) = reg.register_test_with_status("b", "sub-a", Some(7));
+        let (_sub_b_id, _tx, _, _) = reg.register_test_with_status("c", "sub-b", Some(9));
+
+        let top = reg.snapshot_for_caller(None);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].task_id, top_id);
+
+        let sub_a = reg.snapshot_for_caller(Some(7));
+        assert_eq!(sub_a.len(), 1);
+        assert_eq!(sub_a[0].task_id, sub_a_id);
+
+        // Sub-agent 7 sees nothing of sub-agent 9's, of top-level's, etc.
+        assert!(reg.snapshot_for_caller(Some(42)).is_empty());
+    }
+
+    /// `cancel_as_caller` enforces the Model E permission rule.
+    #[tokio::test]
+    async fn cancel_as_caller_returns_forbidden_for_other_spawner() {
+        let reg = BgAgentRegistry::new();
+        let (id, _tx, _, observer) = reg.register_test_with_status("x", "y", Some(7));
+
+        // Wrong caller — not the top-level (None != Some(7)) and not a peer.
+        assert_eq!(
+            reg.cancel_as_caller(id, None),
+            CancelOutcome::Forbidden,
+            "top-level must not be able to cancel sub-agent's task"
+        );
+        assert_eq!(
+            reg.cancel_as_caller(id, Some(99)),
+            CancelOutcome::Forbidden,
+            "sibling sub-agent must not be able to cancel"
+        );
+        assert!(
+            !observer.is_cancelled(),
+            "forbidden calls must NOT fire the cancel token"
+        );
+
+        // Correct caller — the original spawner.
+        assert_eq!(reg.cancel_as_caller(id, Some(7)), CancelOutcome::Cancelled);
+        assert!(observer.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancel_as_caller_returns_not_found_for_unknown_id() {
+        let reg = BgAgentRegistry::new();
+        assert_eq!(
+            reg.cancel_as_caller(999, None),
+            CancelOutcome::NotFound
+        );
+    }
+
+    /// `cancel_for_spawner` cleans up exactly one sub-agent's children
+    /// and leaves siblings + top-level alone. The cleanup-on-exit hook.
+    #[tokio::test]
+    async fn cancel_for_spawner_kills_only_matching_children() {
+        let reg = BgAgentRegistry::new();
+        let (_top, _, _, top_obs) = reg.register_test_with_status("top", "t", None);
+        let (_a1, _, _, a1_obs) = reg.register_test_with_status("a1", "x", Some(7));
+        let (_a2, _, _, a2_obs) = reg.register_test_with_status("a2", "y", Some(7));
+        let (_b, _, _, b_obs) = reg.register_test_with_status("b", "z", Some(9));
+
+        let count = reg.cancel_for_spawner(7);
+        assert_eq!(count, 2, "both of spawner 7's children must be signalled");
+
+        assert!(a1_obs.is_cancelled());
+        assert!(a2_obs.is_cancelled());
+        assert!(!top_obs.is_cancelled(), "top-level must be untouched");
+        assert!(!b_obs.is_cancelled(), "sibling spawner's task untouched");
+
+        // Idempotent — calling again after entries are still alive
+        // re-fires the (already-cancelled, no-op) tokens.
+        assert_eq!(reg.cancel_for_spawner(7), 2);
+        // Calling for an unknown spawner returns 0.
+        assert_eq!(reg.cancel_for_spawner(99), 0);
+    }
+
+    /// `wait_for_completion` returns `Completed` and consumes the entry
+    /// (so a subsequent `drain_completed` can't double-inject).
+    #[tokio::test]
+    async fn wait_for_completion_consumes_completed_task() {
+        let reg = BgAgentRegistry::new();
+        let (id, tx, status_tx, _) = reg.register_test_with_status("explore", "map", Some(3));
+
+        // Fire the result, then transition status to terminal so the
+        // wait future wakes up.
+        tx.send(Ok(("final answer".to_string(), vec!["step 1".to_string()])))
+            .unwrap();
+        status_tx
+            .send(AgentStatus::Completed {
+                summary: "final answer".to_string(),
+            })
+            .unwrap();
+
+        let outcome = reg
+            .wait_for_completion(id, Some(3), Duration::from_secs(1))
+            .await;
+        match outcome {
+            WaitOutcome::Completed(result) => {
+                assert!(result.success);
+                assert_eq!(result.output, "final answer");
+                assert_eq!(result.events, vec!["step 1".to_string()]);
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+
+        // Entry must be gone — drain sees nothing.
+        assert_eq!(reg.drain_completed().len(), 0);
+        assert!(reg.snapshot().is_empty());
+    }
+
+    /// `wait_for_completion` returns `TimedOut` with a fresh snapshot
+    /// when the task hasn't finished yet — and crucially leaves the
+    /// entry in the registry so a later drain still works.
+    #[tokio::test]
+    async fn wait_for_completion_timeout_preserves_entry() {
+        let reg = BgAgentRegistry::new();
+        let (id, _tx, status_tx, _) = reg.register_test_with_status("slow", "x", None);
+
+        // Move to Running so the snapshot test below can verify the
+        // current status got carried through.
+        status_tx.send(AgentStatus::Running { iter: 2 }).unwrap();
+
+        let outcome = reg
+            .wait_for_completion(id, None, Duration::from_millis(40))
+            .await;
+        match outcome {
+            WaitOutcome::TimedOut(snap) => {
+                assert_eq!(snap.task_id, id);
+                assert_eq!(snap.status, AgentStatus::Running { iter: 2 });
+            }
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        // Still in pending after a timeout.
+        assert_eq!(reg.snapshot().len(), 1);
+    }
+
+    /// `wait_for_completion` enforces the same Model E permission rule
+    /// as `cancel_as_caller`.
+    #[tokio::test]
+    async fn wait_for_completion_returns_forbidden_for_other_spawner() {
+        let reg = BgAgentRegistry::new();
+        let (id, _tx, _, _) = reg.register_test_with_status("x", "y", Some(5));
+
+        let outcome = reg
+            .wait_for_completion(id, None, Duration::from_millis(20))
+            .await;
+        assert!(
+            matches!(outcome, WaitOutcome::Forbidden),
+            "top-level must not be able to wait on sub-agent task; got {outcome:?}"
+        );
+
+        let outcome = reg
+            .wait_for_completion(id, Some(99), Duration::from_millis(20))
+            .await;
+        assert!(
+            matches!(outcome, WaitOutcome::Forbidden),
+            "sibling sub-agent must not be able to wait; got {outcome:?}"
+        );
+    }
+
+    /// Cancellation between status going terminal and `WaitTask` waking
+    /// up surfaces as `Cancelled` (oneshot closed without sending).
+    #[tokio::test]
+    async fn wait_for_completion_returns_cancelled_when_sender_dropped() {
+        let reg = BgAgentRegistry::new();
+        let (id, tx, status_tx, _) = reg.register_test_with_status("x", "y", None);
+
+        // Drop the sender (simulates task panic / abort), then push
+        // the status to terminal so wait wakes up.
+        drop(tx);
+        status_tx.send(AgentStatus::Cancelled).unwrap();
+
+        let outcome = reg
+            .wait_for_completion(id, None, Duration::from_secs(1))
+            .await;
+        assert!(
+            matches!(outcome, WaitOutcome::Cancelled),
+            "got {outcome:?}"
+        );
+        assert!(reg.snapshot().is_empty(), "entry must be reaped");
+    }
+
+    #[tokio::test]
+    async fn wait_for_completion_returns_not_found_for_unknown_id() {
+        let reg = BgAgentRegistry::new();
+        let outcome = reg
+            .wait_for_completion(999, None, Duration::from_millis(10))
+            .await;
+        assert!(matches!(outcome, WaitOutcome::NotFound), "got {outcome:?}");
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -474,7 +474,12 @@ async fn collect_stream(
                     // Execute eagerly — read-only tools are fast (10–50ms),
                     // the channel buffers incoming chunks while we run.
                     tracing::debug!("Eager dispatch: {} (id={})", tc.function_name, tc.id);
-                    let r = tools.execute(&tc.function_name, &tc.arguments, None).await;
+                    // Eager dispatch only fires for read-only tools (filtered
+                    // above). Bash is never read-only, so `caller_spawner=None`
+                    // is correct here — there is no Bash path to mis-tag.
+                    let r = tools
+                        .execute(&tc.function_name, &tc.arguments, None, None)
+                        .await;
                     eager_results.push((tc.id.clone(), r.output, r.success, r.full_output));
                 }
                 // Always add to tool_calls for persistence and normal flow

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1165,6 +1165,9 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sub_agent_cache,
                 file_tracker,
                 bg_agents,
+                // Phase E of #996: top-level inference has no spawner
+                // identity — bg-task tools see the global scope.
+                None,
             )
             .await?;
         } else if remaining_tools.len() > 1 {
@@ -1182,6 +1185,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sub_agent_cache,
                 file_tracker,
                 bg_agents,
+                None,
             )
             .await?;
         } else if !remaining_tools.is_empty() {
@@ -1199,6 +1203,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sub_agent_cache,
                 file_tracker,
                 bg_agents,
+                None,
             )
             .await?;
         }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -26,8 +26,72 @@ use koda_sandbox::{CwdProvider, GitWorktreeProvider, WorkspaceProvider};
 #[cfg(target_os = "macos")]
 use koda_sandbox::ClonefileProvider;
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+/// Process-wide allocator for sub-agent invocation IDs.
+///
+/// Phase E of #996. Each `execute_sub_agent` call (foreground or
+/// background) draws a fresh id; that id becomes the **spawner tag**
+/// for any background work this sub-agent registers, and is the key
+/// used to cancel that work when the sub-agent exits.
+///
+/// Top-level inference uses `None` (no invocation id). Sub-agents at
+/// any nesting depth use `Some(N)`.
+///
+/// `u32::MAX` invocations is comfortably more than any single Code
+/// Puppy session needs; we don't bother with wrap-around handling.
+/// Starts at 1 so `0` can stay reserved for "unset" should the type
+/// ever change.
+static NEXT_INVOCATION_ID: AtomicU32 = AtomicU32::new(1);
+
+/// Allocate a fresh invocation id. See [`NEXT_INVOCATION_ID`].
+pub(crate) fn next_invocation_id() -> u32 {
+    NEXT_INVOCATION_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// RAII cleanup hook for #996 Phase E.
+///
+/// On drop, cancels every bg-agent registry entry tagged with this
+/// sub-agent's invocation id. That covers the two ways a sub-agent
+/// can exit and leave orphans:
+///
+///   1. **Iteration cap** (`Ok(iteration_cap_marker(...))`) — the
+///      sub-agent ran out of inference iterations *while* one of its
+///      bg children was still running.
+///   2. **Error return** (`Err(...)` from any `?` inside the loop) —
+///      e.g. provider failure, persistence failure, `?`-propagated
+///      cancellation.
+///
+/// On the cancel-token path we'd reap anyway via the parent's cascade,
+/// but the spawner-scoped cancel is cheap and idempotent so we just
+/// always run it. `cancel_for_spawner` is `O(n)` over the registry,
+/// which is fine for the < 100-entry registries we expect.
+///
+/// Background shell processes (`Bash{background:true}`) are *not*
+/// covered here — each sub-agent constructs its own `ToolRegistry`
+/// with its own `BgRegistry`, which `Drop`-SIGTERMs everything when
+/// the registry goes out of scope. That handles shell orphans for
+/// free; this struct only needs to deal with the *shared*
+/// `BgAgentRegistry`.
+struct InvocationCleanup<'a> {
+    bg: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    invocation_id: u32,
+}
+
+impl Drop for InvocationCleanup<'_> {
+    fn drop(&mut self) {
+        let cancelled = self.bg.cancel_for_spawner(self.invocation_id);
+        if cancelled > 0 {
+            tracing::debug!(
+                spawner = self.invocation_id,
+                cancelled,
+                "execute_sub_agent exit: cancelled orphaned bg agents",
+            );
+        }
+    }
+}
 
 /// Run a sub-agent in the background. Owns all data (no borrows).
 ///
@@ -119,6 +183,12 @@ async fn run_bg_agent(
         &parent_session,
         &nested_bg,
         &parent_sandbox_policy,
+        // Phase E of #996: the bg agent has no in-process parent in
+        // the spawner sense — its `nested_bg` registry is fresh, and
+        // any bg work it spawns gets tagged with the bg agent's *own*
+        // invocation id (allocated inside the recursive call). The
+        // parent's cascade-cancel covers cross-registry teardown.
+        None,
     )
     .await;
 
@@ -190,8 +260,20 @@ pub(crate) fn execute_sub_agent<'a>(
     // the per-field rules. Pass `&SandboxPolicy::strict_default()`
     // when there is no meaningful parent (top-level invocation).
     parent_sandbox_policy: &'a koda_sandbox::SandboxPolicy,
+    // Phase E of #996: the **caller's** invocation id. Used as the
+    // `spawner` tag on bg-sub-agent reservations so the parent (not
+    // the child) owns the right to wait/cancel its bg children. Pass
+    // `None` when called from top-level inference. Distinct from the
+    // child's own `my_invocation_id`, which is allocated below and
+    // tags any bg work the child itself spawns.
+    parent_spawner: Option<u32>,
 ) -> impl std::future::Future<Output = Result<String>> + Send + 'a {
     async move {
+        // Phase E of #996: allocate this invocation's id up-front. It
+        // becomes the `caller_spawner` for every tool call inside
+        // this sub-agent's loop, AND the `spawner` tag the cleanup
+        // hook below uses to reap any orphaned bg work.
+        let my_invocation_id = next_invocation_id();
         let args: serde_json::Value = serde_json::from_str(arguments)?;
         let agent_name = args["agent_name"].as_str().unwrap_or("task");
         tracing::Span::current().record("agent_name", agent_name);
@@ -230,7 +312,16 @@ pub(crate) fn execute_sub_agent<'a>(
         //    so MutexGuards held across their awaits weren't Send. Bounds
         //    have been added there as well.
         if background {
-            let reservation = bg_agents.reserve(&cancel, None);
+            // Phase E of #996: tag the bg-sub-agent task with the
+            // **parent's** spawner identity. The parent (not the bg
+            // sub-agent itself) owns the right to wait/cancel its
+            // bg children via WaitTask/CancelTask. The bg sub-agent's
+            // own invocation id (`my_invocation_id` allocated above)
+            // is unused on this code path — it would matter if the
+            // bg sub-agent itself were to be cancelled-on-parent-exit,
+            // but the registry's parent->bg cancel-token cascade
+            // already handles that case.
+            let reservation = bg_agents.reserve(&cancel, parent_spawner);
             let task_id = reservation.task_id;
             let bg_cancel = reservation.cancel.clone();
             let bg_tx = reservation.tx;
@@ -281,7 +372,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_rx,
                 entry_cancel,
                 entry_status_rx,
-                None,
+                parent_spawner,
                 handle,
             );
 
@@ -290,6 +381,17 @@ pub(crate) fn execute_sub_agent<'a>(
              Results will be injected when complete."
             ));
         }
+
+        // From this point on, any bg work this invocation spawns is
+        // tagged with `my_invocation_id`. Install the RAII cleanup
+        // guard *now*, after the bg-spawn early-return — a bg-spawn
+        // path's child is intentionally meant to outlive us; the
+        // guard would (correctly!) reap it as an orphan, which is
+        // exactly the behaviour we want to AVOID for the bg branch.
+        let _cleanup = InvocationCleanup {
+            bg: bg_agents,
+            invocation_id: my_invocation_id,
+        };
         // Check result cache (only for stateless calls without a session_id,
         // since session continuations need fresh execution).
         if session_id.is_none()
@@ -589,22 +691,12 @@ pub(crate) fn execute_sub_agent<'a>(
             if !denied.contains(&"AskUser".to_string()) {
                 denied.push("AskUser".to_string());
             }
-            // Layer 2 of #996 — background-task management tools.
-            //
-            // Until Phase E threads the spawning sub-agent's invocation
-            // id through the dispatch layer, sub-agents would call
-            // these tools with `caller_spawner = None` and end up
-            // looking at the top-level scope. That's a Model E
-            // violation (sub-agents must not see siblings' or parents'
-            // tasks). Easiest defence: hide the tools from sub-agents
-            // entirely until spawner threading lands. Phase E removes
-            // these three filters in the same commit that wires the
-            // real `caller_spawner` into `execute_one_tool`.
-            for tool in ["ListBackgroundTasks", "CancelTask", "WaitTask"] {
-                if !denied.iter().any(|d| d == tool) {
-                    denied.push(tool.to_string());
-                }
-            }
+            // Phase E of #996 wired `caller_spawner` through the
+            // dispatch layer, so the bg-task tools (ListBackgroundTasks /
+            // CancelTask / WaitTask) now correctly scope to the calling
+            // sub-agent's own invocation id — a sub-agent only sees
+            // bg work *it* spawned. The earlier blanket denylist that
+            // hid these tools from sub-agents has been removed.
             tools.get_definitions(&sub_config.allowed_tools, &denied)
         };
         let semantic_memory = if sub_config.skip_memory {
@@ -804,6 +896,7 @@ pub(crate) fn execute_sub_agent<'a>(
                                 cancel.clone(),
                                 sub_agent_cache,
                                 bg_agents,
+                                Some(my_invocation_id),
                             )
                             .await;
                             result
@@ -860,6 +953,7 @@ pub(crate) fn execute_sub_agent<'a>(
                                         cancel.clone(),
                                         sub_agent_cache,
                                         bg_agents,
+                                        Some(my_invocation_id),
                                     )
                                     .await;
                                     result
@@ -1263,6 +1357,113 @@ mod b21_tests {
         assert!(
             !m.contains('\n'),
             "marker must be single-line for clean tool-result formatting; got:\n{m}"
+        );
+    }
+}
+
+/// Phase E of #996 — RAII cleanup hook tests.
+///
+/// `InvocationCleanup`'s job: when a sub-agent invocation exits
+/// (success, iteration cap, or error), **fire the cancel token** on
+/// every bg-agent registry entry tagged with that invocation's
+/// spawner id. The actual reaping (removal from `pending`) happens
+/// later — either when the bg future observes its cancel token and
+/// returns, then gets `drain_completed`'d, or when the registry's
+/// own Drop impl aborts the JoinHandle. Either way, the guard's job
+/// is just signalling.
+///
+/// Two contracts to pin:
+///
+///   1. **Drop fires cancel on matching entries.** Entries tagged with
+///      `Some(my_invocation_id)` must observe their cancel token fire
+///      after the guard drops.
+///   2. **Drop leaves non-matching entries alone.** Entries tagged with
+///      a *different* spawner id (sibling sub-agent, top-level, etc.)
+///      must NOT observe their cancel token fire.
+///
+/// We test the guard in isolation rather than driving a full
+/// `execute_sub_agent` because the function is too large to set up
+/// in a unit test. The guard's behaviour is the single load-bearing
+/// piece; everything else is plumbing the compiler already verified.
+#[cfg(test)]
+mod invocation_cleanup_tests {
+    use super::InvocationCleanup;
+    use crate::bg_agent::BgAgentRegistry;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn drop_cancels_entries_tagged_with_matching_spawner() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        // Tag two bg entries with our invocation id. The 4th tuple
+        // element is a clone of the entry's cancel token — we use it
+        // as an observer to detect the guard firing the cancel.
+        let (_id_a, _tx_a, _status_tx_a, cancel_a) =
+            reg.register_test_with_status("scout", "a", Some(7));
+        let (_id_b, _tx_b, _status_tx_b, cancel_b) =
+            reg.register_test_with_status("scout", "b", Some(7));
+        assert!(!cancel_a.is_cancelled() && !cancel_b.is_cancelled(), "setup");
+
+        drop(InvocationCleanup {
+            bg: &reg,
+            invocation_id: 7,
+        });
+
+        assert!(
+            cancel_a.is_cancelled(),
+            "entry A's cancel token must fire when guard drops"
+        );
+        assert!(
+            cancel_b.is_cancelled(),
+            "entry B's cancel token must fire when guard drops"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_leaves_entries_with_different_spawner_alone() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        // Mix: one tagged with our id, one with a sibling's, one with None.
+        let (_id_mine, _tx_m, _status_tx_m, cancel_mine) =
+            reg.register_test_with_status("a", "mine", Some(7));
+        let (_id_sib, _tx_s, _status_tx_s, cancel_sibling) =
+            reg.register_test_with_status("a", "sibling", Some(8));
+        let (_id_top, _tx_t, _status_tx_t, cancel_toplevel) =
+            reg.register_test_with_status("a", "toplevel", None);
+
+        drop(InvocationCleanup {
+            bg: &reg,
+            invocation_id: 7,
+        });
+
+        assert!(
+            cancel_mine.is_cancelled(),
+            "my own (spawner=7) entry must be cancelled"
+        );
+        assert!(
+            !cancel_sibling.is_cancelled(),
+            "sibling sub-agent's (spawner=8) entry must NOT be cancelled"
+        );
+        assert!(
+            !cancel_toplevel.is_cancelled(),
+            "top-level (spawner=None) entry must NOT be cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_with_no_matching_entries_is_noop() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        let (_id, _tx, _status_tx, cancel) =
+            reg.register_test_with_status("a", "x", Some(99));
+
+        // Cleanup for an invocation that never spawned anything —
+        // common case: a sub-agent that did nothing bg-related.
+        drop(InvocationCleanup {
+            bg: &reg,
+            invocation_id: 7,
+        });
+
+        assert!(
+            !cancel.is_cancelled(),
+            "unrelated entry's cancel token must not fire"
         );
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -842,20 +842,13 @@ pub(crate) fn execute_sub_agent<'a>(
                 // sequential dispatcher does the same; without this the
                 // sub-agent would hit the same class of errors *after*
                 // the user had already approved.
-                let validation_error = {
-                    let cache = tools.file_read_cache();
-                    let last_writer = tools.last_writer_cache();
-                    let last_bash = tools.last_bash_cache();
-                    tools::validate::validate_tool_call(
-                        &tc.function_name,
-                        &parsed_args,
-                        effective_root_ref,
-                        Some(&cache),
-                        Some(&last_writer),
-                        Some(&last_bash),
-                    )
-                    .await
-                };
+                let validation_error = tools::validate::validate_with_registry(
+                    &tools,
+                    &tc.function_name,
+                    &parsed_args,
+                    effective_root_ref,
+                )
+                .await;
 
                 let output = if let Some(error) = validation_error {
                     format!("Validation error: {error}")
@@ -1401,7 +1394,10 @@ mod invocation_cleanup_tests {
             reg.register_test_with_status("scout", "a", Some(7));
         let (_id_b, _tx_b, _status_tx_b, cancel_b) =
             reg.register_test_with_status("scout", "b", Some(7));
-        assert!(!cancel_a.is_cancelled() && !cancel_b.is_cancelled(), "setup");
+        assert!(
+            !cancel_a.is_cancelled() && !cancel_b.is_cancelled(),
+            "setup"
+        );
 
         drop(InvocationCleanup {
             bg: &reg,
@@ -1451,8 +1447,7 @@ mod invocation_cleanup_tests {
     #[tokio::test]
     async fn drop_with_no_matching_entries_is_noop() {
         let reg = Arc::new(BgAgentRegistry::new());
-        let (_id, _tx, _status_tx, cancel) =
-            reg.register_test_with_status("a", "x", Some(99));
+        let (_id, _tx, _status_tx, cancel) = reg.register_test_with_status("a", "x", Some(99));
 
         // Cleanup for an invocation that never spawned anything —
         // common case: a sub-agent that did nothing bg-related.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -230,7 +230,7 @@ pub(crate) fn execute_sub_agent<'a>(
         //    so MutexGuards held across their awaits weren't Send. Bounds
         //    have been added there as well.
         if background {
-            let reservation = bg_agents.reserve(&cancel);
+            let reservation = bg_agents.reserve(&cancel, None);
             let task_id = reservation.task_id;
             let bg_cancel = reservation.cancel.clone();
             let bg_tx = reservation.tx;
@@ -281,6 +281,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_rx,
                 entry_cancel,
                 entry_status_rx,
+                None,
                 handle,
             );
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -589,6 +589,22 @@ pub(crate) fn execute_sub_agent<'a>(
             if !denied.contains(&"AskUser".to_string()) {
                 denied.push("AskUser".to_string());
             }
+            // Layer 2 of #996 — background-task management tools.
+            //
+            // Until Phase E threads the spawning sub-agent's invocation
+            // id through the dispatch layer, sub-agents would call
+            // these tools with `caller_spawner = None` and end up
+            // looking at the top-level scope. That's a Model E
+            // violation (sub-agents must not see siblings' or parents'
+            // tasks). Easiest defence: hide the tools from sub-agents
+            // entirely until spawner threading lands. Phase E removes
+            // these three filters in the same commit that wires the
+            // real `caller_spawner` into `execute_one_tool`.
+            for tool in ["ListBackgroundTasks", "CancelTask", "WaitTask"] {
+                if !denied.iter().any(|d| d == tool) {
+                    denied.push(tool.to_string());
+                }
+            }
             tools.get_definitions(&sub_config.allowed_tools, &denied)
         };
         let semantic_memory = if sub_config.skip_memory {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -359,20 +359,13 @@ async fn validate_then_execute_one_tool(
 ) -> (String, String, bool, Option<String>) {
     let parsed_args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
 
-    let validation_error = {
-        let cache = tools.file_read_cache();
-        let last_writer = tools.last_writer_cache();
-        let last_bash = tools.last_bash_cache();
-        tools::validate::validate_tool_call(
-            &tc.function_name,
-            &parsed_args,
-            project_root,
-            Some(&cache),
-            Some(&last_writer),
-            Some(&last_bash),
-        )
-        .await
-    };
+    let validation_error = tools::validate::validate_with_registry(
+        tools,
+        &tc.function_name,
+        &parsed_args,
+        project_root,
+    )
+    .await;
 
     if let Some(error) = validation_error {
         return (
@@ -669,20 +662,14 @@ pub(crate) async fn execute_tools_sequential(
 
         // Pre-flight validation: catch errors before bothering the user
         // with an approval prompt that will inevitably fail.
-        if let Some(error) = {
-            let cache = tools.file_read_cache();
-            let last_writer = tools.last_writer_cache();
-            let last_bash = tools.last_bash_cache();
-            tools::validate::validate_tool_call(
-                &tc.function_name,
-                &parsed_args,
-                project_root,
-                Some(&cache),
-                Some(&last_writer),
-                Some(&last_bash),
-            )
-            .await
-        } {
+        if let Some(error) = tools::validate::validate_with_registry(
+            tools,
+            &tc.function_name,
+            &parsed_args,
+            project_root,
+        )
+        .await
+        {
             record_tool_result(
                 tc,
                 &format!("Validation error: {error}"),

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -326,7 +326,7 @@ pub(crate) async fn execute_one_tool(
             None
         };
         let r = tools
-            .execute(&tc.function_name, &tc.arguments, streaming)
+            .execute(&tc.function_name, &tc.arguments, streaming, caller_spawner)
             .await;
         (r.output, r.success, r.full_output)
     };

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -236,6 +236,7 @@ pub(crate) async fn execute_one_tool(
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    caller_spawner: Option<u32>,
 ) -> (String, String, bool, Option<String>) {
     let (result, success, full_output) = if matches!(
         tc.function_name.as_str(),
@@ -244,19 +245,15 @@ pub(crate) async fn execute_one_tool(
         // Layer 2 of #996 — background-task management tools.
         //
         // These need the `Arc<BgAgentRegistry>` (not held by the
-        // ToolRegistry) plus the caller's spawner identity (only
-        // known here at the dispatch layer), so they can't go
-        // through the generic `tools.execute()` path. Phase E will
-        // thread a real `caller_spawner` from sub_agent_dispatch;
-        // for now top-level callers see `None` everywhere, which
-        // gives them access to their own (top-level-spawned) tasks
-        // — the most common case.
+        // ToolRegistry) plus the caller's spawner identity (now
+        // threaded as `caller_spawner`), so they can't go through
+        // the generic `tools.execute()` path.
         let r = crate::tools::bg_task_tools::execute(
             &tc.function_name,
             &tc.arguments,
             bg_agents,
             &tools.bg_registry,
-            None, // Phase E: pass real caller_spawner here
+            caller_spawner,
         )
         .await;
         (r.output, r.success, r.full_output)
@@ -307,6 +304,12 @@ pub(crate) async fn execute_one_tool(
             // Phase 5 PR-4 of #934: hand the parent's effective policy
             // to the child so `compose()` can stack restrictions.
             &policy,
+            // Phase E of #996: parent's spawner identity. The new
+            // sub-agent uses this to tag any bg-sub-agent reservation
+            // it makes (so the parent owns/can-cancel its bg children),
+            // and allocates a fresh `my_invocation_id` internally for
+            // its own bg-task scoping.
+            caller_spawner,
         );
         match Box::pin(fut).await {
             Ok(output) => (output, true, None),
@@ -352,6 +355,7 @@ async fn validate_then_execute_one_tool(
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    caller_spawner: Option<u32>,
 ) -> (String, String, bool, Option<String>) {
     let parsed_args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
 
@@ -391,6 +395,7 @@ async fn validate_then_execute_one_tool(
         cancel,
         sub_agent_cache,
         bg_agents,
+        caller_spawner,
     )
     .await
 }
@@ -410,6 +415,7 @@ pub(crate) async fn execute_tools_parallel(
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    caller_spawner: Option<u32>,
 ) -> Result<()> {
     let count = tool_calls.len();
     sink.emit(EngineEvent::Info {
@@ -436,6 +442,7 @@ pub(crate) async fn execute_tools_parallel(
                 cancel.clone(),
                 sub_agent_cache,
                 bg_agents,
+                caller_spawner,
             )
         })
         .collect();
@@ -487,6 +494,7 @@ pub(crate) async fn execute_tools_split_batch(
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    caller_spawner: Option<u32>,
 ) -> Result<()> {
     // Partition into parallelizable vs sequential
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
@@ -521,6 +529,7 @@ pub(crate) async fn execute_tools_split_batch(
                     cancel.clone(),
                     sub_agent_cache,
                     bg_agents,
+                    caller_spawner,
                 )
             })
             .collect();
@@ -565,6 +574,7 @@ pub(crate) async fn execute_tools_split_batch(
                 sub_agent_cache,
                 file_tracker,
                 bg_agents,
+                caller_spawner,
             )
             .await?;
         }
@@ -587,6 +597,7 @@ pub(crate) async fn execute_tools_split_batch(
             sub_agent_cache,
             file_tracker,
             bg_agents,
+            caller_spawner,
         )
         .await?;
     }
@@ -610,6 +621,7 @@ pub(crate) async fn execute_tools_sequential(
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    caller_spawner: Option<u32>,
 ) -> Result<()> {
     for tc in tool_calls {
         // Check for interrupt before each tool
@@ -805,6 +817,7 @@ pub(crate) async fn execute_tools_sequential(
             cancel.clone(),
             sub_agent_cache,
             bg_agents,
+            caller_spawner,
         )
         .await;
         record_tool_result(

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -237,7 +237,30 @@ pub(crate) async fn execute_one_tool(
     sub_agent_cache: &SubAgentCache,
     bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
 ) -> (String, String, bool, Option<String>) {
-    let (result, success, full_output) = if tc.function_name == "InvokeAgent" {
+    let (result, success, full_output) = if matches!(
+        tc.function_name.as_str(),
+        "ListBackgroundTasks" | "CancelTask" | "WaitTask"
+    ) {
+        // Layer 2 of #996 — background-task management tools.
+        //
+        // These need the `Arc<BgAgentRegistry>` (not held by the
+        // ToolRegistry) plus the caller's spawner identity (only
+        // known here at the dispatch layer), so they can't go
+        // through the generic `tools.execute()` path. Phase E will
+        // thread a real `caller_spawner` from sub_agent_dispatch;
+        // for now top-level callers see `None` everywhere, which
+        // gives them access to their own (top-level-spawned) tasks
+        // — the most common case.
+        let r = crate::tools::bg_task_tools::execute(
+            &tc.function_name,
+            &tc.arguments,
+            bg_agents,
+            &tools.bg_registry,
+            None, // Phase E: pass real caller_spawner here
+        )
+        .await;
+        (r.output, r.success, r.full_output)
+    } else if tc.function_name == "InvokeAgent" {
         // Sub-agents inherit the parent's approval mode.
         //
         // Runtime invariant: the sub-agent dispatch loop short-circuits

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -26,6 +26,7 @@ const CANONICAL: &[&str] = &[
     "ActivateSkill",
     "AskUser",
     "Bash",
+    "CancelTask",
     "Delete",
     "Edit",
     "Glob",
@@ -33,12 +34,14 @@ const CANONICAL: &[&str] = &[
     "InvokeAgent",
     "List",
     "ListAgents",
+    "ListBackgroundTasks",
     "ListSkills",
     "MemoryRead",
     "MemoryWrite",
     "Read",
     "RecallContext",
     "TodoWrite",
+    "WaitTask",
     "WebFetch",
     "WebSearch",
     "Write",
@@ -138,6 +141,13 @@ static ALIASES: LazyLock<HashMap<String, &'static str>> = LazyLock::new(|| {
     // Recall
     m.insert("recall_context".into(), "RecallContext");
     m.insert("recall".into(), "RecallContext");
+
+    // #996 Layer 2 — background-task management
+    m.insert("list_background_tasks".into(), "ListBackgroundTasks");
+    m.insert("list_bg_tasks".into(), "ListBackgroundTasks");
+    m.insert("cancel_task".into(), "CancelTask");
+    m.insert("wait_task".into(), "WaitTask");
+    m.insert("wait_for_task".into(), "WaitTask");
 
     m
 });

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -1,34 +1,105 @@
 //! Background process registry.
 //!
 //! Tracks processes spawned by `Bash { background: true }` so they can be
-//! listed, and so they are cleaned up (SIGTERM) when the session ends.
+//! listed, waited on, killed, and cleaned up (SIGTERM) when the session ends
+//! or the spawning sub-agent exits (Model E, see #996).
 //!
 //! ## Usage
 //!
 //! ```text
 //! Model calls: Bash { command: "npm run dev", background: true }
-//!   → Process spawned, PID recorded in BgRegistry
+//!   → Process spawned, PID + spawner recorded in BgRegistry
 //!   → Tool returns immediately: "Started PID 12345"
 //!   → Model continues with other work
 //!   → On session end: all tracked PIDs receive SIGTERM
+//!   → On spawning sub-agent exit: kill_for_spawner reaps that
+//!     sub-agent's processes (Model E cleanup-on-exit)
 //! ```
+//!
+//! ## Status lifecycle
+//!
+//! Each tracked process has a [`BgProcessStatus`] that transitions
+//! `Running` → `Exited { code }` (natural exit) or `Running` → `Killed`
+//! (we sent SIGTERM). [`BgRegistry::reap`] is the sole writer of the
+//! `Exited` transition; it calls `try_wait` on every still-running child
+//! and updates status without blocking. The TUI / LLM tool layers call
+//! `reap()` before producing a snapshot so the displayed status is fresh.
+//!
+//! Entries persist past terminal status so the LLM can observe the exit
+//! code via `ListBackgroundTasks` / `WaitTask`. Manual purge is the
+//! caller's job for now (sessions are short; auto-purge can come later).
 //!
 //! ## Design
 //!
 //! Each `ToolRegistry` owns one `BgRegistry`. All background processes for
 //! the session are keyed by PID. The registry is `Mutex`-protected since
-//! the spawning thread and the cleanup path may differ.
+//! the spawning thread, the reaper, and the cleanup path all touch it.
 
+use crate::bg_agent::CancelOutcome;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tokio::process::Child;
 
-/// Metadata stored alongside the child handle.
-pub struct BgEntry {
-    /// The original shell command string.
+/// Lifecycle of a single tracked background process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BgProcessStatus {
+    /// Child process is still alive (last `try_wait` returned `Ok(None)`).
+    Running,
+    /// Child has exited naturally. `code` is the OS exit code if the
+    /// platform reported one (POSIX always does for normal exits;
+    /// signal-killed processes report `None` on most platforms).
+    Exited {
+        /// Process exit code as reported by the OS, or `None` for
+        /// signal-killed (POSIX returns no code in that case).
+        code: Option<i32>,
+    },
+    /// We sent SIGTERM via [`BgRegistry::kill`] / [`BgRegistry::kill_as_caller`].
+    /// The child may still be alive briefly; the reaper transitions it
+    /// to `Exited` once it's actually gone.
+    Killed,
+}
+
+/// Snapshot of a tracked background process — what `/agents` (combined
+/// view, see #996 Layer 2) and the `ListBackgroundTasks` LLM tool render.
+///
+/// Cloned out of the registry under the lock so callers can format /
+/// display without holding it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BgProcessSnapshot {
+    /// OS process id. Stable for the process's lifetime; reused by
+    /// the kernel after it exits (so don't compare snapshots across
+    /// long pauses).
+    pub pid: u32,
+    /// The original shell command string. Surfaced verbatim by the
+    /// TUI; truncation is the renderer's job.
     pub command: String,
-    /// The spawned child process handle (used for `start_kill` on drop).
-    pub child: Child,
+    /// Wall-clock duration since insert. Computed at snapshot time,
+    /// so successive snapshots of the same process report different
+    /// ages.
+    pub age: Duration,
+    /// Latest known status (set by [`BgRegistry::reap`] / `kill`).
+    pub status: BgProcessStatus,
+    /// Sub-agent invocation id of the spawner, or `None` for the
+    /// top-level inference loop. Drives [`BgRegistry::kill_for_spawner`]
+    /// (Model E cleanup-on-exit) and the LLM scope-filter.
+    pub spawner: Option<u32>,
+}
+
+/// Metadata stored alongside the child handle.
+struct BgEntry {
+    /// The original shell command string.
+    command: String,
+    /// The spawned child process handle (used for `start_kill` on
+    /// kill-paths and `try_wait` on reap).
+    child: Child,
+    /// When the entry was inserted. Drives `age` in snapshots.
+    started_at: Instant,
+    /// Current status. Only [`BgRegistry::reap`] and the kill-paths
+    /// transition this away from `Running`.
+    status: BgProcessStatus,
+    /// Sub-agent that spawned this process. `None` = top-level.
+    spawner: Option<u32>,
 }
 
 /// Registry of running background processes, scoped to one session.
@@ -46,16 +117,27 @@ impl BgRegistry {
         }
     }
 
-    /// Register a spawned child.  Returns the PID.
-    pub fn insert(&self, pid: u32, command: String, child: Child) -> u32 {
-        self.inner
-            .lock()
-            .unwrap()
-            .insert(pid, BgEntry { command, child });
+    /// Register a spawned child. `spawner` is the sub-agent invocation
+    /// id (`None` for top-level). Returns the PID.
+    pub fn insert(&self, pid: u32, command: String, child: Child, spawner: Option<u32>) -> u32 {
+        self.inner.lock().unwrap().insert(
+            pid,
+            BgEntry {
+                command,
+                child,
+                started_at: Instant::now(),
+                status: BgProcessStatus::Running,
+                spawner,
+            },
+        );
         pid
     }
 
     /// Return a snapshot of running PIDs + commands for display.
+    ///
+    /// **Legacy path** kept for the TUI's existing `/agents` rendering
+    /// (#1042). New code should prefer [`Self::snapshot`] which carries
+    /// status, age, and spawner.
     pub fn list(&self) -> Vec<(u32, String)> {
         self.inner
             .lock()
@@ -65,7 +147,40 @@ impl BgRegistry {
             .collect()
     }
 
-    /// How many processes are currently tracked.
+    /// Snapshot every tracked process for `/agents` and the
+    /// `ListBackgroundTasks` LLM tool. Sorted by ascending PID.
+    ///
+    /// **Unscoped**: returns every entry regardless of spawner. Used by
+    /// the TUI (humans get the global view) and as the engine of
+    /// [`Self::snapshot_for_caller`].
+    pub fn snapshot(&self) -> Vec<BgProcessSnapshot> {
+        let guard = self.inner.lock().unwrap();
+        let now = Instant::now();
+        let mut out: Vec<_> = guard
+            .iter()
+            .map(|(pid, e)| BgProcessSnapshot {
+                pid: *pid,
+                command: e.command.clone(),
+                age: now.saturating_duration_since(e.started_at),
+                status: e.status,
+                spawner: e.spawner,
+            })
+            .collect();
+        out.sort_by_key(|s| s.pid);
+        out
+    }
+
+    /// Scoped snapshot for the `ListBackgroundTasks` LLM tool. Same
+    /// Model E rule as [`crate::bg_agent::BgAgentRegistry::snapshot_for_caller`]:
+    /// strict spawner equality, `None == None`.
+    pub fn snapshot_for_caller(&self, caller_spawner: Option<u32>) -> Vec<BgProcessSnapshot> {
+        self.snapshot()
+            .into_iter()
+            .filter(|s| s.spawner == caller_spawner)
+            .collect()
+    }
+
+    /// How many processes are currently tracked (any status).
     pub fn len(&self) -> usize {
         self.inner.lock().unwrap().len()
     }
@@ -73,6 +188,102 @@ impl BgRegistry {
     /// Returns `true` if no background processes are tracked.
     pub fn is_empty(&self) -> bool {
         self.inner.lock().unwrap().is_empty()
+    }
+
+    /// Non-blocking poll on every still-`Running` child. Transitions
+    /// any that have exited to `Exited { code }` so subsequent
+    /// snapshots see the fresh status.
+    ///
+    /// Cheap: zero syscalls if the registry is empty; one `waitpid`
+    /// per running child otherwise. Safe to call before every
+    /// `snapshot()` (the TUI does so via the slash command path).
+    pub fn reap(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        for entry in guard.values_mut() {
+            if entry.status != BgProcessStatus::Running {
+                continue;
+            }
+            match entry.child.try_wait() {
+                Ok(Some(exit)) => {
+                    entry.status = BgProcessStatus::Exited { code: exit.code() };
+                }
+                Ok(None) => { /* still running */ }
+                Err(e) => {
+                    // try_wait can fail if the OS lost track (rare).
+                    // Log + treat as terminal so we don't spin.
+                    tracing::warn!("BgRegistry reap try_wait failed for PID {}: {e}", entry
+                        .child
+                        .id()
+                        .unwrap_or(0));
+                    entry.status = BgProcessStatus::Exited { code: None };
+                }
+            }
+        }
+    }
+
+    /// Send SIGTERM to a tracked PID. Returns `true` if the PID was
+    /// known (whether or not the kill succeeded — the underlying error
+    /// is logged).
+    ///
+    /// Status flips to `Killed` immediately; the reaper will surface
+    /// the eventual `Exited { code }` once the child is reaped by the
+    /// kernel. **Unscoped** — TUI `/cancel` contract; LLM goes through
+    /// [`Self::kill_as_caller`].
+    pub fn kill(&self, pid: u32) -> bool {
+        let mut guard = self.inner.lock().unwrap();
+        let Some(entry) = guard.get_mut(&pid) else {
+            return false;
+        };
+        if entry.status == BgProcessStatus::Running {
+            if let Err(e) = entry.child.start_kill() {
+                tracing::warn!("BgRegistry::kill: failed to SIGTERM PID {pid}: {e}");
+            }
+            entry.status = BgProcessStatus::Killed;
+        }
+        true
+    }
+
+    /// Scoped kill for the `CancelTask` LLM tool. Same Model E rule
+    /// as [`crate::bg_agent::BgAgentRegistry::cancel_as_caller`].
+    pub fn kill_as_caller(&self, pid: u32, caller_spawner: Option<u32>) -> CancelOutcome {
+        let mut guard = self.inner.lock().unwrap();
+        let Some(entry) = guard.get_mut(&pid) else {
+            return CancelOutcome::NotFound;
+        };
+        if entry.spawner != caller_spawner {
+            return CancelOutcome::Forbidden;
+        }
+        if entry.status == BgProcessStatus::Running {
+            if let Err(e) = entry.child.start_kill() {
+                tracing::warn!("BgRegistry::kill_as_caller: SIGTERM PID {pid}: {e}");
+            }
+            entry.status = BgProcessStatus::Killed;
+        }
+        CancelOutcome::Cancelled
+    }
+
+    /// SIGTERM every still-running child whose `spawner` matches.
+    /// Cleanup-on-exit hook for sub-agent exit (Model E). Returns
+    /// the count of processes signalled. Idempotent.
+    pub fn kill_for_spawner(&self, spawner: u32) -> usize {
+        let mut guard = self.inner.lock().unwrap();
+        let mut count = 0;
+        for entry in guard.values_mut() {
+            if entry.spawner != Some(spawner) {
+                continue;
+            }
+            if entry.status == BgProcessStatus::Running {
+                if let Err(e) = entry.child.start_kill() {
+                    tracing::warn!(
+                        "BgRegistry::kill_for_spawner: SIGTERM PID {}: {e}",
+                        entry.child.id().unwrap_or(0)
+                    );
+                }
+                entry.status = BgProcessStatus::Killed;
+                count += 1;
+            }
+        }
+        count
     }
 }
 
@@ -83,11 +294,14 @@ impl Default for BgRegistry {
 }
 
 impl Drop for BgRegistry {
-    /// Best-effort SIGTERM all tracked processes when the session ends.
+    /// Best-effort SIGTERM all still-running tracked processes when
+    /// the session ends.
     fn drop(&mut self) {
         let mut guard = self.inner.lock().unwrap();
         for (pid, entry) in guard.iter_mut() {
-            // start_kill is sync (sends SIGTERM on Unix / TerminateProcess on Windows).
+            if entry.status != BgProcessStatus::Running {
+                continue;
+            }
             if let Err(e) = entry.child.start_kill() {
                 tracing::warn!("BgRegistry drop: failed to kill PID {pid}: {e}");
             } else {
@@ -101,32 +315,146 @@ impl Drop for BgRegistry {
 mod tests {
     use super::*;
 
+    fn spawn_sleep_child() -> (u32, Child) {
+        // 60s sleep gives every test plenty of headroom; we either kill
+        // it explicitly or let Drop SIGTERM it.
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id().expect("pid");
+        (pid, child)
+    }
+
+    fn spawn_true_child() -> (u32, Child) {
+        let child = tokio::process::Command::new("true").spawn().expect("spawn");
+        let pid = child.id().unwrap_or(99999);
+        (pid, child)
+    }
+
     #[test]
     fn registry_starts_empty() {
         let reg = BgRegistry::new();
         assert_eq!(reg.len(), 0);
         assert!(reg.list().is_empty());
-    }
-
-    #[test]
-    fn is_empty_reflects_state() {
-        let reg = BgRegistry::new();
-        assert!(reg.is_empty());
+        assert!(reg.snapshot().is_empty());
     }
 
     #[tokio::test]
-    async fn insert_increments_len_and_appears_in_list() {
+    async fn insert_records_spawner_and_appears_in_snapshot() {
         let reg = BgRegistry::new();
-        // Spawn a trivial command so we have a real Child handle.
-        let child = tokio::process::Command::new("true").spawn().unwrap();
-        let pid = child.id().unwrap_or(9999);
-        let returned_pid = reg.insert(pid, "true".into(), child);
-        assert_eq!(returned_pid, pid);
-        assert_eq!(reg.len(), 1);
-        assert!(!reg.is_empty());
-        let entries = reg.list();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].0, pid);
-        assert_eq!(entries[0].1, "true");
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, Some(7));
+
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap[0].pid, pid);
+        assert_eq!(snap[0].command, "sleep 60");
+        assert_eq!(snap[0].status, BgProcessStatus::Running);
+        assert_eq!(snap[0].spawner, Some(7));
+    }
+
+    #[tokio::test]
+    async fn snapshot_for_caller_filters_by_spawner() {
+        let reg = BgRegistry::new();
+        let (p1, c1) = spawn_sleep_child();
+        let (p2, c2) = spawn_sleep_child();
+        let (p3, c3) = spawn_sleep_child();
+        reg.insert(p1, "a".into(), c1, None);
+        reg.insert(p2, "b".into(), c2, Some(7));
+        reg.insert(p3, "c".into(), c3, Some(9));
+
+        let top = reg.snapshot_for_caller(None);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].pid, p1);
+
+        let sub_7 = reg.snapshot_for_caller(Some(7));
+        assert_eq!(sub_7.len(), 1);
+        assert_eq!(sub_7[0].pid, p2);
+
+        // Sibling sees nothing of peer's.
+        assert!(reg.snapshot_for_caller(Some(42)).is_empty());
+    }
+
+    #[tokio::test]
+    async fn reap_transitions_finished_children_to_exited() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_true_child();
+        reg.insert(pid, "true".into(), child, None);
+
+        // `true` exits ~immediately, but tokio's try_wait needs time
+        // for the SIGCHLD handler to register the exit. Poll up to 1s.
+        let mut observed = None;
+        for _ in 0..50 {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            reg.reap();
+            let snap = reg.snapshot();
+            if let BgProcessStatus::Exited { code } = snap[0].status {
+                observed = Some(code);
+                break;
+            }
+        }
+        assert_eq!(
+            observed,
+            Some(Some(0)),
+            "reap should observe `true` exiting with code 0 within 1s"
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_transitions_to_killed_and_returns_true() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, None);
+
+        assert!(reg.kill(pid));
+        assert_eq!(reg.snapshot()[0].status, BgProcessStatus::Killed);
+
+        // Unknown PID → false.
+        assert!(!reg.kill(987654));
+    }
+
+    #[tokio::test]
+    async fn kill_as_caller_enforces_spawner_scope() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, Some(5));
+
+        // Wrong caller(s).
+        assert_eq!(reg.kill_as_caller(pid, None), CancelOutcome::Forbidden);
+        assert_eq!(reg.kill_as_caller(pid, Some(99)), CancelOutcome::Forbidden);
+        assert_eq!(reg.snapshot()[0].status, BgProcessStatus::Running);
+
+        // Correct caller.
+        assert_eq!(reg.kill_as_caller(pid, Some(5)), CancelOutcome::Cancelled);
+        assert_eq!(reg.snapshot()[0].status, BgProcessStatus::Killed);
+
+        // Unknown PID for any caller → NotFound.
+        assert_eq!(reg.kill_as_caller(987654, None), CancelOutcome::NotFound);
+    }
+
+    #[tokio::test]
+    async fn kill_for_spawner_kills_only_matching_running_children() {
+        let reg = BgRegistry::new();
+        let (p_top, c_top) = spawn_sleep_child();
+        let (p_a, c_a) = spawn_sleep_child();
+        let (p_b, c_b) = spawn_sleep_child();
+        reg.insert(p_top, "top".into(), c_top, None);
+        reg.insert(p_a, "a".into(), c_a, Some(7));
+        reg.insert(p_b, "b".into(), c_b, Some(9));
+
+        let count = reg.kill_for_spawner(7);
+        assert_eq!(count, 1);
+
+        let by_pid: HashMap<u32, BgProcessStatus> =
+            reg.snapshot().into_iter().map(|s| (s.pid, s.status)).collect();
+        assert_eq!(by_pid[&p_top], BgProcessStatus::Running);
+        assert_eq!(by_pid[&p_a], BgProcessStatus::Killed);
+        assert_eq!(by_pid[&p_b], BgProcessStatus::Running);
+
+        // Idempotent — second call won't re-kill the now-Killed child.
+        assert_eq!(reg.kill_for_spawner(7), 0);
+        // Unknown spawner → 0.
+        assert_eq!(reg.kill_for_spawner(99), 0);
     }
 }

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -41,6 +41,32 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::process::Child;
 
+/// Outcome of [`BgRegistry::wait_for_exit_as_caller`].
+///
+/// Mirrors [`crate::bg_agent::WaitOutcome`] but carries process-specific
+/// terminal info (exit code) instead of an agent result. The two enums
+/// stay separate because they really are different things — forcing one
+/// to wear the other's shape would mean optionalizing fields that aren't
+/// optional in their natural domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessWaitOutcome {
+    /// Process has exited — either naturally or as a result of an
+    /// earlier `kill`. `code` is the OS exit code if reported.
+    Exited {
+        /// Same semantics as [`BgProcessStatus::Exited::code`].
+        code: Option<i32>,
+    },
+    /// Wait deadline elapsed; the process is still running. The
+    /// returned snapshot reflects the latest state at the moment the
+    /// timeout fired (e.g. age has advanced).
+    TimedOut(BgProcessSnapshot),
+    /// PID is not in the registry (never tracked, or already removed).
+    NotFound,
+    /// PID exists but caller's `spawner` does not match. Model E
+    /// permission rule.
+    Forbidden,
+}
+
 /// Lifecycle of a single tracked background process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BgProcessStatus {
@@ -262,6 +288,76 @@ impl BgRegistry {
         CancelOutcome::Cancelled
     }
 
+    /// Block until a tracked process exits, with a timeout. Same
+    /// Model E permission rule as [`Self::kill_as_caller`].
+    ///
+    /// Implementation: poll-based. Calls [`Self::reap`] every
+    /// `POLL_INTERVAL`; cheap because reap is a `try_wait` per
+    /// running child. Once status leaves `Running`, returns
+    /// [`ProcessWaitOutcome::Exited`] (mapping `Killed` → `Exited`
+    /// with `code: None` if the OS hasn't reported the exit yet —
+    /// the model only cares that the process is gone).
+    ///
+    /// On timeout, leaves the entry in the registry so it can still
+    /// be queried via [`Self::snapshot`] / re-waited.
+    pub async fn wait_for_exit_as_caller(
+        &self,
+        pid: u32,
+        caller_spawner: Option<u32>,
+        timeout: Duration,
+    ) -> ProcessWaitOutcome {
+        const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+        // Sanity-check: known + owned. Done up-front so we can fail
+        // fast on the common error cases without spinning.
+        {
+            let guard = self.inner.lock().unwrap();
+            match guard.get(&pid) {
+                None => return ProcessWaitOutcome::NotFound,
+                Some(e) if e.spawner != caller_spawner => return ProcessWaitOutcome::Forbidden,
+                Some(_) => {}
+            }
+        }
+
+        let deadline = Instant::now() + timeout;
+        loop {
+            self.reap();
+            {
+                let guard = self.inner.lock().unwrap();
+                let Some(entry) = guard.get(&pid) else {
+                    return ProcessWaitOutcome::NotFound;
+                };
+                match entry.status {
+                    BgProcessStatus::Running => {}
+                    BgProcessStatus::Exited { code } => {
+                        return ProcessWaitOutcome::Exited { code };
+                    }
+                    BgProcessStatus::Killed => {
+                        return ProcessWaitOutcome::Exited { code: None };
+                    }
+                }
+            }
+
+            if Instant::now() >= deadline {
+                let guard = self.inner.lock().unwrap();
+                let Some(entry) = guard.get(&pid) else {
+                    return ProcessWaitOutcome::NotFound;
+                };
+                let now = Instant::now();
+                return ProcessWaitOutcome::TimedOut(BgProcessSnapshot {
+                    pid,
+                    command: entry.command.clone(),
+                    age: now.saturating_duration_since(entry.started_at),
+                    status: entry.status,
+                    spawner: entry.spawner,
+                });
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            tokio::time::sleep(POLL_INTERVAL.min(remaining)).await;
+        }
+    }
+
     /// SIGTERM every still-running child whose `spawner` matches.
     /// Cleanup-on-exit hook for sub-agent exit (Model E). Returns
     /// the count of processes signalled. Idempotent.
@@ -431,6 +527,79 @@ mod tests {
 
         // Unknown PID for any caller → NotFound.
         assert_eq!(reg.kill_as_caller(987654, None), CancelOutcome::NotFound);
+    }
+
+    #[tokio::test]
+    async fn wait_for_exit_returns_exited_when_child_finishes() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_true_child();
+        reg.insert(pid, "true".into(), child, None);
+
+        let outcome = reg
+            .wait_for_exit_as_caller(pid, None, Duration::from_secs(2))
+            .await;
+        assert_eq!(outcome, ProcessWaitOutcome::Exited { code: Some(0) });
+    }
+
+    #[tokio::test]
+    async fn wait_for_exit_returns_exited_when_already_killed() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, Some(7));
+        reg.kill(pid); // status → Killed
+
+        let outcome = reg
+            .wait_for_exit_as_caller(pid, Some(7), Duration::from_secs(1))
+            .await;
+        assert_eq!(outcome, ProcessWaitOutcome::Exited { code: None });
+    }
+
+    #[tokio::test]
+    async fn wait_for_exit_returns_timed_out_with_snapshot() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, None);
+
+        let outcome = reg
+            .wait_for_exit_as_caller(pid, None, Duration::from_millis(150))
+            .await;
+        match outcome {
+            ProcessWaitOutcome::TimedOut(snap) => {
+                assert_eq!(snap.pid, pid);
+                assert_eq!(snap.status, BgProcessStatus::Running);
+                assert_eq!(snap.spawner, None);
+            }
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+        assert_eq!(reg.snapshot().len(), 1, "entry must be preserved on timeout");
+    }
+
+    #[tokio::test]
+    async fn wait_for_exit_enforces_spawner_scope() {
+        let reg = BgRegistry::new();
+        let (pid, child) = spawn_sleep_child();
+        reg.insert(pid, "sleep 60".into(), child, Some(5));
+
+        assert_eq!(
+            reg.wait_for_exit_as_caller(pid, None, Duration::from_millis(20))
+                .await,
+            ProcessWaitOutcome::Forbidden
+        );
+        assert_eq!(
+            reg.wait_for_exit_as_caller(pid, Some(99), Duration::from_millis(20))
+                .await,
+            ProcessWaitOutcome::Forbidden
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_exit_returns_not_found_for_unknown_pid() {
+        let reg = BgRegistry::new();
+        assert_eq!(
+            reg.wait_for_exit_as_caller(987654, None, Duration::from_millis(10))
+                .await,
+            ProcessWaitOutcome::NotFound
+        );
     }
 
     #[tokio::test]

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -237,10 +237,10 @@ impl BgRegistry {
                 Err(e) => {
                     // try_wait can fail if the OS lost track (rare).
                     // Log + treat as terminal so we don't spin.
-                    tracing::warn!("BgRegistry reap try_wait failed for PID {}: {e}", entry
-                        .child
-                        .id()
-                        .unwrap_or(0));
+                    tracing::warn!(
+                        "BgRegistry reap try_wait failed for PID {}: {e}",
+                        entry.child.id().unwrap_or(0)
+                    );
                     entry.status = BgProcessStatus::Exited { code: None };
                 }
             }
@@ -571,7 +571,11 @@ mod tests {
             }
             other => panic!("expected TimedOut, got {other:?}"),
         }
-        assert_eq!(reg.snapshot().len(), 1, "entry must be preserved on timeout");
+        assert_eq!(
+            reg.snapshot().len(),
+            1,
+            "entry must be preserved on timeout"
+        );
     }
 
     #[tokio::test]
@@ -615,8 +619,11 @@ mod tests {
         let count = reg.kill_for_spawner(7);
         assert_eq!(count, 1);
 
-        let by_pid: HashMap<u32, BgProcessStatus> =
-            reg.snapshot().into_iter().map(|s| (s.pid, s.status)).collect();
+        let by_pid: HashMap<u32, BgProcessStatus> = reg
+            .snapshot()
+            .into_iter()
+            .map(|s| (s.pid, s.status))
+            .collect();
         assert_eq!(by_pid[&p_top], BgProcessStatus::Running);
         assert_eq!(by_pid[&p_a], BgProcessStatus::Killed);
         assert_eq!(by_pid[&p_b], BgProcessStatus::Running);

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -1,0 +1,315 @@
+//! Background task management tools (Layer 2 of #996).
+//!
+//! Three LLM tools that let the model see, cancel, and wait for any
+//! background work it has spawned — both background sub-agents
+//! (`InvokeAgent { background: true }`) and background shell processes
+//! (`Bash { background: true }`):
+//!
+//! | Tool | Purpose |
+//! |------|---------|
+//! | `ListBackgroundTasks` | Snapshot every running task (no args). |
+//! | `CancelTask`          | Send cancel/SIGTERM by `task_id`. |
+//! | `WaitTask`            | Block until a task finishes, with timeout. |
+//!
+//! ## ID format
+//!
+//! Task IDs are prefixed strings so the model can tell agent tasks and
+//! shell processes apart at a glance:
+//!
+//! - `agent:N`   — bg-agent task (the `task_id` from
+//!   [`crate::bg_agent::BgAgentRegistry::reserve`]).
+//! - `process:N` — bg shell process (the OS PID from
+//!   [`crate::tools::bg_process::BgRegistry::insert`]).
+//!
+//! Bare numeric IDs (`5`) are accepted by the TUI's `/cancel` and
+//! resolve to `agent:5` for back-compat with #1042; the LLM tools
+//! always require the prefix.
+//!
+//! ## Scope (Model E, see #996 discussion)
+//!
+//! Each tool is filtered to the caller's own tasks: top-level sees
+//! only top-level-spawned, sub-agent N sees only its own. Cross-spawner
+//! cancel/wait returns a `Forbidden` error. This is enforced at the
+//! [`BgAgentRegistry`] / [`BgRegistry`] layer; the tool layer just
+//! produces a useful message when it sees `CancelOutcome::Forbidden`
+//! / `WaitOutcome::Forbidden`.
+//!
+//! [`BgAgentRegistry`]: crate::bg_agent::BgAgentRegistry
+//! [`BgRegistry`]: crate::tools::bg_process::BgRegistry
+
+use crate::providers::ToolDefinition;
+use serde_json::json;
+
+/// Maximum `timeout_secs` a `WaitTask` call may request. Higher values
+/// are clamped down by the dispatch layer before reaching the registry.
+///
+/// Bounds the worst-case time the inference loop can be parked on a
+/// single tool call. 300 s = 5 min is generous for "wait for a build
+/// to finish" while still preventing a confused model from asking for
+/// `timeout_secs: 86400`.
+pub const WAIT_TASK_MAX_TIMEOUT_SECS: u32 = 300;
+
+/// Default `timeout_secs` when the model omits the parameter.
+pub const WAIT_TASK_DEFAULT_TIMEOUT_SECS: u32 = 30;
+
+/// Return tool definitions for the LLM.
+pub fn definitions() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: "ListBackgroundTasks".to_string(),
+            description:
+                "List every background task you have running — both background sub-agents (spawned via \
+                InvokeAgent { background: true }) and background shell processes (spawned via Bash \
+                { background: true }).\n\n\
+                Returns a JSON array of objects, each with:\n\
+                - task_id: prefixed string. \"agent:N\" for sub-agent tasks, \"process:N\" for shell processes.\n\
+                - task_type: \"agent\" or \"process\".\n\
+                - description: agent name + prompt for agents; the original command for processes.\n\
+                - status: \"pending\" | \"running\" | \"completed\" | \"errored\" | \"cancelled\" \
+                (agents) or \"running\" | \"exited\" | \"killed\" (processes).\n\
+                - age_secs: wall-clock seconds since the task was spawned.\n\
+                - exit_code: present only for exited processes.\n\n\
+                Use this when:\n\
+                - You launched background work and want to check progress before doing more.\n\
+                - You need a task_id to feed CancelTask or WaitTask.\n\n\
+                Do NOT use this when:\n\
+                - You're not sure whether you launched anything (you'd see an empty array — \
+                cheap, but pointless if you didn't intend to background work).\n\n\
+                Scope: returns only YOUR tasks. You will never see another agent's tasks or \
+                the user's top-level tasks here."
+                    .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: "CancelTask".to_string(),
+            description:
+                "Cancel a single background task by its task_id (from ListBackgroundTasks).\n\n\
+                For sub-agent tasks (\"agent:N\"): fires the per-task cancel token. The agent \
+                observes it on its next inference iteration and shuts down cleanly. The \
+                cancellation result will appear in your conversation as a normal sub-agent \
+                completion with a cancelled marker.\n\n\
+                For shell processes (\"process:N\"): sends SIGTERM. The process status \
+                transitions to \"killed\" immediately; the OS exit code surfaces on the next \
+                ListBackgroundTasks / WaitTask call once the process is fully reaped.\n\n\
+                Idempotent — calling on an already-cancelled / already-exited task is a \
+                successful no-op. Returns an error if the task_id is unknown OR if you don't \
+                own the task (Model E scope: you can only cancel tasks you spawned)."
+                    .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Prefixed task id from ListBackgroundTasks: \
+                                        \"agent:N\" or \"process:N\"."
+                    }
+                },
+                "required": ["task_id"],
+                "additionalProperties": false
+            }),
+        },
+        ToolDefinition {
+            name: "WaitTask".to_string(),
+            description: format!(
+                "Block until a background task finishes (or timeout fires).\n\n\
+                Returns the task's terminal state and result so you don't have to keep \
+                polling ListBackgroundTasks. Prefer WaitTask over a polling loop — one \
+                tool call instead of many.\n\n\
+                For sub-agent tasks (\"agent:N\"): on completion, returns the agent's full \
+                output. The result will NOT also appear in the auto-drain on the next \
+                iteration — WaitTask consumes it.\n\n\
+                For shell processes (\"process:N\"): on exit, returns the OS exit code. \
+                Process stdout/stderr is NOT captured — if you need the output, redirect \
+                inside the command (e.g. `Bash {{ command: \"cmd > /tmp/out.log 2>&1\", \
+                background: true }}`) and Read the file separately.\n\n\
+                If the task hasn't finished by `timeout_secs`, returns the current status \
+                without consuming the task — you can call again to keep waiting. Default \
+                {default}s, max {max}s. Returns an error if the task_id is unknown or \
+                doesn't belong to you.",
+                default = WAIT_TASK_DEFAULT_TIMEOUT_SECS,
+                max = WAIT_TASK_MAX_TIMEOUT_SECS,
+            ),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Prefixed task id: \"agent:N\" or \"process:N\"."
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": WAIT_TASK_MAX_TIMEOUT_SECS,
+                        "description": format!(
+                            "Maximum seconds to wait. Default {default}, capped at {max} to \
+                             prevent runaway parks of the inference loop.",
+                            default = WAIT_TASK_DEFAULT_TIMEOUT_SECS,
+                            max = WAIT_TASK_MAX_TIMEOUT_SECS,
+                        )
+                    }
+                },
+                "required": ["task_id"],
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+/// Parsed task id (prefix + numeric).
+///
+/// `parse_task_id` produces this from the model-supplied string so the
+/// dispatch layer can route to the right registry without re-parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskId {
+    /// Bg-agent task — `agent:N`.
+    Agent(u32),
+    /// Bg shell process — `process:N`.
+    Process(u32),
+}
+
+/// Parse a model-supplied `task_id` string.
+///
+/// Accepts:
+/// - `"agent:N"` → [`TaskId::Agent`]
+/// - `"process:N"` → [`TaskId::Process`]
+/// - `"N"` (bare numeric) → [`TaskId::Agent`] for back-compat with the
+///   `/cancel <id>` UX shipped in #1042. The LLM tool descriptions
+///   *require* the prefix; this lookup tolerates the bare form so the
+///   TUI can share the same parser without diverging.
+///
+/// Returns an `Err(message)` the dispatch layer can hand back to the
+/// model verbatim when the input is malformed.
+pub fn parse_task_id(input: &str) -> Result<TaskId, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("task_id is empty".to_string());
+    }
+    if let Some(rest) = trimmed.strip_prefix("agent:") {
+        return rest
+            .parse::<u32>()
+            .map(TaskId::Agent)
+            .map_err(|_| format!("invalid agent id: '{rest}' (expected non-negative integer)"));
+    }
+    if let Some(rest) = trimmed.strip_prefix("process:") {
+        return rest
+            .parse::<u32>()
+            .map(TaskId::Process)
+            .map_err(|_| format!("invalid process id: '{rest}' (expected non-negative integer)"));
+    }
+    // Bare numeric → agent (TUI back-compat, see doc above).
+    if let Ok(n) = trimmed.parse::<u32>() {
+        return Ok(TaskId::Agent(n));
+    }
+    Err(format!(
+        "unrecognized task_id '{input}'; expected \"agent:N\" or \"process:N\""
+    ))
+}
+
+/// Clamp a model-supplied `timeout_secs` into the allowed range.
+///
+/// `None` → [`WAIT_TASK_DEFAULT_TIMEOUT_SECS`].
+/// `Some(0)` → 1 (degenerate but harmless; we don't error out on 0).
+/// `Some(> WAIT_TASK_MAX_TIMEOUT_SECS)` → cap.
+pub fn clamp_wait_timeout_secs(requested: Option<u32>) -> u32 {
+    let raw = requested.unwrap_or(WAIT_TASK_DEFAULT_TIMEOUT_SECS);
+    raw.clamp(1, WAIT_TASK_MAX_TIMEOUT_SECS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definitions_returns_three_tools_with_expected_names() {
+        let defs = definitions();
+        let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+        assert_eq!(names, vec!["ListBackgroundTasks", "CancelTask", "WaitTask"]);
+    }
+
+    #[test]
+    fn list_background_tasks_takes_no_arguments() {
+        let defs = definitions();
+        let list = defs
+            .iter()
+            .find(|d| d.name == "ListBackgroundTasks")
+            .unwrap();
+        // Required must be empty (or absent).
+        let required = list.parameters.get("required");
+        assert!(
+            required.is_none() || required.unwrap().as_array().unwrap().is_empty(),
+            "ListBackgroundTasks must take no required args"
+        );
+    }
+
+    #[test]
+    fn cancel_and_wait_require_task_id() {
+        let defs = definitions();
+        for name in ["CancelTask", "WaitTask"] {
+            let def = defs.iter().find(|d| d.name == name).unwrap();
+            let required = def.parameters["required"].as_array().unwrap();
+            assert!(
+                required.iter().any(|v| v == "task_id"),
+                "{name} must require task_id"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_task_id_accepts_prefixed_forms() {
+        assert_eq!(parse_task_id("agent:7").unwrap(), TaskId::Agent(7));
+        assert_eq!(parse_task_id("process:12345").unwrap(), TaskId::Process(12345));
+        // Whitespace tolerance — models sometimes add it.
+        assert_eq!(parse_task_id("  agent:1  ").unwrap(), TaskId::Agent(1));
+    }
+
+    #[test]
+    fn parse_task_id_accepts_bare_numeric_as_agent() {
+        // TUI back-compat: `/cancel 5` → agent:5.
+        assert_eq!(parse_task_id("5").unwrap(), TaskId::Agent(5));
+    }
+
+    #[test]
+    fn parse_task_id_rejects_bad_input() {
+        assert!(parse_task_id("").is_err());
+        assert!(parse_task_id("   ").is_err());
+        assert!(parse_task_id("agent:").is_err());
+        assert!(parse_task_id("agent:abc").is_err());
+        assert!(parse_task_id("process:-1").is_err());
+        assert!(parse_task_id("foobar").is_err());
+        assert!(parse_task_id("mcp:1").is_err()); // future prefix not yet wired
+    }
+
+    #[test]
+    fn clamp_wait_timeout_handles_none_default() {
+        assert_eq!(
+            clamp_wait_timeout_secs(None),
+            WAIT_TASK_DEFAULT_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn clamp_wait_timeout_caps_at_max() {
+        assert_eq!(
+            clamp_wait_timeout_secs(Some(86400)),
+            WAIT_TASK_MAX_TIMEOUT_SECS
+        );
+    }
+
+    #[test]
+    fn clamp_wait_timeout_floors_at_one() {
+        assert_eq!(clamp_wait_timeout_secs(Some(0)), 1);
+    }
+
+    #[test]
+    fn clamp_wait_timeout_passes_through_in_range() {
+        assert_eq!(clamp_wait_timeout_secs(Some(45)), 45);
+        assert_eq!(
+            clamp_wait_timeout_secs(Some(WAIT_TASK_MAX_TIMEOUT_SECS)),
+            WAIT_TASK_MAX_TIMEOUT_SECS
+        );
+    }
+}

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -38,13 +38,17 @@
 //! [`BgRegistry`]: crate::tools::bg_process::BgRegistry
 
 use crate::providers::ToolDefinition;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::bg_agent::{AgentStatus, BgAgentRegistry, BgAgentResult, BgTaskSnapshot, CancelOutcome, WaitOutcome};
-use crate::tools::bg_process::{BgProcessSnapshot, BgProcessStatus, BgRegistry, ProcessWaitOutcome};
+use crate::bg_agent::{
+    AgentStatus, BgAgentRegistry, BgAgentResult, BgTaskSnapshot, CancelOutcome, WaitOutcome,
+};
 use crate::tools::ToolResult;
+use crate::tools::bg_process::{
+    BgProcessSnapshot, BgProcessStatus, BgRegistry, ProcessWaitOutcome,
+};
 
 /// Maximum `timeout_secs` a `WaitTask` call may request. Higher values
 /// are clamped down by the dispatch layer before reaching the registry.
@@ -525,7 +529,10 @@ mod tests {
     #[test]
     fn parse_task_id_accepts_prefixed_forms() {
         assert_eq!(parse_task_id("agent:7").unwrap(), TaskId::Agent(7));
-        assert_eq!(parse_task_id("process:12345").unwrap(), TaskId::Process(12345));
+        assert_eq!(
+            parse_task_id("process:12345").unwrap(),
+            TaskId::Process(12345)
+        );
         // Whitespace tolerance — models sometimes add it.
         assert_eq!(parse_task_id("  agent:1  ").unwrap(), TaskId::Agent(1));
     }
@@ -597,8 +604,7 @@ mod tests {
     #[tokio::test]
     async fn execute_list_includes_caller_agent_tasks() {
         let (agents, processes) = fresh_registries();
-        let (id, _tx, _, _) =
-            agents.register_test_with_status("explore", "map repo", None);
+        let (id, _tx, _, _) = agents.register_test_with_status("explore", "map repo", None);
 
         let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
         assert!(r.success);
@@ -634,8 +640,7 @@ mod tests {
     #[tokio::test]
     async fn execute_cancel_succeeds_for_owned_agent_task() {
         let (agents, processes) = fresh_registries();
-        let (id, _tx, _, observer) =
-            agents.register_test_with_status("x", "y", None);
+        let (id, _tx, _, observer) = agents.register_test_with_status("x", "y", None);
 
         let r = execute(
             "CancelTask",
@@ -670,8 +675,7 @@ mod tests {
     #[tokio::test]
     async fn execute_cancel_returns_forbidden_for_cross_caller() {
         let (agents, processes) = fresh_registries();
-        let (id, _tx, _, observer) =
-            agents.register_test_with_status("x", "y", Some(5));
+        let (id, _tx, _, observer) = agents.register_test_with_status("x", "y", Some(5));
 
         // Top-level (None) tries to cancel sub-agent 5's task.
         let r = execute(
@@ -683,7 +687,11 @@ mod tests {
         )
         .await;
         assert!(!r.success);
-        assert!(r.output.contains("not owned by this caller"), "got: {}", r.output);
+        assert!(
+            r.output.contains("not owned by this caller"),
+            "got: {}",
+            r.output
+        );
         assert!(!observer.is_cancelled(), "forbidden must NOT fire token");
     }
 
@@ -708,11 +716,13 @@ mod tests {
     #[tokio::test]
     async fn execute_wait_returns_completed_for_finished_agent() {
         let (agents, processes) = fresh_registries();
-        let (id, tx, status_tx, _) =
-            agents.register_test_with_status("explore", "map", None);
-        tx.send(Ok(("final answer".into(), vec!["e1".into()]))).unwrap();
+        let (id, tx, status_tx, _) = agents.register_test_with_status("explore", "map", None);
+        tx.send(Ok(("final answer".into(), vec!["e1".into()])))
+            .unwrap();
         status_tx
-            .send(AgentStatus::Completed { summary: "final".into() })
+            .send(AgentStatus::Completed {
+                summary: "final".into(),
+            })
             .unwrap();
 
         let r = execute(
@@ -740,8 +750,7 @@ mod tests {
         // Bind ALL four to keep the channels alive — if status_tx
         // drops, the watch sender is gone and `wait_for_terminal_status`
         // early-returns, surfacing as Cancelled instead of TimedOut.
-        let (id, _tx, _status_tx, _observer) =
-            agents.register_test_with_status("slow", "x", None);
+        let (id, _tx, _status_tx, _observer) = agents.register_test_with_status("slow", "x", None);
 
         let r = execute(
             "WaitTask",

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -38,7 +38,13 @@
 //! [`BgRegistry`]: crate::tools::bg_process::BgRegistry
 
 use crate::providers::ToolDefinition;
-use serde_json::json;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::bg_agent::{AgentStatus, BgAgentRegistry, BgAgentResult, BgTaskSnapshot, CancelOutcome, WaitOutcome};
+use crate::tools::bg_process::{BgProcessSnapshot, BgProcessStatus, BgRegistry, ProcessWaitOutcome};
+use crate::tools::ToolResult;
 
 /// Maximum `timeout_secs` a `WaitTask` call may request. Higher values
 /// are clamped down by the dispatch layer before reaching the registry.
@@ -219,6 +225,264 @@ pub fn clamp_wait_timeout_secs(requested: Option<u32>) -> u32 {
     raw.clamp(1, WAIT_TASK_MAX_TIMEOUT_SECS)
 }
 
+// ══ Execution ══════════════════════════════════════════════════════════════════════════════════════
+//
+// Dispatch entry point for the three Layer-2 tools. Called from
+// `tool_dispatch::execute_one_tool` when `tool_name` matches; never
+// goes through `ToolRegistry::execute()` because we need the
+// `Arc<BgAgentRegistry>` (not stored on the registry) and the caller's
+// spawner identity (only known at the dispatch layer).
+
+/// Render an [`AgentStatus`] as the lower-case status string we
+/// surface to the model. Stable strings — they're documented in the
+/// `ListBackgroundTasks` tool description and become part of the
+/// tool API surface.
+fn agent_status_str(s: &AgentStatus) -> &'static str {
+    match s {
+        AgentStatus::Pending => "pending",
+        AgentStatus::Running { .. } => "running",
+        AgentStatus::Completed { .. } => "completed",
+        AgentStatus::Errored { .. } => "errored",
+        AgentStatus::Cancelled => "cancelled",
+    }
+}
+
+/// Render a [`BgProcessStatus`] as the lower-case status string.
+fn process_status_str(s: &BgProcessStatus) -> &'static str {
+    match s {
+        BgProcessStatus::Running => "running",
+        BgProcessStatus::Exited { .. } => "exited",
+        BgProcessStatus::Killed => "killed",
+    }
+}
+
+fn agent_snapshot_to_json(s: &BgTaskSnapshot) -> Value {
+    json!({
+        "task_id": format!("agent:{}", s.task_id),
+        "task_type": "agent",
+        "description": format!("{}: {}", s.agent_name, s.prompt),
+        "status": agent_status_str(&s.status),
+        "age_secs": s.age.as_secs(),
+    })
+}
+
+fn process_snapshot_to_json(s: &BgProcessSnapshot) -> Value {
+    let mut obj = json!({
+        "task_id": format!("process:{}", s.pid),
+        "task_type": "process",
+        "description": s.command.clone(),
+        "status": process_status_str(&s.status),
+        "age_secs": s.age.as_secs(),
+    });
+    if let BgProcessStatus::Exited { code } = s.status {
+        obj.as_object_mut()
+            .unwrap()
+            .insert("exit_code".into(), json!(code));
+    }
+    obj
+}
+
+/// Helper for emitting an Err-shaped [`ToolResult`] with a model-readable
+/// message. The dispatch layer surfaces this back to the model as a
+/// failed tool call — same convention as every other tool.
+fn err(msg: impl Into<String>) -> ToolResult {
+    ToolResult {
+        output: msg.into(),
+        success: false,
+        full_output: None,
+    }
+}
+
+fn ok(value: Value) -> ToolResult {
+    ToolResult {
+        output: value.to_string(),
+        success: true,
+        full_output: None,
+    }
+}
+
+/// Dispatch a Layer-2 tool call. Returns a [`ToolResult`] in the same
+/// shape as `ToolRegistry::execute()` so the dispatch layer can plug
+/// it in without special-casing further.
+///
+/// `tool_name` must be one of `"ListBackgroundTasks"`, `"CancelTask"`,
+/// `"WaitTask"`. Any other name is a programmer error in the dispatch
+/// router — we return an `err` so it's loud-but-safe in production.
+pub async fn execute(
+    tool_name: &str,
+    arguments: &str,
+    bg_agents: &Arc<BgAgentRegistry>,
+    bg_processes: &BgRegistry,
+    caller_spawner: Option<u32>,
+) -> ToolResult {
+    match tool_name {
+        "ListBackgroundTasks" => execute_list(bg_agents, bg_processes, caller_spawner),
+        "CancelTask" => execute_cancel(arguments, bg_agents, bg_processes, caller_spawner),
+        "WaitTask" => execute_wait(arguments, bg_agents, bg_processes, caller_spawner).await,
+        other => err(format!(
+            "bg_task_tools::execute called with unknown tool '{other}' \
+             (router bug — should have matched in tool_dispatch)"
+        )),
+    }
+}
+
+fn execute_list(
+    bg_agents: &BgAgentRegistry,
+    bg_processes: &BgRegistry,
+    caller_spawner: Option<u32>,
+) -> ToolResult {
+    // Refresh process statuses so the model sees the latest exit codes.
+    bg_processes.reap();
+
+    let mut entries: Vec<Value> = bg_agents
+        .snapshot_for_caller(caller_spawner)
+        .iter()
+        .map(agent_snapshot_to_json)
+        .collect();
+    entries.extend(
+        bg_processes
+            .snapshot_for_caller(caller_spawner)
+            .iter()
+            .map(process_snapshot_to_json),
+    );
+    ok(Value::Array(entries))
+}
+
+fn execute_cancel(
+    arguments: &str,
+    bg_agents: &BgAgentRegistry,
+    bg_processes: &BgRegistry,
+    caller_spawner: Option<u32>,
+) -> ToolResult {
+    let args: Value = match serde_json::from_str(arguments) {
+        Ok(v) => v,
+        Err(e) => return err(format!("CancelTask: invalid JSON arguments: {e}")),
+    };
+    let task_id_str = match args.get("task_id").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return err("CancelTask: missing required 'task_id' (string)"),
+    };
+    let task_id = match parse_task_id(task_id_str) {
+        Ok(t) => t,
+        Err(e) => return err(format!("CancelTask: {e}")),
+    };
+
+    let outcome = match task_id {
+        TaskId::Agent(n) => bg_agents.cancel_as_caller(n, caller_spawner),
+        TaskId::Process(n) => bg_processes.kill_as_caller(n, caller_spawner),
+    };
+
+    match outcome {
+        CancelOutcome::Cancelled => ok(json!({
+            "task_id": task_id_str,
+            "cancelled": true,
+        })),
+        CancelOutcome::NotFound => err(format!(
+            "CancelTask: no background task with id '{task_id_str}' \
+             (already finished, never existed, or already drained)"
+        )),
+        CancelOutcome::Forbidden => err(format!(
+            "CancelTask: task '{task_id_str}' is not owned by this caller"
+        )),
+    }
+}
+
+async fn execute_wait(
+    arguments: &str,
+    bg_agents: &BgAgentRegistry,
+    bg_processes: &BgRegistry,
+    caller_spawner: Option<u32>,
+) -> ToolResult {
+    let args: Value = match serde_json::from_str(arguments) {
+        Ok(v) => v,
+        Err(e) => return err(format!("WaitTask: invalid JSON arguments: {e}")),
+    };
+    let task_id_str = match args.get("task_id").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return err("WaitTask: missing required 'task_id' (string)"),
+    };
+    let task_id = match parse_task_id(task_id_str) {
+        Ok(t) => t,
+        Err(e) => return err(format!("WaitTask: {e}")),
+    };
+    let timeout_secs = clamp_wait_timeout_secs(
+        args.get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32),
+    );
+    let timeout = Duration::from_secs(timeout_secs as u64);
+
+    match task_id {
+        TaskId::Agent(n) => {
+            let outcome = bg_agents
+                .wait_for_completion(n, caller_spawner, timeout)
+                .await;
+            agent_wait_to_tool_result(task_id_str, outcome)
+        }
+        TaskId::Process(n) => {
+            let outcome = bg_processes
+                .wait_for_exit_as_caller(n, caller_spawner, timeout)
+                .await;
+            process_wait_to_tool_result(task_id_str, outcome)
+        }
+    }
+}
+
+fn agent_wait_to_tool_result(task_id_str: &str, outcome: WaitOutcome) -> ToolResult {
+    match outcome {
+        WaitOutcome::Completed(BgAgentResult {
+            agent_name,
+            prompt,
+            output,
+            success,
+            events,
+        }) => ok(json!({
+            "task_id": task_id_str,
+            "status": if success { "completed" } else { "errored" },
+            "agent_name": agent_name,
+            "prompt": prompt,
+            "output": output,
+            "events": events,
+        })),
+        WaitOutcome::Cancelled => ok(json!({
+            "task_id": task_id_str,
+            "status": "cancelled",
+        })),
+        WaitOutcome::TimedOut(snap) => ok(json!({
+            "task_id": task_id_str,
+            "status": "timed_out",
+            "current": agent_snapshot_to_json(&snap),
+        })),
+        WaitOutcome::NotFound => err(format!(
+            "WaitTask: no background task with id '{task_id_str}'"
+        )),
+        WaitOutcome::Forbidden => err(format!(
+            "WaitTask: task '{task_id_str}' is not owned by this caller"
+        )),
+    }
+}
+
+fn process_wait_to_tool_result(task_id_str: &str, outcome: ProcessWaitOutcome) -> ToolResult {
+    match outcome {
+        ProcessWaitOutcome::Exited { code } => ok(json!({
+            "task_id": task_id_str,
+            "status": "exited",
+            "exit_code": code,
+        })),
+        ProcessWaitOutcome::TimedOut(snap) => ok(json!({
+            "task_id": task_id_str,
+            "status": "timed_out",
+            "current": process_snapshot_to_json(&snap),
+        })),
+        ProcessWaitOutcome::NotFound => err(format!(
+            "WaitTask: no background task with id '{task_id_str}'"
+        )),
+        ProcessWaitOutcome::Forbidden => err(format!(
+            "WaitTask: task '{task_id_str}' is not owned by this caller"
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,5 +575,198 @@ mod tests {
             clamp_wait_timeout_secs(Some(WAIT_TASK_MAX_TIMEOUT_SECS)),
             WAIT_TASK_MAX_TIMEOUT_SECS
         );
+    }
+
+    // ── execute() dispatch tests ─────────────────────────────────────────────────────
+
+    fn fresh_registries() -> (Arc<BgAgentRegistry>, BgRegistry) {
+        (Arc::new(BgAgentRegistry::new()), BgRegistry::new())
+    }
+
+    /// `ListBackgroundTasks` on empty registries returns `[]`, success.
+    #[tokio::test]
+    async fn execute_list_returns_empty_array_when_no_tasks() {
+        let (agents, processes) = fresh_registries();
+        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        assert!(r.success);
+        assert_eq!(r.output, "[]");
+    }
+
+    /// `ListBackgroundTasks` shows the caller's agent tasks with the
+    /// agreed-upon shape (prefixed task_id, lower-case status).
+    #[tokio::test]
+    async fn execute_list_includes_caller_agent_tasks() {
+        let (agents, processes) = fresh_registries();
+        let (id, _tx, _, _) =
+            agents.register_test_with_status("explore", "map repo", None);
+
+        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        assert!(r.success);
+        let arr: Value = serde_json::from_str(&r.output).unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["task_id"], format!("agent:{id}"));
+        assert_eq!(arr[0]["task_type"], "agent");
+        assert_eq!(arr[0]["status"], "pending");
+        assert_eq!(arr[0]["description"], "explore: map repo");
+    }
+
+    /// Caller scoping: a sub-agent caller (Some(7)) must not see the
+    /// top-level (None) task. Defence-in-depth on top of the
+    /// sub_agent_dispatch denylist.
+    #[tokio::test]
+    async fn execute_list_filters_out_other_callers_tasks() {
+        let (agents, processes) = fresh_registries();
+        agents.register_test_with_status("a", "top", None);
+        agents.register_test_with_status("b", "sub", Some(7));
+
+        let top = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        let arr: Value = serde_json::from_str(&top.output).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1, "top sees only its own");
+
+        let sub = execute("ListBackgroundTasks", "{}", &agents, &processes, Some(7)).await;
+        let arr: Value = serde_json::from_str(&sub.output).unwrap();
+        assert_eq!(arr.as_array().unwrap().len(), 1, "sub sees only its own");
+    }
+
+    /// `CancelTask` routes `agent:N` to BgAgentRegistry and reports
+    /// success in the structured payload.
+    #[tokio::test]
+    async fn execute_cancel_succeeds_for_owned_agent_task() {
+        let (agents, processes) = fresh_registries();
+        let (id, _tx, _, observer) =
+            agents.register_test_with_status("x", "y", None);
+
+        let r = execute(
+            "CancelTask",
+            &json!({ "task_id": format!("agent:{id}") }).to_string(),
+            &agents,
+            &processes,
+            None,
+        )
+        .await;
+        assert!(r.success, "got: {}", r.output);
+        assert!(observer.is_cancelled(), "cancel token must fire");
+        let payload: Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(payload["cancelled"], true);
+        assert_eq!(payload["task_id"], format!("agent:{id}"));
+    }
+
+    #[tokio::test]
+    async fn execute_cancel_returns_not_found_for_unknown_id() {
+        let (agents, processes) = fresh_registries();
+        let r = execute(
+            "CancelTask",
+            &json!({ "task_id": "agent:9999" }).to_string(),
+            &agents,
+            &processes,
+            None,
+        )
+        .await;
+        assert!(!r.success);
+        assert!(r.output.contains("no background task"), "got: {}", r.output);
+    }
+
+    #[tokio::test]
+    async fn execute_cancel_returns_forbidden_for_cross_caller() {
+        let (agents, processes) = fresh_registries();
+        let (id, _tx, _, observer) =
+            agents.register_test_with_status("x", "y", Some(5));
+
+        // Top-level (None) tries to cancel sub-agent 5's task.
+        let r = execute(
+            "CancelTask",
+            &json!({ "task_id": format!("agent:{id}") }).to_string(),
+            &agents,
+            &processes,
+            None,
+        )
+        .await;
+        assert!(!r.success);
+        assert!(r.output.contains("not owned by this caller"), "got: {}", r.output);
+        assert!(!observer.is_cancelled(), "forbidden must NOT fire token");
+    }
+
+    #[tokio::test]
+    async fn execute_cancel_rejects_malformed_json() {
+        let (agents, processes) = fresh_registries();
+        let r = execute("CancelTask", "not-json", &agents, &processes, None).await;
+        assert!(!r.success);
+        assert!(r.output.contains("invalid JSON"), "got: {}", r.output);
+    }
+
+    #[tokio::test]
+    async fn execute_cancel_rejects_missing_task_id() {
+        let (agents, processes) = fresh_registries();
+        let r = execute("CancelTask", "{}", &agents, &processes, None).await;
+        assert!(!r.success);
+        assert!(r.output.contains("missing required"), "got: {}", r.output);
+    }
+
+    /// `WaitTask` on a completed agent task returns `status:completed`
+    /// + the agent's output, and consumes the entry (drain sees nothing).
+    #[tokio::test]
+    async fn execute_wait_returns_completed_for_finished_agent() {
+        let (agents, processes) = fresh_registries();
+        let (id, tx, status_tx, _) =
+            agents.register_test_with_status("explore", "map", None);
+        tx.send(Ok(("final answer".into(), vec!["e1".into()]))).unwrap();
+        status_tx
+            .send(AgentStatus::Completed { summary: "final".into() })
+            .unwrap();
+
+        let r = execute(
+            "WaitTask",
+            &json!({ "task_id": format!("agent:{id}"), "timeout_secs": 1 }).to_string(),
+            &agents,
+            &processes,
+            None,
+        )
+        .await;
+        assert!(r.success, "got: {}", r.output);
+        let payload: Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(payload["status"], "completed");
+        assert_eq!(payload["output"], "final answer");
+        assert_eq!(payload["events"].as_array().unwrap().len(), 1);
+        // Consumed — not in registry anymore.
+        assert_eq!(agents.snapshot().len(), 0);
+    }
+
+    /// `WaitTask` timeout returns `status:timed_out` + a snapshot of
+    /// the still-running task.
+    #[tokio::test]
+    async fn execute_wait_returns_timed_out_with_snapshot() {
+        let (agents, processes) = fresh_registries();
+        // Bind ALL four to keep the channels alive — if status_tx
+        // drops, the watch sender is gone and `wait_for_terminal_status`
+        // early-returns, surfacing as Cancelled instead of TimedOut.
+        let (id, _tx, _status_tx, _observer) =
+            agents.register_test_with_status("slow", "x", None);
+
+        let r = execute(
+            "WaitTask",
+            // Timeout below 1s gets clamped to 1s by clamp_wait_timeout_secs;
+            // we still want the test to be fast — 1 s is the minimum the
+            // tool surface allows.
+            &json!({ "task_id": format!("agent:{id}"), "timeout_secs": 1 }).to_string(),
+            &agents,
+            &processes,
+            None,
+        )
+        .await;
+        assert!(r.success);
+        let payload: Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(payload["status"], "timed_out");
+        assert_eq!(payload["current"]["task_id"], format!("agent:{id}"));
+        // Entry preserved.
+        assert_eq!(agents.snapshot().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_tool_name_returns_error() {
+        let (agents, processes) = fresh_registries();
+        let r = execute("NotAToolWeKnow", "{}", &agents, &processes, None).await;
+        assert!(!r.success);
+        assert!(r.output.contains("unknown tool"));
     }
 }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -609,6 +609,10 @@ impl ToolRegistry {
         name: &str,
         arguments: &str,
         sink_for_streaming: Option<(&dyn crate::engine::EngineSink, &str)>,
+        // Phase E of #996: forwarded to `Bash` so that bg-shell
+        // entries are tagged with the calling agent's invocation id.
+        // Every other tool ignores this. Top-level callers pass `None`.
+        caller_spawner: Option<u32>,
     ) -> ToolResult {
         let raw = arguments.trim();
         let raw = if raw.is_empty() { "{}" } else { raw };
@@ -675,6 +679,7 @@ impl ToolRegistry {
                     self.sandbox_policy(),
                     self.proxy_port(),
                     self.socks5_port(),
+                    caller_spawner,
                 )
                 .await;
                 return match shell_result {

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -82,6 +82,13 @@ pub fn classify_tool(name: &str) -> ToolEffect {
         "WebSearch" => ToolEffect::ReadOnly,   // read-only search
         "InvokeAgent" => ToolEffect::ReadOnly, // sub-agents inherit parent's mode
 
+        // Background task management (Layer 2 of #996). ListBackgroundTasks
+        // is a pure read; CancelTask / WaitTask signal but don't write
+        // files — they're idempotent observation/control of work the
+        // model already started. Treating as ReadOnly avoids an approval
+        // prompt every time the model checks on a bg task.
+        "ListBackgroundTasks" | "CancelTask" | "WaitTask" => ToolEffect::ReadOnly,
+
         // Local mutations — write to filesystem or local state
         "Write" | "Edit" | "MemoryWrite" | "TodoWrite" => ToolEffect::LocalMutation,
 
@@ -119,6 +126,9 @@ pub fn is_mutating_tool(name: &str) -> bool {
 pub mod agent;
 pub mod ask_user;
 pub mod bg_process;
+/// Background-task management tools — `ListBackgroundTasks`,
+/// `CancelTask`, `WaitTask` (Layer 2 of #996).
+pub mod bg_task_tools;
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
 pub mod fuzzy;
@@ -301,6 +311,9 @@ impl ToolRegistry {
             definitions.insert(def.name.clone(), def);
         }
         for def in agent::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in bg_task_tools::definitions() {
             definitions.insert(def.name.clone(), def);
         }
         for def in ask_user::definitions() {

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -119,6 +119,16 @@ pub async fn run_shell_command(
     policy: &koda_sandbox::SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
+    // Phase E of #996: who invoked this Bash call? Threaded down to
+    // `spawn_background` so the bg-process registry entry is tagged
+    // with the right `spawner`. Without this, a sub-agent that calls
+    // `Bash{background:true}` and later tries to `CancelTask` its
+    // own process gets `Forbidden` because the entry is tagged with
+    // `None` while the caller is `Some(my_invocation_id)`.
+    //
+    // Top-level callers pass `None` and the entry is also tagged
+    // with `None` — the existing top-level happy path is preserved.
+    caller_spawner: Option<u32>,
 ) -> Result<ShellOutput> {
     let command = args["command"]
         .as_str()
@@ -139,6 +149,7 @@ pub async fn run_shell_command(
             policy,
             proxy_port,
             socks5_port,
+            caller_spawner,
         )?;
         return Ok(ShellOutput {
             summary: msg,
@@ -327,6 +338,7 @@ async fn read_streams(
 ///
 /// Returns immediately with PID + instructions. Sync because `spawn()` doesn't
 /// need to await — only `output()` / `wait()` block.
+#[allow(clippy::too_many_arguments)]
 fn spawn_background(
     project_root: &Path,
     command: &str,
@@ -335,6 +347,7 @@ fn spawn_background(
     policy: &koda_sandbox::SandboxPolicy,
     proxy_port: Option<u16>,
     socks5_port: Option<u16>,
+    caller_spawner: Option<u32>,
 ) -> Result<String> {
     // Spawn via sandbox wrapper (enforced for all trust modes).
     // Detach stdio so the process doesn't block on terminal I/O.
@@ -358,7 +371,7 @@ fn spawn_background(
         .id()
         .ok_or_else(|| anyhow::anyhow!("Spawned process has no PID (already exited)"))?;
 
-    bg.insert(pid, command.to_string(), child, None);
+    bg.insert(pid, command.to_string(), child, caller_spawner);
 
     Ok(format!(
         "Background process started.\n  PID:     {pid}\n  Command: {command}\n\
@@ -560,6 +573,7 @@ mod tests {
             &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -584,6 +598,7 @@ mod tests {
             &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -606,6 +621,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
             None,
             None,
         )
@@ -649,6 +665,7 @@ mod tests {
             &policy,
             None,
             None,
+            None,
         )
         .await
         .expect("shell command must succeed");
@@ -681,6 +698,7 @@ mod tests {
             &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -698,6 +716,47 @@ mod tests {
         assert_eq!(registry.len(), 1);
     }
 
+    /// Phase E of #996 regression: when a sub-agent (caller_spawner =
+    /// `Some(N)`) does `Bash{background:true}`, the bg-process entry
+    /// must be tagged with the same `Some(N)`. Without this fix, the
+    /// entry was hard-coded `None`, which meant the sub-agent's later
+    /// `CancelTask` / `WaitTask` (also `Some(N)`) would get
+    /// `Forbidden` because `None != Some(N)`.
+    ///
+    /// We assert at the registry level (`snapshot()` exposes the
+    /// `spawner` field) rather than driving CancelTask, because the
+    /// scoping check is what this PR fixes — the cancel mechanics are
+    /// already covered by `bg_process::tests::kill_as_caller_*`.
+    #[tokio::test]
+    async fn background_spawn_tags_entry_with_caller_spawner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let registry = BgRegistry::new();
+        let args = serde_json::json!({"command": "sleep 60", "background": true});
+        let _ = run_shell_command(
+            tmp.path(),
+            &args,
+            256,
+            &registry,
+            None,
+            &crate::trust::TrustMode::Safe,
+            &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
+            None,
+            Some(42), // sub-agent invocation id
+        )
+        .await
+        .unwrap();
+
+        let snap = registry.snapshot();
+        assert_eq!(snap.len(), 1, "one bg process expected");
+        assert_eq!(
+            snap[0].spawner,
+            Some(42),
+            "bg-process entry must carry the caller's spawner id so a \
+             same-spawner CancelTask doesn't get Forbidden"
+        );
+    }
+
     #[tokio::test]
     async fn background_false_runs_synchronously() {
         let tmp = tempfile::tempdir().unwrap();
@@ -710,6 +769,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
             None,
             None,
         )
@@ -842,6 +902,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
             None,
             None,
         )
@@ -977,6 +1038,7 @@ mod tests {
             &koda_sandbox::SandboxPolicy::strict_default(),
             None,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1076,6 +1138,7 @@ mod tests {
             None,
             &crate::trust::TrustMode::Safe,
             &koda_sandbox::SandboxPolicy::strict_default(),
+            None,
             None,
             None,
         )

--- a/koda-core/src/tools/shell.rs
+++ b/koda-core/src/tools/shell.rs
@@ -358,7 +358,7 @@ fn spawn_background(
         .id()
         .ok_or_else(|| anyhow::anyhow!("Spawned process has no PID (already exited)"))?;
 
-    bg.insert(pid, command.to_string(), child);
+    bg.insert(pid, command.to_string(), child, None);
 
     Ok(format!(
         "Background process started.\n  PID:     {pid}\n  Command: {command}\n\

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -69,6 +69,44 @@ pub async fn validate_tool_call(
     }
 }
 
+/// DRY wrapper: pull the three caches from a `ToolRegistry` and run
+/// the standard pre-flight validation against the given root.
+///
+/// Three call sites used to inline the same 9-line cache-pull-then-
+/// call-validate dance:
+///
+///   * `tool_dispatch::validate_then_execute_one_tool` (parallel +
+///     split-batch arms, validates after auto-approval)
+///   * `tool_dispatch::execute_tools_sequential` (sequential arm,
+///     validates before approval prompting so we don't bother the
+///     user with doomed prompts)
+///   * `sub_agent_dispatch::execute_sub_agent` (sub-agent loop,
+///     validates before per-tool approval branch)
+///
+/// `project_root` is taken explicitly because the sub-agent path
+/// validates against its (possibly worktree-shifted) effective root,
+/// not the registry's `project_root`. Everything else is mechanical
+/// cache plumbing that's identical across call sites.
+pub async fn validate_with_registry(
+    registry: &super::ToolRegistry,
+    tool_name: &str,
+    args: &serde_json::Value,
+    project_root: &Path,
+) -> Option<String> {
+    let read_cache = registry.file_read_cache();
+    let last_writer = registry.last_writer_cache();
+    let last_bash = registry.last_bash_cache();
+    validate_tool_call(
+        tool_name,
+        args,
+        project_root,
+        Some(&read_cache),
+        Some(&last_writer),
+        Some(&last_bash),
+    )
+    .await
+}
+
 /// Build a parenthetical hint describing what tool last modified a file.
 ///
 /// Priority:

--- a/koda-core/tests/builtin_proxy_e2e_test.rs
+++ b/koda-core/tests/builtin_proxy_e2e_test.rs
@@ -111,7 +111,7 @@ async fn bash_sees_proxy_env_pointing_at_session_proxy() {
     let result = session
         .agent
         .tools
-        .execute("Bash", r#"{"command":"echo \"$HTTPS_PROXY\""}"#, None)
+        .execute("Bash", r#"{"command":"echo \"$HTTPS_PROXY\""}"#, None, None)
         .await;
 
     assert!(
@@ -267,7 +267,7 @@ async fn macos_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -301,7 +301,7 @@ async fn macos_kernel_allows_tcp_to_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{proxy_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -369,7 +369,7 @@ async fn linux_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"bash -c 'if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -421,7 +421,7 @@ async fn linux_kernel_allows_tcp_to_proxy_port() {
     // verify /dev/tcp can reach it. Bash explicitly because
     // Ubuntu's /bin/sh is dash (no /dev/tcp, no `${var##*:}`).
     let cmd = r#"{"command":"bash -c 'port=\"${HTTPS_PROXY##*:}\"; if exec 3<>/dev/tcp/127.0.0.1/$port 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}"#;
-    let result = session.agent.tools.execute("Bash", cmd, None).await;
+    let result = session.agent.tools.execute("Bash", cmd, None, None).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -468,6 +468,7 @@ async fn curl_to_blocked_host_returns_403_via_proxy() {
         .execute(
             "Bash",
             r#"{"command":"curl --max-time 5 -sS -o /dev/null -w '%{http_code}\\n' https://blocked.test/ 2>&1; echo exit=$?"}"#,
+            None,
             None,
         )
         .await;

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -223,6 +223,7 @@ mod naming_convention {
         "ActivateSkill",
         "AskUser",
         "Bash",
+        "CancelTask",
         "Delete",
         "Edit",
         "Glob",
@@ -230,12 +231,14 @@ mod naming_convention {
         "InvokeAgent",
         "List",
         "ListAgents",
+        "ListBackgroundTasks",
         "ListSkills",
         "MemoryRead",
         "MemoryWrite",
         "Read",
         "RecallContext",
         "TodoWrite",
+        "WaitTask",
         "WebFetch",
         "WebSearch",
         "Write",
@@ -271,8 +274,9 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 22 built-in tools (AstAnalysis removed in #608, AskUser + WebSearch + TodoWrite added)
-        assert_eq!(BUILTIN_TOOLS.len(), 19);
+        // 22 built-in tools (#996 Layer 2 added ListBackgroundTasks,
+        // CancelTask, WaitTask — bringing 19 → 22).
+        assert_eq!(BUILTIN_TOOLS.len(), 22);
     }
 
     /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -38,7 +38,7 @@ async fn normalized_lowercase_names_are_routable() {
             registry.has_tool(&canonical),
             "Normalized '{raw_name}' -> '{canonical}' is not in the registry"
         );
-        let result = registry.execute(&canonical, "{}", None).await;
+        let result = registry.execute(&canonical, "{}", None, None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw_name}' normalized to '{canonical}' but dispatcher rejected it: {}",
@@ -74,7 +74,7 @@ async fn normalized_snake_case_names_are_routable() {
             canonical, expected,
             "'{raw}' should normalize to '{expected}', got '{canonical}'"
         );
-        let result = registry.execute(&canonical, "{}", None).await;
+        let result = registry.execute(&canonical, "{}", None, None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw}' -> '{canonical}' rejected by dispatcher: {}",

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -14,10 +14,23 @@ fn all_tool_names() -> Vec<String> {
 /// Every tool must be routable in the dispatcher.
 /// Tools handled externally (InvokeAgent) return sentinel strings.
 /// None should return "Unknown tool".
+///
+/// Exception (#996 Layer 2): the background-task management tools
+/// (`ListBackgroundTasks`, `CancelTask`, `WaitTask`) are intentionally
+/// not routed through `ToolRegistry::execute()` — they need an
+/// `Arc<BgAgentRegistry>` plus the caller's spawner identity, neither
+/// of which the `ToolRegistry` holds. They're routed one layer up in
+/// `tool_dispatch::execute_one_tool` (see the early `if matches!(...)
+/// branch there). Skipping them here keeps the test honest about what
+/// `ToolRegistry::execute()` is responsible for.
 #[tokio::test]
 async fn test_all_tools_routable_in_dispatcher() {
+    const HIGHER_LAYER_DISPATCH: &[&str] = &["ListBackgroundTasks", "CancelTask", "WaitTask"];
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for name in all_tool_names() {
+        if HIGHER_LAYER_DISPATCH.contains(&name.as_str()) {
+            continue;
+        }
         let result = registry.execute(&name, "{}", None, None).await;
         assert!(
             !result.output.contains("Unknown tool"),
@@ -103,6 +116,13 @@ fn test_classify_tool_covers_all_tools_explicitly() {
         ("WebFetch", ToolEffect::ReadOnly),
         ("WebSearch", ToolEffect::ReadOnly),
         ("InvokeAgent", ToolEffect::ReadOnly),
+        // Background-task management (#996 Layer 2). All three are
+        // ReadOnly: List is a pure read; Cancel/Wait signal but don't
+        // write files — idempotent control of work the model already
+        // started. See the matching arms in `tools::classify_tool`.
+        ("ListBackgroundTasks", ToolEffect::ReadOnly),
+        ("CancelTask", ToolEffect::ReadOnly),
+        ("WaitTask", ToolEffect::ReadOnly),
         // Local mutations
         ("Write", ToolEffect::LocalMutation),
         ("Edit", ToolEffect::LocalMutation),

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -18,7 +18,7 @@ fn all_tool_names() -> Vec<String> {
 async fn test_all_tools_routable_in_dispatcher() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for name in all_tool_names() {
-        let result = registry.execute(&name, "{}", None).await;
+        let result = registry.execute(&name, "{}", None, None).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "Tool '{name}' is not routed in the dispatcher (tools/mod.rs execute()). \
@@ -34,7 +34,7 @@ async fn test_all_tools_routable_in_dispatcher() {
 async fn test_empty_args_default_to_empty_object() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for input in ["", "  ", "\n", "\t "] {
-        let result = registry.execute("List", input, None).await;
+        let result = registry.execute("List", input, None, None).await;
         assert!(
             !result.output.contains("Invalid JSON"),
             "Empty args '{input:?}' should not produce a JSON parse error. Got: {}",


### PR DESCRIPTION
Closes part of #996.

## What this PR does

Adds three new LLM tools so the model can manage its own background work the same way a human does via `/agents` + `/cancel`:

| Tool | Purpose |
|------|---------|
| `ListBackgroundTasks` | Snapshot every running bg task (no args). |
| `CancelTask` | Cancel by `task_id` (cancel-token for agents, SIGTERM for processes). |
| `WaitTask` | Block until a task finishes, with a bounded timeout (default 30s, max 300s). |

Task IDs are prefixed strings — `agent:N` for `InvokeAgent { background: true }` tasks, `process:N` for `Bash { background: true }` PIDs — so the model can tell them apart at a glance and the tool dispatcher can route to the right registry.

This is **Layer 2** of the three-layer plan agreed in #996. Layers 0 + 1 (`AgentStatus` enum + `/agents` slash command) shipped via #1041 and #1042. **Phase E (sub-agent spawner threading) now also ships in this PR** — see below. Phases F (TUI unification) and G (docs + skill_scope) will follow as separate PRs.

## Model E permission rule

The registries enforce strict spawner-equality scoping (`None == None`, `Some(N) == Some(N)`):

- Top-level model can list/cancel/wait on top-level-spawned tasks
- **Sub-agent N can list/cancel/wait on its own tasks** (Phase E now wires the real `caller_spawner` end-to-end — see "Phase E" below)
- **Cross-spawner access returns `Forbidden`** — sub-agents can't reach across into siblings or the top-level

The unscoped `cancel()` / `snapshot()` methods stay on the registries for the TUI, on the principle that humans at the keyboard implicitly have full authority. LLM tools route through the `*_for_caller` / `*_as_caller` variants.

## Commits

The 11 commits are sequenced for review — each one ends in a workspace-wide green build (verified via `cargo check --workspace --tests` at every SHA, so bisect is friendly):

**Layer 2 core (parts 1–6 + fmt):**
1. `feat(#996): Layer 2 part 1 — spawner field on bg-agent registry`
2. `feat(#996): Layer 2 part 2 — scoped cancel + WaitOutcome on bg-agent registry`
3. `feat(#996): Layer 2 part 3 — process registry gets status, snapshot, kill, scoping`
4. `feat(#996): Layer 2 part 4 — bg_task_tools.rs definitions + parser`
5. `feat(#996): Layer 2 part 5 — bg-process wait_for_exit_as_caller`
6. `feat(#996): Layer 2 part 6 — Phase D dispatch wiring + sub-agent denylist`
7. `style(#996): cargo fmt across Layer 2 commits`

**Review-cycle follow-ups (added during PR review):**

8. `fix(#996): wait_for_completion race — await oneshot directly` — bug discovered while reviewing part 2. The terminal-status branch did `try_recv()` twice back-to-back with no `.await` between them, despite a comment promising "wait a few microseconds". On the multi-thread runtime the waiter could falsely return `Cancelled` for a successful task. Fix: `await` the `oneshot::Receiver` directly with a 50ms inner timeout. Includes a regression test that uses `yield_now()` between sends to reliably reproduce the old race.

9. `feat(#996): Phase E — thread caller_spawner + RAII cleanup` — completes the deferred Phase E work. Adds `caller_spawner: Option<u32>` to `execute_one_tool` / `validate_then_execute_one_tool` / `execute_tools_{parallel,split_batch,sequential}` / `execute_sub_agent`. Each `execute_sub_agent` invocation allocates a fresh `my_invocation_id` from a process-wide `AtomicU32` and threads it into every internal tool call. New `InvocationCleanup` RAII guard fires `cancel_for_spawner(my_invocation_id)` on sub-agent exit (covers iteration-cap returns and error returns). The temporary denylist that hid the bg-task tools from sub-agents is removed — Phase E makes the tools safe to expose. Three focused unit tests on the cleanup guard.

10. `refactor(#996): DRY pre-flight validation — validate_with_registry` — three call sites (`validate_then_execute_one_tool`, `execute_tools_sequential`, `execute_sub_agent`) all inlined the same 9-line cache-pull-then-validate block. Replaced with a single `validate_with_registry(registry, name, args, project_root)` helper. No behaviour change.

11. `fix(#996): bg-shell entry now tagged with caller_spawner` — bug discovered while finishing Phase E. `shell::spawn_background` was hard-coding `bg.insert(... None)`, so a sub-agent doing `Bash{background:true}` created an entry tagged `spawner=None` while the sub-agent's own `CancelTask`/`WaitTask` arrived with `caller_spawner=Some(N)`. `bg_process::kill_as_caller` then returned `Forbidden` — sub-agents could not cancel their own bg shell processes. Threaded `caller_spawner` through `tools.execute` → `run_shell_command` → `spawn_background` → `bg.insert`. Includes a registry-level regression test.

Suggested review order: read each commit's body — they're written as PR-quality narratives, not just titles.

## Phase E (now shipped in this PR)

Phase E was originally deferred and replaced with a temporary denylist (parts 6 + 7 hid the three new tools from sub-agents to prevent Model-E violations). After review feedback this turned out to be a bigger gap than expected — without Phase E, sub-agents had **zero** ability to manage their own background work, which defeats most of the point of bg-task tools.

What Phase E adds:

- **Process-wide `AtomicU32` invocation-id allocator** in `sub_agent_dispatch.rs` (`next_invocation_id()`). Each `execute_sub_agent` call draws a fresh id.
- **Caller-spawner threading** through every tool-dispatch path. The id flows: `execute_one_tool(caller_spawner=Some(N))` → `bg_task_tools::execute(caller_spawner=Some(N))` → `snapshot_for_caller / cancel_as_caller / wait_for_completion(caller_spawner=Some(N))`.
- **Bg-sub-agent reservations** are now tagged with the *caller's* spawner id (the parent owns the right to wait/cancel its bg children).
- **Bg-shell entries** are tagged with the calling agent's invocation id (commit 11 fix).
- **`InvocationCleanup` RAII guard** reaps any orphaned bg children when a sub-agent exits (iteration cap, error, panic — Drop runs in all cases).
- **Denylist removed** — sub-agents can now use `ListBackgroundTasks` / `CancelTask` / `WaitTask` directly.

## JSON output shapes (model-facing API)

```text
ListBackgroundTasks → [
  { task_id: "agent:N",   task_type: "agent",   description, status, age_secs },
  { task_id: "process:N", task_type: "process", description, status, age_secs, exit_code? },
  ...
]

CancelTask → { task_id, cancelled: true }                                   on success
           → error message                                                   on NotFound / Forbidden / parse failure

WaitTask   → { task_id, status: "completed", agent_name, prompt, output, events }   agent terminal-success
           → { task_id, status: "cancelled" }                                       agent terminal-cancel
           → { task_id, status: "timed_out", current: <snapshot> }                  timeout (entry preserved)
           → { task_id, status: "exited", exit_code }                               process exit
           → error message                                                          NotFound / Forbidden / parse failure
```

## Test coverage

`koda-core` lib suite: **1102 → 1107 passing.** No regressions; **47 new tests** total (42 from the original 7 commits + 5 from the review-cycle follow-ups).

| Area | New tests |
|------|-----------|
| `bg_agent` scoped APIs | 9 (filter, forbidden cancel, NotFound, cleanup-on-exit, wait completed/timed-out/forbidden/cancelled/not-found) |
| `bg_agent` race regression (commit 8) | 1 (multi-thread runtime + `yield_now` between sends) |
| `bg_process` registry | 7 (insert, scoped snapshot, reap, kill, scoped kill, kill-for-spawner) |
| `bg_process` wait | 5 (exited, killed-already, timed-out, forbidden, not-found) |
| `bg_task_tools` parser | 10 (definitions surface, prefix parsing, bare-numeric back-compat, malformed input, timeout clamp) |
| `bg_task_tools` dispatch | 11 (empty list, formatting, scoping, cancel success/NotFound/Forbidden/malformed/missing-id, wait completion/timeout, unknown tool) |
| `InvocationCleanup` guard (commit 9) | 3 (matching spawner reaped, sibling/top-level untouched, no-matching no-op) |
| `shell` bg-spawner regression (commit 11) | 1 (registry entry carries `Some(N)` spawner tag) |

Full workspace `cargo test --workspace --lib` green. `cargo clippy --workspace --tests` clean. `cargo fmt` clean.

## What's deferred (will follow as separate PRs)

- ~~**Phase E — spawner threading.**~~ ✅ **Shipped in this PR** (see Phase E section above).
- **Phase F — TUI unification.** `/agents` currently shows only agent tasks; should grow to show processes too. `/cancel` parser already accepts bare numeric (back-compat) but should learn `agent:`/`process:` prefixes.
- **Phase G — docs + skill_scope.** DESIGN.md update, skill_scope entries for the three new tools, system-prompt hints in the bg-agent guidance.

## Anti-patterns deliberately avoided

- **Did not** capture process stdout/stderr in the registry. The model can redirect to a file inside the command (`Bash { command: "cmd > /tmp/out.log 2>&1", background: true }`) and `Read` it. Keeps the registry small and avoids unbounded memory growth.
- **Did not** purge exited processes automatically. They linger in `BgRegistry` so `ListBackgroundTasks` / `WaitTask` can still surface the exit code. Sessions are short; auto-purge can come later.
- **Did not** share the `WaitOutcome` enum between agent and process paths. Tried it; ended up optionalizing fields that aren't optional in their natural domain. Two narrow enums + a small `match` in the dispatch layer reads better.
- **Did not** add `caller_spawner` to every tool's individual handler signature. Phase E threads it only through `ToolRegistry::execute` (where `Bash` consumes it) and the LLM-tool dispatch layer (where `bg_task_tools` consumes it). Every other tool ignores it. Avoids touching ~20 tool-handler signatures for a value 18 of them don't care about.
