### PR TITLE
chore: remove TodoRead ghost references

### DIFF
--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -321,7 +321,7 @@ fn tool_icon(name: &str) -> &'static str {
         "Grep" => "🔍",
         "List" | "Glob" => "📁",
         "WebFetch" => "🌐",
-        "TodoWrite" | "TodoRead" => "📋",
+        "TodoWrite" => "📋",
         "MemoryWrite" | "MemoryRead" => "🧠",
         "InvokeAgent" => "🤖",
         "AskUser" => "💬",

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -67,8 +67,8 @@ use tokio_util::task::AbortOnDropHandle;
 /// when execution actually starts and to one of the terminal variants
 /// (`Completed`, `Errored`, `Cancelled`) when it finishes.
 ///
-/// `Running.iter` is reserved for Layer 4 (live heartbeat) — Layer 0 just
-/// sets it to `0` so the field shape is stable across PRs.
+/// `Running.iter` is reserved for #1058 (live heartbeat) — currently
+/// set to `0` so the field shape is stable until that ships.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentStatus {
     /// Reserved but the spawned future hasn't started yet.
@@ -77,8 +77,8 @@ pub enum AgentStatus {
     /// (1..=20); `0` means "started, no iter info yet" (Layer 0 default).
     Running {
         /// Current inference iteration (1..=20). `0` is the
-        /// Layer-0 placeholder for "started but no per-iter
-        /// reporting wired yet" — Layer 4 will populate this.
+        /// placeholder for "started but no per-iter reporting wired
+        /// yet" — see #1058.
         iter: u8,
     },
     /// User or parent fired the cancel token. Terminal.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -136,7 +136,7 @@ async fn run_bg_agent(
     // anyway. Logging would be noise.
     status_tx: tokio::sync::watch::Sender<crate::bg_agent::AgentStatus>,
 ) {
-    // We don't have per-iteration visibility yet (Layer 4 work);
+    // We don't have per-iteration visibility yet — see #1058.
     // `iter: 0` means "started, no iter info". Once the inference
     // loop inside `execute_sub_agent` learns to push iter updates,
     // the field will reflect 1..=20.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -280,7 +280,6 @@ pub(crate) fn execute_sub_agent<'a>(
         let prompt = args["prompt"]
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
-        let session_id = args["session_id"].as_str().map(|s| s.to_string());
         let is_fork = agent_name == "fork";
         let background = args["background"].as_bool().unwrap_or(false);
 
@@ -392,11 +391,9 @@ pub(crate) fn execute_sub_agent<'a>(
             bg: bg_agents,
             invocation_id: my_invocation_id,
         };
-        // Check result cache (only for stateless calls without a session_id,
-        // since session continuations need fresh execution).
-        if session_id.is_none()
-            && let Some(cached) = sub_agent_cache.get(agent_name, prompt)
-        {
+        // Check result cache — identical (agent_name, prompt) pairs hit
+        // a cache and skip the LLM call. Cheap to retry idempotent tasks.
+        if let Some(cached) = sub_agent_cache.get(agent_name, prompt) {
             sink.emit(EngineEvent::Info {
                 message: format!("  \u{26a1} {agent_name}: cache hit, skipping LLM call"),
             });
@@ -512,27 +509,24 @@ pub(crate) fn execute_sub_agent<'a>(
             cfg
         };
 
-        let sub_session = match session_id {
-            Some(id) => id,
-            None => {
-                let sid = db
-                    .create_session(&sub_config.agent_name, project_root)
-                    .await?;
-                // Fork: copy parent conversation history into the new session.
-                //
-                // **#1022 B20**: was a per-row loop — N×(`insert_message`
-                // + `mark_message_complete` for assistant rows), each
-                // call its own fsync, on the synchronous fork hot path.
-                // For a 200-message parent that's ~600 round-trips and
-                // hundreds of ms of disk wait. Now a single transaction
-                // via `copy_messages_into_session` (one fsync at COMMIT,
-                // `completed_at` written inline for assistant rows).
-                if is_fork {
-                    let parent_history = db.load_context(parent_session_id).await?;
-                    db.copy_messages_into_session(&sid, &parent_history).await?;
-                }
-                sid
+        let sub_session = {
+            let sid = db
+                .create_session(&sub_config.agent_name, project_root)
+                .await?;
+            // Fork: copy parent conversation history into the new session.
+            //
+            // **#1022 B20**: was a per-row loop — N×(`insert_message`
+            // + `mark_message_complete` for assistant rows), each
+            // call its own fsync, on the synchronous fork hot path.
+            // For a 200-message parent that's ~600 round-trips and
+            // hundreds of ms of disk wait. Now a single transaction
+            // via `copy_messages_into_session` (one fsync at COMMIT,
+            // `completed_at` written inline for assistant rows).
+            if is_fork {
+                let parent_history = db.load_context(parent_session_id).await?;
+                db.copy_messages_into_session(&sid, &parent_history).await?
             }
+            sid
         };
 
         db.insert_message(&sub_session, &Role::User, Some(prompt), None, None, None)

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -77,10 +77,6 @@ Key rules:
                         "type": "string",
                         "description": "The task to delegate to the sub-agent"
                     },
-                    "session_id": {
-                        "type": "string",
-                        "description": "Optional session ID to continue a previous sub-agent conversation"
-                    },
                     "background": {
                         "type": "boolean",
                         "description": "Run in background and return immediately (default: false). \

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -21,7 +21,6 @@
 //! | **ListAgents** | `agent` | ReadOnly | List available sub-agents |
 //! | **MemoryRead** | `memory` | ReadOnly | Read project/global memory |
 //! | **MemoryWrite** | `memory` | LocalMutation | Save facts to memory |
-//! | **TodoRead** | `todo` | ReadOnly | Read task list |
 //! | **TodoWrite** | `todo` | LocalMutation | Update task list |
 //! | **AskUser** | `ask_user` | ReadOnly | Ask the user a question |
 //! | **ActivateSkill** | `skills` | ReadOnly | Load a skill's instructions |
@@ -78,7 +77,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
         // Pure reads — zero side-effects
         "Read" | "List" | "Grep" | "Glob" | "MemoryRead" | "ListAgents" | "ListSkills"
-        | "ActivateSkill" | "RecallContext" | "AskUser" | "TodoRead" => ToolEffect::ReadOnly,
+        | "ActivateSkill" | "RecallContext" | "AskUser" => ToolEffect::ReadOnly,
 
         // Remote actions — side-effects on remote services only
         "WebFetch" => ToolEffect::ReadOnly,    // GET-only fetch

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -112,7 +112,6 @@ fn test_classify_tool_covers_all_tools_explicitly() {
         ("ActivateSkill", ToolEffect::ReadOnly),
         ("RecallContext", ToolEffect::ReadOnly),
         ("AskUser", ToolEffect::ReadOnly),
-        ("TodoRead", ToolEffect::ReadOnly),
         ("WebFetch", ToolEffect::ReadOnly),
         ("WebSearch", ToolEffect::ReadOnly),
         ("InvokeAgent", ToolEffect::ReadOnly),


### PR DESCRIPTION
## What

Removes three dead references to a `TodoRead` tool that no longer exists:

| File | What was removed |
|---|---|
| `koda-core/src/tools/mod.rs` | Module doc table row |
| `koda-core/src/tools/mod.rs` | Dead arm in `classify_tool()` — unreachable because the tool is never registered |
| `koda-cli/src/transcript.rs` | Dead icon mapping arm |

## Why

`TodoRead` has no `ToolDefinition`, no dispatch handler, and is never inserted into the tool registry. The model cannot call it. The `classify_tool` arm was unreachable; if somehow hit it would have returned `ReadOnly` instead of the default `LocalMutation` fallthrough — wrong, but also impossible.

## No behaviour change

Pure deletion. No logic was attached to any of these references.