### PR TITLE
chore: release v0.2.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,104 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-04-28
+
+Patch release. 8 bug-fix commits since v0.2.21, no new features, no public
+API changes. Highlights: a sub-agent loop-spin bug that was burning ~20×
+the LLM calls per multi-turn invocation, the matching TUI rendering bug
+that hid it, a Linux sandbox TOCTOU window on `.git/config`, and four
+smaller correctness fixes (Gemini schema, prompt-builder discovery,
+`List` tool header, ClonefileProvider `$TMPDIR` fallback).
+
+### Security
+
+- **SEC-002 — sandbox now pre-creates `.git/config` to close TOCTOU
+  window** (#1092). On Linux (bwrap backend), `apply_git_config_deny`
+  previously skipped the `--ro-bind` of `.git/config` if the file did
+  not exist at sandbox-build time. A child process inside the sandbox
+  could then race to create the file before the deny took effect, and
+  inject `core.fsmonitor = <cmd>` for later host-side execution. Fix
+  unconditionally pre-creates `.git/hooks/` and `.git/config` (empty
+  file, mtime-preserving on existing repos) before binding them
+  read-only, so the deny applies regardless of repo state. Brings the
+  bwrap backend to parity with Seatbelt's SBPL deny rules (which
+  already covered non-existent paths). Regression test
+  `git_config_deny_pre_creates_for_non_git_dir_to_close_toctou` pins
+  the contract.
+
+### Fixed
+
+- **Sub-agents no longer spin on the same tool call until the
+  iteration cap** (#1102, closes #1101). `sub_agent_dispatch` inserted
+  assistant tool-call rows into the session DB but never called
+  `mark_message_complete`. `load_context` filters
+  `(role = 'assistant' AND completed_at IS NULL)` rows, so every loop
+  iteration the sub-agent's effective context collapsed back to
+  `[system, user]`; `prune_mismatched_tool_calls` then dropped the
+  orphaned tool-result rows. The model re-issued the same tool call
+  every iteration until hitting `MAX_SUB_AGENT_ITERATIONS = 20`,
+  burning ~20× the intended LLM calls. Affected every multi-turn
+  sub-agent (`explore`, `plan`, `verify`, `task`, all user-defined
+  sub-agents, all background `Task` agents). One-line fix mirrors
+  the parent inference loop's pattern at
+  `inference.rs::mark_message_complete`. Regression test
+  `sub_agent_marks_assistant_messages_complete_so_loop_progresses`.
+- **TUI tool headers now show the actual file path, not always `.`**
+  (#1099). The renderer in `koda-cli/src/tool_header.rs` looked up
+  the wrong key in the tool-call args JSON, so `Read`, `List`,
+  `Grep`, `Glob`, and friends always displayed `● List .` regardless
+  of what path the model passed. Made debugging agent behavior
+  effectively impossible — the loop-spin bug fixed in #1102 was
+  invisible behind this for 8 days because every iteration's `List
+  /Users/lijun/repo` rendered identically as `● List .`. Fix maps
+  each tool's actual dispatch key to the header. Regression test
+  `path_bearing_tools_render_actual_dispatch_key`.
+- **Built-in sub-agents now appear in the system prompt** (#1098).
+  The prompt builder called the wrong discovery function, listing
+  user-installed agents but omitting `explore`, `plan`, `verify`,
+  `task`. Result: the model could see them in `/agents` output but
+  refused to call them with "No sub-agents are configured." Fix
+  routes both surfaces through `discover_all_agents`, which also
+  filters reserved names (`koda`, `default`) to prevent
+  self-delegation. Regression tests
+  `built_in_agents_appear_in_prompt_with_no_installed_agents` and
+  `task_is_general_purpose_subagent_and_main_agent_is_hidden`.
+- **Gemini provider sends tool parameters under
+  `parametersJsonSchema`, not `parameters`** (#1097). Gemini's
+  function-declaration schema rejects `additionalProperties` under
+  the `parameters` key but accepts the full JSON Schema vocabulary
+  under `parametersJsonSchema`. Pre-fix: every Gemini tool call
+  returned HTTP 400 `Unknown name "additionalProperties"`. Affected
+  all Gemini-family models. Regression test
+  `function_declaration_serializes_under_parameters_json_schema`.
+- **`List` tool output starts with a `Listing: <path>` header**
+  (#1096, closes #1094). Empty-directory listings previously
+  produced a bare `(empty directory)` string with no path context,
+  and capped listings dropped the header too. Now every `List`
+  result begins with the resolved directory path, matching
+  `Read`/`Grep` behavior. Four regression tests in `file_tools.rs`.
+- **`ClonefileProvider` falls back to `$TMPDIR` when
+  `project_root == $HOME`** (#1095, closes #1093). `clonefile(2)`
+  returns `EPERM` when the destination is a descendant of the
+  source. The default `clones_root` lives at
+  `$HOME/.koda/clones/<hash>/`, so running `koda` from `$HOME`
+  meant every `provision()` failed and sub-agents with write tools
+  could not be dispatched at all. Fix detects the recursion via a
+  new `choose_clones_root` helper and falls back to
+  `$TMPDIR/koda-clones/<hash>/`; if both candidates would land
+  inside `project_root`, returns `Err` so `pick_write_provider`
+  falls back to `GitWorktreeProvider`. Five boundary-class
+  regression tests.
+- **`bg_agent_iter_counter_advances_via_status_channel` test pinned
+  to `multi_thread` runtime** (#1091, closes #1090). The default
+  `current_thread` tokio flavor only progresses spawned tasks when
+  the test task explicitly yields; on macOS CI runners under load
+  this caused the test to time out at 5s polling deadline despite
+  the dispatch path being fully synchronous. Production runs on
+  `multi_thread`; tests now match. Diagnostic panic was added that
+  dumps the events vector + final snapshot on failure, so any
+  future regression in this area is actionable instantly.
+
 ## [0.2.21] - 2026-04-27
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.21)
+10. Sync version with workspace (currently 0.2.22)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.21"
+version = "0.2.22"
 edition.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
 license.workspace = true
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.21" }
+koda-core = { path = "../koda-core", version = "0.2.22" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -77,6 +77,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.21", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.22", features = ["test-support"] }
 serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.21"
+version = "0.2.22"
 edition.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license.workspace = true
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.21" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.22" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -168,7 +168,7 @@ fn load_agents_from_dir(dir: &Path, source: &'static str, agents: &mut HashMap<S
         // identity — they are NOT sub-agents and must not appear in
         // discovery output (the `/agents` listing, the prompt's
         // `## Available Sub-Agents` section, or `InvokeAgent` dispatch).
-        // Pre-#XXXX, the prompt builder filtered both names locally;
+        // Pre-#1098, the prompt builder filtered both names locally;
         // now that all callers route through `discover_all_agents`,
         // the filter belongs here.
         if agent_name == "default" || agent_name == "koda" {

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.21"
+version = "0.2.22"
 edition.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
 license.workspace = true

--- a/koda-sandbox/src/workspace.rs
+++ b/koda-sandbox/src/workspace.rs
@@ -402,7 +402,7 @@ impl ClonefileProvider {
     /// never fell back to `GitWorktreeProvider` and sub-agents with
     /// write tools could not be dispatched at all.
     ///
-    /// We now detect this up front via [`choose_clones_root`] and
+    /// We now detect this up front via `choose_clones_root` and
     /// fall back to `$TMPDIR/koda-clones/<hash>/`. macOS's default
     /// `$TMPDIR` (`/var/folders/...`) is never inside `$HOME`, so
     /// the fallback always works on stock installs. If both


### PR DESCRIPTION
# Release v0.2.22

Cuts v0.2.21 → **v0.2.22**.

Patch release. 8 bug-fix commits since v0.2.21, no new features, no
public API changes.

## Headlines

- 🔥 **#1102 — Sub-agent loop-spin fix.** `sub_agent_dispatch` forgot
  to call `mark_message_complete` on assistant rows. `load_context`
  filters incomplete assistant rows, so every loop iteration the
  sub-agent's effective context collapsed to `[system, user]`. The
  model re-issued the same tool call up to the `MAX_SUB_AGENT_ITERATIONS = 20`
  cap — burning ~20× the intended LLM calls per multi-turn invocation.
  Affected `explore`, `plan`, `verify`, `task`, all user-defined
  sub-agents, all background `Task` agents.
- 🐛 **#1099 — TUI lying about paths.** Tool headers always rendered
  `● List .` / `● Read .` regardless of args. Hid #1102 for 8 days.
- 🔒 **#1092 — SEC-002 Linux sandbox TOCTOU.** Bwrap's
  `apply_git_config_deny` skipped the `--ro-bind` of `.git/config`
  when the file didn't exist, opening a window for a child to create
  it and inject `core.fsmonitor = <cmd>`. Now pre-creates
  unconditionally. Brings bwrap parity with Seatbelt.
- 🐛 **#1098** — built-in sub-agents (`explore`, `plan`, `verify`,
  `task`) now appear in the system prompt; pre-fix the model could
  see them in `/agents` but refused to call them.
- 🐛 **#1097** — Gemini provider sends tool params under
  `parametersJsonSchema` (the only key Gemini accepts with
  `additionalProperties`). Pre-fix every Gemini tool call 400'd.
- 🐛 #1096 — `List` tool output starts with `Listing: <path>` header
  (no more bare `(empty directory)`).
- 🐛 #1095 — `ClonefileProvider` falls back to `$TMPDIR` when
  `project_root == $HOME` (clonefile EPERMs on descendants).
- 🧪 #1091 — `bg_agent_iter_counter_advances_via_status_channel`
  pinned to `multi_thread` runtime; was deadlocking on macOS CI.

See `CHANGELOG.md` for the full categorized list with full PR
descriptions and regression test names.

## Quality gates

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✅ clean |
| `cargo clippy --workspace --features koda-core/test-support --all-targets -- -D warnings` | ✅ clean (~35s) |
| `cargo test --workspace --features koda-core/test-support` | ✅ **2199 passed, 0 failed, 13 ignored** (~3.5min) |
| `RUSTFLAGS=-Dwarnings RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` | ✅ clean (after fixing intra-doc link, see below) |
| `cargo audit --no-fetch` | ✅ 0 vulns, 0 warnings (495 deps) |

## Sub-agent review summary

Four agents ran in parallel during release prep. Findings:

### Caught and fixed in this PR

- 🔴 **P1 (rust-programmer)** — `cargo doc` failed with broken
  intra-doc link `[choose_clones_root]` at
  `koda-sandbox/src/workspace.rs:405`. The function is private and
  the doc is on `pub fn new`, so neither `[Self::choose_clones_root]`
  (private-intra-doc-links) nor the bare name (no-resolve) worked.
  Fixed by escaping to literal text — it's prose, not an actionable
  link.
- 🔴 **P1 (code-reviewer + rust-programmer)** — CHANGELOG `[Unreleased]`
  was empty despite 8 shipping commits (the exact scenario the
  koda-release skill's pre-flight check warns about — added after
  v0.2.21). Reconciled all 8 commits into a `[0.2.22]` section with
  #1092 prominently under `### Security`.
- 🔴 **P1 (rust-programmer)** — workspace versions still 0.2.21.
  Bumped 5 spots across 3 `Cargo.toml`s + `CLAUDE.md`.
- 🟢 **P3 (code-reviewer)** — backfilled `Pre-#XXXX` placeholder →
  `Pre-#1098` in `koda-core/src/tools/agent.rs:171` (1-line cosmetic
  fix, cheap to ship in this PR).

### Confirmed clean

- **Public API surface**: zero pub additions or breakages
  (`git diff v0.2.21..HEAD -- '**/lib.rs' '**/Cargo.toml'` is empty
  for any `pub` line). Patch bump is correct per semver.
- **Tokio test-flavor audit**: 6 test files mix `tokio::spawn` with
  `#[tokio::test]`; 5 are timer-driven cancel-helpers safe under
  `current_thread`, and the one that wasn't (`bg_agent` test) was
  already pinned to `multi_thread` in #1091.
- **Sandbox**: SEC-002 fix verified present in
  `koda-sandbox/src/bwrap.rs:210-235` with proper regression test
  `git_config_deny_pre_creates_for_non_git_dir_to_close_toctou`.
- **Cargo.toml metadata**: all 3 publishable crates are publish-ready
  (description, license, repository, keywords 5/5, README on disk).
- **`cargo audit`**: 0 vulnerabilities, 0 warnings across 495 deps.
- **No new unsafe blocks**, no hardcoded secrets, no traversal
  vectors introduced since v0.2.21.

### Manual smoke list (qa-expert) — to verify before tagging

The QA agent provided a specific, surface-mapped smoke list. The high-priority items are:

- **A. Sub-agent visibility & dispatch** (#1098 + #1102): `/agents`
  lists built-ins, then `use explore to summarize <file>` runs
  multi-turn and returns a final answer (not stuck in a loop).
- **B. TUI tool-header path rendering** (#1099): headers show actual
  `file_path` not `.` for `Read`/`List`/`Grep`/`Glob`.
- **C. List directory header** (#1096): `list <empty_dir>` shows
  `<path>:` header before `(empty directory)`.
- **D. Gemini provider** (#1097): tool calls don't 400 on
  `additionalProperties`.
- **E. macOS sandbox `cwd == $HOME` fallback** (#1095): `cd ~ && koda`
  can run a sandboxed bash command without recursive-clones-root error.
- **F. Linux sandbox TOCTOU** (#1092): in a non-git dir,
  `git init && git config core.fsmonitor 'echo PWNED > /tmp/koda_pwn'`
  inside the sandbox does not write `core.fsmonitor` to host
  `.git/config`.
- **G/H. ACP/headless/wizard regression sanity**.

### Deferred items (tracked)

The koda-release skill mandates bundling P3 findings into ONE tracking
issue per release to prevent the audit-dust anti-pattern (where each
release files 4-7 standalone P3 issues that all close within 24 hours
as out-of-scope). Bundle issue will be created post-merge.

P3-bundle items:
- (rust-programmer) Add `rust-version` (MSRV) to `[workspace.package]`
  so downstream users get a clear MSRV signal instead of mysterious
  build failures.
- (rust-programmer) Expand `koda-core` `categories` from 1 → up to 5
  (`asynchronous`, `api-bindings` are reasonable candidates).
- (rust-programmer) Run `cargo update` to refresh `Cargo.lock` patch
  pins (no major/minor bumps for a patch release).
- (rust-programmer) Consider `ratatui-textarea` 0.9 → newer post-release
  (TUI regressions are user-visible, don't bump pre-release).
- (security-auditor) Internal TOCTOU in `apply_git_config_deny`
  between `Path::exists()` and `File::create` — explicitly
  non-exploitable per audit (the only "attacker" who'd race-create
  `.git/config` is one trying to inject hooks; truncation actually
  helps). Worth a defense-in-depth refactor when convenient.
- (security-auditor) `apply_git_config_deny` doesn't handle git
  worktrees where `.git` is a file (`gitdir: ...`) — pre-existing
  in v0.2.21, not a SEC-002 regression. Worth a follow-up when
  `GitWorktreeProvider` Linux usage gets exercised in CI.

P2 items (one) — addressed inline:
- (qa-expert) The bwrap SEC-002 regression test
  `git_config_deny_pre_creates_for_non_git_dir_to_close_toctou` is
  `#[cfg(target_os = "linux")]` so didn't execute on the macOS audit
  host. **Will verify the Linux CI job in this PR's `Test (ubuntu-latest)`
  run shows that exact test name passing before pushing the v0.2.22
  tag.**

## Verdict

Ship it. 🐶

Once CI is green and the Linux test-name verification clears, merge
and tag.
