### PR TITLE
test: harden test infrastructure against Tokio runtime mismatches and unsafe env mutation (#1109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
       # No rust-cache — fmt doesn't compile anything. Skipping cache saves
       # the ~10s setup overhead and keeps the job at ~30s end-to-end.
       - run: cargo fmt --all --check
+      # #1109 F2 guard: every #[tokio::test] in modules that touch
+      # tokio::spawn / BgAgentRegistry / sub-agent dispatch / watch /
+      # broadcast must use flavor="multi_thread". Pure text scan, ~1s,
+      # rides the fmt job because it's the cheapest place that already
+      # has Python and a checkout.
+      - name: Check tokio test flavor (#1109 F2)
+        run: python3 scripts/check_tokio_test_flavor.py
 
   clippy:
     name: Clippy

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -73,8 +73,10 @@ const VERBOSE_BASH_CHARS: usize = 500;
 const HYPERLINK_KILL_SWITCH: &str = "KODA_TRANSCRIPT_HYPERLINKS";
 
 fn hyperlinks_enabled() -> bool {
+    // **#1109 F1**: read via runtime_env so tests can flip this without
+    // `unsafe { std::env::set_var }`.
     !matches!(
-        std::env::var(HYPERLINK_KILL_SWITCH).ok().as_deref(),
+        koda_core::runtime_env::get(HYPERLINK_KILL_SWITCH).as_deref(),
         Some("off" | "0" | "false" | "no")
     )
 }
@@ -782,23 +784,14 @@ mod tests {
     #[test]
     fn kill_switch_disables_hyperlinks() {
         let _g = HYPERLINK_ENV_LOCK.lock().unwrap();
-        // Save & restore so we don't leak env across tests in this thread.
-        let prev = std::env::var(HYPERLINK_KILL_SWITCH).ok();
-        // SAFETY: tests in this binary run in parallel by default; the
-        // module-level `HYPERLINK_ENV_LOCK` mutex (acquired above)
-        // serializes this writer with every reader test that asserts on
-        // hyperlinks being on, so no parallel reader sees the "off"
-        // value mid-test. See the lock's doc comment for the race this
-        // existed to prevent (PR #1107).
-        unsafe { std::env::set_var(HYPERLINK_KILL_SWITCH, "off") };
+        // **#1109 F1**: was `unsafe { std::env::set_var }` with snapshot/restore.
+        // Now uses [`koda_core::runtime_env`] — thread-safe, no UB, no
+        // `std::env` mutation. The HYPERLINK_ENV_LOCK still serializes us
+        // against parallel reader tests in this binary.
+        koda_core::runtime_env::set(HYPERLINK_KILL_SWITCH, "off");
         let msg = assistant_with_call("Read", r#"{"file_path":"/x.rs"}"#);
         let out = render(&[msg], &default_meta(), false);
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var(HYPERLINK_KILL_SWITCH, v),
-                None => std::env::remove_var(HYPERLINK_KILL_SWITCH),
-            }
-        }
+        koda_core::runtime_env::remove(HYPERLINK_KILL_SWITCH);
         assert!(out.contains("`/x.rs`"), "plain text expected, got:\n{out}");
         assert!(!out.contains("file:///"), "link should be suppressed");
     }

--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -558,7 +558,7 @@ mod tests {
     /// Both registries empty: render the explicit "No background
     /// tasks." line. Without it the user might wonder if `/agents`
     /// is broken.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_empty_renders_explicit_message() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -575,7 +575,7 @@ mod tests {
     /// **prefixed** id (`agent:N`), agent name, and the Pending
     /// status icon. Pinning the row content keeps the slash command's
     /// contract stable across refactors.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_renders_each_pending_agent_with_prefix() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -602,7 +602,7 @@ mod tests {
     /// rendered output. This is the contract that lets `/agents`
     /// show live state — if it ever stales, the slash command
     /// becomes useless.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_reflects_running_status() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -628,7 +628,7 @@ mod tests {
     /// Layer-0 placeholder semantics: `Running { iter: 0 }` means
     /// "started but no per-iter info yet" — don't render a misleading
     /// `"iter 0/20"`. Layer 4 (#1058) populated the field for bg agents.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_hides_iter_zero_placeholder() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -650,7 +650,7 @@ mod tests {
     /// each with the `process:` prefix. We spawn a real `sleep 60`
     /// so the snapshot reads from a live entry and we can
     /// later kill it in cleanup.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_renders_processes_with_prefix() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -682,7 +682,7 @@ mod tests {
     /// Phase F: agents and processes share one table. With both
     /// registries populated we should see both prefixes in the
     /// output — neither registry should crowd the other out.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_unifies_both_registries() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -704,7 +704,7 @@ mod tests {
     /// Happy path for an agent: known `agent:N` → cancel fires,
     /// success message surfaces, and the underlying token observed
     /// the cancel.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_agent_id_reports_success_and_fires_token() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -728,7 +728,7 @@ mod tests {
     /// and the registry transitions the entry into `Killed`. The
     /// child eventually exits but we don't wait on it here — the
     /// reaper handles that.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_process_id_kills_and_reports_success() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -751,7 +751,7 @@ mod tests {
     /// Unknown agent id → warn, don't crash. The user should learn
     /// the correct id (or that the task already finished) without us
     /// throwing or silently no-oping.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_agent_id_reports_helpful_error() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -766,7 +766,7 @@ mod tests {
 
     /// Unknown process id → warn, don't crash. Same shape as the
     /// agent equivalent so users get a consistent error story.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_process_id_reports_helpful_error() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();
@@ -783,7 +783,7 @@ mod tests {
     /// arg) renders Usage — not a panic, and not a misleading "task
     /// 0 not found." The Usage line must mention both prefix forms
     /// so the user learns the new syntax.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_none_id_renders_usage_with_both_prefixes() {
         let mut buf = ScrollBuffer::new(64);
         let reg = BgAgentRegistry::new();

--- a/koda-core/src/approval_flow.rs
+++ b/koda-core/src/approval_flow.rs
@@ -103,7 +103,7 @@ mod tests {
 
     // ── handle_ask_user ────────────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_returns_answer() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -142,7 +142,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), Some("b".to_string()));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_emits_request_event_with_question_and_options() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -178,7 +178,7 @@ mod tests {
         drop(cmd_tx);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_ignores_response_with_wrong_id() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), Some("correct".to_string()));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_returns_none_on_interrupt() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -246,7 +246,7 @@ mod tests {
         assert!(cancel.is_cancelled(), "interrupt should cancel the token");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_returns_none_when_channel_closes() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), None);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ask_user_returns_none_on_cancellation() {
         let sink = Arc::new(TestSink::new());
         let (_cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -286,7 +286,7 @@ mod tests {
 
     // ── request_approval ───────────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_returns_approve() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -332,7 +332,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Approve));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_returns_reject() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -378,7 +378,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Reject));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_emits_event_with_tool_name_and_detail() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -419,7 +419,7 @@ mod tests {
         drop(cmd_tx);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_ignores_response_with_wrong_id() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -475,7 +475,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), Some(ApprovalDecision::Approve));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_returns_none_on_interrupt() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -503,7 +503,7 @@ mod tests {
         assert!(cancel.is_cancelled());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_returns_none_when_channel_closes() {
         let sink = Arc::new(TestSink::new());
         let (cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);
@@ -530,7 +530,7 @@ mod tests {
         assert_eq!(task.await.unwrap(), None);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn request_approval_returns_none_on_cancellation() {
         let sink = Arc::new(TestSink::new());
         let (_cmd_tx, cmd_rx) = mpsc::channel::<EngineCommand>(8);

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -957,7 +957,7 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn register_and_complete() {
         let reg = BgAgentRegistry::new();
         let (task_id, tx) = reg.register_test("explore", "find all tests");
@@ -978,7 +978,7 @@ mod tests {
         assert_eq!(reg.pending_count(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_only_completed() {
         let reg = BgAgentRegistry::new();
         let (_id1, tx1) = reg.register_test("task", "build");
@@ -992,7 +992,7 @@ mod tests {
         assert_eq!(reg.pending_count(), 1); // explore still pending
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dropped_sender_reports_cancelled() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("task", "build");
@@ -1004,7 +1004,7 @@ mod tests {
         assert!(results[0].output.contains("cancelled"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn error_result() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("verify", "check");
@@ -1024,7 +1024,7 @@ mod tests {
     /// the user only saw spawn + completion lines. The fix is
     /// useless if the trace gets dropped at any of the three hops,
     /// so this test pins the round-trip end-to-end.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn events_propagate_through_drain_for_success() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("explore", "map repo");
@@ -1050,7 +1050,7 @@ mod tests {
     /// — "the agent tried Read, Bash, Edit, then errored" is the
     /// kind of breadcrumb that turns a black-box failure into a
     /// debuggable one.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn events_propagate_through_drain_for_failure() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("build", "compile");
@@ -1070,7 +1070,7 @@ mod tests {
     /// #1022 B9 corollary: cancelled / panicked tasks have *no*
     /// trace available (the buffering sink died with the task), and
     /// that's an explicitly-empty Vec rather than uninitialized.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancelled_task_has_empty_event_trace() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("flaky", "x");
@@ -1090,7 +1090,7 @@ mod tests {
     /// `Drop`), the spawned future would keep running after the
     /// registry — and any worktrees / API tokens / writes it owns —
     /// were dropped. That's the leak we're fixing.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn registry_drop_aborts_pending_tasks() {
         let reg = BgAgentRegistry::new();
         let parent = CancellationToken::new();
@@ -1150,7 +1150,7 @@ mod tests {
     /// Phase 1 of #1022, B2 regression test: cancelling the parent
     /// token must cascade to bg-agent child tokens handed out by
     /// `reserve`.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancel_cascades_to_reserved_child() {
         let reg = BgAgentRegistry::new();
         let parent = CancellationToken::new();
@@ -1180,7 +1180,7 @@ mod tests {
     /// This is the hook the future `/cancel <id>` slash command and
     /// `CancelAgent` LLM tool will call. Verifies a known id returns
     /// true *and* the underlying token actually fires.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_task_fires_token() {
         let reg = BgAgentRegistry::new();
         let (task_id, _tx, _status_tx, observer) =
@@ -1198,7 +1198,7 @@ mod tests {
     /// `cancel` on an unknown / already-drained id must return false
     /// instead of panicking. The slash command and LLM tool will
     /// surface this to the user as "no such task".
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_task_returns_false() {
         let reg = BgAgentRegistry::new();
         assert!(
@@ -1211,7 +1211,7 @@ mod tests {
     /// (the underlying [`CancellationToken::cancel`] is itself
     /// idempotent). Both calls return true while the entry is still
     /// in `pending`; a third call after drain returns false.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_is_idempotent_while_pending() {
         let reg = BgAgentRegistry::new();
         let (task_id, _tx, _status_tx, _observer) =
@@ -1227,7 +1227,7 @@ mod tests {
     /// `snapshot()` must return one entry per pending task with
     /// stable ordering by `task_id`. Status defaults to `Pending`
     /// because no spawned future has flipped it yet.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_lists_pending_tasks_in_id_order() {
         let reg = BgAgentRegistry::new();
         let (id_a, _tx_a) = reg.register_test("explore", "map");
@@ -1251,7 +1251,7 @@ mod tests {
     /// or yielding required (`watch::Receiver::borrow` is sync).
     /// This is the contract that lets the status-bar pill (Layer 3)
     /// and live `/agents -v` (Layer 1) reflect transitions immediately.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_reflects_status_writes() {
         let reg = BgAgentRegistry::new();
         let (task_id, _tx, status_tx, _cancel) =
@@ -1286,7 +1286,7 @@ mod tests {
     /// that two successive snapshots show a non-decreasing age and
     /// that the value is non-negative (saturating subtraction
     /// prevents underflow if the system clock jumps backwards).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_age_is_monotonic() {
         let reg = BgAgentRegistry::new();
         let (_id, _tx) = reg.register_test("explore", "x");
@@ -1303,7 +1303,7 @@ mod tests {
     /// `snapshot()` on an empty registry returns an empty Vec, not a
     /// panic and not None. `/agents` will use this to render "No
     /// background agents."
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_empty_registry_is_empty_vec() {
         let reg = BgAgentRegistry::new();
         assert!(reg.snapshot().is_empty());
@@ -1314,7 +1314,7 @@ mod tests {
     /// contract that `/agents` reflects the *currently-pending* set,
     /// not historical tasks. The Layer 1 "recently-completed lingers
     /// 30 s" UX is implemented at the *display* layer, not here.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_drops_drained_tasks() {
         let reg = BgAgentRegistry::new();
         let (_id, tx) = reg.register_test("explore", "x");
@@ -1334,7 +1334,7 @@ mod tests {
     /// `snapshot_for_caller(None)` returns only top-level tasks;
     /// `snapshot_for_caller(Some(N))` returns only N's tasks. Cross-spawner
     /// visibility is exactly zero — the Model E isolation guarantee.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_for_caller_filters_by_spawner() {
         let reg = BgAgentRegistry::new();
         let (top_id, _tx, _, _) = reg.register_test_with_status("a", "top", None);
@@ -1354,7 +1354,7 @@ mod tests {
     }
 
     /// `cancel_as_caller` enforces the Model E permission rule.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_as_caller_returns_forbidden_for_other_spawner() {
         let reg = BgAgentRegistry::new();
         let (id, _tx, _, observer) = reg.register_test_with_status("x", "y", Some(7));
@@ -1380,7 +1380,7 @@ mod tests {
         assert!(observer.is_cancelled());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_as_caller_returns_not_found_for_unknown_id() {
         let reg = BgAgentRegistry::new();
         assert_eq!(reg.cancel_as_caller(999, None), CancelOutcome::NotFound);
@@ -1388,7 +1388,7 @@ mod tests {
 
     /// `cancel_for_spawner` cleans up exactly one sub-agent's children
     /// and leaves siblings + top-level alone. The cleanup-on-exit hook.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_for_spawner_kills_only_matching_children() {
         let reg = BgAgentRegistry::new();
         let (_top, _, _, top_obs) = reg.register_test_with_status("top", "t", None);
@@ -1413,7 +1413,7 @@ mod tests {
 
     /// `wait_for_completion` returns `Completed` and consumes the entry
     /// (so a subsequent `drain_completed` can't double-inject).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_consumes_completed_task() {
         let reg = BgAgentRegistry::new();
         let (id, tx, status_tx, _) = reg.register_test_with_status("explore", "map", Some(3));
@@ -1448,7 +1448,7 @@ mod tests {
     /// `wait_for_completion` returns `TimedOut` with a fresh snapshot
     /// when the task hasn't finished yet — and crucially leaves the
     /// entry in the registry so a later drain still works.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_timeout_preserves_entry() {
         let reg = BgAgentRegistry::new();
         let (id, _tx, status_tx, _) = reg.register_test_with_status("slow", "x", None);
@@ -1473,7 +1473,7 @@ mod tests {
 
     /// `wait_for_completion` enforces the same Model E permission rule
     /// as `cancel_as_caller`.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_forbidden_for_other_spawner() {
         let reg = BgAgentRegistry::new();
         let (id, _tx, _, _) = reg.register_test_with_status("x", "y", Some(5));
@@ -1497,7 +1497,7 @@ mod tests {
 
     /// Cancellation between status going terminal and `WaitTask` waking
     /// up surfaces as `Cancelled` (oneshot closed without sending).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_cancelled_when_sender_dropped() {
         let reg = BgAgentRegistry::new();
         let (id, tx, status_tx, _) = reg.register_test_with_status("x", "y", None);
@@ -1514,7 +1514,7 @@ mod tests {
         assert!(reg.snapshot().is_empty(), "entry must be reaped");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_not_found_for_unknown_id() {
         let reg = BgAgentRegistry::new();
         let outcome = reg

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -44,21 +44,23 @@ pub struct Database {
 }
 
 /// Get the koda config directory (~/.config/koda/).
+///
+/// **#1109 F1**: reads via [`crate::runtime_env::get`] (thread-safe with
+/// `mask`/fallback semantics) instead of `std::env::var`. Tests can now
+/// inject or hide these keys without `unsafe { set_var }`.
 pub fn config_dir() -> Result<std::path::PathBuf> {
-    let base = std::env::var("XDG_CONFIG_HOME")
-        .ok()
+    let base = crate::runtime_env::get("XDG_CONFIG_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| {
             // Unix: $HOME/.config  (XDG Base Directory spec fallback)
-            std::env::var("HOME")
-                .ok()
+            crate::runtime_env::get("HOME")
                 .map(|h| std::path::PathBuf::from(h).join(".config"))
         })
         .or({
             // Windows: %APPDATA%  (e.g. C:\Users\Alice\AppData\Roaming)
             #[cfg(windows)]
             {
-                std::env::var("APPDATA").ok().map(std::path::PathBuf::from)
+                crate::runtime_env::get("APPDATA").map(std::path::PathBuf::from)
             }
             #[cfg(not(windows))]
             {

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -53,8 +53,7 @@ pub fn config_dir() -> Result<std::path::PathBuf> {
         .map(std::path::PathBuf::from)
         .or_else(|| {
             // Unix: $HOME/.config  (XDG Base Directory spec fallback)
-            crate::runtime_env::get("HOME")
-                .map(|h| std::path::PathBuf::from(h).join(".config"))
+            crate::runtime_env::get("HOME").map(|h| std::path::PathBuf::from(h).join(".config"))
         })
         .or({
             // Windows: %APPDATA%  (e.g. C:\Users\Alice\AppData\Roaming)

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -1123,16 +1123,18 @@ async fn test_purge_compacted() {
 
 // ── config_dir ─────────────────────────────────────────────────────────
 
-/// Serialize tests that mutate XDG_CONFIG_HOME.
+/// Serialize tests that mutate XDG_CONFIG_HOME (in the runtime-env map).
 static XDG_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
 fn test_config_dir_with_xdg() {
     let _guard = XDG_MUTEX.lock().unwrap();
-    // SAFETY: serialized via XDG_MUTEX
-    unsafe { std::env::set_var("XDG_CONFIG_HOME", "/tmp/test_xdg_config") };
+    // **#1109 F1**: was `unsafe { std::env::set_var(...) }`. Now uses
+    // the thread-safe runtime-env map; production [`config_dir`] reads
+    // via [`crate::runtime_env::get`] so the override is observed.
+    crate::runtime_env::set("XDG_CONFIG_HOME", "/tmp/test_xdg_config");
     let dir = super::config_dir().unwrap();
-    unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    crate::runtime_env::remove("XDG_CONFIG_HOME");
     // Always ends with "koda"
     assert!(dir.ends_with("koda"), "got: {dir:?}");
     assert!(
@@ -1144,8 +1146,13 @@ fn test_config_dir_with_xdg() {
 #[test]
 fn test_config_dir_with_home() {
     let _guard = XDG_MUTEX.lock().unwrap();
-    unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
+    // **#1109 F1**: mask hides any developer-exported XDG_CONFIG_HOME
+    // from production code so we exercise the HOME fallback branch.
+    // Uses the runtime-env mask facility — no `unsafe`, no std::env mutation.
+    crate::runtime_env::remove("XDG_CONFIG_HOME");
+    crate::runtime_env::mask("XDG_CONFIG_HOME");
     let dir = super::config_dir().unwrap();
+    crate::runtime_env::unmask("XDG_CONFIG_HOME");
     // Should end with koda regardless of base path
     assert!(dir.ends_with("koda"), "got: {dir:?}");
 }

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -138,10 +138,17 @@ impl EngineSink for BufferingSink {
 }
 
 /// A sink that collects events into a Vec for testing.
+///
+/// Optionally also broadcasts each event to subscribers (#1109 F3) so
+/// tests can wait deterministically for a specific event (e.g.
+/// `ToolCallStart`) instead of guessing wall-clock delays.
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Default)]
 pub struct TestSink {
     events: std::sync::Mutex<Vec<EngineEvent>>,
+    /// `Some` after [`subscribe`] is called; broadcasts every emit().
+    /// Lazy so tests that don't need it pay no allocation.
+    broadcaster: std::sync::Mutex<Option<tokio::sync::broadcast::Sender<EngineEvent>>>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -165,11 +172,78 @@ impl TestSink {
     pub fn is_empty(&self) -> bool {
         self.events.lock().unwrap().is_empty()
     }
+
+    /// Subscribe to a live broadcast of events as they're emitted.
+    ///
+    /// **#1109 F3**: replaces `loop { sleep; check sink.events() }`
+    /// patterns with `recv().await`. The broadcaster is created lazily
+    /// on first call — emits before subscription are still captured
+    /// in [`events`] but won't appear in the receiver stream.
+    ///
+    /// Channel capacity is 256, more than enough for any test
+    /// scenario; lagging receivers will see
+    /// [`tokio::sync::broadcast::error::RecvError::Lagged`].
+    pub fn subscribe(&self) -> tokio::sync::broadcast::Receiver<EngineEvent> {
+        let mut guard = self.broadcaster.lock().unwrap();
+        let sender = guard.get_or_insert_with(|| {
+            let (tx, _) = tokio::sync::broadcast::channel(256);
+            tx
+        });
+        sender.subscribe()
+    }
+
+    /// Wait for the first event matching `pred` or until `timeout`.
+    /// Returns `Ok(event)` on match, `Err` on timeout or channel close.
+    ///
+    /// Convenience wrapper around [`subscribe`]: handles the
+    /// already-emitted-before-subscribe case by scanning [`events`]
+    /// once, then waits on the live channel for fresh events.
+    pub async fn wait_for<F>(
+        &self,
+        timeout: std::time::Duration,
+        pred: F,
+    ) -> Result<EngineEvent, &'static str>
+    where
+        F: Fn(&EngineEvent) -> bool,
+    {
+        // Subscribe BEFORE the historical scan so we don't miss events
+        // emitted between the scan and subscribe (the classic
+        // "check-then-wait" race).
+        let mut rx = self.subscribe();
+        // Scan history first — maybe the event has already fired.
+        if let Some(ev) = self.events().into_iter().find(|e| pred(e)) {
+            return Ok(ev);
+        }
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err("timeout waiting for predicate");
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(ev)) if pred(&ev) => return Ok(ev),
+                Ok(Ok(_)) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                    return Err("sink closed");
+                }
+                Err(_) => return Err("timeout waiting for predicate"),
+            }
+        }
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]
 impl EngineSink for TestSink {
     fn emit(&self, event: EngineEvent) {
+        // Best-effort broadcast first (cheap if no subscribers).
+        // Acquiring the lock briefly is fine because emit is always
+        // called from a tokio task, never from a sync hot loop.
+        if let Some(tx) = self.broadcaster.lock().unwrap().as_ref() {
+            // Ignore the SendError on zero subscribers; storage path
+            // below is still authoritative.
+            let _ = tx.send(event.clone());
+        }
         self.events.lock().unwrap().push(event);
     }
 }

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -146,7 +146,7 @@ impl EngineSink for BufferingSink {
 #[derive(Debug, Default)]
 pub struct TestSink {
     events: std::sync::Mutex<Vec<EngineEvent>>,
-    /// `Some` after [`subscribe`] is called; broadcasts every emit().
+    /// `Some` after [`Self::subscribe`] is called; broadcasts every emit().
     /// Lazy so tests that don't need it pay no allocation.
     broadcaster: std::sync::Mutex<Option<tokio::sync::broadcast::Sender<EngineEvent>>>,
 }
@@ -178,7 +178,7 @@ impl TestSink {
     /// **#1109 F3**: replaces `loop { sleep; check sink.events() }`
     /// patterns with `recv().await`. The broadcaster is created lazily
     /// on first call — emits before subscription are still captured
-    /// in [`events`] but won't appear in the receiver stream.
+    /// in [`Self::events`] but won't appear in the receiver stream.
     ///
     /// Channel capacity is 256, more than enough for any test
     /// scenario; lagging receivers will see
@@ -195,8 +195,8 @@ impl TestSink {
     /// Wait for the first event matching `pred` or until `timeout`.
     /// Returns `Ok(event)` on match, `Err` on timeout or channel close.
     ///
-    /// Convenience wrapper around [`subscribe`]: handles the
-    /// already-emitted-before-subscribe case by scanning [`events`]
+    /// Convenience wrapper around [`Self::subscribe`]: handles the
+    /// already-emitted-before-subscribe case by scanning [`Self::events`]
     /// once, then waits on the live channel for fresh events.
     pub async fn wait_for<F>(
         &self,

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1351,7 +1351,7 @@ mod tests {
 
     // ── Text streaming ───────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_accumulates_text_deltas() {
         let result = run_collect(
             vec![
@@ -1370,7 +1370,7 @@ mod tests {
         assert_eq!(result.char_count, 12);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_empty_stream_returns_empty() {
         let result = run_collect(vec![StreamChunk::Done(TokenUsage::default())], None).await;
 
@@ -1379,7 +1379,7 @@ mod tests {
         assert!(result.tool_calls.is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_preserves_usage_from_done() {
         let usage = TokenUsage {
             prompt_tokens: 42,
@@ -1403,7 +1403,7 @@ mod tests {
 
     // ── Thinking blocks ──────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_thinking_then_text() {
         let result = run_collect(
             vec![
@@ -1423,7 +1423,7 @@ mod tests {
 
     // ── Tool calls ───────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_tool_calls_batch() {
         let tc = ToolCall {
             id: "tc_1".into(),
@@ -1445,7 +1445,7 @@ mod tests {
         assert!(result.text.is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_eager_executes_read_only_tool() {
         // Read is read-only + auto-approved → should be eagerly executed.
         let tmp = tempfile::tempdir().unwrap();
@@ -1481,7 +1481,7 @@ mod tests {
         assert!(success);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_does_not_eagerly_execute_mutating_tool() {
         // Write is mutating → should NOT be eagerly executed.
         let tc = ToolCall {
@@ -1509,7 +1509,7 @@ mod tests {
 
     // ── Cancellation ─────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_cancellation_sets_interrupted() {
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
@@ -1540,7 +1540,7 @@ mod tests {
 
     // ── Network errors ───────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_network_error_preserves_partial() {
         let result = run_collect(
             vec![
@@ -1556,7 +1556,7 @@ mod tests {
         assert_eq!(result.text, "partial response");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_network_error_with_no_text() {
         let result = run_collect(vec![StreamChunk::NetworkError("timeout".into())], None).await;
 

--- a/koda-core/src/mcp/manager.rs
+++ b/koda-core/src/mcp/manager.rs
@@ -430,7 +430,7 @@ mod tests {
 
     // ── call_tool on disconnected server ───────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn call_tool_on_disconnected_server_returns_err() {
         let mgr = manager_with_mixed_clients();
         let result = mgr
@@ -444,7 +444,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn call_tool_on_nonexistent_server_returns_err() {
         let mgr = McpManager::new();
         let result = mgr.call_tool("ghost__tool", serde_json::json!({})).await;
@@ -453,7 +453,7 @@ mod tests {
         assert!(msg.contains("not found"), "expected 'not found' in: {msg}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn call_tool_with_invalid_name_returns_err() {
         let mgr = McpManager::new();
         let result = mgr.call_tool("no_separator", serde_json::json!({})).await;
@@ -467,7 +467,7 @@ mod tests {
 
     // ── remove_server purges annotation cache ─────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn remove_server_purges_annotations() {
         let mut mgr = McpManager::new();
         let c = McpClient::new("myserver".into(), dummy_config());
@@ -486,7 +486,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn remove_nonexistent_server_returns_false() {
         let mut mgr = McpManager::new();
         assert!(!mgr.remove_server("ghost").await);
@@ -498,7 +498,7 @@ mod tests {
     /// client and its annotations are purged BEFORE the new connect attempt.
     /// Even if the new connect fails (dummy `false` command), the stale
     /// annotations from the previous server must be gone.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn add_server_collision_purges_old_annotations() {
         let mut mgr = McpManager::new();
 
@@ -526,7 +526,7 @@ mod tests {
     /// `reconnect_server` must purge annotations for the given server
     /// before attempting the reconnect.  Even if the reconnect fails
     /// (dummy `false` command), stale entries must be gone.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reconnect_server_purges_stale_annotations() {
         let mut mgr = McpManager::new();
 
@@ -552,7 +552,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reconnect_server_nonexistent_returns_err() {
         let mut mgr = McpManager::new();
         let result = mgr.reconnect_server("ghost").await;
@@ -673,7 +673,7 @@ mod tests {
 
     // ── shutdown ────────────────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_clears_all_annotations() {
         let mut mgr = McpManager::new();
         // Two clients, each contributing tools/annotations.
@@ -693,7 +693,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_on_empty_manager_is_noop() {
         let mut mgr = McpManager::new();
         // Should not panic; should leave manager empty.
@@ -840,7 +840,7 @@ mod tests {
     /// Removing one server must not touch any *other* server's annotations.
     /// Regression guard against a buggy `retain` predicate that over-purges
     /// (e.g., `starts_with(name)` instead of `parse_mcp_tool_name() == name`).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn remove_server_does_not_touch_other_servers_annotations() {
         let mut mgr = McpManager::new();
 
@@ -869,7 +869,7 @@ mod tests {
     }
 
     /// Same prefix-isolation guard, but for `add_server` collisions.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn add_server_collision_does_not_touch_prefix_neighbour() {
         let mut mgr = McpManager::new();
 

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -99,13 +99,31 @@ impl MockProvider {
         }
     }
 
-    /// Create from `KODA_MOCK_RESPONSES` env var (JSON array).
+    /// Create from `KODA_MOCK_RESPONSES` runtime env var (JSON array).
     ///
     /// Format: `[{"text":"hello"}, {"tool":"Read","args":{"path":"f.txt"}}, {"error":"boom"}]`
+    ///
+    /// **#1109 F1**: reads via [`crate::runtime_env::get`] (thread-safe
+    /// `RwLock<HashMap>` with fallback to `std::env::var`) instead of
+    /// `std::env::var` directly. This lets in-process tests inject the
+    /// script via [`crate::runtime_env::set`] — no `unsafe { set_var }`,
+    /// no Rust 2024 UB. Sub-process tests (e.g. `koda-cli/tests/smoke_test`)
+    /// continue to work because `runtime_env::get` falls back to the real
+    /// process env when the runtime map has no entry.
     pub fn from_env() -> Self {
-        let json = std::env::var("KODA_MOCK_RESPONSES").unwrap_or_else(|_| "[]".into());
+        let json = crate::runtime_env::get("KODA_MOCK_RESPONSES").unwrap_or_else(|| "[]".into());
+        Self::from_json_str(&json)
+    }
+
+    /// Pure parser — build a provider from a JSON-array string. Extracted
+    /// so lib tests can exercise the parsing logic without touching the
+    /// global env (#1109 F1).
+    ///
+    /// Panics if `json` is not a valid JSON array. Callers feeding
+    /// untrusted input should `serde_json::from_str` themselves first.
+    pub fn from_json_str(json: &str) -> Self {
         let raw: Vec<serde_json::Value> =
-            serde_json::from_str(&json).expect("KODA_MOCK_RESPONSES must be a JSON array");
+            serde_json::from_str(json).expect("KODA_MOCK_RESPONSES must be a JSON array");
         let responses = raw
             .into_iter()
             .map(|v| {
@@ -329,8 +347,11 @@ impl LlmProvider for MockProvider {
 mod tests {
     use super::*;
 
-    /// Serialize env-var mutations across parallel tests.
-    static ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // **#1109 F1**: previously this module had its own `ENV_MUTEX` to
+    // serialize tests that mutated `KODA_MOCK_RESPONSES` via
+    // `unsafe { std::env::set_var }`. Both are gone now —
+    // [`MockProvider::from_json_str`] is the pure parser; lib tests
+    // call it directly without touching any global.
 
     #[tokio::test]
     async fn test_text_response() {
@@ -417,79 +438,69 @@ mod tests {
         }
     }
 
-    // ── from_env ─────────────────────────────────────────────────────
+    // ── from_env / from_json_str ───────────────────────────────
+    //
+    // **#1109 F1**: previously each test set `KODA_MOCK_RESPONSES` via
+    // `unsafe { std::env::set_var }` (UB in Rust 2024) and serialized
+    // access via a local `ENV_MUTEX`. Both went away once `from_env`
+    // delegated to a pure parser — the parser is what we actually want
+    // to test, the env-var read is a one-line wrapper.
 
     #[test]
-    fn test_from_env_no_var_gives_empty_provider() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        // SAFETY: serialized via ENV_MUTEX
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
-        let provider = MockProvider::from_env();
+    fn test_from_json_str_empty_array_gives_empty_provider() {
+        let provider = MockProvider::from_json_str("[]");
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::Text(t) if t.is_empty()));
     }
 
     #[test]
-    fn test_from_env_with_text_response() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "hello from env"}]"#);
-        }
-        let provider = MockProvider::from_env();
+    fn test_from_env_falls_back_to_empty_when_unset() {
+        // Smoke test for the env-reading wrapper. Uses a key that
+        // production reads (`KODA_MOCK_RESPONSES`) BUT relies on the
+        // runtime-env fallback to an unset process var, so we don't
+        // touch any global state. If a sibling test has already set
+        // the runtime entry, that's still fine — `from_env` just
+        // delegates to `from_json_str`, which we test directly above.
+        // This test exists to pin that the wrapper compiles and the
+        // parse-empty path is reachable.
+        let _ = MockProvider::from_env(); // must not panic
+    }
+
+    #[test]
+    fn test_from_json_str_with_text_response() {
+        let provider = MockProvider::from_json_str(r#"[{"text": "hello from env"}]"#);
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::Text(t) if t == "hello from env"));
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
     }
 
     #[test]
-    fn test_from_env_with_tool_call() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::set_var(
-                "KODA_MOCK_RESPONSES",
-                r#"[{"tool": "Bash", "args": {"command": "ls"}}]"#,
-            );
-        }
-        let provider = MockProvider::from_env();
+    fn test_from_json_str_with_tool_call() {
+        let provider = MockProvider::from_json_str(
+            r#"[{"tool": "Bash", "args": {"command": "ls"}}]"#,
+        );
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::ToolCalls(calls) if calls[0].function_name == "Bash"));
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
     }
 
     #[test]
-    fn test_from_env_with_error() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"error": "boom"}]"#);
-        }
-        let provider = MockProvider::from_env();
+    fn test_from_json_str_with_error() {
+        let provider = MockProvider::from_json_str(r#"[{"error": "boom"}]"#);
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::Error(e) if e == "boom"));
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
     }
 
     #[test]
-    fn test_from_env_with_rate_limit() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"rate_limit": true}]"#);
-        }
-        let provider = MockProvider::from_env();
+    fn test_from_json_str_with_rate_limit() {
+        let provider = MockProvider::from_json_str(r#"[{"rate_limit": true}]"#);
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::RateLimit));
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
     }
 
     #[test]
-    fn test_from_env_with_context_overflow() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        unsafe {
-            std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"context_overflow": true}]"#);
-        }
-        let provider = MockProvider::from_env();
+    fn test_from_json_str_with_context_overflow() {
+        let provider = MockProvider::from_json_str(r#"[{"context_overflow": true}]"#);
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::ContextOverflow));
-        unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
     }
 
     // ── provider metadata ─────────────────────────────────────────────

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -475,9 +475,8 @@ mod tests {
 
     #[test]
     fn test_from_json_str_with_tool_call() {
-        let provider = MockProvider::from_json_str(
-            r#"[{"tool": "Bash", "args": {"command": "ls"}}]"#,
-        );
+        let provider =
+            MockProvider::from_json_str(r#"[{"tool": "Bash", "args": {"command": "ls"}}]"#);
         let next = provider.next_response();
         assert!(matches!(next, MockResponse::ToolCalls(calls) if calls[0].function_name == "Bash"));
     }

--- a/koda-core/src/providers/mock.rs
+++ b/koda-core/src/providers/mock.rs
@@ -353,7 +353,7 @@ mod tests {
     // [`MockProvider::from_json_str`] is the pure parser; lib tests
     // call it directly without touching any global.
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_text_response() {
         let provider = MockProvider::new(vec![MockResponse::Text("hello".into())]);
         let collector = provider
@@ -374,7 +374,7 @@ mod tests {
         assert!(chunks.iter().any(|c| matches!(c, StreamChunk::Done(_))));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_tool_call_response() {
         let provider = MockProvider::new(vec![MockResponse::tool_call(
             "Bash",
@@ -397,7 +397,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_error_response() {
         let provider = MockProvider::new(vec![MockResponse::Error("boom".into())]);
         let result = provider
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(p.provider_name(), "mock");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_list_models_returns_mock_model() {
         let p = MockProvider::new(vec![]);
         let models = p.list_models().await.unwrap();
@@ -521,7 +521,7 @@ mod tests {
 
     // ── non-streaming chat ───────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_text_response() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::Text("hi there".into())]);
@@ -530,7 +530,7 @@ mod tests {
         assert!(resp.tool_calls.is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_empty_queue_returns_empty_text() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![]);
@@ -538,7 +538,7 @@ mod tests {
         assert_eq!(resp.content.as_deref(), Some(""));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_rate_limit_is_error() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::RateLimit]);
@@ -554,7 +554,7 @@ mod tests {
 
     // ── remaining chat() variants ───────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_tool_calls_response() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::tool_call(
@@ -567,7 +567,7 @@ mod tests {
         assert_eq!(resp.tool_calls[0].function_name, "Bash");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_text_max_tokens_stop_reason() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider =
@@ -577,7 +577,7 @@ mod tests {
         assert_eq!(resp.usage.stop_reason, "max_tokens");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_context_overflow_is_error() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::ContextOverflow]);
@@ -589,7 +589,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_chat_network_error() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::NetworkError {
@@ -602,7 +602,7 @@ mod tests {
 
     // ── chat_stream() remaining variants ────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_stream_text_max_tokens() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::TextMaxTokens("hi there".into())]);
@@ -615,7 +615,7 @@ mod tests {
         assert!(done.is_some(), "should emit max_tokens Done chunk");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_stream_tool_calls_eager() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::ToolCallsEager(vec![ToolCall {
@@ -635,7 +635,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_stream_network_error() {
         let settings = ModelSettings::defaults_for("mock", &crate::config::ProviderType::LMStudio);
         let provider = MockProvider::new(vec![MockResponse::NetworkError {

--- a/koda-core/src/providers/stream_collector.rs
+++ b/koda-core/src/providers/stream_collector.rs
@@ -193,7 +193,7 @@ mod tests {
         chunks
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_basic_sse_parsing() {
         let sse = "data: hello\ndata: world\n";
         let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
@@ -204,7 +204,7 @@ mod tests {
         assert!(matches!(&chunks[2], StreamChunk::Done(u) if u.completion_tokens == 2));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_done_sentinel_triggers_early_finish() {
         let sse = "data: first\ndata: [DONE]\ndata: should-not-appear\n";
         let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
@@ -214,7 +214,7 @@ mod tests {
         assert!(matches!(&chunks[1], StreamChunk::Done(u) if u.completion_tokens == 1));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_non_data_lines_are_ignored() {
         let sse = "event: message_start\ndata: payload\n: comment\nretry: 5000\n";
         let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
@@ -224,7 +224,7 @@ mod tests {
     }
 
     /// SSE spec allows `data:` without a trailing space.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_data_without_space_parsed() {
         let sse = "data:hello\ndata:world\n";
         let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
@@ -235,7 +235,7 @@ mod tests {
     }
 
     /// Mixed `data: ` and `data:` lines should both be parsed.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_data_mixed_space_variants() {
         let sse = "data: with-space\ndata:no-space\n";
         let chunks = drive_parser(Box::new(EchoParser::new()), sse).await;
@@ -249,7 +249,7 @@ mod tests {
 
     use crate::providers::anthropic::AnthropicChunkParser;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_anthropic_text_stream() {
         let sse = r#"data: {"type":"message_start","message":{"usage":{"input_tokens":100,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":50}}}
 data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
@@ -274,7 +274,7 @@ data: {"type":"message_stop"}
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_anthropic_thinking_stream() {
         let sse = r#"data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
@@ -290,7 +290,7 @@ data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input
         assert!(matches!(&chunks[2], StreamChunk::Done(_)));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_anthropic_tool_use_stream() {
         let sse = r#"data: {"type":"message_start","message":{"usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
 data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc_1","name":"read_file","input":{}}}
@@ -316,7 +316,7 @@ data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input
 
     use crate::providers::gemini::GeminiChunkParser;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_gemini_text_stream() {
         let sse = r#"data: {"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":null}],"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":5,"cachedContentTokenCount":0,"thoughtsTokenCount":0}}
 data: {"candidates":[{"content":{"parts":[{"text":" world"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":10,"cachedContentTokenCount":0,"thoughtsTokenCount":0}}
@@ -335,7 +335,7 @@ data: {"candidates":[{"content":{"parts":[{"text":" world"}]},"finishReason":"ST
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_gemini_thinking_stream() {
         let sse = r#"data: {"candidates":[{"content":{"parts":[{"text":"Reasoning...","thought":true}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"cachedContentTokenCount":0,"thoughtsTokenCount":5}}
 data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":10,"cachedContentTokenCount":0,"thoughtsTokenCount":5}}
@@ -352,7 +352,7 @@ data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]},"finishReason":"ST
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_gemini_tool_call_stream() {
         let sse = r#"data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"list_files","args":{"dir":"."}}},{"functionCall":{"name":"read_file","args":{"path":"x"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"cachedContentTokenCount":0,"thoughtsTokenCount":0}}
 "#;
@@ -372,7 +372,7 @@ data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]},"finishReason":"ST
 
     use crate::providers::openai_compat::OpenAiChunkParser;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_openai_text_stream() {
         // Note: StreamTagFilter holds back up to MAX_TAG_LEN (16) bytes to detect
         // <think> tags spanning chunks. Short deltas get buffered until flush.
@@ -405,7 +405,7 @@ data: {"candidates":[{"content":{"parts":[{"text":"Answer"}]},"finishReason":"ST
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_openai_reasoning_stream() {
         let sse = r#"data: {"choices":[{"delta":{"reasoning_content":"Let me think..."},"finish_reason":null}],"usage":null}
 data: {"choices":[{"delta":{"content":"Answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"completion_tokens_details":{"reasoning_tokens":3}}}
@@ -423,7 +423,7 @@ data: [DONE]
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_openai_tool_call_stream() {
         let sse = r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read","arguments":""}}]},"finish_reason":null}],"usage":null}
 data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"f\":\"a\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}
@@ -443,7 +443,7 @@ data: [DONE]
         assert!(matches!(&chunks[1], StreamChunk::Done(u) if u.stop_reason == "tool_calls"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_openai_length_normalized_to_max_tokens() {
         let sse = r#"data: {"choices":[{"delta":{"content":"x"},"finish_reason":"length"}],"usage":null}
 data: [DONE]

--- a/koda-core/src/runtime_env.rs
+++ b/koda-core/src/runtime_env.rs
@@ -14,8 +14,8 @@
 //!
 //! ## Masking (#1109 F1)
 //!
-//! [`mask`] / [`unmask`] let tests *hide* a process-env var from
-//! [`get`] without mutating `std::env`. Production code reading
+//! `mask` / `unmask` let tests *hide* a process-env var from
+//! `get` without mutating `std::env`. Production code reading
 //! `runtime_env::get("HTTP_PROXY")` will see `None` for masked keys
 //! even if the user's shell exported `HTTP_PROXY`. This is the
 //! `unsafe`-free way to isolate tests that exercise env-driven config
@@ -55,7 +55,7 @@ pub fn set(key: impl Into<String>, value: impl Into<String>) {
 ///
 /// Lookup order:
 /// 1. Runtime map (set via [`set`]).
-/// 2. Mask check — if [`mask`]ed, return `None` immediately.
+/// 2. Mask check — if `mask`ed, return `None` immediately.
 /// 3. Process environment via `std::env::var`.
 pub fn get(key: &str) -> Option<String> {
     if let Some(val) = env_map()
@@ -84,7 +84,7 @@ pub fn is_set(key: &str) -> bool {
 ///
 /// Returns the previous runtime-map value if one was set. After removal
 /// [`get`] will fall back to the process environment as usual (unless the
-/// key is also [`mask`]ed).
+/// key is also `mask`ed).
 ///
 /// Primarily intended for tests that need to leave the runtime map clean
 /// for siblings — production code should rarely need this.

--- a/koda-core/src/runtime_env.rs
+++ b/koda-core/src/runtime_env.rs
@@ -3,7 +3,7 @@
 //! Replaces `unsafe { std::env::set_var() }` with a concurrent map
 //! that is safe to read/write from any tokio task.
 //!
-//! Read priority: runtime map → process environment.
+//! Read priority: runtime map → mask check → process environment.
 //!
 //! ## Why not `std::env::set_var`?
 //!
@@ -11,26 +11,52 @@
 //! Rust 2024 edition). Since Koda uses tokio with multiple tasks (main
 //! REPL, background agents, version checker), we need a thread-safe
 //! alternative.
+//!
+//! ## Masking (#1109 F1)
+//!
+//! [`mask`] / [`unmask`] let tests *hide* a process-env var from
+//! [`get`] without mutating `std::env`. Production code reading
+//! `runtime_env::get("HTTP_PROXY")` will see `None` for masked keys
+//! even if the user's shell exported `HTTP_PROXY`. This is the
+//! `unsafe`-free way to isolate tests that exercise env-driven config
+//! paths (e.g. proxy honoring, localhost bypass) without spawning a
+//! sub-process.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{OnceLock, RwLock};
 
 static RUNTIME_ENV: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+static MASKED_KEYS: OnceLock<RwLock<HashSet<String>>> = OnceLock::new();
 
 fn env_map() -> &'static RwLock<HashMap<String, String>> {
     RUNTIME_ENV.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
+fn masked() -> &'static RwLock<HashSet<String>> {
+    MASKED_KEYS.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
 /// Set a runtime environment variable (thread-safe).
+///
+/// Implicitly unmasks `key` — a runtime override always wins over a mask.
 pub fn set(key: impl Into<String>, value: impl Into<String>) {
+    let key = key.into();
+    masked()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&key);
     env_map()
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .insert(key.into(), value.into());
+        .insert(key, value.into());
 }
 
 /// Get a runtime variable, falling back to `std::env::var`.
-/// Checks our runtime map first, then the real process environment.
+///
+/// Lookup order:
+/// 1. Runtime map (set via [`set`]).
+/// 2. Mask check — if [`mask`]ed, return `None` immediately.
+/// 3. Process environment via `std::env::var`.
 pub fn get(key: &str) -> Option<String> {
     if let Some(val) = env_map()
         .read()
@@ -38,6 +64,13 @@ pub fn get(key: &str) -> Option<String> {
         .get(key)
     {
         return Some(val.clone());
+    }
+    if masked()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .contains(key)
+    {
+        return None;
     }
     std::env::var(key).ok()
 }
@@ -50,7 +83,8 @@ pub fn is_set(key: &str) -> bool {
 /// Remove a key from the runtime map (does **not** touch process env).
 ///
 /// Returns the previous runtime-map value if one was set. After removal
-/// [`get`] will fall back to the process environment as usual.
+/// [`get`] will fall back to the process environment as usual (unless the
+/// key is also [`mask`]ed).
 ///
 /// Primarily intended for tests that need to leave the runtime map clean
 /// for siblings — production code should rarely need this.
@@ -59,6 +93,28 @@ pub fn remove(key: &str) -> Option<String> {
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .remove(key)
+}
+
+/// Mask `key`: future [`get`] calls return `None` for this key,
+/// even if `std::env::var(key)` would otherwise return a value.
+///
+/// Use this in tests that need to assert behavior under "env var unset"
+/// without resorting to `unsafe { std::env::remove_var(...) }`. The mask
+/// is process-global and lives in the same `OnceLock` as the runtime
+/// map, so combine with `koda_test_utils::ENV_MUTEX` for serialization.
+pub fn mask(key: impl Into<String>) {
+    masked()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(key.into());
+}
+
+/// Lift a previous [`mask`] on `key`. Idempotent.
+pub fn unmask(key: &str) {
+    masked()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(key);
 }
 
 #[cfg(test)]
@@ -112,6 +168,77 @@ mod tests {
         assert!(
             get("HOME").is_some(),
             "process env HOME must survive a runtime-map remove"
+        );
+    }
+
+    // ── mask / unmask (#1109 F1) ─────────────────────────────
+
+    #[test]
+    fn test_mask_hides_process_env_from_get() {
+        // HOME is set in every sane environment; mask should hide it.
+        // Use a unique-ish key to avoid colliding with siblings under
+        // parallel `cargo test` execution.
+        const KEY: &str = "KODA_TEST_MASK_HIDES_PROC";
+        // SAFETY: we don't touch std::env here — we install a mask on a
+        // fake key and verify get() returns None.
+        // (No actual std::env mutation; this comment is descriptive only.)
+        assert_eq!(get(KEY), None, "precondition: key not set");
+        mask(KEY);
+        assert_eq!(get(KEY), None, "masked key returns None");
+        // Even if a runtime override existed prior, mask leaves it intact;
+        // verify by setting an override AFTER masking — set() unmasks.
+        set(KEY, "shadow");
+        assert_eq!(
+            get(KEY),
+            Some("shadow".to_string()),
+            "runtime override wins over mask"
+        );
+        // Cleanup
+        remove(KEY);
+        unmask(KEY);
+    }
+
+    #[test]
+    fn test_unmask_restores_process_env_visibility() {
+        // Use a unique synthetic key so we don't race with parallel
+        // tests that read HOME (e.g. db::tests::test_config_dir_with_home,
+        // now that production reads HOME via runtime_env::get).
+        const KEY: &str = "KODA_TEST_UNMASK_RESTORES";
+        // Seed a value via the runtime map so masking has something to hide.
+        set(KEY, "runtime_value");
+        assert_eq!(get(KEY), Some("runtime_value".to_string()));
+        // mask doesn't shadow runtime overrides — to test the fallback path,
+        // remove the runtime override first, then mask, then unmask.
+        remove(KEY);
+        // Now KEY only exists in process env (or doesn't exist at all).
+        // Mask should make get() return None either way.
+        mask(KEY);
+        assert_eq!(get(KEY), None, "masked key returns None");
+        unmask(KEY);
+        // After unmask, get() returns whatever process env says (likely None
+        // for our synthetic key). The contract is "unmask restores fallback
+        // behavior", which we verify by confirming get() now returns the
+        // same value as raw std::env::var.
+        assert_eq!(
+            get(KEY),
+            std::env::var(KEY).ok(),
+            "after unmask, get() falls back to process env"
+        );
+    }
+
+    #[test]
+    fn test_set_implicitly_unmasks() {
+        const KEY: &str = "KODA_TEST_SET_UNMASKS";
+        mask(KEY);
+        assert_eq!(get(KEY), None);
+        set(KEY, "value");
+        assert_eq!(get(KEY), Some("value".to_string()));
+        // Verify the mask was actually cleared, not just shadowed.
+        remove(KEY);
+        assert_eq!(
+            get(KEY),
+            std::env::var(KEY).ok(),
+            "after set+remove, get falls back to process env (mask gone)"
         );
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -1433,7 +1433,7 @@ mod invocation_cleanup_tests {
     use crate::bg_agent::BgAgentRegistry;
     use std::sync::Arc;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_cancels_entries_tagged_with_matching_spawner() {
         let reg = Arc::new(BgAgentRegistry::new());
         // Tag two bg entries with our invocation id. The 4th tuple
@@ -1463,7 +1463,7 @@ mod invocation_cleanup_tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_leaves_entries_with_different_spawner_alone() {
         let reg = Arc::new(BgAgentRegistry::new());
         // Mix: one tagged with our id, one with a sibling's, one with None.
@@ -1493,7 +1493,7 @@ mod invocation_cleanup_tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_with_no_matching_entries_is_noop() {
         let reg = Arc::new(BgAgentRegistry::new());
         let (_id, _tx, _status_tx, cancel) = reg.register_test_with_status("a", "x", Some(99));

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -996,7 +996,7 @@ mod tests {
     /// included a Delete of a file Koda created earlier in the
     /// session — pure perf regression, but the kind of
     /// classification mismatch that compounds.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_can_parallelize_delete_owned_file_uses_tracker() {
         let dir = tempfile::TempDir::new().unwrap();
         let db = crate::db::Database::open(&dir.path().join("test.db"))

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -436,7 +436,7 @@ mod tests {
         assert!(reg.snapshot().is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn insert_records_spawner_and_appears_in_snapshot() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -450,7 +450,7 @@ mod tests {
         assert_eq!(snap[0].spawner, Some(7));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_for_caller_filters_by_spawner() {
         let reg = BgRegistry::new();
         let (p1, c1) = spawn_sleep_child();
@@ -472,7 +472,7 @@ mod tests {
         assert!(reg.snapshot_for_caller(Some(42)).is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reap_transitions_finished_children_to_exited() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_true_child();
@@ -497,7 +497,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn kill_transitions_to_killed_and_returns_true() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -510,7 +510,7 @@ mod tests {
         assert!(!reg.kill(987654));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn kill_as_caller_enforces_spawner_scope() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -529,7 +529,7 @@ mod tests {
         assert_eq!(reg.kill_as_caller(987654, None), CancelOutcome::NotFound);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_exit_returns_exited_when_child_finishes() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_true_child();
@@ -541,7 +541,7 @@ mod tests {
         assert_eq!(outcome, ProcessWaitOutcome::Exited { code: Some(0) });
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_exit_returns_exited_when_already_killed() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(outcome, ProcessWaitOutcome::Exited { code: None });
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_exit_returns_timed_out_with_snapshot() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -578,7 +578,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_exit_enforces_spawner_scope() {
         let reg = BgRegistry::new();
         let (pid, child) = spawn_sleep_child();
@@ -596,7 +596,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_exit_returns_not_found_for_unknown_pid() {
         let reg = BgRegistry::new();
         assert_eq!(
@@ -606,7 +606,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn kill_for_spawner_kills_only_matching_running_children() {
         let reg = BgRegistry::new();
         let (p_top, c_top) = spawn_sleep_child();

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -591,7 +591,7 @@ mod tests {
     }
 
     /// `ListBackgroundTasks` on empty registries returns `[]`, success.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_list_returns_empty_array_when_no_tasks() {
         let (agents, processes) = fresh_registries();
         let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
@@ -601,7 +601,7 @@ mod tests {
 
     /// `ListBackgroundTasks` shows the caller's agent tasks with the
     /// agreed-upon shape (prefixed task_id, lower-case status).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_list_includes_caller_agent_tasks() {
         let (agents, processes) = fresh_registries();
         let (id, _tx, _, _) = agents.register_test_with_status("explore", "map repo", None);
@@ -620,7 +620,7 @@ mod tests {
     /// Caller scoping: a sub-agent caller (Some(7)) must not see the
     /// top-level (None) task. Defence-in-depth on top of the
     /// sub_agent_dispatch denylist.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_list_filters_out_other_callers_tasks() {
         let (agents, processes) = fresh_registries();
         agents.register_test_with_status("a", "top", None);
@@ -637,7 +637,7 @@ mod tests {
 
     /// `CancelTask` routes `agent:N` to BgAgentRegistry and reports
     /// success in the structured payload.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_succeeds_for_owned_agent_task() {
         let (agents, processes) = fresh_registries();
         let (id, _tx, _, observer) = agents.register_test_with_status("x", "y", None);
@@ -657,7 +657,7 @@ mod tests {
         assert_eq!(payload["task_id"], format!("agent:{id}"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_returns_not_found_for_unknown_id() {
         let (agents, processes) = fresh_registries();
         let r = execute(
@@ -672,7 +672,7 @@ mod tests {
         assert!(r.output.contains("no background task"), "got: {}", r.output);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_returns_forbidden_for_cross_caller() {
         let (agents, processes) = fresh_registries();
         let (id, _tx, _, observer) = agents.register_test_with_status("x", "y", Some(5));
@@ -695,7 +695,7 @@ mod tests {
         assert!(!observer.is_cancelled(), "forbidden must NOT fire token");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_rejects_malformed_json() {
         let (agents, processes) = fresh_registries();
         let r = execute("CancelTask", "not-json", &agents, &processes, None).await;
@@ -703,7 +703,7 @@ mod tests {
         assert!(r.output.contains("invalid JSON"), "got: {}", r.output);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_rejects_missing_task_id() {
         let (agents, processes) = fresh_registries();
         let r = execute("CancelTask", "{}", &agents, &processes, None).await;
@@ -713,7 +713,7 @@ mod tests {
 
     /// `WaitTask` on a completed agent task returns `status:completed`
     /// + the agent's output, and consumes the entry (drain sees nothing).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_wait_returns_completed_for_finished_agent() {
         let (agents, processes) = fresh_registries();
         let (id, tx, status_tx, _) = agents.register_test_with_status("explore", "map", None);
@@ -744,7 +744,7 @@ mod tests {
 
     /// `WaitTask` timeout returns `status:timed_out` + a snapshot of
     /// the still-running task.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_wait_returns_timed_out_with_snapshot() {
         let (agents, processes) = fresh_registries();
         // Bind ALL four to keep the channels alive — if status_tx
@@ -777,7 +777,7 @@ mod tests {
     /// The three terminal states are `completed`, `timed_out`, and
     /// `cancelled`. The first two have existing tests; this is the
     /// third path — the one that was missing (#1048).
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_wait_returns_cancelled_when_token_fires() {
         let (agents, processes) = fresh_registries();
         let (id, tx, status_tx, observer) = agents.register_test_with_status("slow", "x", None);
@@ -811,7 +811,7 @@ mod tests {
         assert_eq!(agents.snapshot().len(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_unknown_tool_name_returns_error() {
         let (agents, processes) = fresh_registries();
         let r = execute("NotAToolWeKnow", "{}", &agents, &processes, None).await;

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -1295,7 +1295,7 @@ mod tests {
         (registry, dir, db, sid)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn todo_write_emits_todo_update_event_on_first_write() {
         let (registry, _dir, _db, _sid) = registry_with_session().await;
         let sink = crate::engine::sink::TestSink::new();
@@ -1321,7 +1321,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn todo_write_suppresses_event_on_unchanged_rewrite() {
         let (registry, _dir, _db, _sid) = registry_with_session().await;
         let payload = r#"{"todos":[{"content":"A","status":"pending","priority":"high"}]}"#;
@@ -1352,7 +1352,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn todo_write_returns_model_message_even_without_sink() {
         // Production paths sometimes call `execute` with `None` for
         // the sink (top-level tool runs that aren't streaming). Must
@@ -1370,7 +1370,7 @@ mod tests {
         assert!(result.output.contains("0/1 done"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn todo_write_rejects_two_in_progress_at_dispatch() {
         // Engine-enforced single-in-progress: must surface as a
         // failed ToolResult, not a successful one with a warning.

--- a/koda-core/src/tools/validate.rs
+++ b/koda-core/src/tools/validate.rs
@@ -465,7 +465,7 @@ mod tests {
 
     // ── Edit validation ───────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_valid_replacement() {
         let dir = setup();
         let args = json!({
@@ -479,7 +479,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_missing_path() {
         let dir = setup();
         let args = json!({"replacements": [{"old_str": "x", "new_str": "y"}]});
@@ -489,7 +489,7 @@ mod tests {
         assert!(err.contains("path"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_file_not_found() {
         let dir = setup();
         let args = json!({
@@ -503,7 +503,7 @@ mod tests {
         assert!(err.contains("Write"), "{err}"); // suggests Write
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_empty_replacements() {
         let dir = setup();
         let args = json!({"path": "hello.txt", "replacements": []});
@@ -513,7 +513,7 @@ mod tests {
         assert!(err.contains("empty"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_empty_old_str() {
         let dir = setup();
         let args = json!({
@@ -526,7 +526,7 @@ mod tests {
         assert!(err.contains("empty"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_old_str_fuzzy_match_passes_validation() {
         // File has trailing spaces; model sends clean needle — should pass pre-flight.
         let dir = TempDir::new().unwrap();
@@ -547,7 +547,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_old_str_not_found() {
         let dir = setup();
         let args = json!({
@@ -560,7 +560,7 @@ mod tests {
         assert!(err.contains("not found"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_missing_new_str() {
         let dir = setup();
         let args = json!({
@@ -575,14 +575,14 @@ mod tests {
 
     // ── Write validation ──────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_new_file_valid() {
         let dir = setup();
         let args = json!({"path": "brand_new.txt", "content": "hello"});
         assert!(validate_write(&args, dir.path()).await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_existing_without_overwrite() {
         let dir = setup();
         let args = json!({"path": "hello.txt", "content": "replaced"});
@@ -591,14 +591,14 @@ mod tests {
         assert!(err.contains("overwrite=true"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_existing_with_overwrite() {
         let dir = setup();
         let args = json!({"path": "hello.txt", "content": "replaced", "overwrite": true});
         assert!(validate_write(&args, dir.path()).await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_missing_content() {
         let dir = setup();
         let args = json!({"path": "foo.txt"});
@@ -608,14 +608,14 @@ mod tests {
 
     // ── Delete validation ─────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn delete_valid_file() {
         let dir = setup();
         let args = json!({"path": "hello.txt"});
         assert!(validate_delete(&args, dir.path()).await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn delete_not_found() {
         let dir = setup();
         let args = json!({"path": "nope.txt"});
@@ -623,7 +623,7 @@ mod tests {
         assert!(err.contains("not found"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn delete_nonempty_dir_without_recursive() {
         let dir = setup();
         let args = json!({"path": "subdir"});
@@ -631,7 +631,7 @@ mod tests {
         assert!(err.contains("recursive"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn delete_nonempty_dir_with_recursive() {
         let dir = setup();
         let args = json!({"path": "subdir", "recursive": true});
@@ -640,7 +640,7 @@ mod tests {
 
     // ── file_path alias acceptance ──────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_accepts_file_path_param() {
         let dir = setup();
         let args = json!({
@@ -654,14 +654,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_accepts_file_path_param() {
         let dir = setup();
         let args = json!({"file_path": "brand_new.txt", "content": "hello"});
         assert!(validate_write(&args, dir.path()).await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn delete_accepts_file_path_param() {
         let dir = setup();
         let args = json!({"file_path": "hello.txt"});
@@ -703,7 +703,7 @@ mod tests {
         cache
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_stale_file_detected() {
         let dir = setup();
         let file = dir.path().join("hello.txt");
@@ -720,7 +720,7 @@ mod tests {
         assert!(err.contains("Read it again"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_fresh_file_no_stale_warning() {
         let dir = setup();
         let file = dir.path().join("hello.txt");
@@ -739,7 +739,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_no_cache_entry_no_stale_warning() {
         // File was never read via Read tool — empty cache, no stale warning.
         let dir = setup();
@@ -758,7 +758,7 @@ mod tests {
 
     // ── Staleness hint messages (#804 item 7) ─────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn stale_file_hints_last_writer_tool() {
         let dir = setup();
         let file = dir.path().join("hello.txt");
@@ -782,7 +782,7 @@ mod tests {
         assert!(err.contains("last written by Edit"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn stale_file_hints_bash_when_no_writer_entry() {
         let dir = setup();
         let file = dir.path().join("hello.txt");
@@ -900,7 +900,7 @@ mod tests {
         assert!(err.contains("actual code"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_rejects_omission_in_new_str() {
         let dir = setup();
         let args = json!({
@@ -916,7 +916,7 @@ mod tests {
         assert!(err.contains("omission placeholder"), "{err}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_allows_normal_new_str() {
         let dir = setup();
         let args = json!({

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -914,7 +914,7 @@ mod tests {
 
     // ── File lifecycle (#465) tests ──
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_delete_owned_file_auto_approved() {
         let dir = tempfile::TempDir::new().unwrap();
         let db = crate::db::Database::open(&dir.path().join("test.db"))
@@ -933,7 +933,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_delete_unowned_file_needs_confirmation_in_safe() {
         let dir = tempfile::TempDir::new().unwrap();
         let db = crate::db::Database::open(&dir.path().join("test.db"))
@@ -950,7 +950,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_delete_owned_file_safe_mode_auto_approved() {
         let dir = tempfile::TempDir::new().unwrap();
         let db = crate::db::Database::open(&dir.path().join("test.db"))

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -18,13 +18,32 @@ use koda_core::{
 };
 use koda_test_utils::{ChatMessage, LlmProvider, TestSink, ToolDefinition};
 use std::path::PathBuf;
+use std::sync::Mutex;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 
-/// A mock provider that sleeps forever in `chat_stream`, simulating
-/// a model that never returns (or takes very long to start streaming).
-struct SlowProvider;
+/// A mock provider that signals when `chat_stream` is entered, then
+/// sleeps forever — simulating a model that hangs on the initial
+/// HTTP request. The signal lets tests cancel deterministically as
+/// soon as inference reaches the provider, rather than guessing a
+/// wall-clock delay (#1109 F3).
+struct SlowProvider {
+    /// Fired exactly once when `chat_stream` is first invoked.
+    entered: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl SlowProvider {
+    fn new() -> (Self, oneshot::Receiver<()>) {
+        let (tx, rx) = oneshot::channel();
+        (
+            Self {
+                entered: Mutex::new(Some(tx)),
+            },
+            rx,
+        )
+    }
+}
 
 #[async_trait]
 impl LlmProvider for SlowProvider {
@@ -43,7 +62,13 @@ impl LlmProvider for SlowProvider {
         _tools: &[ToolDefinition],
         _settings: &koda_core::config::ModelSettings,
     ) -> Result<koda_core::providers::stream_collector::SseCollector> {
-        // Simulate a model that hangs on the initial HTTP request
+        // Notify the test that we've reached the provider — the earliest
+        // meaningful cancellation point. Tests subscribe to this signal
+        // instead of guessing a wall-clock delay.
+        if let Some(tx) = self.entered.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+        // Simulate a model that hangs on the initial HTTP request.
         tokio::time::sleep(Duration::from_secs(60)).await;
         unreachable!("should be cancelled before this returns")
     }
@@ -69,7 +94,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         .unwrap();
 
     let config = KodaConfig::default_for_testing(ProviderType::LMStudio);
-    let provider = SlowProvider;
+    let (provider, entered_rx) = SlowProvider::new();
     let tools = ToolRegistry::new(PathBuf::from("."), 100_000);
     let tool_defs: Vec<ToolDefinition> = vec![];
     let sink = TestSink::new();
@@ -77,10 +102,12 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     let mut file_tracker = koda_core::file_tracker::FileTracker::new(&session_id, db.clone()).await;
 
-    // Cancel after 100ms — well before SlowProvider's 60s sleep
+    // **#1109 F3**: was `sleep(100ms).await` to give inference time to
+    // start. Replaced with a oneshot signal so cancel fires the moment
+    // inference reaches the provider — deterministic, immune to slow CI.
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = entered_rx.await;
         cancel_clone.cancel();
     });
 

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -57,7 +57,7 @@ impl LlmProvider for SlowProvider {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cancel_during_chat_stream_returns_immediately() {
     let tmp = tempfile::tempdir().unwrap();
     let db = Database::init(tmp.path()).await.unwrap();

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -455,22 +455,30 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         MockResponse::Text("parent done".into()),
     ]);
 
-    // **#1109 macOS-fix**: poll `bg_agents.drain_status_events()`
-    // directly instead of relying on the parent's inference_loop to
-    // forward events to the test sink. Background agents enqueue
-    // `BgTaskUpdate` events on the registry; the parent's loop drains
-    // them at the top of each iteration. After `run_inference`
-    // returns, *no one* drains them — so subscribing to the sink
-    // misses every bg event that fires after parent completes. Going
-    // straight to the registry queue is race-free: events are pushed
-    // there as soon as the bg task emits them. The polling here is
-    // bounded by a 10s budget; on a healthy machine it returns in a
-    // few ms. See PR #1113 diagnostic for the full story.
+    // **#1109 macOS-fix**: BgTaskUpdate events live in TWO places
+    // depending on timing:
+    //
+    //   * If the bg task completed BEFORE `run_inference` returned
+    //     (typical on macOS CI), the parent's `inference_loop` already
+    //     drained the events into the test sink — they're in the
+    //     returned `events` vec, and the registry's queue is empty.
+    //
+    //   * If the bg task completed AFTER `run_inference` returned
+    //     (typical on slower local machines), the parent never got
+    //     a chance to drain them, and they're sitting in the registry
+    //     queue waiting for `drain_status_events()`.
+    //
+    // We collect from BOTH sources to be race-free in either timing
+    // regime. See PR #1113 diagnostic for the full story.
     use koda_core::engine::EngineEvent;
-    let _ = env.run_inference(&provider).await;
+    let events_from_sink = env.run_inference(&provider).await;
+
+    let mut bg_events: Vec<EngineEvent> = events_from_sink
+        .into_iter()
+        .filter(|ev| matches!(ev, EngineEvent::BgTaskUpdate { .. }))
+        .collect();
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let mut bg_events: Vec<EngineEvent> = Vec::new();
     let saw_terminal = loop {
         for ev in env.bg_agents.drain_status_events() {
             bg_events.push(ev);

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -455,66 +455,97 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         MockResponse::Text("parent done".into()),
     ]);
 
-    let events = env.run_inference(&provider).await;
+    // **#1109 macOS-fix**: poll `bg_agents.drain_status_events()`
+    // directly instead of relying on the parent's inference_loop to
+    // forward events to the test sink. Background agents enqueue
+    // `BgTaskUpdate` events on the registry; the parent's loop drains
+    // them at the top of each iteration. After `run_inference`
+    // returns, *no one* drains them — so subscribing to the sink
+    // misses every bg event that fires after parent completes. Going
+    // straight to the registry queue is race-free: events are pushed
+    // there as soon as the bg task emits them. The polling here is
+    // bounded by a 10s budget; on a healthy machine it returns in a
+    // few ms. See PR #1113 diagnostic for the full story.
+    use koda_core::engine::EngineEvent;
+    let _ = env.run_inference(&provider).await;
 
-    // Diagnostic: the dispatch path between `reserve()` and `attach()`
-    // is fully synchronous (no `.await` points), so the entry MUST be
-    // in the registry by the time inference returns.  If we ever fail
-    // the snapshot poll below, dump the events vector — it will tell
-    // us whether `InvokeAgent` even dispatched, whether the background
-    // branch was taken, and whether the parent reached "parent done".
-    let task_id = {
-        const REGISTRATION_BUDGET: Duration = Duration::from_secs(5);
-        let deadline = tokio::time::Instant::now() + REGISTRATION_BUDGET;
-        loop {
-            let snap = env.bg_agents.snapshot();
-            if let Some(task) = snap.first() {
-                break task.task_id;
-            }
-            if tokio::time::Instant::now() >= deadline {
-                panic!(
-                    "background agent was never registered in the registry within {REGISTRATION_BUDGET:?}.\n\
-                     events from inference_loop ({} total): {events:#?}\n\
-                     final snapshot: {:#?}",
-                    events.len(),
-                    env.bg_agents.snapshot()
-                );
-            }
-            tokio::time::sleep(Duration::from_millis(5)).await;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut bg_events: Vec<EngineEvent> = Vec::new();
+    let saw_terminal = loop {
+        for ev in env.bg_agents.drain_status_events() {
+            bg_events.push(ev);
         }
+        let terminal = bg_events.iter().any(|ev| {
+            matches!(
+                ev,
+                EngineEvent::BgTaskUpdate {
+                    status: AgentStatus::Completed { .. }
+                        | AgentStatus::Errored { .. }
+                        | AgentStatus::Cancelled,
+                    ..
+                }
+            )
+        });
+        if terminal {
+            break true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break false;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
     };
+    assert!(
+        saw_terminal,
+        "bg task never reached a terminal state within 10s.\nbg_events ({} total): {bg_events:#?}",
+        bg_events.len()
+    );
 
-    // Subscribe gives us the last-sent status value plus change
-    // notifications going forward.
-    let mut rx = env
-        .bg_agents
-        .subscribe(task_id)
-        .expect("task_id must be in registry: snapshot confirmed it above");
+    let bg_updates: Vec<&AgentStatus> = bg_events
+        .iter()
+        .filter_map(|ev| match ev {
+            EngineEvent::BgTaskUpdate { status, .. } => Some(status),
+            _ => None,
+        })
+        .collect();
 
-    // Drive the receiver to a terminal state.
-    // `Completed` proves the loop ran ≥ 1 full iteration (QA-001 core).
-    let final_status = loop {
-        let status = rx.borrow_and_update().clone();
-        if matches!(
-            status,
-            AgentStatus::Completed { .. } | AgentStatus::Errored { .. } | AgentStatus::Cancelled
-        ) {
-            break status;
-        }
+    assert!(
+        !bg_updates.is_empty(),
+        "expected at least one BgTaskUpdate event; bg_events ({} total): {bg_events:#?}",
+        bg_events.len()
+    );
 
-        match tokio::time::timeout(Duration::from_secs(10), rx.changed()).await {
-            Ok(Ok(())) => continue, // new value available; loop to inspect it
-            Ok(Err(_closed)) => {
-                // Sender dropped — final value is buffered; pick it up.
-                break rx.borrow().clone();
-            }
-            Err(_elapsed) => {
-                panic!("bg agent did not reach a terminal state within 10s");
-            }
-        }
-    };
+    // QA-001 core: the loop ran ≥ 1 full iteration. The engine emits
+    // Running {{ iter }} at the TOP of each iteration, so iter ≥ 1
+    // proves the loop body completed at least once.
+    let max_iter_seen = bg_updates
+        .iter()
+        .filter_map(|s| match s {
+            AgentStatus::Running { iter } => Some(*iter),
+            _ => None,
+        })
+        .max();
+    assert!(
+        matches!(max_iter_seen, Some(n) if n >= 1),
+        "expected Running {{ iter >= 1 }}; saw max iter = {max_iter_seen:?}.\nbg_events: {bg_events:#?}"
+    );
 
-    match &final_status {
+    let final_status = bg_updates
+        .iter()
+        .rev()
+        .find(|s| {
+            matches!(
+                s,
+                AgentStatus::Completed { .. }
+                    | AgentStatus::Errored { .. }
+                    | AgentStatus::Cancelled
+            )
+        })
+        .copied()
+        .unwrap_or_else(|| {
+            panic!("bg task never reached a terminal state.\nbg_updates: {bg_updates:#?}")
+        });
+
+    match final_status {
         AgentStatus::Completed { summary } => {
             assert!(
                 !summary.is_empty(),
@@ -524,7 +555,7 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         }
         AgentStatus::Errored { error } => panic!("bg agent errored: {error}"),
         AgentStatus::Cancelled => panic!("bg agent was unexpectedly cancelled"),
-        _ => unreachable!("loop only breaks on terminal states"),
+        _ => unreachable!("filter above only keeps terminal states"),
     }
     // Removed only after the bg task has finished reading it.
     runtime_env::remove("KODA_MOCK_RESPONSES");

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -455,58 +455,24 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         MockResponse::Text("parent done".into()),
     ]);
 
-    // **#1109 macOS-fix**: BgTaskUpdate events live in TWO places
-    // depending on timing:
-    //
-    //   * If the bg task completed BEFORE `run_inference` returned
-    //     (typical on macOS CI), the parent's `inference_loop` already
-    //     drained the events into the test sink — they're in the
-    //     returned `events` vec, and the registry's queue is empty.
-    //
-    //   * If the bg task completed AFTER `run_inference` returned
-    //     (typical on slower local machines), the parent never got
-    //     a chance to drain them, and they're sitting in the registry
-    //     queue waiting for `drain_status_events()`.
-    //
-    // We collect from BOTH sources to be race-free in either timing
-    // regime. See PR #1113 diagnostic for the full story.
+    // Use the `collect_bg_events_after` helper from koda-test-utils
+    // — it merges the events vec from `run_inference` (what the
+    // parent's inference_loop drained into the sink) with the
+    // registry's `drain_status_events()` queue (whatever was emitted
+    // after parent finished). See the helper's docs for the full
+    // race-condition rationale (#1109, PR #1113).
     use koda_core::engine::EngineEvent;
     let events_from_sink = env.run_inference(&provider).await;
-
-    let mut bg_events: Vec<EngineEvent> = events_from_sink
-        .into_iter()
-        .filter(|ev| matches!(ev, EngineEvent::BgTaskUpdate { .. }))
-        .collect();
-
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-    let saw_terminal = loop {
-        for ev in env.bg_agents.drain_status_events() {
-            bg_events.push(ev);
-        }
-        let terminal = bg_events.iter().any(|ev| {
-            matches!(
-                ev,
-                EngineEvent::BgTaskUpdate {
-                    status: AgentStatus::Completed { .. }
-                        | AgentStatus::Errored { .. }
-                        | AgentStatus::Cancelled,
-                    ..
-                }
+    let bg_events = env
+        .collect_bg_events_after(events_from_sink, Duration::from_secs(10))
+        .await
+        .unwrap_or_else(|partial| {
+            panic!(
+                "bg task never reached a terminal state within 10s.\n\
+                 bg_events ({} total): {partial:#?}",
+                partial.len()
             )
         });
-        if terminal {
-            break true;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            break false;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    };
-    assert!(
-        saw_terminal,
-        "bg task never reached a terminal state within 10s.\nbg_events ({} total): {bg_events:#?}",
-        bg_events.len()
-    );
 
     let bg_updates: Vec<&AgentStatus> = bg_events
         .iter()

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -1,6 +1,6 @@
 //! E2E tests: sub-agent invocation and caching.
 
-use koda_core::{bg_agent::AgentStatus, engine::EngineEvent, persistence::Persistence};
+use koda_core::{bg_agent::AgentStatus, engine::EngineEvent, persistence::Persistence, runtime_env};
 use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
 use std::time::Duration;
 
@@ -23,14 +23,7 @@ async fn test_sub_agent_invocation_e2e() {
         .to_string(),
     )
     .unwrap();
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var(
-            "KODA_MOCK_RESPONSES",
-            r#"[{"text": "Echo: review the auth module"}]"#,
-        );
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "Echo: review the auth module"}]"#);
 
     env.insert_user_message("delegate to echo-agent").await;
 
@@ -45,11 +38,7 @@ async fn test_sub_agent_invocation_e2e() {
         MockResponse::Text("Sub-agent says: Echo: review the auth module".into()),
     ]);
     let events = env.run_inference(&provider).await;
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::remove_var("KODA_MOCK_RESPONSES");
-    }
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     assert!(
         events.iter().any(
@@ -138,16 +127,10 @@ async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
     // the sub-agent would reload a context missing the assistant
     // tool-call turn and re-issue the same call — burning the
     // second response on another tool call instead of the text.
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var(
-            "KODA_MOCK_RESPONSES",
-            r#"[
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[
                 {"tool_calls": [{"id": "tc_1", "name": "ListSkills", "arguments": "{}"}]},
                 {"text": "sub-agent done"}
-            ]"#,
-        );
-    }
+            ]"#);
 
     env.insert_user_message("delegate").await;
 
@@ -162,11 +145,7 @@ async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
         MockResponse::Text("parent done".into()),
     ]);
     let _events = env.run_inference(&provider).await;
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::remove_var("KODA_MOCK_RESPONSES");
-    }
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     // Find the sub-agent's session. `list_sessions` returns newest-first,
     // so the loop-test-agent session is at the top (created after the
@@ -234,11 +213,7 @@ async fn test_sub_agent_cache_hit_skips_llm() {
         .to_string(),
     )
     .unwrap();
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "cached result"}]"#);
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "cached result"}]"#);
     env.insert_user_message("call the agent twice").await;
 
     let provider = MockProvider::new(vec![
@@ -253,10 +228,7 @@ async fn test_sub_agent_cache_hit_skips_llm() {
         MockResponse::Text("Done with both calls.".into()),
     ]);
     let events = env.run_inference(&provider).await;
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::remove_var("KODA_MOCK_RESPONSES");
-    }
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     let cache_hit = events
         .iter()
@@ -323,13 +295,9 @@ async fn skip_memory_excludes_project_memory_from_sub_agent() {
     // Write a distinctive sentinel to the project memory file.
     std::fs::write(env.root.join("MEMORY.md"), "SENTINEL_XYZ").unwrap();
     write_agent_config(&env, "lean-agent", /* skip_memory */ true);
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
     let calls = invoke_agent_and_take_calls(&env, "lean-agent").await;
-    unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     assert!(
         !calls.is_empty(),
@@ -355,13 +323,9 @@ async fn without_skip_memory_project_memory_reaches_sub_agent() {
     // Same sentinel — but this agent does NOT skip memory.
     std::fs::write(env.root.join("MEMORY.md"), "SENTINEL_XYZ").unwrap();
     write_agent_config(&env, "full-agent", /* skip_memory */ false);
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "sub done"}]"#);
     let calls = invoke_agent_and_take_calls(&env, "full-agent").await;
-    unsafe { std::env::remove_var("KODA_MOCK_RESPONSES") };
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     assert!(
         !calls.is_empty(),
@@ -402,13 +366,7 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
     // call `InvokeAgent` (which should be refused), then emits its
     // final text. The refusal must not abort the sub-agent.
     //
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var(
-            "KODA_MOCK_RESPONSES",
-            r#"[{"tool": "InvokeAgent", "args": {"agent_name": "would-recurse", "prompt": "recurse"}}, {"text": "final after refusal"}]"#,
-        );
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"tool": "InvokeAgent", "args": {"agent_name": "would-recurse", "prompt": "recurse"}}, {"text": "final after refusal"}]"#);
 
     env.insert_user_message("delegate").await;
     let provider = MockProvider::new(vec![
@@ -419,11 +377,7 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
         MockResponse::Text("parent done".into()),
     ]);
     let _events = env.run_inference(&provider).await;
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::remove_var("KODA_MOCK_RESPONSES");
-    }
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 
     // The sub-agent's final text reached the parent — i.e. the refusal
     // did not abort the sub-agent loop, and the parent received a
@@ -470,13 +424,7 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
     write_agent_config(&env, "bg-counter-agent", /* skip_memory */ true);
 
     // Give the background agent's mock provider a single text response.
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
-    unsafe {
-        std::env::set_var(
-            "KODA_MOCK_RESPONSES",
-            r#"[{"text": "background work done"}]"#,
-        );
-    }
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "background work done"}]"#);
 
     env.insert_user_message("launch background agent").await;
 
@@ -564,10 +512,6 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
         AgentStatus::Cancelled => panic!("bg agent was unexpectedly cancelled"),
         _ => unreachable!("loop only breaks on terminal states"),
     }
-
-    // SAFETY: ENV_MUTEX serializes all tests that touch this env var.
     // Removed only after the bg task has finished reading it.
-    unsafe {
-        std::env::remove_var("KODA_MOCK_RESPONSES");
-    }
+    runtime_env::remove("KODA_MOCK_RESPONSES");
 }

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -1,6 +1,8 @@
 //! E2E tests: sub-agent invocation and caching.
 
-use koda_core::{bg_agent::AgentStatus, engine::EngineEvent, persistence::Persistence, runtime_env};
+use koda_core::{
+    bg_agent::AgentStatus, engine::EngineEvent, persistence::Persistence, runtime_env,
+};
 use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
 use std::time::Duration;
 
@@ -23,7 +25,10 @@ async fn test_sub_agent_invocation_e2e() {
         .to_string(),
     )
     .unwrap();
-    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "Echo: review the auth module"}]"#);
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[{"text": "Echo: review the auth module"}]"#,
+    );
 
     env.insert_user_message("delegate to echo-agent").await;
 
@@ -127,10 +132,13 @@ async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
     // the sub-agent would reload a context missing the assistant
     // tool-call turn and re-issue the same call — burning the
     // second response on another tool call instead of the text.
-    runtime_env::set("KODA_MOCK_RESPONSES", r#"[
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[
                 {"tool_calls": [{"id": "tc_1", "name": "ListSkills", "arguments": "{}"}]},
                 {"text": "sub-agent done"}
-            ]"#);
+            ]"#,
+    );
 
     env.insert_user_message("delegate").await;
 
@@ -366,7 +374,10 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
     // call `InvokeAgent` (which should be refused), then emits its
     // final text. The refusal must not abort the sub-agent.
     //
-    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"tool": "InvokeAgent", "args": {"agent_name": "would-recurse", "prompt": "recurse"}}, {"text": "final after refusal"}]"#);
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[{"tool": "InvokeAgent", "args": {"agent_name": "would-recurse", "prompt": "recurse"}}, {"text": "final after refusal"}]"#,
+    );
 
     env.insert_user_message("delegate").await;
     let provider = MockProvider::new(vec![
@@ -424,7 +435,10 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
     write_agent_config(&env, "bg-counter-agent", /* skip_memory */ true);
 
     // Give the background agent's mock provider a single text response.
-    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "background work done"}]"#);
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[{"text": "background work done"}]"#,
+    );
 
     env.insert_user_message("launch background agent").await;
 

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -4,7 +4,7 @@ use koda_core::{bg_agent::AgentStatus, engine::EngineEvent, persistence::Persist
 use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
 use std::time::Duration;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sub_agent_invocation_e2e() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -103,7 +103,7 @@ async fn test_sub_agent_invocation_e2e() {
 /// on repeated tool calls and never reach the text reply — OR the DB
 /// will end up with assistant rows where `completed_at IS NULL`.
 /// Either failure is asserted below.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -194,7 +194,7 @@ async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_sub_agent_cache_hit_skips_llm() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -287,7 +287,7 @@ async fn invoke_agent_and_take_calls(
 }
 
 #[cfg(feature = "test-support")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn skip_memory_excludes_project_memory_from_sub_agent() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -315,7 +315,7 @@ async fn skip_memory_excludes_project_memory_from_sub_agent() {
 }
 
 #[cfg(feature = "test-support")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn without_skip_memory_project_memory_reaches_sub_agent() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -355,7 +355,7 @@ async fn without_skip_memory_project_memory_reaches_sub_agent() {
 /// `"InvokeAgent is handled by the inference loop."` — and for the
 /// stack-overflow risk that allowing real recursion would have created.
 #[cfg(feature = "test-support")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
     let _lock = ENV_MUTEX.lock().await;
     let env = Env::new().await;
@@ -404,7 +404,7 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
 //
 // **Runtime flavor**: the production code path uses `tokio::spawn` for
 // background sub-agents (see `sub_agent_dispatch::run_bg_agent` and the
-// B5 comment block). On `current_thread` runtimes (the `#[tokio::test]`
+// B5 comment block). On `current_thread` runtimes (the `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`
 // default) `tokio::spawn` queues the future but it can ONLY make
 // progress when the test task explicitly yields. The dispatch path
 // itself is fully synchronous between `reserve()` and `attach()`, but

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -225,7 +225,9 @@ async fn test_cancel_during_streaming() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
 
-    struct HangingProvider;
+    struct HangingProvider {
+        entered: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
 
     #[async_trait]
     impl LlmProvider for HangingProvider {
@@ -243,6 +245,11 @@ async fn test_cancel_during_streaming() {
             _: &[ToolDefinition],
             _: &ModelSettings,
         ) -> Result<koda_core::providers::stream_collector::SseCollector> {
+            // **#1109 F3**: signal entry so the test cancels deterministically
+            // instead of guessing a wall-clock delay.
+            if let Some(tx) = self.entered.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
             unreachable!()
         }
@@ -254,6 +261,11 @@ async fn test_cancel_during_streaming() {
         }
     }
 
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let provider = HangingProvider {
+        entered: std::sync::Mutex::new(Some(entered_tx)),
+    };
+
     let sink = koda_core::engine::sink::TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     let tool_defs = env.tool_defs();
@@ -261,9 +273,10 @@ async fn test_cancel_during_streaming() {
     let mut file_tracker =
         koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
 
+    // **#1109 F3**: was `sleep(100ms).await` — replaced with oneshot wait.
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let _ = entered_rx.await;
         cancel_clone.cancel();
     });
 
@@ -274,7 +287,7 @@ async fn test_cancel_during_streaming() {
         db: &env.db,
         session_id: &env.session_id,
         system_prompt: "You are a test assistant.",
-        provider: &HangingProvider,
+        provider: &provider,
         tools: &env.tools,
         tool_defs: &tool_defs,
         pending_images: None,

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -19,7 +19,7 @@ use tokio_util::sync::CancellationToken;
 
 // ── Core pipeline tests ───────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_text_response_streams_and_persists() {
     let env = Env::new().await;
     env.insert_user_message("say hello").await;
@@ -48,7 +48,7 @@ async fn test_text_response_streams_and_persists() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_tool_call_executes_and_returns() {
     let env = Env::new().await;
     env.insert_user_message("run echo").await;
@@ -87,7 +87,7 @@ async fn test_tool_call_executes_and_returns() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_tool_in_sandbox() {
     let env = Env::new().await;
     let test_file = env.root.join("test_data.txt");
@@ -122,7 +122,7 @@ async fn test_read_tool_in_sandbox() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_write_tool_creates_file_in_sandbox() {
     let env = Env::new().await;
     env.insert_user_message("create a file").await;
@@ -145,7 +145,7 @@ async fn test_write_tool_creates_file_in_sandbox() {
     assert_eq!(content, "hello from mock");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_provider_error_emits_error_event() {
     let env = Env::new().await;
     env.insert_user_message("trigger error").await;
@@ -197,7 +197,7 @@ async fn test_provider_error_emits_error_event() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_session_history_persists_across_turns() {
     let env = Env::new().await;
 
@@ -220,7 +220,7 @@ async fn test_session_history_persists_across_turns() {
     assert!(contents.iter().any(|c| c.contains("second answer")));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_cancel_during_streaming() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;

--- a/koda-core/tests/http_client_config_test.rs
+++ b/koda-core/tests/http_client_config_test.rs
@@ -154,7 +154,6 @@ async fn http_proxy_routes_remote_requests_through_proxy() {
 
     let proxied = proxy.received_requests().await;
     assert_eq!(proxied.len(), 1, "request must be routed through the proxy");
-
 }
 
 #[tokio::test]
@@ -188,7 +187,6 @@ async fn localhost_traffic_bypasses_proxy_even_when_set() {
         1,
         "upstream must receive the request directly"
     );
-
 }
 
 #[tokio::test]
@@ -219,7 +217,6 @@ async fn proxy_basic_auth_from_env_vars_attaches_proxy_authorization_header() {
         .expect("Proxy-Authorization header must be set when PROXY_USER/PROXY_PASS are present");
     // Basic alice:s3cret = YWxpY2U6czNjcmV0
     assert_eq!(auth, "Basic YWxpY2U6czNjcmV0");
-
 }
 
 #[tokio::test]
@@ -247,7 +244,6 @@ async fn invalid_proxy_url_degrades_gracefully_to_no_proxy() {
         1,
         "malformed proxy URL must not block legitimate localhost traffic"
     );
-
 }
 
 #[tokio::test]
@@ -291,5 +287,4 @@ async fn read_timeout_aborts_silent_servers_quickly() {
         msg.contains("timeout") || msg.contains("timed out") || msg.contains("operation"),
         "error should mention timeout, got: {msg}"
     );
-
 }

--- a/koda-core/tests/http_client_config_test.rs
+++ b/koda-core/tests/http_client_config_test.rs
@@ -9,13 +9,21 @@
 //! (the reqwest proxy machinery only kicks in on actual `.send()`).
 //! That makes them integration tests, not unit tests.
 //!
-//! ## Test isolation
+//! ## Test isolation (#1109 F1)
 //!
 //! All tests in this file mutate process-wide state in
 //! [`koda_core::runtime_env`] (the runtime env-var map).
 //! [`koda_test_utils::ENV_MUTEX`] serializes them so concurrent test
 //! runners don't trample each other, and [`EnvGuard`] (defined below)
-//! removes any keys this test set when it returns — even on panic.
+//! removes any keys this test set/masked when it returns — even on panic.
+//!
+//! Previously this file used `unsafe { std::env::remove_var(...) }` to
+//! hide a developer's exported `HTTP_PROXY` from the production code
+//! path (which falls back to `std::env::var` when the runtime map has
+//! no entry). That `unsafe` is gone now: [`runtime_env::mask`] makes
+//! [`runtime_env::get`] return `None` for masked keys regardless of
+//! the real process env. No `std::env` mutation, no UB, no snapshot
+//! restore dance.
 //!
 //! Related: #914 covers the missing retry/backoff/timeout layer; once
 //! that lands, retry-on-429 and timeout-on-stall tests can use the
@@ -30,67 +38,66 @@ use koda_test_utils::ENV_MUTEX;
 use koda_test_utils::network::FakeLlmServer;
 use serde_json::{Value, json};
 
-// ── Helpers ───────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────
 
-/// Drops registered runtime-env keys when scope ends. Survives test panics
-/// thanks to RAII, so a failing test cannot leak env state into siblings.
+/// Proxy-related env keys that production reads. Tests need to hide
+/// the developer's real values so the runtime override is what gets
+/// observed.
+const PROXY_ENV_KEYS: &[&str] = &[
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "PROXY_USER",
+    "PROXY_PASS",
+];
+
+/// RAII guard for runtime-env state. Tracks both `set` and `mask`
+/// operations so they're undone on drop — surviving panics so a
+/// failing test cannot leak env state into siblings.
 struct EnvGuard<'a> {
-    keys: Vec<&'a str>,
+    set_keys: Vec<&'a str>,
+    masked_keys: Vec<&'a str>,
 }
 
 impl<'a> EnvGuard<'a> {
     fn new() -> Self {
-        Self { keys: Vec::new() }
+        Self {
+            set_keys: Vec::new(),
+            masked_keys: Vec::new(),
+        }
     }
 
     /// Set the runtime-env var and remember to remove it at drop.
     fn set(&mut self, key: &'a str, value: &str) {
         runtime_env::set(key, value);
-        self.keys.push(key);
+        self.set_keys.push(key);
+    }
+
+    /// Mask the key so [`runtime_env::get`] returns `None` regardless
+    /// of process env. Lifted at drop.
+    fn mask(&mut self, key: &'a str) {
+        runtime_env::mask(key);
+        self.masked_keys.push(key);
+    }
+
+    /// Mask every proxy-related env key. Convenience for the common
+    /// pre-test setup that previously called
+    /// `snapshot_and_clear_process_proxy_env`.
+    fn mask_all_proxy_env(&mut self) {
+        for k in PROXY_ENV_KEYS {
+            self.mask(k);
+        }
     }
 }
 
 impl Drop for EnvGuard<'_> {
     fn drop(&mut self) {
-        for k in &self.keys {
+        for k in &self.set_keys {
             runtime_env::remove(k);
         }
-    }
-}
-
-/// Pre-clear every proxy-related env var in the **process** environment.
-///
-/// We can't use [`runtime_env::remove`] for these because the runtime-env
-/// fallback to `std::env::var` would still surface them.
-/// Returns the original values so [`PROCESS_ENV_GUARD`] can restore them.
-fn snapshot_and_clear_process_proxy_env() -> Vec<(&'static str, Option<String>)> {
-    const KEYS: &[&str] = &[
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "PROXY_USER",
-        "PROXY_PASS",
-    ];
-    let snap: Vec<_> = KEYS.iter().map(|k| (*k, std::env::var(k).ok())).collect();
-    // SAFETY: ENV_MUTEX is held by the caller, so no other thread is reading
-    // these vars concurrently. This block only runs in tests.
-    unsafe {
-        for k in KEYS {
-            std::env::remove_var(k);
-        }
-    }
-    snap
-}
-
-fn restore_process_env(snap: Vec<(&'static str, Option<String>)>) {
-    // SAFETY: ENV_MUTEX still held by the caller.
-    unsafe {
-        for (k, v) in snap {
-            match v {
-                Some(val) => std::env::set_var(k, val),
-                None => std::env::remove_var(k),
-            }
+        for k in &self.masked_keys {
+            runtime_env::unmask(k);
         }
     }
 }
@@ -125,7 +132,6 @@ fn user_msg() -> ChatMessage {
 #[tokio::test]
 async fn http_proxy_routes_remote_requests_through_proxy() {
     let _g = ENV_MUTEX.lock().await;
-    let proc_snap = snapshot_and_clear_process_proxy_env();
 
     // The proxy is a FakeLlmServer — it won't actually forward, just match
     // the path regex on the inbound proxied request and respond 200. That's
@@ -134,6 +140,7 @@ async fn http_proxy_routes_remote_requests_through_proxy() {
     proxy.mount_chat_ok(ok_chat_body()).await;
 
     let mut env = EnvGuard::new();
+    env.mask_all_proxy_env();
     env.set("HTTP_PROXY", &proxy.url());
 
     // Target a non-localhost host so the proxy is consulted (the bypass
@@ -148,14 +155,11 @@ async fn http_proxy_routes_remote_requests_through_proxy() {
     let proxied = proxy.received_requests().await;
     assert_eq!(proxied.len(), 1, "request must be routed through the proxy");
 
-    drop(env);
-    restore_process_env(proc_snap);
 }
 
 #[tokio::test]
 async fn localhost_traffic_bypasses_proxy_even_when_set() {
     let _g = ENV_MUTEX.lock().await;
-    let proc_snap = snapshot_and_clear_process_proxy_env();
 
     // Two servers: a "proxy" we expect to be skipped, an "upstream" we
     // expect to receive the request directly because the URL is localhost.
@@ -165,6 +169,7 @@ async fn localhost_traffic_bypasses_proxy_even_when_set() {
     upstream.mount_chat_ok(ok_chat_body()).await;
 
     let mut env = EnvGuard::new();
+    env.mask_all_proxy_env();
     env.set("HTTP_PROXY", &proxy.url());
 
     let provider = OpenAiCompatProvider::new(&upstream.url(), Some("sk-test".into()));
@@ -184,19 +189,17 @@ async fn localhost_traffic_bypasses_proxy_even_when_set() {
         "upstream must receive the request directly"
     );
 
-    drop(env);
-    restore_process_env(proc_snap);
 }
 
 #[tokio::test]
 async fn proxy_basic_auth_from_env_vars_attaches_proxy_authorization_header() {
     let _g = ENV_MUTEX.lock().await;
-    let proc_snap = snapshot_and_clear_process_proxy_env();
 
     let proxy = FakeLlmServer::spawn().await;
     proxy.mount_chat_ok(ok_chat_body()).await;
 
     let mut env = EnvGuard::new();
+    env.mask_all_proxy_env();
     env.set("HTTP_PROXY", &proxy.url());
     env.set("PROXY_USER", "alice");
     env.set("PROXY_PASS", "s3cret");
@@ -217,14 +220,11 @@ async fn proxy_basic_auth_from_env_vars_attaches_proxy_authorization_header() {
     // Basic alice:s3cret = YWxpY2U6czNjcmV0
     assert_eq!(auth, "Basic YWxpY2U6czNjcmV0");
 
-    drop(env);
-    restore_process_env(proc_snap);
 }
 
 #[tokio::test]
 async fn invalid_proxy_url_degrades_gracefully_to_no_proxy() {
     let _g = ENV_MUTEX.lock().await;
-    let proc_snap = snapshot_and_clear_process_proxy_env();
 
     // Garbage proxy URL: the production code logs a warning and returns a
     // proxy-less client rather than panicking. Verify by making a request
@@ -233,6 +233,7 @@ async fn invalid_proxy_url_degrades_gracefully_to_no_proxy() {
     upstream.mount_chat_ok(ok_chat_body()).await;
 
     let mut env = EnvGuard::new();
+    env.mask_all_proxy_env();
     env.set("HTTP_PROXY", "://this is not a url@@@");
 
     let provider = OpenAiCompatProvider::new(&upstream.url(), Some("sk-test".into()));
@@ -247,8 +248,6 @@ async fn invalid_proxy_url_degrades_gracefully_to_no_proxy() {
         "malformed proxy URL must not block legitimate localhost traffic"
     );
 
-    drop(env);
-    restore_process_env(proc_snap);
 }
 
 #[tokio::test]
@@ -258,7 +257,6 @@ async fn read_timeout_aborts_silent_servers_quickly() {
     // half-open socket a NAT box quietly dropped) would hang the agent
     // forever. Now KODA_READ_TIMEOUT_SECS bounds idle time between reads.
     let _g = ENV_MUTEX.lock().await;
-    let proc_snap = snapshot_and_clear_process_proxy_env();
 
     let upstream = FakeLlmServer::spawn().await;
     // Server takes 3s to start sending; client should give up at ~1s.
@@ -267,6 +265,7 @@ async fn read_timeout_aborts_silent_servers_quickly() {
         .await;
 
     let mut env = EnvGuard::new();
+    env.mask_all_proxy_env();
     env.set("KODA_READ_TIMEOUT_SECS", "1");
 
     let provider = OpenAiCompatProvider::new(&upstream.url(), Some("sk-test".into()));
@@ -293,6 +292,4 @@ async fn read_timeout_aborts_silent_servers_quickly() {
         "error should mention timeout, got: {msg}"
     );
 
-    drop(env);
-    restore_process_env(proc_snap);
 }

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -341,14 +341,14 @@ async fn cancel_during_tool_execution() {
         MockResponse::Text("should not reach this".into()),
     ]);
 
-    let cancel = CancellationToken::new();
-    let cancel_clone = cancel.clone();
-    tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-        cancel_clone.cancel();
-    });
-
-    let (result, _events) = env.run_inference_cancellable(&provider, cancel).await;
+    // **#1109 F3**: was `tokio::spawn(sleep(200ms); cancel())`. Replaced
+    // with event-driven cancel: fire as soon as the engine emits
+    // ToolCallStart for our Bash invocation. Deterministic and faster.
+    let (result, _events) = env
+        .run_inference_cancel_on_event(&provider, |ev| {
+            matches!(ev, koda_core::engine::EngineEvent::ToolCallStart { name, .. } if name == "Bash")
+        })
+        .await;
 
     assert!(result.is_ok(), "cancel should be graceful");
     // Should finish quickly (not wait 10 seconds).

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -8,7 +8,6 @@
 
 use koda_core::{engine::EngineEvent, persistence::Persistence};
 use koda_test_utils::{Env, MockProvider, MockResponse};
-use tokio_util::sync::CancellationToken;
 
 // ── Rate limit retry ─────────────────────────────────────────
 

--- a/koda-core/tests/inference_edge_test.rs
+++ b/koda-core/tests/inference_edge_test.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 
 // ── Rate limit retry ─────────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rate_limit_then_success() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -45,7 +45,7 @@ async fn rate_limit_then_success() {
     assert!(last.contains("recovered!"), "DB: {last}");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rate_limit_exhausted_returns_error() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -70,7 +70,7 @@ async fn rate_limit_exhausted_returns_error() {
 
 // ── Network error mid-stream ─────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn network_error_mid_stream_discards_response() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -104,7 +104,7 @@ async fn network_error_mid_stream_discards_response() {
 
 // ── Empty response retry ─────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_response_after_tool_use_retries_once() {
     let env = Env::new().await;
     env.insert_user_message("do something").await;
@@ -137,7 +137,7 @@ async fn empty_response_after_tool_use_retries_once() {
 
 // ── max_tokens truncation ────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn max_tokens_continues_loop() {
     let env = Env::new().await;
     env.insert_user_message("write a long essay").await;
@@ -170,7 +170,7 @@ async fn max_tokens_continues_loop() {
 
 // ── Loop detection ───────────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn loop_detection_injects_feedback_then_stops() {
     let env = Env::new().await;
     env.insert_user_message("keep trying").await;
@@ -240,7 +240,7 @@ async fn loop_detection_injects_feedback_then_stops() {
 
 // ── Eager tool execution (ToolCallReady) ─────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn eager_execution_of_read_only_tools() {
     let env = Env::new().await;
     let test_file = env.root.join("eagerly_read.txt");
@@ -281,7 +281,7 @@ async fn eager_execution_of_read_only_tools() {
 
 // ── Multiple tool calls in parallel ──────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn multiple_read_only_tools_dispatch() {
     let env = Env::new().await;
     let f1 = env.root.join("file1.txt");
@@ -330,7 +330,7 @@ async fn multiple_read_only_tools_dispatch() {
 
 // ── Cancel during tool execution ─────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancel_during_tool_execution() {
     let env = Env::new().await;
     env.insert_user_message("run a slow command").await;
@@ -358,7 +358,7 @@ async fn cancel_during_tool_execution() {
 
 // ── Server error graceful exit ───────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn server_error_exits_gracefully() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -380,7 +380,7 @@ async fn server_error_exits_gracefully() {
 
 // ── Context overflow recovery ────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn context_overflow_attempts_compact_and_retry() {
     let env = Env::new().await;
 
@@ -434,7 +434,7 @@ async fn context_overflow_attempts_compact_and_retry() {
 
 // ── Token usage tracking ─────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn footer_includes_token_usage() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -462,7 +462,7 @@ async fn footer_includes_token_usage() {
 
 // ── Multi-turn tool use ──────────────────────────────────────
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn multi_step_tool_chain_persists_all() {
     let env = Env::new().await;
     let target = env.root.join("chained.txt");

--- a/koda-core/tests/mcp_http_transport_test.rs
+++ b/koda-core/tests/mcp_http_transport_test.rs
@@ -142,7 +142,7 @@ async fn spawn_echo_server() -> (String, CancellationToken, CapturedHeaders) {
 // McpClient SSRF guard (which correctly blocks loopback in production).
 
 /// Connect + tool discovery: the echo tool must appear in tools/list.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transport_connect_discovers_echo_tool() {
     let (url, ct, _captured) = spawn_echo_server().await;
 
@@ -171,7 +171,7 @@ async fn transport_connect_discovers_echo_tool() {
 }
 
 /// Bearer token forwarding: every POST must carry `Authorization: Bearer <t>`.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transport_bearer_token_forwarded_on_every_request() {
     let (url, ct, captured) = spawn_echo_server().await;
     let token = "super-secret-test-token-xyz";
@@ -207,7 +207,7 @@ async fn transport_bearer_token_forwarded_on_every_request() {
 
 /// No token: when no bearer_token is configured the Authorization header must
 /// be absent from every request.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn transport_no_token_omits_auth_header() {
     let (url, ct, captured) = spawn_echo_server().await;
 
@@ -254,7 +254,7 @@ fn loopback_config(port: u16, bearer: Option<String>) -> McpServerConfig {
 
 /// McpClient::connect() must fail with an SSRF error for loopback URLs,
 /// even when a real MCP server is listening on that port.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_client_connect_rejects_loopback_ssrf() {
     let (url, ct, _) = spawn_echo_server().await;
     // Extract the port from the URL to build a loopback config.
@@ -287,7 +287,7 @@ async fn mcp_client_connect_rejects_loopback_ssrf() {
 }
 
 /// Connecting to a metadata endpoint must also be rejected.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcp_client_connect_rejects_metadata_endpoint() {
     let config = McpServerConfig {
         transport: McpTransport::Http {

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -71,7 +71,7 @@ async fn make_session(
 
 /// `run_turn()` must emit `TurnStart` as the first event and
 /// `TurnEnd { reason: Complete }` as the last event after a successful turn.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn session_run_turn_emits_turn_start_and_end() {
     let env = Env::new().await;
     env.insert_user_message("say hello").await;
@@ -136,7 +136,7 @@ async fn session_run_turn_emits_turn_start_and_end() {
 }
 
 /// Cancelling the token during inference causes `TurnEnd` to carry reason `Cancelled`.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn session_cancellation_produces_turn_end_cancelled() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
@@ -221,7 +221,7 @@ async fn session_cancellation_produces_turn_end_cancelled() {
 
 /// Messages from two separate `run_turn()` calls on the same session must
 /// both appear in the DB afterward.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn session_persists_messages_across_two_turns() {
     let env = Env::new().await;
 

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -141,8 +141,11 @@ async fn session_cancellation_produces_turn_end_cancelled() {
     let env = Env::new().await;
     env.insert_user_message("hello").await;
 
-    // A provider that hangs forever so that cancellation can be observed.
-    struct HangingProvider;
+    // A provider that signals when entered, then hangs forever so that
+    // cancellation can be observed deterministically (#1109 F3).
+    struct HangingProvider {
+        entered: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
 
     #[async_trait]
     impl LlmProvider for HangingProvider {
@@ -160,6 +163,9 @@ async fn session_cancellation_produces_turn_end_cancelled() {
             _: &[ToolDefinition],
             _: &koda_core::config::ModelSettings,
         ) -> Result<koda_core::providers::stream_collector::SseCollector> {
+            if let Some(tx) = self.entered.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;
             unreachable!()
         }
@@ -171,12 +177,17 @@ async fn session_cancellation_produces_turn_end_cancelled() {
         }
     }
 
-    let (mut session, cancel) = make_session(&env, Box::new(HangingProvider)).await;
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let provider = HangingProvider {
+        entered: std::sync::Mutex::new(Some(entered_tx)),
+    };
+    let (mut session, cancel) = make_session(&env, Box::new(provider)).await;
 
-    // Cancel after 100 ms so the test completes quickly.
+    // **#1109 F3**: was `sleep(100ms).await` — replaced with oneshot wait
+    // so cancel fires the moment inference reaches the provider.
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let _ = entered_rx.await;
         cancel_clone.cancel();
     });
 

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -23,7 +23,7 @@ fn all_tool_names() -> Vec<String> {
 /// `tool_dispatch::execute_one_tool` (see the early `if matches!(...)
 /// branch there). Skipping them here keeps the test honest about what
 /// `ToolRegistry::execute()` is responsible for.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_all_tools_routable_in_dispatcher() {
     const HIGHER_LAYER_DISPATCH: &[&str] = &["ListBackgroundTasks", "CancelTask", "WaitTask"];
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
@@ -43,7 +43,7 @@ async fn test_all_tools_routable_in_dispatcher() {
 
 /// Empty/whitespace-only arguments should be treated as `{}`, not error.
 /// Regression test for #513.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_empty_args_default_to_empty_object() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for input in ["", "  ", "\n", "\t "] {

--- a/koda-sandbox/src/bwrap_proxy.rs
+++ b/koda-sandbox/src/bwrap_proxy.rs
@@ -315,7 +315,7 @@ mod tests {
         assert_eq!(rewrite_proxy_url_port("http://", 9999), None);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn uds_bridge_forwards_bytes_to_tcp_listener() {
         // End-to-end: spin up a TCP listener, spawn the bridge, write
         // through the UDS, expect the bytes to arrive at the TCP side.
@@ -348,7 +348,7 @@ mod tests {
         cleanup_uds_path(&uds_path);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn uds_bridge_removes_stale_socket_file() {
         // Pre-create a stale file at the UDS path; the bridge must
         // unlink-and-rebind rather than failing with EADDRINUSE.

--- a/koda-sandbox/src/proxy/builtin.rs
+++ b/koda-sandbox/src/proxy/builtin.rs
@@ -152,14 +152,14 @@ mod tests {
         assert!(p.filter.is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn spawn_returns_handle_with_assigned_port() {
         let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();
         assert!(h.port > 0, "ephemeral port must be non-zero");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn spawned_proxy_serves_403_for_disallowed_host() {
         let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();
@@ -167,7 +167,7 @@ mod tests {
         assert!(status.starts_with("HTTP/1.1 403"), "got: {status:?}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dropping_handle_stops_accepting() {
         // Spawn, confirm it accepts, drop, confirm it no longer accepts.
         let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
@@ -209,7 +209,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ca_bundle_is_none_for_builtin() {
         // 3b deliberately ships no MITM. Built-in proxy has no CA to
         // advertise. 3d will swap this to Some(generated_path).
@@ -223,7 +223,7 @@ mod tests {
     /// path has a connectable socket inside the eventual `--unshare-net`
     /// sandbox.
     #[cfg(target_os = "linux")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn linux_spawn_attaches_uds_bridge() {
         let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();
@@ -241,7 +241,7 @@ mod tests {
     /// spawn can re-bind cleanly. Without this, repeated session
     /// creation in the same process would accumulate stale sockets.
     #[cfg(target_os = "linux")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn linux_drop_removes_uds_path() {
         let p = BuiltInProxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();

--- a/koda-sandbox/src/proxy/builtin_socks5.rs
+++ b/koda-sandbox/src/proxy/builtin_socks5.rs
@@ -86,14 +86,14 @@ mod tests {
         assert!(p.filter.is_empty());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn spawn_returns_handle_with_assigned_port() {
         let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();
         assert!(h.port > 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn spawned_proxy_serves_403_equivalent_for_disallowed_host() {
         let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();
@@ -119,7 +119,7 @@ mod tests {
         assert_eq!(reply[1], 0x02);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dropping_handle_stops_accepting() {
         let p = BuiltInSocks5Proxy::new(Filter::new(["github.com"]).unwrap());
         let h = p.spawn().await.unwrap();

--- a/koda-sandbox/src/proxy/relay.rs
+++ b/koda-sandbox/src/proxy/relay.rs
@@ -164,7 +164,7 @@ mod tests {
         (addr, l)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn relays_bytes_in_both_directions_until_eof() {
         // Topology:
         //   client ──┐         ┌── server (echo)
@@ -207,7 +207,7 @@ mod tests {
         server_task.await.unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn idle_timeout_fires_when_both_sides_silent() {
         // Neither side ever writes after handshake. The idle timeout
         // is the only thing keeping us from hanging forever.
@@ -247,7 +247,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn total_timeout_fires_even_when_traffic_is_active() {
         // Server keeps trickling bytes forever — idle timeout never
         // fires because something is always arriving. Only the total
@@ -303,7 +303,7 @@ mod tests {
         let _ = drain.await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn clean_half_close_propagates_without_idle_fire() {
         // Client closes its write half but still wants to read replies.
         // copy_one_direction client→server returns Ok(0); server→client

--- a/koda-sandbox/src/proxy/server.rs
+++ b/koda-sandbox/src/proxy/server.rs
@@ -313,14 +313,14 @@ mod tests {
         (status_line, rest)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn server_bind_uses_ephemeral_port_when_none() {
         let s = Server::bind(None, Filter::default()).await.unwrap();
         let p = s.port();
         assert!(p > 0, "ephemeral port must be non-zero");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rejects_non_connect_with_405() {
         let server = Server::bind(None, Filter::new(["github.com"]).unwrap())
             .await
@@ -338,7 +338,7 @@ mod tests {
         assert!(buf.starts_with("HTTP/1.1 405"), "got: {buf:?}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rejects_disallowed_host_with_403() {
         let server = Server::bind(None, Filter::new(["github.com"]).unwrap())
             .await
@@ -350,7 +350,7 @@ mod tests {
         assert!(status.starts_with("HTTP/1.1 403"), "got: {status:?}");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn allows_listed_host_and_tunnels_payload() {
         // The payload our fake upstream sends; the test asserts the
         // proxy relays it byte-for-byte to us through the tunnel.
@@ -383,7 +383,7 @@ mod tests {
         assert_eq!(body_str, payload, "tunneled body mismatch");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn returns_502_when_upstream_unreachable() {
         // Allowlist contains the host but the port is dead.
         let server = Server::bind(None, Filter::new(["127.0.0.1"]).unwrap())
@@ -405,7 +405,7 @@ mod tests {
     /// CONNECT must be tunnelled through that proxy rather than dialed
     /// directly. We stand up a fake corp proxy that records the
     /// CONNECT it receives, then chain through it.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn chains_through_upstream_http_proxy() {
         // Real upstream that the corp proxy will dial on our behalf.
         let payload = "PAYLOAD-FROM-REAL-UPSTREAM";
@@ -476,7 +476,7 @@ mod tests {
     /// upstream and back onto the direct path. Critical because
     /// `*.walmart.com` (and friends) are corp-internal and routing
     /// them through Zscaler produces 403s.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn chains_skips_upstream_for_no_proxy_hosts() {
         let payload = "DIRECT-NOT-CHAINED";
         let (real_port, _) = fake_upstream(payload).await;
@@ -526,7 +526,7 @@ mod tests {
     /// required) must surface as 502 to the client — we have no
     /// credentials to retry with, and silently sending the request
     /// direct would defeat the point of the corp policy.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn surfaces_upstream_407_as_502() {
         let corp_listener = StdTcpListener::bind("127.0.0.1:0").await.unwrap();
         let corp_port = corp_listener.local_addr().unwrap().port();

--- a/koda-sandbox/src/proxy/socks5.rs
+++ b/koda-sandbox/src/proxy/socks5.rs
@@ -449,14 +449,14 @@ mod tests {
         reply
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn greeting_accepts_noauth() {
         let (port, _task) = spawn(Filter::default()).await;
         let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
         assert_eq!(greet_noauth(&mut sock).await, [0x05, 0x00]);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn greeting_rejects_no_acceptable_auth() {
         let (port, _task) = spawn(Filter::default()).await;
         let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
@@ -467,7 +467,7 @@ mod tests {
         assert_eq!(reply, [0x05, 0xFF]);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn connect_domain_blocked_by_filter() {
         let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
         let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
@@ -477,7 +477,7 @@ mod tests {
         assert_eq!(reply[1], REP_NOT_ALLOWED);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ipv4_literal_rejected_with_atyp_unsupported() {
         // IP literal bypasses hostname filter, so we hard-refuse.
         let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(reply[1], REP_ADDRESS_TYPE_NOT_SUPPORTED);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ipv6_literal_rejected_with_atyp_unsupported() {
         let (port, _task) = spawn(Filter::new(["github.com"]).unwrap()).await;
         let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
@@ -507,7 +507,7 @@ mod tests {
         assert_eq!(reply[1], REP_ADDRESS_TYPE_NOT_SUPPORTED);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn bind_command_refused() {
         let (port, _task) = spawn(Filter::default()).await;
         let mut sock = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
@@ -521,7 +521,7 @@ mod tests {
         assert_eq!(reply[1], REP_COMMAND_NOT_SUPPORTED);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn allowed_domain_succeeds_then_relays() {
         // Stand up a tiny upstream that echoes one byte.
         let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/koda-sandbox/src/worker.rs
+++ b/koda-sandbox/src/worker.rs
@@ -442,7 +442,7 @@ mod tests {
 
     // ── Protocol mechanics (unchanged from 2a) ───────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ping_returns_pong() {
         let (mut host, _join) = spawn_worker();
         write_message(&mut host, &Request::Ping).await.unwrap();
@@ -450,7 +450,7 @@ mod tests {
         assert_eq!(resp, Response::Pong);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_acks_then_worker_exits() {
         let (mut host, join) = spawn_worker();
         write_message(&mut host, &Request::Shutdown).await.unwrap();
@@ -464,7 +464,7 @@ mod tests {
             .expect("worker returned Err");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn peer_eof_exits_loop_cleanly() {
         let (host, join) = spawn_worker();
         drop(host);
@@ -475,7 +475,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn worker_loops_for_multiple_requests() {
         let (mut host, _join) = spawn_worker();
         for _ in 0..5 {
@@ -487,7 +487,7 @@ mod tests {
 
     // ── FS handlers ──────────────────────────────────────────────────
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_handler_returns_file_contents() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("hello.txt");
@@ -512,7 +512,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_handler_creates_file() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("out.txt");
@@ -532,7 +532,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"written");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn edit_handler_replaces_string() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("e.txt");
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "foo BAR baz");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn stat_handler_reports_file_metadata() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("s.txt");
@@ -575,7 +575,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn read_missing_file_returns_io_error() {
         let dir = TempDir::new().unwrap();
         let (mut host, _join) = spawn_worker();
@@ -611,7 +611,7 @@ mod tests {
         (host, join)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_inside_root_is_allowed() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("allowed.txt");
@@ -633,7 +633,7 @@ mod tests {
         assert_eq!(std::fs::read(&path).unwrap(), b"ok");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn write_outside_root_is_denied() {
         let root = TempDir::new().unwrap();
         let outside = TempDir::new().unwrap();
@@ -661,7 +661,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dangerous_system_path_always_denied() {
         let dir = TempDir::new().unwrap();
         // Even though root is set, /etc directly is always blocked.
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn symlink_escape_is_denied() {
         let root = TempDir::new().unwrap();
         let outside = TempDir::new().unwrap();

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -295,4 +295,108 @@ impl Env {
 
         (result, sink.events())
     }
+
+    /// Collect every `BgTaskUpdate` event a background sub-agent will
+    /// emit, regardless of which side of the parent's `inference_loop`
+    /// drained them.
+    ///
+    /// **Why this helper exists** (#1109, PR #1113):
+    ///
+    /// `BgTaskUpdate` events flow through a single-consumer queue
+    /// inside [`BgAgentRegistry`]. The parent's `inference_loop`
+    /// drains them on every iteration and forwards to the sink. A
+    /// test that asserts on these events is racing the parent for
+    /// the same queue:
+    ///
+    /// * If the bg task **finishes before `run_inference` returns**,
+    ///   the parent drained everything into the sink — the events
+    ///   live in the `events` vec, and the registry queue is empty.
+    /// * If the bg task **finishes after `run_inference` returns**,
+    ///   the parent never got a chance — the events are sitting in
+    ///   the registry queue waiting for `drain_status_events()`.
+    ///
+    /// Which side wins is non-deterministic (depends on tokio worker
+    /// scheduling, OS, CI runner load). This helper merges both
+    /// sources so callers don't have to know.
+    ///
+    /// # Arguments
+    ///
+    /// * `events_from_run_inference` — the `Vec<EngineEvent>`
+    ///   returned by [`Self::run_inference`] (or any of its
+    ///   variants). `BgTaskUpdate` events are filtered out; other
+    ///   event types are ignored.
+    /// * `terminal_timeout` — how long to keep polling
+    ///   [`BgAgentRegistry::drain_status_events`] waiting for a
+    ///   terminal status (`Completed`, `Errored`, `Cancelled`). Use
+    ///   a generous bound (e.g. 10s) — on a healthy machine the
+    ///   helper returns in single-digit milliseconds.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(events)` if a terminal `BgTaskUpdate` was observed within
+    /// `terminal_timeout`, where `events` contains every
+    /// `BgTaskUpdate` from both sources in arrival order (sink-side
+    /// events first, then queue-drained events).
+    ///
+    /// `Err(events)` if the timeout elapsed without a terminal
+    /// status. The partial event list is returned for diagnostics.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let events = env.run_inference(&provider).await;
+    /// let bg_events = env
+    ///     .collect_bg_events_after(events, Duration::from_secs(10))
+    ///     .await
+    ///     .expect("bg task never reached terminal state");
+    /// assert!(bg_events.iter().any(|e| matches!(
+    ///     e, EngineEvent::BgTaskUpdate {
+    ///         status: AgentStatus::Completed { .. }, ..
+    ///     }
+    /// )));
+    /// ```
+    pub async fn collect_bg_events_after(
+        &self,
+        events_from_run_inference: Vec<EngineEvent>,
+        terminal_timeout: std::time::Duration,
+    ) -> Result<Vec<EngineEvent>, Vec<EngineEvent>> {
+        let mut bg_events: Vec<EngineEvent> = events_from_run_inference
+            .into_iter()
+            .filter(|ev| matches!(ev, EngineEvent::BgTaskUpdate { .. }))
+            .collect();
+
+        let deadline = tokio::time::Instant::now() + terminal_timeout;
+        loop {
+            for ev in self.bg_agents.drain_status_events() {
+                bg_events.push(ev);
+            }
+            if bg_events.iter().any(is_terminal_bg_update) {
+                return Ok(bg_events);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(bg_events);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+}
+
+/// Returns `true` if `ev` is a [`EngineEvent::BgTaskUpdate`] in a
+/// terminal status (`Completed`, `Errored`, or `Cancelled`).
+///
+/// Extracted as a free function so [`Env::collect_bg_events_after`]
+/// stays readable; the matcher itself is non-trivial because
+/// `AgentStatus` has additional non-terminal variants we must not
+/// mistakenly treat as final.
+fn is_terminal_bg_update(ev: &EngineEvent) -> bool {
+    use koda_core::bg_agent::AgentStatus;
+    matches!(
+        ev,
+        EngineEvent::BgTaskUpdate {
+            status: AgentStatus::Completed { .. }
+                | AgentStatus::Errored { .. }
+                | AgentStatus::Cancelled,
+            ..
+        }
+    )
 }

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -245,10 +245,18 @@ impl Env {
             .await
     }
 
-    /// Same as [`run_inference_full`] but lets the caller supply the
-    /// sink — used by [`run_inference_cancel_on_event`] which needs to
+    /// Same as `run_inference_full` but lets the caller supply the
+    /// sink — used by `run_inference_cancel_on_event` which needs to
     /// subscribe to the live event stream before inference begins.
-    async fn run_inference_with_sink(
+    ///
+    /// **Public so tests for asynchronously-spawned work (e.g.
+    /// background sub-agents) can subscribe to the sink BEFORE
+    /// inference starts and keep reading after it returns** — events
+    /// emitted by tokio::spawn'd tasks may arrive after the parent's
+    /// inference_loop completes, so the static `events()` snapshot at
+    /// return time is not canonical for those tests. See the QA-001
+    /// regression in `e2e_agent_test.rs` for the worked example.
+    pub async fn run_inference_with_sink(
         &self,
         provider: &dyn LlmProvider,
         cancel: CancellationToken,

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 /// Mutex to serialize tests that share process-global env vars
-/// (KODA_MOCK_RESPONSES).  `#[tokio::test]` runs tests concurrently
+/// (KODA_MOCK_RESPONSES).  `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` runs tests concurrently
 /// within the same process, so unsynchronized set_var/remove_var
 /// on the same env var is a data race.
 pub static ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -241,7 +241,8 @@ impl Env {
         provider: &dyn LlmProvider,
         cancel: CancellationToken,
     ) -> (anyhow::Result<()>, Vec<EngineEvent>) {
-        self.run_inference_with_sink(provider, cancel, Arc::new(TestSink::new())).await
+        self.run_inference_with_sink(provider, cancel, Arc::new(TestSink::new()))
+            .await
     }
 
     /// Same as [`run_inference_full`] but lets the caller supply the

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -197,13 +197,62 @@ impl Env {
         self.run_inference_full(provider, cancel).await
     }
 
+    /// Run inference and cancel as soon as an event matching `pred` is
+    /// emitted by the engine.
+    ///
+    /// **#1109 F3**: replaces `tokio::spawn(async { sleep(N).await; cancel(); })`
+    /// patterns. Cancellation fires the moment the synchronization
+    /// point of interest (e.g. `ToolCallStart`) is observed, making
+    /// the test deterministic regardless of CI runner speed.
+    pub async fn run_inference_cancel_on_event<F>(
+        &self,
+        provider: &dyn LlmProvider,
+        pred: F,
+    ) -> (anyhow::Result<()>, Vec<EngineEvent>)
+    where
+        F: Fn(&EngineEvent) -> bool + Send + Sync + 'static,
+    {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        // Build the sink up-front so we can subscribe before inference
+        // starts — otherwise the predicate could miss the event we're
+        // waiting for.
+        let sink = Arc::new(TestSink::new());
+        let mut rx = sink.subscribe();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) if pred(&ev) => {
+                        cancel_clone.cancel();
+                        break;
+                    }
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        self.run_inference_with_sink(provider, cancel, sink).await
+    }
+
     /// Full inference run with all knobs exposed.
     async fn run_inference_full(
         &self,
         provider: &dyn LlmProvider,
         cancel: CancellationToken,
     ) -> (anyhow::Result<()>, Vec<EngineEvent>) {
-        let sink = TestSink::new();
+        self.run_inference_with_sink(provider, cancel, Arc::new(TestSink::new())).await
+    }
+
+    /// Same as [`run_inference_full`] but lets the caller supply the
+    /// sink — used by [`run_inference_cancel_on_event`] which needs to
+    /// subscribe to the live event stream before inference begins.
+    async fn run_inference_with_sink(
+        &self,
+        provider: &dyn LlmProvider,
+        cancel: CancellationToken,
+        sink: Arc<TestSink>,
+    ) -> (anyhow::Result<()>, Vec<EngineEvent>) {
         let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
         let tool_defs = self.tool_defs();
         let mut file_tracker =
@@ -226,7 +275,7 @@ impl Env {
             tool_defs: &tool_defs,
             pending_images: None,
             mode: self.trust,
-            sink: &sink,
+            sink: sink.as_ref(),
             cancel,
             cmd_rx: &mut cmd_rx,
             file_tracker: &mut file_tracker,

--- a/scripts/check_tokio_test_flavor.py
+++ b/scripts/check_tokio_test_flavor.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""CI guard for #1109 F2: every `#[tokio::test]` in a Rust file that
+exercises tokio::spawn / BgAgentRegistry / sub-agent dispatch / watch /
+broadcast channels MUST use `flavor = "multi_thread"` to match production
+runtime semantics.
+
+The default `current_thread` runtime queues `tokio::spawn`'d futures but
+only polls them when the test future yields — which doesn't happen on a
+single-task await chain. Production runs multi-thread, so the test
+flavor mismatch silently hides bugs (#1090, etc.).
+
+Usage:
+    python3 scripts/check_tokio_test_flavor.py           # check workspace
+    python3 scripts/check_tokio_test_flavor.py --fix     # auto-promote (local dev)
+
+Exit codes:
+    0 — all clear
+    1 — at least one offending test found
+
+This is intentionally a Python script rather than a clippy lint or rustc
+plugin because (a) zero added build deps, (b) it runs in <1s, (c) it
+greps for textual patterns which is exactly the granularity we want
+(adding a clippy lint would require nightly/macro_rules wizardry).
+
+Refs #1109 (Phase 2 / F2).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Modules that exercise spawn-style concurrency. If a file imports any of
+# these patterns AND has a bare `#[tokio::test]`, the test is at risk.
+DANGER_PATTERNS = re.compile(
+    r"\btokio::spawn\b"
+    r"|\bBgAgentRegistry\b"
+    r"|\bsub_agent_dispatch\b"
+    r"|\btokio::sync::watch\b"
+    r"|\btokio::sync::broadcast\b"
+)
+
+# Bare `#[tokio::test]` — flavor not specified.
+BARE_TOKIO_TEST = re.compile(r"#\[tokio::test\](?!\()")
+# What we want it replaced with.
+MULTI_THREAD_TEST = '#[tokio::test(flavor = "multi_thread", worker_threads = 2)]'
+
+# Skip these directories under workspace root.
+SKIP_DIRS = {"target", ".git", "node_modules", "dist", "build"}
+
+
+def find_rs_files(root: Path) -> list[Path]:
+    """Walk root, return every .rs file outside SKIP_DIRS."""
+    files = []
+    for p in root.rglob("*.rs"):
+        if any(part in SKIP_DIRS for part in p.parts):
+            continue
+        files.append(p)
+    return files
+
+
+def check_file(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_no, line)] for every offending bare #[tokio::test]
+    in `path`. Empty list = file is clean (or doesn't import any
+    danger patterns)."""
+    src = path.read_text(encoding="utf-8", errors="replace")
+    if not DANGER_PATTERNS.search(src):
+        return []
+    offenders: list[tuple[int, str]] = []
+    for i, line in enumerate(src.splitlines(), start=1):
+        if BARE_TOKIO_TEST.search(line):
+            offenders.append((i, line.strip()))
+    return offenders
+
+
+def fix_file(path: Path) -> int:
+    """Promote every bare #[tokio::test] in `path` to multi_thread.
+    Returns the count of replacements made."""
+    src = path.read_text(encoding="utf-8", errors="replace")
+    new_src, n = BARE_TOKIO_TEST.subn(MULTI_THREAD_TEST, src)
+    if n > 0:
+        path.write_text(new_src, encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Auto-promote offenders (developer convenience).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="Workspace root (default: repo root inferred from script location).",
+    )
+    args = parser.parse_args()
+
+    files = find_rs_files(args.root)
+
+    if args.fix:
+        total = 0
+        changed_files = 0
+        for f in files:
+            src = f.read_text(encoding="utf-8", errors="replace")
+            if not DANGER_PATTERNS.search(src):
+                continue
+            n = fix_file(f)
+            if n:
+                changed_files += 1
+                total += n
+                print(f"  promoted {n:3d} test(s) in {f.relative_to(args.root)}")
+        print(f"\nTotal: {total} test(s) promoted across {changed_files} file(s).")
+        return 0
+
+    # Default mode: report only.
+    bad: list[tuple[Path, list[tuple[int, str]]]] = []
+    for f in files:
+        offenders = check_file(f)
+        if offenders:
+            bad.append((f, offenders))
+
+    if not bad:
+        print("[#1109 F2 guard] OK — every #[tokio::test] in danger-pattern modules uses multi_thread.")
+        return 0
+
+    print("[#1109 F2 guard] FAIL — found bare #[tokio::test] in modules that")
+    print("                 use tokio::spawn / BgAgentRegistry / sub-agent dispatch /")
+    print("                 watch / broadcast channels. These tests run on the")
+    print("                 current_thread runtime by default, which silently")
+    print("                 hides spawned-future bugs (see #1090).")
+    print()
+    print("Offenders:")
+    for path, offenders in bad:
+        rel = path.relative_to(args.root)
+        for ln, line in offenders:
+            print(f"  {rel}:{ln}: {line}")
+    print()
+    print("Fix: add (flavor = \"multi_thread\", worker_threads = 2) to each.")
+    print("Or run: python3 scripts/check_tokio_test_flavor.py --fix")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# test: harden test infrastructure against Tokio runtime mismatches and unsafe env mutation (#1109)

Closes #1109.

## Background

Three flake-hunt PRs in the last 30 days (#1089, #1090, #1102) all chased the same root cause: tests built on top of `current_thread` Tokio runtimes that secretly never polled their `tokio::spawn`'d futures, plus a smattering of `unsafe { std::env::set_var }` UB and arbitrary `tokio::time::sleep(N)` "wait until something probably happened" gates. Each of those PRs was a point fix. This one closes the class.

The work is split into three independent phases per the issue's hit list. Each phase is self-contained, fully tested, and could ship on its own — they're stacked here so the CI guard from F2 also covers the test-utils changes from F3.

## Phase 1 — F1: zero `unsafe { std::env::set_var/remove_var }` in in-process tests

**Commit:** `4e0d533 test(env): eliminate unsafe std::env mutations from in-process tests`

Rust 2024 made `std::env::set_var` `unsafe` for a real reason: it's a data race against any other thread reading `std::env`. Tokio multi-thread runtimes have many such threads. The previous test code worked around this with snapshot/restore dances and per-file `ENV_MUTEX` statics — fragile and easy to forget.

**Approach:** route every test-mutated env var through the existing thread-safe `koda_core::runtime_env` map. Production reads of `XDG_CONFIG_HOME`, `KODA_MOCK_RESPONSES`, and `KODA_TRANSCRIPT_HYPERLINKS` now go through `runtime_env::get` (falls back to `std::env::var` if not overridden). New `mask`/`unmask` API lets tests assert the "env var unset" branch without touching `std::env` at all.

| Change | Before | After |
|---|---|---|
| `db::config_dir` reads | `std::env::var(...)` | `runtime_env::get(...)` |
| `MockProvider::from_env` | `std::env::var(...)` | `runtime_env::get(...)` |
| `transcript::hyperlinks_enabled` | `std::env::var(...)` | `runtime_env::get(...)` |
| Test snapshot/restore dance | 200+ LOC across 3 files | deleted |
| Duplicate `ENV_MUTEX` in `providers/mock.rs` | yes | gone (`from_json_str` extracted) |

**Acceptance criteria** from the issue:

```bash
$ grep -rn 'unsafe { std::env::\(set_var\|remove_var\)' \
       koda-core/tests koda-core/src/providers/mock.rs \
       koda-core/src/db koda-cli/src/transcript.rs
# (only doc comments referencing the removed pattern remain)
```

**Out of scope:** `koda-sandbox/src/stage2.rs` post-fork pre-exec env setup is legitimately single-threaded (Linux `clone`/`exec` boundary) and `unsafe`-correct. Sharing `runtime_env` with `koda-sandbox` would require extracting it to a new workspace crate (cyclic dep otherwise) — deserves its own change.

## Phase 2 — F2: every spawn-touching `#[tokio::test]` runs on `multi_thread`

**Commit:** `d2bce63 test(runtime): switch tokio::test to multi_thread in spawn-touching modules`

The default `#[tokio::test]` runtime is `current_thread`. It queues `tokio::spawn`'d futures but only polls them when the test future yields. Production runs `new_multi_thread()`. So tests asserting on side effects of spawned work were silently flaky-prone — exactly the #1090 root cause.

**Total promoted: 243 `#[tokio::test]` → `multi_thread, worker_threads = 2`**

<details>
<summary>Per-file breakdown</summary>

```
Runtime-spawning lib tests:
  koda-core/src/bg_agent.rs                  : 26
  koda-core/src/tools/validate.rs            : 26
  koda-core/src/providers/stream_collector.rs: 15
  koda-core/src/providers/mock.rs            : 14
  koda-core/src/approval_flow.rs             : 13
  koda-core/src/mcp/manager.rs               : 12
  koda-core/src/tools/bg_task_tools.rs       : 12
  koda-core/src/tools/bg_process.rs          : 11
  koda-core/src/inference.rs                 : 10
  koda-core/src/sub_agent_dispatch.rs        :  3
  koda-core/src/trust.rs                     :  3
  koda-core/src/tools/mod.rs                 :  4
  koda-core/src/tool_dispatch.rs             :  1

E2E / integration tests:
  koda-core/tests/inference_edge_test.rs     : 13
  koda-core/tests/e2e_test.rs                :  7
  koda-core/tests/e2e_agent_test.rs          :  7
  koda-core/tests/mcp_http_transport_test.rs :  5
  koda-core/tests/session_test.rs            :  3
  koda-core/tests/tool_wiring_test.rs        :  2
  koda-core/tests/cancel_test.rs             :  1

TUI / CLI:
  koda-cli/src/tui_bg_tasks.rs               : 11

Sandbox proxy / worker:
  koda-sandbox/src/worker.rs                 : 13
  koda-sandbox/src/proxy/server.rs           :  8
  koda-sandbox/src/proxy/socks5.rs           :  7
  koda-sandbox/src/proxy/builtin.rs          :  6
  koda-sandbox/src/proxy/relay.rs            :  4
  koda-sandbox/src/proxy/builtin_socks5.rs   :  3
  koda-sandbox/src/bwrap_proxy.rs            :  2

Misc:
  koda-test-utils/src/env.rs                 :  1
```
</details>

**CI guard added:** `scripts/check_tokio_test_flavor.py` runs in the `fmt` job (~1s, no extra deps). Fails CI if any future bare `#[tokio::test]` lands in a module that imports `tokio::spawn` / `BgAgentRegistry` / `sub_agent_dispatch` / `watch` / `broadcast`. Also has a `--fix` mode for local dev.

## Phase 3 — F3: polling sleeps → channel/event sync

**Commit:** `d805ab6 test(sync): replace polling sleeps with channel/event sync`

Pattern eliminated:
```rust
let cancel_clone = cancel.clone();
tokio::spawn(async move {
    tokio::time::sleep(Duration::from_millis(100)).await; // ← guess
    cancel_clone.cancel();
});
```

Replaced with one of:

1. **`oneshot::Sender` fired by the mock provider on `chat_stream` entry.** Cancel fires the moment inference reaches the provider — deterministic, immune to slow CI.
   - `cancel_test.rs::test_cancel_during_chat_stream_returns_immediately`
   - `e2e_test.rs::test_cancel_during_streaming`
   - `session_test.rs::session_cancellation_produces_turn_end_cancelled`

2. **Live event subscription via the new `TestSink::subscribe()` broadcast channel.** Cancel fires on first `EngineEvent` matching a predicate.
   - `inference_edge_test.rs::cancel_during_tool_execution` (cancels on first `ToolCallStart { name: "Bash" }`)

**Infrastructure additions** (intentionally small, single-purpose):

| API | Where | Purpose |
|---|---|---|
| `TestSink::subscribe()` | `koda-core/src/engine/sink.rs` | Returns a `broadcast::Receiver<EngineEvent>`. Lazy: zero allocation when no test calls subscribe. |
| `TestSink::wait_for(timeout, pred)` | same | One-shot helper: scans history first, then waits on live channel. Race-free. |
| `Env::run_inference_cancel_on_event(provider, pred)` | `koda-test-utils/src/env.rs` | Wraps the pattern: subscribe before inference starts, spawn a cancel-on-match watcher, run inference. |

The `wait_for` and `run_inference_cancel_on_event` helpers make the no-polling pattern the path of least resistance for any future cancel/race test. Net effect: 4 sleep-based race-prone patterns gone, all four affected tests now finish in **< 0.5s** instead of `100ms wait + actual work`.

**Out of scope (intentional):**
- `inference.rs::tests::test_collect_stream_cancellation` uses `sleep(50ms)` as deliberate stream sequencing, not polling. Replacing it would require a more complex channel handshake with no real flake-risk benefit.
- `inference.rs:289` is production retry backoff, not a test.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` | ✅ |
| `cargo test --workspace --features test-support --no-fail-fast` | ✅ 48 / 48 suites, 0 failures |
| `python3 scripts/check_tokio_test_flavor.py` (the new CI guard) | ✅ |

## Files changed

```
.github/workflows/ci.yml                            |   8 +
scripts/check_tokio_test_flavor.py                  | 158 +++++++++ (new)
koda-cli/src/transcript.rs                          |  +/- runtime_env reads
koda-cli/src/tui_bg_tasks.rs                        |  +/- multi_thread
koda-core/src/approval_flow.rs                      |  +/- multi_thread
koda-core/src/bg_agent.rs                           |  +/- multi_thread
koda-core/src/db/mod.rs                             |  +/- runtime_env reads
koda-core/src/db/tests.rs                           |  +/- mask/unmask
koda-core/src/engine/sink.rs                        |  +/- subscribe/wait_for
koda-core/src/inference.rs                          |  +/- multi_thread
koda-core/src/mcp/manager.rs                        |  +/- multi_thread
koda-core/src/providers/mock.rs                     |  +/- from_json_str split
koda-core/src/providers/stream_collector.rs         |  +/- multi_thread
koda-core/src/runtime_env.rs                        |  +/- mask/unmask API
koda-core/src/sub_agent_dispatch.rs                 |  +/- multi_thread
koda-core/src/tool_dispatch.rs                      |  +/- multi_thread
koda-core/src/tools/{bg_process,bg_task_tools,mod,validate}.rs |  +/- multi_thread
koda-core/src/trust.rs                              |  +/- multi_thread
koda-core/tests/cancel_test.rs                      |  oneshot signal
koda-core/tests/e2e_agent_test.rs                   |  runtime_env + multi_thread
koda-core/tests/e2e_test.rs                         |  oneshot signal + multi_thread
koda-core/tests/http_client_config_test.rs          |  EnvGuard::mask_all_proxy_env
koda-core/tests/inference_edge_test.rs              |  cancel_on_event + multi_thread
koda-core/tests/mcp_http_transport_test.rs          |  multi_thread
koda-core/tests/session_test.rs                     |  oneshot signal + multi_thread
koda-core/tests/tool_wiring_test.rs                 |  multi_thread
koda-sandbox/src/{worker,bwrap_proxy,proxy/*}.rs    |  multi_thread (43 tests)
koda-test-utils/src/env.rs                          |  +/- run_inference_cancel_on_event
44 files changed, 916 insertions(+), 504 deletions(-)
```

## Reviewer notes

- The 243-test multi_thread switch is mechanical; the CI guard ensures it stays mechanical going forward. New tests in danger-pattern modules will be caught at PR time, not at flake time.
- `TestSink::subscribe()` is opt-in (lazy `broadcaster: Mutex<Option<...>>`). Existing tests that just call `sink.events()` pay zero cost.
- `runtime_env::mask` / `unmask` is the smallest surface change that lets tests express "this env var is unset" without `unsafe { std::env::remove_var }`. Production code is unaware — it just calls `runtime_env::get`.
- No production behavior change. Every diff is either test infra or a `runtime_env::get` substitution for `std::env::var` (which falls back to `std::env::var` when no override is set).
