### PR TITLE
chore: bundle v0.2.22 P3 release-polish items (#1104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,37 @@ jobs:
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           fi
       - name: Test
-        run: cargo test --workspace --features koda-core/test-support
+        run: cargo test --workspace --features koda-core/test-support 2>&1 | tee test-output.log
+        # `tee` keeps live streaming for the GH log AND captures output
+        # for the assertion step below. We pipe stderr to stdout because
+        # cargo test prints test names to stderr in some configurations.
+      # #1104: regression guard — fail CI if the bwrap SEC-002 / TOCTOU
+      # tests didn't actually run. Without this, a future cfg-gate or
+      # test-binary split could silently exclude them and we'd only
+      # find out by getting hacked. Linux-only: bwrap is gated to
+      # `target_os = "linux"`.
+      - name: Assert bwrap SEC-002 regression tests ran (#1104)
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          required_tests=(
+            git_config_deny_pre_creates_for_non_git_dir_to_close_toctou
+            git_config_deny_adds_ro_bind_for_existing_git_dir
+            git_config_deny_skips_worktree_gitdir_pointer
+            git_config_deny_preserves_existing_config_mtime
+          )
+          missing=()
+          for t in "${required_tests[@]}"; do
+            if ! grep -qE "test bwrap::tests::${t} \.\.\. ok" test-output.log; then
+              missing+=("$t")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Required bwrap regression tests did not run:"
+            printf '  - %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "✓ All ${#required_tests[@]} bwrap SEC-002/TOCTOU regression tests ran."
 
   doc:
     name: Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ default-members = ["koda-cli"]
 
 [workspace.package]
 edition = "2024"
+# Pinned to the actual minimum required by current code (uses
+# `u64::is_multiple_of`, stable since 1.87). Surfacing this gives
+# downstream consumers a clear MSRV signal instead of a late
+# compile error from older toolchains. Bump in lockstep with any
+# new stdlib feature usage; clippy's incompatible_msrv lint will
+# catch the next drift.
+rust-version = "1.87"
 license = "MIT"
 repository = "https://github.com/lijunzh/koda"
 homepage = "https://github.com/lijunzh/koda"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "koda-cli"
 version = "0.2.22"
 edition.workspace = true
+rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
 license.workspace = true
 repository.workspace = true

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -2,13 +2,16 @@
 name = "koda-core"
 version = "0.2.22"
 edition.workspace = true
+rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 keywords = ["ai", "coding-agent", "llm", "engine", "unix"]
-categories = ["development-tools"]
+# crates.io permits up to 5 categories; surface the async + LLM-API
+# nature so search lands the crate beyond just "development-tools".
+categories = ["development-tools", "asynchronous", "api-bindings"]
 authors.workspace = true
 
 [lib]

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -2,6 +2,7 @@
 name = "koda-sandbox"
 version = "0.2.22"
 edition.workspace = true
+rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"
 license.workspace = true
 repository.workspace = true

--- a/koda-sandbox/src/bwrap.rs
+++ b/koda-sandbox/src/bwrap.rs
@@ -212,19 +212,47 @@ fn apply_git_config_deny(cmd: &mut Command, root: &str) {
     let hooks = format!("{git_dir}/hooks");
     let config = format!("{git_dir}/config");
 
+    // Worktree handling (#1104): when `.git` is a regular file (the
+    // `gitdir: <path>` pointer git uses for worktrees / submodules),
+    // `create_dir_all(".git/hooks")` returns NotADirectory. Detect and
+    // skip the deny dance — surfacing the case via tracing instead of
+    // silently swallowing the error and letting bwrap crash later
+    // with an opaque "source doesn't exist" at launch. The hardening
+    // this layer provides is best-effort (the seatbelt backend covers
+    // the same ground via deny rules); skipping it for the worktree
+    // edge case is the right trade-off versus parsing the gitdir
+    // pointer and chasing the real .git directory.
+    if let Ok(meta) = std::fs::symlink_metadata(&git_dir)
+        && meta.is_file()
+    {
+        tracing::warn!(
+            target: "koda::sandbox",
+            git_dir = %git_dir,
+            "skipping apply_git_config_deny: .git is a file (worktree/submodule); \
+             rely on seatbelt-style policy or set fs.allow_git_config=true"
+        );
+        return;
+    }
+
     // Pre-create the hooks dir (this also creates `.git/` if missing).
     // `create_dir_all` is idempotent and never truncates existing
     // contents, so a real repo's hooks directory is preserved as-is.
     let _ = std::fs::create_dir_all(&hooks);
 
-    // Pre-create `.git/config` only if it doesn't exist. We use the
-    // explicit existence check rather than `OpenOptions::create(true)`
-    // so that on a real repo we never accidentally touch the file's
-    // mtime — some tools (e.g. `git status`'s mtime-based caches)
-    // care. An empty file is a valid git config; git treats it as
-    // "no overrides, use defaults".
-    if !Path::new(&config).exists() {
-        let _ = std::fs::File::create(&config);
+    // Pre-create `.git/config` only if it doesn't exist. Use
+    // `create_new(true)` for an atomic "create-if-absent" — closes the
+    // TOCTOU window between an existence check and the create call
+    // (#1104). On a real repo with an existing config, `create_new`
+    // fails with `AlreadyExists` without modifying the file (no mtime
+    // touch, no truncation), which is exactly what we want. Any other
+    // error we ignore for the same reason as below: the bind below
+    // will surface a clear failure if anything is genuinely wrong.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&config)
+    {
+        Ok(_) | Err(_) => {} // existing file or transient FS error
     }
 
     // If the create_dir_all above failed (e.g. parent unwritable),
@@ -728,6 +756,77 @@ mod tests {
         assert!(
             !has_hooks_ro_bind,
             "allow_git_config=true must not add ro-bind for .git/hooks"
+        );
+    }
+
+    /// **#1104**: when `.git` is a regular file (the `gitdir: ...`
+    /// pointer used by git worktrees / submodules), the deny dance
+    /// must skip cleanly instead of (a) silently swallowing
+    /// `NotADirectory` and (b) causing bwrap to crash later with
+    /// "source doesn't exist".
+    #[test]
+    fn git_config_deny_skips_worktree_gitdir_pointer() {
+        let dir = tempfile::tempdir().unwrap();
+        // Worktree shape: .git is a file, not a directory.
+        std::fs::write(
+            dir.path().join(".git"),
+            b"gitdir: /some/main/.git/worktrees/my-wt\n",
+        )
+        .unwrap();
+
+        let mut cmd = Command::new("true");
+        let root = dir.path().to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+
+        // The .git file must remain a file (we didn't try to convert
+        // it into a directory or otherwise touch it).
+        assert!(
+            std::fs::symlink_metadata(dir.path().join(".git"))
+                .unwrap()
+                .is_file(),
+            ".git file must remain unchanged"
+        );
+
+        // No --ro-bind for hooks/config should have been added.
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            args.is_empty(),
+            "worktree case must add zero bind args (got: {args:?})"
+        );
+    }
+
+    /// **#1104**: the TOCTOU fix uses `create_new(true)` which fails
+    /// atomically on existing files — verify the existing config's
+    /// mtime is not bumped (the property the original existence-check
+    /// guard was protecting). Sleep-free: compare snapshots taken
+    /// before/after the call.
+    #[test]
+    fn git_config_deny_preserves_existing_config_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let git = dir.path().join(".git");
+        std::fs::create_dir_all(git.join("hooks")).unwrap();
+        let config = git.join("config");
+        std::fs::write(&config, b"[core]\nexisting=yes\n").unwrap();
+        let before = std::fs::metadata(&config).unwrap().modified().unwrap();
+
+        let mut cmd = Command::new("true");
+        let root = dir.path().to_string_lossy();
+        apply_git_config_deny(&mut cmd, &root);
+
+        let after = std::fs::metadata(&config).unwrap().modified().unwrap();
+        assert_eq!(
+            before, after,
+            "existing git config mtime must not be touched (TOCTOU fix invariant)"
+        );
+        // And contents must be byte-identical.
+        assert_eq!(
+            std::fs::read(&config).unwrap(),
+            b"[core]\nexisting=yes\n",
+            "contents must be unchanged"
         );
     }
 }


### PR DESCRIPTION
Knocks out 5 of 7 P3 items from #1104. The remaining 2 are intentionally deferred with full receipts (below).

## Items shipped

| # | Item | What changed |
|---|---|---|
| 1 | `rust-version` MSRV | Set to `1.87` (the actual code floor — `u64::is_multiple_of`). Auditor recommended 1.85 (edition floor) but real code requires 1.87. Clippy's `incompatible_msrv` lint now actively prevents stdlib drift. Propagated via `workspace = true` to all 3 publishable crates. **Bonus:** the MSRV pin is already load-bearing — see #3 receipts below. |
| 2 | `koda-core` categories | Expanded `["development-tools"]` → `["development-tools", "asynchronous", "api-bindings"]`. Two more crates.io search lanes; well under the 5-cap. |
| 5 | TOCTOU in `apply_git_config_deny` | Replaced `exists()`-then-`File::create()` with `OpenOptions::create_new(true)` for atomic create-if-absent. Closes the race window without touching mtime on existing repos (the property the original guard was protecting). New regression test `git_config_deny_preserves_existing_config_mtime` asserts the mtime invariant directly. |
| 6 | Worktree handling in `apply_git_config_deny` | When `.git` is a `gitdir: …` file (worktree/submodule case), `create_dir_all(".git/hooks")` returned NotADirectory, `let _` swallowed it, bwrap then crashed at launch with opaque "source doesn't exist". Now: detect the file case via `symlink_metadata().is_file()`, `tracing::warn!`, skip the deny binds cleanly. New regression test `git_config_deny_skips_worktree_gitdir_pointer`. |
| 7 | CI guard for SEC-002 regression tests | New Linux-only post-test step greps `test-output.log` for 4 specific SEC-002/TOCTOU test names; fails CI if any are missing. Closes the 'silent test exclusion' window the qa-expert flagged. Bash array keeps the list maintainable. CI run confirmed: `✓ All 4 bwrap SEC-002/TOCTOU regression tests ran.` |

## Items NOT shipped — with full receipts

### #3 `cargo update` — deferred (real upstream regression)

Re-attempted with corporate proxy under the new MSRV pin. **Two findings:**

**Finding A — the bad news:** Even with MSRV-aware resolution, `libc 0.2.186` + `rpassword 7.5.0` is build-broken on macOS:

```
Pre-update lockfile:  libc 0.2.185 + rpassword 7.4.0  ✅ builds
Post-update lockfile: libc 0.2.186 + rpassword 7.5.0  ❌ macOS build break
```

Root cause: `libc 0.2.186` removed an Apple-side polyfill exposing `__errno_location` (a glibc-Linux-only symbol; Apple uses `__error()`). `rpassword 7.5.0` calls into it unconditionally — that's an upstream `rpassword` bug, not something a lockfile bump can route around. `rpassword 7.5.0` is the latest published version, so we can't bump past it either.

Two real-fix paths exist (pin `libc < 0.2.186`, or replace `rpassword` with e.g. `dialoguer`/`security-framework`), but both deserve their own focused PR with isolated review, not a buried line in a P3 polish bundle.

**Finding B — the good news:** Item #1's MSRV pin (`rust-version = "1.87"`) is **already paying its own salary**. Cargo's MSRV-aware resolver held back **6 packages** that would have required Rust 1.88+:

```
darling      v0.23.0    (held: requires Rust 1.88.0)
darling_core v0.23.0    (held: requires Rust 1.88.0)
darling_macro v0.23.0   (held: requires Rust 1.88.0)
image        v0.25.10   (held: requires Rust 1.88.0)
instability  v0.3.12    (held: requires Rust 1.88)
time*        v0.3.47    (held: requires Rust 1.88.0)
```

Without the MSRV pin we'd have silently consumed those, then surprised some downstream user (or our own future toolchain pin). So #1 isn't just metadata — it's load-bearing.

### #4 `ratatui-textarea` bump — deferred (auditor was wrong about the version)

Investigated. **There is no upgrade target.**

```
Crate we use:     ratatui-textarea  → Cargo.toml: "0.9"  → Lockfile: 0.9.1
Latest published: ratatui-textarea  → 0.9.1   ← we're already there
```

The auditor likely confused our crate with one of these unrelated lineages:

| Crate | Targets | Latest | Our dep? |
|---|---|---|---|
| `ratatui-textarea` | ratatui (modern) | 0.9.1 | ✅ |
| `tui-textarea` | tui-rs + ratatui | 0.7.0 | ❌ |
| `tui-textarea-2` | community fork | 0.10.2 | ❌ |

So the deferral isn't "TUI risk" — it's "we're already on the head."

**Strategic follow-up filed:** #1116 — *"Long-term: internalize TUI textarea (own the composer surface, drop ratatui-textarea dep)"*. Codex (`codex-rs/tui/src/bottom_pane/textarea.rs`) hand-rolled a 2,660-line `TextArea` rather than depend on any third-party widget; that issue captures when/whether koda should consider the same path.

## Verification

```
cargo fmt --all --check                                → clean
cargo clippy --workspace --all-targets -- -Dwarnings   → clean
cargo test -p koda-sandbox                             → 319 pass
cargo test -p koda-core --features test-support        → 1139 pass
cargo test -p koda-cli                                 → 470 pass
python3 scripts/check_tokio_test_flavor.py             → OK
CI run #25083950520                                    → all 7 jobs pass
  └─ Assert bwrap SEC-002 regression tests ran (#1104) → ✓ All 4 ran
```

bwrap-specific regression tests added (3 of 4 are macOS-skipped because `bwrap` is `#[cfg(target_os = "linux")]`); the new CI guard step in this same PR enforces they ran successfully on the Ubuntu runner.

Refs #1104. Spawned #1116.
