### PR TITLE
fix(sandbox): SEC-001 — git-deny via deny_write_within_allow so it wins last-match

### DIFF
--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -252,7 +252,33 @@ pub fn policy_for_agent(trust: crate::trust::TrustMode, project_root: &Path) -> 
     let canonical_root = project_root
         .canonicalize()
         .unwrap_or_else(|_| project_root.to_path_buf());
-    policy.fs.allow_write = vec![canonical_root.into()];
+    policy.fs.allow_write = vec![canonical_root.clone().into()];
+
+    // SEC-001 (v0.2.21 release audit): Gap 1 of #1072 was silently
+    // neutralized on Seatbelt because the pre-overlay
+    // `git_config_deny_rules` were emitted BEFORE the policy overlay's
+    // `allow_write (subpath ROOT)`, and SBPL is last-match-wins. So the
+    // canonical resolution for `{ROOT}/.git/config` was
+    // `allow → deny → allow` → write permitted.
+    //
+    // Fix: seed `deny_write_within_allow` with the same git paths.
+    // Both backends emit `deny_write_within_allow` AFTER `allow_write`
+    // in their overlay (seatbelt: policy_overlay_rules, bwrap: Layer 4),
+    // so these denies WIN the last-match resolution and actually enforce
+    // the protection claimed by #1073.
+    //
+    // The pre-overlay `git_config_deny_rules` / `apply_git_config_deny`
+    // calls are now redundant on the deny side but kept because the bwrap
+    // variant has a side effect (pre-creating `.git/hooks` to close the
+    // SEC-002 TOCTOU window). Cleanup of the redundant deny emission is a
+    // separate refactor — security fix stays minimal.
+    if !policy.fs.allow_git_config {
+        policy.fs.deny_write_within_allow = vec![
+            canonical_root.join(".git/hooks").into(),
+            canonical_root.join(".git/config").into(),
+        ];
+    }
+
     policy
 }
 
@@ -1284,6 +1310,44 @@ mod tests {
                 policy.fs.allow_write.len(),
                 1,
                 "even with a missing root, allow_write must have one entry"
+            );
+        }
+    }
+
+    // ── SEC-001 (v0.2.21 release audit) ──────────────────────────
+
+    #[test]
+    fn policy_for_agent_seeds_git_deny_when_allow_git_config_is_false() {
+        // SEC-001: without this seed, the pre-overlay git denies in
+        // build_command_inner are last-match-overridden by the overlay's
+        // allow_write, neutralizing the entire #1073 protection.
+        // strict_default() sets allow_git_config = false, so every trust
+        // mode must seed the deny pair.
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = dir.path().canonicalize().unwrap();
+        for mode in [
+            crate::trust::TrustMode::Plan,
+            crate::trust::TrustMode::Safe,
+            crate::trust::TrustMode::Auto,
+        ] {
+            let policy = policy_for_agent(mode, dir.path());
+            assert!(
+                !policy.fs.allow_git_config,
+                "strict_default precondition: allow_git_config must be false"
+            );
+            let denies: Vec<&std::path::Path> = policy
+                .fs
+                .deny_write_within_allow
+                .iter()
+                .map(|p| p.as_path())
+                .collect();
+            assert!(
+                denies.contains(&canonical.join(".git/hooks").as_path()),
+                "{mode:?}: deny_write_within_allow must contain .git/hooks, got {denies:?}"
+            );
+            assert!(
+                denies.contains(&canonical.join(".git/config").as_path()),
+                "{mode:?}: deny_write_within_allow must contain .git/config, got {denies:?}"
             );
         }
     }

--- a/koda-sandbox/src/seatbelt.rs
+++ b/koda-sandbox/src/seatbelt.rs
@@ -831,6 +831,117 @@ mod tests {
         );
     }
 
+    // ── SEC-001 (v0.2.21 release audit): resolution-aware tests ──────
+    //
+    // SBPL is last-match-wins. The pre-#1085 tests above only assert that
+    // deny strings APPEAR in the profile, not that they WIN resolution.
+    // SEC-001 was a real escape: deny rules were emitted but immediately
+    // overridden by the policy overlay's `allow file-write* (subpath ROOT)`.
+    // These tests model rule resolution and would have caught the bug.
+
+    /// Walk the SBPL profile and return the index (line offset) of the
+    /// LAST rule that grants/denies `file-write*` for `path`.
+    /// Returns `("allow" | "deny", line_idx)` of the winning rule, or
+    /// `None` if no rule mentions the path.
+    ///
+    /// A rule "matches" `path` if the path equals its `literal` arg or
+    /// is equal-to-or-a-descendant-of its `subpath` arg. This mirrors
+    /// macOS sandbox's actual resolution semantics for the rule shapes
+    /// we emit.
+    fn last_write_rule_for(profile: &str, path: &str) -> Option<(&'static str, usize)> {
+        let mut winner: Option<(&'static str, usize)> = None;
+        for (idx, line) in profile.lines().enumerate() {
+            let trimmed = line.trim_start();
+            let kind = if trimmed.starts_with("(allow file-write*") {
+                "allow"
+            } else if trimmed.starts_with("(deny file-write*") {
+                "deny"
+            } else {
+                continue;
+            };
+            // Extract the quoted argument: ...(literal "X")) or ...(subpath "X"))
+            let Some(q1) = line.find('"') else { continue };
+            let Some(q2) = line[q1 + 1..].find('"') else {
+                continue;
+            };
+            let arg = &line[q1 + 1..q1 + 1 + q2];
+            let matches = if line[..q1].contains("(literal") {
+                arg == path
+            } else if line[..q1].contains("(subpath") {
+                path == arg || path.starts_with(&format!("{arg}/"))
+            } else {
+                false
+            };
+            if matches {
+                winner = Some((kind, idx));
+            }
+        }
+        winner
+    }
+
+    #[test]
+    fn sec_001_git_config_write_is_denied_in_resolved_profile() {
+        // Mirror what policy_for_agent (in koda-core) seeds: the project
+        // root in allow_write AND the git deny pair in
+        // deny_write_within_allow. Without the deny_write_within_allow
+        // seed, this test fails (allow at line N wins after deny at line
+        // M, where M < N) — which is exactly SEC-001.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_write = vec!["/work".into()];
+        policy.fs.deny_write_within_allow =
+            vec!["/work/.git/hooks".into(), "/work/.git/config".into()];
+        let cmd = build_command("true", Path::new("/work"), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+
+        let (kind, _idx) = last_write_rule_for(profile, "/work/.git/config")
+            .expect("some rule must mention /work/.git/config");
+        assert_eq!(
+            kind, "deny",
+            "SEC-001 regression: last matching write rule for /work/.git/config must be `deny`. \
+             Profile:\n{profile}"
+        );
+
+        let (kind, _idx) = last_write_rule_for(profile, "/work/.git/hooks/post-checkout")
+            .expect("some rule must mention /work/.git/hooks/post-checkout");
+        assert_eq!(
+            kind, "deny",
+            "SEC-001 regression: last matching write rule for a hook script must be `deny`. \
+             Profile:\n{profile}"
+        );
+    }
+
+    #[test]
+    fn sec_001_unrelated_project_path_remains_writable() {
+        // Sanity check on the resolution simulator and the fix: paths that
+        // are NOT under the protected git subpaths must still be writable.
+        // Otherwise the fix would have over-corrected and broken normal
+        // workflows.
+        let mut policy = SandboxPolicy::strict_default();
+        policy.fs.allow_write = vec!["/work".into()];
+        policy.fs.deny_write_within_allow =
+            vec!["/work/.git/hooks".into(), "/work/.git/config".into()];
+        let cmd = build_command("true", Path::new("/work"), &policy).unwrap();
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let profile = &args[1];
+
+        let (kind, _idx) = last_write_rule_for(profile, "/work/src/main.rs")
+            .expect("some rule must mention /work/src/main.rs (via subpath /work)");
+        assert_eq!(
+            kind, "allow",
+            "SEC-001 fix must not over-correct: a normal source file under \
+             the project root must still be writable. Profile:\n{profile}"
+        );
+    }
+
     // ── Phase 3a: proxied network rules ─────────────────────────────
 
     #[test]


### PR DESCRIPTION
# Fix SEC-001: git-deny rules silently neutralized by policy overlay

Caught during the v0.2.21 release audit by `security-auditor` sub-agent.
PR #1073 shipped a security label without the security behavior.

## The bug

SBPL is **last-match-wins**. The seatbelt rule order in
`build_command_inner` for any caller going through `policy_for_agent`
(i.e. all real callers) was:

| Order | Source | Rule (write rules only) |
|---|---|---|
| #1 | `build_profile_string` (baseline) | `(allow file-write* (subpath "{ROOT}") …)` |
| #4 | `git_config_deny_rules` (Gap 1, #1073) | `(deny file-write* (subpath "{ROOT}/.git/hooks"))` |
| #5 | `git_config_deny_rules` (Gap 1, #1073) | `(deny file-write* (literal "{ROOT}/.git/config"))` |
| #6 | `policy_overlay_rules` → allow_write (Gap 3, #1073) | `(allow file-write* (subpath "{ROOT}"))` ⚠️ |

For `{ROOT}/.git/config` the cascade was `allow → deny → allow` →
**WRITE PERMITTED**. The Gap 1 protection was dead code on the Seatbelt
backend whenever `policy.fs.allow_write` contained the project root —
which Gap 3 just made the default for **every trust mode** in
`policy_for_agent` (`koda-core/src/sandbox.rs:255`).

The two stated git-escape vectors (`git config core.fsmonitor`, dropping
a `post-checkout` hook) remained unmitigated despite #1073's claim
"Gap 1 closed."

### Why the existing tests missed it

`build_command_includes_git_deny_rules_when_not_allowed` (seatbelt.rs
line ~786) only asserted the deny **strings appear** in the profile —
it didn't model resolution. SBPL's last-match-wins semantics means
appearance ≠ enforcement.

### Bwrap impact

Same class of bug: `apply_git_config_deny` does `--ro-bind {root}/.git/hooks`
before `apply_policy_overlay`'s Layer 3 calls `--bind {root} {root}`,
which shadows the nested mount.

## The fix

Seed `policy.fs.deny_write_within_allow` in `policy_for_agent` with
`[{root}/.git/hooks, {root}/.git/config]` whenever `!policy.fs.allow_git_config`.
Both backends emit `deny_write_within_allow` AFTER `allow_write`:

- **Seatbelt**: `policy_overlay_rules` emits `deny_write_within_allow`
  rules at the very end (after `allow_write`), so they win last-match.
- **Bwrap**: Layer 4 (`--ro-bind`) runs after Layer 3 (`--bind`), so
  the read-only re-binds enforce after the writable bind.

One policy change fixes both backends. The pre-overlay
`git_config_deny_rules` / `apply_git_config_deny` calls become redundant
on the deny side but are kept because the bwrap variant has a side
effect (pre-creating `.git/hooks/` to mitigate SEC-002 TOCTOU). Removing
the redundancy is a separate refactor — security fix stays minimal.

## Tests added

### 1. `policy_for_agent_seeds_git_deny_when_allow_git_config_is_false` (koda-core)

Asserts that `policy_for_agent` puts both git paths into
`deny_write_within_allow` for every trust mode when `allow_git_config = false`
(the default from `strict_default()`).

**Verified load-bearing**: with the production fix temporarily reverted,
this test fails:

```
Plan: deny_write_within_allow must contain .git/hooks, got []
test result: FAILED. 0 passed; 1 failed
```

### 2. `sec_001_git_config_write_is_denied_in_resolved_profile` (koda-sandbox)

Builds a real seatbelt profile, walks the rules in order with a small
SBPL resolution simulator (`last_write_rule_for`), and asserts the
**last** matching write rule for `/work/.git/config` and
`/work/.git/hooks/post-checkout` is `deny`. This is the
"resolution-aware" test the auditor specifically called out as missing.

### 3. `sec_001_unrelated_project_path_remains_writable` (koda-sandbox)

Sanity check: `/work/src/main.rs` (a normal source file under the
project root) must still resolve to `allow`. Catches over-correction.

## Quality gates

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --features koda-core/test-support -D warnings` ✅
- `cargo test --workspace --features koda-core/test-support` ✅ (all 1500+ tests pass)

## Out of scope (follow-ups)

- **SEC-002** (bwrap TOCTOU window for fresh `git init`): pre-create
  empty `.git/config` file in `apply_git_config_deny` alongside the
  existing `.git/hooks/` pre-creation. Tracked separately.
- Cleanup of redundant pre-overlay `git_config_deny_rules` /
  `apply_git_config_deny` deny emission. Cosmetic only after this PR.

Closes the SEC-001 finding from the v0.2.21 release audit.
Refs #1045, #1072, #1073.
