### PR TITLE
chore(api): pre-1.0 hardening on bg_agent public types (#1130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`#[non_exhaustive]` on `BgTaskSnapshot` and `BgAgentResult`** (#1130).
+  Future fields (e.g. token usage, parent task id, daemon-side metadata)
+  can be added without it being a breaking change. Both structs are
+  constructed only inside `koda-core`, so the attribute imposes zero
+  friction on consumers — they only read fields. Pre-1.0 hardening
+  ahead of the daemon epic (#1150).
+- **`#[must_use]` on snapshot, result, and outcome types** —
+  `BgTaskSnapshot`, `BgAgentResult`, `CancelOutcome`, `WaitOutcome`
+  (#1130). Each carries dispatch-layer-relevant information; silently
+  dropping any of them is almost always a bug. Free safety lint with
+  no behavioural change.
+- **`koda-sandbox` crates.io category `concurrency`** (#1130). The
+  sandbox supervises concurrent tool execution and sub-agent spawn,
+  so the category is a genuine fit. Improves discoverability without
+  category-stuffing.
+
+### Notes
+
+- **`#[non_exhaustive]` deliberately NOT applied to `AgentStatus`,
+  `CancelOutcome`, `WaitOutcome`** (#1130). The audit's blanket
+  recommendation didn't account for `koda-cli` exhaustively matching
+  these enums in three rendering / dispatch paths — a missed-variant
+  compile error there is a *feature*, not a wart. Attaching
+  `#[non_exhaustive]` would have downgraded those checks to wildcards
+  and silently hidden bugs the next time we add a status variant.
+
 ## [0.2.23] - 2026-04-29
 
 Feature + reliability release. 12 commits since v0.2.22 covering: a

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -113,7 +113,17 @@ pub enum AgentStatus {
 ///
 /// Cloned out of the registry under the lock so callers can format/display
 /// without holding it. `age` is computed from `started_at` at snapshot time.
+///
+/// `#[non_exhaustive]`: external crates may add fields like `parent_task_id`,
+/// `cancel_token`, or daemon-side metadata in future minor releases without
+/// it being a breaking change. Constructed only inside `koda-core`, so the
+/// attribute imposes zero friction on consumers (they only read fields).
+///
+/// `#[must_use]`: ignoring a snapshot is almost always a bug — the only
+/// reason to call `snapshot()` is to inspect or render the contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+#[must_use = "a snapshot is only useful if you read its fields"]
 pub struct BgTaskSnapshot {
     /// Monotonic id assigned at `reserve()` time. Stable for the
     /// lifetime of the task; reused across snapshots.
@@ -159,7 +169,15 @@ pub struct BgTaskSnapshot {
 pub type BgPayload = (String, Vec<String>);
 
 /// A completed background agent result.
+///
+/// `#[non_exhaustive]`: future fields (e.g. token usage, latency, model
+/// version) can be added without a breaking change. Constructed only
+/// inside `koda-core`; external callers only read fields.
+///
+/// `#[must_use]`: an agent result that's never inspected is dead work.
 #[derive(Debug)]
+#[non_exhaustive]
+#[must_use = "the whole point of running a bg agent is to inspect its result"]
 pub struct BgAgentResult {
     /// The agent name that produced this result.
     pub agent_name: String,
@@ -744,7 +762,16 @@ impl BgAgentRegistry {
 ///
 /// Mirrors HTTP-ish status codes so the LLM-tool layer can produce
 /// useful error messages without inspecting registry internals.
+///
+/// `#[must_use]`: silently dropping the outcome of a cancel call is
+/// always a bug — the dispatch layer translates each variant into a
+/// distinct LLM-tool response payload.
+///
+/// Note: deliberately NOT `#[non_exhaustive]`. The `koda-cli` rendering
+/// layer matches every variant exhaustively, and the compiler-driven
+/// missed-variant warning we get from that is a feature, not a wart.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "every CancelOutcome maps to a distinct dispatch-layer response"]
 pub enum CancelOutcome {
     /// Task existed, caller owned it, cancel token fired.
     Cancelled,
@@ -760,7 +787,12 @@ pub enum CancelOutcome {
 ///
 /// Encodes the four resolutions of a `WaitTask` call. The LLM-tool
 /// layer translates each into a serialised payload the model receives.
+///
+/// `#[must_use]`: the entire purpose of `wait_for_completion` is its
+/// outcome — discarding it would be a bug. (See `CancelOutcome` for
+/// why this enum is also NOT `#[non_exhaustive]`.)
 #[derive(Debug)]
+#[must_use = "the wait result drives the LLM tool's response payload"]
 pub enum WaitOutcome {
     /// Task reached a terminal `Completed`/`Errored` status before
     /// the timeout fired. Carries the drained [`BgAgentResult`] so

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
 keywords = ["sandbox", "security", "filesystem", "unix", "ai"]
-categories = ["os", "filesystem"]
+categories = ["os", "filesystem", "concurrency"]
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Closes 3/5 of #1130 (the v0.2.23 release-time polish bundle). Pure additive / lint-only / metadata changes — no behavioural change, no API break.

## Why now

This is being landed as part of the **v0.2.24 polish window** before the daemon epic (#1150) starts. Pre-1.0 enum/struct hardening on `koda-core/bg_agent` types lets the daemon work add fields freely without breaking-change cascades, and the `#[must_use]` lints catch any new code that forgets to handle a snapshot/result/outcome.

## What's in this PR

### `#[non_exhaustive]` on snapshot/result **structs**

| Type | Why |
|---|---|
| `BgTaskSnapshot` | External code only reads fields. Future fields (token usage, parent task id, daemon metadata) become non-breaking. |
| `BgAgentResult` | Same. |

### `#[must_use]` on snapshot/result/outcome types

| Type | Diagnostic message |
|---|---|
| `BgTaskSnapshot` | "a snapshot is only useful if you read its fields" |
| `BgAgentResult` | "the whole point of running a bg agent is to inspect its result" |
| `CancelOutcome` | "every CancelOutcome maps to a distinct dispatch-layer response" |
| `WaitOutcome` | "the wait result drives the LLM tool's response payload" |

Free safety lint. Clippy clean — no actual ignored returns in tree (the lints are net-new defenders, not retroactive cleanups).

### crates.io categories

- `koda-sandbox`: + `concurrency` (genuine fit — sandbox supervises concurrent tool execution and sub-agent spawn)

## What's deliberately NOT in this PR

### `#[non_exhaustive]` on the `AgentStatus` / `CancelOutcome` / `WaitOutcome` **enums**

The audit's blanket recommendation didn't account for `koda-cli` exhaustively matching `AgentStatus` in **three** rendering / dispatch paths:

- `koda-cli/src/headless.rs:281`
- `koda-cli/src/acp_adapter.rs:149`
- `koda-cli/src/tui_bg_tasks.rs:294`

Today, when we add a new variant like `Paused` or `Throttled`, those three call sites fail to compile and we *must* think about how each renderer handles it. Attaching `#[non_exhaustive]` would downgrade those to wildcard arms (`_ => "?".to_string()`) and silently hide missed-variant bugs.

This is documented inline on each enum's doc-comment so the next auditor doesn't reopen it.

### Sub-agent natural-termination test (#1130 sub-item 1)

**Superseded by #1153.** The original test was meant to assert the post-cap natural-termination path (model says stop). #1153 reintroduced a soft cap (30 turns + grace), so termination now goes through a different mechanism. A test against the old shape would just be wrong.

### Transcript-fold rendering test (#1130 sub-item 2)

**Deferred to its own PR.** This needs ~2 hours of focused work (build a representative `messages` + `session_events` fixture, render via `transcript.rs`, snapshot-assert the folded markdown). Worth doing but doesn't fit the v0.2.24 polish window. Will file a follow-up issue if not done before v0.2.24 cuts.

## Verification

- ✅ `cargo build -p koda-core -p koda-cli -p koda-sandbox` clean
- ✅ `cargo clippy --workspace --all-targets` zero warnings
- ✅ `cargo fmt --all --check` clean
- ✅ `python3 scripts/check_tokio_test_flavor.py` OK
- ✅ `cargo test -p koda-core` (bg_agent filter) — 33/33 pass
- ✅ Pre-push hooks (fmt + clippy) passed
- ⚡ Zero callsite changes needed (`#[must_use]` not violated anywhere)

## Files

- `koda-core/src/bg_agent.rs` — +32 lines (4 attributes + doc comments explaining the design choices)
- `koda-sandbox/Cargo.toml` — +1 category
- `CHANGELOG.md` — `[Unreleased]` entries
