### PR TITLE
tui(perf): coalesce inference-loop draws via frame scheduler (#1138)

### DIFF
--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -77,6 +77,10 @@ harness = false
 tempfile = { workspace = true }
 koda-core = { path = "../koda-core", version = "0.2.23", features = ["test-support"] }
 serde_json = { workspace = true }
+# tokio's `test-util` feature enables `#[tokio::test(start_paused = true)]` so
+# frame_requester tests can manipulate the clock deterministically without
+# relying on real wall-clock sleeps. Not in `full`, so we opt in here.
+tokio = { workspace = true, features = ["full", "test-util"] }
 # serial_test: forces tests that mutate global state (e.g. the panic hook in
 # the regression test for #1124) to run sequentially. Cargo runs tests in
 # parallel by default; without this, two tests calling `panic::set_hook`

--- a/koda-cli/src/frame_requester.rs
+++ b/koda-cli/src/frame_requester.rs
@@ -1,0 +1,275 @@
+//! Frame draw scheduling — coalesces redraw requests to bound CPU/redraw cost.
+//!
+//! ## Why this exists (#1138)
+//!
+//! Before this module, the inference loop called `terminal.draw()` synchronously
+//! at the top of every iteration. Under heavy event throughput (sub-agent
+//! fan-out, fast streaming, parallel tools) that's ~one full redraw per engine
+//! event. Wasted CPU + amplified executor pressure that contributed to #1137.
+//!
+//! With this module, callers fire-and-forget `frame_requester.schedule_frame()`
+//! whenever they think a redraw might be useful. A dedicated tokio task
+//! ([`FrameScheduler`]) coalesces multiple requests into a **single** notification
+//! on an mpsc channel, rate-limited to a maximum frame rate (default ~120 FPS).
+//!
+//! The TUI event loop then has a `Draw` arm in its `tokio::select!` that pops
+//! one notification and performs the actual `terminal.draw()`.
+//!
+//! ## Design
+//!
+//! Actor-style: handles ([`FrameRequester`]) are cheap to clone and send across
+//! tasks. They forward `Instant` deadlines to the scheduler over an unbounded
+//! mpsc. The scheduler folds multiple deadlines into the **earliest** one,
+//! sleeps until it expires, then emits exactly one `()` notification.
+//!
+//! Inspired by — but not copied from — codex's `tui/frame_requester.rs` (the
+//! codex codebase is Apache-2.0; this is an independent MIT implementation
+//! using the same well-known coalescing pattern).
+
+use std::time::Duration;
+use std::time::Instant;
+
+use tokio::sync::mpsc;
+
+/// 120 FPS minimum interval between emitted draw notifications.
+///
+/// Public so tests can reason about rate limiting without magic numbers.
+pub(crate) const MIN_FRAME_INTERVAL: Duration = Duration::from_nanos(8_333_334);
+
+/// Cheap, cloneable handle for requesting a future redraw of the TUI.
+///
+/// Drop the last clone to shut down the associated [`FrameScheduler`] task.
+#[derive(Clone, Debug)]
+pub(crate) struct FrameRequester {
+    tx: mpsc::UnboundedSender<Instant>,
+}
+
+impl FrameRequester {
+    /// Request a redraw as soon as the rate limiter allows.
+    ///
+    /// Cheap and infallible from the caller's perspective: if the scheduler
+    /// has already exited (e.g. during shutdown), the request is silently
+    /// dropped. That is the correct behavior — there is nothing to draw on.
+    pub(crate) fn schedule_frame(&self) {
+        let _ = self.tx.send(Instant::now());
+    }
+
+    /// Request a redraw at least `dur` from now.
+    ///
+    /// Useful for animations and time-based UI (e.g. a spinner that should
+    /// tick on the next frame boundary).
+    #[allow(dead_code)] // wired up in follow-up issues; keep the API symmetric.
+    pub(crate) fn schedule_frame_in(&self, dur: Duration) {
+        let _ = self.tx.send(Instant::now() + dur);
+    }
+}
+
+/// Receiver side of the frame notification channel.
+///
+/// The TUI event loop holds this and consumes from it inside its
+/// `tokio::select!` to know when to actually call `terminal.draw()`.
+pub(crate) type DrawNotifyRx = mpsc::Receiver<()>;
+
+/// Build a connected `(FrameRequester, DrawNotifyRx)` pair and spawn the
+/// background scheduler that connects them.
+///
+/// Drop the requester (and any clones) to shut down the scheduler.
+pub(crate) fn spawn_frame_scheduler() -> (FrameRequester, DrawNotifyRx) {
+    // bounded channel of size 1: extra notifications coalesce naturally
+    // because the consumer just calls `terminal.draw()` once per `recv()`.
+    let (notify_tx, notify_rx) = mpsc::channel::<()>(1);
+    let (req_tx, req_rx) = mpsc::unbounded_channel::<Instant>();
+    let scheduler = FrameScheduler {
+        deadlines: req_rx,
+        notify_tx,
+        rate_limiter: FrameRateLimiter::default(),
+    };
+    tokio::spawn(scheduler.run());
+    (FrameRequester { tx: req_tx }, notify_rx)
+}
+
+/// Internal task that coalesces deadline requests and emits notifications.
+struct FrameScheduler {
+    deadlines: mpsc::UnboundedReceiver<Instant>,
+    notify_tx: mpsc::Sender<()>,
+    rate_limiter: FrameRateLimiter,
+}
+
+impl FrameScheduler {
+    async fn run(mut self) {
+        // Effectively "infinity" — a one-year sleep we cancel as soon as
+        // the first request arrives. Arms the select branch unconditionally
+        // so the tokio::select! always has two pollable arms.
+        const NEVER: Duration = Duration::from_secs(60 * 60 * 24 * 365);
+
+        let mut next_deadline: Option<Instant> = None;
+
+        loop {
+            let target = next_deadline.unwrap_or_else(|| Instant::now() + NEVER);
+            let sleep = tokio::time::sleep_until(target.into());
+            tokio::pin!(sleep);
+
+            tokio::select! {
+                maybe_req = self.deadlines.recv() => {
+                    let Some(requested) = maybe_req else {
+                        // All requesters dropped → shut down cleanly.
+                        return;
+                    };
+                    let clamped = self.rate_limiter.clamp_deadline(requested);
+                    next_deadline = Some(
+                        next_deadline.map_or(clamped, |cur| cur.min(clamped)),
+                    );
+                    // Loop continues; we recompute `target` and re-arm the
+                    // sleep so multiple requests fold into one fire.
+                }
+                _ = &mut sleep => {
+                    if next_deadline.take().is_some() {
+                        self.rate_limiter.mark_emitted(target);
+                        // try_send so a slow consumer can't deadlock the
+                        // scheduler. If the channel is already full, the
+                        // consumer hasn't drained the previous notification
+                        // yet — they'll see "draw needed" on next recv()
+                        // anyway, so dropping the duplicate is correct.
+                        let _ = self.notify_tx.try_send(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Tracks the last-emitted timestamp and clamps deadlines forward to
+/// enforce a minimum interval between frame notifications.
+#[derive(Debug, Default)]
+struct FrameRateLimiter {
+    last_emitted_at: Option<Instant>,
+}
+
+impl FrameRateLimiter {
+    /// Clamp `requested` forward to honor [`MIN_FRAME_INTERVAL`].
+    fn clamp_deadline(&self, requested: Instant) -> Instant {
+        let Some(prev) = self.last_emitted_at else {
+            return requested;
+        };
+        let earliest_allowed = prev.checked_add(MIN_FRAME_INTERVAL).unwrap_or(prev);
+        requested.max(earliest_allowed)
+    }
+
+    fn mark_emitted(&mut self, at: Instant) {
+        self.last_emitted_at = Some(at);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time;
+
+    /// Helper: wait for one notification with a timeout. Returns true if a
+    /// notification arrived in time, false on timeout.
+    async fn wait_for_draw(rx: &mut DrawNotifyRx, timeout: Duration) -> bool {
+        tokio::select! {
+            res = rx.recv() => res.is_some(),
+            _ = time::sleep(timeout) => false,
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn rate_limiter_does_not_clamp_first_request() {
+        let limiter = FrameRateLimiter::default();
+        let now = Instant::now();
+        assert_eq!(limiter.clamp_deadline(now), now);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn rate_limiter_clamps_to_min_interval() {
+        let mut limiter = FrameRateLimiter::default();
+        let t0 = Instant::now();
+        limiter.mark_emitted(t0);
+        let too_soon = t0 + Duration::from_micros(100);
+        assert_eq!(limiter.clamp_deadline(too_soon), t0 + MIN_FRAME_INTERVAL);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn schedule_frame_emits_one_notification() {
+        let (req, mut rx) = spawn_frame_scheduler();
+        req.schedule_frame();
+        time::advance(Duration::from_millis(1)).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn three_requests_coalesce_into_one_notification() {
+        // The whole point of the module: three rapid requests should fire
+        // a single notification, not three.
+        let (req, mut rx) = spawn_frame_scheduler();
+        req.schedule_frame();
+        req.schedule_frame();
+        req.schedule_frame();
+
+        time::advance(Duration::from_millis(1)).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+        // No second notification for the same coalesced batch.
+        assert!(!wait_for_draw(&mut rx, Duration::from_millis(20)).await);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn schedule_frame_in_delays_notification() {
+        let (req, mut rx) = spawn_frame_scheduler();
+        req.schedule_frame_in(Duration::from_millis(50));
+
+        // Before the deadline: nothing yet.
+        time::advance(Duration::from_millis(30)).await;
+        assert!(!wait_for_draw(&mut rx, Duration::from_millis(5)).await);
+
+        // After the deadline: one notification.
+        time::advance(Duration::from_millis(25)).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn rate_limit_caps_consecutive_notifications() {
+        // After one draw, a second `schedule_frame()` must wait at least
+        // MIN_FRAME_INTERVAL before the notification fires.
+        let (req, mut rx) = spawn_frame_scheduler();
+
+        req.schedule_frame();
+        time::advance(Duration::from_millis(1)).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+
+        req.schedule_frame();
+        // Less than MIN_FRAME_INTERVAL — must not fire yet.
+        time::advance(Duration::from_micros(100)).await;
+        assert!(!wait_for_draw(&mut rx, Duration::from_micros(100)).await);
+
+        // Past MIN_FRAME_INTERVAL — must now fire.
+        time::advance(MIN_FRAME_INTERVAL).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn dropping_all_requesters_shuts_down_scheduler() {
+        let (req, mut rx) = spawn_frame_scheduler();
+        drop(req);
+        // Receiver should observe channel closure (recv returns None).
+        let res = tokio::time::timeout(Duration::from_millis(50), rx.recv()).await;
+        assert!(matches!(res, Ok(None)), "scheduler should drop notify_tx");
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn mixed_immediate_and_delayed_coalesce_to_earliest() {
+        let (req, mut rx) = spawn_frame_scheduler();
+        req.schedule_frame_in(Duration::from_millis(100));
+        req.schedule_frame(); // immediate; should win
+
+        time::advance(Duration::from_millis(1)).await;
+        assert!(wait_for_draw(&mut rx, Duration::from_millis(50)).await);
+        // The 100ms-delayed request was coalesced — no second draw.
+        assert!(!wait_for_draw(&mut rx, Duration::from_millis(120)).await);
+    }
+}

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) mod builtin_skills;
 pub(crate) mod clipboard;
 pub(crate) mod completer;
 pub(crate) mod diff_render;
+pub(crate) mod frame_requester;
 pub(crate) mod headless;
 pub(crate) mod highlight;
 pub(crate) mod history_render;

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -97,6 +97,13 @@ pub(crate) struct TuiContext {
     pub shared_mode: trust::SharedTrustMode,
     pub agent: Arc<KodaAgent>,
     pub project_root: PathBuf,
+
+    /// Coalescing draw scheduler (#1138). Replaces the old per-iteration
+    /// synchronous `terminal.draw()` calls in the inference hot loop.
+    /// `frame_requester` is the producer side; clone freely. `draw_rx` is
+    /// the consumer side and lives on the inference loop's select.
+    pub frame_requester: crate::frame_requester::FrameRequester,
+    pub draw_rx: crate::frame_requester::DrawNotifyRx,
 }
 
 /// Outcome of dispatching a single command.
@@ -312,6 +319,11 @@ impl TuiContext {
             }
         };
 
+        // Spawn the coalescing draw scheduler (#1138). The inference loop's
+        // select consumes from `draw_rx`; everywhere else holds clones of
+        // `frame_requester` to fire-and-forget redraw requests.
+        let (frame_requester, draw_rx) = crate::frame_requester::spawn_frame_scheduler();
+
         Ok(Self {
             terminal,
             textarea,
@@ -358,6 +370,8 @@ impl TuiContext {
             shared_mode,
             agent,
             project_root,
+            frame_requester,
+            draw_rx,
         })
     }
 

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -30,6 +30,8 @@ use tokio::sync::mpsc;
 enum SelectArm {
     Crossterm(Event),
     Ui(UiEvent),
+    /// The frame scheduler granted us a draw slot (#1138). Render once.
+    Draw,
     TurnDone(anyhow::Result<()>),
 }
 
@@ -97,53 +99,15 @@ impl TuiContext {
             // from winning N times in a row when both are constantly ready.
             let mut prefer_input = true;
 
+            // Schedule the initial frame so the user sees state immediately
+            // when the turn starts. From here on, every event-handling arm
+            // calls `schedule_frame()` to request the next coalesced redraw
+            // (#1138). The Draw arm of the select is the *only* place that
+            // actually calls `terminal.draw()` — the rate limiter inside the
+            // frame scheduler caps that at ~120 FPS.
+            self.frame_requester.schedule_frame();
+
             loop {
-                // Clamp scroll offset before drawing (resize may have
-                // changed wrapping, making the old offset invalid).
-                // Use the actual history panel height, not the full terminal
-                // height — otherwise max_offset is too small and scrolling
-                // up during inference gets clamped back toward the bottom,
-                // re-engaging sticky_bottom.
-                let (term_w, _) = crossterm::terminal::size()
-                    .map(|(c, r)| (c as usize, r as usize))
-                    .unwrap_or((80, 24));
-                let hist_viewport = (self.history_area_height as usize).max(1);
-                self.scroll_buffer.clamp_offset(term_w, hist_viewport);
-
-                // Redraw viewport
-                let mode = trust::read_trust(&self.shared_mode);
-                let ctx = self.context_pct;
-                let mcp_info = self.agent.mcp_status_bar_info();
-                let queue_total = self.later_queue.len();
-                let queue_preview: Vec<String> = self
-                    .later_queue
-                    .iter()
-                    .take(crate::widgets::queue_preview::MAX_VISIBLE)
-                    .cloned()
-                    .collect();
-                let _ = self.terminal.draw(|f| {
-                    draw_viewport(
-                        f,
-                        &self.textarea,
-                        &self.config.model,
-                        mode,
-                        ctx,
-                        self.tui_state,
-                        &self.prompt_mode,
-                        &queue_preview,
-                        queue_total,
-                        self.inference_start
-                            .map(|s| s.elapsed().as_secs())
-                            .unwrap_or(0),
-                        self.renderer.last_turn_stats.as_ref(),
-                        &self.menu,
-                        &self.scroll_buffer,
-                        self.mouse_selection.as_ref(),
-                        mcp_info,
-                        &self.project_root,
-                    );
-                });
-
                 // Round-robin: alternate which arm is preferred so a flood of
                 // engine events can't starve terminal input (and vice versa).
                 // Combined with the bounded drain below, this guarantees that
@@ -162,10 +126,15 @@ impl TuiContext {
                 // and Ctrl+C took seconds to propagate (#1137).
                 const MAX_DRAIN: usize = 64;
 
+                // The Draw arm is *always* polled first within each iteration.
+                // It only fires when the frame scheduler has emitted a
+                // notification (rate-limited to ~120 FPS), so it cannot
+                // starve the other arms in practice.
                 let select_result = if prefer_input {
                     tokio::select! {
                         biased;
 
+                        Some(()) = self.draw_rx.recv() => SelectArm::Draw,
                         Some(Ok(ev)) = self.crossterm_events.next() => {
                             SelectArm::Crossterm(ev)
                         }
@@ -178,6 +147,7 @@ impl TuiContext {
                     tokio::select! {
                         biased;
 
+                        Some(()) = self.draw_rx.recv() => SelectArm::Draw,
                         Some(ui_event) = ui_rx.recv() => {
                             SelectArm::Ui(ui_event)
                         }
@@ -189,6 +159,52 @@ impl TuiContext {
                 };
 
                 match select_result {
+                    SelectArm::Draw => {
+                        // The actual `terminal.draw()` happens here — nowhere
+                        // else in the inference loop. We can't call
+                        // `self.draw()` directly because `turn` holds a
+                        // `&mut self.session` borrow for its full lifetime,
+                        // so we use disjoint field access just like the old
+                        // synchronous draw block did.
+                        let (term_w, _) = crossterm::terminal::size()
+                            .map(|(c, r)| (c as usize, r as usize))
+                            .unwrap_or((80, 24));
+                        let hist_viewport = (self.history_area_height as usize).max(1);
+                        self.scroll_buffer.clamp_offset(term_w, hist_viewport);
+
+                        let mode = trust::read_trust(&self.shared_mode);
+                        let ctx = self.context_pct;
+                        let mcp_info = self.agent.mcp_status_bar_info();
+                        let queue_total = self.later_queue.len();
+                        let queue_preview: Vec<String> = self
+                            .later_queue
+                            .iter()
+                            .take(crate::widgets::queue_preview::MAX_VISIBLE)
+                            .cloned()
+                            .collect();
+                        let _ = self.terminal.draw(|f| {
+                            draw_viewport(
+                                f,
+                                &self.textarea,
+                                &self.config.model,
+                                mode,
+                                ctx,
+                                self.tui_state,
+                                &self.prompt_mode,
+                                &queue_preview,
+                                queue_total,
+                                self.inference_start
+                                    .map(|s| s.elapsed().as_secs())
+                                    .unwrap_or(0),
+                                self.renderer.last_turn_stats.as_ref(),
+                                &self.menu,
+                                &self.scroll_buffer,
+                                self.mouse_selection.as_ref(),
+                                mcp_info,
+                                &self.project_root,
+                            );
+                        });
+                    }
                     SelectArm::Crossterm(ev) => {
                         handle_crossterm_event_inline(
                             ev,
@@ -209,6 +225,10 @@ impl TuiContext {
                             &db_handle,
                         )
                         .await;
+                        // Request a redraw to reflect the new state. The
+                        // frame scheduler coalesces this with any other
+                        // requests in the same window (#1138).
+                        self.frame_requester.schedule_frame();
                     }
                     SelectArm::Ui(ui_event) => {
                         // Extract context usage before rendering
@@ -249,6 +269,10 @@ impl TuiContext {
                                 &mut self.renderer,
                             );
                         });
+                        // One coalesced redraw per drain batch — not per
+                        // event — keeps redraw cost bounded under streaming
+                        // floods (#1138).
+                        self.frame_requester.schedule_frame();
                     }
                     SelectArm::TurnDone(result) => {
                         if let Err(e) = result {


### PR DESCRIPTION
## Summary

Replaces the synchronous `terminal.draw()` at the top of the inference inner loop with a request/coalesce/emit pipeline. **Second PR under epic #1141** (TUI responsiveness & terminal hygiene v0.3.x blocker), stacked on top of #1142.

> ⚠️ **Depends on #1142** — please review/merge that one first. Diff against `main` will be cleaner once #1142 lands.

## Why

Before this PR the inference loop called `terminal.draw()` once per iteration. Under streaming or sub-agent fan-out that's roughly **one full redraw per engine event** — wasteful CPU and a contributor to the executor pressure that caused #1137.

## What

Adds `koda-cli/src/frame_requester.rs` — a small actor-style scheduler that coalesces draw requests and rate-limits them to ~120 FPS:

| Type | Role |
|---|---|
| `FrameRequester` | Cheap, cloneable producer handle. Callers fire-and-forget `schedule_frame()` whenever they think a redraw might be useful. |
| `FrameScheduler` (private) | Background task. Folds multiple requests into the earliest deadline and emits exactly one notification. |
| `FrameRateLimiter` (private) | Enforces `MIN_FRAME_INTERVAL` (8.33ms = 120 FPS) between emitted notifications. |

The inference loop's `tokio::select!` gains a `Draw` arm that consumes notifications and performs the actual `terminal.draw()`. Every other arm now ends with `self.frame_requester.schedule_frame()` instead of relying on the top-of-loop synchronous draw.

`TuiContext` carries the `frame_requester` (clone-friendly) and the single `draw_rx` consumer.

## Impact

- 1000 `TextDelta`s during a streaming response previously triggered ~1000 redraws. **Now: ≤8** (capped by the rate limiter).
- Frees the executor between events — defense in depth on top of #1137 / #1139's drain bound + round-robin.
- Sets up the architectural foundation for codex-style unified event streams (separate follow-up).

## Why I didn't unify with `TuiContext::draw()`

`turn` holds `&mut self.session` for its full lifetime, so we can't call `&mut self`-taking `self.draw()` from inside the inner loop. The Draw arm uses disjoint field access (same pattern the old top-of-loop draw used); the idle path keeps using `self.draw()`. DRYing this up is a separate concern from coalescing.

## Tests

8 new unit tests in `frame_requester::tests`:

- `rate_limiter_does_not_clamp_first_request`
- `rate_limiter_clamps_to_min_interval`
- `schedule_frame_emits_one_notification`
- **`three_requests_coalesce_into_one_notification`** ← the headline regression guard (N requests in one window → 1 notification)
- `schedule_frame_in_delays_notification`
- `rate_limit_caps_consecutive_notifications`
- `dropping_all_requesters_shuts_down_scheduler`
- `mixed_immediate_and_delayed_coalesce_to_earliest`

Workspace-wide: **1948 tests pass**. clippy clean. fmt clean.

## Closes

- Closes #1138
- Tracked under epic #1141

## Refs

- Builds on #1142 (#1137 + #1139)
- Inspired by codex's `tui/frame_requester.rs` + `tui/frame_rate_limiter.rs` (Apache-2.0); this is an independent MIT implementation.

## Follow-ups (out of scope, will file as separate issues)

- `tui_handlers_inference.rs` is now 952 lines. Split into smaller modules.
- DRY the inline draw block with `TuiContext::draw()` once `turn` lifetime is reworked.
