### PR TITLE
refactor(tool_header): unify detail_spans/detail_text via ToolCallSummary

### DIFF
--- a/koda-cli/src/tool_header.rs
+++ b/koda-cli/src/tool_header.rs
@@ -30,6 +30,7 @@
 
 use crate::highlight;
 use crate::theme::{self, BOLD, DIM};
+use koda_core::tools::summary::{ToolCallKind, ToolCallSummary};
 use ratatui::text::{Line, Span};
 use serde_json::Value;
 
@@ -83,198 +84,142 @@ pub fn build_header_line_from_str(indent: &str, name: &str, args_json: &str) -> 
 ///
 /// Returns an empty vec if the args don't carry a useful detail
 /// (e.g. unknown tool with no string args).
+///
+/// Implementation: parses args once into a [`ToolCallSummary`] (which
+/// owns *all* arg-key conventions, see `koda_core::tools::summary`)
+/// and renders the styled spans by pattern-matching on the resulting
+/// [`ToolCallKind`]. Pre-#1100 each tool had its own inline
+/// `first_string(args, &[...])` lookup duplicated between here and
+/// [`detail_text`]; the duplication caused two drift bugs in two days
+/// (#1094 then #1099) before consolidation.
 pub fn detail_spans(name: &str, args: &Value) -> Vec<Span<'static>> {
-    match name {
-        "Bash" => bash_detail(args),
-        "Read" | "Write" | "Edit" | "Delete" => path_detail(args),
-        "Grep" => grep_detail(args),
-        "Glob" => glob_detail(args),
-        "List" => list_detail(args),
-        "WebFetch" => webfetch_detail(args),
-        _ => generic_detail(args),
-    }
+    summary_spans(&ToolCallSummary::from_call(name, args))
 }
 
 /// Plain-text rendering of a tool call detail (no styling).
 ///
 /// Mirrors [`detail_spans`] but returns a `String` for non-TUI
-/// consumers (clipboard / file export via `transcript.rs`). Per-tool
-/// dispatch is kept identical so the same `(name, args)` pair always
-/// produces the same human-readable summary regardless of output medium.
+/// consumers (clipboard / file export via `transcript.rs`). Both
+/// formatters consume the same [`ToolCallSummary`], so the rendered
+/// string is guaranteed to describe the same `(tool, args)` pair as
+/// the live header.
 ///
 /// `bash_chars` controls Bash command truncation (typically 80 in
 /// summary mode, 500 in verbose). All other tools use
 /// [`MAX_DETAIL_CHARS`] for consistency with TUI rendering.
 pub fn detail_text(name: &str, args: &Value, bash_chars: usize) -> String {
-    match name {
-        "Bash" => bash_text(args, bash_chars),
-        "Read" | "Write" | "Edit" | "Delete" => path_text(args),
-        "Grep" => grep_text(args),
-        "Glob" => glob_text(args),
-        "List" => list_text(args),
-        "WebFetch" => webfetch_text(args),
-        _ => generic_text(args),
-    }
+    summary_text(&ToolCallSummary::from_call(name, args), bash_chars)
 }
 
-// ── Per-tool detail builders ──────────────────────────────────────────
+// ── Renderers ─────────────────────────────────────────────────────────
+//
+// Both renderers pattern-match on the SAME [`ToolCallKind`] so they
+// can't drift on which arg key means "the path" or "the query." If a
+// tool's display shape changes, both surfaces follow from one edit
+// here. If a new tool needs a specialized shape, add a variant in
+// `koda_core::tools::summary` and pattern-match it in BOTH renderers
+// below — the compiler will fail the missing arm and tell you about it.
 
-fn bash_detail(args: &Value) -> Vec<Span<'static>> {
-    let cmd = first_string(args, &["command", "cmd"]).unwrap_or_default();
-    if cmd.is_empty() {
-        return Vec::new();
-    }
-    let truncated = truncate_for_header(&cmd);
-    highlight::highlight_inline(&truncated, "bash")
-}
-
-fn path_detail(args: &Value) -> Vec<Span<'static>> {
-    let path = first_string(args, &["file_path", "path"]).unwrap_or_default();
-    if path.is_empty() {
-        return Vec::new();
-    }
-    vec![Span::styled(truncate_for_header(&path), theme::PATH)]
-}
-
-fn grep_detail(args: &Value) -> Vec<Span<'static>> {
-    let pattern = first_string(args, &["search_string", "pattern"]).unwrap_or_default();
-    if pattern.is_empty() {
-        return Vec::new();
-    }
-    // Key order matches `tools::grep::run`'s arg lookup so the rendered
-    // detail always shows the path the tool actually searched. Pre-fix
-    // we checked obsolete `directory`/`path` keys that never matched
-    // the schema (the param has been `file_path` since day one), so
-    // every Grep header silently rendered "in ." regardless of the
-    // real target. See koda#1099 for the cross-tool repro.
-    let dir =
-        first_string(args, &["file_path", "path", "directory"]).unwrap_or_else(|| ".".to_string());
-    vec![
-        Span::styled(format!("\"{pattern}\""), theme::MATCH_HIT),
-        Span::styled(" in ".to_string(), DIM),
-        Span::styled(truncate_for_header(&dir), theme::PATH),
-    ]
-}
-
-fn glob_detail(args: &Value) -> Vec<Span<'static>> {
-    let pattern = first_string(args, &["pattern"]).unwrap_or_default();
-    if pattern.is_empty() {
-        return Vec::new();
-    }
-    let mut spans = vec![Span::styled(truncate_for_header(&pattern), theme::PATH)];
-    // Glob takes an optional `file_path` base directory. When present,
-    // surface it so the user can tell `Glob '*.toml'` from project
-    // root vs from `koda-cli/`. Hidden when omitted (project root
-    // default) to keep headers tight for the common case.
-    if let Some(base) = first_string(args, &["file_path", "path", "directory"]) {
-        spans.push(Span::styled(" in ".to_string(), DIM));
-        spans.push(Span::styled(truncate_for_header(&base), theme::PATH));
-    }
-    spans
-}
-
-fn list_detail(args: &Value) -> Vec<Span<'static>> {
-    // Same key ordering as `tools::file_tools::list_directory` — if
-    // the dispatch reads `file_path` first, the renderer must too,
-    // or the header lies about which directory was actually listed.
-    let dir =
-        first_string(args, &["file_path", "path", "directory"]).unwrap_or_else(|| ".".to_string());
-    vec![Span::styled(truncate_for_header(&dir), theme::PATH)]
-}
-
-fn webfetch_detail(args: &Value) -> Vec<Span<'static>> {
-    let url = first_string(args, &["url"]).unwrap_or_default();
-    if url.is_empty() {
-        return Vec::new();
-    }
-    vec![Span::styled(truncate_for_header(&url), theme::PATH)]
-}
-
-fn generic_detail(args: &Value) -> Vec<Span<'static>> {
-    let obj = match args.as_object() {
-        Some(o) => o,
-        None => return Vec::new(),
-    };
-    for (_, v) in obj.iter().take(1) {
-        if let Some(s) = v.as_str() {
-            return vec![Span::styled(truncate_for_header(s), DIM)];
-        }
-    }
-    Vec::new()
-}
-
-// ── Per-tool plain-text builders (no styling, for transcripts) ──────────────
-
-fn bash_text(args: &Value, bash_chars: usize) -> String {
-    let cmd = first_string(args, &["command", "cmd"]).unwrap_or_default();
-    if cmd.chars().count() > bash_chars {
-        truncate_chars(&cmd, bash_chars)
-    } else {
-        cmd
-    }
-}
-
-fn path_text(args: &Value) -> String {
-    first_string(args, &["file_path", "path"]).unwrap_or_default()
-}
-
-fn grep_text(args: &Value) -> String {
-    let pattern = first_string(args, &["search_string", "pattern"]).unwrap_or_default();
-    if pattern.is_empty() {
-        return String::new();
-    }
-    // Mirror `grep_detail`'s key list so transcript exports show the
-    // same directory the live header surfaced.
-    let dir =
-        first_string(args, &["file_path", "path", "directory"]).unwrap_or_else(|| ".".to_string());
-    // Quotes match the TUI rendering (see `grep_detail`) so transcript and
-    // live view show the same string for the same args.
-    format!("\"{pattern}\" in {dir}")
-}
-
-fn glob_text(args: &Value) -> String {
-    let pattern = first_string(args, &["pattern"]).unwrap_or_default();
-    if pattern.is_empty() {
-        return String::new();
-    }
-    match first_string(args, &["file_path", "path", "directory"]) {
-        Some(base) => format!("{pattern} in {base}"),
-        None => pattern,
-    }
-}
-
-fn list_text(args: &Value) -> String {
-    first_string(args, &["file_path", "path", "directory"]).unwrap_or_else(|| ".".to_string())
-}
-
-fn webfetch_text(args: &Value) -> String {
-    first_string(args, &["url"]).unwrap_or_default()
-}
-
-fn generic_text(args: &Value) -> String {
-    let obj = match args.as_object() {
-        Some(o) => o,
-        None => return String::new(),
-    };
-    for (_, v) in obj.iter().take(1) {
-        if let Some(s) = v.as_str() {
-            return if s.chars().count() > MAX_DETAIL_CHARS {
-                truncate_chars(s, MAX_DETAIL_CHARS)
+/// Render a [`ToolCallSummary`] as styled TUI spans.
+fn summary_spans(s: &ToolCallSummary) -> Vec<Span<'static>> {
+    match &s.kind {
+        ToolCallKind::Bash { command } => {
+            if command.is_empty() {
+                Vec::new()
             } else {
-                s.to_string()
-            };
+                highlight::highlight_inline(&truncate_for_header(command), "bash")
+            }
         }
+        ToolCallKind::Path { path } => {
+            if path.is_empty() {
+                Vec::new()
+            } else {
+                vec![Span::styled(truncate_for_header(path), theme::PATH)]
+            }
+        }
+        ToolCallKind::Grep { pattern, dir } => {
+            if pattern.is_empty() {
+                Vec::new()
+            } else {
+                vec![
+                    Span::styled(format!("\"{pattern}\""), theme::MATCH_HIT),
+                    Span::styled(" in ".to_string(), DIM),
+                    Span::styled(truncate_for_header(dir), theme::PATH),
+                ]
+            }
+        }
+        ToolCallKind::Glob { pattern, base } => {
+            if pattern.is_empty() {
+                Vec::new()
+            } else {
+                let mut spans = vec![Span::styled(truncate_for_header(pattern), theme::PATH)];
+                if let Some(base) = base {
+                    spans.push(Span::styled(" in ".to_string(), DIM));
+                    spans.push(Span::styled(truncate_for_header(base), theme::PATH));
+                }
+                spans
+            }
+        }
+        ToolCallKind::List { dir } => {
+            // `dir` is never empty — `ToolCallSummary::from_call` defaults
+            // to "." when args omit a path. So no emptiness branch needed.
+            vec![Span::styled(truncate_for_header(dir), theme::PATH)]
+        }
+        ToolCallKind::WebFetch { url } => {
+            if url.is_empty() {
+                Vec::new()
+            } else {
+                vec![Span::styled(truncate_for_header(url), theme::PATH)]
+            }
+        }
+        ToolCallKind::Generic { value } => match value {
+            Some(v) => vec![Span::styled(truncate_for_header(v), DIM)],
+            None => Vec::new(),
+        },
     }
-    String::new()
+}
+
+/// Render a [`ToolCallSummary`] as plain text (transcripts, clipboards).
+fn summary_text(s: &ToolCallSummary, bash_chars: usize) -> String {
+    match &s.kind {
+        ToolCallKind::Bash { command } => {
+            if command.chars().count() > bash_chars {
+                truncate_chars(command, bash_chars)
+            } else {
+                command.clone()
+            }
+        }
+        ToolCallKind::Path { path } => path.clone(),
+        ToolCallKind::Grep { pattern, dir } => {
+            if pattern.is_empty() {
+                String::new()
+            } else {
+                // Quotes match the TUI rendering above so transcript and
+                // live view show the same string for the same args.
+                format!("\"{pattern}\" in {dir}")
+            }
+        }
+        ToolCallKind::Glob { pattern, base } => {
+            if pattern.is_empty() {
+                String::new()
+            } else {
+                match base {
+                    Some(b) => format!("{pattern} in {b}"),
+                    None => pattern.clone(),
+                }
+            }
+        }
+        ToolCallKind::List { dir } => dir.clone(),
+        ToolCallKind::WebFetch { url } => url.clone(),
+        ToolCallKind::Generic { value } => match value {
+            Some(v) if v.chars().count() > MAX_DETAIL_CHARS => truncate_chars(v, MAX_DETAIL_CHARS),
+            Some(v) => v.clone(),
+            None => String::new(),
+        },
+    }
 }
 
 // ── Internals ─────────────────────────────────────────────────────────
-
-/// Return the first present string value among the candidate keys.
-fn first_string(args: &Value, keys: &[&str]) -> Option<String> {
-    keys.iter()
-        .find_map(|k| args.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()))
-}
 
 /// Truncate a header detail to `MAX_DETAIL_BYTES` with an ellipsis.
 ///
@@ -657,6 +602,50 @@ mod tests {
         assert_eq!(out, "");
     }
 
+    /// Meta-test pinning the #1100 consolidation: every variant of
+    /// `ToolCallKind` must produce non-empty output from BOTH
+    /// renderers given a representative non-empty input. If someone
+    /// adds a new variant and forgets to handle it in `summary_spans`
+    /// or `summary_text`, the compiler's exhaustive-match check
+    /// fires *first* (good); but if they handle it with `=> Vec::new()`
+    /// or `=> String::new()` to silence the compiler, this test fires
+    /// next and tells them they shipped an invisible tool. Keeps both
+    /// renderers honest.
+    #[test]
+    fn every_tool_call_kind_renders_in_both_surfaces() {
+        let cases: Vec<(&str, serde_json::Value, &str)> = vec![
+            ("Bash", json!({"command": "ls"}), "Bash"),
+            ("Read", json!({"file_path": "x"}), "Path"),
+            (
+                "Grep",
+                json!({"search_string": "x", "file_path": "y"}),
+                "Grep",
+            ),
+            ("Glob", json!({"pattern": "*.rs"}), "Glob"),
+            ("List", json!({"file_path": "x"}), "List"),
+            (
+                "WebFetch",
+                json!({"url": "https://example.com"}),
+                "WebFetch",
+            ),
+            ("UnknownTool", json!({"k": "v"}), "Generic"),
+        ];
+        for (name, args, kind_label) in cases {
+            let spans = detail_spans(name, &args);
+            let text = detail_text(name, &args, 500);
+            assert!(
+                !spans.is_empty(),
+                "summary_spans returned empty for {kind_label} variant ({name}); \
+                 either the variant lost its renderer arm or the test input is wrong"
+            );
+            assert!(
+                !text.is_empty(),
+                "summary_text returned empty for {kind_label} variant ({name}); \
+                 either the variant lost its renderer arm or the test input is wrong"
+            );
+        }
+    }
+
     // ── cross-layer: dispatch body ↔ TUI header agreement ────────────────
     //
     // koda has multiple independent formatters for tool calls:
@@ -684,8 +673,11 @@ mod tests {
     // `koda_sandbox::fs::FileSystem` impl that koda-cli doesn't depend
     // on); their renderer-vs-dispatch agreement is pinned by
     // `path_bearing_tools_render_actual_dispatch_key` above. The full
-    // structural fix (a single `ToolCallSummary` formatter shared by
-    // all four layers) is tracked separately.
+    // structural fix landed in #1100: both renderers now consume a
+    // single `koda_core::tools::summary::ToolCallSummary` parsed once
+    // from the args, so they cannot drift on which key means "the
+    // path." `every_tool_call_kind_renders_in_both_surfaces` above
+    // pins the consolidation.
 
     #[tokio::test]
     async fn list_call_path_appears_in_both_body_and_header() {

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -411,6 +411,22 @@ mod tests {
     use super::*;
     use koda_core::persistence::Message;
 
+    /// Serializes tests that depend on `HYPERLINK_KILL_SWITCH`.
+    ///
+    /// `kill_switch_disables_hyperlinks` mutates the env var while the
+    /// other tests in this module just read it via `hyperlinks_enabled()`.
+    /// Since env vars are process-global and `cargo test` runs tests in
+    /// parallel by default, the writer can flip the var to "off" mid-read
+    /// of any other test that calls `render()` and asserts on hyperlinks.
+    /// On macOS this raced ~50% of the time and blocked PR #1107.
+    ///
+    /// Lock acquisition: every test that depends on the env var's value
+    /// (one writer, three readers) takes this lock for its full duration.
+    /// Other transcript tests don't assert on hyperlinks at all (they
+    /// look at headers, paths, code blocks, etc.) so they don't need the
+    /// lock and can keep running in parallel.
+    static HYPERLINK_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     fn make_msg(role: Role, content: &str) -> Message {
         Message {
             id: 0,
@@ -638,6 +654,7 @@ mod tests {
 
     #[test]
     fn read_path_emits_markdown_link_with_file_uri() {
+        let _g = HYPERLINK_ENV_LOCK.lock().unwrap();
         let msg = assistant_with_call("Read", r#"{"file_path":"src/main.rs"}"#);
         let meta = SessionMeta {
             project_root: "/home/user/proj".into(),
@@ -652,6 +669,7 @@ mod tests {
 
     #[test]
     fn absolute_read_path_skips_root_join() {
+        let _g = HYPERLINK_ENV_LOCK.lock().unwrap();
         let msg = assistant_with_call("Read", r#"{"file_path":"/etc/hosts"}"#);
         let meta = SessionMeta {
             project_root: "/home/user/proj".into(),
@@ -666,6 +684,7 @@ mod tests {
 
     #[test]
     fn webfetch_url_becomes_self_link() {
+        let _g = HYPERLINK_ENV_LOCK.lock().unwrap();
         let msg = assistant_with_call("WebFetch", r#"{"url":"https://example.com/x"}"#);
         let out = render(&[msg], &default_meta(), false);
         assert!(
@@ -696,12 +715,15 @@ mod tests {
 
     #[test]
     fn kill_switch_disables_hyperlinks() {
+        let _g = HYPERLINK_ENV_LOCK.lock().unwrap();
         // Save & restore so we don't leak env across tests in this thread.
         let prev = std::env::var(HYPERLINK_KILL_SWITCH).ok();
-        // SAFETY: tests in this binary run in parallel by default; this env
-        // var is only read by transcript code, and the only readers in this
-        // file are `kill_switch_*` tests. Running them with `--test-threads=1`
-        // is the official escape hatch if they ever flake.
+        // SAFETY: tests in this binary run in parallel by default; the
+        // module-level `HYPERLINK_ENV_LOCK` mutex (acquired above)
+        // serializes this writer with every reader test that asserts on
+        // hyperlinks being on, so no parallel reader sees the "off"
+        // value mid-test. See the lock's doc comment for the race this
+        // existed to prevent (PR #1107).
         unsafe { std::env::set_var(HYPERLINK_KILL_SWITCH, "off") };
         let msg = assistant_with_call("Read", r#"{"file_path":"/x.rs"}"#);
         let out = render(&[msg], &default_meta(), false);

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -146,6 +146,10 @@ pub mod recall;
 pub mod shell;
 /// Skill discovery and activation tools (`ListSkills`, `ActivateSkill`).
 pub mod skill_tools;
+/// Renderer-agnostic tool-call display payload (the single source of
+/// truth for "what does a tool call show?"). See [`summary`] for the
+/// drift problem this exists to solve.
+pub mod summary;
 /// Session-scoped task list tool (`TodoWrite`).
 pub mod todo;
 /// Pre-flight validation for tool calls (runs before approval).

--- a/koda-core/src/tools/summary.rs
+++ b/koda-core/src/tools/summary.rs
@@ -1,0 +1,445 @@
+//! Single source of truth for "what does a tool call display?".
+//!
+//! Pre-#1100 (this module), every rendering surface — TUI live header,
+//! transcript export, history replay — re-parsed the raw tool-call
+//! JSON args independently. Each surface had its own
+//! `first_string(args, &["file_path", "path", "directory"])` lookup
+//! list, and they drifted twice in two days:
+//!
+//! - **#1094 → #1096**: the `List` LLM-facing body lost its
+//!   `Listing: <path>` header, leaving the model unable to tell
+//!   parallel `List` calls apart.
+//! - **#1099**: the TUI header read the wrong arg keys for
+//!   `List`/`Grep`/`Glob`, rendering every call as `● List .`
+//!   regardless of the actual path. This *hid* the loop-spin bug
+//!   #1102 for 8 days because every iteration's `List
+//!   /Users/lijun/repo` looked identical to `List .`.
+//!
+//! Both bugs had the same shape — "a layer that displays a tool call
+//! looked at the wrong key in the args JSON" — and required separate
+//! fixes in separate files. The root cause was duplication: each
+//! rendering layer owned its own JSON parser.
+//!
+//! ## What this module owns
+//!
+//! `ToolCallSummary` is a pure data struct that captures everything
+//! a renderer needs to know about a tool call:
+//!
+//! - The tool's name (e.g. `"List"`, `"Grep"`).
+//! - The structured payload, in `ToolCallKind` — one variant per
+//!   tool family that has its own display shape.
+//!
+//! `ToolCallSummary::from_call` is the **only** place that knows
+//! which arg keys mean "the path" or "the search pattern" for each
+//! tool. If a tool's schema renames `file_path` → `target` tomorrow,
+//! one constructor changes and every renderer follows.
+//!
+//! ## What this module does NOT own
+//!
+//! No rendering knowledge — no `ratatui::Span`, no ANSI colors, no
+//! truncation. Renderers (currently `koda-cli/src/tool_header.rs`)
+//! pattern-match on the `ToolCallKind` enum and produce their own
+//! medium-specific output. This keeps `koda-core` headless and means
+//! a future ACP/JSON renderer can plug in without touching this
+//! module at all.
+
+use serde_json::Value;
+
+/// A renderer-agnostic description of a tool call's display payload.
+///
+/// Built once by [`ToolCallSummary::from_call`] from the raw JSON
+/// args; consumed by every rendering surface (TUI header, transcript,
+/// history replay) via pattern matching on [`Self::kind`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallSummary {
+    /// Tool name as the dispatcher sees it (e.g. `"List"`, `"Grep"`).
+    pub name: String,
+    /// Structured per-tool payload.
+    pub kind: ToolCallKind,
+}
+
+/// Per-tool display payload — one variant per shape, not per tool.
+///
+/// `Read`/`Write`/`Edit`/`Delete` all share `Path` because they all
+/// display "one file path." `Grep` gets its own variant because it
+/// has both a pattern and a directory. Variants are added only when
+/// a tool's display shape genuinely differs; otherwise we reuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolCallKind {
+    /// `Bash` — a single command string.
+    Bash {
+        /// The shell command to execute. Empty string means the args
+        /// didn't carry a recognized command/cmd key.
+        command: String,
+    },
+    /// `Read` / `Write` / `Edit` / `Delete` — a single file path.
+    /// Empty string means the args didn't carry a recognized key.
+    Path {
+        /// The file path the operation targets.
+        path: String,
+    },
+    /// `Grep` — a search pattern in a directory.
+    /// `dir` defaults to `"."` when the args omit it.
+    Grep {
+        /// The search pattern (regex or literal, tool-defined).
+        pattern: String,
+        /// The directory to search in; `"."` when omitted.
+        dir: String,
+    },
+    /// `Glob` — a glob pattern, optionally rooted at `base`.
+    /// `base` is `None` when the call uses the project root default.
+    Glob {
+        /// The glob pattern (e.g. `"**/*.rs"`).
+        pattern: String,
+        /// Optional base directory to root the glob at.
+        base: Option<String>,
+    },
+    /// `List` — a directory path. Defaults to `"."` when omitted.
+    List {
+        /// The directory to list; `"."` when omitted from args.
+        dir: String,
+    },
+    /// `WebFetch` — a URL.
+    WebFetch {
+        /// The URL to fetch.
+        url: String,
+    },
+    /// Fallback for tools without a specialized shape: the first
+    /// string-valued argument (object iteration order), or `None`
+    /// if the args have no string values.
+    Generic {
+        /// First string-valued argument in object-iteration order,
+        /// or `None` if no such value exists.
+        value: Option<String>,
+    },
+}
+
+impl ToolCallSummary {
+    /// Parse a tool call into its display payload.
+    ///
+    /// **This is the only function that knows arg-key conventions.**
+    /// Adding a new path-bearing tool means adding one match arm
+    /// here; renderers pick it up automatically.
+    ///
+    /// Key-list conventions (must match the dispatcher's lookup
+    /// order in `koda-core/src/tools/*.rs`):
+    ///
+    /// | Tool                        | Path keys                              | Pattern keys                  |
+    /// |-----------------------------|----------------------------------------|-------------------------------|
+    /// | `Read`/`Write`/`Edit`/`Delete` | `file_path`, `path`                 | —                             |
+    /// | `Grep`                      | `file_path`, `path`, `directory`       | `search_string`, `pattern`    |
+    /// | `Glob`                      | `file_path`, `path`, `directory`       | `pattern`                     |
+    /// | `List`                      | `file_path`, `path`, `directory`       | —                             |
+    /// | `Bash`                      | —                                      | `command`, `cmd`              |
+    /// | `WebFetch`                  | —                                      | `url`                         |
+    pub fn from_call(name: &str, args: &Value) -> Self {
+        let kind = match name {
+            "Bash" => ToolCallKind::Bash {
+                command: first_string(args, &["command", "cmd"]).unwrap_or_default(),
+            },
+            "Read" | "Write" | "Edit" | "Delete" => ToolCallKind::Path {
+                path: first_string(args, &["file_path", "path"]).unwrap_or_default(),
+            },
+            "Grep" => ToolCallKind::Grep {
+                pattern: first_string(args, &["search_string", "pattern"]).unwrap_or_default(),
+                dir: first_string(args, &["file_path", "path", "directory"])
+                    .unwrap_or_else(|| ".".to_string()),
+            },
+            "Glob" => ToolCallKind::Glob {
+                pattern: first_string(args, &["pattern"]).unwrap_or_default(),
+                base: first_string(args, &["file_path", "path", "directory"]),
+            },
+            "List" => ToolCallKind::List {
+                dir: first_string(args, &["file_path", "path", "directory"])
+                    .unwrap_or_else(|| ".".to_string()),
+            },
+            "WebFetch" => ToolCallKind::WebFetch {
+                url: first_string(args, &["url"]).unwrap_or_default(),
+            },
+            _ => ToolCallKind::Generic {
+                value: first_string_in_object(args),
+            },
+        };
+        Self {
+            name: name.to_string(),
+            kind,
+        }
+    }
+}
+
+/// Return the first present string value among the candidate keys.
+fn first_string(args: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| args.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()))
+}
+
+/// Return the first string value in object-iteration order, or `None`
+/// if the args aren't an object or have no string values.
+///
+/// Used as the `Generic` fallback for tools we don't have a
+/// specialized shape for. Object-iteration order is `serde_json`'s
+/// insertion-preserving order, which means the first key the tool's
+/// schema declares wins — usually the most informative one.
+fn first_string_in_object(args: &Value) -> Option<String> {
+    args.as_object()?
+        .iter()
+        .find_map(|(_, v)| v.as_str().map(|s| s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── Bash ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn bash_reads_command_key() {
+        let s = ToolCallSummary::from_call("Bash", &json!({ "command": "ls -la" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Bash {
+                command: "ls -la".into()
+            }
+        );
+    }
+
+    #[test]
+    fn bash_falls_back_to_cmd_alias() {
+        let s = ToolCallSummary::from_call("Bash", &json!({ "cmd": "echo hi" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Bash {
+                command: "echo hi".into()
+            }
+        );
+    }
+
+    #[test]
+    fn bash_with_no_command_yields_empty() {
+        let s = ToolCallSummary::from_call("Bash", &json!({}));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Bash {
+                command: String::new()
+            }
+        );
+    }
+
+    // ── Path family (Read/Write/Edit/Delete) ──────────────────────────
+
+    #[test]
+    fn read_write_edit_delete_share_path_shape() {
+        for name in ["Read", "Write", "Edit", "Delete"] {
+            let s = ToolCallSummary::from_call(name, &json!({ "file_path": "src/foo.rs" }));
+            assert_eq!(
+                s.kind,
+                ToolCallKind::Path {
+                    path: "src/foo.rs".into()
+                },
+                "{name} should produce ToolCallKind::Path"
+            );
+        }
+    }
+
+    #[test]
+    fn path_falls_back_to_path_alias() {
+        let s = ToolCallSummary::from_call("Read", &json!({ "path": "legacy.rs" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Path {
+                path: "legacy.rs".into()
+            }
+        );
+    }
+
+    // ── Grep ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn grep_reads_search_string_and_file_path() {
+        let s = ToolCallSummary::from_call(
+            "Grep",
+            &json!({ "search_string": "TODO", "file_path": "src/" }),
+        );
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Grep {
+                pattern: "TODO".into(),
+                dir: "src/".into()
+            }
+        );
+    }
+
+    #[test]
+    fn grep_pattern_alias_works_for_legacy_callers() {
+        let s = ToolCallSummary::from_call(
+            "Grep",
+            &json!({ "pattern": "fn main", "directory": "src/" }),
+        );
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Grep {
+                pattern: "fn main".into(),
+                dir: "src/".into()
+            }
+        );
+    }
+
+    #[test]
+    fn grep_default_directory_is_dot() {
+        let s = ToolCallSummary::from_call("Grep", &json!({ "search_string": "x" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Grep {
+                pattern: "x".into(),
+                dir: ".".into()
+            }
+        );
+    }
+
+    // ── Glob ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn glob_with_no_base_leaves_base_none() {
+        let s = ToolCallSummary::from_call("Glob", &json!({ "pattern": "*.rs" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Glob {
+                pattern: "*.rs".into(),
+                base: None
+            }
+        );
+    }
+
+    #[test]
+    fn glob_surfaces_file_path_as_base_when_present() {
+        let s = ToolCallSummary::from_call(
+            "Glob",
+            &json!({ "pattern": "*.toml", "file_path": "koda-cli/" }),
+        );
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Glob {
+                pattern: "*.toml".into(),
+                base: Some("koda-cli/".into()),
+            }
+        );
+    }
+
+    // ── List ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn list_default_directory_is_dot() {
+        let s = ToolCallSummary::from_call("List", &json!({}));
+        assert_eq!(s.kind, ToolCallKind::List { dir: ".".into() });
+    }
+
+    #[test]
+    fn list_uses_file_path_key_from_schema() {
+        let s = ToolCallSummary::from_call("List", &json!({ "file_path": "koda-core/src/" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::List {
+                dir: "koda-core/src/".into()
+            }
+        );
+    }
+
+    // ── WebFetch ──────────────────────────────────────────────────────
+
+    #[test]
+    fn webfetch_reads_url() {
+        let s = ToolCallSummary::from_call("WebFetch", &json!({ "url": "https://example.com" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::WebFetch {
+                url: "https://example.com".into()
+            }
+        );
+    }
+
+    // ── Generic fallback ──────────────────────────────────────────────
+
+    #[test]
+    fn generic_picks_first_string_value_in_object_order() {
+        let s = ToolCallSummary::from_call("UnknownTool", &json!({ "a": "first", "b": "second" }));
+        assert_eq!(
+            s.kind,
+            ToolCallKind::Generic {
+                value: Some("first".into())
+            }
+        );
+    }
+
+    #[test]
+    fn generic_with_no_string_values_yields_none() {
+        let s = ToolCallSummary::from_call("UnknownTool", &json!({ "n": 42 }));
+        assert_eq!(s.kind, ToolCallKind::Generic { value: None });
+    }
+
+    #[test]
+    fn generic_with_non_object_args_yields_none() {
+        let s = ToolCallSummary::from_call("UnknownTool", &json!("just a string"));
+        assert_eq!(s.kind, ToolCallKind::Generic { value: None });
+    }
+
+    // ── Pinning tests for the bug class this module exists to prevent ─
+
+    /// Regression test for the #1099 bug class: every path-bearing
+    /// tool MUST honor `file_path` (the schema-blessed key the
+    /// dispatcher actually reads) before any legacy alias. Pre-fix
+    /// the renderers checked obsolete keys first and silently
+    /// rendered `.` for every call.
+    ///
+    /// This is the structural equivalent of
+    /// `path_bearing_tools_render_actual_dispatch_key` in
+    /// `tool_header.rs` — that test pins the renderer's output;
+    /// this one pins the data layer the renderer reads from.
+    #[test]
+    fn path_bearing_tools_honor_file_path_key() {
+        let cases = [
+            (
+                "List",
+                json!({ "file_path": "alpha", "path": "WRONG", "directory": "WRONG" }),
+                "alpha",
+            ),
+            (
+                "Grep",
+                json!({
+                    "search_string": "x",
+                    "file_path": "bravo",
+                    "path": "WRONG",
+                    "directory": "WRONG",
+                }),
+                "bravo",
+            ),
+            (
+                "Glob",
+                json!({ "pattern": "*", "file_path": "charlie", "path": "WRONG" }),
+                "charlie",
+            ),
+            (
+                "Read",
+                json!({ "file_path": "delta", "path": "WRONG" }),
+                "delta",
+            ),
+        ];
+
+        for (name, args, expected) in cases {
+            let s = ToolCallSummary::from_call(name, &args);
+            let actual = match &s.kind {
+                ToolCallKind::List { dir } => dir.clone(),
+                ToolCallKind::Grep { dir, .. } => dir.clone(),
+                ToolCallKind::Glob { base, .. } => base.clone().unwrap_or_default(),
+                ToolCallKind::Path { path } => path.clone(),
+                other => panic!("{name} produced unexpected kind {other:?}"),
+            };
+            assert_eq!(
+                actual, expected,
+                "{name}: must read `file_path` first — that's the key the dispatcher reads. \
+                 Pre-#1099, renderers checked obsolete keys first and silently rendered \
+                 wrong paths for every call."
+            );
+        }
+    }
+}


### PR DESCRIPTION
refactor(tool_header): unify detail_spans/detail_text via ToolCallSummary

Closes #1100.

## The drift problem this fixes

Pre-PR, every rendering surface for a tool call (TUI live header,
transcript export, history replay) re-parsed the raw JSON args
independently. Each surface had its own
`first_string(args, &["file_path", "path", "directory"])` lookup
list, and they drifted twice in two days:

- #1094 -> #1096: the `List` LLM-facing body lost its
  `Listing: <path>` header, leaving the model unable to tell
  parallel `List` calls apart.
- #1099: the TUI header read the wrong arg keys for
  `List`/`Grep`/`Glob`, rendering every call as `* List .`
  regardless of the actual path. This *hid* the loop-spin bug
  #1102 for 8 days because every iteration's `List /Users/lijun/repo`
  looked identical to `List .`.

Both bugs had the same shape -- "a layer that displays a tool call
looked at the wrong key in the args JSON" -- and required separate
fixes in separate files. The root cause was duplication: each
rendering layer owned its own JSON parser.

## What this PR does

1. New module `koda_core::tools::summary`:
   - `ToolCallSummary` data struct + `ToolCallKind` enum (one
     variant per display shape, not per tool).
   - `ToolCallSummary::from_call(name, args)` is the **only** place
     that knows arg-key conventions for every tool. 17 unit tests
     pin every variant + the `path_bearing_tools_honor_file_path_key`
     regression check for the #1099 bug class.

2. `tool_header.rs` consolidation:
   - `detail_spans` and `detail_text` are now thin wrappers that
     parse args once via `ToolCallSummary::from_call` and dispatch
     to two unified renderers (`summary_spans` / `summary_text`).
   - Deleted 14 per-tool duplicated functions (bash_detail/bash_text,
     path_detail/path_text, grep_detail/grep_text, glob_detail/
     glob_text, list_detail/list_text, webfetch_detail/webfetch_text,
     generic_detail/generic_text) and the now-unused `first_string`
     helper.
   - Both renderers exhaustively pattern-match on `ToolCallKind`,
     so adding a tool with a new display shape is a one-edit change
     in `summary.rs` + a missing-arm compiler error in both
     renderers (impossible to forget one).

3. New meta-test `every_tool_call_kind_renders_in_both_surfaces`
   pins the consolidation invariant. If someone silences the
   missing-arm error with `=> Vec::new()`, this test fires next.

## Verification

- All 31 pre-existing `tool_header` tests pass (byte-identical output).
- 17 new `summary` tests pass.
- 1 new meta-test passes.
- Workspace: 2217 passed, 0 failed, 13 ignored.
- `cargo fmt --all --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo doc --workspace -- -D warnings`: clean.

## Why ToolCallSummary lives in koda-core

The data is renderer-agnostic (no `ratatui::Span`, no ANSI). Putting
it in `koda-core` keeps the engine headless and means a future
ACP/JSON renderer can reuse the same parser without a TUI dep.
