### PR TITLE
fix(sub-agent): mark assistant messages complete so multi-turn loops progress

### DIFF
--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -790,15 +790,29 @@ pub(crate) fn execute_sub_agent<'a>(
                 Some(serde_json::to_string(&response.tool_calls)?)
             };
 
-            db.insert_message(
-                &sub_session,
-                &Role::Assistant,
-                response.content.as_deref(),
-                tool_calls_json.as_deref(),
-                None,
-                Some(&response.usage),
-            )
-            .await?;
+            // **koda#1101**: capture msg_id and mark the assistant
+            // message complete. Pre-fix this call discarded the row
+            // ID and never marked complete, so `load_context` (which
+            // filters out `(role = 'assistant' AND completed_at IS
+            // NULL)`) dropped every sub-agent assistant turn from
+            // the next iteration's history. The orphan tool-result
+            // rows then got pruned by `prune_mismatched_tool_calls`,
+            // leaving the sub-agent with `[system, user]` only — it
+            // re-issued the same tool call every iteration until the
+            // cap. Mirrors the parent inference loop's pattern at
+            // `inference.rs::mark_message_complete`. The contract is
+            // pinned by `db::tests::load_context_excludes_incomplete_assistant_messages`.
+            let assistant_msg_id = db
+                .insert_message(
+                    &sub_session,
+                    &Role::Assistant,
+                    response.content.as_deref(),
+                    tool_calls_json.as_deref(),
+                    None,
+                    Some(&response.usage),
+                )
+                .await?;
+            db.mark_message_complete(assistant_msg_id).await?;
 
             if response.tool_calls.is_empty() {
                 let result = response

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -88,6 +88,133 @@ async fn test_sub_agent_invocation_e2e() {
     );
 }
 
+/// Regression for koda#1101: the sub-agent dispatch loop forgot to
+/// mark its assistant messages complete via `db.mark_message_complete`.
+/// Because `load_context` filters out
+/// `(role = 'assistant' AND completed_at IS NULL)` rows, every
+/// iteration the sub-agent reloaded a context with **no assistant
+/// turns** — then `prune_mismatched_tool_calls` orphan-pruned the
+/// tool result rows, leaving only `[system, user]`. The sub-agent
+/// re-issued the same tool call forever, hitting the iteration cap.
+///
+/// User-visible symptom (post-#1099 when paths actually rendered):
+///
+/// ```text
+/// ● List /Users/lijun/repo
+/// ● List /Users/lijun/repo
+/// ● List /Users/lijun/repo
+/// ... (repeats until iteration cap or Ctrl+C)
+/// ```
+///
+/// This test scripts the sub-agent's mock provider to:
+///   1. Issue a `ListSkills` tool call (no-arg, no-side-effect tool)
+///   2. Reply with final text
+///
+/// If the bug is present, the sub-agent will burn all `KODA_MOCK_RESPONSES`
+/// on repeated tool calls and never reach the text reply — OR the DB
+/// will end up with assistant rows where `completed_at IS NULL`.
+/// Either failure is asserted below.
+#[tokio::test]
+async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("loop-test-agent.json"),
+        serde_json::json!({
+            "name": "loop-test-agent",
+            "system_prompt": "You are a test agent. Call ListSkills then reply done.",
+            "allowed_tools": ["ListSkills"],
+            "provider": "mock",
+            "base_url": "http://localhost:0"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // Sub-agent script: tool call, then final text. With the bug,
+    // the sub-agent would reload a context missing the assistant
+    // tool-call turn and re-issue the same call — burning the
+    // second response on another tool call instead of the text.
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::set_var(
+            "KODA_MOCK_RESPONSES",
+            r#"[
+                {"tool_calls": [{"id": "tc_1", "name": "ListSkills", "arguments": "{}"}]},
+                {"text": "sub-agent done"}
+            ]"#,
+        );
+    }
+
+    env.insert_user_message("delegate").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({
+                "agent_name": "loop-test-agent",
+                "prompt": "do the thing"
+            }),
+        ),
+        MockResponse::Text("parent done".into()),
+    ]);
+    let _events = env.run_inference(&provider).await;
+
+    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
+    unsafe {
+        std::env::remove_var("KODA_MOCK_RESPONSES");
+    }
+
+    // Find the sub-agent's session. `list_sessions` returns newest-first,
+    // so the loop-test-agent session is at the top (created after the
+    // parent test session, before the parent's final text response).
+    let sessions = env.db.list_sessions(10, &env.root).await.unwrap();
+    let sub_session = sessions
+        .iter()
+        .find(|s| s.agent_name == "loop-test-agent")
+        .unwrap_or_else(|| {
+            panic!(
+                "loop-test-agent session must exist; got: {:?}",
+                sessions.iter().map(|s| &s.agent_name).collect::<Vec<_>>()
+            )
+        });
+
+    // Direct DB-level assertion: load_context applies the same filter
+    // the sub-agent's loop applies. If any assistant row has
+    // `completed_at IS NULL`, it'll be missing here, which is the
+    // exact mechanism that caused the loop spin.
+    let context = env.db.load_context(&sub_session.id).await.unwrap();
+    let assistant_turns = context
+        .iter()
+        .filter(|m| matches!(m.role, koda_core::persistence::Role::Assistant))
+        .count();
+    assert!(
+        assistant_turns >= 1,
+        "sub-agent's load_context must include at least one assistant turn; found {assistant_turns}. \
+         Pre-fix this was zero because mark_message_complete was never called, so every iteration \
+         the sub-agent saw `[system, user]` only and re-issued the same tool call. Context: {context:#?}"
+    );
+
+    // Belt-and-suspenders: load_all_messages bypasses the completed_at
+    // filter, so any drift between the two counts pinpoints incomplete
+    // assistant rows even if `assistant_turns` happens to be ≥1
+    // for some other reason.
+    let all = env.db.load_all_messages(&sub_session.id).await.unwrap();
+    let all_assistant = all
+        .iter()
+        .filter(|m| matches!(m.role, koda_core::persistence::Role::Assistant))
+        .count();
+    assert_eq!(
+        all_assistant, assistant_turns,
+        "every assistant row in the sub-agent session must be visible to load_context; \
+         all={all_assistant}, filtered={assistant_turns}. Drift = some assistant rows have \
+         completed_at IS NULL = the loop-spin bug is back."
+    );
+}
+
 #[tokio::test]
 async fn test_sub_agent_cache_hit_skips_llm() {
     let _lock = ENV_MUTEX.lock().await;


### PR DESCRIPTION
## Symptom

Sub-agents (e.g. `explore`) call the same tool on the same args over and over until hitting the iteration cap, then return `[ERROR: ...iteration cap...]`. Direct user repro after #1099 made the paths visible:

```
> use sub agent to explore ~/repo to understand its structure and provide
  recommendations to improve it.

● InvokeAgent explore
  🤖 Sub-agent: explore
  ● List /Users/lijun/repo
  ● List /Users/lijun/repo
  ● List /Users/lijun/repo
  ● List /Users/lijun/repo
  ● List /Users/lijun/repo
  ● List /Users/lijun/repo
  │ [cancelled by parent]
⚠ Interrupted
```

The model isn't being dumb — it's calling List on the right path. It just has no way to see that it already did.

## Root cause

`koda-core/src/sub_agent_dispatch.rs` line 793 inserts the assistant response into the database but **never marks it complete**:

```rust
db.insert_message(
    &sub_session,
    &Role::Assistant,
    response.content.as_deref(),
    tool_calls_json.as_deref(),
    None,
    Some(&response.usage),
)
.await?;  // ← discards the row ID, never calls mark_message_complete
```

The parent inference loop does it right (`koda-core/src/inference.rs:990`):

```rust
let msg_id = db.insert_message(...).await?;
db.mark_message_complete(msg_id).await?;
```

`load_context` (`koda-core/src/db/queries.rs:357`) filters with:

```sql
WHERE session_id = ? AND compacted_at IS NULL
  AND (role != 'assistant' OR completed_at IS NOT NULL)
```

So every loop iteration:

1. Sub-agent inserts an assistant tool-call row → `completed_at = NULL`.
2. Sub-agent inserts the tool-result row → `tool_call_id` references the assistant row.
3. Loop iterates. `load_context` drops the assistant row (incomplete).
4. `prune_mismatched_tool_calls` drops the tool-result row (orphaned `tool_call_id`).
5. Sub-agent's effective context is `[system, user]` — identical to iteration 1.
6. Sub-agent re-issues the same tool call. Goto 1.

The loop only exits when the iteration cap (`MAX_SUB_AGENT_ITERATIONS = 20`) is hit, costing 20 LLM calls + a sub-agent budget burn for zero progress.

## Why it wasn't caught earlier

- Pre-#1099, all the `List` calls rendered as `● List .` regardless of args, so the loop-spin looked indistinguishable from "the agent calling List on `.` a few times" — no visible smoking gun.
- The iteration cap exit produces a clean-looking `[ERROR: ...]` marker, not a panic, so it didn't show up in tests as a crash.
- Existing e2e tests script the sub-agent for 1-2 turns ending in a text response. Single-tool-call-then-text doesn't exercise the multi-turn-tool-using path that exposes the missing `mark_message_complete`.
- The contract `(role = 'assistant' AND completed_at IS NULL) → invisible to load_context` is documented in `db::tests::load_context_excludes_incomplete_assistant_messages`, but no test pinned the inverse: "every assistant message a *running* loop inserts must be visible on the next iteration."

## Fix

One-line behavior change: capture the row ID and mark complete.

```rust
let assistant_msg_id = db.insert_message(...).await?;
db.mark_message_complete(assistant_msg_id).await?;
```

## Test added (also in PR)

`sub_agent_marks_assistant_messages_complete_so_loop_progresses` —
scripts a sub-agent provider with `[tool_call, text]`, runs inference,
then queries the sub-agent's session and asserts:

1. `load_context` returns ≥1 assistant turn (regression for the exact mechanism).
2. `load_all_messages` (no filter) and `load_context` (filtered) return the same assistant count — no incomplete rows hiding.

Without the fix the test fails at assertion 1 with literally `found 0` assistant turns and the diagnostic shows `load_context` returning only the user message.

## Impact

- **Cost**: every sub-agent call that needed >1 turn was burning ~20× the LLM calls it should have. `explore`, `plan`, `verify`, and any user-defined sub-agent that does multi-step work was affected. Background `Task` agents likewise.
- **UX**: silent failure dressed up as an iteration cap. Users see the marker, assume the model is dumb, retry with a different prompt → same loop.
- **Data**: orphan assistant rows pile up in the DB with `completed_at IS NULL` for every prior sub-agent run. Cosmetic (they're filtered out everywhere) but real disk growth.

🐶 generated by code puppy
