### PR TITLE
fix(#1054): validate sub-agent session_id before INSERT to avoid raw FK error

### DIFF
--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -171,6 +171,19 @@ impl Persistence for Database {
         Ok(id)
     }
 
+    /// #1054: cheap existence check for sub-agent dispatch validation.
+    ///
+    /// `SELECT 1 ... LIMIT 1` over the primary key — a single index probe,
+    /// no row materialisation. Hot path: every `InvokeAgent` call that
+    /// passes a `session_id` runs this once before the FK-bearing INSERT.
+    async fn session_exists(&self, session_id: &str) -> Result<bool> {
+        let row: Option<(i64,)> = sqlx::query_as("SELECT 1 FROM sessions WHERE id = ? LIMIT 1")
+            .bind(session_id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.is_some())
+    }
+
     /// Insert a message into the conversation log.
     async fn insert_message(
         &self,

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -43,6 +43,45 @@ async fn test_create_session() {
     assert!(!id.is_empty());
 }
 
+/// **#1054**: `session_exists` is the cheap pre-INSERT validator the
+/// sub-agent dispatch path uses to reject hallucinated `session_id`
+/// arguments before they trip the `messages.session_id → sessions.id`
+/// FK and surface SQLite error 787 to the model.
+///
+/// Pin the three behaviours we depend on:
+///
+/// 1. Returns `true` for a freshly-created session.
+/// 2. Returns `false` for a syntactically-valid-but-unknown UUID.
+/// 3. Returns `false` for a deleted session (covers the "session was
+///    purged between turns" case from the issue).
+#[tokio::test]
+async fn test_session_exists() {
+    let (db, _tmp) = setup().await;
+
+    // 1. Fresh session is found.
+    let id = db.create_session("default", _tmp.path()).await.unwrap();
+    assert!(
+        db.session_exists(&id).await.unwrap(),
+        "freshly-created session must be found"
+    );
+
+    // 2. Unknown UUID is rejected (the hallucination case).
+    assert!(
+        !db.session_exists("deadbeef-0000-0000-0000-000000000000")
+            .await
+            .unwrap(),
+        "unknown session_id must return false (the FK-error case)"
+    );
+
+    // 3. Deleted session is rejected (the purge case).
+    let deleted = db.create_session("default", _tmp.path()).await.unwrap();
+    assert!(db.delete_session(&deleted).await.unwrap());
+    assert!(
+        !db.session_exists(&deleted).await.unwrap(),
+        "deleted session_id must return false"
+    );
+}
+
 #[tokio::test]
 async fn test_insert_and_load_messages() {
     let (db, _tmp) = setup().await;

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -192,6 +192,15 @@ pub trait Persistence: Send + Sync {
 
     /// Create a new session, returning its unique ID.
     async fn create_session(&self, agent_name: &str, project_root: &Path) -> Result<String>;
+    /// Returns `true` if a session row with the given ID exists.
+    ///
+    /// Used by sub-agent dispatch (#1054) to validate caller-supplied
+    /// `session_id` arguments before issuing INSERTs that would otherwise
+    /// trip the `messages.session_id → sessions.id` FOREIGN KEY constraint
+    /// and surface a raw SQLite error to the model. Implementations should
+    /// hit the `sessions` table directly — do **not** rely on side effects
+    /// of other queries.
+    async fn session_exists(&self, session_id: &str) -> Result<bool>;
     /// List recent sessions for the given project root.
     async fn list_sessions(&self, limit: i64, project_root: &Path) -> Result<Vec<SessionInfo>>;
     /// Delete a session by ID. Returns `true` if it existed.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -513,7 +513,27 @@ pub(crate) fn execute_sub_agent<'a>(
         };
 
         let sub_session = match session_id {
-            Some(id) => id,
+            Some(id) => {
+                // **#1054**: validate caller-supplied `session_id` before any
+                // INSERT against `messages` — the FK
+                // (`messages.session_id → sessions.id`) would otherwise raise
+                // SQLite error 787 and surface as a raw
+                // "FOREIGN KEY constraint failed" string to the model.
+                // Models (especially when fanning out parallel `InvokeAgent`
+                // calls) sometimes hallucinate a UUID, copy one from another
+                // context, or pass an ID for a session that has been purged.
+                // Treat that as a structural failure and return the standard
+                // `[ERROR: sub-agent ...]` marker so the model re-strategizes
+                // the same way it does for an iteration-cap or workspace
+                // failure (see `iteration_cap_marker` /
+                // `workspace_provision_failure_marker`).
+                if !db.session_exists(&id).await? {
+                    let marker = unknown_session_marker(agent_name, &id);
+                    sub_agent_cache.put(agent_name, prompt, &marker);
+                    return Ok(marker);
+                }
+                id
+            }
             None => {
                 let sid = db
                     .create_session(&sub_config.agent_name, project_root)
@@ -1147,6 +1167,26 @@ fn workspace_provision_failure_marker(agent_name: &str, reason: &str) -> String 
     )
 }
 
+/// **#1054**: structural-failure marker returned when the caller supplies
+/// a `session_id` that doesn't exist in the `sessions` table.
+///
+/// Pre-fix the dispatch path passed the unknown ID straight into
+/// `insert_message`, hitting the `messages.session_id → sessions.id` FK and
+/// surfacing SQLite error 787 ("FOREIGN KEY constraint failed") as the
+/// tool-call result — a string the model has no idea what to do with.
+///
+/// Same `[ERROR:` prefix as the other markers in this file so the model
+/// treats it as structural metadata rather than a sub-agent answer, and
+/// includes the bad ID + a concrete remediation hint ("omit `session_id`").
+fn unknown_session_marker(agent_name: &str, session_id: &str) -> String {
+    format!(
+        "[ERROR: sub-agent '{agent_name}' was passed an unknown session_id '{session_id}' that \
+         does not exist. Only pass a session_id returned by a prior InvokeAgent call in this \
+         conversation — never invent one. Omit the `session_id` argument to start a fresh \
+         sub-agent session.]"
+    )
+}
+
 #[cfg(test)]
 mod b18_tests {
     //! **#1022 B18** regression tests for the iteration-cap marker.
@@ -1347,6 +1387,114 @@ mod b21_tests {
     #[test]
     fn marker_is_single_line() {
         let m = workspace_provision_failure_marker("writer", "clonefile: ENOTSUP");
+        assert!(
+            !m.contains('\n'),
+            "marker must be single-line for clean tool-result formatting; got:\n{m}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod issue_1054_tests {
+    //! **#1054** regression tests for the unknown-`session_id` marker.
+    //!
+    //! Pre-fix: when the model passed an `InvokeAgent { session_id: ... }`
+    //! whose ID didn't exist in `sessions` (hallucinated UUID, copy-paste
+    //! from another context, purged session), the dispatch path passed the
+    //! ID straight into `insert_message` and the call surfaced the raw
+    //! SQLite error 787 ("FOREIGN KEY constraint failed") as the tool
+    //! result. The model has no way to recover from that string.
+    //!
+    //! Fix: validate `session_id` via `Persistence::session_exists` before
+    //! the FK-bearing INSERT and return the standard `[ERROR: sub-agent
+    //! ...]` marker so the model re-strategizes the same way it does for
+    //! iteration-cap and workspace-provision failures.
+    //!
+    //! These tests pin the *contract* of the marker (not its exact
+    //! wording):
+    //!
+    //! - `[ERROR:` prefix so the model treats it as structural failure.
+    //! - The agent name appears so multi-agent flows can disambiguate.
+    //! - The bad session_id appears so the parent can see what was
+    //!   rejected (helps debug the hallucination if it recurs).
+    //! - A re-strategize hint that mentions omitting `session_id` — the
+    //!   actually-correct next step in 99% of cases.
+    //! - Single-line so it formats cleanly as a tool result.
+    //!
+    //! End-to-end coverage of the dispatch short-circuit (validate →
+    //! cache → return) requires standing up the full sub-agent harness
+    //! with a mock `Persistence`. The unit-level coverage here plus the
+    //! `Persistence::session_exists` test in the db tests module is the
+    //! regression net; behavioural integration is verified by manual
+    //! repro of the `minimax-m2.7` parallel-fanout case from the issue.
+
+    use super::unknown_session_marker;
+
+    #[test]
+    fn marker_has_error_prefix() {
+        let m = unknown_session_marker("explore", "deadbeef-0000-0000-0000-000000000000");
+        assert!(
+            m.starts_with("[ERROR:"),
+            "marker must start with `[ERROR:` so the model treats it as \
+             structural failure metadata, not a sub-agent answer; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_includes_agent_name() {
+        let m = unknown_session_marker("explore", "deadbeef-0000-0000-0000-000000000000");
+        assert!(
+            m.contains("'explore'"),
+            "marker must name the sub-agent so multi-agent fanouts can \
+             disambiguate which call was rejected; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_includes_bad_session_id() {
+        // Surfacing the rejected ID makes the failure traceable when
+        // it recurs — e.g. a model keeps inventing the same UUID
+        // across turns.
+        let bad = "deadbeef-0000-0000-0000-000000000000";
+        let m = unknown_session_marker("explore", bad);
+        assert!(
+            m.contains(bad),
+            "marker must include the rejected session_id verbatim so it's \
+             diagnosable; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_tells_model_to_omit_session_id() {
+        // The actually-correct fix in nearly every case is "don't pass
+        // session_id at all" — the model rarely has a legitimate prior
+        // sub-agent session to continue. The hint must spell that out.
+        let m = unknown_session_marker("explore", "x");
+        let lower = m.to_lowercase();
+        assert!(
+            lower.contains("omit") && lower.contains("session_id"),
+            "marker must tell the model to omit `session_id` to start a \
+             fresh session; got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_warns_against_inventing_ids() {
+        // The other failure mode is the model continuing to hallucinate
+        // IDs. Make the "don't invent" rule explicit so the model has
+        // a clear constraint to follow on retry.
+        let m = unknown_session_marker("explore", "x");
+        let lower = m.to_lowercase();
+        assert!(
+            lower.contains("never invent") || lower.contains("do not invent"),
+            "marker must warn against inventing session_ids on retry; \
+             got: {m}"
+        );
+    }
+
+    #[test]
+    fn marker_is_single_line() {
+        let m = unknown_session_marker("explore", "deadbeef-0000-0000-0000-000000000000");
         assert!(
             !m.contains('\n'),
             "marker must be single-line for clean tool-result formatting; got:\n{m}"

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -79,7 +79,12 @@ Key rules:
                     },
                     "session_id": {
                         "type": "string",
-                        "description": "Optional session ID to continue a previous sub-agent conversation"
+                        "description": "Optional. Continue a previous sub-agent conversation. \
+                            ONLY pass an ID that was returned by a prior InvokeAgent call in \
+                            this same conversation — never invent, guess, or copy one from \
+                            another context. Omit this argument to start a fresh sub-agent \
+                            session (the common case). Unknown IDs are rejected with an \
+                            [ERROR: sub-agent ...] marker."
                     },
                     "background": {
                         "type": "boolean",


### PR DESCRIPTION
Fixes #1054.

## Problem

When the model invoked `InvokeAgent` with a `session_id` argument that didn't exist in the `sessions` table — most often a hallucinated UUID during parallel fan-out, but also a copy from another context or an ID that had been purged — the dispatch path passed the ID straight into `Persistence::insert_message`. The `messages.session_id → sessions.id` FK then raised SQLite error 787 and the user-facing tool result was:

```
Error invoking sub-agent: error returned from database: (code: 787) FOREIGN KEY constraint failed
```

The model has no recovery strategy for that string. Reproduction with `minimax-m2.7` fanning out three parallel `InvokeAgent` calls failed three-for-three.

## Fix

1. **Add `Persistence::session_exists`** — a cheap `SELECT 1 FROM sessions WHERE id = ? LIMIT 1` (single index probe, no row materialisation). Hot path: every `InvokeAgent` call that supplies a `session_id` runs this once before the FK-bearing INSERT.

2. **Validate `session_id` in `execute_sub_agent`** — at the top of the `Some(id)` branch in `koda-core/src/sub_agent_dispatch.rs`. On miss, return the standard `[ERROR: sub-agent ...]` marker (cached, same as the other structural-failure markers) so the model treats it as metadata and re-strategizes — same contract `iteration_cap_marker` and `workspace_provision_failure_marker` already use. The marker explicitly tells the model to omit `session_id` to start a fresh session, and warns against inventing IDs on retry.

3. **Tighten the `InvokeAgent` schema** — the `session_id` description now says it must only be an ID returned by a prior `InvokeAgent` call in the same conversation, never invented or copied, and that omitting the argument is the right move for a fresh sub-agent session.

## Tests

- `db::tests::test_session_exists` — pins the three behaviours we depend on:
  - fresh session found,
  - unknown UUID rejected,
  - deleted session rejected (the post-purge case from the issue).
- `sub_agent_dispatch::issue_1054_tests` — six contract tests for the new marker (`[ERROR:` prefix, agent name, bad id, omit-hint, no-invent warning, single-line) following the same pattern as the existing `b18_tests` (iteration cap) and `b21_tests` (workspace provision).

```
running 7 tests
test sub_agent_dispatch::issue_1054_tests::marker_has_error_prefix ... ok
test sub_agent_dispatch::issue_1054_tests::marker_warns_against_inventing_ids ... ok
test sub_agent_dispatch::issue_1054_tests::marker_includes_agent_name ... ok
test sub_agent_dispatch::issue_1054_tests::marker_is_single_line ... ok
test sub_agent_dispatch::issue_1054_tests::marker_includes_bad_session_id ... ok
test sub_agent_dispatch::issue_1054_tests::marker_tells_model_to_omit_session_id ... ok
test db::tests::test_session_exists ... ok

test result: ok. 7 passed; 0 failed
```

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the full `cargo test --workspace --features koda-core/test-support` all pass on this branch (modulo two pre-existing `koda-cli/src/transcript.rs` failures that also fail on `main` and are unrelated to this change).

## Out of scope

End-to-end coverage of the dispatch short-circuit (validate → cache → return) requires a mock `Persistence` injection point that doesn't exist on the public seam yet. The unit-level coverage above plus the manual repro from the issue is the regression net for now.