### PR TITLE
fix(microcompact): canonicalize at lookup, drop dual-case, fix latent List bug (closes #1083)

### DIFF
--- a/koda-core/src/microcompact.rs
+++ b/koda-core/src/microcompact.rs
@@ -21,21 +21,33 @@ use std::collections::HashMap;
 pub const CLEARED_MESSAGE: &str = "[Old tool result content cleared]";
 
 /// Tools whose results can be safely cleared (output is re-obtainable).
+///
+/// **Canonical names only.**  `is_compactable` normalizes input through
+/// `tool_normalize::normalize_tool_name` before lookup, so any spelling
+/// the model emits — PascalCase, snake_case, camelCase, or any registered
+/// alias — routes to the same canonical entry here.  This means:
+///
+/// 1. **No dual-case redundancy.**  Adding `"read"` next to `"Read"` is
+///    pointless; the lookup canonicalizes first.
+/// 2. **Spellings must match `tool_normalize::CANONICAL`** exactly.
+///    For example, the canonical name for the file-listing tool is
+///    `"List"`, not `"ListFiles"`.  The `compactable_tools_are_canonical`
+///    test enforces this at test time — if an entry here ever drifts
+///    out of sync with `CANONICAL`, the test breaks loudly.
+///
+/// History: this constant used to list both PascalCase and snake_case
+/// variants of every entry, which (a) was redundant after #1075 wired
+/// `normalize_tool_calls` into `inference.rs` before persistence, and
+/// (b) hid a latent bug — `"ListFiles"` is not the canonical name, so
+/// `List` results were never compacted.  Fixed in #1083.
 const COMPACTABLE_TOOLS: &[&str] = &[
     "Read",
-    "read",
     "Bash",
-    "bash",
     "Grep",
-    "grep",
     "Glob",
-    "glob",
-    "ListFiles",
-    "list_files",
+    "List",
     "WebSearch",
-    "web_search",
     "WebFetch",
-    "web_fetch",
 ];
 
 /// Number of most-recent compactable tool results to keep intact.
@@ -182,7 +194,13 @@ struct CompactableResult {
 }
 
 fn is_compactable(tool_name: &str) -> bool {
-    COMPACTABLE_TOOLS.contains(&tool_name)
+    // Canonicalize the spelling first so PascalCase / snake_case /
+    // camelCase / any registered alias all hit the same entry.  See the
+    // doc comment on `COMPACTABLE_TOOLS` for the rationale.  Cheap:
+    // `normalize_tool_name` is a single `HashMap::get` on a lowercased
+    // input, falling back to pass-through for unknown names.
+    let canonical = crate::tool_normalize::normalize_tool_name(tool_name);
+    COMPACTABLE_TOOLS.contains(&canonical.as_str())
 }
 
 fn estimate_tokens(content: &str) -> usize {
@@ -249,11 +267,64 @@ mod tests {
         assert!(is_compactable("Bash"));
         assert!(is_compactable("Grep"));
         assert!(is_compactable("Glob"));
+        assert!(is_compactable("List"));
         assert!(is_compactable("WebSearch"));
         assert!(is_compactable("WebFetch"));
         assert!(!is_compactable("InvokeAgent"));
         assert!(!is_compactable("TodoWrite"));
         assert!(!is_compactable("AskUser"));
+    }
+
+    /// Regression for the latent bug discovered in #1083: post-#1075,
+    /// every `list_files` / `ListFiles` call is normalized to `"List"`
+    /// before persistence, so the old `COMPACTABLE_TOOLS` entries
+    /// (`"ListFiles"`, `"list_files"`) were dead code and `List`
+    /// results were never compacted.
+    #[test]
+    fn test_is_compactable_list_canonical_name() {
+        assert!(
+            is_compactable("List"),
+            "canonical name 'List' must be compactable \
+             (regression for the #1083 latent bug)"
+        );
+    }
+
+    /// Belt-and-suspenders: legacy DB rows from before #1075 may still
+    /// carry snake_case or alternate PascalCase spellings.  Defensive
+    /// normalization at the lookup site means any registered alias
+    /// hits the same canonical entry, so old sessions stay compactable
+    /// without a DB migration.
+    #[test]
+    fn test_is_compactable_accepts_aliases_for_legacy_rows() {
+        // snake_case (legacy pre-#1075 spelling)
+        assert!(is_compactable("list_files"));
+        assert!(is_compactable("read_file"));
+        assert!(is_compactable("web_fetch"));
+        assert!(is_compactable("web_search"));
+        assert!(is_compactable("grep_search"));
+        // alternate PascalCase that the audit's old constant listed
+        assert!(is_compactable("ListFiles"));
+        // single-letter aliases
+        assert!(is_compactable("ls"));
+        assert!(is_compactable("rg"));
+    }
+
+    /// Compile-time-ish drift guard: every entry in `COMPACTABLE_TOOLS`
+    /// must already be its own canonical form, otherwise the lookup is
+    /// dead code (the input gets normalized before comparison).  Catches
+    /// the exact class of bug #1083 fixed: an entry like `"ListFiles"`
+    /// that doesn't match `tool_normalize::CANONICAL`.
+    #[test]
+    fn test_compactable_tools_are_canonical() {
+        for &name in COMPACTABLE_TOOLS {
+            let canonical = crate::tool_normalize::normalize_tool_name(name);
+            assert_eq!(
+                canonical, name,
+                "COMPACTABLE_TOOLS entry {name:?} is not canonical — \
+                 it normalizes to {canonical:?}.  Either add it to \
+                 `tool_normalize::CANONICAL` or use the canonical spelling."
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #1083. Spun out from #1074 (architecture audit, P3 follow-up). **Bug fix bonus included.**

## TL;DR

Started as a chore (drop redundant snake_case entries). Ended as a bug fix: `COMPACTABLE_TOOLS` listed `"ListFiles"` but the canonical name is `"List"`, so every `List`/`ListFiles`/`list_files` tool result in production was being stored as `"List"` and **never compacted**.

## What was wrong (two bugs, not one)

1. **Snake_case entries unreachable** (the audit's finding). Post-#1075, `tool_normalize::normalize_tool_calls` runs in `inference.rs:947` *before* persistence. So `"read"`, `"bash"`, `"web_fetch"`, etc. were dead code — nothing in the DB has those spellings anymore.

2. **PascalCase entries didn't match canonical names** (newly discovered while implementing #1083). The canonical name for the file-listing tool is `"List"` per `tool_normalize::CANONICAL`, not `"ListFiles"`. So:

   ```
   model emits "list_files"
     → normalize_tool_calls → "List"
     → persisted to DB as "List"
     → is_compactable("List")
     → COMPACTABLE_TOOLS.contains("List")  → FALSE
     → never compacted ❌
   ```

This is a real behavioral bug, not just cosmetic redundancy.

## Solution: defensive normalization at lookup

Original #1083 plan was a DB migration to canonicalize `function_name` in every persisted row, then drop the snake_case half of the constant. ~150 LOC, half-day, with non-trivial DB-corruption risk on migration failure.

Better path: normalize **input** at the lookup site instead of normalizing **data** at rest.

```rust
// Before
const COMPACTABLE_TOOLS: &[&str] = &[
    "Read", "read", "Bash", "bash", "Grep", "grep",
    "Glob", "glob", "ListFiles", "list_files",
    "WebSearch", "web_search", "WebFetch", "web_fetch",
];
fn is_compactable(tool_name: &str) -> bool {
    COMPACTABLE_TOOLS.contains(&tool_name)
}

// After
const COMPACTABLE_TOOLS: &[&str] =
    &["Read", "Bash", "Grep", "Glob", "List", "WebSearch", "WebFetch"];
fn is_compactable(tool_name: &str) -> bool {
    let canonical = crate::tool_normalize::normalize_tool_name(tool_name);
    COMPACTABLE_TOOLS.contains(&canonical.as_str())
}
```

| | Issue's original plan (DB migration) | This PR |
|---|---|---|
| LOC change | ~150 | **+80 / −9** (~10 actual code) |
| DB risk | Migration failure could corrupt user DBs | **Zero** |
| Fixes the latent `List` bug | Yes | Yes |
| Drops dual-case redundancy | Yes | Yes |
| Defends against future spelling drift | No | **Yes** (any registered alias just works) |
| Time to ship | Half-day | 30 minutes |

## Drift guard

New test `test_compactable_tools_are_canonical` asserts every entry in `COMPACTABLE_TOOLS` already equals its own canonical form. If anyone re-introduces a `"ListFiles"`-class bug (entry doesn't match `tool_normalize::CANONICAL`), the test breaks loudly with a fix-it message. **Catches the exact class of bug #1083 fixed.**

## Test coverage

| Test | Purpose |
|---|---|
| `test_is_compactable` | Extended to cover `"List"` (was missing — that's why the bug went undetected) |
| `test_is_compactable_list_canonical_name` | Explicit regression test for the bug |
| `test_is_compactable_accepts_aliases_for_legacy_rows` | Verifies snake_case (legacy DB rows) + alternate PascalCase still route to the same canonical entry |
| `test_compactable_tools_are_canonical` | Drift guard — prevents recurrence |

All existing tests stay green: `is_compactable("write")` still returns `false` because `"write"` normalizes to `"Write"` which isn't in `COMPACTABLE_TOOLS` by design.

## Acceptance (per #1083, with scope upgrade)

- ✅ Snake_case entries dropped from `COMPACTABLE_TOOLS`
- ✅ Latent `"ListFiles"` bug fixed (bonus, not in original spec)
- ✅ **No DB migration needed** (architecturally better than spec)
- ✅ `cargo test --workspace` passes — 1,879 lib + ~440 integration tests
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` clean
- ✅ `cargo fmt --all` no diff
- ✅ Drift guard test prevents recurrence

## Out of scope

- No DB migration (intentionally — defensive normalization makes it unnecessary)
- No new behaviour beyond the bug fix
- Did not audit other `*_TOOLS` constants for similar drift — this is the only one with this pattern (verified via `grep -n "_TOOLS: &\[&str\]"`)
