### PR TITLE
sub-agents: trust the model, drop the iteration cap

### DIFF
--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -298,11 +298,13 @@ fn agent_status_spans(status: &koda_core::bg_agent::AgentStatus) -> Vec<Span<'st
                 // placeholder for "started but no per-iter info
                 // wired yet." Foreground sub-agents still send 0;
                 // background agents emit live updates (Layer 4, #1058). Don't
-                // render "iter 0/20" — it misleads the user into
+                // render "iter 0" — it misleads the user into
                 // thinking nothing has happened.
                 "\u{25b6} Running".to_string()
             } else {
-                format!("\u{25b6} Running (iter {iter}/20)")
+                // #1110 removed the sub-agent iteration cap, so there's
+                // no denominator to display anymore. Just show the count.
+                format!("\u{25b6} Running (iter {iter})")
             };
             vec![Span::styled(label, CYAN.add_modifier(Modifier::BOLD))]
         }
@@ -621,14 +623,14 @@ mod tests {
         );
         // iter > 0 surfaces the per-iter detail.
         assert!(
-            text.contains("iter 7/20"),
+            text.contains("iter 7"),
             "expected per-iter detail when iter > 0, got: {text}"
         );
     }
 
     /// Layer-0 placeholder semantics: `Running { iter: 0 }` means
     /// "started but no per-iter info yet" — don't render a misleading
-    /// `"iter 0/20"`. Layer 4 (#1058) populated the field for bg agents.
+    /// `"iter 0"`. Layer 4 (#1058) populated the field for bg agents.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn list_background_tasks_hides_iter_zero_placeholder() {
         let mut buf = ScrollBuffer::new(64);
@@ -642,7 +644,7 @@ mod tests {
         let text = buffer_text(&buf);
         assert!(text.contains("Running"));
         assert!(
-            !text.contains("iter 0/20"),
+            !text.contains("iter 0"),
             "iter 0 should not render the per-iter detail (it's a Layer-0 placeholder), got: {text}"
         );
     }

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -70,9 +70,11 @@ use crate::engine::EngineEvent;
 /// when execution actually starts and to one of the terminal variants
 /// (`Completed`, `Errored`, `Cancelled`) when it finishes.
 ///
-/// `Running.iter` reflects the current inference iteration (1..=20).
-/// Background agents emit live updates via Layer 4 (#1058); `0` is
-/// the entry-point placeholder before the first iteration fires.
+/// `Running.iter` reflects the current inference iteration. Background
+/// agents emit live updates via Layer 4 (#1058); `0` is the entry-point
+/// placeholder before the first iteration fires. There is no upper bound
+/// (#1110 removed the sub-agent cap) — the counter widens to `u32` so
+/// long-running agents can't silently wrap.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum AgentStatus {
@@ -81,11 +83,13 @@ pub enum AgentStatus {
     /// Actively executing. `iter` is the current inference iteration
     /// (1..=20); `0` means "started, no iter info yet" (Layer 0 default).
     Running {
-        /// Current inference iteration (1..=20). `0` is the
-        /// entry-point placeholder emitted before the first iteration
-        /// in `run_bg_agent`; background agents update this live
-        /// (Layer 4, #1058).
-        iter: u8,
+        /// Current inference iteration (1..). `0` is the entry-point
+        /// placeholder emitted before the first iteration in
+        /// `run_bg_agent`; background agents update this live
+        /// (Layer 4, #1058). `u32` because #1110 removed the sub-agent
+        /// iteration cap and a meandering weak model could plausibly
+        /// exceed `u8::MAX` before context exhaustion.
+        iter: u32,
     },
     /// User or parent fired the cancel token. Terminal.
     Cancelled,

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1361,6 +1361,8 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 sink.emit(EngineEvent::Warn {
                     message: format!(
                         "Loop guard: {detail} — model ignored feedback, stopping. \
+                         This often means the current model isn't capable enough for the \
+                         task; consider switching to a stronger model. \
                          Send a follow-up message to continue."
                     ),
                 });

--- a/koda-core/src/loop_guard.rs
+++ b/koda-core/src/loop_guard.rs
@@ -25,8 +25,11 @@
 //!
 //! 1. **Consecutive identical calls** — same `(tool, args)` called
 //!    `CONSECUTIVE_REPEAT_THRESHOLD` times in a row → inject feedback.
-//! 2. **Hard iteration cap** — absolute ceiling on loop iterations.
-//!    User can extend interactively.
+//! 2. **Hard iteration cap (top-level only)** — absolute ceiling on
+//!    the main inference loop. User can extend interactively.
+//!    Sub-agent loops are **uncapped** as of #1110; they trust the
+//!    model and rely on consecutive-identical detection, provider
+//!    stop reasons, cancellation, and context bounds (P3 in DESIGN.md).
 
 use crate::providers::ToolCall;
 use std::collections::VecDeque;
@@ -34,8 +37,11 @@ use std::collections::VecDeque;
 /// Default hard cap for the main inference loop.
 pub const MAX_ITERATIONS_DEFAULT: u32 = 200;
 
-/// Hard cap for sub-agent loops.
-pub const MAX_SUB_AGENT_ITERATIONS: usize = 20;
+// `MAX_SUB_AGENT_ITERATIONS` deleted in #1110: per `DESIGN.md` P3 ("Build for
+// the world six months from now"), sub-agents trust the model and rely on
+// `LoopDetector`, provider stop reasons, cancellation, and context bounds
+// instead of a hardcoded iteration count. Codex and Zed both ship without
+// any per-sub-agent iteration cap.
 
 /// How many **consecutive** identical tool calls (same name + args) trigger
 /// loop detection. "Consecutive" means the same fingerprint appears this

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -9,7 +9,6 @@ use crate::approval_flow::request_approval;
 use crate::config::KodaConfig;
 use crate::db::{Database, Role};
 use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
-use crate::loop_guard;
 use crate::memory;
 use crate::persistence::Persistence;
 use crate::preview;
@@ -54,15 +53,15 @@ pub(crate) fn next_invocation_id() -> u32 {
 /// RAII cleanup hook for #996 Phase E.
 ///
 /// On drop, cancels every bg-agent registry entry tagged with this
-/// sub-agent's invocation id. That covers the two ways a sub-agent
-/// can exit and leave orphans:
+/// sub-agent's invocation id. That covers the way a sub-agent can
+/// exit and leave orphans:
 ///
-///   1. **Iteration cap** (`Ok(iteration_cap_marker(...))`) — the
-///      sub-agent ran out of inference iterations *while* one of its
-///      bg children was still running.
-///   2. **Error return** (`Err(...)` from any `?` inside the loop) —
+///   1. **Error return** (`Err(...)` from any `?` inside the loop) —
 ///      e.g. provider failure, persistence failure, `?`-propagated
 ///      cancellation.
+///   2. **`LoopDetector` hard stop** — model ignored feedback after
+///      consecutive identical tool calls; surfaced via the inference
+///      helpers, not as a marker string here.
 ///
 /// On the cancel-token path we'd reap anyway via the parent's cascade,
 /// but the spawner-scoped cancel is cheap and idempotent so we just
@@ -757,7 +756,13 @@ pub(crate) fn execute_sub_agent<'a>(
             &tools.skill_registry,
         );
 
-        for iter in 1u8..=loop_guard::MAX_SUB_AGENT_ITERATIONS as u8 {
+        for iter in 1u32.. {
+            // #1110: sub-agents have no hardcoded iteration cap. Termination
+            // is driven by the model (clean stop, no tool calls), `LoopDetector`
+            // (consecutive identical calls -> feedback -> hard stop), parent
+            // cancellation, or context exhaustion. Per DESIGN.md P3:
+            // "Let the model drive [...] don't scaffold around weakness."
+            //
             // Layer 4 of #996 + #1076: push the live iteration counter
             // so `/agents`, the status-bar pill, AND ACP / headless /
             // TUI clients all reflect real progress instead of the
@@ -1065,53 +1070,12 @@ pub(crate) fn execute_sub_agent<'a>(
                 .await?;
             }
         }
-
-        sink.emit(EngineEvent::Warn {
-            message: format!(
-                "Sub-agent '{agent_name}' hit its iteration limit ({}). Returning partial result.",
-                loop_guard::MAX_SUB_AGENT_ITERATIONS
-            ),
-        });
-        // Release workspace on iteration limit exit.
-        if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
-            sink.emit(EngineEvent::Info {
-                message: format!("  \u{1f335} {agent_name}: {hint}"),
-            });
-        }
-        // **#1022 B18**: pre-fix returned a free-text
-        // `"(sub-agent reached maximum iterations)"` that was visually
-        // success-shaped — indistinguishable from a normal sub-agent
-        // answer. The parent model would treat it as a tool result
-        // and either (a) try to keep working with the meaningless
-        // string, or (b) re-issue the same `InvokeAgent` call,
-        // burning another 20 LLM iterations to fail the same way.
-        //
-        // Two prongs to the fix:
-        //
-        // 1. **Bracketed-marker format** matches the established
-        //    failure-result convention (`[cancelled by parent]`,
-        //    `[cancelled]`, `[Background agent X failed]`). The
-        //    `[ERROR: ...]` prefix is unambiguous to the model:
-        //    "this is not a sub-agent answer, this is structural
-        //    failure metadata." Includes the cap as a number so the
-        //    model can reason about whether the task was decomposable.
-        //    Format extracted to `iteration_cap_marker` so the
-        //    contract can be unit-tested without standing up the
-        //    full sub-agent harness.
-        //
-        // 2. **Cache the result** so a second identical call returns
-        //    the same marker immediately instead of burning another
-        //    20 iterations. Keyed by `(agent_name, prompt_hash)`,
-        //    so a *reformulated* prompt is still attempted (parent
-        //    can adapt). Cache is invalidated on any file mutation
-        //    (see `SubAgentCache::invalidate`) so a write-then-retry
-        //    flow naturally bypasses the marker. This makes the
-        //    iteration-cap behave like every other sub-agent
-        //    result — the cache is the right place to record
-        //    "don't try this again unless something changed."
-        let result = iteration_cap_marker(agent_name, loop_guard::MAX_SUB_AGENT_ITERATIONS);
-        sub_agent_cache.put(agent_name, prompt, &result);
-        Ok(result)
+        // #1110: unreachable in practice. The `for iter in 1u32..` range is
+        // unbounded; the loop only exits via `return Ok(...)` (clean stop or
+        // cancellation), `return Err(...)` (provider/persistence failure), or
+        // `LoopDetector` short-circuit inside the inference helpers. This
+        // sentinel keeps rustc happy about the function's return type.
+        unreachable!("sub-agent loop exits via return; the iteration range is unbounded");
     }
 }
 
@@ -1167,38 +1131,14 @@ fn pick_write_provider(
     Box::new(GitWorktreeProvider::new(project_root, agent_name))
 }
 
-// \u2500\u2500 Iteration-cap marker (#1022 B18) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
-
-/// Build the structural-failure marker returned when a sub-agent
-/// exhausts its iteration budget without producing a final answer.
-///
-/// Format follows the established bracketed-marker convention used
-/// throughout the dispatch path (`[cancelled by parent]`,
-/// `[cancelled]`, `[Background agent X failed]`). The `[ERROR:`
-/// prefix is the unambiguous "this is metadata, not content" signal
-/// to the model.
-///
-/// Extracted as a free function so the contract (must contain
-/// `[ERROR:`, the agent name, the cap as a number, and a
-/// re-strategize hint) can be regression-tested without standing up
-/// the full sub-agent harness.
-fn iteration_cap_marker(agent_name: &str, cap: usize) -> String {
-    format!(
-        "[ERROR: sub-agent '{agent_name}' exceeded its iteration cap of {cap} without producing \
-         a final answer. Decompose the task into smaller pieces, or attempt the work \
-         directly without delegating.]"
-    )
-}
-
-/// **#1022 B21**: structural-failure marker returned when an
 /// isolated sub-agent's workspace provider can't provision.
 ///
 /// Replaces the pre-fix silent fallback to `project_root` — which
 /// dropped the sub-agent into the parent's unisolated working
 /// tree and let parallel sub-agents race on the same files.
 ///
-/// Same format / `[ERROR:` prefix as `iteration_cap_marker` so
-/// the model treats it as structural failure metadata rather
+/// Same `[ERROR:` prefix convention as other structural-failure
+/// markers so the model treats it as failure metadata rather
 /// than a sub-agent answer. Includes the failure reason so the
 /// parent can adapt (e.g. switch to a read-only sub-agent if
 /// the underlying issue is non-APFS volume / no git repo).
@@ -1209,106 +1149,6 @@ fn workspace_provision_failure_marker(agent_name: &str, reason: &str) -> String 
          resolve the workspace setup issue, retry without write tools, or attempt the work \
          directly without delegating.]"
     )
-}
-
-#[cfg(test)]
-mod b18_tests {
-    //! **#1022 B18** regression tests for the iteration-cap marker.
-    //!
-    //! These pin the *contract* of the marker string \u2014 not its
-    //! exact wording, but the load-bearing pieces:
-    //!
-    //! - `[ERROR:` prefix so the model treats it as structural
-    //!   failure metadata, not a sub-agent answer (the pre-fix
-    //!   `"(sub-agent reached maximum iterations)"` had no such
-    //!   marker and was indistinguishable from a normal result).
-    //! - The agent name appears so multi-agent flows can identify
-    //!   which sub-agent capped out.
-    //! - The cap appears as a number so the model can reason about
-    //!   decomposability ("did it run out of budget at 20 or 200?").
-    //! - A re-strategize hint appears so the model has a concrete
-    //!   next action instead of just retrying.
-    //!
-    //! The cache integration (`sub_agent_cache.put` two lines above
-    //! the call) is verified by code review \u2014 it's adjacent to the
-    //! marker construction and the call shape is obvious. A full
-    //! e2e cap-and-retry test would require the mock provider to
-    //! issue 21+ tool calls in a row; the cost/value ratio doesn't
-    //! justify it for what's effectively a one-line cache write.
-    use super::iteration_cap_marker;
-    use crate::loop_guard::MAX_SUB_AGENT_ITERATIONS;
-
-    #[test]
-    fn marker_has_error_prefix() {
-        let m = iteration_cap_marker("scout", 20);
-        assert!(
-            m.starts_with("[ERROR:"),
-            "marker must start with `[ERROR:` so the model treats it \
-             as structural failure metadata, not a sub-agent answer; \
-             got: {m}"
-        );
-    }
-
-    #[test]
-    fn marker_includes_agent_name() {
-        let m = iteration_cap_marker("scout", 20);
-        assert!(
-            m.contains("'scout'"),
-            "marker must name the capped sub-agent; got: {m}"
-        );
-    }
-
-    #[test]
-    fn marker_includes_cap_as_number() {
-        let m = iteration_cap_marker("scout", 20);
-        assert!(
-            m.contains("20"),
-            "marker must include the cap as a number so the model can \
-             reason about decomposability; got: {m}"
-        );
-    }
-
-    #[test]
-    fn marker_includes_restrategize_hint() {
-        let m = iteration_cap_marker("scout", 20);
-        // Either of the two suggested actions is fine \u2014 we just
-        // want the model to see that it has options other than
-        // retrying the same call.
-        assert!(
-            m.to_lowercase().contains("decompose")
-                || m.to_lowercase().contains("attempt the work directly"),
-            "marker must give the model a concrete next action; got: {m}"
-        );
-    }
-
-    #[test]
-    fn marker_uses_real_cap_constant() {
-        // Sanity: the call site passes `MAX_SUB_AGENT_ITERATIONS`,
-        // not a magic number. If someone refactors the constant to
-        // a different name and forgets to update the call site, the
-        // test wouldn't catch it directly \u2014 but this at least
-        // documents the wired-in expectation.
-        let m = iteration_cap_marker("agent", MAX_SUB_AGENT_ITERATIONS);
-        assert!(m.contains(&MAX_SUB_AGENT_ITERATIONS.to_string()));
-    }
-
-    #[test]
-    fn marker_is_single_line_for_tool_result_clarity() {
-        // Sub-agent results land in `tool_call_id`-keyed message
-        // content. Multi-line markers would format awkwardly in
-        // the user-facing trace; single-line keeps the failure
-        // visible at a glance. This catches a future "helpful"
-        // refactor that spreads the message across lines.
-        // content. Multi-line markers would format awkwardly in
-        // the user-facing trace; single-line keeps the failure
-        // visible at a glance. This catches a future "helpful"
-        // refactor that spreads the message across lines.
-        let m = iteration_cap_marker("scout", 20);
-        assert!(
-            !m.contains('\n'),
-            "marker must be single-line for clean tool-result formatting; got:\n{m}"
-        );
-    }
 }
 
 #[cfg(test)]

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -52,6 +52,10 @@ Use InvokeAgent when:
 - Work is independent and can run in parallel with your current reasoning
 - A specialist persona adds value (explore for search, plan for architecture, verify for testing)
 
+Agent selection:
+- For read-only exploration / search / analysis, prefer 'explore' (faster, cheaper, no isolated workspace).
+- For implementation that needs file writes, use 'task' (the default; isolated worktree).
+
 Do NOT use InvokeAgent when:
 - A single Read, Grep, or Glob would answer the question (overhead > benefit)
 - The task requires real-time back-and-forth with the user (sub-agents have no way to ask questions; AskUser is filtered from their tool set)
@@ -61,7 +65,7 @@ Key rules:
 - Sub-agent results are NOT shown to the user — you must summarize them in your reply
 - Sub-agents CANNOT spawn other sub-agents. Plan all fan-out at this level; the InvokeAgent tool is filtered from every sub-agent's tool set.
 - Identical (agent_name, prompt) calls hit a cache and skip the LLM call. Cheap to retry idempotent tasks; no need to memoize yourself.
-- A result starting with '[ERROR: sub-agent ...]' is a structural failure (e.g. iteration cap, workspace setup), not a model answer. Re-strategize rather than treat as content.
+- A result starting with '[ERROR: sub-agent ...]' is a structural failure (e.g. workspace setup, isolation issue), not a model answer. Re-strategize rather than treat as content.
 - Always write a clear, self-contained prompt — the sub-agent hasn't seen your conversation
 - Include specific file paths, function names, and success criteria in your prompt
 - Omit agent_name to use the 'task' worker (full write access)"

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -60,7 +60,11 @@ use crate::tools::bg_process::{
 pub const WAIT_TASK_MAX_TIMEOUT_SECS: u32 = 300;
 
 /// Default `timeout_secs` when the model omits the parameter.
-pub const WAIT_TASK_DEFAULT_TIMEOUT_SECS: u32 = 30;
+///
+/// 60 s suits a sub-agent inference round (multi-iteration thinking + tool
+/// use can easily run 30-60 s) without forcing the model into a busy-poll
+/// loop. Short shell-process waits should pass an explicit smaller value.
+pub const WAIT_TASK_DEFAULT_TIMEOUT_SECS: u32 = 60;
 
 /// Return tool definitions for the LLM.
 pub fn definitions() -> Vec<ToolDefinition> {
@@ -128,7 +132,11 @@ pub fn definitions() -> Vec<ToolDefinition> {
                 "Block until a background task finishes (or timeout fires).\n\n\
                 Returns the task's terminal state and result so you don't have to keep \
                 polling ListBackgroundTasks. Prefer WaitTask over a polling loop — one \
-                tool call instead of many.\n\n\
+                tool call instead of many. Call WaitTask sparingly: only when you need \
+                the result for the next critical-path step. Pick a duration that means \
+                'I'm willing to wait this long', not 'check back quickly' — for sub-agent \
+                tasks (multi-iteration inference) prefer 120-300 s; the default suits \
+                short shell-process waits.\n\n\
                 For sub-agent tasks (\"agent:N\"): on completion, returns the agent's full \
                 output. The result will NOT also appear in the auto-drain on the next \
                 iteration — WaitTask consumes it.\n\n\

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -89,7 +89,10 @@ async fn test_sub_agent_invocation_e2e() {
 /// iteration the sub-agent reloaded a context with **no assistant
 /// turns** — then `prune_mismatched_tool_calls` orphan-pruned the
 /// tool result rows, leaving only `[system, user]`. The sub-agent
-/// re-issued the same tool call forever, hitting the iteration cap.
+/// re-issued the same tool call forever, previously hitting the
+/// (now-removed, see #1110) iteration cap; today the same scenario
+/// would terminate via `LoopDetector` consecutive-identical detection
+/// or context exhaustion.
 ///
 /// User-visible symptom (post-#1099 when paths actually rendered):
 ///
@@ -97,7 +100,7 @@ async fn test_sub_agent_invocation_e2e() {
 /// ● List /Users/lijun/repo
 /// ● List /Users/lijun/repo
 /// ● List /Users/lijun/repo
-/// ... (repeats until iteration cap or Ctrl+C)
+/// ... (repeats until LoopDetector hard-stop or Ctrl+C)
 /// ```
 ///
 /// This test scripts the sub-agent's mock provider to:


### PR DESCRIPTION
## Summary

Per `DESIGN.md` **P3** (*"Build for the world six months from now"*), removes the hardcoded 20-iteration ceiling on sub-agent loops. Termination is driven by the model (clean stop, no tool calls), `LoopDetector` (consecutive identical calls → feedback → hard stop), parent cancellation, or context exhaustion — the same set of mechanisms Codex and Zed rely on.

> *"Let the model drive [...] don't scaffold around weakness."* — DESIGN.md P3

## Audit of reference codebases

| Mechanism | koda (before) | Codex | Zed |
|---|---|---|---|
| Sub-agent iteration cap | **20** | None | None |
| Iteration heartbeat | None | None | None |
| Loop detection | `LoopDetector` (consecutive-identical → feedback → hard stop) | None | None |
| Failure surfacing | `[ERROR: ...]` markers + `LoopDetector` warn | `Errored(String)` | `enum CompletionError { MaxTokens, Refusal, Other }` |

We have *more* safety than either reference (LoopDetector + sandbox + worktree budget + structural-failure markers); the cap was redundant scaffolding for a model weakness P3 explicitly tells us not to compensate for.

## Changes

### Closes #1110 — sub-agent dispatch trust
- delete `MAX_SUB_AGENT_ITERATIONS = 20` and the bounded `for iter in 1..=20` loop
- delete `iteration_cap_marker` + its `b18_tests` regression mod
- widen `AgentStatus::Running.iter` `u8` → `u32` (a meandering weak model could plausibly exceed `u8::MAX` before context exhaustion; silent wraparound would mislead the TUI)
- drop the `/20` denominator from TUI iter rendering
- add *"consider switching to a stronger model"* hint to the `LoopDetector` hard-stop message — the one place we have a smoking-gun signal that the model (not the task) is the problem
- `InvokeAgent` description gets one line steering read-only work to `explore` (faster, cheaper, no isolated workspace) and writes to `task`

### Closes #1106 — WaitTask default too short for sub-agents
- bump `WAIT_TASK_DEFAULT_TIMEOUT_SECS` 30 → **60** (sub-agent inference rounds take real time; default should mean *"I'm willing to wait this long"*, not *"check back quickly"*)
- description nudge: prefer 120-300 s for sub-agent waits, call sparingly

## What we explicitly did NOT add

- ❌ Iteration heartbeat warnings — Codex/Zed don't have them, P3 says don't scaffold
- ❌ `SubAgentFailureCause` enum — Codex doesn't categorize, just passes the error through
- ❌ Auto-injected "you've taken N iterations, wrap up" message — that's the model's job
- ❌ Per-agent `max_iterations` parsing in sub-agent context — we just deleted the cap

## Net diff

**+72 / −203 lines.** We delete more than we add.

## Verification

- ✅ `cargo test --workspace --lib --tests` — 1934 tests pass, 0 failures
- ✅ `cargo clippy --workspace --all-targets -- -D warnings` — clean
- ✅ `cargo fmt --all --check` — clean
- ✅ Pre-push hooks (clippy) — pass

Closes #1110
Closes #1106
