### PR TITLE
test(bg-agent): switch to multi_thread runtime + diagnostic dump (#1090)

### DIFF
--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -320,9 +320,22 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
 // loop actually ran; reaching it implies `iter ≥ 1` was sent because
 // `run_bg_agent` sends `Running { iter: n }` at the top of each
 // iteration and `Completed` is only emitted after the loop exits.
+//
+// **Runtime flavor**: the production code path uses `tokio::spawn` for
+// background sub-agents (see `sub_agent_dispatch::run_bg_agent` and the
+// B5 comment block). On `current_thread` runtimes (the `#[tokio::test]`
+// default) `tokio::spawn` queues the future but it can ONLY make
+// progress when the test task explicitly yields. The dispatch path
+// itself is fully synchronous between `reserve()` and `attach()`, but
+// the spawned future's first poll happens lazily — and on macOS CI
+// runners we observed cases where the test's polling loop spun on a
+// snapshot that never updated, suggesting the dispatch future itself
+// hadn't completed before the test resumed. Pinning to `multi_thread`
+// matches production semantics and gives the spawned task a dedicated
+// worker, eliminating the scheduling pathology. See #1090.
 
 #[cfg(feature = "test-support")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn bg_agent_iter_counter_advances_via_status_channel() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -353,23 +366,31 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         MockResponse::Text("parent done".into()),
     ]);
 
-    env.run_inference(&provider).await;
+    let events = env.run_inference(&provider).await;
 
-    // The background task is registered in env.bg_agents before
-    // before spawn), so it should appear in the snapshot immediately.
-    // Poll with a 5-second deadline in case the runtime hasn’t scheduled
-    // the spawned task yet.
+    // Diagnostic: the dispatch path between `reserve()` and `attach()`
+    // is fully synchronous (no `.await` points), so the entry MUST be
+    // in the registry by the time inference returns.  If we ever fail
+    // the snapshot poll below, dump the events vector — it will tell
+    // us whether `InvokeAgent` even dispatched, whether the background
+    // branch was taken, and whether the parent reached "parent done".
     let task_id = {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        const REGISTRATION_BUDGET: Duration = Duration::from_secs(5);
+        let deadline = tokio::time::Instant::now() + REGISTRATION_BUDGET;
         loop {
             let snap = env.bg_agents.snapshot();
             if let Some(task) = snap.first() {
                 break task.task_id;
             }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "background agent was never registered in the registry within 5s"
-            );
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "background agent was never registered in the registry within {REGISTRATION_BUDGET:?}.\n\
+                     events from inference_loop ({} total): {events:#?}\n\
+                     final snapshot: {:#?}",
+                    events.len(),
+                    env.bg_agents.snapshot()
+                );
+            }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
     };


### PR DESCRIPTION
Closes #1090 (if multi_thread is the bug); otherwise the new diagnostic dump will tell us what to fix next.

## TL;DR

`#[tokio::test]` defaults to **`current_thread`** runtime. Production runs background sub-agents on a **`multi_thread`** runtime (per the B5 comment in `sub_agent_dispatch.rs`). The test was exercising a different scheduling model than the code it tests — switching to `multi_thread` matches production semantics.

## Investigation summary

I worked through the four candidates listed in #1090:

| # | Candidate | Verdict |
|---|---|---|
| 1 | Different `Arc<BgAgentRegistry>` instances | ❌ Ruled out — `koda-test-utils/src/env.rs:217` confirms `Arc::clone(&self.bg_agents)` is wired into `InferenceContext.bg_agents` |
| 2 | Dispatch errors out before `attach()` | 🟡 Possible but unproven — `run_inference_dyn` asserts `is_ok()`, so any propagated Err would have shown a different test failure. Diagnostic dump will reveal if InvokeAgent silently failed |
| 3 | `current_thread` tokio runtime + macOS scheduling quirk | ✅ **Most likely** — production is multi_thread (B5 comment), test was current_thread |
| 4 | Test sees a registry that gets cleared | ❌ Ruled out — no `InvocationCleanup` runs on the bg early-return path |

The dispatch path itself is fully synchronous between `reserve()` (line 343) and `attach()` (line 398). No `.await` in between. So `attach()` MUST run before `return Ok(...)`. Yet macOS post-merge CI saw an empty registry for the entire 15s polling window.

The only remaining hypothesis that doesn't require a real logic bug: the dispatch future itself (the LLM-tool call that wraps dispatch) doesn't get to its return value before the test resumes polling — possible only on `current_thread` runtime under unusual scheduling.

## Why this PR is two changes, not one

1. **Switch to `multi_thread` runtime** — the principled fix matching production
2. **Diagnostic dump on failure** — insurance against being wrong about (1)

If (1) doesn't fix it, (2) turns the next failure into a single-iteration root cause: the panic message will dump the events vector and final snapshot, so we'll see exactly what `inference_loop` produced.

## Verification

- ✅ Test passes locally, **20/20 sequential runs at 0.04s each**
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` clean
- ✅ `cargo fmt --all --check` clean
- ✅ No public API changes, no feature flag changes
- ✅ DRY: extracted `REGISTRATION_BUDGET` const so deadline & message can't drift apart

## What gets closed

- #1090 — if CI passes, root cause is confirmed and we close it
- The PR title intentionally does NOT use 'fix:' to avoid claiming victory until CI proves the fix. If CI passes, I'll re-tag the merge commit message.

Refs: PR #1089 (closed — wrong approach), Issue #1090 (full investigation log)