### PR TITLE
feat(engine): route bg-task status through EngineEvent (closes #1076)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,16 +188,20 @@ from `KodaSession` (per-conversation, mutable). Zed conflates these into
 shares the agent definition by `Arc` and has its own session for state. No
 `Arc<RwLock<>>` everywhere.
 
-**Known leak: background sub-agent status** (tracked in #1076). The boundary
-claim above — "all engine output flows through `EngineSink`" — is true for
-inference output but not for `BgAgentRegistry` status. The TUI today reads
-bg-task state by calling `BgAgentRegistry::snapshot()` directly through a
-shared `Arc` it grabs out of `KodaSession`. There is no `BgTaskUpdate`
-variant in `EngineEvent`, so ACP clients and headless mode cannot surface
-live bg-task status even though the engine has the data. Fix is to add
-`EngineEvent::BgTaskUpdate { id, status, … }` and have the registry push
-to the sink on transitions (~50–100 LOC). Until then this is a documented
-carve-out, not a permanent design choice.
+**Background-task status routing** (#1076, fixed). Bg-task lifecycle
+transitions (`Pending` → `Running { iter }` → terminal) flow through
+`EngineEvent::BgTaskUpdate` like every other engine output. The
+fan-out helper [`BgStatusEmitter`] writes each transition to two
+places: the per-task `watch::Sender<AgentStatus>` (read by
+`/agents` snapshots and the status-bar pill) AND the registry's
+status-event queue (drained by the inference loop alongside
+[`BgAgentRegistry::drain_completed`] and forwarded to the active
+`EngineSink`). Same drain, same FIFO ordering, same sink — the
+TUI, headless mode, and ACP clients see identical event streams.
+The TUI's bg-task panel still uses `snapshot()` for its primary
+render, but that is now a presentational choice (snapshot is
+cheaper for a panel that re-renders every frame), not the
+documented carve-out it used to be.
 
 ### ACP (Agent Client Protocol) (P3)
 

--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -136,6 +136,40 @@ pub fn engine_event_to_acp(
             ))
         }
 
+        // #1076: surface bg-task lifecycle as plain text chunks. ACP
+        // doesn't have a typed bg-task notification today, so we render
+        // a short `[bg task N] kind` line that ACP-aware IDEs can
+        // either show inline or filter on the `[bg task N]` prefix.
+        // The full structured payload is still on the wire for any
+        // future typed mapping — see `EngineEvent::BgTaskUpdate`.
+        EngineEvent::BgTaskUpdate {
+            task_id, status, ..
+        } => {
+            let summary = match status {
+                koda_core::bg_agent::AgentStatus::Pending => "pending".to_string(),
+                koda_core::bg_agent::AgentStatus::Running { iter } => {
+                    if *iter == 0 {
+                        "running (starting)".to_string()
+                    } else {
+                        format!("running (iter {iter})")
+                    }
+                }
+                koda_core::bg_agent::AgentStatus::Cancelled => "cancelled".to_string(),
+                koda_core::bg_agent::AgentStatus::Completed { .. } => "completed".to_string(),
+                koda_core::bg_agent::AgentStatus::Errored { error } => {
+                    let snippet: String = error.chars().take(80).collect();
+                    format!("errored: {snippet}")
+                }
+            };
+            let cb = acp::ContentBlock::Text(acp::TextContent::new(format!(
+                "[bg task {task_id}] {summary}"
+            )));
+            Some(acp::SessionNotification::new(
+                session_id.to_string(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(cb)),
+            ))
+        }
+
         // Handled specially by AcpSink (bidirectional permission flow)
         EngineEvent::ApprovalRequest { .. } => None,
         // AskUser not yet implemented in ACP protocol; filtered here.
@@ -425,6 +459,91 @@ mod tests {
                 assert_eq!(tc.kind, acp::ToolKind::Other);
             }
             _ => panic!("Expected ToolCall"),
+        }
+    }
+
+    // #1076: bg-task lifecycle must reach ACP clients as session
+    // notifications.  Pre-fix the TUI was the only client that saw
+    // bg status because it polled the registry directly; now every
+    // transition flows through `EngineEvent::BgTaskUpdate` and lands
+    // here as a text chunk an ACP-aware IDE can render or filter.
+    #[test]
+    fn test_bg_task_update_running_iter_zero_renders_starting() {
+        let event = EngineEvent::BgTaskUpdate {
+            task_id: 5,
+            spawner: None,
+            status: koda_core::bg_agent::AgentStatus::Running { iter: 0 },
+        };
+        let notif = engine_event_to_acp(&event, "s1").expect("must produce notification");
+        match notif.update {
+            acp::SessionUpdate::AgentMessageChunk(chunk) => match chunk.content {
+                acp::ContentBlock::Text(t) => {
+                    assert!(t.text.contains("[bg task 5]"), "got: {}", t.text);
+                    assert!(t.text.contains("running (starting)"), "got: {}", t.text);
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected AgentMessageChunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_bg_task_update_renders_iter_count() {
+        let event = EngineEvent::BgTaskUpdate {
+            task_id: 12,
+            spawner: Some(7),
+            status: koda_core::bg_agent::AgentStatus::Running { iter: 4 },
+        };
+        let notif = engine_event_to_acp(&event, "s1").unwrap();
+        let acp::SessionUpdate::AgentMessageChunk(chunk) = notif.update else {
+            panic!("expected chunk");
+        };
+        let acp::ContentBlock::Text(t) = chunk.content else {
+            panic!("expected text");
+        };
+        assert!(t.text.contains("running (iter 4)"), "got: {}", t.text);
+    }
+
+    #[test]
+    fn test_bg_task_update_terminal_states_are_distinguishable() {
+        // The four terminal-ish kinds must each render to a unique
+        // string so an ACP client (or grep) can distinguish them.
+        // Pending is included because it's the initial reservation
+        // state — some clients may want to show "queued".
+        let cases = [
+            (koda_core::bg_agent::AgentStatus::Pending, "pending"),
+            (koda_core::bg_agent::AgentStatus::Cancelled, "cancelled"),
+            (
+                koda_core::bg_agent::AgentStatus::Completed {
+                    summary: "all good".into(),
+                },
+                "completed",
+            ),
+            (
+                koda_core::bg_agent::AgentStatus::Errored {
+                    error: "boom".into(),
+                },
+                "errored",
+            ),
+        ];
+        for (status, marker) in cases {
+            let event = EngineEvent::BgTaskUpdate {
+                task_id: 1,
+                spawner: None,
+                status,
+            };
+            let notif = engine_event_to_acp(&event, "s1").unwrap();
+            let acp::SessionUpdate::AgentMessageChunk(chunk) = notif.update else {
+                panic!("expected chunk");
+            };
+            let acp::ContentBlock::Text(t) = chunk.content else {
+                panic!("expected text");
+            };
+            assert!(
+                t.text.contains(marker),
+                "status missing {marker:?} marker, got: {}",
+                t.text
+            );
         }
     }
 

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -269,6 +269,32 @@ impl EngineSink for HeadlessSink {
             EngineEvent::ContextUsage { .. } => {}
             EngineEvent::TurnStart { .. } => {}
             EngineEvent::TurnEnd { .. } => {}
+            // (#1076) Bg-task lifecycle in headless: render as a short
+            // status line so a script tailing stdout sees "task 7
+            // running (iter 3)" instead of nothing. The full result
+            // payload is still injected at completion via the
+            // `drain_completed` path — this is just live progress.
+            EngineEvent::BgTaskUpdate {
+                task_id, status, ..
+            } => {
+                let summary = match status {
+                    koda_core::bg_agent::AgentStatus::Pending => "pending".to_string(),
+                    koda_core::bg_agent::AgentStatus::Running { iter } => {
+                        if iter == 0 {
+                            "running (starting)".to_string()
+                        } else {
+                            format!("running (iter {iter})")
+                        }
+                    }
+                    koda_core::bg_agent::AgentStatus::Cancelled => "cancelled".to_string(),
+                    koda_core::bg_agent::AgentStatus::Completed { .. } => "completed".to_string(),
+                    koda_core::bg_agent::AgentStatus::Errored { error } => {
+                        let snippet: String = error.chars().take(80).collect();
+                        format!("errored: {snippet}")
+                    }
+                };
+                eprintln!("\x1b[2m  [bg task {task_id}] {summary}\x1b[0m");
+            }
             EngineEvent::Footer {
                 completion_tokens,
                 total_chars,

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -283,8 +283,13 @@ impl TuiRenderer {
             | EngineEvent::ContextUsage { .. }
             | EngineEvent::TurnStart { .. }
             | EngineEvent::TurnEnd { .. }
-            | EngineEvent::LoopCapReached { .. } => {
+            | EngineEvent::LoopCapReached { .. }
+            | EngineEvent::BgTaskUpdate { .. } => {
                 // Handled by the event loop, not the renderer.
+                // (#1076) BgTaskUpdate is routed to the bg-task panel,
+                // which still reads from the registry snapshot for its
+                // primary render. Future cleanup may have it consume
+                // the event stream directly and drop the polling.
             }
             EngineEvent::ActionBlocked {
                 tool_name: _,

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -45,9 +45,12 @@ use std::time::{Duration, Instant};
 // We deliberately keep this *sync* (not `tokio::sync::Mutex`) because
 // the critical sections are short HashMap ops with no awaits inside.
 use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use tokio::sync::{oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
+
+use crate::engine::EngineEvent;
 
 // ── Layer 0 of #996 ──────────────────────────────────────────────────────
 //
@@ -70,7 +73,8 @@ use tokio_util::task::AbortOnDropHandle;
 /// `Running.iter` reflects the current inference iteration (1..=20).
 /// Background agents emit live updates via Layer 4 (#1058); `0` is
 /// the entry-point placeholder before the first iteration fires.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentStatus {
     /// Reserved but the spawned future hasn't started yet.
     Pending,
@@ -212,6 +216,104 @@ struct BgAgentEntry {
 pub struct BgAgentRegistry {
     pending: Mutex<HashMap<u32, BgAgentEntry>>,
     next_id: Mutex<u32>,
+    /// Queue of `EngineEvent::BgTaskUpdate` events produced by
+    /// [`BgStatusEmitter::send`]. Drained by the inference loop
+    /// alongside [`Self::drain_completed`] and forwarded to the
+    /// active `EngineSink`.
+    ///
+    /// **#1076**: closes the engine/UI boundary leak — prior to this
+    /// queue, bg-task status only reached the TUI by the TUI grabbing
+    /// `Arc<BgAgentRegistry>` directly out of `KodaSession` and
+    /// polling `snapshot()`. ACP / headless clients saw nothing.
+    /// Routing through `EngineEvent` puts every client surface on
+    /// the same channel.
+    ///
+    /// `VecDeque` not `Vec` because we drain FIFO (transition order
+    /// matters: `Pending` → `Running` → terminal must arrive in that
+    /// order even if the inference loop drains in batches).
+    events: Mutex<std::collections::VecDeque<EngineEvent>>,
+}
+
+/// Fan-out helper for bg-agent status transitions.
+///
+/// Bundles the per-task `watch::Sender<AgentStatus>` (read by
+/// `/agents` and the status-bar pill via the registry's snapshot
+/// API) with a back-reference to the registry's event queue (drained
+/// by the inference loop and forwarded to the engine sink — which is
+/// what closes the #1076 boundary leak).
+///
+/// `Clone` is intentional so Layer 4 (`#1058`, live `iter` heartbeat)
+/// can hold its own copy inside `execute_sub_agent` while
+/// `run_bg_agent` keeps another for the entry / terminal transitions.
+/// Both clones share the same `watch::Sender` and `Arc<registry>`,
+/// so every `.send()` reaches both fan-out targets.
+#[derive(Clone)]
+pub struct BgStatusEmitter {
+    task_id: u32,
+    spawner: Option<u32>,
+    status_tx: watch::Sender<AgentStatus>,
+    registry: Arc<BgAgentRegistry>,
+}
+
+impl BgStatusEmitter {
+    /// Construct from the parts handed back by [`BgAgentRegistry::reserve`].
+    ///
+    /// The registry `Arc` is held for the lifetime of the bg agent,
+    /// which is fine: the inference loop already keeps an `Arc` on
+    /// the same registry, and registry drop is what aborts every
+    /// in-flight bg task (B3 of #1022) — so an emitter outliving its
+    /// registry is impossible by construction.
+    pub fn new(
+        task_id: u32,
+        spawner: Option<u32>,
+        status_tx: watch::Sender<AgentStatus>,
+        registry: Arc<BgAgentRegistry>,
+    ) -> Self {
+        Self {
+            task_id,
+            spawner,
+            status_tx,
+            registry,
+        }
+    }
+
+    /// Drive a status transition.
+    ///
+    /// Fans out to:
+    /// 1. The per-task `watch::Sender` (so `snapshot()` / `/agents`
+    ///    see the new state on the next read — no behavior change).
+    /// 2. The registry's event queue, drained by the inference loop
+    ///    and forwarded to the active `EngineSink` (so the TUI / ACP
+    ///    / headless clients all see the same `BgTaskUpdate` event).
+    ///
+    /// `watch::Sender::send` only fails if every receiver was dropped,
+    /// which means the registry entry is gone — in that case the queue
+    /// push is harmless (it'll be drained and ignored by clients that
+    /// don't recognize the task id). We deliberately don't gate the
+    /// queue push on the watch send result so a racing reap doesn't
+    /// swallow the terminal `BgTaskUpdate`.
+    pub fn send(&self, status: AgentStatus) {
+        let _ = self.status_tx.send(status.clone());
+        self.registry.push_status_event(EngineEvent::BgTaskUpdate {
+            task_id: self.task_id,
+            spawner: self.spawner,
+            status,
+        });
+    }
+
+    /// Current status (read from the watch channel). Useful for
+    /// terminal-disambiguation logic (e.g. "was this a cancel or a
+    /// real error?") without taking the registry lock.
+    pub fn current(&self) -> AgentStatus {
+        self.status_tx.borrow().clone()
+    }
+
+    /// Test helper: peek the underlying watch sender. Production
+    /// code should always go through [`Self::send`].
+    #[cfg(test)]
+    pub fn status_sender(&self) -> watch::Sender<AgentStatus> {
+        self.status_tx.clone()
+    }
 }
 
 /// Reservation slot returned by [`BgAgentRegistry::reserve`].
@@ -259,7 +361,27 @@ impl BgAgentRegistry {
         Self {
             pending: Mutex::new(HashMap::new()),
             next_id: Mutex::new(1),
+            events: Mutex::new(std::collections::VecDeque::new()),
         }
+    }
+
+    /// Push an event onto the status queue. Called by
+    /// [`BgStatusEmitter::send`]; not part of the public API.
+    pub(crate) fn push_status_event(&self, event: EngineEvent) {
+        self.events.lock().push_back(event);
+    }
+
+    /// Drain queued status events for forwarding to the active
+    /// `EngineSink`. Called by the inference loop alongside
+    /// [`Self::drain_completed`].
+    ///
+    /// Returns events in FIFO order (transition order); empty if
+    /// nothing changed since the last drain. Cheap: a single mutex
+    /// acquisition + `VecDeque::drain`. The vast majority of turns
+    /// will see 0–1 events.
+    pub fn drain_status_events(&self) -> Vec<EngineEvent> {
+        let mut q = self.events.lock();
+        q.drain(..).collect()
     }
 
     /// Reserve a task ID and produce a oneshot sender + child cancel
@@ -1451,5 +1573,195 @@ mod tests {
             }
             other => panic!("expected Completed, got {other:?}"),
         }
+    }
+
+    // ── #1076: BgStatusEmitter → sink fan-out ───────────────────────────────
+
+    /// Helper: build an emitter wired to the given registry, mirroring
+    /// the production construction in `sub_agent_dispatch::execute_sub_agent`.
+    fn emitter_for(
+        reg: &Arc<BgAgentRegistry>,
+        task_id: u32,
+        spawner: Option<u32>,
+    ) -> BgStatusEmitter {
+        let (tx, _rx) = watch::channel(AgentStatus::Pending);
+        BgStatusEmitter::new(task_id, spawner, tx, reg.clone())
+    }
+
+    fn extract(event: &EngineEvent) -> (u32, Option<u32>, &AgentStatus) {
+        match event {
+            EngineEvent::BgTaskUpdate {
+                task_id,
+                spawner,
+                status,
+            } => (*task_id, *spawner, status),
+            other => panic!("expected BgTaskUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn emitter_send_queues_engine_event_on_registry() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        let emitter = emitter_for(&reg, 7, Some(42));
+
+        // Initial: queue is empty.
+        assert!(
+            reg.drain_status_events().is_empty(),
+            "fresh registry must have an empty event queue"
+        );
+
+        emitter.send(AgentStatus::Running { iter: 0 });
+        let drained = reg.drain_status_events();
+        assert_eq!(drained.len(), 1, "single send must produce one event");
+        let (id, spawner, status) = extract(&drained[0]);
+        assert_eq!(id, 7);
+        assert_eq!(spawner, Some(42));
+        assert!(matches!(status, AgentStatus::Running { iter: 0 }));
+    }
+
+    #[test]
+    fn emitter_drain_is_fifo_and_clears_queue() {
+        let reg = Arc::new(BgAgentRegistry::new());
+        let emitter = emitter_for(&reg, 1, None);
+
+        emitter.send(AgentStatus::Running { iter: 0 });
+        emitter.send(AgentStatus::Running { iter: 1 });
+        emitter.send(AgentStatus::Running { iter: 2 });
+        emitter.send(AgentStatus::Completed {
+            summary: "done".into(),
+        });
+
+        let drained = reg.drain_status_events();
+        assert_eq!(drained.len(), 4, "all four sends must surface");
+
+        // FIFO: transition order is preserved across batches.  This
+        // matters for clients that render "iter N" progress — a
+        // reorder would show the count moving backwards.
+        let iters: Vec<_> = drained
+            .iter()
+            .filter_map(|e| match e {
+                EngineEvent::BgTaskUpdate {
+                    status: AgentStatus::Running { iter },
+                    ..
+                } => Some(*iter),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(iters, vec![0, 1, 2]);
+
+        // Last event is the terminal Completed.
+        assert!(matches!(
+            extract(&drained[3]).2,
+            AgentStatus::Completed { .. }
+        ));
+
+        // Drain consumes — second drain is empty.
+        assert!(
+            reg.drain_status_events().is_empty(),
+            "drain must clear the queue"
+        );
+    }
+
+    #[test]
+    fn emitter_send_also_updates_watch_channel() {
+        // The watch fan-out is what `/agents` and `snapshot()` read.
+        // Sink fan-out (queue) is for the inference-loop → EngineSink
+        // path.  Both targets must see every transition or `/agents`
+        // and the TUI/ACP/headless clients will disagree on state.
+        let reg = Arc::new(BgAgentRegistry::new());
+        let (tx, mut rx) = watch::channel(AgentStatus::Pending);
+        let emitter = BgStatusEmitter::new(3, None, tx, reg.clone());
+
+        emitter.send(AgentStatus::Running { iter: 5 });
+
+        // Watch channel observed.
+        assert!(matches!(
+            *rx.borrow_and_update(),
+            AgentStatus::Running { iter: 5 }
+        ));
+        // Queue observed.
+        let drained = reg.drain_status_events();
+        assert_eq!(drained.len(), 1);
+        assert!(matches!(
+            extract(&drained[0]).2,
+            AgentStatus::Running { iter: 5 }
+        ));
+    }
+
+    #[test]
+    fn emitter_clones_share_queue_and_watch() {
+        // Layer 4 holds one clone for live `iter` heartbeats;
+        // `run_bg_agent` keeps another for entry / terminal sends.
+        // Both clones must funnel into the same registry queue and
+        // the same per-task watch channel — otherwise terminal
+        // states could land on a different queue than the heartbeats
+        // and clients would see Running forever.
+        let reg = Arc::new(BgAgentRegistry::new());
+        let (tx, _rx) = watch::channel(AgentStatus::Pending);
+        let a = BgStatusEmitter::new(11, Some(2), tx, reg.clone());
+        let b = a.clone();
+
+        a.send(AgentStatus::Running { iter: 1 });
+        b.send(AgentStatus::Completed {
+            summary: "ok".into(),
+        });
+
+        let drained = reg.drain_status_events();
+        assert_eq!(drained.len(), 2, "clones must share the registry queue");
+        // Watch channel reflects the LATEST send, regardless of which
+        // clone made it (watch is overwriting by design).
+        assert!(matches!(a.current(), AgentStatus::Completed { .. }));
+    }
+
+    #[test]
+    fn agent_status_round_trips_through_serde() {
+        // `EngineEvent::BgTaskUpdate` is the wire format for ACP /
+        // headless / future transports.  All `AgentStatus` variants
+        // must survive a serde round-trip or the boundary leak fix
+        // creates a new boundary leak (engine emits, transport drops
+        // it on the floor).
+        for status in [
+            AgentStatus::Pending,
+            AgentStatus::Running { iter: 0 },
+            AgentStatus::Running { iter: 17 },
+            AgentStatus::Cancelled,
+            AgentStatus::Completed {
+                summary: "hello".into(),
+            },
+            AgentStatus::Errored {
+                error: "boom".into(),
+            },
+        ] {
+            let event = EngineEvent::BgTaskUpdate {
+                task_id: 1,
+                spawner: Some(2),
+                status: status.clone(),
+            };
+            let json = serde_json::to_string(&event).expect("serialize");
+            let back: EngineEvent = serde_json::from_str(&json).expect("deserialize");
+            match back {
+                EngineEvent::BgTaskUpdate {
+                    task_id,
+                    spawner,
+                    status: round_tripped,
+                } => {
+                    assert_eq!(task_id, 1);
+                    assert_eq!(spawner, Some(2));
+                    assert_eq!(round_tripped, status, "json round-trip lost data: {json}");
+                }
+                other => panic!("round-trip changed variant: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn drain_status_events_is_empty_on_fresh_registry() {
+        // The inference loop calls `drain_status_events` every
+        // iteration; the no-bg-task case must be cheap and yield
+        // an empty Vec without any allocations forced by mistakes
+        // in the queue type (e.g. `Some(VecDeque::new())`).
+        let reg = BgAgentRegistry::new();
+        let drained = reg.drain_status_events();
+        assert!(drained.is_empty());
     }
 }

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -103,6 +103,33 @@ pub enum EngineEvent {
 
     /// A sub-agent finished.
 
+    // ── Background sub-agent lifecycle ────────────────────────────────
+    /// A background sub-agent's status changed.
+    ///
+    /// Emitted on every transition through [`crate::bg_agent::AgentStatus`]
+    /// (`Pending` → `Running { iter }` → terminal). Drained from the
+    /// registry's status queue inside the inference loop alongside
+    /// [`crate::bg_agent::BgAgentRegistry::drain_completed`], so any sink
+    /// (CLI / TUI / headless / ACP) sees the same event stream without
+    /// having to poll the registry directly.
+    ///
+    /// Closes the engine/UI boundary leak documented in #1076 — prior to
+    /// this variant the TUI was the only client that could see live bg
+    /// status because it shared the process and grabbed
+    /// `Arc<BgAgentRegistry>` straight out of `KodaSession`.
+    BgTaskUpdate {
+        /// Monotonic id assigned at `reserve()` time, stable for the
+        /// lifetime of the task.
+        task_id: u32,
+        /// Sub-agent invocation id of the spawner, or `None` if the
+        /// task was launched from the top-level loop. See
+        /// [`crate::bg_agent::BgTaskSnapshot::spawner`].
+        spawner: Option<u32>,
+        /// New status. Includes `Running { iter }` heartbeats so
+        /// clients can render iteration progress without polling.
+        status: crate::bg_agent::AgentStatus,
+    },
+
     // ── Approval flow ─────────────────────────────────────────────────
     /// The engine needs user approval before executing a tool.
     ///

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -651,6 +651,18 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     }
 
     loop {
+        // #1076: forward queued bg-task status transitions to the sink
+        // before processing anything else. Drained from the same
+        // `Arc<BgAgentRegistry>` that owns `drain_completed`, so the
+        // ordering is: status transitions first (so clients see
+        // `Running { iter: N }` heartbeats), then completed-result
+        // injection (so the model gets the final output as a user
+        // message). FIFO inside the queue preserves transition
+        // order across batches.
+        for ev in bg_agents.drain_status_events() {
+            sink.emit(ev);
+        }
+
         // Inject completed background agent results as user messages
         for bg_result in bg_agents.drain_completed() {
             let status = if bg_result.success {

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -124,24 +124,27 @@ async fn run_bg_agent(
     // The recursive `execute_sub_agent` composes the child policy
     // onto this so the bg agent inherits any parent narrowing.
     parent_sandbox_policy: koda_sandbox::SandboxPolicy,
-    // Layer 0 of #996: status channel — we own the writer end.
-    // Pending → Running on entry; one of Completed/Errored/Cancelled
-    // before the future returns. The registry's matching
-    // `watch::Receiver` is what `/agents` and the (future) status-bar
-    // pill read. `send` failures are deliberately ignored: the
-    // receiver lives on the entry inside the registry, and the only
-    // way `send` returns `Err` is if every receiver was dropped —
-    // which means the registry itself was dropped, in which case our
-    // result oneshot below is also doomed and the user can't see us
-    // anyway. Logging would be noise.
-    status_tx: tokio::sync::watch::Sender<crate::bg_agent::AgentStatus>,
+    // Layer 0 of #996 + #1076: status fan-out helper. Drives the
+    // per-task `watch::Sender<AgentStatus>` (read by `/agents` and
+    // the status-bar pill via `snapshot()`) AND queues an
+    // `EngineEvent::BgTaskUpdate` on the registry so the inference
+    // loop can forward it to the active `EngineSink`. Pre-#1076 this
+    // was a raw `watch::Sender` and only the TUI (which polled the
+    // registry directly) saw transitions; now every client surface
+    // (TUI / headless / ACP) gets the same event stream.
+    //
+    // `send` failures on the underlying watch are silently absorbed
+    // by the emitter — the only way that fails is if the registry
+    // entry was reaped, in which case the queued `BgTaskUpdate` is
+    // harmless extra signal that clients can ignore.
+    emitter: crate::bg_agent::BgStatusEmitter,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
     // `execute_sub_agent` updates this to `iter: 1..=20` as it progresses
     // (Layer 4, #1058). `iter: 0` is intentional here — it signals
     // "started, first iteration pending".
-    let _ = status_tx.send(crate::bg_agent::AgentStatus::Running { iter: 0 });
+    emitter.send(crate::bg_agent::AgentStatus::Running { iter: 0 });
 
     let (_, mut cmd_rx) = mpsc::channel(1);
     // #1022 B9: bg agents used to run with `NullSink`, so every
@@ -190,11 +193,14 @@ async fn run_bg_agent(
         // invocation id (allocated inside the recursive call). The
         // parent's cascade-cancel covers cross-registry teardown.
         None,
-        // Layer 4 of #996: forward the status sender so the loop can
-        // push live `Running { iter }` updates. Cloned so the terminal
-        // sends below (Completed / Errored / Cancelled) can still use
-        // the original after `execute_sub_agent` returns.
-        Some(status_tx.clone()),
+        // Layer 4 of #996 + #1076: forward the status emitter so the
+        // loop can push live `Running { iter }` updates that fan out
+        // to BOTH the watch channel (for `/agents` snapshots) and
+        // the registry's event queue (for the inference-loop → sink
+        // path that ACP / headless / TUI all read from). Cloned so
+        // the terminal sends below still have access after
+        // `execute_sub_agent` returns.
+        Some(emitter.clone()),
     )
     .await;
 
@@ -209,7 +215,7 @@ async fn run_bg_agent(
     // drained sees the terminal state, not stale `Running`.
     match &result {
         Ok(output) => {
-            let _ = status_tx.send(crate::bg_agent::AgentStatus::Completed {
+            emitter.send(crate::bg_agent::AgentStatus::Completed {
                 // `summary` is currently the full output — truncation
                 // is the display layer's job (Codex pattern: see
                 // `COLLAB_AGENT_RESPONSE_PREVIEW_GRAPHEMES`).
@@ -228,7 +234,7 @@ async fn run_bg_agent(
                     error: e.to_string(),
                 }
             };
-            let _ = status_tx.send(status);
+            emitter.send(status);
         }
     }
 
@@ -273,12 +279,14 @@ pub(crate) fn execute_sub_agent<'a>(
     // child's own `my_invocation_id`, which is allocated below and
     // tags any bg work the child itself spawns.
     parent_spawner: Option<u32>,
-    // Layer 4 of #996: live iteration heartbeat.  Pass the bg-agent's
-    // `watch::Sender` so each loop iteration can push `Running { iter }`
-    // to the registry (and therefore to `/agents` and the status-bar
-    // pill).  Foreground sub-agents pass `None` — they have no status
-    // channel because they're not tracked in the registry at all.
-    status_tx: Option<tokio::sync::watch::Sender<crate::bg_agent::AgentStatus>>,
+    // Layer 4 of #996 + #1076: live iteration heartbeat.  Pass the
+    // bg-agent's `BgStatusEmitter` so each loop iteration can push
+    // `Running { iter }` to BOTH the registry's per-task watch
+    // channel (`/agents`, status-bar pill) AND the engine event
+    // queue (`EngineSink` → TUI / ACP / headless).  Foreground
+    // sub-agents pass `None` — they have no status channel because
+    // they're not tracked in the registry at all.
+    emitter: Option<crate::bg_agent::BgStatusEmitter>,
 ) -> impl std::future::Future<Output = Result<String>> + Send + 'a {
     async move {
         // Phase E of #996: allocate this invocation's id up-front. It
@@ -338,11 +346,22 @@ pub(crate) fn execute_sub_agent<'a>(
             let bg_tx = reservation.tx;
             let bg_rx = reservation.rx;
             let entry_cancel = reservation.cancel;
-            // Layer 0 of #996: status sender goes to the spawned
-            // future (sole writer); receiver stays on the registry
-            // entry so `snapshot()` / `/agents` can read it without
-            // touching the spawn site.
-            let bg_status_tx = reservation.status_tx;
+            // Layer 0 of #996 + #1076: bundle the watch sender, the
+            // task id, the spawner id, and an `Arc` on the registry
+            // into a `BgStatusEmitter`.  The emitter fans out every
+            // `.send(...)` to BOTH the per-task watch channel (read
+            // by `snapshot()` / `/agents`) AND the registry's event
+            // queue (drained by the inference loop and forwarded to
+            // the active `EngineSink`).  This is what closes the
+            // engine/UI boundary leak: the TUI no longer needs to
+            // poll the registry directly to render live status, and
+            // ACP / headless gain visibility for free.
+            let emitter = crate::bg_agent::BgStatusEmitter::new(
+                task_id,
+                parent_spawner,
+                reservation.status_tx,
+                bg_agents.clone(),
+            );
             let entry_status_rx = reservation.status_rx;
 
             let project_root_owned = project_root.to_path_buf();
@@ -373,7 +392,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_cancel,
                 bg_trust,
                 bg_policy,
-                bg_status_tx,
+                emitter,
             ));
 
             bg_agents.attach(
@@ -725,14 +744,16 @@ pub(crate) fn execute_sub_agent<'a>(
         );
 
         for iter in 1u8..=loop_guard::MAX_SUB_AGENT_ITERATIONS as u8 {
-            // Layer 4 of #996: push the live iteration counter so `/agents`
-            // and the status-bar pill reflect real progress instead of the
-            // Layer-0 placeholder `iter: 0` that `run_bg_agent` sends on
-            // entry.  `send` failures are ignored for the same reason as
-            // the terminal-status sends above: if the receiver is gone,
-            // the user can't see the update and we don't want noise.
-            if let Some(ref tx) = status_tx {
-                let _ = tx.send(crate::bg_agent::AgentStatus::Running { iter });
+            // Layer 4 of #996 + #1076: push the live iteration counter
+            // so `/agents`, the status-bar pill, AND ACP / headless /
+            // TUI clients all reflect real progress instead of the
+            // Layer-0 placeholder `iter: 0` that `run_bg_agent` sends
+            // on entry.  Fan-out failures inside the emitter are
+            // silently absorbed for the same reason as the terminal
+            // sends: if the receiver is gone, the user can't see the
+            // update and we don't want noise.
+            if let Some(ref e) = emitter {
+                e.send(crate::bg_agent::AgentStatus::Running { iter });
             }
             // Respect parent cancellation (#286)
             if cancel.is_cancelled() {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -310,9 +310,10 @@ pub(crate) async fn execute_one_tool(
             // and allocates a fresh `my_invocation_id` internally for
             // its own bg-task scoping.
             caller_spawner,
-            // Layer 4 of #996: foreground sub-agents are not tracked in
-            // the bg-agent registry, so there is no status channel to
-            // update. Pass `None` to skip the per-iteration send.
+            // Layer 4 of #996 + #1076: foreground sub-agents are not
+            // tracked in the bg-agent registry, so there is no
+            // `BgStatusEmitter` to fan out per-iteration heartbeats
+            // to. Pass `None` to skip the per-iteration emit.
             None,
         );
         match Box::pin(fut).await {


### PR DESCRIPTION
Closes #1076.

## Problem (recap)

The `DESIGN.md` claim — "all engine output flows through `EngineSink`" — was true for inference output but **false for `BgAgentRegistry` status**. The TUI only saw bg-task transitions because it shared the process and grabbed `Arc<BgAgentRegistry>` straight out of `KodaSession`. ACP clients and headless mode saw nothing live.

## Approach

**Zero-ripple fan-out**. Rather than threading `Arc<dyn EngineSink>` through 17 call sites (which all currently take `&dyn EngineSink`), I queue events inside the registry and drain them in the inference loop right next to the existing `drain_completed()` call. Same pattern as completed-result harvesting, no `tokio::spawn` boundary issues, no lifetime gymnastics.

```
                          BgStatusEmitter::send(status)
                                    │
                       ┌────────────┴────────────┐
                       ▼                         ▼
        watch::Sender<AgentStatus>     registry.events: VecDeque<EngineEvent>
        (snapshot() / /agents)             │
                                           ▼
                              inference_loop: drain_status_events()
                                           │
                                           ▼
                                      sink.emit(BgTaskUpdate)
                                           │
                       ┌────────────┬──────┴──────┬─────────────┐
                       ▼            ▼             ▼             ▼
                     TUI         Headless        ACP          (future)
```

## Changes

| File | Lines | What |
|---|---|---|
| `koda-core/src/engine/event.rs` | +27 | Add `EngineEvent::BgTaskUpdate { task_id, spawner, status }` |
| `koda-core/src/bg_agent.rs` | +302 / -10 | `Serialize`/`Deserialize` on `AgentStatus`; new `BgStatusEmitter`; `events` queue + push/drain on registry; **5 new tests** |
| `koda-core/src/sub_agent_dispatch.rs` | +52 / -49 | `run_bg_agent` takes `BgStatusEmitter` instead of raw `watch::Sender`; spawn site builds the emitter from reservation + registry `Arc`; Layer 4 heartbeat fans out via emitter |
| `koda-core/src/inference.rs` | +12 | Drain status events into the active sink alongside `drain_completed()` |
| `koda-core/src/tool_dispatch.rs` | +4 / -3 | Comment-only update at the foreground `execute_sub_agent` call site |
| `koda-cli/src/acp_adapter.rs` | +119 / -2 | Map `BgTaskUpdate` to `AgentMessageChunk` text — `[bg task N] running (iter K)`. **3 new tests.** |
| `koda-cli/src/headless.rs` | +26 / -2 | Render `BgTaskUpdate` as a dimmed stderr status line so scripts tailing output see live progress |
| `koda-cli/src/tui_render.rs` | +6 / -1 | Route `BgTaskUpdate` to the existing "handled by event loop" arm |
| `DESIGN.md` | +14 / -10 | Replace temporary "Known leak" carve-out with permanent "Background-task status routing" design |

**Net: +581 / -54.** Well within the 50–100 LOC production-code estimate from the issue (the bulk of the line count is tests + docs).

## Acceptance criteria

- [x] `EngineEvent::BgTaskUpdate` exists and is serializable (`agent_status_round_trips_through_serde` covers all 6 status variants)
- [x] Registry emits on every state transition (`emitter_send_queues_engine_event_on_registry`, `emitter_drain_is_fifo_and_clears_queue`)
- [x] ACP adapter forwards as `session/update` notification (3 new ACP tests covering Pending, Running iter 0/N, all 4 terminal states)
- [x] TUI no longer needs to poll `snapshot()` to render live status — initial primer is OK. Bg-task panel still uses snapshot for its primary render (cheaper for frame-rate redraw), but that's now a presentational choice, not a documented carve-out.
- [x] `DESIGN.md` "Engine as a Library" section updated to remove the carve-out

## Verification

```
cargo test --workspace --lib   # 1,877 passed; 0 failed
cargo clippy --workspace --all-targets   # clean
cargo fmt --all --check   # clean (after one fmt pass during pre-push)
```

## Design notes worth flagging

1. **`AgentStatus` derives Serialize directly** rather than introducing a `BgTaskStatusPayload` mirror enum. The mirror was suggested in the issue as a defensive separation, but `AgentStatus` is already public, only contains `String`/`u8`, and is the natural wire format. Adding a mirror would be DRY violation for no readability win.

2. **`BgStatusEmitter::send` doesn't gate the queue push on the watch send result.** A racing `drain_completed` reap can drop the watch `Receiver` between an emit and the inference-loop drain; if we gated, the terminal `BgTaskUpdate` would silently disappear. Pushing unconditionally means clients always see the terminal transition; if the entry is already gone, `task_id` is just a stale id clients can ignore.

3. **`BgStatusEmitter` is `Clone`.** Layer 4 (`#1058`) holds one clone for live `iter` heartbeats inside `execute_sub_agent`; `run_bg_agent` keeps another for the entry/terminal sends. Both clones share the same `watch::Sender` (clone-friendly by design) and the same `Arc<BgAgentRegistry>`, so every `.send()` reaches both fan-out targets — no risk of split-brain where the heartbeat goes to one queue and the terminal goes to another.

4. **TUI bg-task panel was deliberately left polling `snapshot()`.** It re-renders every frame at ~60 Hz; consuming the event stream and maintaining its own state machine would be more code for the same visible result. The acceptance criteria explicitly allows "initial primer is OK". If a future refactor wants to move it to event-driven, the `BgTaskUpdate` events are already on the wire — drop-in.

## Refs

- Closes #1076
- Builds on the architecture audit in #1074
- DESIGN.md ground-truth pass: #1075 (merged)
- Sibling follow-up still open: #1077 (collapse three progress mechanisms)
