### PR TITLE
feat: multi-sub-agent UX polish — items (b), (d), (e) of #1158

### DIFF
--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -377,8 +377,16 @@ pub fn render(
 ///
 /// One bullet per event, kind-prefixed so the reader can scan for
 /// task-state transitions vs. info messages without parsing JSON.
-/// Bg-task updates are pretty-printed (`task N: Pending → Running`)
+/// Bg-task updates are pretty-printed (`agent:N: Pending → Running`)
 /// because raw JSON in a transcript is illegible noise.
+///
+/// **Iter-heartbeat aggregation (#1158 d)**: by default, per-iteration
+/// `Running { iter: N>0 }` heartbeats are dropped from the export and
+/// summarised into one trailing line per task (`agent:N: ran 9
+/// iterations → Completed`). The state transitions (Pending,
+/// Running with iter==0, Cancelled, Completed, Errored) and the iter-0
+/// "started" marker are preserved verbatim. Set `KODA_EXPORT_VERBOSE=1`
+/// to disable the filter and re-emit every heartbeat (debugging).
 fn render_background_activity(out: &mut String, events: &[&SessionEvent]) {
     out.push_str("---\n\n## \u{1f4ca} Background activity\n\n");
     out.push_str(
@@ -386,6 +394,12 @@ fn render_background_activity(out: &mut String, events: &[&SessionEvent]) {
          bg-task state transitions). Pre-#1108 these were sink-only and \
          not exported.</sub>\n\n",
     );
+    let verbose = std::env::var("KODA_EXPORT_VERBOSE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    // Per-task heartbeat counters — only used when not verbose. Keyed
+    // by task_id so multi-agent sessions get one summary line each.
+    let mut iter_counts: std::collections::BTreeMap<u64, u32> = std::collections::BTreeMap::new();
     for ev in events {
         let ts = ev.created_at.as_deref().unwrap_or("");
         match ev.kind.as_str() {
@@ -393,8 +407,14 @@ fn render_background_activity(out: &mut String, events: &[&SessionEvent]) {
                 out.push_str(&format!("- `{ts}` \u{2139}\u{fe0f} {}\n", ev.payload));
             }
             session_event_kind::BG_TASK_UPDATE => {
-                // Best-effort pretty print; fall back to raw on parse
-                // failure so we never lose data.
+                if !verbose
+                    && let Some((tid, iter)) = parse_running_iter(&ev.payload)
+                    && iter > 0
+                {
+                    // Drop heartbeat noise; tally for summary.
+                    *iter_counts.entry(tid).or_insert(0) += 1;
+                    continue;
+                }
                 let pretty =
                     pretty_bg_task_update(&ev.payload).unwrap_or_else(|| ev.payload.clone());
                 out.push_str(&format!("- `{ts}` \u{1f680} {pretty}\n"));
@@ -404,7 +424,34 @@ fn render_background_activity(out: &mut String, events: &[&SessionEvent]) {
             }
         }
     }
+    // Append per-task heartbeat summary (only fires when we actually
+    // dropped heartbeats — no-op for verbose mode and for sessions
+    // whose tasks never emitted iter>0).
+    for (tid, count) in iter_counts {
+        out.push_str(&format!(
+            "- \u{1f4ad} agent:{tid}: {count} iteration{plural} aggregated \
+             (set `KODA_EXPORT_VERBOSE=1` to expand)\n",
+            plural = if count == 1 { "" } else { "s" },
+        ));
+    }
     out.push('\n');
+}
+
+/// Extract `(task_id, iter)` from a `BgTaskUpdate` payload whose
+/// status is `Running { iter: N }`. Returns `None` for any other
+/// status (Pending, Cancelled, Completed, Errored) or malformed JSON
+/// — caller falls back to the regular pretty-print path.
+fn parse_running_iter(payload: &str) -> Option<(u64, u32)> {
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let task_id = v.get("task_id")?.as_u64()?;
+    let iter = v
+        .get("status")?
+        .as_object()?
+        .get("Running")?
+        .as_object()?
+        .get("iter")?
+        .as_u64()?;
+    Some((task_id, iter as u32))
 }
 
 /// Best-effort pretty-printer for a `BgTaskUpdate` JSON payload.
@@ -426,7 +473,7 @@ fn pretty_bg_task_update(payload: &str) -> Option<String> {
             .join(", "),
         _ => status.to_string(),
     };
-    Some(format!("task {task_id}: {status_str}"))
+    Some(format!("agent:{task_id}: {status_str}"))
 }
 
 // ── Verbose-mode helpers ─────────────────────────────────────────────
@@ -1152,8 +1199,110 @@ mod tests {
         );
         assert!(out.contains("context compacted"));
         assert!(
-            out.contains("task 7: Pending"),
-            "BgTaskUpdate JSON must be pretty-printed. got:\n{out}"
+            out.contains("agent:7: Pending"),
+            "BgTaskUpdate JSON must be pretty-printed in canonical agent:N form (#1158 e). got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn iter_heartbeats_aggregated_into_summary_line_by_default() {
+        // #1158 (d): per-iter Running heartbeats are noise in exports.
+        // Default mode should drop them and emit ONE summary line per
+        // task at the bottom. State transitions (Pending, Completed,
+        // iter==0 "started" marker) must remain visible.
+        let events = vec![
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":"Pending"}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":0}}}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":1}}}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":2}}}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":3}}}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Completed":{"summary":"done"}}}"#,
+                None,
+            ),
+        ];
+        let out = render(&[], &events, &default_meta(), true);
+        // State transitions must survive.
+        assert!(out.contains("agent:1: Pending"), "missing Pending: {out}");
+        assert!(
+            out.contains("\"iter\":0"),
+            "iter==0 marker must survive (treated as state transition): {out}"
+        );
+        assert!(out.contains("Completed"), "Completed must survive: {out}");
+        // The 3 iter>0 heartbeats must NOT appear individually.
+        assert!(
+            !out.contains("\"iter\":1"),
+            "iter=1 heartbeat should be aggregated, not shown raw: {out}"
+        );
+        assert!(
+            !out.contains("\"iter\":2"),
+            "iter=2 heartbeat should be aggregated: {out}"
+        );
+        // Summary line must show the count of dropped heartbeats.
+        assert!(
+            out.contains("agent:1: 3 iterations aggregated"),
+            "missing per-task summary line: {out}"
+        );
+    }
+
+    #[test]
+    fn verbose_mode_re_emits_every_iter_heartbeat() {
+        // #1158 (d): KODA_EXPORT_VERBOSE=1 disables aggregation so
+        // operators can debug bg-agent loops post-hoc.
+        // SAFETY: tests in this module run sequentially per
+        // `#[cfg(test)]` defaults; we restore the var before returning.
+        // SAFETY (Rust 2024): set_var/remove_var are unsafe because
+        // they mutate process-global env. Documented as fine in
+        // single-threaded test contexts.
+        // SAFETY: tests run sequentially; mutating process env in a
+        // single-threaded test context is the documented use case.
+        unsafe {
+            std::env::set_var("KODA_EXPORT_VERBOSE", "1");
+        }
+        let events = vec![
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":1}}}"#,
+                None,
+            ),
+            ev(
+                session_event_kind::BG_TASK_UPDATE,
+                r#"{"task_id":1,"status":{"Running":{"iter":2}}}"#,
+                None,
+            ),
+        ];
+        let out = render(&[], &events, &default_meta(), true);
+        unsafe {
+            std::env::remove_var("KODA_EXPORT_VERBOSE");
+        }
+        assert!(
+            out.contains("\"iter\":1") && out.contains("\"iter\":2"),
+            "verbose mode must preserve all heartbeats: {out}"
+        );
+        assert!(
+            !out.contains("aggregated"),
+            "verbose mode must NOT emit summary line: {out}"
         );
     }
 

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -410,6 +410,13 @@ impl TuiContext {
         let selection = self.mouse_selection.as_ref();
         let mcp_info = self.agent.mcp_status_bar_info();
         let project_root = self.project_root.clone();
+        // #1158 (b): ambient bg-task pill so users know work is in
+        // flight without running `/bg-tasks`. Both registries are
+        // shared `Arc`s; counts are O(1) hashmap len lookups.
+        let bg_counts = (
+            self.session.bg_agents.pending_count(),
+            self.agent.tools.bg_registry.len(),
+        );
 
         let mut history_rect = None;
         if let Err(e) = self.terminal.draw(|f| {
@@ -429,6 +436,7 @@ impl TuiContext {
                 scroll_buffer,
                 selection,
                 mcp_info,
+                bg_counts,
                 &project_root,
             ));
         }) {

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -85,6 +85,15 @@ impl TuiContext {
         self.inference_start = Some(std::time::Instant::now());
         self.renderer.last_turn_stats = None;
 
+        // #1158 (b): clone the bg-task registry handles BEFORE pinning
+        // the turn future. The future borrows `self.session` mutably for
+        // its entire lifetime, so `self.session.bg_agents` becomes
+        // unreachable inside the streaming loop. The agent registry is
+        // an `Arc` (cheap clone); the process registry isn't, so we
+        // clone the enclosing `Arc<KodaAgent>` and reach through it.
+        let bg_agents_for_status = self.session.bg_agents.clone();
+        let agent_for_status = self.agent.clone();
+
         // Run the inference turn as a pinned future
         {
             let turn = self
@@ -175,6 +184,11 @@ impl TuiContext {
                         let mode = trust::read_trust(&self.shared_mode);
                         let ctx = self.context_pct;
                         let mcp_info = self.agent.mcp_status_bar_info();
+                        // #1158 (b): keep status pill alive during streaming turns.
+                        let bg_counts = (
+                            bg_agents_for_status.pending_count(),
+                            agent_for_status.tools.bg_registry.len(),
+                        );
                         let queue_total = self.later_queue.len();
                         let queue_preview: Vec<String> = self
                             .later_queue
@@ -201,6 +215,7 @@ impl TuiContext {
                                 &self.scroll_buffer,
                                 self.mouse_selection.as_ref(),
                                 mcp_info,
+                                bg_counts,
                                 &self.project_root,
                             );
                         });

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -44,6 +44,10 @@ pub(crate) fn draw_viewport(
     scroll_buffer: &ScrollBuffer,
     selection: Option<&crate::mouse_select::Selection>,
     mcp_info: Option<McpStatusBarInfo>,
+    // Background-task counts (running sub-agents, running shell
+    // processes). Drives the status-bar pill added in #1158 (b);
+    // both zero → segment hidden by `StatusBar::with_bg_counts`.
+    bg_counts: (usize, usize),
     project_root: &std::path::Path,
 ) -> ratatui::layout::Rect {
     let area = frame.area();
@@ -188,6 +192,10 @@ pub(crate) fn draw_viewport(
     }
     if let Some(mcp) = mcp_info {
         sb = sb.with_mcp_info(mcp);
+    }
+    let (bg_agents, bg_processes) = bg_counts;
+    if bg_agents > 0 || bg_processes > 0 {
+        sb = sb.with_bg_counts(bg_agents, bg_processes);
     }
     frame.render_widget(sb, status_row);
 

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -37,6 +37,12 @@ pub struct StatusBar<'a> {
     scroll_info: Option<(usize, usize)>,
     /// MCP server status (None = no servers configured, hidden).
     mcp_info: Option<McpStatusBarInfo>,
+    /// Background agent + shell-process counts (#1158 item b).
+    /// Both zero → segment hidden. The pill makes it discoverable
+    /// that work is happening even when the user has scrolled away
+    /// from the launch confirmation.
+    bg_agents: usize,
+    bg_processes: usize,
 }
 
 /// Stats from the most recent inference turn.
@@ -64,6 +70,8 @@ impl<'a> StatusBar<'a> {
             last_turn: None,
             scroll_info: None,
             mcp_info: None,
+            bg_agents: 0,
+            bg_processes: 0,
         }
     }
 
@@ -99,6 +107,17 @@ impl<'a> StatusBar<'a> {
 
     pub fn with_mcp_info(mut self, info: McpStatusBarInfo) -> Self {
         self.mcp_info = Some(info);
+        self
+    }
+
+    /// Attach background-task counts (running sub-agents and running
+    /// shell processes). Both `0` → segment hidden, mirroring the
+    /// MCP / queue segments. See #1158 item (b): without this pill
+    /// users had no ambient hint that bg work was in flight unless
+    /// they ran `/bg-tasks` explicitly.
+    pub fn with_bg_counts(mut self, agents: usize, processes: usize) -> Self {
+        self.bg_agents = agents;
+        self.bg_processes = processes;
         self
     }
 }
@@ -245,6 +264,35 @@ impl Widget for StatusBar<'_> {
                 format!(" \u{26a1}{}/{} ", mcp.connected, mcp.total),
                 Style::default().fg(mcp_color),
             ));
+        }
+
+        // Background activity pill (#1158 item b) — sub-agents and
+        // shell processes share one segment. Cyan matches the
+        // "in-flight" semantics already used for the elapsed-time
+        // hourglass. Only rendered when at least one is nonzero so
+        // the bar stays compact during ordinary chat.
+        if self.bg_agents > 0 || self.bg_processes > 0 {
+            spans.push(Span::styled(
+                "\u{2502}",
+                Style::default().fg(Color::Rgb(60, 60, 60)),
+            ));
+            let mut label = String::from(" ");
+            if self.bg_agents > 0 {
+                // \u{1f916} = 🤖. Agents listed first because they're
+                // the higher-cost / longer-lived workers.
+                label.push_str(&format!("\u{1f916} {}", self.bg_agents));
+            }
+            if self.bg_agents > 0 && self.bg_processes > 0 {
+                label.push(' ');
+            }
+            if self.bg_processes > 0 {
+                // \u{2699} = ⚙ (gear). Variation selector \u{fe0f}
+                // forces emoji presentation on terminals that default
+                // the bare codepoint to monochrome text glyph.
+                label.push_str(&format!("\u{2699}\u{fe0f} {}", self.bg_processes));
+            }
+            label.push(' ');
+            spans.push(Span::styled(label, Style::default().fg(Color::Cyan)));
         }
 
         // Elapsed time during inference
@@ -498,6 +546,86 @@ mod tests {
         assert!(
             cwd_pos < model_pos,
             "cwd ({cwd_pos}) must come before model ({model_pos}) in: {text}"
+        );
+    }
+
+    // ── #1158 (b): background-task pill ───────────────────
+
+    #[test]
+    fn bg_pill_hidden_when_both_counts_zero() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_bg_counts(0, 0);
+        let text = render_bar(bar, 200);
+        // Neither emoji should appear.
+        assert!(
+            !text.contains('\u{1f916}'),
+            "🤖 should be hidden when zero agents: {text}"
+        );
+        assert!(
+            !text.contains('\u{2699}'),
+            "⚙ should be hidden when zero processes: {text}"
+        );
+    }
+
+    #[test]
+    fn bg_pill_shows_only_agents_when_processes_zero() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_bg_counts(2, 0);
+        let text = render_bar(bar, 200);
+        assert!(
+            text.contains('\u{1f916}') && text.contains('2'),
+            "agents pill missing or wrong count: {text}"
+        );
+        assert!(
+            !text.contains('\u{2699}'),
+            "process gear must NOT render when count=0: {text}"
+        );
+    }
+
+    #[test]
+    fn bg_pill_shows_only_processes_when_agents_zero() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_bg_counts(0, 3);
+        let text = render_bar(bar, 200);
+        assert!(
+            text.contains('\u{2699}') && text.contains('3'),
+            "processes pill missing or wrong count: {text}"
+        );
+        assert!(
+            !text.contains('\u{1f916}'),
+            "agent robot must NOT render when count=0: {text}"
+        );
+    }
+
+    #[test]
+    fn bg_pill_shows_both_when_both_nonzero() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_bg_counts(2, 5);
+        let text = render_bar(bar, 200);
+        // Agents listed first per the rendering convention
+        // (higher-cost / longer-lived workers come first).
+        let agent_pos = text.find('\u{1f916}').expect("agent emoji missing");
+        let proc_pos = text.find('\u{2699}').expect("process gear missing");
+        assert!(
+            agent_pos < proc_pos,
+            "agents must render before processes: {text}"
+        );
+        assert!(text.contains('2') && text.contains('5'));
+    }
+
+    #[test]
+    fn bg_pill_renders_in_cyan_to_match_inflight_palette() {
+        // Agents pill should render with Color::Cyan to match the
+        // hourglass / elapsed-time "in-flight" semantic. Other colors
+        // would imply different state (yellow=warning, red=error).
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_bg_counts(1, 0);
+        let area = Rect::new(0, 0, 200, 1);
+        let mut buf = Buffer::empty(area);
+        bar.render(area, &mut buf);
+        // Find the cell containing the robot emoji and check its fg color.
+        let cell_x = (0..200u16)
+            .find(|&x| buf.cell((x, 0)).map(|c| c.symbol()) == Some("\u{1f916}"))
+            .expect("🤖 cell missing from rendered buffer");
+        assert_eq!(
+            buf.cell((cell_x, 0)).unwrap().fg,
+            Color::Cyan,
+            "bg pill must render in cyan (in-flight palette)"
         );
     }
 }

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -362,7 +362,7 @@ impl BgStatusEmitter {
 /// (future per-task `/cancel <id>` UX, #996).
 pub struct BgAgentReservation {
     /// Monotonically-assigned task ID. Surfaces in user-facing
-    /// messages (`Background agent 'foo' started (task 7)`) and
+    /// messages (`Background agent 'foo' started (agent:7)`) and
     /// keys the per-task `/cancel <id>` UX (#996).
     pub task_id: u32,
     /// Sender half of the result oneshot. Move into the spawned

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -446,7 +446,7 @@ pub(crate) fn execute_sub_agent<'a>(
             );
 
             return Ok(format!(
-                "Background agent '{agent_name_owned}' started (task {task_id}). \
+                "Background agent '{agent_name_owned}' started (agent:{task_id}). \
              Results will be injected when complete."
             ));
         }


### PR DESCRIPTION
Closes 3 of 5 items in #1158. Items (c) and (g) are intentionally deferred to #1159 (tool_result injection refactor) per the cross-link plan, since both become trivial / no-ops once tool_results stop being synthetically injected as user messages.

## Item (b) — status bar background-tasks pill 🔴 user-visible

Adds an ambient '🤖 N ⚙️ M' segment to the status bar showing running sub-agents and shell processes. Both counts hidden when zero (mirrors MCP and queue segments). Cyan to match the in-flight palette (elapsed-time hourglass).

**Why it matters:** the original bug report flagged a 45-second blackout between 4 sub-agent launches and the first completion, with no indication that work was happening. Notably one of the explore agents IN THAT SESSION flagged this exact gap as a finding — the product asked us to fix the product. 😄

**Files:**
- `koda-cli/src/widgets/status_bar.rs` — new `with_bg_counts(agents, processes)` builder, segment renders right after MCP and before elapsed
- `koda-cli/src/tui_viewport.rs` — `draw_viewport` gains `bg_counts: (usize, usize)` param
- `koda-cli/src/tui_context/mod.rs` + `tui_handlers_inference.rs` — both call sites query the registries; the streaming-loop call site clones `Arc<BgAgentRegistry>` + `Arc<KodaAgent>` because the turn future holds `&mut self.session` for its entire lifetime

## Item (e) — canonical task naming

User-facing strings now use the canonical `agent:N` form that matches the existing `ListBackgroundTasks` JSON, `WaitTask` args, and `/agents` panel. Three incoherent forms collapsed to one:

- `sub_agent_dispatch`: `'started (task 7)'` → `'started (agent:7)'`
- `transcript` pretty-print: `'task 7: Pending'` → `'agent:7: Pending'`

**Naming choice:** the issue proposed `task:N` but I went with `agent:N` because the `TaskId` enum already discriminates `Agent` vs `Process` (both `u32`) — a flat `task:N` would be ambiguous on the unified surface. Filed a comment-on-issue about this if anyone disagrees.

## Item (d) — filter iter-heartbeat noise on export

Per-iteration `Running { iter: N }` heartbeats were 50+ lines of debug telemetry in transcript exports. Default behavior now drops them and emits ONE summary line per task at the bottom of the Background activity section:

```
- 💭 agent:1: 9 iterations aggregated (set `KODA_EXPORT_VERBOSE=1` to expand)
```

State transitions (`Pending`, iter==0 'started' marker, `Cancelled`, `Completed`, `Errored`) are preserved verbatim — only iter > 0 heartbeats are aggregated. Set `KODA_EXPORT_VERBOSE=1` for full debug output.

## Test coverage

- 5 new tests in `status_bar.rs` (hidden, agents-only, processes-only, both-shown, cyan-color verification)
- 2 new tests in `transcript.rs` (aggregation default, verbose bypass)
- Existing `top_level_events_appear_in_background_activity_section` updated for canonical naming
- Full koda-cli (505 tests) and koda-core (1134 tests) suites green
- `cargo clippy --all-targets -- -D warnings` clean

## What's intentionally NOT in this PR

| Item | Status | Why deferred |
|---|---|---|
| (c) De-duplicate completion summaries 3× | → #1159 | The triplication is an artifact of the synthetic user-message injection. After #1159 lands, summaries naturally appear once (in the WaitTask tool_result) — fixing it now would be wasted work. |
| (g) Sub-agent trace count tense fix | → #1159 | Same root cause: trace events are attached to the dispatch-time tool_call message because the result is injected as a separate user message. After #1159, traces attach to the (real) tool_result and the tense becomes naturally correct. |

## Pre-flight verification

Per the koda-release skill's audit-dust prevention rules:
- ✅ Read the actual transcript file referenced in #1158 to confirm the gap
- ✅ Verified the existing `/agents` panel uses `agent:N` before changing other strings to match
- ✅ Confirmed all 5 status-bar tests assert against real Buffer cells, not just text matches

Closes the (b), (d), (e) checkboxes in #1158.