### PR TITLE
chore: release v0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.25] - 2026-04-30
+
+Background-tasks UX release. 5 PRs since v0.2.24 reshape `WaitTask` into
+an atomic multi-task gather (#1161), polish the multi-sub-agent UX with
+a status-bar pill and verbose-export escape hatch (#1160), and fix
+three user-reported rendering regressions where multi-task `WaitTask`
+results dumped raw JSON instead of pretty-printed per-task summaries
+(#1162, #1164, #1165). The shared formatter primitives now live in a
+single `wait_task_format` module so the live TUI, resumed history, and
+`/export` transcript all render identically.
+
+### Behaviour change — `WaitTask` schema is now multi-task
+
+- **`WaitTask` request shape changed** from `{"task_id": "agent:1"}`
+  to `{"task_ids": ["agent:1", "agent:2", ...]}` (#1157, PR #1161).
+  The response shape changed correspondingly to a `{tasks: [...],
+  summary: {...}}` envelope with per-task `status` and error
+  isolation — a failure in one task no longer fails the whole call.
+  This is **breaking for any system prompt, skill, or external
+  agent that hardcoded the v0.2.24 single-task shape**. Single-task
+  waits still work; the array just has length 1. Full schema and
+  migration notes in [tools.md](./docs/src/tools.md#waittask).
+
+### Behaviour change — sub-agent "started" message format
+
+- **Sub-agent started messages now use `agent:N` instead of `task N`**
+  (#1158, PR #1160). The model uses these IDs as-is when constructing
+  `WaitTask({task_ids: ["agent:1"]})` calls, so the prefix matches
+  what `WaitTask` consumes. This is observable in the transcript and
+  in the LLM-facing dispatch result string.
+
+### Added
+
+- **Atomic multi-task `WaitTask`** (#1157, PR #1161). One tool call
+  can now gather results for any number of background tasks in
+  parallel, with per-task timeout, per-task error isolation, and a
+  summary tally (success / failed / timeout / cancelled / forbidden
+  / not_found). Replaces the previous one-task-at-a-time wait pattern
+  that forced the model to round-trip per task.
+- **Multi-sub-agent UX polish** (#1158, PR #1160). New status-bar pill
+  shows live counts of running/waiting background agents at a glance.
+  Per-iteration heartbeat lines (`Running (Nx)`) are now suppressed
+  in `/export` output by default, focusing transcripts on terminal
+  task outcomes. Set `KODA_EXPORT_VERBOSE=1` to restore the old
+  verbose behaviour when debugging heartbeat aggregation — see
+  [configuration.md](./docs/src/configuration.md#display).
+- **`### WaitTask` reference subsection in `tools.md`** documenting
+  the new request/response schema, per-task status values, error
+  isolation semantics, and v0.2.24 → v0.2.25 migration. Promotes
+  what was previously only in the model-facing tool description into
+  the user-facing reference.
+- **Shared `wait_task_format` module** (#1163 follow-up, PR #1165).
+  Three render surfaces (live TUI, resumed history, transcript export)
+  now share a single source of truth for status icons, preview-line
+  extraction, and per-task summary formatting. Future status values
+  added to one place light up everywhere automatically.
+
+### Fixed
+
+- **`WaitTask` multi-task results no longer render as raw JSON**
+  (#1157 follow-up, PR #1162). The transcript exporter previously
+  dumped the entire `{tasks: [...], summary: {...}}` envelope
+  verbatim instead of pretty-printing per-task summaries. Now
+  renders as a structured per-task list with status icons, agent
+  names, and preview lines.
+- **`tool_id_to_name` mapping survives Gemini's per-turn tool ID
+  reuse** (#1164). Gemini reuses the same tool_call_id across
+  multiple turns within a session, which collided with the
+  exporter's id→name map and caused later turns to mis-render the
+  tool name. The map is now built incrementally per-turn rather
+  than session-wide.
+- **Live TUI and resumed history render `WaitTask` identically to
+  `/export`** (#1163 follow-up-2, PR #1165). Two more rendering
+  surfaces had been dumping raw JSON; both now route through the
+  shared `wait_task_format::try_render_wait_task_lines` primitive
+  introduced in this release. The same id-collision fix from
+  #1164 was applied to `history_render` so resumed sessions also
+  benefit.
+
 ## [0.2.24] - 2026-04-29
 
 Reliability + observability release. 10 commits since v0.2.23 covering:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.24)
+10. Sync version with workspace (currently 0.2.25)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -63,6 +63,7 @@ leak escape bytes, etc.).
 |---------|---------|--------------|
 | `KODA_SYNTAX_HIGHLIGHT` | on | `off`, `0`, `false`, or `no` |
 | `KODA_TRANSCRIPT_HYPERLINKS` | on | `off`, `0`, `false`, or `no` |
+| `KODA_EXPORT_VERBOSE` | off | (set to `1`, `true`, `yes`, or `on` to enable) |
 
 - **`KODA_SYNTAX_HIGHLIGHT`** controls TUI syntax highlighting for
   `Read`, `Bash` headers, and inline code. Disable for monochrome
@@ -71,6 +72,11 @@ leak escape bytes, etc.).
 - **`KODA_TRANSCRIPT_HYPERLINKS`** controls markdown-style hyperlinks
   in `/copy` and `/export` output. Disable if you paste transcripts
   into a viewer that mangles `[text](file:///abs/path)` syntax.
+- **`KODA_EXPORT_VERBOSE`** restores per-iteration sub-agent
+  heartbeat lines (`Running (Nx)`) in `/export` output. Off by
+  default (since v0.2.25) so transcripts focus on terminal task
+  outcomes; enable when debugging heartbeat aggregation or
+  long-running sub-agents that never seem to terminate.
 
 Both flags accept the same negative values; everything else (including
 empty string and `on`) keeps the feature enabled.

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -46,3 +46,58 @@ within the project sandbox are auto-approved.
 | Outside-project write | Write/Edit to paths outside project root | ❌ Deny | ⏸ Prompt | ⏸ Prompt |
 
 See [Trust modes](./approval.md) for the canonical policy matrix.
+
+## WaitTask
+
+`WaitTask` blocks until one or more background tasks (sub-agents or
+shell processes) finish. As of v0.2.25 it is an **atomic multi-task
+gather**: pass an array of task IDs and get back results for all of
+them in a single tool call, with per-task error isolation.
+
+### Request shape
+
+```json
+{
+  "task_ids": ["agent:1", "agent:2", "sh:7"]
+}
+```
+
+- `task_ids` (required): array of strings. Each ID comes from the
+  "started" message printed by `InvokeAgent` (e.g. `agent:1`) or by
+  `Bash` when run in the background (e.g. `sh:7`).
+- One ID per task; duplicates are deduplicated.
+- Per-task budget is **300 seconds** (5 minutes). The budget is
+  per-task, not per-call: gathering 4 tasks does not give you 1200 s.
+
+### Response shape
+
+```json
+{
+  "tasks": [
+    {"task_id": "agent:1", "status": "success", "result": {...}},
+    {"task_id": "agent:2", "status": "failed",  "error": "..."},
+    {"task_id": "sh:7",     "status": "timeout"}
+  ],
+  "summary": {
+    "total": 3, "success": 1, "failed": 1, "timeout": 1,
+    "cancelled": 0, "forbidden": 0, "not_found": 0
+  }
+}
+```
+
+Per-task `status` is one of: `success`, `failed`, `timeout`,
+`cancelled`, `forbidden` (caller does not own the task), or
+`not_found` (typo or already-reaped task).
+
+### Error isolation
+
+A failure in one task does **not** fail the whole call. The model can
+inspect the `summary` block to decide what to retry. This is the
+breaking change from v0.2.24, where `WaitTask` accepted a single
+`task_id` and returned the bare result envelope.
+
+### Migration from v0.2.24
+
+Any prompt or skill that hardcoded `{"task_id": "agent:1"}` must be
+updated to `{"task_ids": ["agent:1"]}`. Single-task waits still work
+— the array just has length 1.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -14,7 +14,7 @@ Each crash appends a delimited block:
 ```
 ======================================================================
 [2026-04-29T20:55:32Z] PANIC
-version:    koda 0.2.24
+version:    koda 0.2.25
 location:   koda-core/src/foo.rs:42:8
 thread:     <unnamed>
 message:    assertion failed: x > 0

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.24"
+version = "0.2.25"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.24" }
+koda-core = { path = "../koda-core", version = "0.2.25" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -75,7 +75,7 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.24", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.25", features = ["test-support"] }
 serde_json = { workspace = true }
 # tokio's `test-util` feature enables `#[tokio::test(start_paused = true)]` so
 # frame_requester tests can manipulate the clock deterministically without

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.24"
+version = "0.2.25"
 edition.workspace = true
 rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.24" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.25" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -474,7 +474,7 @@ async fn execute_wait(
     let task_results: Vec<Value> = futures_util::future::join_all(futures).await;
 
     // Roll up status counts so the model can branch on "all done" /
-    // "some still running" without re-iterang the array. Tally
+    // "some still running" without re-iterating the array. Tally
     // every status string we emit — missing keys default to 0 in
     // JSON consumers so we don't bother with a fixed schema.
     let mut summary = serde_json::Map::new();

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.24"
+version = "0.2.25"
 edition.workspace = true
 rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"


### PR DESCRIPTION
Background-tasks UX release. v0.2.24 → v0.2.25.

## Headline

5 PRs since v0.2.24 reshape `WaitTask` into an atomic multi-task gather, polish the multi-sub-agent UX, and fix three rendering surfaces that had been dumping raw JSON for multi-task results. Net code delta in this release window: feature work landed across 13 files; renderer divergence between live TUI / resumed history / `/export` collapsed onto a single shared `wait_task_format` module.

## Included PRs

- **#1160** — feat: multi-sub-agent UX polish (status-bar pill, `KODA_EXPORT_VERBOSE`, `agent:N` naming)
- **#1161** — feat(bg-tasks): rewrite `WaitTask` as atomic multi-task gather (#1157)
- **#1162** — fix(transcript): pretty-print `WaitTask` multi-task results
- **#1164** — fix(transcript): build `tool_id_to_name` incrementally to survive Gemini per-turn id reuse
- **#1165** — fix(tui): pretty-print `WaitTask` in live TUI + resumed history (#1163 follow-up-2)

## ⚠️ Breaking changes (model-facing, not Rust)

- **`WaitTask` request schema** — `{"task_id": "agent:1"}` → `{"task_ids": ["agent:1", ...]}`. Single-task waits still work (array of length 1). Any system prompt, skill, or external agent that hardcoded the v0.2.24 single-task shape needs updating. Full migration in [tools.md § WaitTask](./docs/src/tools.md#waittask).
- **Sub-agent started-message format** — `task N` → `agent:N`. The model uses these IDs to construct subsequent `WaitTask` calls, so this matches the new `WaitTask` consumer.

Rust public API surface is **strictly additive** (4 new `pub fn` in `koda-cli`, zero removals, zero signature changes on existing `pub` items) — patch bump (`0.2.24 → 0.2.25`) is semver-correct under cargo's 0.x rules.

## Mechanical bumps

| Crate | From | To |
|---|---|---|
| `koda-core` | 0.2.24 | 0.2.25 |
| `koda-cli` | 0.2.24 | 0.2.25 (+ 2 internal path-dep pins) |
| `koda-sandbox` | 0.2.24 | 0.2.25 (+ 1 internal path-dep pin) |
| `koda-test-utils` | 0.1.0 | (unchanged, `publish = false`) |
| `Cargo.lock` | regenerated | ✅ |

## Documentation

- `CHANGELOG.md` — `[Unreleased]` section was empty despite 5 merged PRs (the v0.2.22 SEC-002 scenario the koda-release skill explicitly warns about). Reconciled from commit history per the skill's mandatory pre-flight rule.
- `CLAUDE.md` — version reference bumped.
- `docs/src/troubleshooting.md` — example output bumped.
- `docs/src/configuration.md` — documented `KODA_EXPORT_VERBOSE` escape hatch (was source-comment-only — flagged as P2 by code-reviewer).
- `docs/src/tools.md` — promoted `WaitTask` from one-line table row to a full `### WaitTask` subsection covering schema, status values, error isolation, and migration (flagged as P2 by code-reviewer).

## Polish

- `koda-core/src/tools/bg_task_tools.rs:477` — typo `re-iterang` → `re-iterating` (caught by code-reviewer agent).

## Audit summary

All 4 release-prep audit agents converged on a clean release. Pre-flight verification (the audit-dust prevention rules) caught zero false positives this cycle.

| Agent | P1 | P2 | P3-bundle | Status |
|---|---|---|---|---|
| code-reviewer | 0 | 4 | 2 | All P2 addressed in this PR |
| rust-programmer | 0 | 3 | 3 | All P2 addressed in this PR |
| security-auditor | 0 | 0 | 3 | Sandbox surface byte-identical to v0.2.24, `cargo audit` clean |
| qa-expert | 0 | 2 | 2 | Changelog addressed; provider smoke is a pre-tag manual step |

P3-bundle items will be filed as a single tracking issue per the audit-dust prevention rule (skill Phase 4 step 5) — see "Deferred items" below once filed.

## Quality gates (verified locally on macOS)

- ✅ `cargo fmt --all --check`
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings`
- ✅ `cargo test --workspace --features koda-core/test-support` — **2297 passed, 0 failed, 14 ignored** (intentional: 12 curl/network E2E + 2 manual prompt-sizer)
- ✅ `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- ✅ `scripts/check_tokio_test_flavor.py` (#1109 F2 guard)
- ✅ `cargo audit --deny unsound --deny yanked` (483 deps scanned)

## Pre-tag manual smoke checklist (qa-expert P2)

Before merging + tagging, run a 5-min smoke per provider against the new `WaitTask` schema:

- [ ] Spawn 4× `InvokeAgent` in parallel, then `WaitTask({task_ids: ["agent:1", "agent:2", "agent:3", "agent:4"]})`
- [ ] Verify: one tool_call returns all 4 results, no synthetic-user-message tool_results inject afterward, `summary` block present
- [ ] Run on **claude-sonnet-4-6** (or current Anthropic flagship)
- [ ] Run on **gemini-2.x** (id-collision regression #1164 specifically affected this provider)
- [ ] Run on **gpt-4-class** (or current OpenAI-compat)
- [ ] Live TUI + resumed history + transcript export all render the multi-task results identically

## Cut by

The koda-release skill (https://github.com/lijunzh/koda/issues — see `.wibey/skills/koda-release` if curious about the workflow).

### Deferred items (tracked)

- [ ] **#1169** — Bundle: v0.2.25 release-time polish (consolidates 7 P3 audit findings: 1 metadata, 1 lint sweep, 1 SECURITY.md placeholder, 2 cargo-audit CI tweaks, 1 tui_render wiring test, 1 release-PR template)