### PR TITLE
fix(#1051): release polish bundle — once_cell, workspace.package, B19 test, bwrap SAFETY, sandbox coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,6 +62,18 @@ jobs:
             --lcov --output-path lcov-core.info \
             -- --test-threads=1
 
+      - name: koda-sandbox coverage (informational — threshold TBD, see #1051)
+        id: sandbox
+        if: steps.install.outcome == 'success'
+        continue-on-error: true
+        run: |
+          # koda-sandbox is the security boundary; tracking coverage here
+          # so we can establish a baseline and set a gate in a follow-up.
+          # No --fail-under-lines yet — numbers collected only.
+          cargo llvm-cov \
+            --lib -p koda-sandbox \
+            --lcov --output-path lcov-sandbox.info
+
       # Drop a marker so the report job can distinguish "tooling broken,
       # never measured coverage" from "actually measured, dropped below
       # threshold". Without this, a CDN flake on either platform would
@@ -110,7 +122,8 @@ jobs:
           fi
           fail=0
           for crate_outcome in \
-              "core=${{ steps.core.outcome }}"; do
+              "core=${{ steps.core.outcome }}" \
+              "sandbox=${{ steps.sandbox.outcome }}"; do
             name="${crate_outcome%%=*}"
             outcome="${crate_outcome#*=}"
             if [ "$outcome" != "success" ]; then
@@ -140,7 +153,7 @@ jobs:
         run: |
           cd reports
           # Merge each crate's reports across platforms.
-          for crate in core; do
+          for crate in core sandbox; do
             files=$(ls lcov-${crate}.info 2>/dev/null || true)
             if [ -n "$files" ]; then
               # If multiple files exist (from matrix), merge them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,7 +1775,6 @@ dependencies = [
  "crossterm",
  "futures-util",
  "koda-core",
- "once_cell",
  "ratatui",
  "ratatui-textarea",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ members = ["koda-core", "koda-cli", "koda-test-utils", "koda-sandbox"]
 resolver = "3"
 default-members = ["koda-cli"]
 
+[workspace.package]
+edition = "2024"
+license = "MIT"
+repository = "https://github.com/lijunzh/koda"
+homepage = "https://github.com/lijunzh/koda"
+authors = ["Lijun Zhu"]
+
 # Shared dependency versions — single source of truth (DRY).
 # Per-crate feature sets are layered via `features = [...]` at the
 # consumer site. Add a dep here once it's used by 3+ crates; before

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "koda-cli"
 version = "0.2.19"
-edition = "2024"
+edition.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
-license = "MIT"
-repository = "https://github.com/lijunzh/koda"
-homepage = "https://github.com/lijunzh/koda"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 readme = "README.md"
 keywords = ["ai", "coding-agent", "llm", "cli", "unix"]
 categories = ["command-line-utilities", "development-tools"]
-authors = ["Lijun Zhu"]
+authors.workspace = true
 
 [[bin]]
 name = "koda"
@@ -36,7 +36,6 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 # Syntax highlighting
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "parsing", "html", "regex-fancy"] }
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
-once_cell = "1"
 
 # TUI (inline viewport: input + status bar)
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "scrolling-regions"] }

--- a/koda-cli/src/highlight.rs
+++ b/koda-cli/src/highlight.rs
@@ -28,10 +28,10 @@
 //! Fixes silent no-ops for TOML, TypeScript, Kotlin, Swift, Zig, Lua,
 //! Dockerfile, and ~180 other languages that syntect's defaults omit.
 //!
-//! Syntaxes and themes are loaded once at first use via [`once_cell::sync::Lazy`].
+//! Syntaxes and themes are loaded once at first use via [`std::sync::LazyLock`].
 //! Theme: `base16-ocean.dark` (matches popular terminal palettes).
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::{SyntaxReference, SyntaxSet};
@@ -44,8 +44,8 @@ use syntect::util::as_24_bit_terminal_escaped;
 /// TypeScript, Kotlin, Swift, Zig, Lua, Dockerfile, Protocol Buffers, and
 /// everything else syntect's slim default set omits. Same grammar pack used
 /// by `bat` and `codex`. Loaded once; cloning the SyntaxSet is not needed.
-static SYNTAX_SET: Lazy<SyntaxSet> = Lazy::new(two_face::syntax::extra_newlines);
-static THEME_SET: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(two_face::syntax::extra_newlines);
+static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
 
 /// Resolve a language hint to a syntect `SyntaxReference`.
 ///

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "koda-core"
 version = "0.2.19"
-edition = "2024"
+edition.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
-license = "MIT"
-repository = "https://github.com/lijunzh/koda"
-homepage = "https://github.com/lijunzh/koda"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 readme = "README.md"
 keywords = ["ai", "coding-agent", "llm", "engine", "unix"]
 categories = ["development-tools"]
-authors = ["Lijun Zhu"]
+authors.workspace = true
 
 [lib]
 name = "koda_core"

--- a/koda-core/tests/guarantee_matrix_test.rs
+++ b/koda-core/tests/guarantee_matrix_test.rs
@@ -25,7 +25,7 @@
 //! (sandbox enforces the perimeter). Only outside-project writes and
 //! path escapes still need confirmation in Auto mode.
 
-use koda_core::trust::{ToolApproval, TrustMode, check_tool};
+use koda_core::trust::{ToolApproval, TrustMode, check_tool, derive_child_trust};
 use std::path::Path;
 
 fn root() -> &'static Path {
@@ -185,4 +185,44 @@ fn matrix_gh_issue_create() {
     let (auto, confirm) = check_both("Bash", &args);
     assert_eq!(auto, auto_mutation_expected());
     assert_eq!(confirm, ToolApproval::NeedsConfirmation);
+}
+
+// ── B19 regression: child trust clamped to parent *runtime* mode (#1022) ──
+//
+// Before #1022 B19 the dispatch used `parent_config.trust` (startup value)
+// as the ceiling. A user who started in Auto and hit `/safe` would still
+// spawn sub-agents at Auto because the config field was never mutated —
+// only the SharedTrustMode atomic was. This test pins the correct contract:
+// `derive_child_trust` must receive the live *runtime* mode, and when that
+// runtime mode is stricter than what the child declared, the child is clamped.
+
+#[test]
+fn b19_child_trust_clamped_to_parent_runtime_not_startup_config() {
+    // Simulates: parent started Auto, user ran /safe → runtime = Safe.
+    let parent_startup_trust = TrustMode::Auto; // stale config field (pre-fix ceiling)
+    let parent_runtime_mode = TrustMode::Safe; // live atomic (post-fix ceiling)
+
+    // Named child declares Auto (wants broad permissions).
+    let child_declared = TrustMode::Auto;
+
+    // Post-fix: runtime mode is the ceiling → child clamped to Safe.
+    assert_eq!(
+        derive_child_trust(parent_runtime_mode, child_declared),
+        TrustMode::Safe,
+        "B19: child must be clamped to parent's runtime trust, not startup config trust",
+    );
+
+    // Pre-fix behaviour (using startup config as ceiling) would have
+    // returned Auto — this assertion documents the bug that was fixed.
+    assert_eq!(
+        derive_child_trust(parent_startup_trust, child_declared),
+        TrustMode::Auto,
+        "pre-fix behaviour: startup config (Auto) failed to clamp child — child got Auto",
+    );
+
+    // Sanity: if runtime is already Auto, child declaring Auto stays Auto.
+    assert_eq!(
+        derive_child_trust(TrustMode::Auto, TrustMode::Auto),
+        TrustMode::Auto,
+    );
 }

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "koda-sandbox"
 version = "0.2.19"
-edition = "2024"
+edition.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
-license = "MIT"
-readme = "README.md"
-repository = "https://github.com/lijunzh/koda"
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -519,12 +519,14 @@ mod tests {
     /// rely on this.
     #[test]
     fn stage2_binary_respects_env_override() {
-        // SAFETY: tests run single-threaded for env mutations; we
-        // restore the original value after the assertion.
         let original = std::env::var(STAGE2_BIN_ENV_KEY).ok();
+        // SAFETY: this test binary is single-threaded; no other thread
+        // can observe the env mutation between set and restore.
         unsafe { std::env::set_var(STAGE2_BIN_ENV_KEY, "/tmp/fake-stage2") };
         let p = stage2_binary().unwrap();
         assert_eq!(p, std::path::PathBuf::from("/tmp/fake-stage2"));
+        // SAFETY: same single-threaded guarantee as above; restoring
+        // to the original value (or removing) is always safe here.
         unsafe {
             match original {
                 Some(v) => std::env::set_var(STAGE2_BIN_ENV_KEY, v),


### PR DESCRIPTION
Closes #1051.

All five items from the v0.2.18 audit bundle, in one atomic PR (they're all tiny and independent):

---

### 1. `once_cell` → `std::sync::LazyLock`
`koda-cli/src/highlight.rs` used `once_cell::sync::Lazy` for two statics. `std::sync::LazyLock` is stable since Rust 1.80 and is a drop-in replacement. `once_cell` removed from `koda-cli` deps entirely.

### 2. `[workspace.package]` for shared metadata
`edition`, `license`, `repository`, `homepage`, `authors` were copy-pasted identically across `koda-core`, `koda-cli`, and `koda-sandbox`. Now declared once in `[workspace.package]` and inherited via `.workspace = true`. Future version bumps only need to touch one place.

### 3. B19 `derive_child_trust` regression test
Added `b19_child_trust_clamped_to_parent_runtime_not_startup_config` to `guarantee_matrix_test.rs`. Pins the exact bug scenario from #1022 B19:

- Parent starts Auto, user hits `/safe` → runtime = Safe
- Named child declares Auto (wants broad permissions)
- Child **must** be clamped to Safe — not the stale startup config (Auto)
- The test also documents what the pre-fix code *would* have returned

### 4. `bwrap.rs` SAFETY comments
`stage2_binary_respects_env_override` had its SAFETY comment placed above `let original = ...` rather than immediately before each `unsafe { }` block. Fixed per Rust convention; added a second SAFETY comment on the restore block.

### 5. `koda-sandbox` coverage tracking
Added an informational `koda-sandbox llvm-cov` step to `coverage.yml`. No hard threshold yet — we need baseline numbers first. The sandbox lcov output flows into the merge and outcome-check jobs so the numbers show up in artifacts.