### PR TITLE
fix(gemini): send tool params under `parametersJsonSchema` (not `parameters`)

### DIFF
--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -226,6 +226,19 @@ struct GeminiToolConfig {
 struct FunctionDeclaration {
     name: String,
     description: String,
+    /// Tool parameter schema. Sent under the `parametersJsonSchema`
+    /// wire field instead of `parameters` because our schemas use
+    /// JSON Schema features Gemini's strict OpenAPI 3.0 `parameters`
+    /// field rejects (notably `additionalProperties: false`, which
+    /// the bg-task tools use to prevent hallucinated args — and
+    /// which OpenAI structured outputs also require).
+    ///
+    /// The Gemini API exposes both fields side by side: `parameters`
+    /// is OpenAPI 3.0 (strict subset), `parametersJsonSchema` is
+    /// full JSON Schema. The 1st-party gemini-cli uses the
+    /// JSON-Schema field for the same reason. See:
+    /// https://ai.google.dev/api/caching#FunctionDeclaration
+    #[serde(rename = "parametersJsonSchema")]
     parameters: serde_json::Value,
 }
 
@@ -974,6 +987,58 @@ mod tests {
     fn test_build_tools_empty() {
         let tools = GeminiProvider::build_tools(&[]);
         assert!(tools.is_empty());
+    }
+
+    /// Regression for the 400 we'd get sending JSON-Schema features
+    /// (notably `additionalProperties: false`, which the bg-task
+    /// tools use) under Gemini's strict OpenAPI-3.0 `parameters`
+    /// field. Fix is to serialize as `parametersJsonSchema` instead
+    /// — the JSON-Schema-aware sibling field. The 1st-party
+    /// gemini-cli does the same. See:
+    /// https://ai.google.dev/api/caching#FunctionDeclaration
+    ///
+    /// Without this rename the API rejects the request with:
+    ///   Unknown name "additionalProperties" at
+    ///   'tools[0].function_declarations[N].parameters'
+    #[test]
+    fn function_declaration_serializes_under_parameters_json_schema() {
+        let tools = vec![ToolDefinition {
+            name: "CancelTask".into(),
+            description: "cancel a bg task".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "task_id": { "type": "string" }
+                },
+                "required": ["task_id"],
+                "additionalProperties": false
+            }),
+        }];
+        let gemini_tools = GeminiProvider::build_tools(&tools);
+        let wire = serde_json::to_value(&gemini_tools[0]).unwrap();
+        let decl = &wire["functionDeclarations"][0];
+
+        // The whole point: schema lives under `parametersJsonSchema`,
+        // NOT `parameters`. Sending under `parameters` triggers the
+        // "Unknown name 'additionalProperties'" 400.
+        assert!(
+            decl.get("parametersJsonSchema").is_some(),
+            "expected `parametersJsonSchema` field in wire payload, got: {wire}"
+        );
+        assert!(
+            decl.get("parameters").is_none(),
+            "`parameters` field must NOT appear (Gemini rejects JSON Schema there): {wire}"
+        );
+
+        // The schema itself must be passed through verbatim — no
+        // sanitization, no field-stripping. additionalProperties:
+        // false is a feature, not a bug: it stops Gemini from
+        // hallucinating extra args, exactly like OpenAI strict mode.
+        assert_eq!(
+            decl["parametersJsonSchema"]["additionalProperties"],
+            serde_json::json!(false),
+            "additionalProperties must survive intact: {wire}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR

Gemini chat sessions on `main` are returning HTTP 400 for any tool list that includes the bg-task tools (`ListBackgroundTasks`, `CancelTask`, `WaitTask`):

```
Gemini API returned 400 Bad Request:
Unknown name "additionalProperties" at 'tools[0].function_declarations[6].parameters'
Unknown name "additionalProperties" at 'tools[0].function_declarations[7].parameters'
Unknown name "additionalProperties" at 'tools[0].function_declarations[19].parameters'
```

The bg-task tools (added in #996 Layer 2) declare `additionalProperties: false` to prevent the model from hallucinating extra args. Our Gemini provider was serializing tool schemas under the `parameters` JSON field, which Gemini interprets as a strict OpenAPI 3.0 subset that **rejects** `additionalProperties`. Fix: serialize under `parametersJsonSchema` instead — the JSON-Schema-aware sibling field that the Gemini REST API exposes for exactly this case.

## Approach: validated against gemini-cli

Before writing the fix I cross-checked against the 1st-party Google CLI in `~/repo/gemini-cli`:

```bash
$ grep additionalProperties packages/core/src/tools/definitions/model-family-sets/*.ts
default-legacy.ts:      additionalProperties: false,
default-legacy.ts:      additionalProperties: false,
default-legacy.ts:      additionalProperties: false,
gemini-3.ts:            additionalProperties: false,
gemini-3.ts:            additionalProperties: false,
gemini-3.ts:            additionalProperties: false,
```

Gemini CLI keeps `additionalProperties: false` in their tool schemas verbatim. They route them through the `parametersJsonSchema` field on `FunctionDeclaration`, NOT `parameters`. Both fields exist side by side in the Gemini REST API:

| Field | Schema dialect | Accepts `additionalProperties`? |
|---|---|---|
| `parameters` | OpenAPI 3.0 strict subset | ❌ |
| `parametersJsonSchema` | full JSON Schema | ✅ |

Reference: https://ai.google.dev/api/caching#FunctionDeclaration

So this is a Google-blessed pattern, not a workaround.

## Why NOT sanitize on our side

My first instinct was to recursively strip `additionalProperties` from schemas before sending them to Gemini. **The user pushed back and asked me to validate against gemini-cli first** — and that pushback was correct. Three reasons sanitization is the wrong fix:

1. **Loses strict-mode behavior on Gemini itself.** `additionalProperties: false` is a feature: it tells the model not to invent args. Stripping it on the way out makes Gemini sloppier than it has to be.
2. **Doesn't future-proof.** Any other JSON-Schema-only field would need the same workaround (`$schema`, `oneOf`, `patternProperties`, …).
3. **Re-implements work the Gemini REST API already did for us** by exposing two parallel fields.

## The fix

One line. Rename the wire field with serde:

```rust
#[derive(Serialize)]
struct FunctionDeclaration {
    name: String,
    description: String,
    #[serde(rename = "parametersJsonSchema")]
    parameters: serde_json::Value,
}
```

Schemas now pass through verbatim (no sanitization, no field-stripping) under the JSON-Schema-aware field. The Rust field name stays `parameters` so no caller code changes.

## Tests

- ✅ `function_declaration_serializes_under_parameters_json_schema` — direct regression: builds a tool with `additionalProperties: false`, asserts the wire payload puts the schema under `parametersJsonSchema` (not `parameters`), and asserts `additionalProperties` survives intact (no sanitization)
- ✅ Pre-existing `test_build_tools` and `test_build_tools_empty` still pass — tool-list count and config structure unchanged
- ✅ All 25 gemini-module tests pass
- ✅ Workspace-wide: 1887 unit tests pass, 0 failures
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` clean
- ✅ `cargo fmt --all --check` clean

## Compatibility

Rust API surface unchanged. `ToolDefinition.parameters` and the internal `FunctionDeclaration.parameters` Rust field both keep their names — only the JSON wire encoding changes. Zero caller-side updates needed.

## Files changed

```
koda-core/src/providers/gemini.rs | 65 +++++++++++++++++++++++++++++++++++++++
1 file changed, 65 insertions(+)
```

Single file, single concern. The diff is one rename + extensive docstring + one regression test (the docstring and test are the bulk of the lines).