### PR TITLE
chore: release v0.2.19 — fix crates.io publish pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,13 @@ jobs:
       - name: Check tag matches workspace versions
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
+          SANDBOX_VER=$(grep '^version' koda-sandbox/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CORE_VER=$(grep '^version' koda-core/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           CLI_VER=$(grep '^version' koda-cli/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG" != "$SANDBOX_VER" ]; then
+            echo "::error::Tag v$TAG does not match koda-sandbox version $SANDBOX_VER"
+            exit 1
+          fi
           if [ "$TAG" != "$CORE_VER" ]; then
             echo "::error::Tag v$TAG does not match koda-core version $CORE_VER"
             exit 1
@@ -38,7 +43,7 @@ jobs:
             echo "::error::Tag v$TAG does not match koda-cli version $CLI_VER"
             exit 1
           fi
-          echo "✅ Tag v$TAG matches koda-core ($CORE_VER) and koda-cli ($CLI_VER)"
+          echo "✅ Tag v$TAG matches koda-sandbox ($SANDBOX_VER), koda-core ($CORE_VER), koda-cli ($CLI_VER)"
 
 
   # Security audit — run after version is verified but before burning
@@ -132,7 +137,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      # Publish order follows dependency graph: koda-core → koda-cli.
+      # Publish order follows dependency graph: koda-sandbox → koda-core → koda-cli.
+      # Each crate waits for its dep to appear in the sparse index before publishing,
+      # otherwise cargo resolve will fail with "no matching version".
+      - name: Publish koda-sandbox
+        run: cargo publish -p koda-sandbox
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Wait for koda-sandbox in sparse index
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          URL="https://index.crates.io/ko/da/koda-sandbox"
+          echo "Polling $URL for koda-sandbox $VERSION ..."
+          for i in $(seq 1 20); do
+            if curl -sf "$URL" | grep -q "\"vers\":\"${VERSION}\""; then
+              echo "✅ koda-sandbox $VERSION is in the index (attempt $i)"
+              exit 0
+            fi
+            echo "  attempt $i/20 — not yet, sleeping 15s"
+            sleep 15
+          done
+          echo "⚠️ timed out after 300s — koda-sandbox $VERSION may still propagate"
       - name: Publish koda-core
         run: cargo publish -p koda-core
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.19] - 2026-04-26
+
+Infrastructure release. Fixes the crates.io publish pipeline that was
+broke in v0.2.18, and supersedes that release. No API or behaviour changes.
+
+> **v0.2.18 note:** the GitHub Release binaries for v0.2.18 are correct and
+> usable, but `koda-core` and `koda-cli` were never published to crates.io
+> (`cargo publish` died because `koda-sandbox` lacked a `version` field).
+> v0.2.18 has been marked pre-release on GitHub to avoid confusion.
+> `cargo install koda-cli` will install v0.2.19.
+
+### Fixed
+
+- **`koda-sandbox` missing `version` in `koda-core` dependency caused
+  `cargo publish` to fail** (#1052). `koda-core/Cargo.toml` declared
+  `koda-sandbox = { path = "../koda-sandbox" }` with no `version`. When
+  cargo publishes and strips `path`, it has no constraint to substitute and
+  rejects the manifest outright. Fixed by:
+  1. Removing `publish = false` from `koda-sandbox/Cargo.toml` — the crate
+     is now a first-class published workspace member.
+  2. Bumping `koda-sandbox` from `0.1.0` to match the workspace version
+     (`0.2.19`) so all three crates are versioned in lockstep.
+  3. Adding `version = "0.2.19"` to the `koda-sandbox` dep in
+     `koda-core/Cargo.toml`.
+  4. Expanding `release.yml` `verify-version` to check `koda-sandbox`
+     alongside `koda-core` and `koda-cli`.
+  5. Prepending a `Publish koda-sandbox` + sparse-index-wait step to the
+     `publish` job so the dep is in the registry before `koda-core` resolves
+     it.
+
 ## [0.2.18] - 2026-04-26
 
 Large architectural release with two main threads: a full kernel-sandbox

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.18)
+10. Sync version with workspace (currently 0.2.19)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.1.0"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 description = "A high-performance AI coding agent for macOS and Linux"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.18" }
+koda-core = { path = "../koda-core", version = "0.2.19" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -78,6 +78,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.18", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.19", features = ["test-support"] }
 serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license = "MIT"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.19" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
 name = "koda-sandbox"
-version = "0.1.0"
+version = "0.2.19"
 edition = "2024"
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/lijunzh/koda"
-publish = false
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Fixes #1052. Supersedes v0.2.18 (binaries were fine; crates.io publish never landed).

## What broke in v0.2.18

`koda-core/Cargo.toml` declared `koda-sandbox` as a path-only dep with no `version`:
```toml
koda-sandbox = { path = "../koda-sandbox" }  # ← no version
```
When `cargo publish -p koda-core` strips the `path` key, it has nothing left to resolve against the registry → exit 101.

## Changes

| File | Change |
|---|---|
| `koda-sandbox/Cargo.toml` | Version `0.1.0` → `0.2.19`; removed `publish = false` |
| `koda-core/Cargo.toml` | `koda-sandbox` dep gains `version = "0.2.19"` |
| `koda-cli/Cargo.toml` | Version bump `0.2.18` → `0.2.19`, `koda-core` pin updated |
| `release.yml` | `verify-version` now checks all 3 crates incl. `koda-sandbox`; publish job prepends `koda-sandbox` step + sparse-index wait |
| `CHANGELOG.md` | v0.2.19 entry + v0.2.18 supersession note |

## Publish order after this fix
```
koda-sandbox 0.2.19  →  (sparse index wait)
koda-core    0.2.19  →  (sparse index wait)
koda-cli     0.2.19
```

Closes #1052