### PR TITLE
feat(bg-agent): live iteration counter in background agent status (#1058)

### DIFF
--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -57,7 +57,7 @@
 //!   PR. Drained results still inject into the conversation, so the
 //!   user isn't missing info, just visual confirmation.
 //! - Status-bar pill — Layer 3 / PR #1044.
-//! - Per-iter `iter` updates — Layer 4 / PR #1045.
+//! - Per-iter `iter` updates — Layer 4 / PR #1058 (landed).
 //!
 //! [`parse_task_id`]: koda_core::tools::bg_task_tools::parse_task_id
 
@@ -296,7 +296,8 @@ fn agent_status_spans(status: &koda_core::bg_agent::AgentStatus) -> Vec<Span<'st
             let label = if *iter == 0 {
                 // PR #1041's `Running { iter: 0 }` is a Layer-0
                 // placeholder for "started but no per-iter info
-                // wired yet." Layer 4 will populate it. Don't
+                // wired yet." Foreground sub-agents still send 0;
+                // background agents emit live updates (Layer 4, #1058). Don't
                 // render "iter 0/20" — it misleads the user into
                 // thinking nothing has happened.
                 "\u{25b6} Running".to_string()
@@ -626,7 +627,7 @@ mod tests {
 
     /// Layer-0 placeholder semantics: `Running { iter: 0 }` means
     /// "started but no per-iter info yet" — don't render a misleading
-    /// `"iter 0/20"`. Layer 4 (PR #1045) will populate the field.
+    /// `"iter 0/20"`. Layer 4 (#1058) populated the field for bg agents.
     #[tokio::test]
     async fn list_background_tasks_hides_iter_zero_placeholder() {
         let mut buf = ScrollBuffer::new(64);

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -67,8 +67,9 @@ use tokio_util::task::AbortOnDropHandle;
 /// when execution actually starts and to one of the terminal variants
 /// (`Completed`, `Errored`, `Cancelled`) when it finishes.
 ///
-/// `Running.iter` is reserved for #1058 (live heartbeat) — currently
-/// set to `0` so the field shape is stable until that ships.
+/// `Running.iter` reflects the current inference iteration (1..=20).
+/// Background agents emit live updates via Layer 4 (#1058); `0` is
+/// the entry-point placeholder before the first iteration fires.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AgentStatus {
     /// Reserved but the spawned future hasn't started yet.
@@ -77,8 +78,9 @@ pub enum AgentStatus {
     /// (1..=20); `0` means "started, no iter info yet" (Layer 0 default).
     Running {
         /// Current inference iteration (1..=20). `0` is the
-        /// placeholder for "started but no per-iter reporting wired
-        /// yet" — see #1058.
+        /// entry-point placeholder emitted before the first iteration
+        /// in `run_bg_agent`; background agents update this live
+        /// (Layer 4, #1058).
         iter: u8,
     },
     /// User or parent fired the cancel token. Terminal.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -136,10 +136,11 @@ async fn run_bg_agent(
     // anyway. Logging would be noise.
     status_tx: tokio::sync::watch::Sender<crate::bg_agent::AgentStatus>,
 ) {
-    // We don't have per-iteration visibility yet — see #1058.
-    // `iter: 0` means "started, no iter info". Once the inference
-    // loop inside `execute_sub_agent` learns to push iter updates,
-    // the field will reflect 1..=20.
+    // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
+    // shows the agent as active before the first LLM call. The loop inside
+    // `execute_sub_agent` updates this to `iter: 1..=20` as it progresses
+    // (Layer 4, #1058). `iter: 0` is intentional here — it signals
+    // "started, first iteration pending".
     let _ = status_tx.send(crate::bg_agent::AgentStatus::Running { iter: 0 });
 
     let (_, mut cmd_rx) = mpsc::channel(1);
@@ -189,6 +190,11 @@ async fn run_bg_agent(
         // invocation id (allocated inside the recursive call). The
         // parent's cascade-cancel covers cross-registry teardown.
         None,
+        // Layer 4 of #996: forward the status sender so the loop can
+        // push live `Running { iter }` updates. Cloned so the terminal
+        // sends below (Completed / Errored / Cancelled) can still use
+        // the original after `execute_sub_agent` returns.
+        Some(status_tx.clone()),
     )
     .await;
 
@@ -267,6 +273,12 @@ pub(crate) fn execute_sub_agent<'a>(
     // child's own `my_invocation_id`, which is allocated below and
     // tags any bg work the child itself spawns.
     parent_spawner: Option<u32>,
+    // Layer 4 of #996: live iteration heartbeat.  Pass the bg-agent's
+    // `watch::Sender` so each loop iteration can push `Running { iter }`
+    // to the registry (and therefore to `/agents` and the status-bar
+    // pill).  Foreground sub-agents pass `None` — they have no status
+    // channel because they're not tracked in the registry at all.
+    status_tx: Option<tokio::sync::watch::Sender<crate::bg_agent::AgentStatus>>,
 ) -> impl std::future::Future<Output = Result<String>> + Send + 'a {
     async move {
         // Phase E of #996: allocate this invocation's id up-front. It
@@ -712,7 +724,16 @@ pub(crate) fn execute_sub_agent<'a>(
             &tools.skill_registry,
         );
 
-        for _ in 0..loop_guard::MAX_SUB_AGENT_ITERATIONS {
+        for iter in 1u8..=loop_guard::MAX_SUB_AGENT_ITERATIONS as u8 {
+            // Layer 4 of #996: push the live iteration counter so `/agents`
+            // and the status-bar pill reflect real progress instead of the
+            // Layer-0 placeholder `iter: 0` that `run_bg_agent` sends on
+            // entry.  `send` failures are ignored for the same reason as
+            // the terminal-status sends above: if the receiver is gone,
+            // the user can't see the update and we don't want noise.
+            if let Some(ref tx) = status_tx {
+                let _ = tx.send(crate::bg_agent::AgentStatus::Running { iter });
+            }
             // Respect parent cancellation (#286)
             if cancel.is_cancelled() {
                 // Release workspace on cancellation (best-effort, no user hint).

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -310,6 +310,10 @@ pub(crate) async fn execute_one_tool(
             // and allocates a fresh `my_invocation_id` internally for
             // its own bg-task scoping.
             caller_spawner,
+            // Layer 4 of #996: foreground sub-agents are not tracked in
+            // the bg-agent registry, so there is no status channel to
+            // update. Pass `None` to skip the per-iteration send.
+            None,
         );
         match Box::pin(fut).await {
             Ok(output) => (output, true, None),


### PR DESCRIPTION
Closes #1058. Completes Layer 4 of #996.

## What

Background sub-agents now push a live `Running { iter: N }` update to the registry at the start of every inference iteration. `/agents` and the status-bar pill show **`▶ Running (iter 3/20)`** instead of a flat `▶ Running`.

## Why it was broken

`run_bg_agent` sent `Running { iter: 0 }` once on entry (the Layer-0 placeholder) and never updated it. The TUI renderer already knew how to display `iter N/20` — the engine side just never fed it real numbers.

## Changes

### `koda-core/src/sub_agent_dispatch.rs`

- `execute_sub_agent` gains one new final parameter:
  ```rust
  status_tx: Option<tokio::sync::watch::Sender<AgentStatus>>,
  ```
  Foreground sub-agents pass `None`; `run_bg_agent` passes `Some(status_tx.clone())`.
- `for _ in 0..MAX_SUB_AGENT_ITERATIONS` → `for iter in 1u8..=20u8`.
- First thing inside each lap: `tx.send(Running { iter })` when `status_tx` is `Some`. Send failures are silently ignored (same policy as the existing terminal-status sends).

### `koda-core/src/tool_dispatch.rs`

- Pass `None` for `status_tx` — foreground sub-agents have no registry entry.

### Comments only

- `bg_agent.rs`, `tui_bg_tasks.rs`, `sub_agent_dispatch.rs` — replaced "reserved for #1058 / Layer 4 will populate" language with present-tense descriptions.

## What was already in place (no changes needed)

`agent_status_spans` in `tui_bg_tasks.rs` already rendered `▶ Running (iter N/20)` for `iter > 0` and suppressed the `iter 0/20` display for the placeholder. The two tests covering this were already green — this PR closes the engine-side gap they were written against.

## Stats

4 files changed, +40 / −12 lines.

## Tests

`cargo test` — **497 passed, 0 failed**
`RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` — clean
`cargo fmt` + `cargo clippy` — clean
