### PR TITLE
test(tui): regression test that panic hook restores TTY and chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
  "ratatui-textarea",
  "regex",
  "serde_json",
+ "serial_test",
  "syntect",
  "tempfile",
  "time",
@@ -2954,6 +2955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2993,6 +3003,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -3087,6 +3103,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -77,4 +77,9 @@ harness = false
 tempfile = { workspace = true }
 koda-core = { path = "../koda-core", version = "0.2.23", features = ["test-support"] }
 serde_json = { workspace = true }
+# serial_test: forces tests that mutate global state (e.g. the panic hook in
+# the regression test for #1124) to run sequentially. Cargo runs tests in
+# parallel by default; without this, two tests calling `panic::set_hook`
+# would race and produce flaky results.
+serial_test = "3"
 

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -569,12 +569,111 @@ pub(crate) fn restore_terminal(_terminal: &mut Term) {
 /// Pattern lifted from `codex-rs/tui/src/tui.rs`; see issue #1119 for the
 /// comparative analysis.
 fn set_panic_hook() {
+    // Production callers always restore the real terminal. The inner
+    // helper takes the restore callback as a parameter so the regression
+    // test in #1124 can substitute a spy without depending on a real TTY.
+    install_panic_hook(restore_terminal_modes);
+}
+
+/// Install a panic hook that calls `restore` (best-effort) before chaining
+/// to whatever hook was previously installed. Extracted from
+/// [`set_panic_hook`] purely so the chain-integrity contract can be
+/// asserted under `#[cfg(test)]` without touching real terminal state.
+fn install_panic_hook(restore: fn()) {
     let original = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         // Best-effort: ignore errors here, we're already failing.
-        restore_terminal_modes();
+        restore();
         original(info);
     }));
+}
+
+#[cfg(test)]
+mod panic_hook_tests {
+    //! Regression tests for the panic hook installed by
+    //! [`super::set_panic_hook`] (issue #1120).
+    //!
+    //! The contract under test:
+    //!
+    //! 1. The injected `restore` callback must run on panic (otherwise
+    //!    the user's terminal stays in raw mode + alternate screen after
+    //!    a crash — the original UX bug from #1119).
+    //! 2. The previously-installed panic hook must still run afterwards
+    //!    (so the panic message + backtrace still surface). A naive
+    //!    refactor that drops the chain via `set_hook(Box::new(...))`
+    //!    without first capturing `take_hook()` would silently break
+    //!    this and we'd never know until the next user crash.
+    //!
+    //! `serial_test` is load-bearing: the panic hook is global mutable
+    //! state and Rust runs tests in parallel by default. Without
+    //! `#[serial]`, two tests calling `panic::set_hook` would race.
+
+    use super::install_panic_hook;
+    use serial_test::serial;
+    use std::panic;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    // The panic-hook closure must be `'static`, so the spy state has to
+    // live in `static`s rather than locals. `#[serial]` keeps these
+    // single-writer-at-a-time across the whole crate's test suite.
+    static RESTORE_CALLED: AtomicBool = AtomicBool::new(false);
+    static ORIGINAL_RAN: AtomicUsize = AtomicUsize::new(0);
+
+    fn spy_restore() {
+        RESTORE_CALLED.store(true, Ordering::SeqCst);
+    }
+
+    #[test]
+    #[serial]
+    fn panic_hook_restores_terminal_then_chains_to_original() {
+        // Reset spy state from any previous test run.
+        RESTORE_CALLED.store(false, Ordering::SeqCst);
+        ORIGINAL_RAN.store(0, Ordering::SeqCst);
+
+        // Snapshot whatever hook the test harness installed so we can
+        // restore it on the way out and not poison sibling tests.
+        let saved = panic::take_hook();
+
+        // Install a no-op "original" that just records it ran. Using a
+        // silent hook also keeps the panic message out of test output.
+        panic::set_hook(Box::new(|_| {
+            ORIGINAL_RAN.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        // Now layer the chain under test on top.
+        install_panic_hook(spy_restore);
+
+        // Trigger a panic; `catch_unwind` swallows it but the hook still
+        // fires synchronously before the unwind propagates.
+        let result = panic::catch_unwind(|| {
+            panic!("intentional panic for #1124 regression test");
+        });
+        assert!(
+            result.is_err(),
+            "catch_unwind should have caught the deliberate panic"
+        );
+
+        // Contract 1: the restore callback ran.
+        assert!(
+            RESTORE_CALLED.load(Ordering::SeqCst),
+            "spy_restore should have been invoked by the panic hook"
+        );
+
+        // Contract 2: the previously-installed hook ran exactly once.
+        // Two invocations would mean we accidentally double-chained;
+        // zero would mean we clobbered the chain (the actual bug we're
+        // guarding against).
+        assert_eq!(
+            ORIGINAL_RAN.load(Ordering::SeqCst),
+            1,
+            "the previously-installed hook should be invoked exactly once"
+        );
+
+        // Cleanup: drop the chained hook and reinstate the test
+        // harness's hook so we leave global state exactly as we found it.
+        let _ = panic::take_hook();
+        panic::set_hook(saved);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What does this PR do?

Fixes #1124.

The panic hook installed by `koda-cli/src/tui_viewport.rs::set_panic_hook` (added in #1120 to fix the post-crash terminal-corruption UX bug from #1119) had no regression test. A careless refactor that dropped the `take_hook()` / `set_hook()` chaining or the `restore_terminal_modes()` call would silently re-introduce the original bug — and we'd only find out when the next user crashed.

## Changes

1. **Refactor (no behaviour change):** extract `install_panic_hook(restore: fn())` so the chain logic can be exercised under `#[cfg(test)]` without depending on a real TTY. Production `set_panic_hook()` becomes a one-liner that passes `restore_terminal_modes` as the callback.

2. **New regression test** `panic_hook_tests::panic_hook_restores_terminal_then_chains_to_original`:
   - Uses `serial_test::serial` to serialise access to the global panic hook (the panic hook is global mutable state; without `#[serial]` two tests calling `panic::set_hook` would race).
   - Installs a no-op spy "original" hook that increments a counter.
   - Layers `install_panic_hook` on top with a spy restore callback that flips an atomic flag.
   - Triggers a panic via `catch_unwind`.
   - Asserts both contracts:
     - the restore callback fired (otherwise the terminal stays corrupt — the original UX bug)
     - the original hook fired exactly once (chain integrity — a naive refactor that drops `take_hook()` would silently break this)
   - Restores the saved hook on the way out so sibling tests aren't poisoned.

3. **Adds `serial_test = "3"` as a `koda-cli` dev-dep.** The crate isn't shared across 3+ workspace members yet, so it stays local rather than being promoted to `[workspace.dependencies]` (per the existing "premature DRY (YAGNI)" comment in the workspace `Cargo.toml`).

## Mutation-test verification

I deliberately broke the implementation in two ways and confirmed the test catches each before reverting:

| Mutation | Test result |
|---|---|
| Drop `take_hook()` so chain is silently clobbered | ❌ FAILED (caught: `ORIGINAL_RAN == 0`) |
| Drop the `restore()` call from the chain | ❌ FAILED (caught: `RESTORE_CALLED == false`) |
| Production code restored | ✅ PASSED |

A passing-by-default test is worth zero — this one earns its keep on both contracts.

## Type
- [x] Docs / tests only

## Files changed

| File | What changed |
|------|--------------|
| `koda-cli/src/tui_viewport.rs` | Extract `install_panic_hook(restore)` helper; add `panic_hook_tests` module with the regression test |
| `koda-cli/Cargo.toml` | Add `serial_test = "3"` to `[dev-dependencies]` with rationale comment |
| `Cargo.lock` | Auto-updated for `serial_test` 3.4.0 + transitive deps (`serial_test_derive`, `scc`, `sdd`) |

## Testing

- [x] `cargo test -p koda-cli --lib` — 480 passed, 0 failed
- [x] `cargo clippy -p koda-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Manually mutation-tested against two distinct break modes; both caught.

## Checklist
- [ ] No files over 600 lines — **`tui_viewport.rs` is 768 lines** (was 669 on `main`; +99 from this PR's refactor + test module). The file was already over the soft cap before this PR, and splitting it just to host the new test would force the test out of an inline `#[cfg(test)] mod` and break the unit-test contract on the private `install_panic_hook` helper. A proper modularisation of `tui_viewport.rs` should be its own PR. Filing as a known-deferred item rather than papering over it.
- [x] No `unwrap()` in non-test code (test code uses asserts only)
- [x] CHANGELOG.md updated — N/A, internal test infra, no user-facing behaviour change
- [x] `docs/src/` updated — N/A, internal test infra
