### PR TITLE
fix(#1050): add issue ref and release-gate for RUSTSEC-2026-0097 suppression

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -40,6 +40,8 @@ ignore = [
 
     # RUSTSEC-2026-0097 — rand 0.8.x / 0.9.x: unsound with custom log handler
     #
+    # Tracking issue: #1050
+    #
     # The advisory is triggered by two transitive dependency chains we don't
     # directly control:
     #   rand 0.8.5  ← phf_generator 0.11 ← termwiz ← ratatui (TUI rendering)
@@ -49,6 +51,11 @@ ignore = [
     # The unsoundness only manifests when an application installs a custom
     # global `log` handler *and* calls `rand::rng()` from inside that handler.
     # koda uses `tracing`, not a custom `log` handler, so we are not exposed.
+    #
+    # Suppression assumption: koda-cli must NOT use LogTracer or tracing_log
+    # (which would bridge log → tracing and silently flip the exposure).
+    # The release workflow verifies this with a grep check — see
+    # .github/workflows/release.yml "Verify RUSTSEC-2026-0097 suppression".
     #
     # Track resolution: remove this ignore once tungstenite ≥ 0.30 and
     # phf_generator ≥ 0.12 ship with rand 0.10 bounds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,17 @@ jobs:
         run: cargo install cargo-audit --locked
       - name: Run cargo audit
         run: cargo audit --deny unsound --deny yanked
+      - name: Verify RUSTSEC-2026-0097 suppression
+        # The RUSTSEC-2026-0097 suppression in .cargo/audit.toml is valid only
+        # as long as koda-cli does not use LogTracer or tracing_log (which would
+        # bridge the log crate into tracing and flip our exposure). Fail the
+        # release if that assumption is ever violated. See #1050.
+        run: |
+          if grep -rn 'LogTracer\|tracing_log' koda-cli/src/; then
+            echo "::error::RUSTSEC-2026-0097 suppression invalid: LogTracer/tracing_log found in koda-cli/src. Remove the usage or drop the suppression in .cargo/audit.toml."
+            exit 1
+          fi
+          echo "✅ RUSTSEC-2026-0097 suppression valid: no LogTracer/tracing_log in koda-cli/src"
 
   # Cross-platform tests before shipping binaries.
   # Depends on verify-version + audit: no point burning 30+ min of cross-platform


### PR DESCRIPTION
Closes #1050.

## Changes

### `.cargo/audit.toml`
- Added `# Tracking issue: #1050` to the RUSTSEC-2026-0097 suppression block
- Documented the suppression assumption explicitly: koda-cli must not use `LogTracer` or `tracing_log`, which would bridge `log → tracing` and silently flip the exposure

### `.github/workflows/release.yml`
- Added **"Verify RUSTSEC-2026-0097 suppression"** step in the `audit` job, immediately after `cargo audit`
- Greps `koda-cli/src/` for `LogTracer` and `tracing_log`; fails the release with a clear error message if found
- Verified locally: grep returns clean today ✅

## Why a CI gate and not just a doc comment?

The suppression rationale is "we don't use `LogTracer`" — that's an assumption about future code, not just current code. A comment rots silently; a CI step enforces it on every release.