### PR TITLE
test: complete #1109 F1+F3 cleanup (sandbox unsafe set_var + last polling sleep)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1511,31 +1511,69 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn collect_stream_cancellation_sets_interrupted() {
+        use std::sync::Arc;
         let cancel = CancellationToken::new();
         let cancel_clone = cancel.clone();
 
         let (tx, mut rx) = mpsc::channel(32);
-        let sink = TestSink::new();
+        // **#1109 F3**: Arc the sink so the spawned producer can
+        // observe when the consumer has emitted the partial chunk.
+        // Replaces the old `sleep(50ms)` polling pattern (the only
+        // remaining wall-clock-budget test in this file) with the
+        // signal-based `TestSink::wait_for` primitive added in F3.
+        let sink = Arc::new(TestSink::new());
         let tmp = tempfile::tempdir().unwrap();
         let tools = test_tools(tmp.path());
 
-        // Send one delta, then cancel, then try to send more.
+        let sink_for_producer = Arc::clone(&sink);
         tokio::spawn(async move {
+            // 1. Send the partial chunk.
             let _ = tx.send(StreamChunk::TextDelta("partial".into())).await;
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // 2. Wait until `collect_stream` has actually consumed it
+            //    (signalled by the TextDelta event reaching the sink).
+            //    Was: sleep(50ms) — fine on a laptop, racy on macOS CI.
+            sink_for_producer
+                .wait_for(std::time::Duration::from_secs(5), |ev| {
+                    matches!(
+                        ev,
+                        crate::engine::EngineEvent::TextDelta { text } if text == "partial"
+                    )
+                })
+                .await
+                .expect("consumer should emit TextDelta within 5s");
+
+            // 3. Now safe to cancel: we know `partial` is in the result.
             cancel_clone.cancel();
-            // This should be ignored after cancel:
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+            // 4. Try to send another chunk after cancel — it should
+            //    NOT appear in the final result. No sleep needed: the
+            //    main task's `collect_stream.await` will have returned
+            //    by the time we reach the assertions, so the post-
+            //    cancel send races nothing.
             let _ = tx.send(StreamChunk::TextDelta(" ignored".into())).await;
         });
 
-        let result =
-            collect_stream(&mut rx, &sink, &cancel, &tools, TrustMode::Auto, tmp.path()).await;
+        let result = collect_stream(
+            &mut rx,
+            sink.as_ref(),
+            &cancel,
+            &tools,
+            TrustMode::Auto,
+            tmp.path(),
+        )
+        .await;
 
         assert!(result.interrupted);
         assert!(result.network_error.is_none());
         // Partial text should be captured up to cancellation.
         assert!(result.text.contains("partial"));
+        // Defensive: the post-cancel send must not leak into result.text.
+        assert!(
+            !result.text.contains("ignored"),
+            "post-cancel chunk leaked into result.text: {:?}",
+            result.text
+        );
     }
 
     // ── Network errors ───────────────────────────────────────────

--- a/koda-sandbox/benches/acquire_slot.rs
+++ b/koda-sandbox/benches/acquire_slot.rs
@@ -268,12 +268,11 @@ fn ensure_worker_bin() {
         if p.ends_with("debug") || p.ends_with("release") {
             let bin = p.join("koda-fs-worker");
             if bin.exists() {
-                // SAFETY: bench process is single-threaded at this
-                // point (we haven't built the tokio runtime yet) and
-                // we set this exactly once.
-                unsafe {
-                    std::env::set_var("KODA_FS_WORKER_BIN", &bin);
-                }
+                // **#1109 F1**: was `unsafe { std::env::set_var }`
+                // (UB in Rust 2024 if any bench thread reads env). Now
+                // uses the OnceLock-backed override published from the
+                // lib.
+                koda_sandbox::worker_client::set_worker_binary_for_tests(bin);
                 return;
             }
         }

--- a/koda-sandbox/benches/parallel_dispatch.rs
+++ b/koda-sandbox/benches/parallel_dispatch.rs
@@ -417,10 +417,10 @@ fn ensure_worker_bin() {
         if p.ends_with("debug") || p.ends_with("release") {
             let bin = p.join("koda-fs-worker");
             if bin.exists() {
-                // SAFETY: bench process single-threaded at startup.
-                unsafe {
-                    std::env::set_var("KODA_FS_WORKER_BIN", &bin);
-                }
+                // **#1109 F1**: was `unsafe { std::env::set_var }` (UB
+                // in Rust 2024 if any bench thread reads env). Now uses
+                // the OnceLock-backed override published from the lib.
+                koda_sandbox::worker_client::set_worker_binary_for_tests(bin);
                 return;
             }
         }

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -259,11 +259,27 @@ fn apply_policy_overlay(cmd: &mut Command, policy: &SandboxPolicy) -> Result<()>
 ///    `koda-core` e2e suite) find the helper without setting an env
 ///    var.
 pub fn stage2_binary() -> Result<PathBuf> {
-    if let Ok(p) = std::env::var(STAGE2_BIN_ENV_KEY) {
-        return Ok(PathBuf::from(p));
-    }
-    if let Ok(p) = std::env::var("CARGO_BIN_EXE_koda-sandbox-stage2") {
-        return Ok(PathBuf::from(p));
+    // Read env once at the boundary; delegate the rest to the pure
+    // resolver below. This keeps the env-binding surface tiny (and
+    // testable independently of the discovery logic).
+    let override_path = std::env::var(STAGE2_BIN_ENV_KEY)
+        .ok()
+        .or_else(|| std::env::var("CARGO_BIN_EXE_koda-sandbox-stage2").ok());
+    stage2_binary_from(override_path.as_deref().map(std::path::Path::new))
+}
+
+/// Pure-logic core of [`stage2_binary`]: given an optional explicit
+/// override path, return it if `Some`; otherwise fall back to the
+/// `current_exe`-sibling / cargo-deps-parent discovery chain.
+///
+/// Extracted in #1109 F1 so tests can exercise the override branch
+/// without `unsafe { std::env::set_var }` (UB in Rust 2024 when other
+/// threads concurrently read env). Tests pass the override path
+/// explicitly; the env-binding wrapper above remains 3 trivial lines
+/// not worth a dedicated test.
+pub fn stage2_binary_from(env_override: Option<&std::path::Path>) -> Result<PathBuf> {
+    if let Some(p) = env_override {
+        return Ok(p.to_path_buf());
     }
     let exe = std::env::current_exe().context("locate koda executable")?;
 
@@ -579,25 +595,18 @@ mod tests {
         }
     }
 
-    /// Pinned: stage 2 binary discovery honors the env override
+    /// Pinned: stage 2 binary discovery honors the override path
     /// before falling back to current_exe sibling lookup. E2E tests
     /// rely on this.
+    ///
+    /// **#1109 F1**: was `unsafe { std::env::set_var(...) }` which
+    /// is UB in Rust 2024 if any other test in the same binary
+    /// reads env concurrently. Now exercises the pure resolver
+    /// directly — no env mutation, no UB risk.
     #[test]
     fn stage2_binary_respects_env_override() {
-        let original = std::env::var(STAGE2_BIN_ENV_KEY).ok();
-        // SAFETY: this test binary is single-threaded; no other thread
-        // can observe the env mutation between set and restore.
-        unsafe { std::env::set_var(STAGE2_BIN_ENV_KEY, "/tmp/fake-stage2") };
-        let p = stage2_binary().unwrap();
+        let p = stage2_binary_from(Some(std::path::Path::new("/tmp/fake-stage2"))).unwrap();
         assert_eq!(p, std::path::PathBuf::from("/tmp/fake-stage2"));
-        // SAFETY: same single-threaded guarantee as above; restoring
-        // to the original value (or removing) is always safe here.
-        unsafe {
-            match original {
-                Some(v) => std::env::set_var(STAGE2_BIN_ENV_KEY, v),
-                None => std::env::remove_var(STAGE2_BIN_ENV_KEY),
-            }
-        }
     }
 
     // ── Gap 1 of #1072: apply_git_config_deny ──────────────

--- a/koda-sandbox/src/pool/tests.rs
+++ b/koda-sandbox/src/pool/tests.rs
@@ -81,6 +81,12 @@ impl WorkspaceProvider for FailingProvider {
 /// but not for `#[cfg(test)]` modules in the lib crate, so we shell
 /// out to find it the same way `worker_client::worker_binary()` does
 /// for production.
+///
+/// **#1109 F1**: was `unsafe { std::env::set_var(...) }` (UB in
+/// Rust 2024 if any other thread reads env). Now uses
+/// [`crate::worker_client::set_worker_binary_for_tests`] — a
+/// `OnceLock`-backed override that's safe under concurrent test
+/// execution.
 fn ensure_worker_bin() {
     if std::env::var("KODA_FS_WORKER_BIN").is_ok() {
         return;
@@ -95,14 +101,7 @@ fn ensure_worker_bin() {
         if p.ends_with("debug") || p.ends_with("release") {
             let bin = p.join("koda-fs-worker");
             if bin.exists() {
-                // SAFETY: tests here are inherently single-threaded
-                // for env mutation purposes — cargo serializes test
-                // binaries by default and we set this once per
-                // process. Documented in `worker_client::tests` for
-                // the same reason.
-                unsafe {
-                    std::env::set_var("KODA_FS_WORKER_BIN", &bin);
-                }
+                crate::worker_client::set_worker_binary_for_tests(bin);
                 return;
             }
         }

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -62,16 +62,41 @@ fn unique_socket_path() -> PathBuf {
     std::env::temp_dir().join(format!("koda-fs-worker-{pid}-{n}.sock"))
 }
 
-// ── Binary discovery ──────────────────────────────────────────────────────
+// ── Binary discovery ────────────────────────────────────────────────
+
+/// Test-only override for the worker binary path. Set via
+/// [`set_worker_binary_for_tests`] from a test setup helper; takes
+/// precedence over env-var lookup in [`worker_binary`].
+///
+/// **#1109 F1**: replaces `unsafe { std::env::set_var }` in test
+/// helpers (UB in Rust 2024 if any other thread reads env
+/// concurrently). [`OnceLock`] gives us "set once at process
+/// startup" semantics without locks or unsafe.
+static WORKER_BIN_OVERRIDE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+/// Set the worker binary path used by [`worker_binary`]. Idempotent:
+/// after the first successful call, subsequent calls are silently
+/// ignored (matches the "set once per process" semantics tests need).
+///
+/// Intended for test setup helpers. Production code uses env-var or
+/// sibling discovery.
+pub fn set_worker_binary_for_tests(path: PathBuf) {
+    let _ = WORKER_BIN_OVERRIDE.set(path);
+}
 
 /// Locate the `koda-fs-worker` binary.
 ///
 /// Resolution order:
-/// 1. `KODA_FS_WORKER_BIN` env var (explicit override, used in tests).
-/// 2. `CARGO_BIN_EXE_koda-fs-worker` env var (set by Cargo for
+/// 1. [`set_worker_binary_for_tests`] override (test-only).
+/// 2. `KODA_FS_WORKER_BIN` env var (explicit override; legacy entry
+///    point, preserved for backward compatibility).
+/// 3. `CARGO_BIN_EXE_koda-fs-worker` env var (set by Cargo for
 ///    integration tests — NOT available in `#[cfg(test)]` unit tests).
-/// 3. Sibling of the current executable (production install).
+/// 4. Sibling of the current executable (production install).
 fn worker_binary() -> Result<PathBuf> {
+    if let Some(p) = WORKER_BIN_OVERRIDE.get() {
+        return Ok(p.clone());
+    }
     if let Ok(p) = std::env::var("KODA_FS_WORKER_BIN") {
         return Ok(PathBuf::from(p));
     }

--- a/koda-sandbox/src/worker_client.rs
+++ b/koda-sandbox/src/worker_client.rs
@@ -66,17 +66,18 @@ fn unique_socket_path() -> PathBuf {
 
 /// Test-only override for the worker binary path. Set via
 /// [`set_worker_binary_for_tests`] from a test setup helper; takes
-/// precedence over env-var lookup in [`worker_binary`].
+/// precedence over env-var lookup in `worker_binary` (private).
 ///
 /// **#1109 F1**: replaces `unsafe { std::env::set_var }` in test
 /// helpers (UB in Rust 2024 if any other thread reads env
-/// concurrently). [`OnceLock`] gives us "set once at process
-/// startup" semantics without locks or unsafe.
+/// concurrently). [`OnceLock`](std::sync::OnceLock) gives us "set
+/// once at process startup" semantics without locks or unsafe.
 static WORKER_BIN_OVERRIDE: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
 
-/// Set the worker binary path used by [`worker_binary`]. Idempotent:
-/// after the first successful call, subsequent calls are silently
-/// ignored (matches the "set once per process" semantics tests need).
+/// Set the worker binary path used internally by `worker_binary`.
+/// Idempotent: after the first successful call, subsequent calls are
+/// silently ignored (matches the "set once per process" semantics
+/// tests need).
 ///
 /// Intended for test setup helpers. Production code uses env-var or
 /// sibling discovery.


### PR DESCRIPTION
Finishes the remaining acceptance criteria for #1109 left unfinished by PR #1113.

## What this PR does

### F1 — eliminate `unsafe { std::env::set_var }` from koda-sandbox tests + benches

PR #1113 closed AC1 strictly per the issue text (`koda-core/tests` and `koda-core/src/providers/mock.rs`). This PR extends the same hygiene to **koda-sandbox**, which had three more sites of the same Rust 2024 UB:

| File | Old | New |
|---|---|---|
| `koda-sandbox/src/bwrap.rs` (test) | `unsafe { set_var(STAGE2_BIN_ENV_KEY, ...) }` + restore | DI: extracted pure `stage2_binary_from(Option<&Path>)`; test passes the override directly |
| `koda-sandbox/src/pool/tests.rs` (helper) | `unsafe { set_var(\"KODA_FS_WORKER_BIN\", ...) }` | New `worker_client::set_worker_binary_for_tests(PathBuf)` backed by `OnceLock` |
| `koda-sandbox/benches/{acquire_slot,parallel_dispatch}.rs` | `unsafe { set_var(\"KODA_FS_WORKER_BIN\", ...) }` | Same `set_worker_binary_for_tests` API |

**Why DI for bwrap, OnceLock for worker_client?** `stage2_binary`'s discovery logic is small and the test only needs to verify the override branch — pure-function DI is the cleanest extraction (SOLID-D). `worker_binary` is called transitively from production code paths several layers deep; injecting a parameter would ripple through 5+ call sites for zero gain. `OnceLock` gives identical "set once at process startup" semantics with no locks, no `unsafe`, and a one-line API change at the call sites.

The only `unsafe { std::env::set_var }` remaining in the codebase is now `koda-sandbox/src/stage2.rs` — a **post-fork, pre-execvp child** where the process is single-threaded by definition. That's the textbook safe use-case and not what #1109 is about.

### F3 — last polling-sleep test in `inference.rs`

`collect_stream_cancellation_sets_interrupted` was the last test still using wall-clock budgets for synchronization (two `sleep(50ms)` calls). Replaced with the `TestSink::wait_for` primitive added in #1113.

**Bonus**: the new design enables a stronger assertion. The old test only checked `result.text.contains(\"partial\")`. With signal-based coordination we now also assert `!result.text.contains(\"ignored\")` — proving post-cancel chunks really don't leak. That assertion was structurally impossible to write with the old sleep-based design (the assertion would race the spawned task's second sleep).

## Test results

```
cargo test -p koda-sandbox       → 319 pass
cargo test -p koda-core (...)    → 1136 pass
cargo test -p koda-cli           → 465 pass
python3 scripts/check_tokio_test_flavor.py → OK
cargo clippy --all-targets -- -D warnings  → clean
```

Stress: `collect_stream_cancellation_sets_interrupted` 30/30 in <0.01s each (was ~100ms with the sleeps).

## After this PR

- [x] AC1: zero `unsafe { std::env::set_var/remove_var }` in any test or bench code (production stage2 child stays — different problem).
- [x] AC2: only `koda_test_utils` has env mutexes.
- [x] AC3: F2 CI guard green.
- [x] AC4: all six F3 polling-sleep sites converted to channel/event-based waits.
- [ ] AC5: 50 consecutive macOS post-merge runs — emergent, not blockable. Will track via post-merge dashboard.

F4 (back-linking historical race issues #211, #289, #387, #437, #597, #825, #1090) coming as separate GitHub comments — no code change required.

Closes #1109.