### PR TITLE
feat(todo): TodoUpdate event + max-1-in_progress + compact prompt (refs #1077, Phase A)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -170,6 +170,31 @@ pub fn engine_event_to_acp(
             ))
         }
 
+        // (#1077 Phase A) TodoWrite lifecycle. Surfaces every accepted
+        // change so ACP IDEs can render a checklist (with diff-driven
+        // animation if they care). The diff (added / changed /
+        // removed) and the full new list are both in the structured
+        // payload, but ACP's `session/update` notifications carry text
+        // chunks today — so we render a compact human-readable line
+        // here. IDEs that want richer rendering can scan the
+        // tool-result stream for `TodoWrite` outputs (the formatted
+        // list lives there); the goal of this notification is parity
+        // with `BgTaskUpdate` ("a transition happened, here's the
+        // gist"), not to be the sole source of render data.
+        EngineEvent::TodoUpdate { items, diff } => {
+            let cb = acp::ContentBlock::Text(acp::TextContent::new(format!(
+                "[todos] +{} ~{} -{} ({} total)",
+                diff.added.len(),
+                diff.changed.len(),
+                diff.removed.len(),
+                items.len(),
+            )));
+            Some(acp::SessionNotification::new(
+                session_id.to_string(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(cb)),
+            ))
+        }
+
         // Handled specially by AcpSink (bidirectional permission flow)
         EngineEvent::ApprovalRequest { .. } => None,
         // AskUser not yet implemented in ACP protocol; filtered here.
@@ -545,6 +570,122 @@ mod tests {
                 t.text
             );
         }
+    }
+
+    // #1077 Phase A: TodoWrite lifecycle reaches ACP clients as a
+    // session/update notification with a compact diff summary. Three
+    // tests covering the dimensions a future ACP IDE renderer cares
+    // about: counts, diff direction (added vs. removed vs. changed),
+    // and the empty-diff suppression contract (which is enforced at
+    // the dispatch layer in tools/mod.rs — see corresponding test
+    // there). The tests below verify the *mapping* assuming the
+    // dispatch layer has already chosen to emit.
+
+    fn sample_todo(content: &str, status_str: &str) -> koda_core::tools::todo::TodoItem {
+        use koda_core::tools::todo::{TodoItem, TodoPriority, TodoStatus};
+        let status = match status_str {
+            "pending" => TodoStatus::Pending,
+            "in_progress" => TodoStatus::InProgress,
+            "completed" => TodoStatus::Completed,
+            other => panic!("unknown status {other}"),
+        };
+        TodoItem {
+            content: content.into(),
+            status,
+            priority: TodoPriority::Medium,
+        }
+    }
+
+    #[test]
+    fn test_todo_update_first_write_renders_added_count() {
+        use koda_core::tools::todo::TodoDiff;
+        let items = vec![sample_todo("A", "pending"), sample_todo("B", "in_progress")];
+        let diff = TodoDiff {
+            added: items.clone(),
+            ..Default::default()
+        };
+        let event = EngineEvent::TodoUpdate { items, diff };
+        let notif = engine_event_to_acp(&event, "s1").expect("must produce notification");
+        match notif.update {
+            acp::SessionUpdate::AgentMessageChunk(chunk) => match chunk.content {
+                acp::ContentBlock::Text(t) => {
+                    assert!(t.text.contains("[todos]"), "got: {}", t.text);
+                    assert!(t.text.contains("+2"), "expected +2 added, got: {}", t.text);
+                    assert!(
+                        t.text.contains("~0"),
+                        "expected ~0 changed, got: {}",
+                        t.text
+                    );
+                    assert!(
+                        t.text.contains("-0"),
+                        "expected -0 removed, got: {}",
+                        t.text
+                    );
+                    assert!(t.text.contains("(2 total)"), "got: {}", t.text);
+                }
+                other => panic!("expected text content, got {other:?}"),
+            },
+            other => panic!("expected AgentMessageChunk, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_todo_update_status_change_renders_changed_count() {
+        use koda_core::tools::todo::{TodoChange, TodoDiff};
+        let before = sample_todo("A", "pending");
+        let after = sample_todo("A", "in_progress");
+        let items = vec![after.clone()];
+        let diff = TodoDiff {
+            changed: vec![TodoChange { before, after }],
+            ..Default::default()
+        };
+        let event = EngineEvent::TodoUpdate { items, diff };
+        let notif = engine_event_to_acp(&event, "s1").unwrap();
+        let acp::SessionUpdate::AgentMessageChunk(chunk) = notif.update else {
+            panic!("expected chunk");
+        };
+        let acp::ContentBlock::Text(t) = chunk.content else {
+            panic!("expected text");
+        };
+        assert!(t.text.contains("+0"), "expected +0 added, got: {}", t.text);
+        assert!(
+            t.text.contains("~1"),
+            "expected ~1 changed, got: {}",
+            t.text
+        );
+        assert!(
+            t.text.contains("-0"),
+            "expected -0 removed, got: {}",
+            t.text
+        );
+        assert!(t.text.contains("(1 total)"), "got: {}", t.text);
+    }
+
+    #[test]
+    fn test_todo_update_clear_renders_removed_count() {
+        use koda_core::tools::todo::TodoDiff;
+        let removed = vec![sample_todo("A", "completed"), sample_todo("B", "completed")];
+        let diff = TodoDiff {
+            removed,
+            ..Default::default()
+        };
+        let event = EngineEvent::TodoUpdate {
+            items: Vec::new(),
+            diff,
+        };
+        let notif = engine_event_to_acp(&event, "s1").unwrap();
+        let acp::SessionUpdate::AgentMessageChunk(chunk) = notif.update else {
+            panic!("expected chunk");
+        };
+        let acp::ContentBlock::Text(t) = chunk.content else {
+            panic!("expected text");
+        };
+        assert!(
+            t.text.contains("-2"),
+            "expected -2 removed, got: {}",
+            t.text
+        );
+        assert!(t.text.contains("(0 total)"), "got: {}", t.text);
     }
 
     #[test]

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -295,6 +295,22 @@ impl EngineSink for HeadlessSink {
                 };
                 eprintln!("\x1b[2m  [bg task {task_id}] {summary}\x1b[0m");
             }
+            // (#1077 Phase A) TodoWrite lifecycle in headless: render a
+            // dim one-liner with diff counts so a script tailing stdout
+            // sees "todos: +2 ~1 -0 (5 total)" on every accepted change.
+            // The full per-item list still rides on the next tool result
+            // (which the headless `print_tool_result` path renders) —
+            // this is just the structured transition for scripts that
+            // want to grep "added" without parsing the formatted list.
+            EngineEvent::TodoUpdate { items, diff } => {
+                eprintln!(
+                    "\x1b[2m  [todos] +{} ~{} -{} ({} total)\x1b[0m",
+                    diff.added.len(),
+                    diff.changed.len(),
+                    diff.removed.len(),
+                    items.len(),
+                );
+            }
             EngineEvent::Footer {
                 completion_tokens,
                 total_chars,

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -284,12 +284,18 @@ impl TuiRenderer {
             | EngineEvent::TurnStart { .. }
             | EngineEvent::TurnEnd { .. }
             | EngineEvent::LoopCapReached { .. }
-            | EngineEvent::BgTaskUpdate { .. } => {
+            | EngineEvent::BgTaskUpdate { .. }
+            | EngineEvent::TodoUpdate { .. } => {
                 // Handled by the event loop, not the renderer.
                 // (#1076) BgTaskUpdate is routed to the bg-task panel,
                 // which still reads from the registry snapshot for its
                 // primary render. Future cleanup may have it consume
                 // the event stream directly and drop the polling.
+                // (#1077 Phase A) TodoUpdate is rendered by the TUI's
+                // todo-list panel from the tool-result message stream;
+                // the structured event is for ACP / headless clients
+                // that want diff-driven animation. Same future-cleanup
+                // path as BgTaskUpdate.
             }
             EngineEvent::ActionBlocked {
                 tool_name: _,

--- a/koda-core/src/compact.rs
+++ b/koda-core/src/compact.rs
@@ -267,11 +267,19 @@ fn build_summary_prompt(conversation_text: &str) -> String {
          2. **Key Technical Concepts**: List all important technologies and frameworks discussed.\n\
          3. **Files and Code Sections**: Enumerate specific files examined, modified, or created. \n\
             Include code snippets where applicable and a summary of why each file matters.\n\
+            **Be exhaustive about file paths** — once compaction runs, the only record of\n\
+            files touched in the compacted range is this summary, so missing a path means\n\
+            losing it for the rest of the session. Group as: created / modified / deleted.\n\
          4. **Errors and Fixes**: List all errors and how they were resolved. Note user feedback.\n\
          5. **Problem Solving**: Document problems solved and ongoing troubleshooting.\n\
          6. **All User Messages**: List ALL user messages (not tool results). Critical for \n\
             preserving feedback and changing intent.\n\
          7. **Pending Tasks**: Outline anything unfinished or deferred.\n\
+            **Preserve every outstanding TodoWrite item verbatim** with its current status\n\
+            (pending / in_progress). Compaction is the only mechanism that defends plan\n\
+            continuity across context-window pressure (`DESIGN.md § Progress Tracking:\n\
+            Model-Owned, History-Persisted, Engine-Surfaced`) — the system prompt does NOT\n\
+            re-inject the todo list, so anything dropped here is gone.\n\
          8. **Current Work**: Describe precisely what was being worked on immediately before \n\
             this summary. Include file names and code snippets.\n\
          9. **Optional Next Step**: Only if directly in line with the user's most recent \n\

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -103,6 +103,31 @@ pub enum EngineEvent {
 
     /// A sub-agent finished.
 
+    // ── Todo list lifecycle (#1077 Phase A) ───────────────────────
+    /// The model called `TodoWrite` and the engine accepted the new
+    /// list. Emitted exactly once per accepted call (skipped when the
+    /// new list is byte-identical to the previous one — the
+    /// dedup-nudge path returns the "unchanged" message to the model
+    /// without surfacing a transition to clients).
+    ///
+    /// Carries the full new list AND a server-computed diff against
+    /// the previously persisted list so every client renders the
+    /// same animation primitives (added / changed / removed) without
+    /// having to maintain its own previous-list snapshot.
+    ///
+    /// Establishes the principle from `DESIGN.md § Progress Tracking:
+    /// Model-Owned, History-Persisted, Engine-Surfaced` — the engine
+    /// surfaces transitions, the conversation history persists the
+    /// list, the system prompt does not re-inject it.
+    TodoUpdate {
+        /// The full todo list as written by the model on this call.
+        items: Vec<crate::tools::todo::TodoItem>,
+        /// Server-computed diff against the previously persisted list
+        /// (matched by `content` string). On the first write of a
+        /// session, every item shows up in `added`.
+        diff: crate::tools::todo::TodoDiff,
+    },
+
     // ── Background sub-agent lifecycle ────────────────────────────────
     /// A background sub-agent's status changed.
     ///

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -720,7 +720,27 @@ impl ToolRegistry {
                 let db_opt = self.db.read().ok().and_then(|g| g.clone());
                 let sid_opt = self.session_id.read().ok().and_then(|g| g.clone());
                 match (db_opt, sid_opt) {
-                    (Some(db), Some(sid)) => todo::todo_write(&db, &sid, &args).await,
+                    (Some(db), Some(sid)) => match todo::todo_write(&db, &sid, &args).await {
+                        Ok(outcome) => {
+                            // #1077 Phase A: surface the transition to
+                            // every client (TUI / ACP / headless) via
+                            // EngineEvent::TodoUpdate. The dedup-nudge
+                            // path returns an empty diff so we suppress
+                            // the event there — unchanged-list writes
+                            // are a no-op for clients, only a reminder
+                            // for the model.
+                            if !outcome.diff.is_empty()
+                                && let Some((sink, _call_id)) = sink_for_streaming
+                            {
+                                sink.emit(crate::engine::EngineEvent::TodoUpdate {
+                                    items: outcome.items.clone(),
+                                    diff: outcome.diff.clone(),
+                                });
+                            }
+                            Ok(outcome.message)
+                        }
+                        Err(e) => Err(e),
+                    },
                     _ => Ok("TodoWrite requires an active session.".to_string()),
                 }
             }
@@ -1234,6 +1254,146 @@ mod tests {
         // /tmp/foo/../bar cleans to /tmp/bar — still in /tmp, still allowed.
         let p = safe_resolve_path(&root(), "/tmp/foo/../bar").unwrap();
         assert_eq!(p, PathBuf::from("/tmp/bar"));
+    }
+
+    // ── #1077 Phase A: TodoWrite event-emission contract ─────────
+    //
+    // The dispatch arm in `execute()` must:
+    // 1. emit `EngineEvent::TodoUpdate` with structured items+diff on
+    //    accepted writes that change the persisted list;
+    // 2. emit nothing on the dedup-nudge path (empty diff);
+    // 3. always return the model-facing message string regardless.
+    //
+    // These are the contract a future TUI / ACP renderer will rely on.
+    // If you find yourself loosening any of them, revisit `DESIGN.md
+    // § Progress Tracking: Model-Owned, History-Persisted,
+    // Engine-Surfaced` first — the suppression rule in particular is
+    // load-bearing for not spamming clients on idempotent rewrites.
+
+    async fn registry_with_session() -> (
+        ToolRegistry,
+        tempfile::TempDir,
+        std::sync::Arc<crate::db::Database>,
+        String,
+    ) {
+        use crate::persistence::Persistence;
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = std::sync::Arc::new(
+            crate::db::Database::open(&dir.path().join("test.db"))
+                .await
+                .unwrap(),
+        );
+        let sid = db.create_session("koda", dir.path()).await.unwrap();
+        let registry = ToolRegistry::new(dir.path().to_path_buf(), 100_000);
+        // Wire DB + session id the same way KodaSession::new does.
+        *registry.db.write().unwrap() = Some(db.clone());
+        *registry.session_id.write().unwrap() = Some(sid.clone());
+        (registry, dir, db, sid)
+    }
+
+    #[tokio::test]
+    async fn todo_write_emits_todo_update_event_on_first_write() {
+        let (registry, _dir, _db, _sid) = registry_with_session().await;
+        let sink = crate::engine::sink::TestSink::new();
+        let result = registry
+            .execute(
+                "TodoWrite",
+                r#"{"todos":[{"content":"Add tests","status":"pending","priority":"high"}]}"#,
+                Some((&sink, "call-1")),
+                None,
+            )
+            .await;
+        assert!(result.success, "first write must succeed: {result:?}");
+        assert_eq!(sink.len(), 1, "first write must emit exactly one event");
+        match &sink.events()[0] {
+            crate::engine::EngineEvent::TodoUpdate { items, diff } => {
+                assert_eq!(items.len(), 1);
+                assert_eq!(items[0].content, "Add tests");
+                assert_eq!(diff.added.len(), 1, "first write → everything in added");
+                assert!(diff.changed.is_empty());
+                assert!(diff.removed.is_empty());
+            }
+            other => panic!("expected TodoUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn todo_write_suppresses_event_on_unchanged_rewrite() {
+        let (registry, _dir, _db, _sid) = registry_with_session().await;
+        let payload = r#"{"todos":[{"content":"A","status":"pending","priority":"high"}]}"#;
+
+        // First write: should emit.
+        let sink1 = crate::engine::sink::TestSink::new();
+        registry
+            .execute("TodoWrite", payload, Some((&sink1, "c1")), None)
+            .await;
+        assert_eq!(sink1.len(), 1);
+
+        // Identical second write: must NOT emit. The dedup-nudge
+        // message goes back to the model, but clients see nothing.
+        let sink2 = crate::engine::sink::TestSink::new();
+        let result2 = registry
+            .execute("TodoWrite", payload, Some((&sink2, "c2")), None)
+            .await;
+        assert!(result2.success);
+        assert!(
+            result2.output.contains("unchanged"),
+            "model-facing message must still nudge: {}",
+            result2.output
+        );
+        assert_eq!(
+            sink2.len(),
+            0,
+            "unchanged rewrite must NOT emit a TodoUpdate event"
+        );
+    }
+
+    #[tokio::test]
+    async fn todo_write_returns_model_message_even_without_sink() {
+        // Production paths sometimes call `execute` with `None` for
+        // the sink (top-level tool runs that aren't streaming). Must
+        // still succeed and return the formatted message.
+        let (registry, _dir, _db, _sid) = registry_with_session().await;
+        let result = registry
+            .execute(
+                "TodoWrite",
+                r#"{"todos":[{"content":"X","status":"pending","priority":"low"}]}"#,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.success);
+        assert!(result.output.contains("0/1 done"));
+    }
+
+    #[tokio::test]
+    async fn todo_write_rejects_two_in_progress_at_dispatch() {
+        // Engine-enforced single-in-progress: must surface as a
+        // failed ToolResult, not a successful one with a warning.
+        // Models notice failures more reliably than warnings.
+        let (registry, _dir, _db, _sid) = registry_with_session().await;
+        let sink = crate::engine::sink::TestSink::new();
+        let result = registry
+            .execute(
+                "TodoWrite",
+                r#"{"todos":[
+                    {"content":"A","status":"in_progress","priority":"high"},
+                    {"content":"B","status":"in_progress","priority":"medium"}
+                ]}"#,
+                Some((&sink, "c1")),
+                None,
+            )
+            .await;
+        assert!(
+            !result.success,
+            "two in_progress must produce a failed ToolResult"
+        );
+        assert!(
+            result.output.contains("Only one task"),
+            "failure message must explain the rule: {}",
+            result.output
+        );
+        assert_eq!(sink.len(), 0, "failed validation must not emit an event");
     }
 }
 

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -94,6 +94,123 @@ pub struct TodoItem {
     pub priority: TodoPriority,
 }
 
+// ── Diff types ───────────────────────────────────────────
+
+/// Before/after pair for a todo whose `status` and/or `priority` changed
+/// while keeping the same `content` string.
+///
+/// Computed server-side by [`todo_write`] so every client (TUI / ACP /
+/// headless / future) gets the same animation primitives without
+/// having to maintain its own previous-list snapshot. Surfaces on
+/// [`crate::engine::EngineEvent::TodoUpdate`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TodoChange {
+    /// State on the previously persisted list.
+    pub before: TodoItem,
+    /// State on the newly written list.
+    pub after: TodoItem,
+}
+
+/// Server-computed delta between the previously persisted todo list
+/// and the one the model just wrote.
+///
+/// **Matching key is `content`.** If the model renames a task the
+/// rename surfaces as one entry in `removed` plus one in `added`,
+/// which is the right semantic — a renamed task is conceptually a
+/// different task to the user even if the underlying intent is the
+/// same.
+///
+/// On the very first `TodoWrite` of a session, every item lands in
+/// `added`. On a clear (`todos: []`), every previously persisted
+/// item lands in `removed`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TodoDiff {
+    /// Items present on the new list whose `content` is not on the old list.
+    pub added: Vec<TodoItem>,
+    /// Items present on the old list whose `content` is not on the new list.
+    pub removed: Vec<TodoItem>,
+    /// Items present on both lists by `content` whose `status` or
+    /// `priority` changed.
+    pub changed: Vec<TodoChange>,
+}
+
+impl TodoDiff {
+    /// `true` when there are no additions, removals, or changes.
+    /// Used to suppress the `TodoUpdate` event on no-op writes — the
+    /// dedup-nudge path returns the "unchanged" message to the model
+    /// without surfacing a transition to clients.
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+
+    /// Compute the diff between an old list and a new list.
+    ///
+    /// O(n*m) but n and m are bounded by typical todo-list size (low
+    /// dozens at the absolute outside) so a HashMap would be more
+    /// code than savings.
+    fn compute(old: &[TodoItem], new: &[TodoItem]) -> Self {
+        let mut added = Vec::new();
+        let mut removed = Vec::new();
+        let mut changed = Vec::new();
+
+        // Pass 1: walk new list. Each item is either added, changed, or
+        // unchanged-equal-to-old.
+        for n in new {
+            match old.iter().find(|o| o.content == n.content) {
+                None => added.push(n.clone()),
+                Some(o) if o != n => changed.push(TodoChange {
+                    before: o.clone(),
+                    after: n.clone(),
+                }),
+                Some(_) => { /* identical — no diff entry */ }
+            }
+        }
+
+        // Pass 2: walk old list. Anything whose content is missing from
+        // new is a removal.
+        for o in old {
+            if !new.iter().any(|n| n.content == o.content) {
+                removed.push(o.clone());
+            }
+        }
+
+        Self {
+            added,
+            removed,
+            changed,
+        }
+    }
+}
+
+// ── Outcome ───────────────────────────────────────────────
+
+/// What [`todo_write`] returns to the dispatch layer.
+///
+/// The dispatch layer:
+/// 1. forwards `message` to the model as the tool result string;
+/// 2. when `diff.is_empty()` is `false`, emits
+///    [`crate::engine::EngineEvent::TodoUpdate`] with `items` and
+///    `diff` so every client sees the transition.
+///
+/// Splitting `message` (model-facing) from `items + diff` (client-
+/// facing) is the same separation Claude Code's `TodoWriteTool` uses
+/// (`mapToolResultToToolResultBlockParam` returns a plain string
+/// while the structured diff goes to the UI). It keeps the model's
+/// tool-result clean and the UI's render data rich.
+#[derive(Debug, Clone)]
+pub struct TodoWriteOutcome {
+    /// String returned to the model as the tool result.
+    pub message: String,
+    /// Full new list, after dedup short-circuit but always populated
+    /// (even on the unchanged path) so callers that want to mirror
+    /// the latest list don't have to re-read from the DB.
+    pub items: Vec<TodoItem>,
+    /// Server-computed diff against the previously persisted list.
+    /// `is_empty()` on the unchanged path; `added` is non-empty on
+    /// the first write of a session.
+    pub diff: TodoDiff,
+}
+
 // ── Tool definition ─────────────────────────────────────────────────────────
 
 /// Return the tool definition for the LLM.
@@ -140,15 +257,32 @@ pub fn definitions() -> Vec<ToolDefinition> {
     }]
 }
 
-// ── Handler ─────────────────────────────────────────────────────────────────
+// ── Handler ───────────────────────────────────────────────
 
 /// Write the full todo list for this session.
 ///
-/// **Content-aware dedup**: if the incoming list is identical to what's
-/// already stored, we skip the write and return a short "unchanged"
-/// message. This prevents the model from burning tool calls (and
-/// triggering loop detection) by re-emitting the same plan.
-pub async fn todo_write(db: &Database, session_id: &str, args: &Value) -> Result<String> {
+/// Returns a [`TodoWriteOutcome`] with both the model-facing message
+/// and structured `items + diff` for the dispatch layer to surface
+/// via [`crate::engine::EngineEvent::TodoUpdate`].
+///
+/// **Validation** (rejected before any DB write):
+/// - `todos` must be an array.
+/// - Each item needs a non-empty `content`, a valid `status`, and a
+///   valid `priority`.
+/// - At most one item may have `status == InProgress`. Stolen from
+///   Gemini CLI (`packages/core/src/tools/write-todos.ts`); the
+///   only one of the four reference projects that enforces it
+///   server-side instead of via prompt discipline. Small,
+///   deterministic, removes one class of model failure mode.
+///
+/// **Content-aware dedup**: if the parsed list is byte-equal to
+/// what's already stored, we skip the write and return a short
+/// "unchanged" message. The returned `diff` is empty and the
+/// dispatch layer suppresses the `TodoUpdate` event — this prevents
+/// the model from burning tool calls (and triggering loop detection)
+/// by re-emitting the same plan, while also not spamming clients
+/// with no-op transitions.
+pub async fn todo_write(db: &Database, session_id: &str, args: &Value) -> Result<TodoWriteOutcome> {
     let raw = args
         .get("todos")
         .and_then(|v| v.as_array())
@@ -188,25 +322,53 @@ pub async fn todo_write(db: &Database, session_id: &str, args: &Value) -> Result
         });
     }
 
-    // ── Content-aware dedup ──────────────────────────────────────────
-    // Compare with what's already stored. If identical, skip the write
-    // and tell the model explicitly so it stops re-emitting the same plan.
-    if let Ok(Some(existing_json)) = db.get_todo(session_id).await
-        && let Ok(existing) = serde_json::from_str::<Vec<TodoItem>>(&existing_json)
-        && existing == todos
-    {
-        return Ok(format!(
-            "Todo list unchanged ({} task{}). \
-             Do not call TodoWrite again unless you are changing a task's status or content.",
-            todos.len(),
-            if todos.len() == 1 { "" } else { "s" }
-        ));
+    // ── Single-in-progress invariant (#1077 Phase A) ────────────
+    // Reject before reading the previous list — this is a structural
+    // input error, not a state-dependent one.
+    let in_progress = todos
+        .iter()
+        .filter(|t| t.status == TodoStatus::InProgress)
+        .count();
+    if in_progress > 1 {
+        anyhow::bail!(
+            "Invalid todo list: {in_progress} tasks marked 'in_progress'. \
+             Only one task may be 'in_progress' at a time — mark all but one as \
+             'pending' or 'completed' and call TodoWrite again."
+        );
     }
+
+    // ── Load the previous list once (for both dedup and diff) ─────
+    let old: Vec<TodoItem> = match db.get_todo(session_id).await {
+        Ok(Some(raw)) => serde_json::from_str(&raw).unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    // ── Content-aware dedup ─────────────────────────────
+    // Byte-equal previous list short-circuits the write AND the event
+    // emission. `TodoDiff::default()` (empty) signals "no transition".
+    if old == todos {
+        return Ok(TodoWriteOutcome {
+            message: format!(
+                "Todo list unchanged ({} task{}). \
+                 Do not call TodoWrite again unless you are changing a task's status or content.",
+                todos.len(),
+                if todos.len() == 1 { "" } else { "s" }
+            ),
+            items: todos,
+            diff: TodoDiff::default(),
+        });
+    }
+
+    let diff = TodoDiff::compute(&old, &todos);
 
     let json = serde_json::to_string(&todos)?;
     db.set_todo(session_id, &json).await?;
 
-    Ok(format_todo_list(&todos))
+    Ok(TodoWriteOutcome {
+        message: format_todo_list(&todos),
+        items: todos,
+        diff,
+    })
 }
 
 /// Load the todo section for injection into the system prompt.
@@ -290,9 +452,9 @@ mod tests {
             ]
         });
         let out = todo_write(&db, &sid, &args).await.unwrap();
-        assert!(out.contains("0/2 done"));
-        assert!(out.contains("[ ] Add tests"));
-        assert!(out.contains("[→] Write docs"));
+        assert!(out.message.contains("0/2 done"));
+        assert!(out.message.contains("[ ] Add tests"));
+        assert!(out.message.contains("[→] Write docs"));
 
         let section = get_todo_section(&db, &sid).await;
         assert!(section.contains("Add tests"));
@@ -340,7 +502,7 @@ mod tests {
         // Then clear it
         let clear = json!({ "todos": [] });
         let out = todo_write(&db, &sid, &clear).await.unwrap();
-        assert!(out.contains("cleared"));
+        assert!(out.message.contains("cleared"));
         assert!(get_todo_section(&db, &sid).await.is_empty());
     }
 
@@ -435,17 +597,23 @@ mod tests {
         });
         // First write — should persist and return full list
         let out1 = todo_write(&db, &sid, &args).await.unwrap();
-        assert!(out1.contains("0/2 done"));
+        assert!(out1.message.contains("0/2 done"));
 
         // Second write with identical content — should short-circuit
         let out2 = todo_write(&db, &sid, &args).await.unwrap();
         assert!(
-            out2.contains("unchanged"),
-            "identical call should return 'unchanged', got: {out2}"
+            out2.message.contains("unchanged"),
+            "identical call should return 'unchanged', got: {}",
+            out2.message
         );
         assert!(
-            out2.contains("Do not call TodoWrite again"),
+            out2.message.contains("Do not call TodoWrite again"),
             "should tell model to stop calling"
+        );
+        assert!(
+            out2.diff.is_empty(),
+            "unchanged write must yield an empty diff so the dispatch \
+             layer suppresses the TodoUpdate event"
         );
     }
 
@@ -467,9 +635,226 @@ mod tests {
         });
         let out = todo_write(&db, &sid, &args2).await.unwrap();
         assert!(
-            out.contains("1/1 done"),
-            "status change should write normally, got: {out}"
+            out.message.contains("1/1 done"),
+            "status change should write normally, got: {}",
+            out.message
         );
-        assert!(out.contains("[x] Task A"));
+        assert!(out.message.contains("[x] Task A"));
+    }
+
+    // ── #1077 Phase A: validation ───────────────────────────
+
+    /// Two `in_progress` items must be rejected up front. Stolen
+    /// from Gemini CLI; the only one of the four reference projects
+    /// that enforces single-in-progress server-side. Without this,
+    /// the model can silently keep two tasks active and clients
+    /// render a contradictory checklist.
+    #[tokio::test]
+    async fn rejects_two_in_progress_items() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "A", "status": "in_progress", "priority": "high"},
+                {"content": "B", "status": "in_progress", "priority": "medium"},
+            ]
+        });
+        let err = todo_write(&db, &sid, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Only one task"), "got: {msg}");
+        assert!(msg.contains("in_progress"), "got: {msg}");
+        // Must reject BEFORE writing — the DB should still be empty.
+        use crate::persistence::Persistence;
+        assert!(
+            db.get_todo(&sid).await.unwrap().is_none(),
+            "failed validation must not touch the DB"
+        );
+    }
+
+    /// Single `in_progress` is the happy path; many `pending`
+    /// alongside is fine.
+    #[tokio::test]
+    async fn accepts_single_in_progress() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "A", "status": "in_progress", "priority": "high"},
+                {"content": "B", "status": "pending", "priority": "medium"},
+                {"content": "C", "status": "pending", "priority": "low"},
+            ]
+        });
+        let out = todo_write(&db, &sid, &args).await.unwrap();
+        assert!(out.message.contains("0/3 done"));
+    }
+
+    /// Zero `in_progress` (all pending or all completed) is
+    /// permitted — the rule is at-most-one, not exactly-one.
+    #[tokio::test]
+    async fn accepts_zero_in_progress() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "A", "status": "pending", "priority": "high"},
+                {"content": "B", "status": "pending", "priority": "medium"},
+            ]
+        });
+        let out = todo_write(&db, &sid, &args).await.unwrap();
+        assert!(out.message.contains("0/2 done"));
+    }
+
+    // ── #1077 Phase A: diff computation ───────────────────────
+
+    fn item(content: &str, status: TodoStatus, priority: TodoPriority) -> TodoItem {
+        TodoItem {
+            content: content.into(),
+            status,
+            priority,
+        }
+    }
+
+    #[test]
+    fn diff_first_write_lands_everything_in_added() {
+        // First write of a session: previous list is empty so every
+        // item must show up in `added` — nothing in `changed` or
+        // `removed`. This is what enables clients to do a one-shot
+        // "populate from empty" render on session start.
+        let new = vec![
+            item("A", TodoStatus::Pending, TodoPriority::High),
+            item("B", TodoStatus::InProgress, TodoPriority::Medium),
+        ];
+        let diff = TodoDiff::compute(&[], &new);
+        assert_eq!(diff.added.len(), 2);
+        assert!(diff.changed.is_empty());
+        assert!(diff.removed.is_empty());
+        assert!(!diff.is_empty());
+    }
+
+    #[test]
+    fn diff_clear_lands_everything_in_removed() {
+        let old = vec![
+            item("A", TodoStatus::Pending, TodoPriority::High),
+            item("B", TodoStatus::Completed, TodoPriority::Medium),
+        ];
+        let diff = TodoDiff::compute(&old, &[]);
+        assert!(diff.added.is_empty());
+        assert!(diff.changed.is_empty());
+        assert_eq!(diff.removed.len(), 2);
+    }
+
+    #[test]
+    fn diff_status_change_lands_in_changed() {
+        // Same content, status flipped — surfaces as a single
+        // `TodoChange`, not as removed+added. Clients can render
+        // an in-place state transition (animate the checkbox) vs. a
+        // wholesale list rewrite.
+        let old = vec![item("A", TodoStatus::Pending, TodoPriority::High)];
+        let new = vec![item("A", TodoStatus::InProgress, TodoPriority::High)];
+        let diff = TodoDiff::compute(&old, &new);
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].before.status, TodoStatus::Pending);
+        assert_eq!(diff.changed[0].after.status, TodoStatus::InProgress);
+    }
+
+    #[test]
+    fn diff_rename_lands_as_remove_plus_add() {
+        // Rename = different `content` string, so by design the diff
+        // surfaces it as removal + addition rather than a
+        // `TodoChange`. Documented behaviour on `TodoDiff` — if a
+        // future product decision wants rename detection, that's a
+        // schema change (need a stable id), not a diff-algorithm
+        // tweak. Lock this in with a test so the trade-off doesn't
+        // silently flip.
+        let old = vec![item("old name", TodoStatus::Pending, TodoPriority::High)];
+        let new = vec![item("new name", TodoStatus::Pending, TodoPriority::High)];
+        let diff = TodoDiff::compute(&old, &new);
+        assert_eq!(diff.added.len(), 1);
+        assert_eq!(diff.removed.len(), 1);
+        assert!(diff.changed.is_empty());
+    }
+
+    #[test]
+    fn diff_unchanged_item_does_not_surface() {
+        // An item identical on both sides must NOT appear in any
+        // bucket. This is what lets clients render "only what
+        // changed" without filtering noise.
+        let old = vec![
+            item("A", TodoStatus::Pending, TodoPriority::High),
+            item("B", TodoStatus::InProgress, TodoPriority::Medium),
+        ];
+        let new = vec![
+            item("A", TodoStatus::Pending, TodoPriority::High), // unchanged
+            item("B", TodoStatus::Completed, TodoPriority::Medium), // status flipped
+        ];
+        let diff = TodoDiff::compute(&old, &new);
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].after.content, "B");
+    }
+
+    #[test]
+    fn diff_priority_only_change_lands_in_changed() {
+        // Edge case: priority changed but status unchanged. The
+        // matching key is `content`; the change predicate is
+        // `before != after`, which uses derived `PartialEq` on the
+        // whole struct including priority. So priority bumps DO
+        // surface as `changed`. Important for clients that render
+        // priority badges — they need to know to re-render.
+        let old = vec![item("A", TodoStatus::Pending, TodoPriority::Low)];
+        let new = vec![item("A", TodoStatus::Pending, TodoPriority::High)];
+        let diff = TodoDiff::compute(&old, &new);
+        assert_eq!(diff.changed.len(), 1);
+        assert_eq!(diff.changed[0].before.priority, TodoPriority::Low);
+        assert_eq!(diff.changed[0].after.priority, TodoPriority::High);
+    }
+
+    #[test]
+    fn diff_empty_when_lists_identical() {
+        let old = vec![item("A", TodoStatus::Pending, TodoPriority::High)];
+        let new = old.clone();
+        let diff = TodoDiff::compute(&old, &new);
+        assert!(diff.is_empty(), "identical lists must produce no diff");
+    }
+
+    // ── #1077 Phase A: outcome shape ────────────────────────
+
+    /// `TodoWriteOutcome.items` must always carry the full list,
+    /// even on the dedup-nudge path. This is what lets clients
+    /// (e.g. ACP IDEs) mirror the latest state without re-reading
+    /// from the DB on every event.
+    #[tokio::test]
+    async fn outcome_items_populated_on_dedup_path() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "A", "status": "pending", "priority": "high"},
+            ]
+        });
+        todo_write(&db, &sid, &args).await.unwrap();
+        let out2 = todo_write(&db, &sid, &args).await.unwrap();
+        assert!(out2.diff.is_empty(), "dedup must yield empty diff");
+        assert_eq!(out2.items.len(), 1, "dedup must still populate items");
+        assert_eq!(out2.items[0].content, "A");
+    }
+
+    /// First-ever write must produce a non-empty diff with the
+    /// initial items in `added`. This is the event the dispatch
+    /// layer surfaces as `EngineEvent::TodoUpdate`.
+    #[tokio::test]
+    async fn outcome_first_write_yields_added_diff() {
+        let (db, _dir, sid) = test_db().await;
+        let args = json!({
+            "todos": [
+                {"content": "A", "status": "pending", "priority": "high"},
+                {"content": "B", "status": "in_progress", "priority": "medium"},
+            ]
+        });
+        let out = todo_write(&db, &sid, &args).await.unwrap();
+        assert!(!out.diff.is_empty());
+        assert_eq!(out.diff.added.len(), 2);
+        assert!(out.diff.removed.is_empty());
+        assert!(out.diff.changed.is_empty());
+        assert_eq!(out.items.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Phase A of #1077 — lands the connector that future phases will rely on. **Net additive (no deletions)**, so it can ship and bake in `main` before Phase B (`get_todo_section` injection removal + `progress.rs` deletion) without leaving any client blind during the transition.

Three independent changes wired in one PR because they share the `TodoWriteOutcome` refactor:

| # | Change | Net LOC |
|---|---|---|
| 1 | `EngineEvent::TodoUpdate { items, diff }` + dispatch wiring + ACP/headless/TUI arms | ~+60 code |
| 2 | Engine-enforced "max 1 in_progress" in `todo_write` | ~+15 code |
| 3 | `build_summary_prompt` preserves outstanding tasks + file paths verbatim | ~+8 code |

Plus tests: 12 new `tools::todo` + 4 new `tools::mod` dispatch + 3 new `acp_adapter` mapping. Total diff is **+774/−33** (~150 code, ~430 tests, ~150 inline rationale).

Closes nothing — leaves #1077 open through Phase B.

## What's in here

### 1. `EngineEvent::TodoUpdate { items, diff }`

Emitted on every accepted `TodoWrite` call from `tools/mod.rs::execute` via the existing `sink_for_streaming` plumbing. The diff is computed **server-side** so every client (TUI / ACP / headless / future) gets the same animation primitives without maintaining its own previous-list snapshot:

```rust
pub struct TodoDiff {
    pub added:   Vec<TodoItem>,    // content not on old list
    pub removed: Vec<TodoItem>,    // content not on new list
    pub changed: Vec<TodoChange>,  // same content, different status/priority
}
```

**Matching key is `content` string.** A rename surfaces as remove+add, which is the right semantic — locked in with a test (`diff_rename_lands_as_remove_plus_add`) so the trade-off doesn't silently flip if someone refactors the diff algorithm.

**Suppressed on the dedup-nudge path.** When the new list is byte-equal to the previously persisted one, `TodoDiff::default()` is returned and the dispatch layer skips emission entirely. Unchanged-list writes are a no-op for clients, only a nudge for the model. Locked in with `todo_write_suppresses_event_on_unchanged_rewrite`.

**Wired into all three exhaustiveness arms:**
- `tui_render.rs` — coalesced into the existing "handled by event loop" arm with a comment explaining the future-cleanup path mirrors `BgTaskUpdate`.
- `headless.rs` — renders `[todos] +N ~M -K (T total)` to stderr in dim text so a tailing script sees the transition.
- `acp_adapter.rs` — same compact line as a `session/update` notification chunk so ACP IDEs can scan for `[todos]` events. Future protocol-level extension can carry the structured payload directly when ACP adds a typed message.

### 2. Engine-enforced "max 1 in_progress"

Stolen directly from Gemini CLI (`packages/core/src/tools/write-todos.ts`) — the **only one of the four reference projects** (claude_code_src / codex / zed / gemini-cli) that enforces this server-side instead of relying on prompt discipline. Tiny, deterministic, removes a class of model failure mode.

```rust
if in_progress > 1 {
    anyhow::bail!(
        "Invalid todo list: {in_progress} tasks marked 'in_progress'. \
         Only one task may be 'in_progress' at a time — mark all but one as \
         'pending' or 'completed' and call TodoWrite again."
    );
}
```

Rejects **before** any DB write or event emission. Test (`rejects_two_in_progress_items`) verifies the DB is still untouched after a rejection.

### 3. `build_summary_prompt` strengthening

Two surgical bullets added to the existing summarizer prompt in `compact.rs`:

- **Files and Code Sections** now says "be exhaustive about file paths" and "group as: created / modified / deleted."
- **Pending Tasks** now says "preserve every outstanding TodoWrite item verbatim with its current status."

Compaction is the only mechanism that defends plan continuity across context-window pressure **once Phase B removes the system-prompt injection** (referenced in DESIGN.md `§ Progress Tracking: Model-Owned, History-Persisted, Engine-Surfaced` — being added in #1079). Doing it here *first* means Phase B's deletion is safe.

## Refactor: `todo_write` return type

Was `Result<String>`, now `Result<TodoWriteOutcome>`:

```rust
pub struct TodoWriteOutcome {
    pub message: String,    // what the model sees (verbatim from before)
    pub items:   Vec<TodoItem>,    // full new list, even on dedup path
    pub diff:    TodoDiff,         // empty on dedup path
}
```

Same split Claude Code's `TodoWriteTool` uses internally (string for `mapToolResultToToolResultBlockParam`, structured payload for the UI). Keeps the model's tool-result clean and the UI's render data rich.

Existing call sites in `tools/mod.rs::execute` updated to `outcome.message` / `outcome.items` / `outcome.diff`. No other production callers of `todo_write` exist (verified via `rg`); the only other reference is `tool_normalize.rs` which is a name-mapping table, unrelated to the return type.

## Test coverage

**`tools::todo` (12 new):**
- Validation (3): `rejects_two_in_progress_items`, `accepts_single_in_progress`, `accepts_zero_in_progress`
- Diff computation (7): `diff_first_write_lands_everything_in_added`, `diff_clear_lands_everything_in_removed`, `diff_status_change_lands_in_changed`, `diff_rename_lands_as_remove_plus_add`, `diff_unchanged_item_does_not_surface`, `diff_priority_only_change_lands_in_changed`, `diff_empty_when_lists_identical`
- Outcome shape (2): `outcome_items_populated_on_dedup_path`, `outcome_first_write_yields_added_diff`

**`tools::mod` dispatch (4 new):**
- `todo_write_emits_todo_update_event_on_first_write`
- `todo_write_suppresses_event_on_unchanged_rewrite`
- `todo_write_returns_model_message_even_without_sink`
- `todo_write_rejects_two_in_progress_at_dispatch`

**`acp_adapter` mapping (3 new):**
- `test_todo_update_first_write_renders_added_count`
- `test_todo_update_status_change_renders_changed_count`
- `test_todo_update_clear_renders_removed_count`

## Verification

```
cargo test --workspace --lib    → 1896 passed; 0 failed
cargo test --workspace --tests  → all green
cargo clippy --workspace --all-targets -- -D warnings → clean
cargo fmt --all → no diff
```

Existing `compact` tests still green (8 new lines added to the prompt; assertions don't pin on prompt wording, just structural elements like `<analysis>` and `<summary>` tags).

## What this enables

After this lands:
- ACP / headless clients see `TodoWrite` transitions without polling the DB
- Models can no longer mark two tasks `in_progress` simultaneously
- Compaction preserves the todo list and file paths reliably

After Phase B lands (next PR):
- `get_todo_section` system-prompt injection deleted (relies on this PR's event)
- `progress.rs` and call sites deleted (~−365 LOC)
- DESIGN.md principle from #1079 fully enforced in code

## Sequencing

1. ✅ #1079 — DESIGN.md principle + revised plan
2. **#XXXX (this PR) — Phase A: connector + validation + compact prompt**
3. Phase B PR (next) — drop injection + delete `progress.rs` (~−405 LOC)

Refs #1077.
