### PR TITLE
fix(#1045): remove dead session_id parameter from InvokeAgent

### DIFF
--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -280,7 +280,6 @@ pub(crate) fn execute_sub_agent<'a>(
         let prompt = args["prompt"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
-        let session_id = args["session_id"].as_str().map(|s| s.to_string());
         let is_fork = agent_name == "fork";
         let background = args["background"].as_bool().unwrap_or(false);
 
@@ -392,11 +391,9 @@ pub(crate) fn execute_sub_agent<'a>(
             bg: bg_agents,
             invocation_id: my_invocation_id,
         };
-        // Check result cache (only for stateless calls without a session_id,
-        // since session continuations need fresh execution).
-        if session_id.is_none()
-            && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
-        {
+        // Check result cache — identical (agent_name, prompt) pairs hit
+        // a cache and skip the LLM call. Cheap to retry idempotent tasks.
+        if let Some(cached) = sub_agent_cache.get(agent_name, prompt) {
             sink.emit(EngineEvent::Info {
                 message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
             });
@@ -512,27 +509,24 @@ pub(crate) fn execute_sub_agent<'a>(
             cfg
         };
 
-        let sub_session = match session_id {
-            Some(id) => id,
-            None => {
-                let sid = db
-                    .create_session(&sub_config.agent_name, project_root)
-                    .await?;
-                // Fork: copy parent conversation history into the new session.
-                //
-                // **#1022 B20**: was a per-row loop — N×(`insert_message`
-                // + `mark_message_complete` for assistant rows), each
-                // call its own fsync, on the synchronous fork hot path.
-                // For a 200-message parent that's ~600 round-trips and
-                // hundreds of ms of disk wait. Now a single transaction
-                // via `copy_messages_into_session` (one fsync at COMMIT,
-                // `completed_at` written inline for assistant rows).
-                if is_fork {
-                    let parent_history = db.load_context(parent_session_id).await?;
-                    db.copy_messages_into_session(&sid, &parent_history).await?;
-                }
-                sid
+        let sub_session = {
+            let sid = db
+                .create_session(&sub_config.agent_name, project_root)
+                .await?;
+            // Fork: copy parent conversation history into the new session.
+            //
+            // **#1022 B20**: was a per-row loop — N×(`insert_message`
+            // + `mark_message_complete` for assistant rows), each
+            // call its own fsync, on the synchronous fork hot path.
+            // For a 200-message parent that's ~600 round-trips and
+            // hundreds of ms of disk wait. Now a single transaction
+            // via `copy_messages_into_session` (one fsync at COMMIT,
+            // `completed_at` written inline for assistant rows).
+            if is_fork {
+                let parent_history = db.load_context(parent_session_id).await?;
+                db.copy_messages_into_session(&sid, &parent_history).await?
             }
+            sid
         };
 
         db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -77,10 +77,6 @@ Key rules:
                         "type": "string",
                         "description": "The task to delegate to the sub-agent"
                     },
-                    "session_id": {
-                        "type": "string",
-                        "description": "Optional session ID to continue a previous sub-agent conversation"
-                    },
                     "background": {
                         "type": "boolean",
                         "description": "Run in background and return immediately (default: false). \


### PR DESCRIPTION
## Problem

`InvokeAgent` had an optional `session_id` parameter described as _"continue a previous sub-agent conversation"_. It was never wired end-to-end: `InvokeAgent` returns plain text, so the model is never shown a sub-agent session UUID and can only populate this field by **hallucinating** one. Hallucinated UUIDs hit a raw SQLite FK constraint error that was surfaced verbatim to the model.

PR #1055 (now closed) tried to fix this with validation. After surveying Claude Code, Codex, Gemini CLI, and Zed, validation was identified as a bandaid over the wrong thing — the parameter itself is the problem.

## Root cause analysis

**Codex** (the only reference that lets the model reference an agent by ID) does it correctly: `spawn_agent` returns `{ agent_id, nickname }` in a typed `output_schema`. The model reads the ID from the tool result — it never invents one. `resume_agent` then takes that system-issued ID.

**Claude Code, Gemini CLI, and Zed** manage session state entirely host-side; the model never touches an ID.

Koda's `session_id` had no such contract. `InvokeAgent` returns a plain string, so the model could never legitimately populate the field.

## Why `session_id` is not needed

| Use case | How koda actually handles it |
|---|---|
| Parallel fan-out | Model emits multiple `InvokeAgent` calls; each gets a fresh `create_session()` |
| Background agents | Tracked by `task_id` (`"agent:N"`) via `BgAgentRegistry`; managed by `ListBackgroundTasks` / `WaitTask` / `CancelTask` |
| Fork mode | Always creates a fresh session, copies parent history via `copy_messages_into_session()` |
| Session continuation | Was the _intent_ of `session_id` — never wired up, the UUID was never returned to the model |

## Changes

- **`tools/agent.rs`**: remove `session_id` property from the `InvokeAgent` JSON schema
- **`sub_agent_dispatch.rs`**: remove `session_id` extraction from args; collapse `match session_id { Some(id) => id, None => create_session() }` into a direct `create_session()` call (fork branch unchanged); remove the now-redundant `session_id.is_none() &&` guard on the result cache

## Testing

All 116 existing tests pass. No new tests needed — this is a deletion.