### PR TITLE
sandbox: close #1045 – Gap 1 + Gap 3 from #1072 spec

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -212,8 +212,6 @@ pub fn build(
 /// retune. We change values once we have data; we change *where the
 /// values live* now so the change is one-line later.
 pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> SandboxPolicy {
-    // `project_root` reserved for PR-4+ (seeding fs.allow_write).
-    let _ = project_root;
     let mut policy = SandboxPolicy::strict_default();
     policy.limits.wall_time_secs = Some(match trust {
         crate::trust::TrustMode::Plan
@@ -235,6 +233,26 @@ pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> 
         crate::trust::TrustMode::Safe => 5,  // user gate exists, balanced
         crate::trust::TrustMode::Auto => 10, // no human gate — max paranoia
     };
+    // Gap 3 of #1072 (PR-4 of #934): seed allow_write with the canonical
+    // project root so the composition lattice accurately reflects what the
+    // kernel baseline already grants.  Without this, compose()'s intersection
+    // rule for allow_write is vacuously correct but has no observable effect:
+    // intersect([], []) == [] regardless of what the baseline sandbox does.
+    //
+    // Canonicalize so symlink-based project roots don't produce a different
+    // key than their realpath counterpart.  Falls back to the raw path on
+    // non-existent roots — sub-agent dispatch can build policy before its
+    // workspace is materialized (the test "does not panic on nonexistent
+    // project root" pins this contract).
+    //
+    // Plan mode is intentionally included: reads dominate in Plan but writes
+    // ARE permitted within the project (e.g. writing scratch files).  The
+    // higher-layer tool registry is what enforces read-only semantics for
+    // Plan, not the kernel sandbox write-allow list.
+    let canonical_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    policy.fs.allow_write = vec![canonical_root.into()];
     policy
 }
 
@@ -1177,18 +1195,97 @@ mod tests {
 
     #[test]
     fn compose_child_policy_with_strict_default_parent_is_just_child_policy() {
-        // Identity case: when there's no meaningful parent (top-level
-        // invocation, bg-spawned agent), `strict_default()` is the
-        // algebraic identity. The composed policy should equal what
+        // Identity case for *most* fields: when there's no meaningful parent
+        // (top-level invocation, bg-spawned agent), `strict_default()` acts
+        // as the algebraic identity — the composed output matches what
         // `policy_for_agent` would have returned alone.
+        //
+        // Exception — `allow_write`: compose uses parent-wins semantics
+        // ("allows narrow toward parent"), and `strict_default()`'s empty
+        // allow list wins over the child's `[project_root]`.  This is
+        // intentional: a zero-opinion parent shouldn’t grant write permissions
+        // that the parent never explicitly approved.  In practice, top-level
+        // agents never go through `compose_child_policy`; they use
+        // `policy_for_agent` directly.  Sub-agents that DO go through compose
+        // will have a real parent whose `allow_write: [parent_root]` gives
+        // the child's root access via the parent-wins rule, provided the
+        // parent and child share the same project root (the common case).
         let dir = tempfile::tempdir().unwrap();
         let parent = SandboxPolicy::strict_default();
         let composed = compose_child_policy(&parent, crate::trust::TrustMode::Safe, dir.path());
         let child_alone = policy_for_agent(crate::trust::TrustMode::Safe, dir.path());
+        // All fields other than allow_write must match the child's policy.
+        assert_eq!(composed.fs.deny_read, child_alone.fs.deny_read);
         assert_eq!(
-            composed, child_alone,
-            "strict_default parent must be the identity for compose"
+            composed.fs.mandatory_deny_search_depth,
+            child_alone.fs.mandatory_deny_search_depth
         );
+        assert_eq!(
+            composed.fs.allow_git_config,
+            child_alone.fs.allow_git_config
+        );
+        assert_eq!(composed.limits, child_alone.limits);
+        assert_eq!(composed.trust, child_alone.trust);
+        // allow_write: parent-wins on the empty strict_default list — result is
+        // empty regardless of what the child wanted.  Document as the known
+        // non-identity exception, not a bug.
+        assert!(
+            composed.fs.allow_write.is_empty(),
+            "parent-wins: strict_default's empty allow_write beats child's [root]; \
+             top-level agents should NOT go through compose (use policy_for_agent \
+             directly) — #1072 Gap 3 comment"
+        );
+    }
+
+    // ── Gap 3 of #1072: policy_for_agent seeds allow_write ───────────────
+
+    #[test]
+    fn policy_for_agent_seeds_allow_write_with_canonical_root() {
+        // Verifies #1072 Gap 3: the composition lattice only makes sense
+        // if allow_write reflects what the kernel baseline actually grants.
+        // Before this fix, allow_write was always [], making
+        // compose()'s intersection vacuously correct but meaningless.
+        let dir = tempfile::tempdir().unwrap();
+        for mode in [
+            crate::trust::TrustMode::Plan,
+            crate::trust::TrustMode::Safe,
+            crate::trust::TrustMode::Auto,
+        ] {
+            let policy = policy_for_agent(mode, dir.path());
+            assert_eq!(
+                policy.fs.allow_write.len(),
+                1,
+                "policy_for_agent must seed allow_write with the project root \
+                 (one entry) for all trust modes, got {} entries for {mode:?}",
+                policy.fs.allow_write.len()
+            );
+            let want = dir.path().canonicalize().unwrap();
+            assert_eq!(
+                policy.fs.allow_write[0].as_path(),
+                want.as_path(),
+                "seeded allow_write path must be the canonicalized project root"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_for_agent_allow_write_survives_nonexistent_root() {
+        // Regression guard: sub-agent dispatch calls policy_for_agent
+        // before the workspace is materialized on disk.  canonicalize()
+        // fails on missing paths; the fallback to raw path must not panic.
+        let path = std::path::Path::new("/nonexistent/project/root/xyz");
+        for mode in [
+            crate::trust::TrustMode::Plan,
+            crate::trust::TrustMode::Safe,
+            crate::trust::TrustMode::Auto,
+        ] {
+            let policy = policy_for_agent(mode, path);
+            assert_eq!(
+                policy.fs.allow_write.len(),
+                1,
+                "even with a missing root, allow_write must have one entry"
+            );
+        }
     }
 
     #[test]

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -82,6 +82,11 @@ pub fn build_command(
 
     let (mut cmd, home) = base_cmd(project_root);
     apply_credential_denies(&mut cmd, &home);
+    // Gap 1 of #1072: protect git hooks + config when allow_git_config=false.
+    if !policy.fs.allow_git_config {
+        let root = project_root.to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+    }
     apply_policy_overlay(&mut cmd, policy)?;
     cmd.args(["--", "sh", "-c", command])
         .current_dir(project_root);
@@ -121,6 +126,11 @@ pub fn build_command_with_proxy(
 
     let (mut cmd, home) = base_cmd(project_root);
     apply_credential_denies(&mut cmd, &home);
+    // Gap 1 of #1072: protect git hooks + config when allow_git_config=false.
+    if !policy.fs.allow_git_config {
+        let root = project_root.to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+    }
     apply_policy_overlay(&mut cmd, policy)?;
 
     // Network isolation. The fresh netns has no routes anywhere
@@ -167,6 +177,46 @@ fn apply_credential_denies(cmd: &mut Command, home: &str) {
         if Path::new(&p).exists() {
             cmd.args(["--tmpfs", &p]);
         }
+    }
+}
+
+/// Protect `.git/hooks/` and `.git/config` when `allow_git_config` is
+/// false (the default, Gap 1 of #1072).
+///
+/// Strategy mirrors `PROTECTED_PROJECT_SUBDIRS` in [`base_cmd`]:
+///
+/// 1. `pre-create` the hooks directory so bwrap has a mountpoint even
+///    on repos that have never had hooks (avoids the "source doesn't
+///    exist" error that would make `--ro-bind` fail).  Pre-creating
+///    an empty directory is safe — it only matters once `.git` itself
+///    exists, and `create_dir_all` is idempotent.
+/// 2. Bind-mount `.git/hooks/` read-only — sandboxed commands can
+///    see hook names (e.g. for `git log --decorate`) but cannot
+///    create or overwrite them.
+/// 3. `.git/config` is a file so we can't bind-mount it unless it
+///    already exists; when it does, bind it read-only.  When it
+///    doesn't yet exist, there is nothing to protect — a sandboxed
+///    command that runs `git init` will create it, but any subsequent
+///    sandbox invocation will pick up the protection on that next call
+///    since this check re-runs per command.  The window is one
+///    invocation; the seatbelt backend closes it fully via SBPL
+///    (deny rules apply even to paths that don't exist yet).
+///
+/// Only called when `.git/` itself exists — skip entirely on plain
+/// directories that have never been initialised as a repo.
+fn apply_git_config_deny(cmd: &mut Command, root: &str) {
+    let git_dir = format!("{root}/.git");
+    if !Path::new(&git_dir).exists() {
+        return;
+    }
+    // Hooks directory: pre-create + read-only bind.
+    let hooks = format!("{git_dir}/hooks");
+    let _ = std::fs::create_dir_all(&hooks);
+    cmd.args(["--ro-bind", &hooks, &hooks]);
+    // Config file: read-only bind only when present.
+    let config = format!("{git_dir}/config");
+    if Path::new(&config).exists() {
+        cmd.args(["--ro-bind", &config, &config]);
     }
 }
 
@@ -533,5 +583,84 @@ mod tests {
                 None => std::env::remove_var(STAGE2_BIN_ENV_KEY),
             }
         }
+    }
+
+    // ── Gap 1 of #1072: apply_git_config_deny ──────────────────────
+
+    /// `apply_git_config_deny` is a no-op on plain (non-git) directories.
+    #[test]
+    fn git_config_deny_skips_non_git_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cmd = Command::new("true");
+        let args_before: Vec<_> = cmd.as_std().get_args().collect();
+        let root = dir.path().to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+        let args_after: Vec<_> = cmd.as_std().get_args().collect();
+        assert_eq!(
+            args_before.len(),
+            args_after.len(),
+            "no args should be added for a directory with no .git/"
+        );
+    }
+
+    /// Once `.git/` exists, the hooks directory is pre-created and
+    /// bound read-only, and the config file (when present) is also
+    /// bound read-only.
+    #[test]
+    fn git_config_deny_adds_ro_bind_for_existing_git_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let git = dir.path().join(".git");
+        std::fs::create_dir_all(git.join("hooks")).unwrap();
+        std::fs::write(git.join("config"), b"[core]\n").unwrap();
+
+        let mut cmd = Command::new("true");
+        let root = dir.path().to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        // Should see --ro-bind for hooks and --ro-bind for config.
+        assert!(
+            args.windows(3)
+                .any(|w| { w[0] == "--ro-bind" && w[1].ends_with("/.git/hooks") }),
+            "hooks directory must be ro-bound: {args:?}"
+        );
+        assert!(
+            args.windows(3)
+                .any(|w| { w[0] == "--ro-bind" && w[1].ends_with("/.git/config") }),
+            "git config file must be ro-bound when it exists: {args:?}"
+        );
+    }
+
+    /// When `allow_git_config` is explicitly set, `build_command`
+    /// must NOT add the ro-bind mounts.
+    #[test]
+    fn build_command_skips_git_deny_when_allowed() {
+        if !is_available() {
+            eprintln!("bwrap not available; skipping");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        // Create a .git dir so `apply_git_config_deny` would fire if
+        // incorrectly called.
+        std::fs::create_dir_all(dir.path().join(".git/hooks")).unwrap();
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_git_config = true;
+        let cmd = build_command("true", dir.path(), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let has_hooks_ro_bind = args
+            .windows(3)
+            .any(|w| w[0] == "--ro-bind" && w[1].ends_with("/.git/hooks"));
+        assert!(
+            !has_hooks_ro_bind,
+            "allow_git_config=true must not add ro-bind for .git/hooks"
+        );
     }
 }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -592,13 +592,14 @@ mod tests {
     fn git_config_deny_skips_non_git_dir() {
         let dir = tempfile::tempdir().unwrap();
         let mut cmd = Command::new("true");
-        let args_before: Vec<_> = cmd.as_std().get_args().collect();
+        // Count before mutably borrowing cmd — collecting &OsStr refs would
+        // keep an immutable borrow alive across the &mut call (E0502).
+        let count_before = cmd.as_std().get_args().count();
         let root = dir.path().to_string_lossy();
         apply_git_config_deny(&mut cmd, &root);
-        let args_after: Vec<_> = cmd.as_std().get_args().collect();
+        let count_after = cmd.as_std().get_args().count();
         assert_eq!(
-            args_before.len(),
-            args_after.len(),
+            count_before, count_after,
             "no args should be added for a directory with no .git/"
         );
     }

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -146,6 +146,15 @@ fn build_command_inner(
         };
         profile.push_str(&protected_subdir_deny_rules(&root));
         profile.push_str(&credential_deny_rules(home));
+        // Gap 1 of #1072: enforce git hook + config write restrictions
+        // when allow_git_config is false (the default). Emitted after
+        // credential denies and before the caller-supplied policy overlay
+        // so any future explicit allow_read_within_deny entries for git
+        // paths still win. The flag is part of the cache key, so misses
+        // are safe and hits are correct.
+        if !k.policy.fs.allow_git_config {
+            profile.push_str(&git_config_deny_rules(&root));
+        }
         profile.push_str(&overlay);
         profile
     });
@@ -400,6 +409,43 @@ pub(crate) fn credential_deny_rules(home: &str) -> String {
         ));
     }
 
+    rules
+}
+
+/// Deny writes to `.git/config` and `.git/hooks/` when
+/// `policy.fs.allow_git_config` is `false` (the default).
+///
+/// These two paths are the primary vectors for git-based sandbox escape:
+///
+/// - `.git/config` — `git config core.fsmonitor <cmd>` or
+///   `core.hookspath` register arbitrary executables that run on the
+///   next porcelain command.  Preventing writes here blocks the
+///   registration step.
+/// - `.git/hooks/` — direct creation / replacement of hook scripts
+///   (`post-checkout`, `pre-commit`, etc.) achieves the same outcome
+///   without touching `config`.
+///
+/// Seatbelt's last-match-wins semantics let this deny override the
+/// broad `(allow file-write* (subpath "{root}"))` emitted earlier.
+/// Called only when git config writes are restricted — the flag is
+/// part of the seatbelt-cache key, so profiles diverge correctly.
+///
+/// Injection safety: `root` was already validated by
+/// [`validate_seatbelt_path`] at the call site; appending well-known
+/// ASCII subpaths (`.git/hooks`, `.git/config`) introduces no new
+/// S-expression metacharacters.
+pub(crate) fn git_config_deny_rules(root: &str) -> String {
+    let mut rules = String::from(
+        "; ── deny git hook+config writes (allow_git_config = false, #1072 Gap 1) ──\n",
+    );
+    // Deny ALL writes inside .git/hooks — prevents direct hook placement.
+    rules.push_str(&format!(
+        "(deny file-write* (subpath \"{root}/.git/hooks\"))\n"
+    ));
+    // Deny writes to .git/config — blocks `git config core.fsmonitor …`.
+    rules.push_str(&format!(
+        "(deny file-write* (literal \"{root}/.git/config\"))\n"
+    ));
     rules
 }
 
@@ -713,6 +759,75 @@ mod tests {
         assert!(
             credential_pos < overlay_pos,
             "policy overlay must come after credential rules"
+        );
+    }
+
+    // ── Gap 1 of #1072: allow_git_config deny rules ──────────────────
+
+    #[test]
+    fn git_config_deny_rules_cover_hooks_and_config() {
+        let rules = git_config_deny_rules("/work/myproject");
+        assert!(
+            rules.contains("(deny file-write* (subpath \"/work/myproject/.git/hooks\"))"),
+            "hooks subpath must be denied: {rules}"
+        );
+        assert!(
+            rules.contains("(deny file-write* (literal \"/work/myproject/.git/config\"))"),
+            "git/config literal must be denied: {rules}"
+        );
+    }
+
+    #[test]
+    fn git_config_deny_rules_deny_only_writes_not_reads() {
+        // Git commands need to READ hooks and config (e.g. `git status`
+        // reads core.hooksPath). We must deny writes, not reads.
+        let rules = git_config_deny_rules("/work");
+        assert!(
+            !rules.contains("deny file-read*"),
+            "git config deny must not block reads (breaks git porcelain): {rules}"
+        );
+    }
+
+    #[test]
+    fn build_command_includes_git_deny_rules_when_not_allowed() {
+        // End-to-end: policy with allow_git_config=false (the default)
+        // must include the deny rules in the compiled profile.
+        let policy = SandboxPolicy::strict_default(); // allow_git_config is false
+        let cmd = build_command("true", Path::new("/tmp"), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1]; // args: ["-p", "<profile>", "sh", "-c", "true"]
+        assert!(
+            profile.contains(".git/hooks"),
+            "profile must contain git hooks deny when allow_git_config=false"
+        );
+        assert!(
+            profile.contains(".git/config"),
+            "profile must contain git config deny when allow_git_config=false"
+        );
+    }
+
+    #[test]
+    fn build_command_omits_git_deny_rules_when_explicitly_allowed() {
+        // Callers that set allow_git_config=true (e.g. a dedicated
+        // git-workflow agent) must not get the deny rules — they'd break
+        // hook-based workflows that the caller explicitly approved.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_git_config = true;
+        let cmd = build_command("true", Path::new("/tmp"), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+        // The git deny block header must be absent.
+        assert!(
+            !profile.contains("allow_git_config = false, #1072"),
+            "profile must not include git deny rules when allow_git_config=true"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #1045

Implements the two outstanding gaps from the #1072 sandbox spec. Gap 2 (Auto mode hard-fail) was already closed.

---

### Gap 1 — `allow_git_config` enforcement (default: `false`)

Both backends now block writes to `.git/hooks/` and `.git/config` when the policy flag is off (the default), preventing the two primary git-based sandbox-escape vectors:

- `git config core.fsmonitor <cmd>` / `core.hookspath` — blocked via `(deny file-write* (literal "…/.git/config"))`
- Direct hook creation in `.git/hooks/` — blocked via `(deny file-write* (subpath "…/.git/hooks"))`

| Backend | Mechanism |
|---|---|
| **seatbelt (macOS)** | `git_config_deny_rules(root)` — pure SBPL string builder, follows `credential_deny_rules` pattern. Emitted after credential denies, before policy overlay. Flag is part of the cache key so hits are always correct. |
| **bwrap (Linux)** | `apply_git_config_deny(cmd, root)` — pre-creates `.git/hooks/` so bwrap has a mountpoint, then `--ro-bind`s it. `.git/config` gets `--ro-bind`'d only when it already exists. No-op on non-git directories. |

---

### Gap 2 — Auto mode hard-fail ✅ already closed

---

### Gap 3 — Seed `allow_write` with canonical project root

`policy_for_agent()` removes the `let _ = project_root` stub and sets `fs.allow_write = [canonical_root]` across all trust modes.

Before this fix `allow_write` was always `[]`, making `compose()`'s parent-wins rule vacuously correct but meaningless — `intersect([], []) == []` regardless of what the kernel baseline actually grants. Seeding with the project root makes the lattice match reality.

The `compose_child_policy_with_strict_default_parent_is_just_child_policy` test is updated to document the known non-identity exception: `strict_default()` is the algebraic identity for all fields *except* `allow_write`, where parent-wins semantics make the empty parent list override the child's value. Top-level agents never go through `compose` — they call `policy_for_agent` directly.

---

### Tests added (9 new)

**`koda-sandbox` (seatbelt):**
- `git_config_deny_rules_cover_hooks_and_config`
- `git_config_deny_rules_deny_only_writes_not_reads`
- `build_command_includes_git_deny_rules_when_not_allowed`
- `build_command_omits_git_deny_rules_when_explicitly_allowed`

**`koda-sandbox` (bwrap, Linux-only):**
- `git_config_deny_skips_non_git_dir`
- `git_config_deny_adds_ro_bind_for_existing_git_dir`
- `build_command_skips_git_deny_when_allowed`

**`koda-core`:**
- `policy_for_agent_seeds_allow_write_with_canonical_root`
- `policy_for_agent_allow_write_survives_nonexistent_root`