### PR TITLE
fix(transcript): build tool_id_to_name incrementally to survive id reuse (Gemini)

### DIFF
--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -168,21 +168,23 @@ pub fn render(
         render_metadata_table(&mut out, meta);
     }
 
-    // Build tool_call_id → tool_name mapping for result correlation
+    // tool_call_id → tool_name mapping for result correlation, populated
+    // **incrementally during the render walk below** rather than via a
+    // pre-pass over all messages. The pre-pass approach (pre-#1163-followup)
+    // was buggy with providers that reuse tool_call_ids across turns —
+    // notably Gemini, which emits per-turn counters like `gemini_tc_1`,
+    // `gemini_tc_2`, … that reset every assistant message. With a global
+    // pre-pass + last-write-wins, a `WaitTask`-bearing id would get silently
+    // overwritten by a later turn's `Read`, causing the Tool result lookup
+    // at render time to return the wrong tool_name and skip the WaitTask
+    // pretty-printer (#1162) → raw JSON dumped into a code block.
+    //
+    // Walking in order and inserting as we go means each Tool message sees
+    // the rolling map state **as of that point in the transcript**, which
+    // always reflects the most-recent prior Assistant `tool_calls` block —
+    // i.e. the call that actually produced this result. Same map, same
+    // O(N) cost, correct semantics for id-reusing providers.
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
-    for msg in messages {
-        if msg.role == Role::Assistant
-            && let Some(ref tc_json) = msg.tool_calls
-            && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
-        {
-            for call in calls {
-                let (id, name, _args) = extract_tool_call_meta(&call);
-                if !id.is_empty() && name != "Tool" {
-                    tool_id_to_name.insert(id, name);
-                }
-            }
-        }
-    }
 
     // #1108 P2a: bucket sub-agent events by parent tool_call_id so
     // each Tool result can render its folded trace in O(1). Top-level
@@ -247,6 +249,12 @@ pub fn render(
                     let link = hyperlinks_enabled();
                     for call in &calls {
                         let (id, name, args_json) = extract_tool_call_meta(call);
+                        // Register the id→name mapping for the matching
+                        // Tool result that will appear later in the walk.
+                        // See the rationale comment at the top of this fn.
+                        if !id.is_empty() && name != "Tool" {
+                            tool_id_to_name.insert(id.clone(), name.clone());
+                        }
                         let detail = tool_detail_markdown(
                             &name,
                             &args_json,
@@ -1669,6 +1677,66 @@ mod tests {
         assert!(
             !out.contains("<details>"),
             "pretty path must abort cleanly on parse failure: {out}"
+        );
+    }
+
+    #[test]
+    fn wait_task_pretty_survives_gemini_style_tool_id_reuse_across_turns() {
+        // Regression for #1163-followup: providers like Gemini emit
+        // per-turn tool_call_ids (`gemini_tc_1`, `gemini_tc_2`, …)
+        // that **reset every assistant message**, so the same id
+        // legitimately means different tools across turns. The old
+        // pre-pass-then-render approach built `tool_id_to_name` with
+        // last-write-wins semantics across the whole transcript, so a
+        // later `Read` call would silently overwrite the WaitTask
+        // mapping — and the WaitTask result rendered as raw JSON.
+        //
+        // Shape (mirrors the user-reported transcript):
+        //   T1: assistant calls WaitTask  (id=tc_1) → result: WaitTask JSON
+        //   T2: assistant calls Read      (id=tc_1, REUSED) → result: file body
+        //
+        // After the fix, T1's WaitTask result must still pretty-print.
+        let payload = serde_json::json!({
+            "summary": {"total": 1, "completed": 1},
+            "tasks": [{
+                "task_id": "agent:1",
+                "status": "completed",
+                "agent_name": "explore",
+                "output": "All clear.",
+            }],
+        });
+
+        let read_call = serde_json::json!([{
+            "id": "tc_1",
+            "function": {"name": "Read", "arguments": "{\"file_path\":\"a.rs\"}"}
+        }]);
+        let mut read_assistant = make_msg(Role::Assistant, "");
+        read_assistant.tool_calls = Some(read_call.to_string());
+        let mut read_result = make_msg(Role::Tool, "fn main() {}\n");
+        read_result.tool_call_id = Some("tc_1".into());
+
+        let msgs = vec![
+            assistant_calling_wait_task("tc_1"),
+            wait_task_result("tc_1", payload),
+            read_assistant,
+            read_result,
+        ];
+        let out = render(&msgs, &[], &default_meta(), false);
+
+        // Must pretty-print the WaitTask result — the per-task block.
+        assert!(
+            out.contains("<details>") && out.contains("agent:1"),
+            "WaitTask must pretty-print despite later id reuse: {out}"
+        );
+        // Must NOT regress to the raw-JSON code block.
+        assert!(
+            !out.contains("```\n{\"summary\"") && !out.contains("```\n{\"tasks\""),
+            "raw WaitTask JSON must never appear: {out}"
+        );
+        // Sanity: the later Read result is unaffected.
+        assert!(
+            out.contains("fn main()"),
+            "Read result must still render: {out}"
         );
     }
 


### PR DESCRIPTION
## Bug

PR #1162 added a WaitTask pretty-printer, but in real Gemini sessions the WaitTask result was **still rendering as raw JSON in a code block**. Reproducer: session `koda-20260430-150226-use-multiple-explore-sub-agent-to-scan-t.md`, line 60 — the WaitTask result is a one-line escape-soup blob, not the per-task `<details>` blocks PR #1162 promised.

## Root cause: tool_call_id collision across turns

Gemini emits **per-turn tool_call_id counters** (`gemini_tc_1`, `gemini_tc_2`, …) that **reset on every assistant message**. The same id legitimately means different tools across the conversation. Anthropic uses globally-unique ids; OpenAI varies; Gemini reuses.

The renderer's `tool_id_to_name` map was built in a **pre-pass over all messages**, last-write-wins across the whole transcript. So for the bug repro:

| Turn | Assistant tool_calls | Map state after turn |
|---|---|---|
| 14:59:26 | 4× InvokeAgent (`gemini_tc_1`..`gemini_tc_4`) | `gemini_tc_1 → InvokeAgent` |
| 14:59:28 | 1× WaitTask (`gemini_tc_1`) | `gemini_tc_1 → WaitTask` ✅ |
| 15:00:27 | 1× Read (`gemini_tc_1`) | `gemini_tc_1 → Read` ❌ |
| … many more Reads … | | `gemini_tc_1 → Read` |

By render time, the lookup for the WaitTask result returns `"Read"`, the `tool_name == "WaitTask"` gate fails, and the pretty-printer is skipped → raw JSON dumped.

## Fix

Populate `tool_id_to_name` **inside the existing render walk's Assistant branch** instead of a separate pre-pass. Each Tool message then sees the rolling map state *as of its position in the transcript*, which always reflects the most-recent prior Assistant `tool_calls` block — i.e. the call that actually produced this result.

- Same map, same O(N) cost.
- Correct semantics for id-reusing providers (Gemini today, potentially others tomorrow).
- No API change; pure transcript-renderer fix.

## Test

New regression test `wait_task_pretty_survives_gemini_style_tool_id_reuse_across_turns` mirrors the user-reported transcript shape exactly:
```
T1: assistant calls WaitTask  (id=tc_1) → WaitTask JSON result
T2: assistant calls Read      (id=tc_1, REUSED) → file body
```
Without the fix, T1's WaitTask result regresses to a raw-JSON code block. With the fix, T1 pretty-prints AND T2's Read result still renders normally.

Full `koda-cli` lib suite: 510 passed, 0 failed. Clippy clean.

## Related

- Follow-up to #1162 (the WaitTask pretty-printer this fix saves)
- Reported in session `koda-20260430-150226`
- Same bug class would mask any future tool-name-gated rendering (e.g. #1163 Phase 1 `InvokeAgent` foreground pretty-printer, when revisited)
