### PR TITLE
chore: release v0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,90 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.21] - 2026-04-27
+
+### Security
+
+- **SEC-001 — git-deny rules now actually win SBPL resolution** (#1086).
+  PR #1073 emitted `deny file-write*` rules for `.git/config` and
+  `.git/hooks/` BEFORE the policy overlay's `allow file-write* (subpath ROOT)`.
+  Because SBPL is last-match-wins, the cascade `allow → deny → allow`
+  silently re-permitted writes — the protection in #1073 was dead code.
+  Fix seeds `policy.fs.deny_write_within_allow` so the denies are emitted
+  AFTER `allow_write` in both backends (Seatbelt and bwrap), making the
+  protection enforce as documented. Caught during release audit.
+- **Sandbox: closed git-config + git-hooks escape vectors** (#1073, #1086).
+  When `allow_git_config = false` (the default), writes to `.git/config`
+  (blocks `git config core.fsmonitor <cmd>`) and `.git/hooks/*` (blocks
+  direct hook placement) are now denied across both Seatbelt (macOS) and
+  bwrap (Linux) backends.
+
+### Added
+
+- **`EngineEvent::TodoUpdate { items, diff }`** (#1080). The engine now
+  emits a structured event whenever the session task list changes,
+  carrying both the full list and the per-task diff. Replaces the
+  previous system-prompt injection mechanism.
+- **`EngineEvent::BgTaskUpdate { task_id, spawner, status }`** (#1078).
+  Background sub-agent status changes now flow through the engine's
+  event stream instead of a separate side channel.
+- **`koda_core::provider_catalog` module** (#1084). Static lookup tables
+  for `ProviderType` and `ProviderMeta` extracted from `config.rs` for
+  better cohesion.
+- **`koda_core::bg_agent::BgStatusEmitter`** (#1078). Public type for
+  routing background task status updates through the engine.
+- **`koda_core::tools::todo::{TodoChange, TodoDiff, TodoWriteOutcome}`**
+  (#1080). New public types describing structured `TodoWrite` results.
+- **Max-1-in-progress validation for TodoWrite** (#1080). The tool now
+  rejects task lists with more than one in-progress item, enforcing the
+  single-focus invariant promised by the user-facing prompt.
+
+### Changed
+
+- **`koda_core::tools::todo::todo_write` return type**
+  `Result<String>` → `Result<TodoWriteOutcome>` (#1080). Direct callers
+  of `koda-core` need to update their call sites; the CLI consumes via
+  the engine and is unaffected.
+- **Progress tracking is now event-driven, not prompt-injected** (#1080,
+  #1081). `TodoWrite` is the canonical mechanism for task tracking;
+  the engine emits `TodoUpdate` events to interested observers (the
+  TUI, sub-agent callers). System prompt no longer carries progress
+  text, which made compaction smarter and removed a class of subtle
+  drift bugs.
+
+### Removed
+
+- **`koda_core::progress` module** (#1081). The pre-#1077 architecture
+  injected progress summaries directly into the system prompt; this is
+  now handled via `EngineEvent::TodoUpdate`. The module and its
+  `track_progress` / `get_progress_summary` helpers are gone.
+- **`koda_core::tools::todo::get_todo_section`** (#1080). No longer
+  needed; consumers receive todo state via `TodoUpdate` events.
+- **`insta` dev-dependency** (#1071). Snapshot tests rewritten as
+  `assert_eq!` to drop a heavyweight dev dep; the `similar` crate is
+  unified at 3.x across the workspace.
+
+### Fixed
+
+- **`List` tool results were never being microcompacted** (#1085). The
+  `COMPACTABLE_TOOLS` constant carried both PascalCase and snake_case
+  spellings, but lookups happened against canonicalized names that had
+  already been normalized to PascalCase — so the snake_case entries
+  were dead and the PascalCase `List` happened to be missing. Fix
+  canonicalizes at lookup and drops the dual-case anti-pattern; adds a
+  drift guard test to prevent recurrence.
+- **P3 polish bundle for #1045** (#1070). Doc-test comments,
+  `bg_agent.subscribe` correctness, QA-001 iteration test.
+
+### CI / Internal
+
+- **Fail-fast release test matrix** (#1069). macOS test job is
+  cancelled when the Ubuntu job fails first, cutting feedback latency
+  on broken PRs from ~25min to ~10min.
+- **Architecture audit reflected in DESIGN.md** (#1075, #1079).
+  Documentation rewritten to match the actual implementation post-#1077;
+  no behavioral change.
+
 ## [0.2.20] - 2026-04-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.20)
+10. Sync version with workspace (currently 0.2.21)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
 license.workspace = true
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.20" }
+koda-core = { path = "../koda-core", version = "0.2.21" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -77,6 +77,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.20", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.21", features = ["test-support"] }
 serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license.workspace = true
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.20" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.21" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -101,9 +101,9 @@ pub mod output_caps;
 pub mod persistence;
 /// Diff preview generation for file mutations.
 pub mod preview;
-/// Progress reporting helpers for long operations.
 /// System prompt construction.
 pub mod prompt;
+/// Static provider catalog: `ProviderType` + `ProviderMeta` lookup tables.
 pub mod provider_catalog;
 /// LLM provider abstraction — Anthropic, Gemini, OpenAI-compatible.
 pub mod providers;

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
 license.workspace = true


### PR DESCRIPTION
# Release v0.2.21

Cuts v0.2.20 → **v0.2.21**.

## What's in this release

12 commits since v0.2.20. See `CHANGELOG.md` for the full categorized list. Headlines:

- 🔒 **Security**: SEC-001 (#1086) — git-deny rules now actually win SBPL resolution. Previously #1073 emitted denies before the policy overlay's `allow file-write* (subpath ROOT)`, and SBPL is last-match-wins, so the protection was dead code. Caught during this release's audit.
- 🔒 **Security**: Sandbox git-config + git-hooks escape vectors closed (#1073, #1086) on both Seatbelt and bwrap backends.
- 🐛 **Bug fix**: `List` tool results were never being microcompacted (#1085). Real perf/cost regression for anyone on v0.2.20.
- ✨ **Feature**: Progress tracking is now event-driven (`EngineEvent::TodoUpdate`) instead of system-prompt-injected (#1077 sequence: #1078, #1079, #1080, #1081). Smarter compaction, removes a class of drift bugs.
- ✨ **Feature**: Background sub-agent status flows through `EngineEvent::BgTaskUpdate` (#1078).
- 🧹 **Refactor**: `provider_catalog` extracted from `config.rs` (#1084); `insta` dev-dep dropped (#1071).

## Public-API changes (heads-up for direct `koda-core` consumers)

- **Removed**: `koda_core::progress` module (#1081)
- **Removed**: `koda_core::tools::todo::get_todo_section` (#1080)
- **Changed**: `koda_core::tools::todo::todo_write` return type `Result<String>` → `Result<TodoWriteOutcome>` (#1080)
- **Added**: `provider_catalog` module, `EngineEvent::{TodoUpdate, BgTaskUpdate}`, `BgStatusEmitter`, `TodoChange`, `TodoDiff`, `TodoWriteOutcome`

The `koda-cli` binary consumes via the engine and is unaffected. No internal-only `koda-core` users beyond `koda-cli`, so a patch bump (not a minor bump) is correct for this project's reality.

## Pre-flight audit summary

This release was gated by 3 sub-agents (qa-expert timed out; the other 3 returned actionable findings):

| Agent | Verdict | Action |
|---|---|---|
| `code-reviewer` | Flagged 2 P2 doc regressions in `lib.rs` | ✅ Fixed in this PR |
| `rust-programmer` | All quality gates clean (fmt, clippy, doc, test); flagged a SemVer concern that doesn't apply here (no external `koda-core` users) | ✅ Acknowledged & retracted |
| `security-auditor` | **P1 SEC-001 — #1073 was silently neutralized** | ✅ Fixed in #1086 (already merged) |

### P3-bundle deferred items

None worth tracking this cycle. The audit-dust prevention rules in the koda-release skill caught what would otherwise have been ~2-3 P3 issues (test flake observation, dependency patch suggestions) and they got triaged inline rather than spawning issues that would close within 24h.

### P2 deferred items

- **SEC-002** (security-auditor): bwrap TOCTOU window for fresh `git init` repos. Pre-create empty `.git/config` file in `apply_git_config_deny` alongside the existing `.git/hooks/` pre-creation. Will file as a follow-up issue after merge.

## Pre-flight checks

- ✅ `cargo fmt --all --check`
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings`
- ✅ `cargo test --workspace --features koda-core/test-support` (all 1500+ tests pass)
- ✅ `RUSTFLAGS=-Dwarnings RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- ✅ `cargo audit`: 0 vulns / 0 warnings across 495 deps
- ✅ `koda_docs` skill page list synced with `docs/src/*.md`

## Files changed

```
CHANGELOG.md            | 84 +++++  (new [0.2.21] section)
CLAUDE.md               |  2 +-     (version reference)
Cargo.lock              |  6 +-     (regenerated)
koda-core/Cargo.toml    |  4 +-     (version + koda-sandbox dep pin)
koda-cli/Cargo.toml     |  6 +-     (version + koda-core dep pins x2)
koda-sandbox/Cargo.toml |  2 +-     (version)
koda-core/src/lib.rs    |  2 +-     (doc-comment fixes for prompt + provider_catalog)
```

After merge → tag `v0.2.21` on the squash-merge commit → `release.yml` handles the rest.

### Deferred items (tracked)
- [ ] #1088 — sandbox: pre-create empty .git/config to close SEC-002 TOCTOU window
