### PR TITLE
chore: release v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,143 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-04-29
+
+Reliability + observability release. 10 commits since v0.2.23 covering:
+a safety reintroduction for sub-agents (a 30-turn ceiling with a
+gemini-pattern grace turn brings back bounded execution after v0.2.23
+removed the hard cap), a new forensic panic-log feature for crash
+diagnosis, two TUI hot-loop perf improvements (frame coalescing and
+bounded event draining), a startup memory-load fix, security
+hardening on the new panic-log file mode, and continued pre-1.0 API
+hardening on `koda-core/bg_agent` types.
+
+### Behaviour change — sub-agent execution is bounded again
+
+- **Sub-agents now cap at 30 turns with a grace turn** (#1135, PR
+  #1153). v0.2.23 removed `MAX_SUB_AGENT_ITERATIONS` based on the
+  reasoning that modern models terminate cleanly. Real usage showed
+  read-only explorer agents could spin for 100+ seconds on broad
+  prompts before the model decided to stop, with no user feedback in
+  the TUI. The fix matches gemini-cli's pattern: a soft 30-turn cap,
+  then one **grace turn** where the model is told "you've hit the
+  limit, summarize and stop" before the loop is forcibly terminated.
+  Tool calls dropped during the grace turn are reported back to the
+  parent agent (and surfaced in the transcript) via a
+  `[max_turns reached: ...]` marker so the parent can decide whether
+  to retry with a narrower scope. **If you customised sub-agent
+  prompts based on v0.2.23's no-cap messaging, your agents will now
+  be bounded again** — the mechanism differs (soft cap + grace turn
+  vs. hard ceiling), the practical effect is similar.
+
 ### Added
 
-- **`#[non_exhaustive]` on `BgTaskSnapshot` and `BgAgentResult`** (#1130).
-  Future fields (e.g. token usage, parent task id, daemon-side metadata)
-  can be added without it being a breaking change. Both structs are
-  constructed only inside `koda-core`, so the attribute imposes zero
-  friction on consumers — they only read fields. Pre-1.0 hardening
-  ahead of the daemon epic (#1150).
+- **Forensic panic log** (#1122, PR #1152). Panics now write a
+  structured backtrace record to `~/.config/koda/logs/panic.log`,
+  including ISO-8601 timestamp, koda version, panic message, file
+  and line, and the captured backtrace (when `RUST_BACKTRACE=1` or
+  `=full`). The hook is panic-in-panic safe (in-memory buffering
+  before write, all I/O failures swallowed) and rotates at 5 MiB
+  with 3 generations kept. Bounded disk growth even under
+  deterministic crash loops. New `troubleshooting.md` mdBook page
+  documents the location and usage.
+- **`#[non_exhaustive]` on `BgTaskSnapshot` and `BgAgentResult`**
+  (#1130, PR #1155). Future fields (e.g. token usage, parent task
+  id, daemon-side metadata) can be added without it being a
+  breaking change. Both structs are constructed only inside
+  `koda-core`, so the attribute imposes zero friction on consumers
+  — they only read fields. Pre-1.0 hardening ahead of the daemon
+  epic (#1150).
 - **`#[must_use]` on snapshot, result, and outcome types** —
   `BgTaskSnapshot`, `BgAgentResult`, `CancelOutcome`, `WaitOutcome`
-  (#1130). Each carries dispatch-layer-relevant information; silently
-  dropping any of them is almost always a bug. Free safety lint with
-  no behavioural change.
-- **`koda-sandbox` crates.io category `concurrency`** (#1130). The
-  sandbox supervises concurrent tool execution and sub-agent spawn,
-  so the category is a genuine fit. Improves discoverability without
-  category-stuffing.
+  (#1130, PR #1155). Each carries dispatch-layer-relevant
+  information; silently dropping any of them is almost always a
+  bug. Free safety lint with no behavioural change.
+- **`koda-sandbox` crates.io category `concurrency`** (#1130, PR
+  #1155). The sandbox supervises concurrent tool execution and
+  sub-agent spawn, so the category is a genuine fit. Improves
+  discoverability without category-stuffing.
+
+### Fixed
+
+- **`CLAUDE.md` no longer loads twice on startup** (#1136, PR #1151).
+  Previously the agent loaded `CLAUDE.md` once during `KodaAgent::new()`
+  and then again when `rebuild_system_prompt()` ran on first turn,
+  producing duplicate `"Loaded N tokens from CLAUDE.md"` log lines
+  and unnecessary disk I/O. Loaded memory is now cached on the
+  agent and reused.
+
+### Performance
+
+- **Coalesced TUI draws via frame scheduler** (#1138, PR #1143).
+  The inference loop previously called `terminal.draw()` on every
+  ui-event arm, leading to redundant renders when events arrived
+  in bursts. A new `FrameRequester` schedules a single draw per
+  frame interval (60Hz default), measurably reducing CPU on
+  streaming turns without sacrificing responsiveness. Eight
+  `start_paused = true` tokio tests verify the scheduling logic
+  deterministically.
+- **Bounded drain + round-robin select fairness in TUI loop**
+  (#1137 / #1139, PR #1142). Previously the inference loop drained
+  every available event with an unbounded `while let Ok(_) =
+  try_recv()`, which under sustained sub-agent fan-out could
+  starve crossterm input (mouse-escape mis-framing per #540). The
+  drain is now capped at 64 per turn and the `tokio::select!` arm
+  priority rotates each iteration so no producer can monopolise
+  the loop.
+
+### Security
+
+- **`~/.config/koda/logs/` and `panic.log` written with 0o600 / 0o700
+  on Unix** (release-time defense-in-depth from the security
+  audit). Backtraces can transitively contain formatted secrets
+  (e.g. `panic!("auth: {key}")`); the new panic-log feature is now
+  unreadable to other local users on a shared host. Windows
+  inherits ACLs from the parent directory (the desired behaviour).
+  Best-effort — silently no-op on systems that don't support the
+  permission bits.
+
+### Tests / CI
+
+- **`PersistingSink` integration coverage** (#1129, PR #1154). 10
+  multi-thread integration tests covering the full sink-routing
+  contract: tool-call persistence, sub-agent trace folding, error
+  propagation, drop semantics. Closes the test gap from #1112's
+  rapid v0.2.23 landing.
+- **Regression test for `read_timeout` auto-retry on silent SSE**
+  (#1134). Confirms the v0.2.23 timeout fix (#1119) actually
+  retries through `try_with_rate_limit` rather than hard-failing
+  the turn, using a fake server that goes silent and resumes.
+- **Regression test for panic-hook TTY restore + chaining** (#1133).
+  Verifies the v0.2.23 panic hook (#1124) restores terminal state
+  AND chains to the previously-installed hook exactly once,
+  preventing both TTY corruption and double-handling. Refactors
+  `install_panic_hook` to take the restore callback as a parameter
+  for testability.
+- **Coverage workflow treats checkout / runner failures as infra
+  flakes** (#1132). The post-merge coverage job now distinguishes
+  "infrastructure broke" from "coverage actually regressed" — no
+  more bogus issue-filing on transient runner failures.
 
 ### Notes
 
 - **`#[non_exhaustive]` deliberately NOT applied to `AgentStatus`,
-  `CancelOutcome`, `WaitOutcome`** (#1130). The audit's blanket
-  recommendation didn't account for `koda-cli` exhaustively matching
-  these enums in three rendering / dispatch paths — a missed-variant
-  compile error there is a *feature*, not a wart. Attaching
-  `#[non_exhaustive]` would have downgraded those checks to wildcards
-  and silently hidden bugs the next time we add a status variant.
+  `CancelOutcome`, `WaitOutcome`** (#1130, PR #1155). The audit's
+  blanket recommendation didn't account for `koda-cli` exhaustively
+  matching these enums in three rendering / dispatch paths — a
+  missed-variant compile error there is a *feature*, not a wart.
+  Attaching `#[non_exhaustive]` would have downgraded those checks
+  to wildcards and silently hidden bugs the next time we add a
+  status variant.
+- **`KodaAgent` deliberately NOT marked `#[non_exhaustive]`** even
+  though a new `pub semantic_memory` field was added in #1136. The
+  release-time code review flagged this as a P2 consistency item;
+  the cost-benefit analysis was: 3 integration test fixtures
+  construct `KodaAgent` via struct literal (lightweight, no
+  `KodaConfig` plumbing), and `koda-core` is documented as
+  internal-pre-1.0 in `koda-core/README.md`, so the protection
+  has no real consumers today. Revisit when `koda-core` stabilises
+  for external use.
 
 ## [0.2.23] - 2026-04-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.23)
+10. Sync version with workspace (currently 0.2.24)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -14,7 +14,7 @@ Each crash appends a delimited block:
 ```
 ======================================================================
 [2026-04-29T20:55:32Z] PANIC
-version:    koda 0.2.23
+version:    koda 0.2.24
 location:   koda-core/src/foo.rs:42:8
 thread:     <unnamed>
 message:    assertion failed: x > 0

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.23"
+version = "0.2.24"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.23" }
+koda-core = { path = "../koda-core", version = "0.2.24" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -75,7 +75,7 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.23", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.24", features = ["test-support"] }
 serde_json = { workspace = true }
 # tokio's `test-util` feature enables `#[tokio::test(start_paused = true)]` so
 # frame_requester tests can manipulate the clock deterministically without

--- a/koda-cli/src/builtin_skills.rs
+++ b/koda-cli/src/builtin_skills.rs
@@ -25,7 +25,8 @@ pub fn inject_builtin_skills(agent: &mut KodaAgent) {
              configuration, sessions, providers, approval modes, trust modes, \
              sandbox, security, safety, privacy, undo, tools, MCP servers, \
              context management, memory, file attachments, skills, sub-agents, \
-             ACP server, or any other feature documented in the user manual. \
+             ACP server, troubleshooting, panic logs, crash diagnosis, or any \
+             other feature documented in the user manual. \
              Fetch the manual from the URL below with WebFetch.",
         ),
         &format!(
@@ -50,6 +51,7 @@ pub fn inject_builtin_skills(agent: &mut KodaAgent) {
              - {url}memory.html — cross-session memory\n\
              - {url}keybindings.html — full keybinding reference\n\
              - {url}acp.html — ACP server (editor integration)\n\
+             - {url}troubleshooting.html — panic logs, crash diagnosis, common issues\n\
              - {url}introduction.html — overview and getting started",
             url = KODA_DOCS_URL,
         ),

--- a/koda-cli/src/panic_log.rs
+++ b/koda-cli/src/panic_log.rs
@@ -67,10 +67,33 @@ pub fn write_panic_log(info: &PanicHookInfo<'_>) {
     };
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
+        // Restrict the logs directory to owner-only on Unix. Backtraces can
+        // transitively contain formatted secrets (e.g. `panic!("auth: {key}")`),
+        // so we don't want them readable by other local users on a shared host.
+        // Best-effort — silently swallow on systems that don't support it.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o700));
+        }
     }
     let _ = rotate_if_needed(&path, MAX_PANIC_LOG_BYTES, ROTATION_GENERATIONS);
 
-    let Ok(mut file) = OpenOptions::new().append(true).create(true).open(&path) else {
+    // Open with 0o600 on Unix (owner read/write only). On Windows the file
+    // inherits ACLs from the parent directory, which is the desired behaviour.
+    #[cfg(unix)]
+    let open_result = {
+        use std::os::unix::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .mode(0o600)
+            .open(&path)
+    };
+    #[cfg(not(unix))]
+    let open_result = OpenOptions::new().append(true).create(true).open(&path);
+
+    let Ok(mut file) = open_result else {
         return;
     };
 

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.23"
+version = "0.2.24"
 edition.workspace = true
 rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.23" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.24" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.23"
+version = "0.2.24"
 edition.workspace = true
 rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"


### PR DESCRIPTION
**Reliability + observability release.** 10 commits since v0.2.23 covering sub-agent execution bounding (#1135), forensic panic log (#1122), TUI hot-loop perf improvements (#1138, #1137), startup memory-load fix (#1136), pre-1.0 API hardening (#1130), and security hardening on the new panic-log file mode.

## Headline change: sub-agents are bounded again

v0.2.23 removed `MAX_SUB_AGENT_ITERATIONS` based on the reasoning that modern models terminate cleanly. **Real usage showed read-only explorer agents could spin for 100+ seconds on broad prompts before the model decided to stop, with no user feedback in the TUI.** PR #1153 (issue #1135) reintroduces a bounded execution model — a soft 30-turn cap, then one **grace turn** where the model is told "you've hit the limit, summarize and stop" before forcible termination. Tool calls dropped during the grace turn are reported back via a `[max_turns reached: ...]` marker so the parent agent can decide whether to retry with narrower scope.

If you customised sub-agent prompts based on v0.2.23's no-cap messaging, your agents will now be bounded again — the mechanism differs (soft cap + grace turn vs. hard ceiling), the practical effect is similar.

## Changelog summary (full text in `CHANGELOG.md`)

| Section | Items |
|---|---|
| Behaviour change | Sub-agent 30-turn cap + grace turn (#1135 / PR #1153) |
| Added | Forensic panic log → `~/.config/koda/logs/panic.log` (#1122 / PR #1152); `#[non_exhaustive]` + `#[must_use]` on bg_agent types (#1130 / PR #1155); `koda-sandbox` crates.io `concurrency` category |
| Fixed | CLAUDE.md no longer double-loads on startup (#1136 / PR #1151) |
| Performance | Coalesced TUI draws via frame scheduler (#1138 / PR #1143); bounded drain + round-robin select fairness (#1137 / #1139 / PR #1142) |
| Security | `panic.log` written with mode 0o600 on Unix (release-time hardening from this PR's audit) |
| Tests / CI | PersistingSink integration coverage (#1129 / PR #1154); SSE retry regression (#1134); panic-hook chain test (#1133); coverage workflow infra-flake handling (#1132) |

## Audit summary (Phase 2 of koda-release skill)

**ZERO real bugs. ZERO audit-dust issues filed.** Pre-flight rules worked — agents skipped what they would have filed in past releases.

| Agent | Findings | Status |
|---|---|---|
| **code-reviewer** | 1×P1 (CHANGELOG backfill), 1×P2 (`KodaAgent` `#[non_exhaustive]`) | P1 → addressed in this PR. P2 → REJECTED (would break 3 integration test fixtures with no real external consumer to protect; rationale documented in CHANGELOG `Notes` section) |
| **rust-programmer** | 2×P1 (versions, CHANGELOG) | Both addressed in this PR. fmt/clippy/test (2271/0/14)/doc all clean. tokio-flavor guard ✅. |
| **security-auditor** | P3-bundle: `panic.log` mode 0o600 | LANDED in this PR per the user-selected aggressive-scope option. Cargo audit clean. No new `unsafe`. No secrets in diff. Sandbox source unchanged. |
| **qa-expert** | 2×P1 (versions, CHANGELOG), 3×P2 (manual smokes — see below) | P1s addressed. Full test-coverage map: every NEW behaviour in this release has a regression test. |

## ⚠️ Pre-tag manual smoke checklist (P2 items from qa-expert)

These cannot be automated and must be done before pushing the `v0.2.24` tag:

- [ ] **P2-1: panic.log file path on macOS.** Unit tests use `Vec<u8>` and `TempDir` — they never hit the real `~/.config/koda/logs/` path. Build a release binary, induce a panic, verify the file appears AND is owner-readable only:
  ```bash
  cargo build --release -p koda-cli
  # induce a panic somehow (e.g. RUST_BACKTRACE=1 with a dev panic-trigger)
  ls -la ~/.config/koda/logs/panic.log    # should be -rw-------
  ls -ld ~/.config/koda/logs/             # should be drwx------
  cat ~/.config/koda/logs/panic.log       # should show backtrace + version line
  ```
- [ ] **P2-2: sub-agent grace-turn UX.** Spawn the `generalist` agent with a deliberately broad explore-the-repo prompt; watch for the `[max_turns reached: ...]` marker rendering correctly in the TUI transcript and the parent agent's view.
- [ ] **P2-3: TUI smoothness during long streamed turn.** ~2-minute streaming session with a verbose prompt; confirm no perceptible regression vs v0.2.23 and the cwd status bar still updates.

## Verification (Phase 3)

- ✅ `cargo fmt --all --check` clean
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` zero warnings
- ✅ `cargo check --workspace --features koda-core/test-support` clean at 0.2.24
- ✅ `cargo test -p koda-cli panic_log` 5/5 pass (perms change didn't break the unit tests)
- ✅ `python3 scripts/check_tokio_test_flavor.py` OK
- ✅ `cargo audit -n` clean (suppressions documented in `.cargo/audit.toml`)
- ✅ `koda_docs` skill index sync: troubleshooting page now indexed
- ✅ All version refs synced: 3 `Cargo.toml`s, 2 path-deps, `CLAUDE.md`, `docs/src/troubleshooting.md`

## Files

```
CHANGELOG.md                   | 148 +++++++++++++++++++++++++++++++++++------
CLAUDE.md                      |   2 +-
Cargo.lock                     |   6 +-
docs/src/troubleshooting.md    |   2 +-
koda-cli/Cargo.toml            |   6 +-
koda-cli/src/builtin_skills.rs |   4 +-
koda-cli/src/panic_log.rs      |  25 ++++++-
koda-core/Cargo.toml           |   4 +-
koda-sandbox/Cargo.toml        |   2 +-
9 files changed, 167 insertions(+), 32 deletions(-)
```

## Post-merge checklist (Phase 5 of release skill)

After this PR squash-merges to main:

1. `git checkout main && git pull`
2. Run the 3 manual smokes above
3. `git tag -a v0.2.24 -m "Release v0.2.24"`
4. `git push origin v0.2.24` → triggers `release.yml` (verify-version → test → build → github-release → publish crates.io + update-homebrew)

## Pre-flight evidence trail

- Sub-agent reports: see commit message + `Audit summary` section above
- Triage decisions: documented in commit message and CHANGELOG `Notes` section
- Build verification: Phase 3 verification block above
- 6 → 4 open issues going into this release after pre-release backlog triage (closed #1125, #1130, #1145; remaining: #1150 daemon epic, #1144 split refactor, #1116 textarea long-term, #663 Dream)
