### PR TITLE
ci(release): fail-fast test matrix — cancel macOS if Ubuntu fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [verify-version, audit]
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true   # release needs all platforms green — no point continuing if one fails
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:


### PR DESCRIPTION
One-line change to the release test matrix.

## What

`fail-fast: false` → `fail-fast: true` on the `test` matrix in `release.yml`.

## Why

A release needs **all** platforms green before `build` runs. If Ubuntu fails there is nothing useful macOS can tell us — the release is already blocked. With `fail-fast: false`, GitHub Actions keeps the macOS runner alive for its full ~3-min run burning runner-minutes for zero signal.

`fail-fast: true` cancels macOS the moment Ubuntu reports failure, saving up to ~3 runner-minutes per bad release attempt.

## Why NOT parallelize verify-version + audit + test

That was also evaluated and rejected: the current sequential order (`verify-version → audit → test`) intentionally avoids spinning up expensive cross-platform runners when the tag is wrong or a CVE is flagged — both are plausible failure modes. The ~55s wall-clock saving from parallelization isn't worth the runner-minute waste on those (common) failure cases. See discussion on #1067.

## The build matrix stays fail-fast: false

Cross-compilation issues are often target-specific (`aarch64-unknown-linux-gnu` vs `x86_64-apple-darwin`). You want the full picture of which targets broke, not just the first one.