### PR TITLE
ci(coverage): treat checkout / runner failures as infra flakes too

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -87,21 +87,35 @@ jobs:
       # threshold". Without this, a CDN flake on either platform would
       # auto-open / auto-close coverage-regression issues falsely.
       #
+      # `always() &&` is load-bearing: GitHub Actions implicitly gates every
+      # step on `success()` of all prior steps, so without it this step
+      # would be SKIPPED when an upstream step (e.g. actions/checkout, the
+      # toolchain install, or rust-cache) fails — exactly the case where
+      # we most need the marker. See #1131 for the false-positive that
+      # motivated this guard: a transient DNS failure on macOS killed
+      # actions/checkout, no marker was uploaded, and the report job
+      # filed a bogus coverage-regression issue against a clean main.
+      #
       # Filename is sanitized to alphanumerics+`_-` so a future runner OS
       # name with whitespace or punctuation (e.g. "Windows Server 2022")
       # cannot mangle the report job's `basename {} .flake` filter. See #937.
-      - name: Mark infra flake (if install failed)
-        if: steps.install.outcome != 'success'
+      - name: Mark infra flake (if install or any earlier step failed)
+        if: always() && steps.install.outcome != 'success'
         run: |
           set -euo pipefail
           safe_os=$(printf '%s' "${{ runner.os }}" | tr -cd '[:alnum:]_-')
           mkdir -p flake-markers
-          echo "taiki-e/install-action failed on ${{ runner.os }} " \
-               "— likely GitHub releases CDN flake. See run logs." \
-               > "flake-markers/${safe_os}.flake"
+          # Distinguish the two scenarios in the marker body so a human
+          # reading the artifact later can tell what actually broke.
+          if [ "${{ steps.install.outcome }}" = "failure" ]; then
+            reason="taiki-e/install-action failed on ${{ runner.os }} — likely GitHub releases CDN flake."
+          else
+            reason="An upstream step (checkout / toolchain / cache) failed on ${{ runner.os }} before cargo-llvm-cov could be installed."
+          fi
+          echo "$reason See run logs." > "flake-markers/${safe_os}.flake"
 
       - name: Upload infra-flake marker
-        if: steps.install.outcome != 'success'
+        if: always() && steps.install.outcome != 'success'
         uses: actions/upload-artifact@v4
         with:
           name: infra-flake-${{ runner.os }}
@@ -244,6 +258,8 @@ jobs:
 
       - name: Detect infra flake
         id: flake
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if compgen -G "flake-markers/*.flake" > /dev/null; then
@@ -258,6 +274,26 @@ jobs:
                  "Skipping regression-issue bookkeeping; will retry on next push."
             cat flake-markers/*.flake
           else
+            # Belt-and-suspenders: if the matrix job failed but NO platform
+            # uploaded lcov reports, the marker step itself never had a
+            # chance to run (runner image broken, mass GitHub Actions
+            # outage, etc). A real coverage regression would always have
+            # produced lcov files — if there are zero, this is infra. See
+            # the second-order failure mode discussed in #1131. Without
+            # this, a fully-broken runner would still file a bogus
+            # regression issue against a clean main.
+            if [ "${{ needs.coverage.result }}" = "failure" ]; then
+              lcov_count=$(gh api \
+                "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+                --jq '[.artifacts[] | select(.name | startswith("lcov-reports-"))] | length')
+              if [ "$lcov_count" = "0" ]; then
+                echo "detected=true" >> "$GITHUB_OUTPUT"
+                echo "::warning::Coverage matrix failed but no platform " \
+                     "uploaded lcov reports — treating as infra flake " \
+                     "(runner image / Actions service issue). See #1131."
+                exit 0
+              fi
+            fi
             echo "detected=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1131 — a false-positive coverage-regression issue filed against a clean `main` after a transient `actions/checkout` DNS failure on the macOS coverage leg.

The previous flake-marker step in `.github/workflows/coverage.yml` was implicitly gated on `success()` of every prior step (the GitHub Actions default). When `actions/checkout@v6` itself died with `Could not resolve host: github.com`, every downstream step — including the marker step whose whole job is to *announce that the upstream broke* — was silently skipped. The report job then saw zero `infra-flake-*` artifacts, concluded "real regression", and filed [#1131](https://github.com/lijunzh/koda/issues/1131) against commit `7cccccf` (a perfectly green release commit).

## Changes

Two layers of defense in `.github/workflows/coverage.yml`:

1. **Add `always() &&` to the `Mark infra flake` and `Upload infra-flake marker` steps** so they fire even when an upstream step (checkout / toolchain / rust-cache) failed. The marker body now also distinguishes "install action failed" from "earlier step failed" so post-mortem readers can tell what actually broke.

2. **Belt-and-suspenders fallback in the `Detect infra flake` step**: if the matrix `coverage` job failed *and* no platform uploaded any `lcov-reports-*` artifact, treat it as an infra flake regardless of marker presence. A real coverage regression always produces lcov files; zero lcov files means we never measured anything. This covers the second-order failure where even the marker step can't run (broken runner image, full Actions outage, etc.).

## Type
- [x] Bug fix

## Files changed

| File | What changed |
|------|--------------|
| `.github/workflows/coverage.yml` | Add `always() &&` to flake-marker gating; add lcov-count fallback in report job |

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Real coverage regression | files issue | files issue |
| `taiki-e/install-action` flake (the original #930 case) | flake skip | flake skip |
| **`actions/checkout` flake (this PR's #1131 case)** | false-positive issue | flake skip |
| Total runner-image meltdown — even marker can't run | false-positive issue | flake skip (via lcov-count fallback) |

## Testing

- [x] YAML parses cleanly (`yaml.safe_load`)
- [x] `cargo fmt --check` clean (pre-push hook ran)
- [x] `cargo clippy -- -D warnings` clean (pre-push hook ran)
- [x] `cargo test` not applicable — no Rust code changed
- [x] Logic traced through all 4 failure scenarios above; all gates short-circuit correctly

The next push to `main` after this lands will exercise the new logic. If the macOS leg is healthy this time, the workflow should auto-close #1131 via the existing `Close regression issue if green` step. If macOS DNS flakes again, the new `always() &&` guard will upload a marker and the bogus auto-filing will be suppressed.

## Checklist
- [x] No files over 600 lines (`coverage.yml` is 287 lines)
- [x] No `unwrap()` in non-test code (no Rust code touched)
- [x] CHANGELOG.md updated — N/A, internal CI plumbing, no user-facing behaviour change
- [x] `docs/src/` updated — N/A, internal CI plumbing
