### PR TITLE
fix(sub-agent): cap turns at 30 with gemini-pattern grace turn (#1135)

### DIFF
--- a/docs/src/agents.md
+++ b/docs/src/agents.md
@@ -20,6 +20,43 @@ Place JSON files in `.koda/agents/` (project-local) or
 | `system_prompt` | ✓ | The agent's persona and instructions |
 | `model` | | Model alias or ID (defaults to current saved model) |
 | `allowed_tools` | | Subset of tools the agent can call (defaults to all) |
+| `disallowed_tools` | | Tools to deny even if `allowed_tools` is empty |
+| `max_iterations` | | Per-sub-agent turn cap (default: **30** for sub-agents, 200 for top-level). See [Sub-agent budget](#sub-agent-budget). |
+| `skip_memory` | | Skip injecting project/global memory into the prompt (saves tokens for read-only agents) |
+
+## Sub-agent budget
+
+Sub-agents are bounded by a per-invocation turn cap to prevent
+runaway exploration (#1135). The default is **30 turns** —
+empirically enough for any reasonable read-only investigation on a
+moderate codebase, and matching `gemini-cli`'s `DEFAULT_MAX_TURNS`.
+Long-running write agents that legitimately need more can opt up:
+
+```json
+{
+  "name": "big-refactor",
+  "max_iterations": 100,
+  "...": "..."
+}
+```
+
+When a sub-agent hits its budget without producing a final answer,
+Koda runs **one grace turn** with this system reminder appended:
+
+> You have reached the maximum number of turns. You have ONE final
+> chance to complete the task. You MUST respond with your best
+> answer NOW as plain text. DO NOT call any more tools — any tool
+> calls in this response will be ignored.
+
+If the model complies, its grace-turn text becomes the sub-agent's
+result. If the model defies the reminder and emits more tool calls,
+those calls are dropped and the sub-agent returns a `[max_turns
+reached: ...]` marker so the parent (and user) can see what
+happened.
+
+The top-level Koda agent still uses the larger 200-turn cap with
+an interactive extension prompt (`LoopCapReached`) — the budget
+pattern is sub-agent-only.
 
 ## Using agents
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -45,6 +45,31 @@ use tokio_util::sync::CancellationToken;
 /// ever change.
 static NEXT_INVOCATION_ID: AtomicU32 = AtomicU32::new(1);
 
+/// Default per-sub-agent turn cap when the agent JSON does not set
+/// `max_iterations` explicitly (#1135).
+///
+/// Matches the `DEFAULT_MAX_TURNS = 30` used by `gemini-cli`'s agent
+/// runtime — see `packages/core/src/agents/types.ts:51`. Codex does
+/// not cap sub-agents at all ("trust the model"), which is what koda
+/// did between #1110 and this change. The bug from #1135 (read-only
+/// explorer agents spinning for 100+s on broad prompts) is exactly
+/// the failure mode the no-cap regime can't catch: non-identical but
+/// non-progressing tool calls slip past `LoopDetector` and only stop
+/// when the user gives up and hits Ctrl-C.
+///
+/// 30 turns is enough headroom for any reasonable read-only
+/// exploration on a moderate codebase (the offending session in
+/// #1135 used ~26 calls); long-running write agents that need more
+/// can opt up via `"max_iterations": N` in their JSON. Mirrors
+/// gemini's per-agent overrides (cli-help: 10, generalist: 20,
+/// browser: 50, codebase-investigator: 50).
+///
+/// **NOTE**: this only applies to sub-agents. The top-level koda
+/// agent's cap (currently `KodaConfig::max_iterations = 200` per
+/// `config.rs:247`) is unchanged — that path runs interactively and
+/// already has the `EngineEvent::LoopCapReached` extension UX.
+pub(crate) const DEFAULT_SUB_AGENT_MAX_TURNS: u32 = 30;
+
 /// Allocate a fresh invocation id. See [`NEXT_INVOCATION_ID`].
 pub(crate) fn next_invocation_id() -> u32 {
     NEXT_INVOCATION_ID.fetch_add(1, Ordering::Relaxed)
@@ -466,7 +491,12 @@ pub(crate) fn execute_sub_agent<'a>(
         //   model names are not portable ("gemini-2.0-flash" means nothing on
         //   Anthropic), so if the agent has its own provider we leave the model
         //   resolved from that provider's defaults.
-        let sub_config = if is_fork {
+        // #1135: per-agent turn cap. Computed alongside `sub_config`
+        // because for non-fork agents we need the **raw** JSON to
+        // distinguish "explicit max_iterations" from "defaulted to 200
+        // in `KodaConfig::for_agent_invocation`". A tuple return keeps
+        // both values in scope without a redundant disk read.
+        let (sub_config, max_turns) = if is_fork {
             // Fork inherits the parent config verbatim, *except* for
             // trust — which must come from the **runtime** mode
             // (see `derive_child_trust` doc).
@@ -498,7 +528,12 @@ pub(crate) fn execute_sub_agent<'a>(
                 cfg.trust == mode,
                 "fork must inherit parent's runtime trust mode exactly"
             );
-            cfg
+            // Forks inherit the parent's cap (parent could be top-level
+            // koda at 200 or another sub-agent at 30). We don't impose
+            // the sub-agent default on a fork because the model is
+            // continuing the parent's work, not starting a fresh task.
+            let max_turns = cfg.max_iterations;
+            (cfg, max_turns)
         } else {
             // Load the raw JSON first to see what the agent explicitly set.
             let raw = crate::config::KodaConfig::load_agent_json(project_root, agent_name)
@@ -551,7 +586,15 @@ pub(crate) fn execute_sub_agent<'a>(
                 );
             }
 
-            cfg
+            // #1135: read from the **raw** JSON so we can tell
+            // "explicit `max_iterations: N`" apart from "defaulted
+            // to 200 by `KodaConfig::for_agent_invocation`". Without
+            // this distinction every sub-agent would inherit the
+            // 200 default and the gemini-pattern fix would do
+            // nothing for the agents that triggered #1135 (which
+            // don't set the field).
+            let max_turns = raw.max_iterations.unwrap_or(DEFAULT_SUB_AGENT_MAX_TURNS);
+            (cfg, max_turns)
         };
 
         let sub_session = {
@@ -756,6 +799,20 @@ pub(crate) fn execute_sub_agent<'a>(
             &tools.skill_registry,
         );
 
+        // #1135: gemini-pattern grace turn. When `iter > max_turns` we
+        // append a system reminder to the message list ("you have one
+        // final chance — give your best answer NOW, no more tools")
+        // and run exactly one more turn. Whatever the model returns on
+        // that turn is the final answer (tool calls in the grace
+        // response are ignored, not dispatched). Tracked here rather
+        // than via `iter`-arithmetic alone because the loop body must
+        // know which iteration was "the grace one" to decide whether
+        // to dispatch tools or short-circuit to a return.
+        //
+        // Mirrors gemini-cli's `executeFinalWarningTurn` in
+        // `local-executor.ts:436`.
+        let mut grace_turn_done = false;
+
         for iter in 1u32.. {
             // #1110: sub-agents have no hardcoded iteration cap. Termination
             // is driven by the model (clean stop, no tool calls), `LoopDetector`
@@ -797,8 +854,39 @@ pub(crate) fn execute_sub_agent<'a>(
             }
 
             sink.emit(EngineEvent::SpinnerStart {
-                message: format!("  🦥 {agent_name} thinking..."),
+                message: format!("  \u{1f9a5} {agent_name} thinking..."),
             });
+
+            // #1135: append the grace-turn reminder when this iteration
+            // is the one that exceeded the cap. The reminder is stuffed
+            // into the OUTGOING `messages` only — it is not persisted
+            // to the DB, so a future replay won't see it twice. The
+            // strict "text only, no tools" framing matches gemini's
+            // wording (`local-executor.ts::getFinalWarningMessage`).
+            if iter > max_turns && !grace_turn_done {
+                grace_turn_done = true;
+                let warning = format!(
+                    "You have reached the maximum number of turns ({max_turns}) for this \
+                     sub-agent invocation. You have ONE final chance to complete the task. \
+                     You MUST respond with your best answer NOW as plain text. DO NOT call \
+                     any more tools \u{2014} any tool calls in this response will be ignored. \
+                     Summarize what you found, what you would do next if you had more turns, \
+                     and explain that your investigation was interrupted by the budget."
+                );
+                messages.push(ChatMessage::text("system", &warning));
+                tracing::warn!(
+                    agent = agent_name,
+                    iter,
+                    max_turns,
+                    "sub-agent reached max_turns; running grace turn"
+                );
+                sink.emit(EngineEvent::Info {
+                    message: format!(
+                        "  \u{23f3} {agent_name}: reached max turns ({max_turns}); requesting final summary"
+                    ),
+                });
+            }
+
             let response = provider
                 .chat(&messages, &tool_defs, &sub_config.model_settings)
                 .await?;
@@ -833,6 +921,33 @@ pub(crate) fn execute_sub_agent<'a>(
                 )
                 .await?;
             db.mark_message_complete(assistant_msg_id).await?;
+
+            // #1135: if this iteration was the grace turn, return
+            // immediately regardless of whether the model called tools.
+            // The grace contract is exactly one extra LLM call —
+            // dispatching its tool calls would defeat the budget.
+            // Falls through to the normal empty-tool-calls return path
+            // when the model complied (typical case after the strong
+            // "text only" framing); short-circuits with a marker if the
+            // model defied the instruction and tried to keep tooling.
+            if grace_turn_done {
+                let result = match response.content.as_deref() {
+                    Some(text) if !text.trim().is_empty() => text.to_string(),
+                    _ => format!(
+                        "[max_turns reached: agent exceeded the {max_turns}-turn budget \
+                         and did not produce a final summary on its grace turn. \
+                         {n} pending tool call(s) were dropped.]",
+                        n = response.tool_calls.len(),
+                    ),
+                };
+                sub_agent_cache.put(agent_name, prompt, &result);
+                if let Ok(Some(hint)) = workspace.release(&sub_session, &effective_root).await {
+                    sink.emit(EngineEvent::Info {
+                        message: format!("  \u{1f335} {agent_name}: {hint}"),
+                    });
+                }
+                return Ok(result);
+            }
 
             if response.tool_calls.is_empty() {
                 let result = response
@@ -1070,11 +1185,15 @@ pub(crate) fn execute_sub_agent<'a>(
                 .await?;
             }
         }
-        // #1110: unreachable in practice. The `for iter in 1u32..` range is
-        // unbounded; the loop only exits via `return Ok(...)` (clean stop or
-        // cancellation), `return Err(...)` (provider/persistence failure), or
-        // `LoopDetector` short-circuit inside the inference helpers. This
-        // sentinel keeps rustc happy about the function's return type.
+        // #1110 + #1135: unreachable in practice. The `for iter in 1u32..`
+        // range is unbounded; exits are:
+        //   - `return Ok(content)` on a clean (no-tool-calls) response,
+        //   - `return Ok(grace_summary)` after the #1135 grace turn,
+        //   - `return Ok("[cancelled by parent]")` on parent cancellation,
+        //   - `return Err(...)` on a provider/persistence failure.
+        // The grace-turn path guarantees termination within `max_turns + 1`
+        // iterations even when the model refuses to stop on its own — the
+        // class of bug from #1135.
         unreachable!("sub-agent loop exits via return; the iteration range is unbounded");
     }
 }

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -537,3 +537,217 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
     // Removed only after the bg task has finished reading it.
     runtime_env::remove("KODA_MOCK_RESPONSES");
 }
+
+// ── #1135: sub-agent max_turns + grace turn (gemini pattern) ────────────────
+
+/// #1135 regression: a sub-agent that keeps calling tools past its
+/// configured `max_iterations` must hit the gemini-pattern grace turn
+/// and terminate with a synthesized final answer instead of looping
+/// indefinitely.
+///
+/// Scenario:
+/// - Agent JSON declares `max_iterations: 3` (small to keep the test fast).
+/// - Sub-agent's mock script: 4 tool calls (would consume iter 1-4) +
+///   one final text response ("partial findings") which is what the
+///   model produces ON the grace turn (iter 4, since `iter > max_turns`
+///   triggers grace at iter = max + 1 = 4).
+/// - Expected: 3 tool calls actually dispatched (iter 1-3). Iter 4 is
+///   the grace turn — its response is consumed but tool calls (if any)
+///   are NOT dispatched. Final result is the grace-turn text.
+///
+/// Tool choice: `Glob` against a pattern that matches nothing in the
+/// temp dir. Returns an empty list cleanly without needing a real
+/// file fixture, and is auto-approved under `TrustMode::Auto`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sub_agent_grace_turn_terminates_runaway_explorer() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("spinner.json"),
+        serde_json::json!({
+            "name": "spinner",
+            "system_prompt": "You are a test agent that loves Glob.",
+            "allowed_tools": ["Glob"],
+            "max_iterations": 3,
+            "provider": "mock",
+            "base_url": "http://localhost:0"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // Sub-agent's mock responses. Four entries:
+    //   iter 1-3: Glob calls against patterns that won't match (loop
+    //             continues; #1135 simulation — model keeps "exploring"
+    //             without synthesizing).
+    //   iter 4:   Plain text response — the model complies with the
+    //             grace-turn reminder. With max_iterations=3 the loop
+    //             runs iter 1,2,3 (tool calls dispatched), then iter 4
+    //             is the grace turn (`iter > max_turns`). Whatever
+    //             that response is becomes the sub-agent's final
+    //             output (text — grace passes; tool calls — dropped
+    //             with a marker).
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[
+            {"tool": "Glob", "args": {"pattern": "nope_a_*"}},
+            {"tool": "Glob", "args": {"pattern": "nope_b_*"}},
+            {"tool": "Glob", "args": {"pattern": "nope_c_*"}},
+            {"text": "Partial findings: I searched for nope_* patterns and found nothing. My investigation was interrupted."}
+        ]"#,
+    );
+
+    env.insert_user_message("delegate to spinner").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({"agent_name": "spinner", "prompt": "search broadly"}),
+        ),
+        MockResponse::Text("Sub-agent reported back.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+    runtime_env::remove("KODA_MOCK_RESPONSES");
+
+    // The visible UX signal of a triggered grace turn: an `Info` event
+    // with the "reached max turns" message. If this never fires the
+    // grace-turn code path was skipped — #1135 regression.
+    let grace_event_seen = events.iter().any(
+        |e| matches!(e, EngineEvent::Info { message } if message.contains("reached max turns")),
+    );
+    assert!(
+        grace_event_seen,
+        "expected an Info event announcing the grace turn; got: {events:?}"
+    );
+
+    // Sub-agent's `InvokeAgent` tool result must contain the grace-turn
+    // text. If it contains the marker text instead ("[max_turns
+    // reached: ...]"), the model also called tools on the grace turn —
+    // valid but a different code path; the test would need adjusting.
+    // Asserting on the partial-findings string locks in the expected
+    // happy path.
+    let invoke_result = events
+        .iter()
+        .find_map(|e| match e {
+            EngineEvent::ToolCallResult { name, output, .. } if name == "InvokeAgent" => {
+                Some(output.clone())
+            }
+            _ => None,
+        })
+        .expect("InvokeAgent must produce a ToolCallResult event");
+    assert!(
+        invoke_result.contains("Partial findings"),
+        "sub-agent should return the grace-turn text; got: {invoke_result}"
+    );
+
+    // Belt-and-suspenders: verify the loop did NOT issue a 4th
+    // `Glob` tool-call (sub-agents emit `ToolCallStart` per dispatch;
+    // they don't emit `ToolCallResult` because the result lands in
+    // `Role::Tool` rows on the sub-agent's session, not on the
+    // parent's event stream). Counts >= 4 mean the grace turn's own
+    // tool call leaked through to dispatch.
+    let glob_call_count = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                EngineEvent::ToolCallStart { name, is_sub_agent: true, .. } if name == "Glob"
+            )
+        })
+        .count();
+    assert_eq!(
+        glob_call_count, 3,
+        "expected exactly 3 Glob dispatches (iters 1-3); grace turn must not dispatch tools. \
+         got {glob_call_count} Glob ToolCallStart events in events: {events:?}"
+    );
+}
+
+/// #1135 fallback path: when a misbehaving model defies the grace-turn
+/// reminder and emits MORE tool calls instead of a text answer, those
+/// tool calls must NOT be dispatched. Instead the sub-agent returns a
+/// `[max_turns reached: ...]` marker so the parent (and user) get a
+/// clear signal that the budget was hit and the model failed to wrap up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sub_agent_grace_turn_drops_tool_calls_when_model_defies() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("defiant.json"),
+        serde_json::json!({
+            "name": "defiant",
+            "system_prompt": "You ignore reminders and keep tooling.",
+            "allowed_tools": ["Glob"],
+            "max_iterations": 2,
+            "provider": "mock",
+            "base_url": "http://localhost:0"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // 3 tool calls — iter 1,2 dispatched, iter 3 is the grace turn but
+    // model still emits a tool call (the bug class we want to defend
+    // against). Implementation must drop the iter-3 tool call and
+    // synthesize a marker.
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[
+            {"tool": "Glob", "args": {"pattern": "nope_a_*"}},
+            {"tool": "Glob", "args": {"pattern": "nope_b_*"}},
+            {"tool": "Glob", "args": {"pattern": "nope_c_*"}}
+        ]"#,
+    );
+
+    env.insert_user_message("delegate to defiant").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({"agent_name": "defiant", "prompt": "search"}),
+        ),
+        MockResponse::Text("Sub-agent reported back.".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+    runtime_env::remove("KODA_MOCK_RESPONSES");
+
+    // Marker present in the InvokeAgent result.
+    let invoke_result = events
+        .iter()
+        .find_map(|e| match e {
+            EngineEvent::ToolCallResult { name, output, .. } if name == "InvokeAgent" => {
+                Some(output.clone())
+            }
+            _ => None,
+        })
+        .expect("InvokeAgent must produce a ToolCallResult event");
+    assert!(
+        invoke_result.contains("[max_turns reached"),
+        "expected marker for defiant grace turn; got: {invoke_result}"
+    );
+
+    // Only 2 Glob dispatches (iter 1-2). Iter 3 was the grace turn —
+    // its tool call must be dropped, not dispatched. Counts via
+    // `ToolCallStart` because sub-agents don't emit `ToolCallResult`
+    // (results live on the sub-agent's `Role::Tool` rows, not on
+    // the parent's event stream).
+    let glob_call_count = events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                EngineEvent::ToolCallStart { name, is_sub_agent: true, .. } if name == "Glob"
+            )
+        })
+        .count();
+    assert_eq!(
+        glob_call_count, 2,
+        "expected exactly 2 Glob dispatches; the grace turn's tool call \
+         must be dropped, not executed. got: {events:?}"
+    );
+}


### PR DESCRIPTION
Closes #1135.

## The bug

A read-only explorer sub-agent (`explore`) could spin for ~100s on broad prompts before the user gave up and hit Ctrl-C. `LoopDetector` only catches **consecutive identical** tool calls, so non-identical-but-non-progressing exploration (`Glob → Grep → Glob → Grep → ...`) slipped past every guardrail.

## Root cause

Between #1110 (which removed the global iteration cap) and now, sub-agents had **no per-invocation turn budget**. Top-level Koda still caps at 200 turns with the interactive `LoopCapReached` extension prompt, but sub-agents "trusted the model" — same regime codex uses, but without codex's `compact-or-die` wraparound to stop the bleed.

## The fix: gemini-cli's grace-turn pattern

Mirrors `local-executor.ts::executeFinalWarningTurn` from gemini-cli.

| Component | Value |
|---|---|
| Default per-sub-agent cap | `DEFAULT_SUB_AGENT_MAX_TURNS = 30` (matches gemini's `DEFAULT_MAX_TURNS`) |
| Per-agent override | `"max_iterations": N` in agent JSON |
| Fork inheritance | Forks inherit parent's cap (continuation, not fresh task) |
| Grace turn trigger | `iter > max_turns` |
| Grace turn payload | System reminder appended to outgoing messages: "text only, no tools" |
| Compliant model response | Text becomes the sub-agent's result |
| Defiant model response | Tool calls dropped, return `[max_turns reached: ...]` marker |
| UX | New `EngineEvent::Info`: `⏳ <agent>: reached max turns (N); requesting final summary` |

Reads `max_iterations` from the **raw** agent JSON (not `KodaConfig.max_iterations`) so we can distinguish "explicitly set" from "defaulted to 200 by `KodaConfig::for_agent_invocation`". Without that, every sub-agent would inherit 200 and this fix would do nothing.

## Tests

- `test_sub_agent_grace_turn_terminates_runaway_explorer` — compliant path: `max_iterations: 3`, mock script returns 3 tool calls + 1 text. Asserts grace `Info` fires, result contains the text, exactly 3 `Glob` `ToolCallStart` events (iter 4 dispatched nothing).
- `test_sub_agent_grace_turn_drops_tool_calls_when_model_defies` — fallback path: `max_iterations: 2`, mock script returns 3 tool calls (defiant). Asserts result contains `[max_turns reached`, only 2 `Glob` dispatches.

## Verification

- ✅ `cargo build -p koda-core`
- ✅ `cargo clippy --workspace --all-targets` — zero warnings
- ✅ `cargo test -p koda-core` — all green (incl. all 9 sub-agent e2e tests)
- ✅ `cargo fmt --all` clean

## Out of scope

- Top-level Koda's 200-turn cap (separate UX path: `LoopCapReached` interactive extension)
- Per-tool budgets (orthogonal — could be a follow-up)
- Setting `max_iterations: 30` explicitly in `explore.json` — redundant noise; the default already covers it

## Related issues

The closest open neighbors that this fix does **not** address:
- #1135 ✅ closed by this PR
- #1131 (sub-agent context-overflow / 32K tokens) — orthogonal; could compose well with this (overflow → trigger grace turn early instead of erroring)
