### PR TITLE
fix(tui): install panic hook to restore terminal on crash

### DIFF
--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -511,6 +511,12 @@ fn ask_user_menu_height(
 /// Initialize the terminal in fullscreen mode (alternate screen buffer).
 ///
 /// No DSR queries, no cursor position tracking. The app owns every pixel.
+///
+/// Also installs a panic hook that restores the terminal before the panic
+/// propagates — without it, a panic anywhere in the app (provider code, tool
+/// dispatch, ratatui render, tokio task, JSON deserialization, …) leaves the
+/// terminal in raw mode + alternate screen + mouse capture on, which makes
+/// the user's shell unusable until they run `reset` or open a new session.
 pub(crate) fn init_terminal() -> Result<Term> {
     crossterm::terminal::enable_raw_mode()?;
     crossterm::execute!(
@@ -519,6 +525,8 @@ pub(crate) fn init_terminal() -> Result<Term> {
         crossterm::event::EnableBracketedPaste,
         crossterm::event::EnableMouseCapture,
     )?;
+
+    set_panic_hook();
 
     let stdout = std::io::stdout();
     let backend = CrosstermBackend::new(stdout);
@@ -532,15 +540,41 @@ pub(crate) fn init_terminal() -> Result<Term> {
     Ok(terminal)
 }
 
-/// Restore the terminal: exit alternate screen, disable raw mode.
-pub(crate) fn restore_terminal(terminal: &mut Term) {
+/// Disable raw mode + leave alternate screen + drop mouse/paste capture.
+///
+/// Writes directly to `stdout()` so it can run from anywhere — including
+/// the panic hook, which has no access to the `Terminal` value.
+pub(crate) fn restore_terminal_modes() {
     let _ = crossterm::execute!(
-        terminal.backend_mut(),
+        std::io::stdout(),
         crossterm::event::DisableMouseCapture,
         crossterm::event::DisableBracketedPaste,
         crossterm::terminal::LeaveAlternateScreen,
     );
     let _ = crossterm::terminal::disable_raw_mode();
+}
+
+/// Restore the terminal: exit alternate screen, disable raw mode.
+///
+/// Convenience wrapper for the normal-shutdown path that already owns a
+/// `Terminal`. Equivalent to [`restore_terminal_modes`].
+pub(crate) fn restore_terminal(_terminal: &mut Term) {
+    restore_terminal_modes();
+}
+
+/// Install a panic hook that restores the terminal before the original hook
+/// runs (so the panic message + backtrace still surface to the user, but on a
+/// sane TTY rather than a corrupted one).
+///
+/// Pattern lifted from `codex-rs/tui/src/tui.rs`; see issue #1119 for the
+/// comparative analysis.
+fn set_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Best-effort: ignore errors here, we're already failing.
+        restore_terminal_modes();
+        original(info);
+    }));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes the most painful symptom from #1119 — when koda panics during inference, the terminal is left in raw mode + alt screen + mouse capture on, making the user's shell unusable until they run `reset` or open a new terminal.

## What

Adds `set_panic_hook()` that:
1. Takes the original panic hook
2. Restores TTY modes (disable raw mode, leave alt screen, disable mouse capture, disable bracketed paste)
3. Chains to the original hook so the panic message + backtrace still surface

Pattern lifted directly from `codex-rs/tui/src/tui.rs:437` — validated in the comparative audit on #1119 against codex-rs (TUI), zed (GUI), gemini-cli (Ink), and claude-code (Ink). The codex pattern is the industry standard for crossterm-based TUIs.

## Why this is part 1 of 2

This addresses **Finding 3** from #1119 (panic → terminal corruption). It's split out from the timeout/retry fixes (Findings 1 + 2) because:

- It's purely defensive — zero behavior change to the inference path
- It's tiny (~37 lines including doc comments) and easy to review
- It can ship independently while the timeout/retry PR gets more careful test coverage

The companion PR for Findings 1 + 2 (bump `read_timeout` to 300s + add network-transient-error retry classifier) will follow.

## Refactor note

`restore_terminal` previously took `&mut Term` because it called `terminal.backend_mut()` to send escape sequences. Since the panic hook has no access to the `Terminal` value, this PR extracts `restore_terminal_modes()` that writes directly to `std::io::stdout()`. The existing `restore_terminal(&mut Term)` becomes a thin wrapper preserving the normal-shutdown call site's API.

## Testing

- ✅ `cargo check -p koda-cli` — clean
- ✅ `cargo clippy -p koda-cli --all-targets --features koda-core/test-support -- -D warnings` — clean
- ✅ `cargo test -p koda-cli --lib` — 479 tests passing
- 🔬 Manual repro will be possible once a panic-inducing code path is reachable; for now the pattern is well-validated by codex-rs in production

A unit test with `catch_unwind` was considered but skipped because the panic hook is global mutable state that races between parallel tests. If we want to harden later, the `serial_test` crate would be the path.

## Refs

- #1119 (root issue with full audit + comparative analysis)
- `codex-rs/tui/src/tui.rs:437` (source pattern)
