### PR TITLE
chore: release v0.2.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,11 +66,11 @@ jobs:
         # bridge the log crate into tracing and flip our exposure). Fail the
         # release if that assumption is ever violated. See #1050.
         run: |
-          if grep -rn 'LogTracer\|tracing_log' koda-cli/src/; then
-            echo "::error::RUSTSEC-2026-0097 suppression invalid: LogTracer/tracing_log found in koda-cli/src. Remove the usage or drop the suppression in .cargo/audit.toml."
+          if grep -rn 'LogTracer\|tracing_log' koda-cli/src/ koda-core/src/ koda-sandbox/src/; then
+            echo "::error::RUSTSEC-2026-0097 suppression invalid: LogTracer/tracing_log found in workspace src. Remove the usage or drop the suppression in .cargo/audit.toml."
             exit 1
           fi
-          echo "✅ RUSTSEC-2026-0097 suppression valid: no LogTracer/tracing_log in koda-cli/src"
+          echo "✅ RUSTSEC-2026-0097 suppression valid: no LogTracer/tracing_log in workspace src"
 
   # Cross-platform tests before shipping binaries.
   # Depends on verify-version + audit: no point burning 30+ min of cross-platform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.20] - 2026-04-26
+
+### Added
+
+- **Live iteration counter in background agent status** (#1058) — `/agents`
+  and the status-bar pill now show `▶ Running (iter N/20)` as background
+  sub-agents progress through inference iterations, instead of always showing
+  a flat `▶ Running`.
+
+### Removed
+
+- **`TodoRead` tool removed** — the session task list is write-only;
+  `TodoWrite` is the only task-tracking tool. The model sees `TodoWrite`
+  only, removing a redundant read path.
+- **`session_id` parameter removed from `InvokeAgent` tool schema** (#1056).
+  Sub-agent sessions are always freshly created; the parameter was never
+  honoured and caused model hallucination.
+- **`koda_core::approval` re-export shim deleted**. Downstream code should
+  use `koda_core::trust` directly (`TrustMode`, `check_tool`, etc.).
+- **Speculative dead wire-protocol types removed** from `EngineCommand`:
+  variants `UserPrompt`, `SlashCommand(SlashCommand)`, `Quit`; structs
+  `ImageAttachment` and `SlashCommand`. All were `#[allow(dead_code)]` with
+  zero consumers.
+
+### Fixed
+
+- **B19 child-trust regression** (#1022) — child trust mode is now clamped
+  to the parent's *runtime* mode (e.g. after `/safe`), not the startup
+  config mode. Switching to `/safe` mid-session now correctly prevents
+  sub-agents from inheriting the original, wider trust level.
+- **RUSTSEC-2026-0097 release-gate expanded** (#1050) — the CI grep that
+  verifies the `rand` unsoundness suppression now covers all workspace
+  `src/` directories (`koda-cli`, `koda-core`, `koda-sandbox`), not just
+  `koda-cli/src/`.
+
+### Internal
+
+- `once_cell` dep removed from `koda-cli`; replaced with
+  `std::sync::LazyLock` (stable since Rust 1.80).
+- `repl.rs` deleted (−965 LOC); slash-command parse+dispatch folded into a
+  single `match` in `tui_commands.rs`. Adding a slash command now requires
+  one edit instead of four.
+- `koda-sandbox/Cargo.toml` now inherits `homepage`, `authors`, `readme`,
+  and gains `keywords`/`categories` for crates.io discoverability.
+- RUSTSEC-2026-0097 suppression carries a tracking issue (#1050), an
+  exposure rationale, and an exit condition (tungstenite ≥ 0.30).
+
 ## [0.2.19] - 2026-04-26
 
 Infrastructure release. Fixes the crates.io publish pipeline that was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ koda/
 │   │       ├── recall.rs   # RecallContext (session history)
 │   │       ├── shell.rs    # Bash command execution
 │   │       ├── skill_tools.rs # ListSkills, ActivateSkill
-│   │       ├── todo.rs     # TodoRead, TodoWrite
+│   │       ├── todo.rs     # TodoWrite
 │   │       ├── validate.rs # Pre-flight input validation
 │   │       ├── web_fetch.rs# WebFetch (URL content retrieval)
 │   │       └── web_search.rs # WebSearch (DuckDuckGo)
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.19)
+10. Sync version with workspace (currently 0.2.20)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -18,7 +18,6 @@ within the project sandbox are auto-approved.
 | `Think` | Internal | Extended reasoning step (no side effects) |
 | `MemoryRead` | Read-only | Read from project or global memory |
 | `MemoryWrite` | Mutating | Append a fact to a memory file |
-| `TodoRead` | Read-only | Read the session task list |
 | `TodoWrite` | Mutating | Update the session task list |
 | `RecallContext` | Read-only | Search session history for past context |
 | `ListSkills` | Read-only | List available skills |
@@ -34,7 +33,7 @@ within the project sandbox are auto-approved.
 
 | Category | Tools | Plan | Safe | Auto |
 |----------|-------|------|------|------|
-| Read-only | Read, Grep, Glob, ListFiles, WebFetch, WebSearch, TodoRead, RecallContext | ✅ Auto | ✅ Auto | ✅ Auto |
+| Read-only | Read, Grep, Glob, ListFiles, WebFetch, WebSearch, RecallContext | ✅ Auto | ✅ Auto | ✅ Auto |
 | Internal | Think, ActivateSkill | ✅ Auto | ✅ Auto | ✅ Auto |
 | Mutations | Write, Edit, MemoryWrite, TodoWrite | ❌ Deny | ⏸ Prompt | ✅ Auto |
 | Destructive | Delete | ❌ Deny | ⏸ Prompt | ✅ Auto |

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
 license.workspace = true
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.19" }
+koda-core = { path = "../koda-core", version = "0.2.20" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -77,6 +77,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.19", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.20", features = ["test-support"] }
 serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license.workspace = true
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.19" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.20" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -51,8 +51,6 @@
 
 /// Sub-agent configuration, discovery, and invocation.
 pub mod agent;
-/// Tool approval modes, safety gates, and shared mode state.
-/// Deprecated: prefer [`trust`] module. This module re-exports from `trust`.
 /// Approval flow and user interaction during tool execution.
 pub(crate) mod approval_flow;
 /// Heuristic path-escape detection for bash commands.

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+readme = "README.md"
+keywords = ["sandbox", "security", "filesystem", "unix", "ai"]
+categories = ["os", "filesystem"]
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## v0.2.19 → v0.2.20

### What's in this release (8 commits)

**Added**
- Live iteration counter in background agent status (#1058) — `/agents` and the status-bar pill now show `▶ Running (iter N/20)` as background sub-agents progress through inference iterations.

**Removed**
- `TodoRead` tool — the session task list is write-only; `TodoWrite` is the only task-tracking tool.
- `session_id` parameter from `InvokeAgent` tool schema (#1056) — was never honoured, caused model hallucination.
- `koda_core::approval` re-export shim — use `koda_core::trust` directly.
- Dead wire-protocol types: `EngineCommand::{UserPrompt, SlashCommand, Quit}`, `ImageAttachment`, `SlashCommand` enum (all `#[allow(dead_code)]`, zero consumers).

**Fixed**
- B19 child-trust regression (#1022) — child trust clamped to parent's *runtime* mode, not startup config mode.
- RUSTSEC-2026-0097 release-gate grep expanded to cover all workspace `src/` dirs.

**Internal**
- `once_cell` → `std::sync::LazyLock` in `koda-cli`.
- `repl.rs` deleted (−965 LOC); slash-command dispatch folded into a single `match`. New slash commands: one edit instead of four.
- `koda-sandbox/Cargo.toml` gains `readme`, `homepage`, `authors`, `keywords`, `categories` for crates.io.

---

### Sub-agent review summary

Four agents reviewed the codebase before this release PR. All findings have been addressed:

| Finding | Agent | Severity | Resolution |
|---|---|---|---|
| CHANGELOG `[Unreleased]` empty | all | P2 | ✅ Filled — `## [0.2.20]` section above |
| `docs/src/tools.md` still lists deleted `TodoRead` | qa-expert | P2 | ✅ Fixed in this PR |
| `CLAUDE.md` arch tree shows `TodoRead, TodoWrite` | qa-expert | P2 | ✅ Fixed in this PR |
| Orphan deprecated comment over `approval_flow` in `lib.rs` | code-reviewer | P3 | ✅ Fixed in this PR |
| `koda-sandbox` missing `readme`, `homepage`, `authors`, etc. | rust-programmer | P2 | ✅ Fixed in this PR |
| RUSTSEC grep only covers `koda-cli/src/` | security-auditor | P2 | ✅ Expanded in this PR |
| `koda_core::approval` removal is semver-visible | code-reviewer / rust-programmer | P2 | ℹ️ Pre-1.0, personal tool, no external consumers. Accepted as-is. |

### Deferred items (tracked)

- [ ] No P1/P2 standalone items to file. One P3-bundle below.

### P3-bundle (non-blocking, tracked separately)
- `koda-cli` doc tests should use `# no_run` fences instead of `ignored`
- `similar` appears at two versions (2.7.0 + 3.1.0) in lockfile
- Unsafe `std::env::set_var` in parallel test bodies without `#[serial]`
- Integration test for live `iter` counter advancing through real bg-agent run (QA-001)

### Manual verification checklist (run with real provider before tag push)
- [ ] `/agents` shows `▶ Running (iter N/20)` ticking live during a bg-agent run
- [ ] `WaitTask` blocks and returns `Completed` against a running bg-agent
- [ ] `WaitTask` returns `Cancelled` after `CancelTask` fires
- [ ] `koda --version` reports `0.2.20`

### Deferred tracking
- [ ] #1068 — v0.2.20 P3 polish bundle (4 items: no_run fences, similar dedup, serial_test, iter integration test)