### PR TITLE
feat(tui): Phase A of #1146 — KODA_RENDER=inline opt-in mode with native scrollback

### DIFF
--- a/docs/architecture/inline-vs-altscreen.md
+++ b/docs/architecture/inline-vs-altscreen.md
@@ -1,0 +1,205 @@
+# TUI Architecture Comparison — koda design study
+
+> **Status**: Adopted. Tracked in epic #1146.
+> **Decision**: Plan C — bundled inline-first migration including custom textarea (Phase C of epic).
+>
+> See `Recommendation for koda` section below.
+
+**Question:** koda moved from inline to alt-screen because (the recollection is) inline couldn't do rich markdown / syntax highlighting / formatting. Was that the right call?
+
+**Short answer:** No. All three reference CLI agents (codex, claude-code, gemini-cli) ship rich markdown + syntax highlighting **inline-first**. Inline is the dominant paradigm for agent CLIs in 2026. The premise that motivated koda's switch was a tooling problem, not a fundamental limitation — it's solvable, codex literally shows the solution.
+
+---
+
+## TL;DR matrix
+
+| Project | Default mode | Alt-screen role | Markdown / syntax | Mouse capture | Stack |
+|---|---|---|---|---|---|
+| **codex** (Rust) | **Inline** (DECSTBM scroll regions) | On-demand overlays only (pager, image picker, image preview) | Full markdown via `pulldown-cmark` → `Vec<Line>`; syntect syntax highlighting | **None** — uses `?1007h` alternate scroll instead | ratatui + custom `insert_history.rs` |
+| **claude-code** (Node) | **Inline** | Opt-in via `CLAUDE_CODE_FULLSCREEN` env var; auto-disabled in tmux -CC | Full markdown (`Markdown.tsx` 27KB), tables (`MarkdownTable.tsx` 46KB), syntax (`HighlightedCode.tsx` 17KB) | Yes (SGR 1000/1002/1006), with documented caveats | Custom Ink fork |
+| **gemini-cli** (Node) | **Inline** | Configurable via `getUseAlternateBuffer()`; replays history into scrollback on exit | `MarkdownDisplay.tsx` + `InlineMarkdownRenderer` → ANSI; `CodeColorizer.tsx` | Conditional, off by default | Stock Ink |
+| **koda** (Rust) | **Alt-screen** | Always | Custom highlighter via `tui_render.rs` | Yes (full SGR mouse capture) | ratatui |
+| **zed** (Rust) | **Desktop GPU app** — not a TUI | N/A | N/A (GPUI text renderer) | N/A | GPUI custom |
+
+**Three of three reference TUIs are inline-first.** Koda is the outlier.
+
+---
+
+## What "inline" actually means in 2026
+
+Common architecture across codex / claude-code / gemini-cli:
+
+```
+┌─ terminal scrollback (native, OS-managed) ──────────────────────┐
+│ [user] write a function that …                                  │
+│ ⏵ Read foo.rs                                                   │
+│ ⏵ Edit foo.rs                                                   │
+│ ```rust                                                         │
+│ pub fn foo() { … }                                              │  ← finalized history
+│ ```                                                             │     lives in scrollback
+│ Done. Tests pass.                                               │
+│                                                                 │
+├─ live ratatui/Ink viewport (small, bottom-anchored) ────────────┤
+│ Thinking… ⠋ tokens 1.2k/200k                                    │  ← actively re-rendered
+│ > █                                                             │     each frame
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Two regions:
+
+1. **Finalized region**: pre-rendered `Vec<Line>` (markdown + syntax-highlighted) **inserted into terminal scrollback** above the live viewport. Once written, the terminal owns it — selection, copy, search, scroll all native, zero in-app state.
+2. **Live region**: a small bottom-anchored viewport for the prompt + status indicator + spinner + ephemeral UI. This is the *only* part that re-renders each frame.
+
+The tricky bit is step 1: how do you insert `Vec<Line>` into scrollback **above** a live viewport without flickering or scrambling layout? Answer: **DECSTBM scroll regions** (`ESC [ top ; bot r`) + Reverse Index (`ESC M`). You temporarily restrict the scroll region to *just the live viewport rows*, emit reverse-index newlines to slide existing scrollback down, write your new lines into the freed space at the top of the region, then restore the scroll region. Codex's `insert_history.rs` is **32KB of code** doing exactly this, including a Zellij fallback (Zellij silently drops scroll-region escapes).
+
+This **is** the hard part. It is also a solved problem with a 700-line reference implementation sitting in `../codex/codex-rs/tui/src/insert_history.rs`. Apache 2.0 licensed. We can absolutely port it.
+
+---
+
+## Why the original premise ("inline can't do rich rendering") was wrong
+
+Codex is a counter-example to every part of the claim:
+
+- **Markdown**: `markdown_render.rs` (40KB) parses CommonMark via `pulldown-cmark` → `Vec<Line<'static>>` with full styling (bold, italic, headings, lists, blockquotes, links).
+- **Syntax highlighting**: code blocks call `highlight_code_to_lines(&code, &lang)` which uses syntect (the same crate koda already depends on).
+- **Tables**: rendered as ratatui `Lines` with column alignment.
+- **Links**: clickable in iTerm2/kitty/Ghostty via OSC 8 escapes.
+- **Wrapping & resize reflow**: handled by `wrapping.rs` (47KB) + `resize_reflow_cap.rs` — when the terminal resizes, the scrollback is reflowed in place.
+
+All of this works **inline**. The output ends up in native scrollback where the user can select / copy / search it with their terminal's native UI.
+
+The most likely reason koda hit a wall on inline was **ratatui's default `Terminal::draw()` API doesn't expose insert-into-scrollback**. It only knows how to render a `Frame` into a fixed viewport. To do inline-with-scrollback you either:
+
+- (a) Bypass `Terminal::draw()` for finalized content and write escape sequences directly via `crossterm::queue!` — what codex does in `insert_history.rs` + their custom `Terminal` wrapper (`custom_terminal.rs`, 29KB).
+- (b) Use ratatui's experimental `Viewport::Inline(N)` mode — which has rough edges around scroll regions and resize.
+
+The path (a) is non-trivial but well-trodden; we have a working reference 30 feet away.
+
+---
+
+## What koda gains by going inline
+
+| Win | Source |
+|---|---|
+| Native scrollback, search, selection, copy | Terminal owns finalized history |
+| Eliminates the `EnableMouseCapture` bug class entirely (#540, #1137 ancestors) | No mouse capture needed |
+| ~440 LOC of `mouse_select.rs` deleted | Native selection replaces it |
+| ~30% less work per frame (we only re-render the live viewport, not the whole history panel) | Tiny live area |
+| #1140 disappears | No mouse capture means nothing to drop |
+| OS-native shell integration (iTerm2 marks, terminal scroll, etc.) | Inline output is just regular terminal output |
+| Better tmux/screen/ssh behavior | Alt-screen has a bunch of quirks in these envs |
+| Smaller TUI surface area to maintain | Less custom scroll/clipboard code |
+
+## What koda loses
+
+| Loss | Severity | Mitigation |
+|---|---|---|
+| Custom click-and-drag selection feature | Medium-low | Native terminal selection works in iTerm2/Ghostty/kitty/Windows Terminal/WezTerm/Alacritty (the actual user base). `Shift+drag` workaround for tmux. |
+| Always-visible status bar at the screen edge | Medium | Replaced by always-visible *bottom-anchored* status above the prompt, like codex. Visually equivalent for most UX intent. |
+| Always-visible scrollback indicator | Low | Terminals already show their own scrollbars |
+| One screen-cleared view per session | Low (this was a feature, not a bug, for some users) | Optional opt-in alt-screen via env var, like claude-code/gemini do |
+| Custom mouse-driven scroll | Low | Terminal native scroll handles it |
+
+## What about the alt-screen overlays codex uses?
+
+Codex still calls `EnterAlternateScreen` for **specific transient surfaces**:
+- Pager overlay (full-screen log/transcript viewer)
+- Image picker
+- Resume picker
+- OSS model selection wizard
+
+These are modal screens that *want* to obliterate the chat history temporarily, then return. Same pattern works for koda's `/help`, MCP browser, model picker, etc. — they can be alt-screen overlays inside an otherwise-inline app.
+
+This is exactly the **hybrid** model. Inline by default, alt-screen on demand for modal experiences. Codex calls this `enter_alt_screen()` / `leave_alt_screen()` (lines 641 and 663 of `tui.rs`).
+
+---
+
+## Cross-cutting: what every reference does that koda doesn't (yet)
+
+Patterns that are universal across codex / claude-code / gemini-cli:
+
+1. **Frame coalescing scheduler** at ~120 FPS — koda just shipped this in #1143 ✅
+2. **Bounded event drain** in the main loop — koda shipped in #1142 ✅
+3. **No mouse capture by default** — codex, off in claude-code's inline mode, conditional in gemini-cli
+4. **Inline rendering as default** — all three
+5. **Modal alt-screen overlays** — all three for special-purpose surfaces
+6. **Custom Terminal wrapper** that exposes scroll-region writes — codex's `custom_terminal.rs`, similar abstractions in Ink fork
+7. **Markdown pre-rendered to Lines/spans then inserted as scrollback** — codex's `markdown_render.rs` + `insert_history.rs`
+8. **Status indicator widget that lives in the live viewport** — codex's `status_indicator_widget.rs` (16KB), claude-code's `StatusLine.tsx`, gemini's footer
+
+Items 3–8 are all things koda's current architecture makes harder than necessary.
+
+---
+
+## Zed for context (not directly applicable)
+
+Zed is not a TUI; it's a GPU-rendered desktop editor in Rust using GPUI. Their `agent_ui` crate (1.7MB) shows the most polished agent UX in the industry: streaming responses with live syntax highlighting, in-buffer code edits, diff previews, MCP integration, multi-agent orchestration. But the rendering paradigm (GPU-accelerated, retained-mode, pixel-perfect text) is a different universe from terminal output. The value for us is **UX patterns**, not architecture:
+
+- Diff-based tool result rendering (we already do this)
+- Bottom-anchored composer with above-line history (matches inline-first)
+- Slash command palette with rich previews
+- Mention/`@`-completion with file & symbol search
+
+Worth studying for v0.4.x feature parity. Not relevant to the inline-vs-alt-screen decision.
+
+---
+
+## Recommendation for koda
+
+**Go inline.** Specifically: pursue **codex-style hybrid** = inline-first + on-demand alt-screen overlays.
+
+This is a **multi-week refactor** (≈ #1116 territory) but it pays off massively:
+- Closes #1140 and the entire mouse-leak bug class structurally
+- Closes the scroll/selection UX gap with codex
+- Deletes ~440 LOC (`mouse_select.rs`) and reduces ~30% of per-frame work
+- Aligns us with the dominant agent-CLI architecture
+- Unlocks codex parity on resume, pager, and other modal flows
+
+The order I'd suggest:
+
+### Phase 2 (revised)
+1. **File a new umbrella issue**: "Migrate to inline-first rendering with alt-screen overlays"
+2. **Close #1140 with a comment** linking the umbrella — Phase 1's defenses already prevent the leak in practice; the structural fix is via inline migration, not via swapping `?1049h` for `?1007h` in our current alt-screen architecture (which doesn't make sense for our event-routing model).
+3. **Spike**: stand up a minimal proof-of-concept that ports `insert_history.rs` from codex into a `koda-cli/src/insert_history.rs` file (Apache-2.0 attribution). Verify it works against ratatui's `CrosstermBackend` and renders one finalized line into scrollback above a tiny inline viewport.
+4. **Iterate**: migrate one history-cell type at a time (assistant messages first, then tool calls, then commands), keeping the alt-screen mode functional in parallel behind a feature flag (`KODA_RENDER=inline|altscreen`). Lets us bisect regressions.
+5. **Cutover**: flip default to inline once parity is reached, deprecate alt-screen path, remove mouse capture, delete `mouse_select.rs`.
+
+### Issues to file
+
+- **Umbrella**: "Migrate koda from alt-screen to inline-first rendering (codex parity)"
+- **Spike**: "POC: port codex's `insert_history.rs` to koda"
+- **Migration**: one issue per history-cell category to track parity
+
+### Issues to close as obsolete
+
+- **#1140**: replaced by the umbrella above
+- **#1116** (textarea): re-frame as part of the inline migration since codex's textarea works inline
+
+---
+
+## Sanity check on the original recollection
+
+You said koda moved from inline to alt-screen because "inline couldn't do rich syntax highlighting/formatting." Three possibilities for what actually happened:
+
+1. **Ratatui `Viewport::Inline(N)` had bugs** at the time (it's still listed as experimental in some versions). The escape into `Viewport::Fullscreen` + alt-screen sidesteps those bugs. **This is fixable** — codex bypasses ratatui's viewport API for finalized content and only uses it for the live region.
+2. **The koda implementation tried to keep state in ratatui's Buffer for the entire history** instead of writing finalized lines through to scrollback. That doesn't scale and would have looked broken under wrapping/resize. **Also fixable** — separate finalized vs live state.
+3. **Resize reflow was hard** to get right with inline. Codex's `wrapping.rs` (47KB) + `resize_reflow_cap.rs` (6KB) is the proof that it's doable; just not trivial. **Fixable, but it's the hardest part.**
+
+None of these are "rich rendering doesn't work inline." They're all "ratatui's default API doesn't expose what you need; you have to build the missing pieces." Codex built them. We can borrow them.
+
+---
+
+## My honest opinion
+
+Koda's alt-screen choice was a **local optimum** — it solved an immediate "I can't get rich rendering working with ratatui's default `Viewport::Inline`" problem but locked in:
+- Mouse capture as mandatory (which caused #540, #1137)
+- A custom in-app scroll buffer (~440 LOC + ongoing maintenance)
+- A custom click-and-drag selection (~440 LOC of `mouse_select.rs`)
+- Worse tmux/screen/ssh behavior than competitors
+- A divergence from where the agent-CLI ecosystem is converging
+
+The **global optimum** is inline-first hybrid, demonstrated by all three serious agent-CLI competitors. We have a working reference implementation 30 feet away. The migration is multi-week work, but it deletes more code than it adds in the long run.
+
+I'd vote for **doing the migration as v0.4.x flagship work**, with #1140 and #1116 folded into it.
+
+— code 🐶

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -38,7 +38,7 @@ syntect = { version = "5", default-features = false, features = ["default-syntax
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 
 # TUI (inline viewport: input + status bar)
-ratatui = { version = "0.30", default-features = false, features = ["crossterm", "scrolling-regions"] }
+ratatui = { version = "0.30", default-features = false, features = ["crossterm", "scrolling-regions", "unstable-rendered-line-info"] }
 ratatui-textarea = "0.9"
 unicode-width = "0.2"
 

--- a/koda-cli/src/inline_history.rs
+++ b/koda-cli/src/inline_history.rs
@@ -1,0 +1,471 @@
+//! Inline-mode history insertion for koda's TUI.
+//!
+//! In inline mode (the default starting from epic #1146 — see
+//! `docs/architecture/inline-vs-altscreen.md`), finalized chat history lives
+//! in the terminal's *native scrollback* rather than in an in-app scroll
+//! buffer. The bottom 3-10 rows of the screen are an inline ratatui
+//! viewport (status + composer + popups); everything above is real
+//! scrollback owned by the terminal emulator (which means native
+//! selection, search, and scroll all work for free).
+//!
+//! ## How it works under the hood
+//!
+//! `ratatui::Terminal::insert_before(height, draw_fn)` (added in 0.30)
+//! does the heavy lifting: when the `scrolling-regions` cargo feature is
+//! enabled (we have it on — see `koda-cli/Cargo.toml`), it uses the
+//! `\x1b[top;bot r` DECSTBM escape to slide existing scrollback down and
+//! writes the new lines into the freed space above the inline viewport.
+//! Codex's `insert_history.rs` does the same thing manually in 843 lines;
+//! ratatui exposes it as a one-liner because we're already on 0.30.
+//!
+//! ## Cell-by-cell behavior worth knowing
+//!
+//! The inline viewport starts at `y=0` of the screen and grows downward
+//! as `insert_before` is called. Each insert reserves N rows above the
+//! current viewport position and shifts the viewport down by N rows
+//! (until the screen bottom is reached, at which point further inserts
+//! roll the topmost rows off into native scrollback). `TestBackend`
+//! tests in this module cover both regimes.
+//!
+//! ## Why a wrapper module
+//!
+//! The raw `insert_before` API takes a closure that fills a `Buffer` with
+//! a known height. Callers always want to insert "this `Vec<Line>`",
+//! which means computing the wrapped height and rendering via
+//! `Paragraph::wrap`. Centralising that calculation here keeps every
+//! call-site terse and consistent.
+//!
+//! ## What this module is NOT yet
+//!
+//! - URL-aware wrapping (clickable-link preservation across line wraps —
+//!   codex's `wrapping.rs` adds this; we'll port it when needed).
+//! - Zellij fallback (Zellij ignores DECSTBM scroll regions — we'll add a
+//!   detection + fallback path in a later commit if Zellij users complain).
+//!
+//! ## License attribution
+//!
+//! The high-level idea (compute wrapped height, then call into the
+//! terminal's scroll-region machinery) is borrowed from
+//! `codex-rs/tui/src/insert_history.rs` (Apache-2.0). The implementation
+//! itself is a thin shim over ratatui 0.30's upstream `insert_before` and
+//! is original (MIT, like the rest of koda).
+
+use ratatui::{
+    Terminal,
+    backend::Backend,
+    text::Line,
+    widgets::{Paragraph, Widget, Wrap},
+};
+use std::io;
+
+/// Insert finalized history lines into the terminal's scrollback, above
+/// the inline viewport.
+///
+/// Computes the wrapped height of `lines` at the current terminal width,
+/// then delegates to `Terminal::insert_before` to slide existing
+/// scrollback down and write the new content into the freed rows.
+///
+/// Cursor-position-neutral: the inline viewport (composer/status) is
+/// re-rendered in-place by ratatui after the insert, so callers don't
+/// need to redraw afterward.
+///
+/// # Behavior
+///
+/// - **No-op** if `lines` is empty or terminal width is 0.
+/// - **No-op** if the terminal is in `Viewport::Fullscreen` mode
+///   (insert-into-scrollback only makes sense for `Viewport::Inline(_)`).
+/// - **Wraps** lines at the current terminal width using
+///   `Paragraph::wrap(Wrap { trim: false })`. Long lines flow onto the
+///   next scrollback row.
+///
+/// # Errors
+///
+/// Returns whatever the underlying backend returns (typically I/O errors
+/// from writing escape sequences to the terminal).
+///
+/// # Example (conceptual)
+///
+/// ```ignore
+/// use ratatui::text::Line;
+/// // After a tool finishes, push its rendered output into scrollback:
+/// koda_cli::inline_history::push_history(
+///     &mut terminal,
+///     vec![Line::from("✓ Read foo.rs (245 lines)")],
+/// )?;
+/// ```
+#[allow(dead_code)] // wired up in a subsequent commit on the same branch.
+pub fn push_history<B>(
+    terminal: &mut Terminal<B>,
+    lines: Vec<Line<'static>>,
+) -> io::Result<()>
+where
+    B: Backend,
+    B::Error: std::error::Error + Send + Sync + 'static,
+{
+    if lines.is_empty() {
+        return Ok(());
+    }
+
+    // `terminal.size()` is fast (no syscall — cached from last poll).
+    let size = terminal.size().map_err(io::Error::other)?;
+    let width = size.width;
+    if width == 0 {
+        return Ok(());
+    }
+
+    // Compute the wrapped row count. `Paragraph::line_count` accounts for
+    // both hard line breaks in the input and soft wrapping at the
+    // terminal edge, so a single 200-char `Line` at width 80 reports 3.
+    //
+    // We clone here because `insert_before` needs the lines again inside
+    // the closure (FnOnce). The clone is cheap — `Line<'static>` is
+    // mostly `Cow<'static, str>` spans which clone by Arc-bumping the
+    // refcount on owned content.
+    let para = Paragraph::new(lines.clone()).wrap(Wrap { trim: false });
+    let height = para.line_count(width) as u16;
+    if height == 0 {
+        return Ok(());
+    }
+
+    terminal
+        .insert_before(height, |buf| {
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .render(buf.area, buf);
+        })
+        .map_err(io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests verify the *observable* behavior of `push_history`:
+    //! finalized lines actually land above the inline viewport on the
+    //! screen, and overflow into native scrollback once the on-screen
+    //! rows are exhausted.
+    //!
+    //! `TestBackend::assert_buffer_lines` shows the currently-visible
+    //! screen; `assert_scrollback_lines` shows lines that have scrolled
+    //! off the top. Together they're the upstream-recommended way to
+    //! verify `insert_before` semantics (see
+    //! `ratatui-0.30/tests/terminal.rs`).
+
+    use super::*;
+    use ratatui::{
+        Terminal, TerminalOptions, Viewport,
+        backend::TestBackend,
+        prelude::Stylize,
+        widgets::Paragraph,
+    };
+
+    fn inline_terminal(width: u16, height: u16, viewport: u16) -> Terminal<TestBackend> {
+        let backend = TestBackend::new(width, height);
+        Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(viewport),
+            },
+        )
+        .expect("test terminal should construct")
+    }
+
+    /// Draw a known string into the inline viewport so we can later
+    /// assert it survives history insertion intact. The label is
+    /// right-padded with spaces to the full terminal width so every
+    /// cell in the viewport row has an explicit symbol — otherwise
+    /// `assert_buffer_lines` mismatches against `None` cells.
+    fn paint_viewport(terminal: &mut Terminal<TestBackend>, label: &str) {
+        let width = terminal
+            .backend()
+            .size()
+            .map(|s| s.width as usize)
+            .unwrap_or(0);
+        let padded = format!("{label:<width$}");
+        terminal
+            .draw(|f| {
+                let p = Paragraph::new(padded);
+                f.render_widget(p, f.area());
+            })
+            .expect("viewport draw should succeed");
+    }
+
+    /// Helper: assert scrollback is empty regardless of width by
+    /// inspecting the backend's scrollback buffer area directly
+    /// (`assert_scrollback_lines(Vec::<&str>::new())` constructs a
+    /// zero-width expected buffer which spuriously fails width
+    /// assertions).
+    fn assert_scrollback_empty(t: &Terminal<TestBackend>) {
+        // The backend exposes `scrollback()` which returns &Buffer.
+        // A truly-empty scrollback has height 0.
+        let area = t.backend().scrollback().area;
+        assert_eq!(
+            area.height, 0,
+            "expected empty scrollback, found {} rows",
+            area.height
+        );
+    }
+
+    /// Dump the on-screen buffer as `Vec<String>`, treating cells with
+    /// `symbol: None` (i.e. cleared by scroll-region operations but
+    /// never explicitly written) as spaces. This is needed because
+    /// `assert_buffer_lines` does *exact* cell equality, so a freshly-
+    /// scrolled empty cell (`None`) won't match an expected explicit
+    /// space. For our purposes a blank visual cell is a blank visual
+    /// cell regardless of how it got that way.
+    fn dump_buffer(t: &Terminal<TestBackend>) -> Vec<String> {
+        let buf = t.backend().buffer();
+        let area = buf.area;
+        let mut rows = Vec::with_capacity(area.height as usize);
+        for y in area.top()..area.bottom() {
+            let mut row = String::with_capacity(area.width as usize);
+            for x in area.left()..area.right() {
+                let cell = &buf[(x, y)];
+                let sym = cell.symbol();
+                if sym.is_empty() {
+                    row.push(' ');
+                } else {
+                    row.push_str(sym);
+                }
+            }
+            rows.push(row);
+        }
+        rows
+    }
+
+    /// Dump scrollback the same way `dump_buffer` does for the screen.
+    fn dump_scrollback(t: &Terminal<TestBackend>) -> Vec<String> {
+        let buf = t.backend().scrollback();
+        let area = buf.area;
+        let mut rows = Vec::with_capacity(area.height as usize);
+        for y in area.top()..area.bottom() {
+            let mut row = String::with_capacity(area.width as usize);
+            for x in area.left()..area.right() {
+                let cell = &buf[(x, y)];
+                let sym = cell.symbol();
+                if sym.is_empty() {
+                    row.push(' ');
+                } else {
+                    row.push_str(sym);
+                }
+            }
+            rows.push(row);
+        }
+        rows
+    }
+
+    #[test]
+    fn empty_lines_is_a_noop() {
+        // Most basic guarantee: callers can fire-and-forget without
+        // worrying about an empty `insert_before(0, ..)` call panicking
+        // or scrambling the viewport.
+        let mut t = inline_terminal(20, 5, 1);
+        paint_viewport(&mut t, "[viewport]");
+        push_history(&mut t, vec![]).expect("noop must succeed");
+        assert_scrollback_empty(&t);
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "[viewport]          ",
+                "                    ",
+                "                    ",
+                "                    ",
+                "                    ",
+            ]
+        );
+    }
+
+    #[test]
+    fn one_short_line_lands_above_viewport_on_screen() {
+        // The fundamental contract: pushing one line places it
+        // *above* the inline viewport on the visible screen, not
+        // *inside* the viewport. Scrollback stays empty because the
+        // line still fits on screen.
+        let mut t = inline_terminal(20, 5, 1);
+        paint_viewport(&mut t, "[viewport]");
+        push_history(&mut t, vec![Line::from("hello world")]).expect("push must succeed");
+        assert_scrollback_empty(&t);
+        // Inline viewport starts at y=0 and grows downward as content
+        // is inserted: the new line lands at row 0, the viewport row
+        // shifts to row 1.
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "hello world         ",
+                "[viewport]          ",
+                "                    ",
+                "                    ",
+                "                    ",
+            ]
+        );
+    }
+
+    #[test]
+    fn overflow_pushes_oldest_lines_into_scrollback() {
+        // When more lines are pushed than fit above the viewport, the
+        // oldest must roll off the top into native scrollback. This
+        // is what unlocks native terminal selection / search of
+        // historical content.
+        //
+        // Screen: 5 tall, viewport: 1 tall — so 4 rows above viewport
+        // can hold history before overflow. Pushing 6 lines means
+        // lines 0 and 1 should end up in scrollback; lines 2-5 stay
+        // on-screen above the viewport.
+        let mut t = inline_terminal(20, 5, 1);
+        paint_viewport(&mut t, "[viewport]");
+        for i in 0..6 {
+            push_history(&mut t, vec![Line::from(format!("line {i}"))]).unwrap();
+        }
+        assert_eq!(
+            dump_scrollback(&t),
+            vec![
+                "line 0              ",
+                "line 1              ",
+            ]
+        );
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "line 2              ",
+                "line 3              ",
+                "line 4              ",
+                "line 5              ",
+                "[viewport]          ",
+            ]
+        );
+    }
+
+    #[test]
+    fn long_line_wraps_into_multiple_screen_rows() {
+        // A 30-character line at terminal width 20 should wrap to 2
+        // physical rows. This is the wrap-height calculation under
+        // test: if it returned 1, the second half would be lost; if
+        // it returned 3, we'd waste a blank row.
+        let mut t = inline_terminal(20, 8, 1);
+        paint_viewport(&mut t, "[viewport]");
+        let long: String = std::iter::repeat_n('x', 30).collect();
+        push_history(&mut t, vec![Line::from(long)]).expect("long-line push must succeed");
+        assert_scrollback_empty(&t);
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "xxxxxxxxxxxxxxxxxxxx",
+                "xxxxxxxxxx          ",
+                "[viewport]          ",
+                "                    ",
+                "                    ",
+                "                    ",
+                "                    ",
+                "                    ",
+            ]
+        );
+    }
+
+    #[test]
+    fn styled_spans_render_into_history_area() {
+        // Smoke test: styled content (bold, colored) must round-trip
+        // through `Vec<Line>` -> `Buffer` -> screen without being
+        // dropped. We verify the *symbol* content lands correctly;
+        // ratatui's own tests cover style attribute rendering.
+        let mut t = inline_terminal(20, 5, 1);
+        paint_viewport(&mut t, "[viewport]");
+        let line = Line::from(vec!["ERR: ".bold().red(), "boom".into()]);
+        push_history(&mut t, vec![line]).expect("styled push must succeed");
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "ERR: boom           ",
+                "[viewport]          ",
+                "                    ",
+                "                    ",
+                "                    ",
+            ]
+        );
+    }
+
+    #[test]
+    fn fullscreen_viewport_is_a_noop() {
+        // Inserting into a fullscreen viewport doesn't make sense
+        // (there's no scrollback gap). The underlying ratatui call
+        // is a documented no-op; we want to confirm we don't panic
+        // or write garbage in that mode.
+        let backend = TestBackend::new(20, 5);
+        let mut t = Terminal::new(backend).expect("fullscreen terminal");
+        push_history(&mut t, vec![Line::from("ignored")])
+            .expect("fullscreen no-op must succeed");
+        assert_scrollback_empty(&t);
+    }
+
+    #[test]
+    fn boundary_width_line_is_one_row() {
+        // Off-by-one trap: a line of *exactly* `width` chars should
+        // occupy exactly 1 row (not 2). Many wrap algos get this
+        // wrong by writing the boundary char then immediately wrapping
+        // for a phantom "next char".
+        let mut t = inline_terminal(10, 5, 1);
+        paint_viewport(&mut t, "[v]");
+        push_history(&mut t, vec![Line::from("0123456789")]) // exactly 10 chars
+            .expect("boundary push must succeed");
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "0123456789",
+                "[v]       ",
+                "          ",
+                "          ",
+                "          ",
+            ]
+        );
+    }
+
+    #[test]
+    fn multiline_call_preserves_line_boundaries() {
+        // A single `push_history` with multiple lines must not
+        // collapse them into one wrapped paragraph. Each `Line`
+        // boundary should produce a new row.
+        let mut t = inline_terminal(20, 8, 1);
+        paint_viewport(&mut t, "[v]");
+        push_history(
+            &mut t,
+            vec![
+                Line::from("alpha"),
+                Line::from("beta"),
+                Line::from("gamma"),
+            ],
+        )
+        .expect("multi-line push must succeed");
+        assert_eq!(
+            dump_buffer(&t),
+            vec![
+                "alpha               ",
+                "beta                ",
+                "gamma               ",
+                "[v]                 ",
+                "                    ",
+                "                    ",
+                "                    ",
+                "                    ",
+            ]
+        );
+    }
+
+    #[test]
+    fn order_preserved_under_overflow() {
+        // When content rolls into scrollback it must do so in the
+        // order it was pushed — prove there's no reversal or
+        // duplication at the overflow boundary.
+        let mut t = inline_terminal(20, 5, 1);
+        paint_viewport(&mut t, "[v]");
+        push_history(&mut t, vec![Line::from("first")]).unwrap();
+        push_history(&mut t, vec![Line::from("second")]).unwrap();
+        push_history(&mut t, vec![Line::from("third")]).unwrap();
+        push_history(&mut t, vec![Line::from("fourth")]).unwrap();
+        push_history(&mut t, vec![Line::from("fifth")]).unwrap();
+        push_history(&mut t, vec![Line::from("sixth")]).unwrap();
+        assert_eq!(
+            dump_scrollback(&t),
+            vec![
+                "first               ",
+                "second              ",
+            ]
+        );
+    }
+}

--- a/koda-cli/src/inline_history.rs
+++ b/koda-cli/src/inline_history.rs
@@ -94,10 +94,7 @@ use std::io;
 /// )?;
 /// ```
 #[allow(dead_code)] // wired up in a subsequent commit on the same branch.
-pub fn push_history<B>(
-    terminal: &mut Terminal<B>,
-    lines: Vec<Line<'static>>,
-) -> io::Result<()>
+pub fn push_history<B>(terminal: &mut Terminal<B>, lines: Vec<Line<'static>>) -> io::Result<()>
 where
     B: Backend,
     B::Error: std::error::Error + Send + Sync + 'static,
@@ -151,9 +148,7 @@ mod tests {
 
     use super::*;
     use ratatui::{
-        Terminal, TerminalOptions, Viewport,
-        backend::TestBackend,
-        prelude::Stylize,
+        Terminal, TerminalOptions, Viewport, backend::TestBackend, prelude::Stylize,
         widgets::Paragraph,
     };
 
@@ -316,10 +311,7 @@ mod tests {
         }
         assert_eq!(
             dump_scrollback(&t),
-            vec![
-                "line 0              ",
-                "line 1              ",
-            ]
+            vec!["line 0              ", "line 1              ",]
         );
         assert_eq!(
             dump_buffer(&t),
@@ -389,8 +381,7 @@ mod tests {
         // or write garbage in that mode.
         let backend = TestBackend::new(20, 5);
         let mut t = Terminal::new(backend).expect("fullscreen terminal");
-        push_history(&mut t, vec![Line::from("ignored")])
-            .expect("fullscreen no-op must succeed");
+        push_history(&mut t, vec![Line::from("ignored")]).expect("fullscreen no-op must succeed");
         assert_scrollback_empty(&t);
     }
 
@@ -425,11 +416,7 @@ mod tests {
         paint_viewport(&mut t, "[v]");
         push_history(
             &mut t,
-            vec![
-                Line::from("alpha"),
-                Line::from("beta"),
-                Line::from("gamma"),
-            ],
+            vec![Line::from("alpha"), Line::from("beta"), Line::from("gamma")],
         )
         .expect("multi-line push must succeed");
         assert_eq!(
@@ -462,10 +449,7 @@ mod tests {
         push_history(&mut t, vec![Line::from("sixth")]).unwrap();
         assert_eq!(
             dump_scrollback(&t),
-            vec![
-                "first               ",
-                "second              ",
-            ]
+            vec!["first               ", "second              ",]
         );
     }
 }

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -28,6 +28,7 @@ pub(crate) mod headless;
 pub(crate) mod highlight;
 pub(crate) mod history_render;
 pub(crate) mod hyperlink;
+pub(crate) mod inline_history;
 pub(crate) mod input;
 pub(crate) mod md_render;
 pub(crate) mod mouse_select;

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -34,6 +34,7 @@ pub(crate) mod md_render;
 pub(crate) mod mouse_select;
 pub(crate) mod onboarding;
 pub(crate) mod queue_lanes;
+pub(crate) mod render_mode;
 pub(crate) mod scroll_buffer;
 pub(crate) mod server;
 pub(crate) mod sink;

--- a/koda-cli/src/render_mode.rs
+++ b/koda-cli/src/render_mode.rs
@@ -130,7 +130,13 @@ mod tests {
     fn parse_altscreen_aliases() {
         // We accept several spellings because users will guess.
         // Accepting them is cheap and friendlier than erroring.
-        for value in ["altscreen", "alt-screen", "alt_screen", "fullscreen", "ALTSCREEN"] {
+        for value in [
+            "altscreen",
+            "alt-screen",
+            "alt_screen",
+            "fullscreen",
+            "ALTSCREEN",
+        ] {
             assert_eq!(
                 RenderMode::parse(value),
                 RenderMode::Altscreen,

--- a/koda-cli/src/render_mode.rs
+++ b/koda-cli/src/render_mode.rs
@@ -1,0 +1,187 @@
+//! Terminal rendering mode selection.
+//!
+//! Koda supports two TUI rendering strategies; this module owns the
+//! enum and the env-var contract that picks between them.
+//!
+//! ## Modes
+//!
+//! - [`RenderMode::Altscreen`]: the historical default. Enters the
+//!   terminal's *alternate screen buffer*, hides scrollback for the
+//!   duration of the session, captures mouse for our custom selection
+//!   widget, and renders into a `Viewport::Fullscreen`. On exit the
+//!   alternate screen is dropped and the user's previous shell
+//!   contents reappear.
+//!
+//! - [`RenderMode::Inline`]: the new default starting with the v0.4.x
+//!   migration tracked by epic #1146. Stays in the *primary* screen,
+//!   renders into a `Viewport::Inline(N)` anchored to the bottom of
+//!   the terminal, and lets finalized chat history live in the
+//!   terminal's native scrollback (via
+//!   [`crate::inline_history::push_history`]). Mouse capture is *not*
+//!   enabled, so native terminal selection / search work for free.
+//!
+//! ## Selection contract
+//!
+//! At process start [`RenderMode::from_env`] inspects `KODA_RENDER`:
+//!
+//! | Value (case-insensitive) | Mode |
+//! |---|---|
+//! | `inline` | [`RenderMode::Inline`] |
+//! | `altscreen` / `alt-screen` / `alt_screen` / `fullscreen` | [`RenderMode::Altscreen`] |
+//! | unset, empty, or anything else | [`RenderMode::default()`] |
+//!
+//! The default tracks the migration: it is **`Altscreen`** during
+//! Phase A/B of #1146 (so the env var is opt-in for testers), and
+//! flips to **`Inline`** at Phase D cutover. Don't read the default
+//! from random places — always go through [`RenderMode::default`] so
+//! the flip is one-line.
+
+use std::env;
+
+/// Selects which TUI rendering strategy koda uses for this session.
+///
+/// Defaults to [`RenderMode::Altscreen`] for now; will flip to
+/// [`RenderMode::Inline`] when epic #1146 reaches Phase D.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum RenderMode {
+    /// Enter the terminal's alternate screen buffer; render into
+    /// `Viewport::Fullscreen`. Captures mouse for in-app selection.
+    Altscreen,
+    /// Stay in the primary screen; render into a small bottom-anchored
+    /// `Viewport::Inline(N)`; finalized history lives in native
+    /// scrollback. Does not capture mouse.
+    Inline,
+}
+
+impl Default for RenderMode {
+    // Manual impl (vs `#[derive(Default)]` + `#[default]`) so the
+    // migration intent has a place to live and be grep-able. Phase D
+    // of #1146 will flip this single line; reviewers should look
+    // here when bisecting render-mode regressions.
+    #[allow(clippy::derivable_impls)]
+    fn default() -> Self {
+        // Phase A/B of #1146 keeps the historical default. The flip
+        // to `Inline` happens in a single commit at Phase D so it's
+        // easy to bisect.
+        Self::Altscreen
+    }
+}
+
+impl RenderMode {
+    /// Read the `KODA_RENDER` env var and resolve to a render mode.
+    ///
+    /// Falls back to [`RenderMode::default`] when unset, empty, or
+    /// holding an unrecognized value (we don't error — the worst
+    /// case is the user gets the historical UI, which is benign).
+    pub(crate) fn from_env() -> Self {
+        match env::var("KODA_RENDER") {
+            Ok(raw) => Self::parse(&raw),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Pure parser — separated from env access for testability.
+    fn parse(raw: &str) -> Self {
+        let normalized = raw.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "inline" => Self::Inline,
+            "altscreen" | "alt-screen" | "alt_screen" | "fullscreen" => Self::Altscreen,
+            // Unknown / empty: don't surprise the user with a mode
+            // they didn't ask for. Falling back to default also
+            // means future modes can be added without breaking
+            // sessions that hard-coded an unknown value.
+            _ => Self::default(),
+        }
+    }
+
+    /// Convenience predicate for the inline branch.
+    pub(crate) fn is_inline(self) -> bool {
+        matches!(self, Self::Inline)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests cover the env contract end-to-end. We avoid touching the
+    //! real `KODA_RENDER` env var (parallel test runs would race) by
+    //! exercising `parse` directly; one test wraps `from_env` with
+    //! an explicit `KODA_RENDER` set/clear to confirm the env path.
+
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn default_is_altscreen_during_migration_phase_ab() {
+        // Sanity check that the migration default hasn't accidentally
+        // flipped before Phase D. When the cutover happens this test
+        // *should* be updated to assert `Inline` — that update is the
+        // signal that Phase D shipped.
+        assert_eq!(RenderMode::default(), RenderMode::Altscreen);
+    }
+
+    #[test]
+    fn parse_inline_variants() {
+        assert_eq!(RenderMode::parse("inline"), RenderMode::Inline);
+        assert_eq!(RenderMode::parse("INLINE"), RenderMode::Inline);
+        assert_eq!(RenderMode::parse("  Inline  "), RenderMode::Inline);
+    }
+
+    #[test]
+    fn parse_altscreen_aliases() {
+        // We accept several spellings because users will guess.
+        // Accepting them is cheap and friendlier than erroring.
+        for value in ["altscreen", "alt-screen", "alt_screen", "fullscreen", "ALTSCREEN"] {
+            assert_eq!(
+                RenderMode::parse(value),
+                RenderMode::Altscreen,
+                "value {value:?} should parse as Altscreen",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_unknown_falls_back_to_default() {
+        // Garbage values must not panic and must yield a sensible
+        // session. Any unrecognized string falls through to default
+        // (currently Altscreen).
+        for value in ["", "   ", "yes", "true", "0", "splat", "auto"] {
+            assert_eq!(
+                RenderMode::parse(value),
+                RenderMode::default(),
+                "value {value:?} should fall back to default",
+            );
+        }
+    }
+
+    #[test]
+    fn is_inline_predicate() {
+        assert!(RenderMode::Inline.is_inline());
+        assert!(!RenderMode::Altscreen.is_inline());
+    }
+
+    #[test]
+    #[serial] // mutates global env; serialize to avoid races with other env-touching tests
+    fn from_env_reads_koda_render() {
+        // SAFETY: `set_var`/`remove_var` are unsafe in Rust 2024 because
+        // they race with other threads reading env. The `serial` attr
+        // serializes this against other env-touching tests; within this
+        // process there are no other readers during the assertion.
+        // Save and restore the previous value so we don't pollute other
+        // tests' environment.
+        let prev = env::var("KODA_RENDER").ok();
+        unsafe { env::set_var("KODA_RENDER", "inline") };
+        assert_eq!(RenderMode::from_env(), RenderMode::Inline);
+
+        unsafe { env::set_var("KODA_RENDER", "altscreen") };
+        assert_eq!(RenderMode::from_env(), RenderMode::Altscreen);
+
+        unsafe { env::remove_var("KODA_RENDER") };
+        assert_eq!(RenderMode::from_env(), RenderMode::default());
+
+        // Restore prior value so test ordering doesn't matter.
+        match prev {
+            Some(v) => unsafe { env::set_var("KODA_RENDER", v) },
+            None => unsafe { env::remove_var("KODA_RENDER") },
+        }
+    }
+}

--- a/koda-cli/src/scroll_buffer.rs
+++ b/koda-cli/src/scroll_buffer.rs
@@ -96,6 +96,39 @@ impl ScrollBuffer {
         }
     }
 
+    /// Drain *all* buffered lines and reset scroll state.
+    ///
+    /// This is the bridge that lets `RenderMode::Inline` reuse the
+    /// existing push-into-scroll-buffer call sites: the inline
+    /// rendering path calls `drain_pending` once per draw and forwards
+    /// the result to [`crate::inline_history::push_history`], which
+    /// inserts the lines into the terminal's native scrollback above
+    /// the inline viewport. The buffer ends up empty by the time the
+    /// (history-less) inline viewport actually renders.
+    ///
+    /// Returns lines in oldest-first order — the same order callers
+    /// originally pushed them in — so visual ordering is preserved
+    /// when they hit native scrollback.
+    ///
+    /// **Not used in `Altscreen` mode.** The altscreen path renders
+    /// directly out of the buffer; calling this would erase the
+    /// in-app history panel. The contract is enforced by
+    /// `TuiContext::flush_inline_history`, which is the only caller.
+    ///
+    /// Gutter widths are dropped on the floor: they're metadata for
+    /// the in-app NoSelect copy widget, which is altscreen-only.
+    /// Inline mode delegates selection to the native terminal, where
+    /// the gutter chars (already baked into each `Line`'s spans by
+    /// `diff_render`) become part of the selection — same as any
+    /// other terminal output.
+    pub fn drain_pending(&mut self) -> Vec<Line<'static>> {
+        let lines: Vec<Line<'static>> = self.lines.drain(..).collect();
+        self.gutter_widths.clear();
+        self.scroll_offset = 0;
+        self.sticky_bottom = true;
+        lines
+    }
+
     /// Scroll up by `n` visual lines. Disengages sticky bottom.
     pub fn scroll_up(&mut self, n: usize, term_width: usize, viewport_height: usize) {
         self.cached_term_width = term_width;
@@ -674,5 +707,74 @@ mod tests {
         // First line is now "old1"
         let first = line_text(buf.all_lines().next().unwrap());
         assert_eq!(first, "old1");
+    }
+
+    #[test]
+    fn drain_pending_returns_lines_in_push_order_and_empties_buffer() {
+        // Inline-mode contract: after `drain_pending`, the buffer is
+        // empty (so the inline viewport's history panel renders nothing)
+        // and the returned `Vec` preserves the order callers pushed in
+        // (so visual ordering survives the trip into native scrollback).
+        let mut buf = ScrollBuffer::new(100);
+        buf.push(make_line("first"));
+        buf.push(make_line("second"));
+        buf.push(make_line("third"));
+
+        let drained = buf.drain_pending();
+
+        assert_eq!(drained.len(), 3);
+        assert_eq!(line_text(&drained[0]), "first");
+        assert_eq!(line_text(&drained[1]), "second");
+        assert_eq!(line_text(&drained[2]), "third");
+        assert_eq!(buf.len(), 0, "buffer must be empty after drain");
+    }
+
+    #[test]
+    fn drain_pending_resets_scroll_state_to_sticky_bottom() {
+        // After draining, sticky-bottom must be re-engaged so the next
+        // push doesn't accidentally land mid-scroll. (In inline mode
+        // this state is meaningless because the buffer is always
+        // drained before any render, but the invariant keeps the
+        // module easier to reason about.)
+        let mut buf = ScrollBuffer::new(100);
+        for i in 0..20 {
+            buf.push(make_line(&format!("line {i}")));
+        }
+        buf.scroll_up(5, W, 3); // disengage sticky
+        assert!(!buf.is_sticky());
+        assert_ne!(buf.offset(), 0);
+
+        let _ = buf.drain_pending();
+
+        assert!(buf.is_sticky(), "sticky bottom should be re-engaged");
+        assert_eq!(buf.offset(), 0, "scroll offset should reset");
+    }
+
+    #[test]
+    fn drain_pending_on_empty_buffer_is_a_noop() {
+        // Called every draw in inline mode; cheap path matters.
+        let mut buf = ScrollBuffer::new(100);
+        let drained = buf.drain_pending();
+        assert!(drained.is_empty());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn drain_pending_drops_gutter_metadata_with_lines() {
+        // Diff lines push via `push_with_gutter`, which records the
+        // gutter width in a parallel deque. After drain, both deques
+        // must be empty; otherwise a future `push_with_gutter` would
+        // mis-align gutters with lines (panic risk in `enforce_capacity`).
+        let mut buf = ScrollBuffer::new(100);
+        buf.push_with_gutter(make_line("+ added"), 4);
+        buf.push_with_gutter(make_line("- removed"), 4);
+        let _ = buf.drain_pending();
+
+        // Push a normal line and inspect via the public iter API —
+        // if gutter_widths weren't drained alongside lines, this
+        // would push to a 1-len lines deque and a 3-len gutter deque,
+        // and `enforce_capacity` would eventually panic.
+        buf.push(make_line("after"));
+        assert_eq!(buf.len(), 1);
     }
 }

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -10,12 +10,12 @@ mod events;
 mod menus;
 
 use crate::input;
+use crate::render_mode::RenderMode;
 use crate::scroll_buffer::ScrollBuffer;
 use crate::sink::UiEvent;
 use crate::tui_commands::{self, SlashAction};
 use crate::tui_render::TuiRenderer;
 use crate::tui_types::{MenuContent, PromptMode, ProviderWizard, Term, TuiState};
-use crate::render_mode::RenderMode;
 use crate::tui_viewport::{draw_viewport, init_terminal, restore_terminal};
 
 use anyhow::Result;
@@ -552,8 +552,7 @@ impl TuiContext {
                 }
             }
             RenderMode::Inline => {
-                if let Err(err) = crate::inline_history::push_history(&mut self.terminal, lines)
-                {
+                if let Err(err) = crate::inline_history::push_history(&mut self.terminal, lines) {
                     tracing::warn!(
                         error = %err,
                         "inline_history::push_history failed; lines dropped"

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -15,6 +15,7 @@ use crate::sink::UiEvent;
 use crate::tui_commands::{self, SlashAction};
 use crate::tui_render::TuiRenderer;
 use crate::tui_types::{MenuContent, PromptMode, ProviderWizard, Term, TuiState};
+use crate::render_mode::RenderMode;
 use crate::tui_viewport::{draw_viewport, init_terminal, restore_terminal};
 
 use anyhow::Result;
@@ -235,8 +236,9 @@ impl TuiContext {
         };
         let shared_mode = trust::new_shared_trust(initial_mode);
 
-        // Terminal + textarea
-        let terminal = init_terminal()?;
+        // Terminal + textarea — mode comes from KODA_RENDER (epic #1146).
+        let render_mode = RenderMode::from_env();
+        let terminal = init_terminal(render_mode)?;
 
         let mut textarea = TextArea::default();
         textarea.set_cursor_line_style(Style::default());

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -391,6 +391,14 @@ impl TuiContext {
 
     /// Draw the fullscreen viewport.
     pub fn draw(&mut self) -> Result<()> {
+        // Inline mode: drain any history lines pushed since the last
+        // draw and stream them into native scrollback BEFORE the
+        // viewport renders. This is what makes the existing
+        // `scroll_buffer.push(...)` call sites \"just work\" in inline
+        // mode without per-call-site changes — see
+        // `ScrollBuffer::drain_pending` for the contract.
+        self.flush_inline_history();
+
         // Clamp scroll offset to valid bounds before rendering.
         // Necessary after terminal resize changes wrapping math.
         // Use history panel height, not full terminal height — otherwise
@@ -424,6 +432,7 @@ impl TuiContext {
         let selection = self.mouse_selection.as_ref();
         let mcp_info = self.agent.mcp_status_bar_info();
         let project_root = self.project_root.clone();
+        let render_mode = self.render_mode;
 
         let mut history_rect = None;
         if let Err(e) = self.terminal.draw(|f| {
@@ -444,6 +453,7 @@ impl TuiContext {
                 selection,
                 mcp_info,
                 &project_root,
+                render_mode,
             ));
         }) {
             tracing::debug!("draw skipped: {e}");
@@ -453,6 +463,36 @@ impl TuiContext {
             self.history_area_height = rect.height;
         }
         Ok(())
+    }
+
+    /// Drain any history lines pushed into the scroll buffer since the
+    /// last draw and stream them into the terminal's native scrollback
+    /// (inline mode only). No-op in altscreen mode.
+    ///
+    /// This is the keystone of the migration: every existing call site
+    /// that does `self.scroll_buffer.push(...)` gets rerouted into
+    /// `inline_history::push_history` here, without per-call-site edits.
+    /// The buffer is left empty by render time, so the inline viewport's
+    /// (omitted) history panel renders nothing visible.
+    ///
+    /// Errors from `push_history` are logged at warn and swallowed: a
+    /// failed scroll-region escape on an unusual terminal shouldn't
+    /// crash the chat session, and the buffer has already been drained
+    /// (so the lines aren't double-pushed on the next draw).
+    fn flush_inline_history(&mut self) {
+        if !self.render_mode.is_inline() {
+            return;
+        }
+        let lines = self.scroll_buffer.drain_pending();
+        if lines.is_empty() {
+            return;
+        }
+        if let Err(err) = crate::inline_history::push_history(&mut self.terminal, lines) {
+            tracing::warn!(
+                error = %err,
+                "flush_inline_history: push_history failed; lines dropped"
+            );
+        }
     }
 
     /// Push one finalized history line into the appropriate sink for

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -99,6 +99,17 @@ pub(crate) struct TuiContext {
     pub agent: Arc<KodaAgent>,
     pub project_root: PathBuf,
 
+    // ── Render mode ───────────────────────────────────────────
+    /// Selected at process start from `KODA_RENDER`. Drives where
+    /// finalized history lines land:
+    ///
+    /// - `Altscreen`: pushed into [`ScrollBuffer`] for in-app rendering.
+    /// - `Inline`: pushed into the terminal's native scrollback via
+    ///   [`crate::inline_history::push_history`].
+    ///
+    /// See [`Self::emit`] / [`Self::emit_lines`] for the dispatch.
+    pub render_mode: RenderMode,
+
     /// Coalescing draw scheduler (#1138). Replaces the old per-iteration
     /// synchronous `terminal.draw()` calls in the inference hot loop.
     /// `frame_requester` is the producer side; clone freely. `draw_rx` is
@@ -372,6 +383,7 @@ impl TuiContext {
             shared_mode,
             agent,
             project_root,
+            render_mode,
             frame_requester,
             draw_rx,
         })
@@ -443,9 +455,72 @@ impl TuiContext {
         Ok(())
     }
 
-    /// Push a message line into the scroll buffer.
+    /// Push one finalized history line into the appropriate sink for
+    /// the current [`RenderMode`].
+    ///
+    /// - `Altscreen`: appends to [`ScrollBuffer`]; the next draw will
+    ///   render it inside the in-app history panel.
+    /// - `Inline`: forwards to
+    ///   [`crate::inline_history::push_history`], which writes the
+    ///   line directly into the terminal's native scrollback above the
+    ///   inline viewport. Errors are logged and swallowed — a failed
+    ///   scroll-region escape (e.g. a non-VT terminal) shouldn't crash
+    ///   the chat session, and the upstream call would already have
+    ///   left things in a sane state.
+    ///
+    /// Currently dead code: callers still go through
+    /// `self.scroll_buffer.push(...)` directly. The migration to
+    /// route every history-line push through this dispatch happens in
+    /// follow-up commits on the #1146 branch — this commit only
+    /// installs the helper so the diffs there stay small.
+    #[allow(dead_code)]
     pub fn emit(&mut self, line: Line<'static>) {
-        self.scroll_buffer.push(line);
+        match self.render_mode {
+            RenderMode::Altscreen => self.scroll_buffer.push(line),
+            RenderMode::Inline => {
+                if let Err(err) =
+                    crate::inline_history::push_history(&mut self.terminal, vec![line])
+                {
+                    tracing::warn!(
+                        error = %err,
+                        "inline_history::push_history failed; line dropped"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Batched variant of [`Self::emit`].
+    ///
+    /// In `Inline` mode this is meaningfully more efficient than
+    /// looping `emit` because all the lines share a single
+    /// `insert_before` call (one DECSTBM scroll-region transaction
+    /// rather than N). In `Altscreen` mode it just folds into N
+    /// `ScrollBuffer::push` calls; the buffer's internal capacity
+    /// management already handles batches gracefully.
+    ///
+    /// Currently dead code (see note on [`Self::emit`]).
+    #[allow(dead_code)]
+    pub fn emit_lines(&mut self, lines: Vec<Line<'static>>) {
+        if lines.is_empty() {
+            return;
+        }
+        match self.render_mode {
+            RenderMode::Altscreen => {
+                for line in lines {
+                    self.scroll_buffer.push(line);
+                }
+            }
+            RenderMode::Inline => {
+                if let Err(err) = crate::inline_history::push_history(&mut self.terminal, lines)
+                {
+                    tracing::warn!(
+                        error = %err,
+                        "inline_history::push_history failed; lines dropped"
+                    );
+                }
+            }
+        }
     }
 
     /// Clean up terminal and print exit info.

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -176,10 +176,8 @@ impl TuiContext {
                         if self.render_mode.is_inline() {
                             let lines = self.scroll_buffer.drain_pending();
                             if !lines.is_empty()
-                                && let Err(err) = crate::inline_history::push_history(
-                                    &mut self.terminal,
-                                    lines,
-                                )
+                                && let Err(err) =
+                                    crate::inline_history::push_history(&mut self.terminal, lines)
                             {
                                 tracing::warn!(
                                     error = %err,

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -166,6 +166,28 @@ impl TuiContext {
                         // `&mut self.session` borrow for its full lifetime,
                         // so we use disjoint field access just like the old
                         // synchronous draw block did.
+                        //
+                        // Inline mode: drain the scroll buffer into native
+                        // scrollback BEFORE the viewport renders, mirroring
+                        // `TuiContext::flush_inline_history`. Inlined here
+                        // because we can't borrow `self` while `turn` is
+                        // alive; the body is short and the duplication is
+                        // localized to two call sites total.
+                        if self.render_mode.is_inline() {
+                            let lines = self.scroll_buffer.drain_pending();
+                            if !lines.is_empty()
+                                && let Err(err) = crate::inline_history::push_history(
+                                    &mut self.terminal,
+                                    lines,
+                                )
+                            {
+                                tracing::warn!(
+                                    error = %err,
+                                    "inline_history flush (inference loop) failed"
+                                );
+                            }
+                        }
+
                         let (term_w, _) = crossterm::terminal::size()
                             .map(|(c, r)| (c as usize, r as usize))
                             .unwrap_or((80, 24));
@@ -182,6 +204,7 @@ impl TuiContext {
                             .take(crate::widgets::queue_preview::MAX_VISIBLE)
                             .cloned()
                             .collect();
+                        let render_mode = self.render_mode;
                         let _ = self.terminal.draw(|f| {
                             draw_viewport(
                                 f,
@@ -202,6 +225,7 @@ impl TuiContext {
                                 self.mouse_selection.as_ref(),
                                 mcp_info,
                                 &self.project_root,
+                                render_mode,
                             );
                         });
                     }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -5,6 +5,7 @@
 //!
 //! See #472 for the fullscreen migration RFC.
 
+use crate::render_mode::RenderMode;
 use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_types::{MenuContent, PromptMode, Term, TuiState};
 use crate::widgets::queue_preview::QueuePreview;
@@ -508,34 +509,66 @@ fn ask_user_menu_height(
 
 // ── Terminal lifecycle ─────────────────────────────────
 
-/// Initialize the terminal in fullscreen mode (alternate screen buffer).
+/// Initialize the terminal in the requested rendering mode.
 ///
-/// No DSR queries, no cursor position tracking. The app owns every pixel.
+/// Two paths:
 ///
-/// Also installs a panic hook that restores the terminal before the panic
-/// propagates — without it, a panic anywhere in the app (provider code, tool
-/// dispatch, ratatui render, tokio task, JSON deserialization, …) leaves the
-/// terminal in raw mode + alternate screen + mouse capture on, which makes
-/// the user's shell unusable until they run `reset` or open a new session.
-pub(crate) fn init_terminal() -> Result<Term> {
+/// - [`RenderMode::Altscreen`]: enter the alternate screen buffer,
+///   capture mouse for our custom selection widget, render into a
+///   `Viewport::Fullscreen`. The historical default; preserves the
+///   user's previous shell state on exit.
+///
+/// - [`RenderMode::Inline`]: stay in the primary screen, do *not*
+///   capture mouse, render into a `Viewport::Inline(N)`. N is the
+///   current terminal height for now (so visual layout matches
+///   altscreen mode); subsequent commits in epic #1146 shrink this
+///   so finalized history can move into native scrollback.
+///
+/// In both modes we install the same panic hook (which best-effort
+/// resets *all* terminal state) and enable bracketed paste. Mouse
+/// capture and alternate-screen entry are gated by the mode.
+pub(crate) fn init_terminal(mode: RenderMode) -> Result<Term> {
     crossterm::terminal::enable_raw_mode()?;
-    crossterm::execute!(
-        std::io::stdout(),
-        crossterm::terminal::EnterAlternateScreen,
-        crossterm::event::EnableBracketedPaste,
-        crossterm::event::EnableMouseCapture,
-    )?;
+
+    // Always enable bracketed paste so multi-line / IDE paste lands
+    // as one event in either mode.
+    crossterm::execute!(std::io::stdout(), crossterm::event::EnableBracketedPaste,)?;
+
+    if !mode.is_inline() {
+        // Altscreen path: hide scrollback for the duration of the
+        // session, capture mouse for in-app selection.
+        crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::EnterAlternateScreen,
+            crossterm::event::EnableMouseCapture,
+        )?;
+    }
+    // Inline path intentionally skips both: scrollback stays visible
+    // and the user can natively select text in the terminal.
 
     set_panic_hook();
 
     let stdout = std::io::stdout();
     let backend = CrosstermBackend::new(stdout);
-    let terminal = Terminal::with_options(
-        backend,
-        TerminalOptions {
-            viewport: Viewport::Fullscreen,
-        },
-    )?;
+    let viewport = match mode {
+        RenderMode::Altscreen => Viewport::Fullscreen,
+        RenderMode::Inline => {
+            // For Phase A, size the inline viewport to the entire
+            // terminal height so the existing `draw_viewport` layout
+            // continues to fit. Phase B+ will introduce a smaller
+            // composer-only viewport and migrate history rendering
+            // out of the viewport into `inline_history::push_history`.
+            //
+            // Falls back to a sensible non-zero default if the size
+            // probe fails (e.g. detached TTY in some test harnesses).
+            let height = crossterm::terminal::size()
+                .map(|(_w, h)| h)
+                .unwrap_or(24)
+                .max(1);
+            Viewport::Inline(height)
+        }
+    };
+    let terminal = Terminal::with_options(backend, TerminalOptions { viewport })?;
 
     Ok(terminal)
 }
@@ -544,6 +577,12 @@ pub(crate) fn init_terminal() -> Result<Term> {
 ///
 /// Writes directly to `stdout()` so it can run from anywhere — including
 /// the panic hook, which has no access to the `Terminal` value.
+///
+/// Defensively emits *all* the disable escapes regardless of the mode
+/// the session ran in. `DisableMouseCapture` and `LeaveAlternateScreen`
+/// are no-ops on terminals that never received the matching enable, so
+/// it's safe (and simpler) to fire them unconditionally rather than
+/// thread the active [`RenderMode`] through every panic path.
 pub(crate) fn restore_terminal_modes() {
     let _ = crossterm::execute!(
         std::io::stdout(),

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -46,6 +46,7 @@ pub(crate) fn draw_viewport(
     selection: Option<&crate::mouse_select::Selection>,
     mcp_info: Option<McpStatusBarInfo>,
     project_root: &std::path::Path,
+    render_mode: RenderMode,
 ) -> ratatui::layout::Rect {
     let area = frame.area();
 
@@ -79,6 +80,17 @@ pub(crate) fn draw_viewport(
     let queue_preview_height = QueuePreview::height_for(queue_total);
 
     // Layout: History | Sep | Input | Sep | Queue? | Status | Menu
+    //
+    // In Inline render mode, the history panel collapses to 0 rows:
+    // finalized history lines have already been pushed into the
+    // terminal's native scrollback by `flush_inline_history` (see
+    // `TuiContext::draw`). The viewport just renders composer +
+    // status + menu at the bottom of the screen, with the user's
+    // shell scrollback visible above.
+    let history_constraint = match render_mode {
+        RenderMode::Altscreen => Constraint::Min(1),
+        RenderMode::Inline => Constraint::Length(0),
+    };
     let [
         history_area,
         sep_row,
@@ -88,7 +100,7 @@ pub(crate) fn draw_viewport(
         status_row,
         menu_area,
     ] = Layout::vertical([
-        Constraint::Min(1),                       // history: fill remaining space
+        history_constraint,                       // history (0 when inline)
         Constraint::Length(1),                    // top separator
         Constraint::Length(input_height),         // input textarea
         Constraint::Length(1),                    // bottom separator
@@ -98,8 +110,12 @@ pub(crate) fn draw_viewport(
     ])
     .areas(area);
 
-    // ── History panel (scrollable) ────────────────────
-    render_history(frame, scroll_buffer, history_area, selection, project_root);
+    // ── History panel (scrollable) ────────────────────────
+    // Skipped entirely in inline mode — history lives in the
+    // terminal's native scrollback there.
+    if !render_mode.is_inline() {
+        render_history(frame, scroll_buffer, history_area, selection, project_root);
+    }
 
     // ── Top separator: ──────────── 🐻 ─ ─────────────────────
     let sep_width = sep_row.width.saturating_sub(5) as usize;
@@ -553,18 +569,36 @@ pub(crate) fn init_terminal(mode: RenderMode) -> Result<Term> {
     let viewport = match mode {
         RenderMode::Altscreen => Viewport::Fullscreen,
         RenderMode::Inline => {
-            // For Phase A, size the inline viewport to the entire
-            // terminal height so the existing `draw_viewport` layout
-            // continues to fit. Phase B+ will introduce a smaller
-            // composer-only viewport and migrate history rendering
-            // out of the viewport into `inline_history::push_history`.
+            // Size the inline viewport to be a small bottom-anchored
+            // strip so the rest of the terminal can show native
+            // scrollback (which is where finalized history lines
+            // land via `inline_history::push_history`).
             //
-            // Falls back to a sensible non-zero default if the size
-            // probe fails (e.g. detached TTY in some test harnesses).
-            let height = crossterm::terminal::size()
+            // Heuristic: at most 20 rows (enough for input + status +
+            // a generous menu / approval bar without dominating the
+            // screen), and never larger than `terminal_height - 4`
+            // (so even on tiny terminals there's a few rows of
+            // scrollback above). On terminals smaller than 8 rows
+            // we collapse to half the screen — still usable, just
+            // tight.
+            //
+            // Future commits in #1146 may make this dynamic (resize
+            // the viewport per-draw based on what content actually
+            // needs to fit). For Phase A a fixed cap is good enough
+            // to validate the architecture end-to-end.
+            let term_h = crossterm::terminal::size()
                 .map(|(_w, h)| h)
                 .unwrap_or(24)
-                .max(1);
+                .max(2);
+            const MAX_INLINE_ROWS: u16 = 20;
+            const MIN_SCROLLBACK_ABOVE: u16 = 4;
+            let height = if term_h <= 8 {
+                (term_h / 2).max(1)
+            } else {
+                MAX_INLINE_ROWS
+                    .min(term_h.saturating_sub(MIN_SCROLLBACK_ABOVE))
+                    .max(1)
+            };
             Viewport::Inline(height)
         }
     };


### PR DESCRIPTION
## Summary

Closes the original **#996** P0 by exposing PR #1041's `BgAgentRegistry` cancel + snapshot infrastructure to users via two new slash commands:

```text
/agents       List currently-pending background sub-agents.
              Renders a compact table:
                  ID    AGENT     AGE     STATUS
                  1     explore   2m      ▶ Running (iter 8/20)
                  2     verify    45s     ◐ Pending

/cancel <id>  Fire one task's per-task CancellationToken.
              Idempotent. Result still injects on the next user
              turn (with status Cancelled), so partial work isn't lost.
```

This is **Layer 1** of the #996 ladder set out in PR #1041. UI surfaces only — no LLM tools, no shell-registry support, no status-bar pill (those are Layers 2/3/4 — see the table below).

## Layer ladder

| PR | Layer | Surface |
|---|---|---|
| #1041 ✅ | 0 | `AgentStatus` enum + watch channel + per-task cancel + snapshot |
| **this PR** | **1** | **`/agents` and `/cancel <id>` slash commands** |
| next | 2 | `ListBackgroundTasks` / `CancelAgent` / `AgentStatus` LLM tools |
| later | 3 | Status-bar pill (`◇ N agents`) |
| later | 4 | Per-iter heartbeat (populates `Running { iter }`) |

## Scope

This PR is intentionally **agent-only**. Background **shells** (`Bash { background: true }`) need a new `BgRegistry::kill(pid)` API first; deferred to a follow-up PR alongside the ID-disambiguation UX (sequential agent task_id vs OS PID).

The "completed lingers 30s" UX from PR #1041's notes is also deferred — drained results already inject into the conversation, so the user isn't *missing* info, just visual confirmation. Easy add once we want it.

## Files

| File | LOC | What |
|---|---|---|
| `koda-cli/src/tui_bg_agents.rs` (new) | +508 | Handlers, status spans (Codex palette), age formatter, preview truncation, 14 unit tests |
| `koda-cli/src/repl.rs` | +110 | `ReplAction::ListBackgroundTasks` + `ReplAction::CancelBackgroundTask(Option<u32>)` + parser arms + 4 dispatch tests |
| `koda-cli/src/tui_commands.rs` | +15 | Two match arms wiring `ReplAction` → handler. Reach into `session.bg_agents` (PR #1041 wiring), no new lifetimes thread through |
| `koda-cli/src/completer.rs` | +6 | Register `/agents` and `/cancel` in `SLASH_COMMANDS` so tab-completion and `/help` know about them |
| `koda-cli/src/lib.rs` | +1 | Add `tui_bg_agents` to the module list |
| `docs/src/commands.md` | +43 | Doc both commands with the table format and idempotency notes |

## Design notes

- **`/agents` (plural) is disjoint from `/agent` (singular)** — singular is the sub-agent definition picker; plural is the runtime task list. Pinned by a unit test so the two can't accidentally collapse during a refactor.
- **`/cancel` parses missing/non-numeric args to `None`** so the handler can render a `Usage:` line. Falling through to `NotACommand` would treat `/cancel` as a chat message — the worst possible UX.
- **Status icons follow Codex's `multi_agents::status_summary_spans` palette**: ◐ Pending, ▶ Running, ⊗ Cancelled, ✓ Completed, ✗ Errored.
- **`Running { iter: 0 }` renders as just `▶ Running`** — PR #1041 marks `iter: 0` as a Layer-0 placeholder; rendering `"iter 0/20"` would mislead users into thinking nothing happened. Layer 4 will populate the field.
- **Ages round down** (`"119s"` → `"1m"`) to match user intuition (*"how many full Xs has it been running?"*) and avoid jitter at the boundary.
- **Bg-agent code lives in its own `tui_bg_agents.rs` module** rather than `tui_wizards.rs` — it's not a wizard, it's a one-shot status display, more like `tui_mcp.rs`. Keeps both files cohesive and well under 600 lines.

## Tests

- **14 new `tui_bg_agents` unit tests**: `format_age` boundary cases (s/m/h/d, round-down), `summary_preview` (whitespace collapse, char-count truncation, short pass-through), `handle_list_background_tasks` (empty, populated, status reflection, iter-0 placeholder), `handle_cancel_background_task` (known-id + observer fires, unknown-id helpful warn, None-id Usage).
- **4 new `repl` dispatch tests**: `/agents` ↔ `ListBackgroundTasks`, numeric / bare / non-numeric / negative `/cancel` arg cases.
- All tests use `BgAgentRegistry`'s **public** `reserve()` + `attach()` API — the in-crate `register_test*` helpers are `#[cfg(test)]`-gated to `koda-core`, invisible from `koda-cli`. The `register_entry()` helper in `tui_bg_agents::tests` exercises the same surface real callers use, which is arguably more faithful coverage.

## CI

- ✅ `cargo build -p koda-cli`
- ✅ `cargo test -p koda-cli --lib` — **491 passing**, 0 failed (was 477)
- ✅ `cargo clippy --workspace --all-targets -- -D warnings`
- ✅ `cargo fmt --all -- --check`

## Refs

- Bug: #996
- Builds on: #1041 (Layer 0 — pure plumbing)
