### PR TITLE
fix(inference): bump read_timeout 180s→300s and auto-retry transient network errors

### DIFF
--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -47,7 +47,7 @@ All providers use a shared HTTP client with the following timeout defaults:
 | Setting | Default | Env override | Description |
 |---------|---------|--------------|-------------|
 | Connect timeout | 30 s | `KODA_CONNECT_TIMEOUT_SECS` | Time allowed to establish the TCP/TLS connection |
-| Read timeout | 180 s | `KODA_READ_TIMEOUT_SECS` | Time allowed between bytes from the server (per-byte, not total) |
+| Read timeout | 300 s (5 min) | `KODA_READ_TIMEOUT_SECS` | Time allowed between bytes from the server (per-byte, not total) |
 
 The read timeout is **per-byte, not total**. A long streaming response is
 fine as long as bytes keep arriving — the timer resets on each chunk.
@@ -60,8 +60,9 @@ but a stalled connection (server hung after last byte) will fail fast.
   60 or 90. Connection-phase timeouts often manifest as "request timed out"
   with no usage data, which is the giveaway.
 - **Long-running model on a flaky link?** Bump `KODA_READ_TIMEOUT_SECS` to
-  300+. Read-phase timeouts manifest as a partial response cut short
-  partway through generation.
+  600+. Read-phase timeouts manifest as a partial response cut short
+  partway through generation. (Note: koda also auto-retries transient
+  network errors up to 5 times with exponential backoff; see `is_network_transient_error`.)
 - **Local provider (Ollama, LM Studio, vLLM) and you want fail-fast?**
   Drop `KODA_READ_TIMEOUT_SECS` to 30 — local models that hang are usually
   truly hung, not slow.

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -42,8 +42,8 @@ use crate::engine::{EngineCommand, EngineEvent, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference_helpers::{
     AUTO_COMPACT_THRESHOLD, CONTEXT_WARN_THRESHOLD, RATE_LIMIT_MAX_RETRIES, assemble_messages,
-    estimate_tokens, is_context_overflow_error, is_image_rejection_error, is_rate_limit_error,
-    is_server_error, rate_limit_backoff,
+    estimate_tokens, is_context_overflow_error, is_image_rejection_error,
+    is_network_transient_error, is_rate_limit_error, is_server_error, rate_limit_backoff,
 };
 use crate::loop_guard::{LoopAction, LoopDetector};
 use crate::persistence::Persistence;
@@ -255,7 +255,14 @@ async fn preflight_compact_if_needed(
     }
 }
 
-/// Attempt to start a chat stream with exponential backoff on rate limits.
+/// Attempt to start a chat stream with exponential backoff on retryable errors.
+///
+/// Retries on:
+/// - Rate-limit / overload signals (`is_rate_limit_error`)
+/// - Transient network failures (`is_network_transient_error`) — idle
+///   read timeouts, connection resets, broken pipes, DNS hiccups, etc.
+///   These are the dominant failure mode on long reasoning turns where the
+///   model server goes silent past `KODA_READ_TIMEOUT_SECS`. See #1119.
 ///
 /// Returns `Ok(Some(rx))` on success, `Ok(None)` if cancelled during retries,
 /// or `Err` for non-retriable failures.
@@ -275,14 +282,28 @@ async fn try_with_rate_limit(
         };
         match result {
             Ok(collector) => return Ok(Some(collector)),
-            Err(e) if is_rate_limit_error(&e) && attempt + 1 < RATE_LIMIT_MAX_RETRIES => {
+            Err(e)
+                if (is_rate_limit_error(&e) || is_network_transient_error(&e))
+                    && attempt + 1 < RATE_LIMIT_MAX_RETRIES =>
+            {
                 let delay = rate_limit_backoff(attempt);
+                let kind = if is_rate_limit_error(&e) {
+                    "Rate limited"
+                } else {
+                    "Network glitch"
+                };
                 sink.emit(EngineEvent::SpinnerStop);
                 sink.emit(EngineEvent::Warn {
-                    message: format!("\u{23f3} Rate limited. Retrying in {}s...", delay.as_secs()),
+                    message: format!(
+                        "\u{23f3} {kind}. Retrying in {}s (attempt {}/{})...",
+                        delay.as_secs(),
+                        attempt + 1,
+                        RATE_LIMIT_MAX_RETRIES
+                    ),
                 });
                 tracing::warn!(
-                    "Rate limit (attempt {}/{}): {e:#}",
+                    "{} (attempt {}/{}): {e:#}",
+                    kind,
                     attempt + 1,
                     RATE_LIMIT_MAX_RETRIES
                 );
@@ -295,7 +316,7 @@ async fn try_with_rate_limit(
             Err(e) => return Err(e),
         }
     }
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("Rate limit retries exhausted")))
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("Retries exhausted")))
 }
 
 /// Recover from a context overflow error: compact the session, re-assemble

--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -175,6 +175,50 @@ pub fn is_rate_limit_error(err: &anyhow::Error) -> bool {
 /// Maximum number of retries for rate-limited requests.
 pub const RATE_LIMIT_MAX_RETRIES: u32 = 5;
 
+/// Detect if an error is a transient network/transport failure that's worth
+/// auto-retrying with backoff.
+///
+/// Covers low-level network conditions that don't surface as HTTP status
+/// codes: idle-read timeouts, dropped half-open sockets, broken pipes,
+/// short-lived DNS / TLS hiccups, etc. These are NOT recoverable via
+/// context compaction (so they don't belong in `is_context_overflow_error`)
+/// and they're NOT rate-limit signals (so they don't belong in
+/// `is_rate_limit_error`), but they ARE worth retrying because the typical
+/// cause is a stale TCP connection or a transiently-flaky network rather
+/// than a permanent failure.
+///
+/// String patterns mirror the `RETRYABLE_NETWORK_CODES` list maintained by
+/// gemini-cli (`packages/core/src/utils/retry.ts`), translated into the
+/// human-readable forms that `reqwest` / `anyhow` emit on the Rust side.
+/// See issue #1119 for the comparative analysis.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::inference_helpers::is_network_transient_error;
+///
+/// assert!(is_network_transient_error(&anyhow::anyhow!("operation timed out")));
+/// assert!(is_network_transient_error(&anyhow::anyhow!("connection reset by peer")));
+/// assert!(is_network_transient_error(&anyhow::anyhow!("broken pipe")));
+/// assert!(!is_network_transient_error(&anyhow::anyhow!("401 Unauthorized")));
+/// ```
+pub fn is_network_transient_error(err: &anyhow::Error) -> bool {
+    let msg = format!("{err:#}").to_lowercase();
+    msg.contains("operation timed out")
+        || msg.contains("timed out")
+        || msg.contains("connection reset")
+        || msg.contains("connection closed")
+        || msg.contains("connection aborted")
+        || msg.contains("connection refused")
+        || msg.contains("broken pipe")
+        || msg.contains("unexpected end of file")
+        || msg.contains("unexpected eof")
+        || msg.contains("error trying to connect")
+        || msg.contains("dns error")
+        || msg.contains("failed to lookup address")
+        || msg.contains("tls handshake")
+}
+
 /// Compute exponential backoff delay for a retry attempt (1-indexed).
 /// Returns duration in seconds: 2, 4, 8, 16, 32 (capped at 32s).
 ///
@@ -426,6 +470,71 @@ mod tests {
         assert_eq!(rate_limit_backoff(2).as_secs(), 4);
         assert_eq!(rate_limit_backoff(3).as_secs(), 8);
         assert_eq!(rate_limit_backoff(10).as_secs(), 32); // capped
+    }
+
+    #[test]
+    fn test_is_network_transient_error() {
+        // Idle / read timeouts (the original #1119 trigger)
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "error sending request: operation timed out"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "request timed out after 180s"
+        )));
+
+        // Connection-state failures
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "connection reset by peer"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "connection closed before message completed"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "connection aborted"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "connection refused"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!("broken pipe")));
+
+        // Premature stream termination
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "unexpected end of file"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "unexpected EOF"
+        )));
+
+        // Connect-phase failures (caller may want to retry once before erroring)
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "error trying to connect: tcp connect error"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "dns error: failed to lookup address information"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "failed to lookup address information"
+        )));
+        assert!(is_network_transient_error(&anyhow::anyhow!(
+            "tls handshake eof"
+        )));
+
+        // Should NOT match — these belong to other classifiers
+        assert!(!is_network_transient_error(&anyhow::anyhow!(
+            "401 Unauthorized"
+        )));
+        assert!(!is_network_transient_error(&anyhow::anyhow!(
+            "prompt is too long"
+        )));
+        assert!(!is_network_transient_error(&anyhow::anyhow!(
+            "429 Too Many Requests"
+        )));
+        assert!(!is_network_transient_error(&anyhow::anyhow!(
+            "500 Internal Server Error"
+        )));
+        assert!(!is_network_transient_error(&anyhow::anyhow!(
+            "invalid JSON in response"
+        )));
     }
 
     #[test]

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -189,9 +189,14 @@ fn is_localhost_url(url: &str) -> bool {
 /// - Supports separate PROXY_USER / PROXY_PASS env vars
 /// - Bypasses proxy for localhost (LM Studio)
 /// - Applies a connect timeout (default 30s, env: `KODA_CONNECT_TIMEOUT_SECS`)
-///   and a read timeout (default 180s, env: `KODA_READ_TIMEOUT_SECS`).
+///   and a read timeout (default 300s = 5 min, env: `KODA_READ_TIMEOUT_SECS`).
 ///   We deliberately avoid the total-request `.timeout()` because it would
 ///   kill long-running SSE streams during slow tool/agent turns.
+///
+///   The 5-minute default matches `codex-rs/model-provider-info`'s
+///   `DEFAULT_STREAM_IDLE_TIMEOUT_MS` and accommodates reasoning-heavy
+///   models (Gemini 3.x Pro, MiniMax 2.x, etc.) that may silent-think
+///   for several minutes between SSE chunks. See issue #1119.
 pub fn build_http_client(base_url: Option<&str>) -> reqwest::Client {
     let mut builder = reqwest::Client::builder();
 
@@ -211,7 +216,7 @@ pub fn build_http_client(base_url: Option<&str>) -> reqwest::Client {
         .unwrap_or(30);
     let read_timeout = crate::runtime_env::get("KODA_READ_TIMEOUT_SECS")
         .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(180);
+        .unwrap_or(300);
     builder = builder
         .connect_timeout(std::time::Duration::from_secs(connect_timeout))
         .read_timeout(std::time::Duration::from_secs(read_timeout));


### PR DESCRIPTION
Companion to #1120. Together these two PRs close #1119.

Fixes **Findings 1 + 2** from the #1119 audit: long reasoning turns hit the 180s `read_timeout`, the resulting timeout error doesn't match `is_server_error()`, and there's no retry path for transient network failures — so the user sees "connection broken" and reproducing the prompt hits the same wall.

## What changes

### 1. Default `read_timeout`: 180s → 300s

`koda-core/src/providers/mod.rs`. Matches `codex-rs`'s `DEFAULT_STREAM_IDLE_TIMEOUT_MS = 300_000` (`model-provider-info/src/lib.rs:26`). The `KODA_READ_TIMEOUT_SECS` env var still overrides for users who want to tune it for local providers (e.g., set to 30 for fail-fast on Ollama/LM Studio).

### 2. New `is_network_transient_error()` classifier

`koda-core/src/inference_helpers.rs`. Catches the failure modes that previously bubbled up unrecognized:

| Pattern | Real-world trigger |
|---|---|
| `operation timed out` / `timed out` | `read_timeout` firing on a silent model |
| `connection reset` / `connection closed` / `connection aborted` | NAT box dropped a half-open socket |
| `connection refused` | Provider briefly down |
| `broken pipe` | Server killed mid-stream |
| `unexpected end of file` / `unexpected EOF` | TCP FIN without HTTP completion |
| `error trying to connect` | Connect-phase failure |
| `dns error` / `failed to lookup address` | DNS hiccup |
| `tls handshake` | TLS protocol blip |

This list mirrors gemini-cli's `RETRYABLE_NETWORK_CODES` (`packages/core/src/utils/retry.ts:48-57`), translated from Node `errno` codes to the human-readable strings reqwest produces on the Rust side.

### 3. Wired into the existing retry loop

`try_with_rate_limit` in `koda-core/src/inference.rs` now retries on `is_rate_limit_error || is_network_transient_error`. Reuses the existing infrastructure:

- Same `RATE_LIMIT_MAX_RETRIES = 5` budget
- Same `rate_limit_backoff()` curve (2/4/8/16/32s)
- Spinner messaging adapts: "⏳ Network glitch. Retrying in 2s (attempt 1/5)..." vs "⏳ Rate limited. Retrying in 2s (attempt 1/5)..."

I considered renaming the function to `try_with_retry` for accuracy (since it's no longer rate-limit-specific) but kept it as-is to minimize diff; happy to follow up with a rename in a separate PR if reviewers want.

### 4. Doc updates

- `koda-core/src/providers/mod.rs` docstring: bumped to 300s (5 min), notes the codex-rs precedent
- `docs/src/providers.md`: bumped table value, mentions auto-retry behavior

## Why these specific numbers

From the comparative audit on #1119:

| Codebase | Idle timeout | Retry budget |
|---|---|---|
| **koda before** | 180s | 0 (network errors not classified) |
| **koda after (this PR)** | **300s** | **5** |
| codex-rs | 300s (`DEFAULT_STREAM_IDLE_TIMEOUT_MS`) | 5 (`DEFAULT_STREAM_MAX_RETRIES`) |
| gemini-cli | implicit (10 retries × 30s backoff) | 10 (`DEFAULT_MAX_ATTEMPTS`) |
| zed | none (per-call abort) | classifier-based |

Going with codex's exact pair (300s + 5 retries) is the minimum-surprise change that brings koda inline with the closest architectural sibling.

## Tests

- ✅ New `test_is_network_transient_error` — 17 positive cases (timeouts, connection states, premature EOFs, connect/DNS/TLS failures) + 5 negative cases (auth, context overflow, rate limit, 5xx, JSON errors) confirming we don't catch errors that belong to other classifiers
- ✅ `cargo check --workspace` clean
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` clean
- ✅ `cargo fmt --all --check` clean
- ✅ `cargo test --workspace` — all 1140 koda-core (was 1139 before, +1 new test) + 479 koda-cli + all sub-crates passing
- ✅ Pre-existing `read_timeout_aborts_silent_servers_quickly` regression test in `http_client_config_test.rs` unaffected (uses explicit `KODA_READ_TIMEOUT_SECS=1` env override)

## Future work (not in scope for this PR)

Filed as separate ideas in #1119:

- **P1:** Replace `reqwest::read_timeout` with a true app-level `stream_idle_timeout` reset on each parsed SSE chunk (codex-rs's architecture). More semantically correct: "model has been silent" vs "socket has been silent."
- **P1:** Capture panic backtraces to `~/.config/koda/logs/panic.log` (depends on #1120 landing first).
- **P2:** Defend against fragmented mouse escape sequences if leaks persist after #1120 (port gemini-cli's `isIncompleteMouseSequence` pattern).

## Refs

- Closes #1119
- Companion to #1120 (panic hook)
- `codex-rs/model-provider-info/src/lib.rs:26` — 300s default
- `gemini-cli/packages/core/src/utils/retry.ts:48` — `RETRYABLE_NETWORK_CODES` list
