### PR TITLE
chore: release v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,122 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.23] - 2026-04-29
+
+Feature + reliability release. 12 commits since v0.2.22 covering: a
+behavioural shift for sub-agents (the 20-iteration safety cap is gone
+— see DESIGN.md P3), two TUI quality-of-life features (persistent cwd
+in the status bar, terminal-restoring panic hook), richer transcript
+exports (sub-agent traces now persist and fold under their parent
+`InvokeAgent` call), an inference reliability fix (longer SSE
+read-timeout plus auto-retry on transient network errors), and a
+dependency cleanup that removes 16 transitive crates and bumps MSRV
+to Rust 1.88.
+
+### Breaking (koda-core internals)
+
+> `koda-core` is an internal crate published to support the `koda-cli`
+> binary; its public API is not stable pre-1.0. See
+> `koda-core/README.md` for the stability statement. The CLI itself
+> (`koda` binary, `/commands`, TUI keybindings, config schema) has no
+> breaking changes in this release.
+
+- **Removed `pub const MAX_SUB_AGENT_ITERATIONS`** from `koda-core`
+  (#1127, closes #1110). The 20-iteration ceiling on sub-agent loops
+  is gone. Termination is now driven by the model (clean stop, no
+  tool calls), `LoopDetector` (consecutive identical calls → feedback
+  → hard stop), parent cancellation, or context exhaustion — the same
+  set of mechanisms Codex and Zed rely on. Per `DESIGN.md` P3 ("Build
+  for the world six months from now"), the cap was redundant
+  scaffolding for a model weakness P3 explicitly says not to
+  compensate for.
+- **`AgentStatus::Running.iter` widened `u8` → `u32`** in
+  `koda-core/src/bg_agent.rs` (#1127). With the cap gone, a
+  meandering weak model could plausibly exceed `u8::MAX` before
+  context exhaustion; silent wraparound would mislead the TUI status
+  bar.
+- **`WAIT_TASK_DEFAULT_TIMEOUT_SECS` bumped 30 → 60** seconds (#1127,
+  closes #1106). Sub-agent inference rounds take real time; the
+  default should mean "I'm willing to wait this long," not "check
+  back quickly."
+- **MSRV bumped Rust 1.87 → 1.88** (#1118). Required by the dependency
+  cleanup; also unblocks `time 0.3.47` (RUSTSEC-2026-0009).
+
+### Added
+
+- **Persistent cwd in the TUI status bar** (#1117, #1105). The status
+  bar now shows the current working directory, with `$HOME`
+  substituted as `~` and the path right-truncated at segment
+  boundaries to fit the available space. Live-updates on terminal
+  resize. New `format_cwd_compact` helper covered by 9 unit tests.
+- **Sub-agent traces persist and fold in transcript exports** (#1112,
+  partial #1108). Engine `SessionEvent`s and sub-agent traces are
+  now persisted to the session DB via the new `PersistingSink`. On
+  `/export`, sub-agent invocations render nested under the parent
+  `InvokeAgent` tool result, so multi-turn delegation is auditable
+  in the exported markdown. Re-exporting an old session also
+  reflects the hierarchy.
+
+### Changed
+
+- **Sub-agents now trust the model** (#1127, closes #1110, #1106).
+  See the Breaking section for the mechanics. The TUI iteration
+  display drops the `/20` denominator. The `LoopDetector` hard-stop
+  message gains a "consider switching to a stronger model" hint —
+  the one place we have a smoking-gun signal that the model (not
+  the task) is the problem. The `InvokeAgent` tool description gains
+  one line steering read-only work to `explore` (faster, cheaper,
+  no isolated workspace) and writes to `task`.
+- **`WaitTask` description nudge** (#1127, closes #1106): prefer
+  120–300 s for sub-agent waits, call sparingly.
+
+### Fixed
+
+- **Inference: longer SSE read-timeout + auto-retry on transient
+  network errors** (#1121). Bumped `reqwest::read_timeout` 180s →
+  300s to accommodate slow reasoning models (Gemini 3.x Pro,
+  MiniMax, etc.) that can silently buffer on a single SSE chunk for
+  minutes. Wrapped the inference call in `try_with_rate_limit` so
+  transient timeouts and connection resets retry up to 5 times with
+  exponential backoff (`is_network_transient_error` predicate covers
+  "operation timed out", "connection reset", "broken pipe", and
+  related substrings). Mutually exclusive with the existing
+  rate-limit / context-overflow / image-rejection retry paths.
+- **TUI restores terminal on panic** (#1120). Installed a custom
+  panic hook (modeled on `codex-rs/tui/src/tui.rs`) that disables
+  raw mode, releases mouse capture, and exits the alternate screen
+  before chaining to the original hook. Crashes no longer leave the
+  shell in an unusable state requiring `reset`.
+- **Transcript export surfaces tool name + args + call\_id** (#1111,
+  partial #1108). Pre-fix, `/export` markdown showed only the
+  tool's text result without identifying which tool was called or
+  with what arguments. Now each tool block is properly headered.
+
+### Internal
+
+- **Refactor `tool_header`**: unify `detail_spans` and `detail_text`
+  via a single `ToolCallSummary` source of truth (#1107). Eliminates
+  the per-tool drift that contributed to #1099. Pure refactor, no
+  behaviour change.
+- **Test infrastructure hardening** (#1109, #1114). 37 files updated
+  to: (a) replace `unsafe { std::env::set_var }` in tests with
+  dependency-injection helpers (`stage2_binary_from`,
+  `set_worker_binary_for_tests`); (b) add `#[tokio::test(flavor =
+  "multi_thread")]` to every test that exercises code containing
+  `tokio::spawn` (the default `current_thread` flavor can deadlock
+  spawned tasks under macOS CI load); (c) eliminate the last
+  polling-sleep in the sandbox tests. Net `unsafe` count in repo
+  went down. New CI lint `scripts/check_tokio_test_flavor.py`
+  prevents regressions.
+- **Bundle v0.2.22 P3 release-polish items** (#1115, closes #1104).
+  Worktree/submodule-aware `.git/config` skip in bwrap (covers a
+  ClonefileProvider edge case); plus four small doc/test polish
+  items.
+- **chore(deps)**: remove 5 dead direct deps (−16 transitive crates)
+  + bump MSRV to 1.88 (#1118). Smaller supply-chain surface.
+- **ci(deps)**: bump `taiki-e/install-action` 2.75.19 → 2.75.25
+  (#1126).
+
 ## [0.2.22] - 2026-04-28
 
 Patch release. 8 bug-fix commits since v0.2.21, no new features, no public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.22)
+10. Sync version with workspace (currently 0.2.23)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 brew tap lijunzh/koda
 brew install koda
 
-# Cargo (requires Rust toolchain)
+# Cargo (requires Rust toolchain — MSRV 1.88)
 cargo install koda-cli
 
 # From source

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -246,6 +246,13 @@ koda-20260410-143022-refactor-the-auth-module.md
 The transcript includes all user messages, assistant responses, and a
 summary of every tool call. System prompts are excluded.
 
+Sub-agent invocations are folded under the parent `InvokeAgent` tool
+call: the parent's tool-result block contains the full sub-agent trace
+(messages and tool calls) indented as a nested transcript section. The
+folding is driven by `session_events.parent_tool_call_id` in the
+session DB, so re-exporting an old session also reflects the
+hierarchy.
+
 ## `/verbose [on|off]`
 
 Toggles verbose tool output. By default Koda collapses long outputs

--- a/docs/src/tui.md
+++ b/docs/src/tui.md
@@ -30,9 +30,10 @@ Run `koda` with no arguments to open the full-screen TUI.
 - **Queue preview** — shown above the status bar **only when the deferred
   queue has items**. Displays up to 3 rows of pending text with index numbers,
   an overflow count, and keybinding hints. Hidden when the queue is empty.
-- **Status bar** — live view of model, trust mode, context usage bar, MCP
-  server count (when configured), inference time, queue count, and last-turn
-  token/speed stats.
+- **Status bar** — live view of model, trust mode, current working
+  directory (right-truncated to fit, with `~` substitution for `$HOME`),
+  context usage bar, MCP server count (when configured), inference time,
+  queue count, and last-turn token/speed stats.
 
 ## Starting a conversation
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.22"
+version = "0.2.23"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.22" }
+koda-core = { path = "../koda-core", version = "0.2.23" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -75,6 +75,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.22", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.23", features = ["test-support"] }
 serde_json = { workspace = true }
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.22"
+version = "0.2.23"
 edition.workspace = true
 rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.22" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.23" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/README.md
+++ b/koda-core/README.md
@@ -13,7 +13,14 @@ Pure logic with zero terminal dependencies — communicates exclusively through
 - **Inference loop** — streaming tool-use loop with parallel execution
 - **SQLite persistence** — sessions, messages, compaction
 
-**Rust edition:** 2024
+**Rust edition:** 2024 (MSRV 1.88)
+
+> **Stability note:** `koda-core` is published primarily to support the
+> `koda-cli` binary distribution. Its public API is **not** stable
+> pre-1.0 and may change in any release, including patch versions. If
+> you embed `koda-core` directly, pin a specific version and review
+> [`CHANGELOG.md`](https://github.com/lijunzh/koda/blob/main/CHANGELOG.md)
+> before upgrading.
 
 ## Usage
 

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -81,7 +81,8 @@ pub enum AgentStatus {
     /// Reserved but the spawned future hasn't started yet.
     Pending,
     /// Actively executing. `iter` is the current inference iteration
-    /// (1..=20); `0` means "started, no iter info yet" (Layer 0 default).
+    /// (1..); `0` means "started, no iter info yet" (Layer 0 default).
+    /// There is no upper bound — see #1110 / `LoopDetector` for termination.
     Running {
         /// Current inference iteration (1..). `0` is the entry-point
         /// placeholder emitted before the first iteration in

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.22"
+version = "0.2.23"
 edition.workspace = true
 rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"


### PR DESCRIPTION
# Release v0.2.23

Cuts v0.2.22 → **v0.2.23**. Feature + reliability release. 12 commits since v0.2.22.

## Headlines

- 🧠 **#1127 — Sub-agents trust the model.** Removed the hardcoded 20-iteration ceiling on sub-agent loops. Termination is now driven by the model (clean stop), `LoopDetector` (consecutive identical calls → feedback → hard stop), parent cancellation, or context exhaustion — same set of mechanisms Codex and Zed rely on. Per `DESIGN.md` P3 ("Build for the world six months from now"), the cap was redundant scaffolding. Closes #1110.
- ⏱️ **#1106 — `WaitTask` default 30→60s.** Sub-agent inference rounds take real time; the default should mean *"I'm willing to wait this long,"* not *"check back quickly."* Bundled with #1127.
- 🔄 **#1121 — Inference auto-retries transient network errors.** SSE `read_timeout` 180→300s + `try_with_rate_limit` wrapper covering "operation timed out" / "connection reset" / "broken pipe" with exponential backoff. Slow reasoning models (Gemini 3.x Pro, MiniMax) no longer kill sessions on a single buffered chunk.
- 🛟 **#1120 — TUI restores terminal on panic.** Custom panic hook (modeled on `codex-rs/tui/src/tui.rs`) disables raw mode, releases mouse capture, exits alt-screen before chaining to original hook. No more `reset` after a crash.
- 📺 **#1117 — Persistent cwd in TUI status bar.** Right-truncated at segment boundaries with `~` substitution for `$HOME`. Live updates on resize.
- 📜 **#1108 — Sub-agent traces persist + fold in transcripts.** New `PersistingSink` writes `SessionEvent`s to the session DB; `/export` markdown nests sub-agent transcripts under their parent `InvokeAgent` tool result. Re-exporting old sessions also reflects the hierarchy.
- 🧹 **#1118 — MSRV 1.87→1.88, −16 transitive crates.** Required by dep cleanup; also unblocks `time 0.3.47` (RUSTSEC-2026-0009).

## SemVer note

This is a patch release (0.2.22 → 0.2.23) despite three changes that would normally require a minor bump:

| Change | Surface |
|---|---|
| Removed `pub const MAX_SUB_AGENT_ITERATIONS` | `koda-core` only |
| Widened `AgentStatus::Running.iter` `u8 → u32` | `koda-core` only |
| MSRV bumped 1.87 → 1.88 | All crates (source-install only) |

`koda-core` is internal — published to support the `koda-cli` binary distribution but not stable pre-1.0. This is now stated explicitly in `koda-core/README.md`. The CLI itself (`koda` binary, `/commands`, TUI keybindings, config schema) has **no breaking changes** in this release.

## Sub-agent validation summary

All four mandatory release reviewers ran:

| Reviewer | Verdict | Notes |
|---|---|---|
| **code-reviewer** | code clean, docs needed fixing | All P1 doc gaps (CHANGELOG, MSRV in README, stale `1..=20` doc, cwd doc, transcript doc) **fixed inline in this PR** |
| **rust-programmer** | 2208 tests pass, clippy/fmt/doc clean | Flagged the 3 SemVer issues — addressed via internal-crate stance + explicit CHANGELOG breaking section |
| **security-auditor** | 🟢 Ship it — Low risk | `cargo audit` 0/0/0/0 over 479 deps; no new unsafe; sandbox findings none; #1109 actively *removes* `unsafe { set_var }` from tests |
| **qa-expert** | 🚢 Ship pending 6-item smoke | Manual smoke checklist below; one P2/P3 deferred (PersistingSink + retry-loop integration tests — bundled into deferred items) |

**Audit-dust scoreboard:** 0 standalone issues filed by reviewers this cycle (down from v0.2.16's 7-for-7 same-day-closure). Audit-dust prevention rules in the skill held. 🐶

## Test results

- ✅ `cargo fmt --all --check` — clean
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` — clean
- ✅ `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps` — clean
- ✅ `cargo test --workspace --lib --tests` — **2208 passed / 0 failed / 2 ignored** across 251 suites
- ✅ `cargo test -p koda-core --features test-support` — **1160 passed / 0 failed / 1 ignored** (the 9 e2e binaries the rust-programmer flagged as unexercised)

## Manual smoke checklist (recommended before tagging)

```
[ ] #1120  Trigger controlled TUI panic → shell returns to sane state without `reset`
[ ] #1121  Real session vs slow model → confirm "Network glitch. Retrying…" banner fires on idle timeout
[ ] #1117  Open TUI in deeply-nested path → verify left-truncation at 80, 120 cols, live resize
[ ] #1108  Run session with sub-agent → /export → confirm sub-agent trace nests under parent's tool result
[ ] #1127  Stress sub-agent ("explore these 30 files") → confirm natural termination, no abort, no infinite loop
[ ] CI     Both test (ubuntu-latest) and test (macos-latest) green; bwrap SEC-002/TOCTOU regression assertion fires
```

## Changelog

See `CHANGELOG.md` for the full categorized entry (Breaking · Added · Changed · Fixed · Internal). Quick recap of all 12 commits:

- `eef48bc` sub-agents: trust the model, drop the iteration cap (#1127)
- `5114a43` ci(deps): bump taiki-e/install-action 2.75.19 → 2.75.25 (#1126)
- `887f4a3` fix(inference): bump read_timeout 180→300s and auto-retry transient errors (#1121)
- `142e405` fix(tui): install panic hook to restore terminal on crash (#1120)
- `35349b5` chore(deps): remove 5 dead direct deps + bump MSRV to 1.88 (#1118)
- `cbda15d` feat(tui): persistently display cwd in status bar (#1117)
- `51e7f3b` chore: bundle v0.2.22 P3 release-polish items (#1115)
- `e7a9e22` feat(transcript): persist + fold sub-agent traces and engine events (#1112)
- `9ca2e9d` test: complete #1109 F1+F3 cleanup (#1114)
- `5fc047d` test: harden test infrastructure against tokio runtime mismatches (#1109)
- `40961e2` fix(transcript): surface tool name + args + call_id in markdown export (#1111)
- `8779863` refactor(tool_header): unify detail_spans/detail_text via ToolCallSummary (#1107)

Closes #1110
Closes #1106

### Deferred items (tracked)
- [ ] #1129 — test: add integration coverage for PersistingSink routing + try_with_rate_limit transient retry (P2)
- [ ] #1130 — Bundle: v0.2.23 release-time polish (P3 audit findings, 5 items)
