### PR TITLE
fix(tui): pretty-print WaitTask in live TUI + resumed history

### DIFF
--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -29,23 +29,21 @@ const TOOL_OUTPUT_PREVIEW_LINES: usize = 3;
 pub fn render_history_messages(messages: &[Message]) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
 
-    // Build a tool_call_id → tool_name map so tool result messages can
-    // look up which tool produced them and pick the right content style.
+    // tool_call_id → tool_name mapping for result correlation, populated
+    // **incrementally during the render walk below** rather than via a
+    // pre-pass over all messages. Same bug class as #1164 fixed in
+    // `transcript.rs`: providers like Gemini emit per-turn tool_call_ids
+    // (`gemini_tc_1`, `gemini_tc_2`, …) that reset every assistant
+    // message, so a global last-write-wins pre-pass would silently
+    // overwrite an earlier turn's `WaitTask` mapping with a later turn's
+    // `Read`, causing the resumed-history WaitTask result to skip the
+    // pretty-printer and dump raw JSON.
+    //
+    // Walking in order and inserting as we go means each Tool message
+    // sees the rolling map state **as of that point in the transcript**,
+    // which always reflects the most-recent prior Assistant tool_calls
+    // block — i.e. the call that actually produced this result.
     let mut tool_id_to_name: HashMap<String, String> = HashMap::new();
-    for msg in messages {
-        if msg.role == Role::Assistant
-            && let Some(ref tc_json) = msg.tool_calls
-            && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
-        {
-            for call in calls {
-                if let (Some(id), Some(name)) =
-                    (call["id"].as_str(), call["function"]["name"].as_str())
-                {
-                    tool_id_to_name.insert(id.to_string(), name.to_string());
-                }
-            }
-        }
-    }
 
     for msg in messages {
         match msg.role {
@@ -56,6 +54,17 @@ pub fn render_history_messages(messages: &[Message]) -> Vec<Line<'static>> {
                 render_user_message(&mut lines, msg);
             }
             Role::Assistant => {
+                if let Some(ref tc_json) = msg.tool_calls
+                    && let Ok(calls) = serde_json::from_str::<Vec<serde_json::Value>>(tc_json)
+                {
+                    for call in calls {
+                        if let (Some(id), Some(name)) =
+                            (call["id"].as_str(), call["function"]["name"].as_str())
+                        {
+                            tool_id_to_name.insert(id.to_string(), name.to_string());
+                        }
+                    }
+                }
                 render_assistant_message(&mut lines, msg);
             }
             Role::Tool => {
@@ -182,6 +191,21 @@ fn render_tool_call_headers(lines: &mut Vec<Line<'static>>, tc_json: &str) {
 /// - Mutating tools (Bash, Write, Edit…)        → `WRITE_CONTENT` (dim, less important)
 fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message, tool_name: &str) {
     let content = msg.content.as_deref().unwrap_or("");
+
+    // WaitTask returns aggregated multi-task JSON (#1157) that's
+    // user-hostile when dumped raw. Pretty-print it as a per-task
+    // summary instead, mirroring the live streaming render
+    // (`tui_render::render_tool_output`) and the markdown export
+    // (`transcript::pretty_wait_task_output`). Falls back to the
+    // generic line-by-line path on any parse failure so we never
+    // lose the raw content.
+    if tool_name == "WaitTask"
+        && let Some(rendered) = crate::wait_task_format::try_render_wait_task_lines(content)
+    {
+        lines.extend(rendered);
+        return;
+    }
+
     let total_lines = content.lines().count();
 
     let content_style = match classify_tool(tool_name) {
@@ -359,5 +383,123 @@ mod tests {
             .map(|s| s.content.as_ref())
             .collect();
         assert!(all_text.contains("session resumed"));
+    }
+
+    /// Helper: build an Assistant message with a synthetic tool_calls
+    /// JSON declaring one tool call. Used by both regression tests below.
+    fn assistant_calling(name: &str, call_id: &str) -> Message {
+        let calls = serde_json::json!([{
+            "id": call_id,
+            "function": {"name": name, "arguments": "{}"}
+        }]);
+        let mut m = msg(Role::Assistant, "");
+        m.tool_calls = Some(calls.to_string());
+        m
+    }
+
+    /// Helper: build a Tool result message tagged with `tool_call_id`.
+    fn tool_result(call_id: &str, content: &str) -> Message {
+        let mut m = msg(Role::Tool, content);
+        m.tool_call_id = Some(call_id.into());
+        m
+    }
+
+    #[test]
+    fn wait_task_result_renders_as_per_task_summary_not_raw_json() {
+        // The bug from session koda-20260430-152051: WaitTask results
+        // dumped raw JSON in the live TUI / resumed history because
+        // neither surface was WaitTask-aware (the pretty-printer existed
+        // only in `transcript.rs`). After this fix, both TUI surfaces
+        // share the same per-task summary via `wait_task_format`.
+        let payload = serde_json::json!({
+            "summary": {"total": 2, "completed": 2},
+            "tasks": [
+                {"task_id": "agent:1", "status": "completed", "agent_name": "explore",
+                 "output": "Scan finished. Found 0 issues."},
+                {"task_id": "agent:2", "status": "completed", "agent_name": "explore",
+                 "output": "All providers verified."},
+            ],
+        });
+        let messages = vec![
+            assistant_calling("WaitTask", "c1"),
+            tool_result("c1", &payload.to_string()),
+        ];
+        let lines = render_history_messages(&messages);
+        let all: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+
+        // Per-task structure must surface, not the raw JSON soup.
+        assert!(
+            all.contains("2 task(s) gathered")
+                && all.contains("agent:1")
+                && all.contains("agent:2"),
+            "per-task summary missing: {all}"
+        );
+        // Critically: the raw JSON envelope keys must NOT appear as
+        // visible text — that's the bug we're fixing.
+        assert!(
+            !all.contains("\"summary\":") && !all.contains("\"tasks\":"),
+            "raw JSON keys leaked into rendered output: {all}"
+        );
+        // The agent's actual content surfaces in the preview.
+        assert!(
+            all.contains("Scan finished"),
+            "task 1 preview missing: {all}"
+        );
+    }
+
+    #[test]
+    fn wait_task_pretty_survives_gemini_style_tool_id_reuse_across_turns() {
+        // Same id-collision bug class fixed in `transcript.rs` via #1164,
+        // applied to the resumed-history path. Gemini emits per-turn
+        // tool_call_ids (`gemini_tc_1`, …) that reset every assistant
+        // message; the old global pre-pass in `render_history_messages`
+        // would let a later `Read` overwrite an earlier `WaitTask`
+        // mapping, causing the WaitTask result to render as raw JSON
+        // even though the pretty-printer was wired in.
+        //
+        // Shape (mirrors the user-reported pattern):
+        //   T1: assistant calls WaitTask  (id=tc_1) → WaitTask JSON result
+        //   T2: assistant calls Read      (id=tc_1, REUSED) → file body
+        let payload = serde_json::json!({
+            "summary": {"total": 1, "completed": 1},
+            "tasks": [{
+                "task_id": "agent:1",
+                "status": "completed",
+                "agent_name": "explore",
+                "output": "All clear.",
+            }],
+        });
+        let messages = vec![
+            assistant_calling("WaitTask", "tc_1"),
+            tool_result("tc_1", &payload.to_string()),
+            assistant_calling("Read", "tc_1"),
+            tool_result("tc_1", "fn main() {}\n"),
+        ];
+        let lines = render_history_messages(&messages);
+        let all: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+
+        // WaitTask must still pretty-print despite the later Read reusing
+        // the same id.
+        assert!(
+            all.contains("task(s) gathered") && all.contains("agent:1"),
+            "WaitTask pretty render missing despite later id reuse: {all}"
+        );
+        assert!(
+            !all.contains("\"summary\":"),
+            "raw JSON leaked — id-collision bug regressed: {all}"
+        );
+        // Sanity: the later Read result still renders normally.
+        assert!(
+            all.contains("fn main()"),
+            "Read result must still render: {all}"
+        );
     }
 }

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -55,6 +55,7 @@ pub(crate) mod tui_types;
 pub(crate) mod tui_viewport;
 pub(crate) mod tui_wizards;
 pub(crate) mod util;
+pub(crate) mod wait_task_format;
 pub(crate) mod widgets;
 pub(crate) mod wrap_input;
 pub(crate) mod wrap_util;

--- a/koda-cli/src/transcript.rs
+++ b/koda-cli/src/transcript.rs
@@ -502,42 +502,12 @@ fn pretty_bg_task_update(payload: &str) -> Option<String> {
 
 /// Per-task status icon for `WaitTask` pretty-printing. Centralized so
 /// the summary line and per-task headers can't drift.
-fn wait_status_icon(status: &str) -> &'static str {
-    match status {
-        "completed" => "\u{2705}",   // ✅
-        "timed_out" => "\u{23F1}",   // ⏱
-        "cancelled" => "\u{26D4}",   // ⛔
-        "not_found" => "\u{2753}",   // ❓
-        "forbidden" => "\u{1F512}",  // 🔒
-        "parse_error" => "\u{26A0}", // ⚠
-        _ => "\u{2754}",             // ❔
-    }
-}
-
-/// One-line preview of the agent's output for the collapsed `<details>`
-/// summary. Strips markdown noise (headings, blockquotes), collapses
-/// whitespace, truncates with an ellipsis. ~120 chars feels right —
-/// long enough to be informative, short enough not to wrap on most
-/// terminals.
-fn first_meaningful_line(output: &str, max_chars: usize) -> String {
-    for raw in output.lines() {
-        let trimmed = raw
-            .trim()
-            .trim_start_matches('#')
-            .trim_start_matches('>')
-            .trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let collapsed: String = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
-        if collapsed.chars().count() <= max_chars {
-            return collapsed;
-        }
-        let truncated: String = collapsed.chars().take(max_chars).collect();
-        return format!("{truncated}\u{2026}");
-    }
-    String::new()
-}
+///
+/// Re-exported from [`crate::wait_task_format`] so the markdown export,
+/// live TUI ([`crate::tui_render`]), and resumed history
+/// ([`crate::history_render`]) all share one status→glyph table
+/// (#1163-followup-2: pretty WaitTask in the TUI surfaces too).
+use crate::wait_task_format::{first_meaningful_line, wait_status_icon};
 
 /// Pretty-print a `WaitTask` JSON result (#1157) as readable markdown.
 ///
@@ -1738,34 +1708,5 @@ mod tests {
             out.contains("fn main()"),
             "Read result must still render: {out}"
         );
-    }
-
-    #[test]
-    fn first_meaningful_line_strips_markdown_prefixes_and_truncates() {
-        // Unit test for the preview helper — these edge cases would
-        // be tedious to cover via render() integration tests.
-        assert_eq!(
-            first_meaningful_line("### Header\n\nReal content", 50),
-            "Header",
-            "strips markdown heading hashes"
-        );
-        assert_eq!(
-            first_meaningful_line("> blockquote\nbody", 50),
-            "blockquote",
-            "strips blockquote marker"
-        );
-        assert_eq!(
-            first_meaningful_line("   \n\n", 50),
-            "",
-            "all-whitespace input \u{2192} empty preview"
-        );
-        let long = "a".repeat(200);
-        let preview = first_meaningful_line(&long, 50);
-        assert_eq!(
-            preview.chars().count(),
-            51,
-            "truncated preview is max_chars + 1 ellipsis char"
-        );
-        assert!(preview.ends_with('\u{2026}'));
     }
 }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -407,6 +407,20 @@ fn render_tool_output(
         return;
     }
 
+    // WaitTask returns aggregated multi-task JSON (#1157) that's
+    // user-hostile when dumped as a raw escape-soup blob. Pretty-print
+    // it as a per-task summary instead, mirroring the markdown export
+    // (transcript.rs). Falls back to the generic render path on any
+    // parse failure so we never lose the raw content.
+    if name == "WaitTask"
+        && let Some(lines) = crate::wait_task_format::try_render_wait_task_lines(output)
+    {
+        for line in lines {
+            tui_output::emit_line(buffer, line);
+        }
+        return;
+    }
+
     // Collapse consecutive blank lines (3+ → 1) to reduce visual noise,
     // especially from WebFetch HTML-to-text conversion.
     let collapsed = collapse_blank_lines(output);

--- a/koda-cli/src/wait_task_format.rs
+++ b/koda-cli/src/wait_task_format.rs
@@ -1,0 +1,315 @@
+//! Shared formatting primitives for `WaitTask` aggregated results.
+//!
+//! `WaitTask` (#1157) returns a JSON envelope with N sub-task results
+//! (`{tasks: [...], summary: {total, completed, ...}}`). Three rendering
+//! surfaces consume this same payload:
+//!
+//!   1. Markdown export ([`crate::transcript`]) — HTML `<details>` blocks
+//!   2. Live TUI streaming ([`crate::tui_render`]) — ratatui `Span`/`Line`
+//!   3. Resumed history TUI ([`crate::history_render`]) — same as #2
+//!
+//! This module owns the JSON-shape parsing and presentation primitives
+//! (icons, previews) shared by all three surfaces. Each surface owns the
+//! styling/markup appropriate to its medium — markdown wraps in
+//! `<details>`, the TUI emits indented `Line`s with status icons.
+//!
+//! Centralising the icon table and preview helper means a status-set
+//! change (e.g. adding `parse_error`) lights up consistently across all
+//! three renderers in one edit. Pre-#1163-followup these helpers were
+//! duplicated inside `transcript.rs`; the TUI surfaces had no
+//! `WaitTask` awareness at all and dumped raw JSON.
+
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+use crate::tui_output::{BOLD, DIM, TOOL_PREFIX};
+
+/// Per-task status icon. Centralised so the summary line, per-task
+/// header, and resumed-history render can't drift apart. New statuses
+/// added to the engine must land here as well — the catch-all `❔`
+/// makes the omission visible in rendered output rather than failing
+/// silently.
+pub fn wait_status_icon(status: &str) -> &'static str {
+    match status {
+        "completed" => "\u{2705}",   // ✅
+        "timed_out" => "\u{23F1}",   // ⏱
+        "cancelled" => "\u{26D4}",   // ⛔
+        "not_found" => "\u{2753}",   // ❓
+        "forbidden" => "\u{1F512}",  // 🔒
+        "parse_error" => "\u{26A0}", // ⚠
+        _ => "\u{2754}",             // ❔
+    }
+}
+
+/// One-line preview of an agent's output for the collapsed summary
+/// line. Strips markdown noise (heading hashes, blockquote markers),
+/// collapses interior whitespace, truncates with an ellipsis.
+///
+/// 120 chars is the markdown export's preferred width; the TUI uses
+/// shorter limits because terminal columns are scarcer than browser
+/// width. Chars (not bytes) so multibyte content isn't truncated mid
+/// codepoint.
+pub fn first_meaningful_line(output: &str, max_chars: usize) -> String {
+    for raw in output.lines() {
+        let trimmed = raw
+            .trim()
+            .trim_start_matches('#')
+            .trim_start_matches('>')
+            .trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let collapsed: String = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.chars().count() <= max_chars {
+            return collapsed;
+        }
+        let truncated: String = collapsed.chars().take(max_chars).collect();
+        return format!("{truncated}\u{2026}");
+    }
+    String::new()
+}
+
+/// Per-task TUI preview width. Shorter than the markdown export's 120
+/// because terminal columns are shared with the `│` prefix, status
+/// icon, task id, and agent name — anything longer wraps awkwardly.
+const TUI_PREVIEW_CHARS: usize = 80;
+
+/// Render a `WaitTask` JSON payload as styled TUI lines, or `None` on
+/// any parse failure or shape mismatch. Caller falls back to the
+/// generic tool-output render path on `None` — we never want to lose
+/// the raw content when the pretty path can't run.
+///
+/// Output shape (one `│` prefix per line, matching the surrounding
+/// `render_tool_output` convention):
+///
+/// ```text
+///   │ 4 task(s) gathered — ✅ 4 completed
+///   │   ✅ agent:1  explore — The following is a report on the code…
+///   │   ✅ agent:2  explore — I have sufficient information for a…
+///   │   …
+/// ```
+///
+/// Style choices are deliberately conservative: status icon stays
+/// uncoloured (the icon itself carries semantic meaning), task id is
+/// `BOLD` for scanability, agent name is `DIM` (it's contextual, not
+/// the headline), preview stays in default text colour so it stands
+/// out from the prefix chrome.
+pub fn try_render_wait_task_lines(payload: &str) -> Option<Vec<Line<'static>>> {
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let tasks = v.get("tasks")?.as_array()?;
+    if tasks.is_empty() {
+        return None;
+    }
+
+    let summary = v.get("summary").and_then(|s| s.as_object());
+    let count = |k: &str| -> u64 {
+        summary
+            .and_then(|s| s.get(k))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+    let total = summary
+        .and_then(|s| s.get("total"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(tasks.len() as u64);
+
+    // Build the summary suffix in a fixed order so the rendered text is
+    // stable across runs. Zero-count statuses are dropped so a fully
+    // successful gather doesn't render as "✅ 4 completed · ⏱ 0 timed
+    // out · ⛔ 0 cancelled · …".
+    let mut summary_parts: Vec<String> = Vec::new();
+    for (key, label) in [
+        ("completed", "completed"),
+        ("timed_out", "timed out"),
+        ("cancelled", "cancelled"),
+        ("not_found", "not found"),
+        ("forbidden", "forbidden"),
+        ("parse_error", "parse error"),
+    ] {
+        let n = count(key);
+        if n > 0 {
+            summary_parts.push(format!("{} {n} {label}", wait_status_icon(key)));
+        }
+    }
+    let summary_suffix = if summary_parts.is_empty() {
+        String::new()
+    } else {
+        format!(" \u{2014} {}", summary_parts.join(" \u{00B7} "))
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header: "  │ N task(s) gathered — <summary>"
+    lines.push(Line::from(vec![
+        Span::styled("  \u{2502} ", TOOL_PREFIX),
+        Span::styled(format!("{total} task(s) gathered{summary_suffix}"), BOLD),
+    ]));
+
+    // One row per task. We cap output preview to TUI_PREVIEW_CHARS;
+    // longer reports stay reachable via `/export` (full markdown) or
+    // by re-asking the model to summarise.
+    let dim_italic = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::ITALIC);
+
+    for task in tasks {
+        let task_id = task.get("task_id").and_then(|v| v.as_str()).unwrap_or("?");
+        let status = task.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+        let icon = wait_status_icon(status);
+        let agent_name = task
+            .get("agent_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let preview = task
+            .get("output")
+            .and_then(|v| v.as_str())
+            .map(|s| first_meaningful_line(s, TUI_PREVIEW_CHARS))
+            .unwrap_or_default();
+
+        // Spans are pushed conditionally so we don't emit empty
+        // separators when agent_name or preview is missing.
+        let mut spans: Vec<Span<'static>> = vec![
+            Span::styled("  \u{2502} ", TOOL_PREFIX),
+            Span::raw(format!("  {icon} ")),
+            Span::styled(task_id.to_string(), BOLD),
+        ];
+        if !agent_name.is_empty() {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(agent_name.to_string(), DIM));
+        }
+        if !preview.is_empty() {
+            spans.push(Span::raw(" \u{2014} "));
+            spans.push(Span::styled(preview, dim_italic));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    Some(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_covers_known_statuses() {
+        assert_eq!(wait_status_icon("completed"), "\u{2705}");
+        assert_eq!(wait_status_icon("timed_out"), "\u{23F1}");
+        assert_eq!(wait_status_icon("cancelled"), "\u{26D4}");
+        assert_eq!(wait_status_icon("not_found"), "\u{2753}");
+        assert_eq!(wait_status_icon("forbidden"), "\u{1F512}");
+        assert_eq!(wait_status_icon("parse_error"), "\u{26A0}");
+    }
+
+    #[test]
+    fn icon_falls_back_visibly_for_unknown_status() {
+        // The fallback must be a glyph (not empty/space) so a future
+        // status added to the engine without updating this table is
+        // visible in rendered output.
+        let icon = wait_status_icon("brand_new_status");
+        assert!(!icon.is_empty());
+        assert_ne!(icon, " ");
+    }
+
+    #[test]
+    fn first_meaningful_line_strips_markdown_and_truncates() {
+        assert_eq!(
+            first_meaningful_line("### Header\n\nReal content", 50),
+            "Header"
+        );
+        assert_eq!(
+            first_meaningful_line("> blockquote intro\nrest", 50),
+            "blockquote intro"
+        );
+        // Truncation appends ellipsis (single Unicode char, not "...").
+        let long = "a".repeat(200);
+        let out = first_meaningful_line(&long, 10);
+        assert!(out.ends_with('\u{2026}'), "expected ellipsis: {out}");
+        assert_eq!(out.chars().count(), 11); // 10 + ellipsis
+    }
+
+    #[test]
+    fn first_meaningful_line_collapses_interior_whitespace() {
+        // Real LLM output often has tabs / multiple spaces inside a line.
+        // The preview should read as one continuous sentence.
+        assert_eq!(first_meaningful_line("foo   bar\tbaz", 50), "foo bar baz");
+    }
+
+    #[test]
+    fn try_render_returns_none_on_garbage() {
+        assert!(try_render_wait_task_lines("{not json").is_none());
+        assert!(try_render_wait_task_lines("\"a string\"").is_none());
+        assert!(try_render_wait_task_lines("null").is_none());
+    }
+
+    #[test]
+    fn try_render_returns_none_on_missing_tasks() {
+        // Missing or empty tasks → fall back to generic renderer rather
+        // than emit an empty pretty block (which would silently swallow
+        // a structurally-broken payload).
+        assert!(try_render_wait_task_lines(r#"{"summary":{}}"#).is_none());
+        assert!(try_render_wait_task_lines(r#"{"tasks":[]}"#).is_none());
+    }
+
+    #[test]
+    fn try_render_emits_header_plus_one_line_per_task() {
+        let payload = serde_json::json!({
+            "summary": {"total": 2, "completed": 2},
+            "tasks": [
+                {"task_id": "agent:1", "status": "completed", "agent_name": "explore",
+                 "output": "Found 3 issues in the parser."},
+                {"task_id": "agent:2", "status": "completed", "agent_name": "explore",
+                 "output": "All clear in the renderer."},
+            ],
+        });
+        let lines = try_render_wait_task_lines(&payload.to_string()).expect("renders");
+        assert_eq!(lines.len(), 3, "header + 2 task rows: {lines:?}");
+
+        let line_text =
+            |i: usize| -> String { lines[i].spans.iter().map(|s| s.content.as_ref()).collect() };
+        assert!(line_text(0).contains("2 task(s) gathered"));
+        assert!(line_text(0).contains("\u{2705} 2 completed"));
+        assert!(line_text(1).contains("agent:1") && line_text(1).contains("Found 3 issues"));
+        assert!(line_text(2).contains("agent:2") && line_text(2).contains("All clear"));
+    }
+
+    #[test]
+    fn try_render_uses_distinct_icons_for_mixed_statuses() {
+        let payload = serde_json::json!({
+            "summary": {"total": 3, "completed": 1, "timed_out": 1, "cancelled": 1},
+            "tasks": [
+                {"task_id": "agent:1", "status": "completed", "agent_name": "explore",
+                 "output": "OK."},
+                {"task_id": "agent:2", "status": "timed_out", "agent_name": "explore"},
+                {"task_id": "agent:3", "status": "cancelled", "agent_name": "explore"},
+            ],
+        });
+        let lines = try_render_wait_task_lines(&payload.to_string()).expect("renders");
+        let all: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(all.contains("\u{2705}"), "completed icon present: {all}");
+        assert!(all.contains("\u{23F1}"), "timed_out icon present: {all}");
+        assert!(all.contains("\u{26D4}"), "cancelled icon present: {all}");
+    }
+
+    #[test]
+    fn try_render_omits_optional_fields_cleanly() {
+        // Missing agent_name and missing output should NOT produce
+        // dangling separators ("  — " with nothing after).
+        let payload = serde_json::json!({
+            "summary": {"total": 1, "completed": 1},
+            "tasks": [
+                {"task_id": "agent:1", "status": "completed"},
+            ],
+        });
+        let lines = try_render_wait_task_lines(&payload.to_string()).expect("renders");
+        let row: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(!row.contains("\u{2014} "), "no dangling em-dash: {row}");
+        assert!(row.contains("agent:1"), "task id still present: {row}");
+    }
+}


### PR DESCRIPTION
## Bug

PR #1162 added a WaitTask pretty-printer for the **markdown export**; #1164 fixed the id-collision bug that was masking it on Gemini sessions. But the **live TUI tool-output panel** and the **resumed-history TUI render** both had no WaitTask awareness at all and dumped raw JSON. User report: session `koda-20260430-152051` still showed escape-soup blob despite both prior fixes being merged.

**Three render surfaces, three states before this fix:**

| Surface | Code path | Pretty WaitTask? |
|---|---|---|
| 📄 Markdown export | `transcript.rs::pretty_wait_task_output` | ✅ #1162 + #1164 |
| 🎨 Live TUI streaming | `tui_render.rs::render_tool_output` | ❌ raw JSON dump |
| 📋 Resumed history | `history_render.rs::render_tool_result` | ❌ raw JSON dump |

After this fix, all three share the same per-task summary rendering.

## Architecture

Extracted shared formatting primitives to a new module `koda-cli/src/wait_task_format.rs`:

- `wait_status_icon(status) -> &'static str` — status → emoji table
- `first_meaningful_line(output, max_chars) -> String` — markdown-stripped one-line preview
- `try_render_wait_task_lines(payload) -> Option<Vec<Line<'static>>>` — the new TUI-flavored renderer

`transcript.rs` now imports `wait_status_icon` and `first_meaningful_line` from the shared module instead of duplicating them. (The transcript path still owns its own HTML `<details>` markup since markdown and TUI use different output media — but the *primitives* are shared, so a status-set change in one place lights up everywhere.)

`tui_render::render_tool_output` (live streaming path) gets a top-level `if name == "WaitTask"` early-return branch that calls the shared renderer and emits the resulting Lines.

`history_render::render_tool_result` (resume path) gets the same branch.

## Bonus fix: id-collision bug in history_render.rs

`render_history_messages` had the **same pre-pass id-collision bug** that #1164 fixed in `transcript.rs`. Gemini emits per-turn tool_call_ids that reset on every assistant message, so a global last-write-wins pre-pass would silently overwrite an earlier turn's WaitTask mapping with a later turn's Read — causing the WaitTask result to skip the (now-wired) pretty-printer and dump raw JSON on session resume.

Same fix as #1164: populate `tool_id_to_name` incrementally during the render walk's Assistant branch instead of a separate pre-pass. Each Tool message now sees the rolling map state as of its position in the transcript, which always reflects the most-recent prior Assistant tool_calls block.

## Visual before/after

**Before (live TUI):**
```
● WaitTask │ {"summary":{"completed":4,"total":4},"tasks":[{"agent_name":"explore"…
```

**After (live TUI):**
```
● WaitTask
  │ 4 task(s) gathered — ✅ 4 completed
  │   ✅ agent:1  explore — The following is a report on the code search and…
  │   ✅ agent:2  explore — I have sufficient information for a comprehensive…
  │   ✅ agent:3  explore — I have completed the scan of `koda-core/src/tools/`…
  │   ✅ agent:4  explore — I have completed the scan of `koda-cli/src/`…
```

## Tests

- **9 new tests** in `wait_task_format::tests`:
  - `icon_covers_known_statuses` / `icon_falls_back_visibly_for_unknown_status`
  - `first_meaningful_line_strips_markdown_and_truncates`
  - `first_meaningful_line_collapses_interior_whitespace`
  - `try_render_returns_none_on_garbage` / `try_render_returns_none_on_missing_tasks` (defensive)
  - `try_render_emits_header_plus_one_line_per_task`
  - `try_render_uses_distinct_icons_for_mixed_statuses`
  - `try_render_omits_optional_fields_cleanly`
- **2 new tests** in `history_render::tests`:
  - `wait_task_result_renders_as_per_task_summary_not_raw_json` — pins the WaitTask wiring on the resume surface
  - `wait_task_pretty_survives_gemini_style_tool_id_reuse_across_turns` — mirrors #1164's regression
- Removed the now-redundant `first_meaningful_line` test in `transcript.rs` (exhaustively covered in the new module — DRY for tests too).

**Full `koda-cli` lib suite: 520 passed (+10 net), 0 failed. Clippy clean. Fmt clean.**

## Related

- #1162 — WaitTask pretty-printer (markdown export only; this PR extends it to TUI)
- #1164 — `tool_id_to_name` id-collision fix (transcript only; this PR applies the same defense to history_render)
- #1163 — the parked RFC about InvokeAgent return-shape; this PR closes the WaitTask half of the surface-symmetry discussion
