### PR TITLE
feat(debug-bundle): /debug-bundle slash command writing .zip artifacts (RFC #1167 PR α)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
-- **`/debug-bundle` slash command** — writes a self-contained `.tar.gz`
+- **`/debug-bundle` slash command** — writes a self-contained `.zip`
   to `~/.config/koda/debug-bundles/` capturing everything a debugger
   (human or LLM) needs to reason about a session: `conversation.md`
   (rendered via `history_render` — same as the live TUI),
   `messages.json` (raw DB rows), `metadata.json` (session/runtime
   context), `env.txt` (allowlist-filtered env vars, credentials
   length-redacted), and `logs/` (full per-process tracing log + panic
-  log if any). Lives in parallel with `/export`; future PRs unify them
-  per RFC #1167. (#1167 — PR α)
+  log if any). Format chosen for random-access reads (LLM debugging
+  poke-one-file workflows are O(file) instead of O(bundle)) and broad
+  cross-platform UX. Lives in parallel with `/export`; future PRs
+  unify them per RFC #1167. (#1167 — PR α)
 
 ## [0.2.25] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **`/debug-bundle` slash command** — writes a self-contained `.tar.gz`
+  to `~/.config/koda/debug-bundles/` capturing everything a debugger
+  (human or LLM) needs to reason about a session: `conversation.md`
+  (rendered via `history_render` — same as the live TUI),
+  `messages.json` (raw DB rows), `metadata.json` (session/runtime
+  context), `env.txt` (allowlist-filtered env vars, credentials
+  length-redacted), and `logs/` (full per-process tracing log + panic
+  log if any). Lives in parallel with `/export`; future PRs unify them
+  per RFC #1167. (#1167 — PR α)
+
 ## [0.2.25] - 2026-04-30
 
 Background-tasks UX release. 5 PRs since v0.2.24 reshape `WaitTask` into

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +760,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,17 +962,6 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1731,7 +1740,6 @@ dependencies = [
  "base64",
  "clap",
  "crossterm",
- "flate2",
  "futures-util",
  "koda-core",
  "ratatui",
@@ -1740,7 +1748,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "syntect",
- "tar",
  "tempfile",
  "time",
  "tokio",
@@ -1750,6 +1757,7 @@ dependencies = [
  "tracing-subscriber",
  "two-face",
  "unicode-width",
+ "zip",
 ]
 
 [[package]]
@@ -1840,18 +1848,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2239,7 +2235,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2368,12 +2364,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -2705,15 +2695,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3564,17 +3545,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -4802,16 +4772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4915,10 +4875,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1731,7 @@ dependencies = [
  "base64",
  "clap",
  "crossterm",
+ "flate2",
  "futures-util",
  "koda-core",
  "ratatui",
@@ -1728,6 +1740,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "syntect",
+ "tar",
  "tempfile",
  "time",
  "tokio",
@@ -1827,6 +1840,18 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2214,7 +2239,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2343,6 +2368,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -2674,6 +2705,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3524,6 +3564,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4749,6 +4800,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -45,10 +45,13 @@ unicode-width = "0.2"
 # Clipboard (for Ctrl+Y copy)
 arboard = "3"
 
-# Debug bundle: tar.gz packaging for /debug-bundle slash command (RFC #1167).
-# tar streams the bundle directory; flate2 wraps the tar writer in gzip.
-tar = "0.4"
-flate2 = "1"
+# Debug bundle: zip packaging for /debug-bundle slash command (RFC #1167).
+# Chosen over tar.gz for random-access reads (LLM debugging workflows poke
+# at one file at a time; zip's central directory makes that O(file) instead
+# of O(bundle)) and broader cross-platform UX (Windows Explorer browses zips
+# natively). `default-features = false` + `deflate` keeps the dep minimal
+# (no aes-crypto, bzip2, zstd, lzma).
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # ANSI escape code parsing for tool output
 ansi-to-tui = "8"

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -45,6 +45,11 @@ unicode-width = "0.2"
 # Clipboard (for Ctrl+Y copy)
 arboard = "3"
 
+# Debug bundle: tar.gz packaging for /debug-bundle slash command (RFC #1167).
+# tar streams the bundle directory; flate2 wraps the tar writer in gzip.
+tar = "0.4"
+flate2 = "1"
+
 # ANSI escape code parsing for tool output
 ansi-to-tui = "8"
 

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -32,6 +32,11 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
         "Copy last response to clipboard (/copy 2 for 2nd-last)",
         Some("[n]"),
     ),
+    (
+        "/debug-bundle",
+        "Write a self-contained debug .tar.gz to ~/.config/koda/debug-bundles/",
+        None,
+    ),
     ("/diff", "Show git diff (review, commit)", None),
     ("/exit", "Quit the session", None),
     ("/expand", "Show full output of last tool call", None),

--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -34,7 +34,7 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
     ),
     (
         "/debug-bundle",
-        "Write a self-contained debug .tar.gz to ~/.config/koda/debug-bundles/",
+        "Write a self-contained debug .zip to ~/.config/koda/debug-bundles/",
         None,
     ),
     ("/diff", "Show git diff (review, commit)", None),

--- a/koda-cli/src/debug_bundle/env_filter.rs
+++ b/koda-cli/src/debug_bundle/env_filter.rs
@@ -1,0 +1,288 @@
+//! Environment variable filter for debug bundles.
+//!
+//! Applies a hardcoded **allowlist** to `std::env::vars()`. Per RFC #1167
+//! decision D5, there is intentionally **no runtime opt-in** to expose more
+//! variables — to add a new variable, edit the source allowlist and rebuild.
+//!
+//! Three categories:
+//!
+//! - **Allowlisted verbatim** ([`ALLOWLISTED_PREFIXES`] / [`ALLOWLISTED_NAMES`]):
+//!   value is captured as-is. These are koda-internal config (`KODA_*`),
+//!   Rust runtime (`RUST_*`), or terminal/locale knobs whose values are
+//!   never sensitive.
+//!
+//! - **Tracked but value-redacted** ([`REDACT_NAMES`]): we record presence
+//!   and length but not the value. "Is `OPENAI_API_KEY` set?" is often the
+//!   debug question; the actual value is a credential leak waiting to happen.
+//!
+//! - **Everything else**: omitted entirely. This is the safe-by-default
+//!   posture — a future env var with a sensitive name we didn't anticipate
+//!   leaks under denylist but stays redacted under allowlist.
+//!
+//! ## Rationale (from RFC #1167 §D5)
+//!
+//! > Allowlist > denylist for safety: a future env var with a sensitive name
+//! > we didn't anticipate leaks by default under denylist, stays redacted
+//! > under allowlist.
+//!
+//! > No `KODA_DEBUG_BUNDLE_INCLUDE_ENV` runtime opt-in. We own the solution
+//! > and can change source when needed. Minimal runtime config = less
+//! > surface area, less to document, less to test, no foot-guns from users
+//! > opting into leaking their own credentials.
+
+use std::collections::BTreeMap;
+
+/// Names whose **value** is captured verbatim. These are non-sensitive
+/// runtime/terminal/locale knobs.
+pub(super) const ALLOWLISTED_NAMES: &[&str] = &[
+    "TERM",
+    "COLORTERM",
+    "LANG",
+    "SHELL",
+    "EDITOR",
+    "PAGER",
+    "VISUAL",
+    "TZ",
+    "TMPDIR",
+];
+
+/// Prefixes whose **value** is captured verbatim. Anything starting with
+/// these prefixes is included in full.
+pub(super) const ALLOWLISTED_PREFIXES: &[&str] = &[
+    "KODA_", "RUST_", "LC_", // locale categories: LC_ALL, LC_CTYPE, LC_NUMERIC, etc.
+];
+
+/// Names whose **presence and length** are recorded but value is replaced
+/// with `<redacted: N bytes>`. Knowing whether these are set is often the
+/// debug question; the actual value is a credential.
+pub(super) const REDACT_NAMES: &[&str] = &[
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "ELEMENT_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "https_proxy",
+    "http_proxy",
+];
+
+/// Filter an iterator of `(name, value)` pairs through the allowlist.
+///
+/// Returns a `BTreeMap` (sorted output is reproducible across runs, which
+/// makes diffing two bundles meaningful). Names that match neither the
+/// allowlist nor the redact list are dropped entirely.
+///
+/// # Examples
+///
+/// See the unit tests at the bottom of this file for canonical inputs.
+pub(super) fn filter<I, K, V>(vars: I) -> BTreeMap<String, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut out = BTreeMap::new();
+    for (name, value) in vars {
+        let name_ref = name.as_ref();
+        let value_ref = value.as_ref();
+        if let Some(rendered) = classify(name_ref, value_ref) {
+            out.insert(name_ref.to_string(), rendered);
+        }
+    }
+    out
+}
+
+/// Decide what to record for a single env var, or `None` to drop it.
+///
+/// Separated from [`filter`] so it's directly testable without building
+/// an iterator.
+fn classify(name: &str, value: &str) -> Option<String> {
+    if REDACT_NAMES.contains(&name) {
+        return Some(format!("<redacted: {} bytes>", value.len()));
+    }
+    if ALLOWLISTED_NAMES.contains(&name) {
+        return Some(value.to_string());
+    }
+    if ALLOWLISTED_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+    {
+        return Some(value.to_string());
+    }
+    None
+}
+
+/// Render the filtered map to a deterministic `KEY=VALUE\n` text format
+/// suitable for direct inclusion in `env.txt`. Lines are sorted by key
+/// (BTreeMap iteration order) so two bundles diff cleanly.
+pub(super) fn render(filtered: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+    for (key, value) in filtered {
+        out.push_str(key);
+        out.push('=');
+        out.push_str(value);
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn koda_prefix_passes_through_verbatim() {
+        let result = filter([("KODA_RENDER", "inline"), ("KODA_LOG", "debug")]);
+        assert_eq!(result.get("KODA_RENDER"), Some(&"inline".to_string()));
+        assert_eq!(result.get("KODA_LOG"), Some(&"debug".to_string()));
+    }
+
+    #[test]
+    fn rust_prefix_passes_through_verbatim() {
+        let result = filter([("RUST_BACKTRACE", "1"), ("RUST_LOG", "trace")]);
+        assert_eq!(result.get("RUST_BACKTRACE"), Some(&"1".to_string()));
+        assert_eq!(result.get("RUST_LOG"), Some(&"trace".to_string()));
+    }
+
+    #[test]
+    fn lc_prefix_passes_through_verbatim() {
+        let result = filter([("LC_ALL", "en_US.UTF-8"), ("LC_CTYPE", "C")]);
+        assert_eq!(result.get("LC_ALL"), Some(&"en_US.UTF-8".to_string()));
+        assert_eq!(result.get("LC_CTYPE"), Some(&"C".to_string()));
+    }
+
+    #[test]
+    fn explicit_allowlist_names_pass_through() {
+        let result = filter([
+            ("TERM", "xterm-256color"),
+            ("LANG", "en_US.UTF-8"),
+            ("EDITOR", "vim"),
+            ("SHELL", "/bin/zsh"),
+        ]);
+        assert_eq!(result.get("TERM"), Some(&"xterm-256color".to_string()));
+        assert_eq!(result.get("LANG"), Some(&"en_US.UTF-8".to_string()));
+        assert_eq!(result.get("EDITOR"), Some(&"vim".to_string()));
+        assert_eq!(result.get("SHELL"), Some(&"/bin/zsh".to_string()));
+    }
+
+    #[test]
+    fn redact_names_keep_length_drop_value() {
+        let result = filter([
+            ("OPENAI_API_KEY", "sk-proj-abcdef1234567"), // 21 bytes (counted explicitly)
+            ("ANTHROPIC_API_KEY", "sk-ant-api03-xyz"),   // 16 bytes
+            ("GITHUB_TOKEN", "ghp_aaa"),                 //  7 bytes
+        ]);
+        assert_eq!(
+            result.get("OPENAI_API_KEY"),
+            Some(&"<redacted: 21 bytes>".to_string()),
+            "value bytes leaked: check format string"
+        );
+        assert_eq!(
+            result.get("ANTHROPIC_API_KEY"),
+            Some(&"<redacted: 16 bytes>".to_string())
+        );
+        assert_eq!(
+            result.get("GITHUB_TOKEN"),
+            Some(&"<redacted: 7 bytes>".to_string())
+        );
+    }
+
+    #[test]
+    fn proxy_vars_redacted_both_cases() {
+        // Some envs use lowercase http_proxy; we cover both because real
+        // user setups vary (curl reads lowercase, most tools read uppercase).
+        let result = filter([
+            ("HTTPS_PROXY", "http://user:pass@proxy.example.com:8080"),
+            ("http_proxy", "http://internal.example.com:3128"),
+        ]);
+        assert!(result.get("HTTPS_PROXY").unwrap().starts_with("<redacted:"));
+        assert!(result.get("http_proxy").unwrap().starts_with("<redacted:"));
+    }
+
+    #[test]
+    fn pii_corp_id_dropped_entirely() {
+        // HOME, USER, PWD all contain corp ID at Walmart and shouldn't
+        // appear in a bundle that might be shared cross-team or with
+        // an external LLM for debugging.
+        let result = filter([
+            ("HOME", "/Users/l0z05rg"),
+            ("USER", "l0z05rg"),
+            ("PWD", "/Users/l0z05rg/repo/koda"),
+            ("LOGNAME", "l0z05rg"),
+        ]);
+        assert!(!result.contains_key("HOME"), "HOME leaked corp ID");
+        assert!(!result.contains_key("USER"), "USER leaked corp ID");
+        assert!(!result.contains_key("PWD"), "PWD leaked corp ID");
+        assert!(!result.contains_key("LOGNAME"), "LOGNAME leaked corp ID");
+    }
+
+    #[test]
+    fn unknown_var_with_credential_in_value_dropped_by_default() {
+        // The whole point of allowlist > denylist: a future variable name
+        // we never anticipated stays out of the bundle even when its
+        // value looks credential-like.
+        let result = filter([
+            ("FUTURE_API_KEY", "sk-something-secret"),
+            ("VENDOR_X_TOKEN", "xyz-classified"),
+            ("WHATEVER", "value"),
+        ]);
+        assert!(!result.contains_key("FUTURE_API_KEY"));
+        assert!(!result.contains_key("VENDOR_X_TOKEN"));
+        assert!(!result.contains_key("WHATEVER"));
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        let empty: Vec<(&str, &str)> = vec![];
+        let result = filter(empty);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn render_produces_sorted_key_eq_value_lines() {
+        // BTreeMap iteration is sorted, which renders as sorted lines.
+        // This makes diffing two bundles meaningful.
+        let mut input = BTreeMap::new();
+        input.insert("ZULU".to_string(), "z".to_string());
+        input.insert("ALPHA".to_string(), "a".to_string());
+        input.insert("MIKE".to_string(), "m".to_string());
+        let rendered = render(&input);
+        assert_eq!(rendered, "ALPHA=a\nMIKE=m\nZULU=z\n");
+    }
+
+    #[test]
+    fn render_preserves_redaction_marker() {
+        let mut input = BTreeMap::new();
+        input.insert(
+            "OPENAI_API_KEY".to_string(),
+            "<redacted: 21 bytes>".to_string(),
+        );
+        let rendered = render(&input);
+        assert_eq!(rendered, "OPENAI_API_KEY=<redacted: 21 bytes>\n");
+    }
+
+    #[test]
+    fn classify_directly_for_all_three_paths() {
+        // Allowlist-prefix path
+        assert_eq!(
+            classify("KODA_RENDER", "inline"),
+            Some("inline".to_string())
+        );
+        // Allowlist-name path
+        assert_eq!(classify("TERM", "xterm"), Some("xterm".to_string()));
+        // Redact path
+        assert_eq!(
+            classify("OPENAI_API_KEY", "sk-12345"),
+            Some("<redacted: 8 bytes>".to_string())
+        );
+        // Drop path
+        assert_eq!(classify("HOME", "/Users/foo"), None);
+        assert_eq!(classify("RANDOM_FUTURE_VAR", "value"), None);
+    }
+}

--- a/koda-cli/src/debug_bundle/metadata.rs
+++ b/koda-cli/src/debug_bundle/metadata.rs
@@ -1,0 +1,220 @@
+//! Metadata collector for debug bundles.
+//!
+//! Produces `metadata.json` — a structured snapshot of session and runtime
+//! context that a debugger (human or LLM) needs to reason about the bundle
+//! without parsing the conversation. Per RFC #1167, this is intentionally
+//! distinct from `messages.json` (which is the raw DB dump): metadata
+//! answers "what was this session" while messages answer "what happened
+//! in it."
+
+use serde_json::{Value, json};
+
+/// Snapshot of session and runtime context. Constructed at bundle-write
+/// time, serialized to `metadata.json` inside the tarball.
+///
+/// Field choices follow RFC #1167:
+///
+/// - `session_*`, `model`, `provider`, `context_window`: session identity
+/// - `totals`: at-a-glance shape of the conversation
+/// - `koda_version`, `git_sha`: build provenance
+/// - `started_at`, `captured_at`: timeline anchors (RFC 3339)
+/// - `platform`: portable details for cross-machine reproduction
+#[derive(Debug, Clone)]
+pub(super) struct Metadata {
+    pub session_id: String,
+    pub session_title: Option<String>,
+    pub model: Option<String>,
+    pub provider: Option<String>,
+    pub context_window: Option<u64>,
+    pub totals: Totals,
+    pub koda_version: String,
+    pub git_sha: Option<String>,
+    pub started_at: Option<String>,
+    pub captured_at: String,
+    pub platform: Platform,
+}
+
+/// At-a-glance counts. Computed by walking the message slice once at
+/// bundle-write time so the bundle reader doesn't need to re-derive them.
+#[derive(Debug, Clone, Default)]
+pub(super) struct Totals {
+    pub user_msgs: u64,
+    pub assistant_msgs: u64,
+    pub tool_calls: u64,
+    pub tokens_in: u64,
+    pub tokens_out: u64,
+}
+
+/// Portable platform details. `term` is included specifically because
+/// terminal-rendering bugs are a major reason to file a debug bundle.
+#[derive(Debug, Clone)]
+pub(super) struct Platform {
+    pub os: String,
+    pub arch: String,
+    pub term: Option<String>,
+}
+
+impl Metadata {
+    /// Render to `serde_json::Value` ready for `to_string_pretty`.
+    ///
+    /// Field ordering is deliberate (most-identifying first) so that even
+    /// raw `cat metadata.json` is scannable.
+    pub(super) fn to_json(&self) -> Value {
+        json!({
+            "session_id": self.session_id,
+            "session_title": self.session_title,
+            "model": self.model,
+            "provider": self.provider,
+            "context_window": self.context_window,
+            "totals": {
+                "user_msgs": self.totals.user_msgs,
+                "assistant_msgs": self.totals.assistant_msgs,
+                "tool_calls": self.totals.tool_calls,
+                "tokens_in": self.totals.tokens_in,
+                "tokens_out": self.totals.tokens_out,
+            },
+            "koda_version": self.koda_version,
+            "git_sha": self.git_sha,
+            "started_at": self.started_at,
+            "captured_at": self.captured_at,
+            "platform": {
+                "os": self.platform.os,
+                "arch": self.platform.arch,
+                "term": self.platform.term,
+            },
+        })
+    }
+}
+
+/// Build [`Platform`] from the running process's compile-time + env hints.
+///
+/// `os` and `arch` come from `std::env::consts` (build-time constants from
+/// the toolchain — no runtime cost). `term` comes from `$TERM`.
+pub(super) fn current_platform() -> Platform {
+    Platform {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        term: std::env::var("TERM").ok(),
+    }
+}
+
+/// Compile-time koda version (`CARGO_PKG_VERSION` of the bundling crate).
+///
+/// This is pinned at build time so the version inside the bundle matches
+/// the binary that wrote it — which is exactly what a debugger wants.
+pub(super) fn current_koda_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Compile-time git SHA, if `KODA_GIT_SHA` was set during build. Optional
+/// because dev builds may not have this. The release pipeline sets it.
+pub(super) fn current_git_sha() -> Option<String> {
+    option_env!("KODA_GIT_SHA").map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_metadata() -> Metadata {
+        Metadata {
+            session_id: "abc-123".to_string(),
+            session_title: Some("test session".to_string()),
+            model: Some("claude-sonnet-4-6".to_string()),
+            provider: Some("anthropic".to_string()),
+            context_window: Some(200_000),
+            totals: Totals {
+                user_msgs: 5,
+                assistant_msgs: 5,
+                tool_calls: 12,
+                tokens_in: 1234,
+                tokens_out: 567,
+            },
+            koda_version: "0.2.25".to_string(),
+            git_sha: Some("deadbeef".to_string()),
+            started_at: Some("2026-04-30T10:00:00Z".to_string()),
+            captured_at: "2026-04-30T11:00:00Z".to_string(),
+            platform: Platform {
+                os: "macos".to_string(),
+                arch: "aarch64".to_string(),
+                term: Some("xterm-256color".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn json_round_trip_preserves_all_fields() {
+        let meta = fixture_metadata();
+        let value = meta.to_json();
+        // Verify every documented field is present and equals fixture.
+        assert_eq!(value["session_id"], "abc-123");
+        assert_eq!(value["session_title"], "test session");
+        assert_eq!(value["model"], "claude-sonnet-4-6");
+        assert_eq!(value["provider"], "anthropic");
+        assert_eq!(value["context_window"], 200_000);
+        assert_eq!(value["totals"]["user_msgs"], 5);
+        assert_eq!(value["totals"]["assistant_msgs"], 5);
+        assert_eq!(value["totals"]["tool_calls"], 12);
+        assert_eq!(value["totals"]["tokens_in"], 1234);
+        assert_eq!(value["totals"]["tokens_out"], 567);
+        assert_eq!(value["koda_version"], "0.2.25");
+        assert_eq!(value["git_sha"], "deadbeef");
+        assert_eq!(value["started_at"], "2026-04-30T10:00:00Z");
+        assert_eq!(value["captured_at"], "2026-04-30T11:00:00Z");
+        assert_eq!(value["platform"]["os"], "macos");
+        assert_eq!(value["platform"]["arch"], "aarch64");
+        assert_eq!(value["platform"]["term"], "xterm-256color");
+    }
+
+    #[test]
+    fn json_handles_optional_nulls() {
+        let mut meta = fixture_metadata();
+        meta.session_title = None;
+        meta.model = None;
+        meta.provider = None;
+        meta.context_window = None;
+        meta.git_sha = None;
+        meta.started_at = None;
+        meta.platform.term = None;
+
+        let value = meta.to_json();
+        // Required fields still populated.
+        assert_eq!(value["session_id"], "abc-123");
+        assert_eq!(value["koda_version"], "0.2.25");
+        assert_eq!(value["captured_at"], "2026-04-30T11:00:00Z");
+        // Optionals serialize as JSON null (not as missing keys), which
+        // is what `serde_json::json!` does for `Option::None`. This is
+        // the contract the bundle README documents.
+        assert!(value["session_title"].is_null());
+        assert!(value["model"].is_null());
+        assert!(value["provider"].is_null());
+        assert!(value["context_window"].is_null());
+        assert!(value["git_sha"].is_null());
+        assert!(value["started_at"].is_null());
+        assert!(value["platform"]["term"].is_null());
+    }
+
+    #[test]
+    fn current_koda_version_is_workspace_version() {
+        // We can't hardcode the version here (would break every release),
+        // but we can sanity-check the shape: 3 dot-separated numbers.
+        let v = current_koda_version();
+        let parts: Vec<&str> = v.split('.').collect();
+        assert_eq!(parts.len(), 3, "expected MAJOR.MINOR.PATCH, got {v}");
+        for part in parts {
+            assert!(
+                part.chars().all(|c| c.is_ascii_digit()),
+                "non-numeric version part: {part}"
+            );
+        }
+    }
+
+    #[test]
+    fn current_platform_populates_required_fields() {
+        let p = current_platform();
+        // os/arch always present from std::env::consts (compile-time).
+        assert!(!p.os.is_empty());
+        assert!(!p.arch.is_empty());
+        // term may or may not be set (e.g. in CI without TTY) — both OK.
+    }
+}

--- a/koda-cli/src/debug_bundle/metadata.rs
+++ b/koda-cli/src/debug_bundle/metadata.rs
@@ -10,7 +10,7 @@
 use serde_json::{Value, json};
 
 /// Snapshot of session and runtime context. Constructed at bundle-write
-/// time, serialized to `metadata.json` inside the tarball.
+/// time, serialized to `metadata.json` inside the zip.
 ///
 /// Field choices follow RFC #1167:
 ///

--- a/koda-cli/src/debug_bundle/mod.rs
+++ b/koda-cli/src/debug_bundle/mod.rs
@@ -1,13 +1,13 @@
 //! `/debug-bundle` slash command implementation (RFC #1167).
 //!
-//! Produces a self-contained `.tar.gz` artifact a debugger (human or LLM)
+//! Produces a self-contained `.zip` artifact a debugger (human or LLM)
 //! can use to reason about a koda session without needing access to the
 //! original machine.
 //!
 //! ## Bundle layout (per RFC #1167)
 //!
 //! ```text
-//! koda-debug-{YYYYMMDD-HHMMSS}-{session-slug}.tar.gz
+//! koda-debug-{YYYYMMDD-HHMMSS}-{session-slug}.zip
 //! ├── README.md            ← what's in the bundle, opened first by humans
 //! ├── conversation.md      ← history_render → lines_to_text serializer
 //! ├── messages.json        ← raw DB dump (every Message row)
@@ -17,6 +17,20 @@
 //!     ├── koda-<PID>.log   ← FULL per-process log
 //!     └── panic.log        ← if exists, full file (else absent)
 //! ```
+//!
+//! ## Why `.zip` and not `.tar.gz`
+//!
+//! Both formats produce roughly the same compressed size for our content
+//! (text-heavy, sub-MB total). The difference is **random access**: a zip
+//! has a central directory at the tail, so reading one entry is
+//! O(entry size). `tar.gz` is a stream, so reading one entry requires
+//! decompressing the whole archive up to that point.
+//!
+//! For the consumer profile of a debug bundle (LLM agents poking at one
+//! file at a time during a debugging session, claude.ai/chatgpt UI
+//! attachment uploads, Windows colleagues browsing in Explorer), random
+//! access wins decisively. The compression delta (a few percent on text)
+//! is irrelevant at our archive sizes.
 //!
 //! ## Design choices (and why they're not options)
 //!
@@ -39,11 +53,11 @@ mod readme;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use flate2::Compression;
-use flate2::write::GzEncoder;
 use koda_core::persistence::Message;
 use ratatui::text::Line;
 use serde_json::{Value, json};
+use zip::CompressionMethod;
+use zip::write::{SimpleFileOptions, ZipWriter};
 
 use self::metadata::{Metadata, Totals};
 
@@ -69,13 +83,13 @@ pub struct BundleInput<'a> {
     /// Captured-at ISO 8601 timestamp. Caller-supplied (rather than
     /// `now()`-internal) so tests are deterministic.
     pub captured_at: &'a str,
-    /// Where to write the resulting `.tar.gz`. The directory is
+    /// Where to write the resulting `.zip`. The directory is
     /// created if missing.
     pub output_dir: &'a Path,
 }
 
 /// Write a debug bundle. Returns the absolute path of the resulting
-/// `.tar.gz` on success.
+/// `.zip` on success.
 ///
 /// The function is fully synchronous: a debug bundle is small (typically
 /// <1 MB) and the user is staring at the TUI waiting for it. Async would
@@ -85,50 +99,48 @@ pub fn write_bundle(input: &BundleInput<'_>) -> std::io::Result<PathBuf> {
 
     let bundle_path = input.output_dir.join(bundle_filename(input));
     let file = std::fs::File::create(&bundle_path)?;
-    let gz = GzEncoder::new(file, Compression::default());
-    let mut tar = tar::Builder::new(gz);
+    let mut zip = ZipWriter::new(file);
 
     let meta = build_metadata(input);
 
-    // Each `add_file_to_tar` call produces a single entry. Order is the
-    // order we want a human untarring + `ls`-ing to see — README first.
-    add_file_to_tar(&mut tar, "README.md", readme::render(&meta).as_bytes())?;
-    add_file_to_tar(
-        &mut tar,
+    // Each `add_file_to_zip` call produces a single entry. Order is the
+    // order we want a human unzipping + `ls`-ing to see — README first.
+    add_file_to_zip(&mut zip, "README.md", readme::render(&meta).as_bytes())?;
+    add_file_to_zip(
+        &mut zip,
         "metadata.json",
         serde_json::to_string_pretty(&meta.to_json())
             .unwrap_or_default()
             .as_bytes(),
     )?;
-    add_file_to_tar(
-        &mut tar,
+    add_file_to_zip(
+        &mut zip,
         "conversation.md",
         render_conversation(input.messages).as_bytes(),
     )?;
-    add_file_to_tar(
-        &mut tar,
+    add_file_to_zip(
+        &mut zip,
         "messages.json",
         serde_json::to_string_pretty(&messages_to_json(input.messages))
             .unwrap_or_default()
             .as_bytes(),
     )?;
-    add_file_to_tar(&mut tar, "env.txt", render_env().as_bytes())?;
+    add_file_to_zip(&mut zip, "env.txt", render_env().as_bytes())?;
 
     // Logs: best-effort copy. Missing log file (e.g. headless test
     // harness without tracing init) is not an error — the bundle just
     // has no logs/ directory entry.
-    add_logs_to_tar(&mut tar, input)?;
+    add_logs_to_zip(&mut zip, input)?;
 
-    // tar::Builder::into_inner finishes the tar stream + returns the
-    // GzEncoder; flate2 needs an explicit finish() to write the gzip
-    // trailer. Drop won't do it.
-    let gz = tar.into_inner()?;
-    gz.finish()?;
+    // ZipWriter::finish writes the central directory at the tail.
+    // Without this, the file is truncated and unreadable. Drop alone is
+    // not sufficient — the writer needs to know we're done adding.
+    zip.finish()?;
 
     Ok(bundle_path)
 }
 
-/// Build the bundle filename: `koda-debug-{YYYYMMDD-HHMMSS}-{slug}.tar.gz`.
+/// Build the bundle filename: `koda-debug-{YYYYMMDD-HHMMSS}-{slug}.zip`.
 ///
 /// Slug comes from the session title, falling back to "session" if the
 /// title is empty/missing. Slug is sanitized: lowercase, alphanumerics +
@@ -140,7 +152,7 @@ fn bundle_filename(input: &BundleInput<'_>) -> String {
         .map(slugify)
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "session".to_string());
-    format!("koda-debug-{timestamp}-{slug}.tar.gz")
+    format!("koda-debug-{timestamp}-{slug}.zip")
 }
 
 /// Convert ISO 8601 `2026-04-30T22:48:43Z` into `20260430-224843` for use
@@ -176,39 +188,40 @@ fn slugify(s: &str) -> String {
         .collect()
 }
 
-/// Add a single in-memory file to the tar stream.
-fn add_file_to_tar<W: Write>(
-    tar: &mut tar::Builder<W>,
+/// Add a single in-memory file to the zip stream with deflate compression
+/// + Unix 0o644 permissions (so unzippers on Unix produce sane file modes).
+fn add_file_to_zip<W: Write + std::io::Seek>(
+    zip: &mut ZipWriter<W>,
     path: &str,
     contents: &[u8],
 ) -> std::io::Result<()> {
-    let mut header = tar::Header::new_gnu();
-    header.set_path(path)?;
-    header.set_size(contents.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    tar.append(&header, contents)
+    let options = SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    zip.start_file(path, options)
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+    zip.write_all(contents)
 }
 
-/// Copy log files into the tar. Best-effort: missing files are silently
+/// Copy log files into the zip. Best-effort: missing files are silently
 /// skipped (a debug bundle from a headless test harness without tracing
 /// init is still useful).
-fn add_logs_to_tar<W: Write>(
-    tar: &mut tar::Builder<W>,
+fn add_logs_to_zip<W: Write + std::io::Seek>(
+    zip: &mut ZipWriter<W>,
     input: &BundleInput<'_>,
 ) -> std::io::Result<()> {
     let logs_dir = input.config_dir.join("logs");
     let process_log = logs_dir.join(format!("koda-{}.log", input.current_pid));
     if let Ok(contents) = std::fs::read(&process_log) {
-        add_file_to_tar(
-            tar,
+        add_file_to_zip(
+            zip,
             &format!("logs/koda-{}.log", input.current_pid),
             &contents,
         )?;
     }
     let panic_log = logs_dir.join("panic.log");
     if let Ok(contents) = std::fs::read(&panic_log) {
-        add_file_to_tar(tar, "logs/panic.log", &contents)?;
+        add_file_to_zip(zip, "logs/panic.log", &contents)?;
     }
     Ok(())
 }
@@ -429,7 +442,7 @@ mod tests {
         let name = bundle_filename(&input);
         assert!(name.starts_with("koda-debug-20260430-224843-"));
         assert!(name.contains("fix-the-waittask-bug"));
-        assert!(name.ends_with(".tar.gz"));
+        assert!(name.ends_with(".zip"));
     }
 
     #[test]
@@ -451,7 +464,7 @@ mod tests {
             output_dir: &output_dir,
         };
         let name = bundle_filename(&input);
-        assert!(name.contains("-session.tar.gz"));
+        assert!(name.contains("-session.zip"));
     }
 
     #[test]
@@ -484,11 +497,10 @@ mod tests {
         assert_eq!(arr[0]["prompt_tokens"], 100);
         assert_eq!(arr[0]["completion_tokens"], 50);
     }
-    /// Integration test: produce a real bundle, untar it (in memory),
+    /// Integration test: produce a real bundle, unzip it (in memory),
     /// verify every documented file is present and well-formed.
     #[test]
-    fn write_bundle_produces_complete_tarball() {
-        use flate2::read::GzDecoder;
+    fn write_bundle_produces_complete_zip() {
         use std::io::Read;
 
         let messages = vec![
@@ -526,16 +538,15 @@ mod tests {
 
         let bundle_path = write_bundle(&input).expect("bundle write should succeed");
         assert!(bundle_path.exists(), "bundle file not created");
-        assert!(bundle_path.extension().map(|e| e == "gz").unwrap_or(false));
+        assert!(bundle_path.extension().map(|e| e == "zip").unwrap_or(false));
 
-        // Untar in memory and collect every entry.
+        // Unzip in memory and collect every entry.
         let file = std::fs::File::open(&bundle_path).unwrap();
-        let gz = GzDecoder::new(file);
-        let mut archive = tar::Archive::new(gz);
+        let mut archive = zip::ZipArchive::new(file).expect("valid zip");
         let mut found: std::collections::HashMap<String, Vec<u8>> = Default::default();
-        for entry in archive.entries().unwrap() {
-            let mut entry = entry.unwrap();
-            let path = entry.path().unwrap().display().to_string();
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).unwrap();
+            let path = entry.name().to_string();
             let mut buf = Vec::new();
             entry.read_to_end(&mut buf).unwrap();
             found.insert(path, buf);
@@ -562,6 +573,19 @@ mod tests {
             !found.contains_key("logs/panic.log"),
             "panic.log appeared but no source file was seeded"
         );
+
+        // Random-access sanity check — one of the headline reasons we
+        // chose zip over tar.gz. Read just `metadata.json` by name
+        // without iterating the archive.
+        let file2 = std::fs::File::open(&bundle_path).unwrap();
+        let mut archive2 = zip::ZipArchive::new(file2).expect("valid zip");
+        let mut entry = archive2
+            .by_name("metadata.json")
+            .expect("random-access by name");
+        let mut buf = String::new();
+        entry.read_to_string(&mut buf).unwrap();
+        let direct: Value = serde_json::from_str(&buf).unwrap();
+        assert_eq!(direct["session_id"], "test-session-id");
 
         // Spot-check content well-formedness.
         let metadata: Value =
@@ -591,7 +615,6 @@ mod tests {
 
     #[test]
     fn write_bundle_with_panic_log_includes_it() {
-        use flate2::read::GzDecoder;
         use std::io::Read;
 
         let messages: Vec<Message> = vec![];
@@ -619,22 +642,14 @@ mod tests {
         };
         let path = write_bundle(&input).unwrap();
         let file = std::fs::File::open(&path).unwrap();
-        let gz = GzDecoder::new(file);
-        let mut archive = tar::Archive::new(gz);
-        let mut found_panic = false;
-        for entry in archive.entries().unwrap() {
-            let mut entry = entry.unwrap();
-            let p = entry.path().unwrap().display().to_string();
-            if p == "logs/panic.log" {
-                found_panic = true;
-                let mut buf = String::new();
-                entry.read_to_string(&mut buf).unwrap();
-                assert!(buf.contains("panicked"));
-            }
-        }
-        assert!(found_panic, "panic.log seeded but missing from bundle");
+        let mut archive = zip::ZipArchive::new(file).expect("valid zip");
+        let mut entry = archive
+            .by_name("logs/panic.log")
+            .expect("panic.log seeded but missing from bundle");
+        let mut buf = String::new();
+        entry.read_to_string(&mut buf).unwrap();
+        assert!(buf.contains("panicked"));
     }
-
     #[test]
     fn write_bundle_succeeds_with_no_logs_dir() {
         // Headless / fresh-config-dir case: log copying is best-effort,

--- a/koda-cli/src/debug_bundle/mod.rs
+++ b/koda-cli/src/debug_bundle/mod.rs
@@ -1,0 +1,661 @@
+//! `/debug-bundle` slash command implementation (RFC #1167).
+//!
+//! Produces a self-contained `.tar.gz` artifact a debugger (human or LLM)
+//! can use to reason about a koda session without needing access to the
+//! original machine.
+//!
+//! ## Bundle layout (per RFC #1167)
+//!
+//! ```text
+//! koda-debug-{YYYYMMDD-HHMMSS}-{session-slug}.tar.gz
+//! ├── README.md            ← what's in the bundle, opened first by humans
+//! ├── conversation.md      ← history_render → lines_to_text serializer
+//! ├── messages.json        ← raw DB dump (every Message row)
+//! ├── metadata.json        ← session/runtime context
+//! ├── env.txt              ← allowlist-filtered env vars (D5)
+//! └── logs/
+//!     ├── koda-<PID>.log   ← FULL per-process log
+//!     └── panic.log        ← if exists, full file (else absent)
+//! ```
+//!
+//! ## Design choices (and why they're not options)
+//!
+//! - **No runtime knobs.** The env-var allowlist is hardcoded; bundle
+//!   structure is fixed. To extend, edit source. Per RFC §D5: minimal
+//!   runtime config = less surface area, no foot-guns.
+//! - **`history_render` is the single source of truth.** `conversation.md`
+//!   is produced by `history_render::render_history_messages` →
+//!   `lines_to_text`. Same pipeline as the live TUI render and the
+//!   resumed-session display. Per RFC §D1.
+//! - **Logs copied verbatim, not tailed.** Per RFC §D4: each koda
+//!   invocation gets its own log file; bundle takes the whole thing.
+//! - **`panic.log` stays separate from `koda-{PID}.log` on disk.** Per
+//!   RFC §D3. The bundle is the merge point, not the file system.
+
+mod env_filter;
+mod metadata;
+mod readme;
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use koda_core::persistence::Message;
+use ratatui::text::Line;
+use serde_json::{Value, json};
+
+use self::metadata::{Metadata, Totals};
+
+/// Inputs the orchestrator needs to assemble a bundle.
+///
+/// Decoupled from `KodaSession` so unit tests can construct `BundleInput`
+/// directly without standing up a database. The handler in
+/// `tui_commands.rs` is the (only) place that translates a live session
+/// into this shape.
+pub struct BundleInput<'a> {
+    pub session_id: &'a str,
+    pub session_title: Option<&'a str>,
+    pub session_started_at: Option<&'a str>,
+    pub model: Option<&'a str>,
+    pub provider: Option<&'a str>,
+    pub context_window: Option<u64>,
+    pub messages: &'a [Message],
+    /// Used for log discovery (`<config_dir>/logs/koda-<PID>.log`).
+    /// Passed as a parameter rather than read from the live process so
+    /// tests can point at a temp dir.
+    pub config_dir: &'a Path,
+    pub current_pid: u32,
+    /// Captured-at ISO 8601 timestamp. Caller-supplied (rather than
+    /// `now()`-internal) so tests are deterministic.
+    pub captured_at: &'a str,
+    /// Where to write the resulting `.tar.gz`. The directory is
+    /// created if missing.
+    pub output_dir: &'a Path,
+}
+
+/// Write a debug bundle. Returns the absolute path of the resulting
+/// `.tar.gz` on success.
+///
+/// The function is fully synchronous: a debug bundle is small (typically
+/// <1 MB) and the user is staring at the TUI waiting for it. Async would
+/// add complexity without latency benefit.
+pub fn write_bundle(input: &BundleInput<'_>) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(input.output_dir)?;
+
+    let bundle_path = input.output_dir.join(bundle_filename(input));
+    let file = std::fs::File::create(&bundle_path)?;
+    let gz = GzEncoder::new(file, Compression::default());
+    let mut tar = tar::Builder::new(gz);
+
+    let meta = build_metadata(input);
+
+    // Each `add_file_to_tar` call produces a single entry. Order is the
+    // order we want a human untarring + `ls`-ing to see — README first.
+    add_file_to_tar(&mut tar, "README.md", readme::render(&meta).as_bytes())?;
+    add_file_to_tar(
+        &mut tar,
+        "metadata.json",
+        serde_json::to_string_pretty(&meta.to_json())
+            .unwrap_or_default()
+            .as_bytes(),
+    )?;
+    add_file_to_tar(
+        &mut tar,
+        "conversation.md",
+        render_conversation(input.messages).as_bytes(),
+    )?;
+    add_file_to_tar(
+        &mut tar,
+        "messages.json",
+        serde_json::to_string_pretty(&messages_to_json(input.messages))
+            .unwrap_or_default()
+            .as_bytes(),
+    )?;
+    add_file_to_tar(&mut tar, "env.txt", render_env().as_bytes())?;
+
+    // Logs: best-effort copy. Missing log file (e.g. headless test
+    // harness without tracing init) is not an error — the bundle just
+    // has no logs/ directory entry.
+    add_logs_to_tar(&mut tar, input)?;
+
+    // tar::Builder::into_inner finishes the tar stream + returns the
+    // GzEncoder; flate2 needs an explicit finish() to write the gzip
+    // trailer. Drop won't do it.
+    let gz = tar.into_inner()?;
+    gz.finish()?;
+
+    Ok(bundle_path)
+}
+
+/// Build the bundle filename: `koda-debug-{YYYYMMDD-HHMMSS}-{slug}.tar.gz`.
+///
+/// Slug comes from the session title, falling back to "session" if the
+/// title is empty/missing. Slug is sanitized: lowercase, alphanumerics +
+/// dashes only, max 32 chars.
+fn bundle_filename(input: &BundleInput<'_>) -> String {
+    let timestamp = compact_timestamp(input.captured_at);
+    let slug = input
+        .session_title
+        .map(slugify)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "session".to_string());
+    format!("koda-debug-{timestamp}-{slug}.tar.gz")
+}
+
+/// Convert ISO 8601 `2026-04-30T22:48:43Z` into `20260430-224843` for use
+/// in filenames. Implementation: extract all digits, slot the first 8 into
+/// the date component and the next 6 into the time component. Anything
+/// shorter degrades gracefully (still a valid filename).
+fn compact_timestamp(iso: &str) -> String {
+    let digits: String = iso.chars().filter(|c| c.is_ascii_digit()).collect();
+    if digits.len() >= 14 {
+        format!("{}-{}", &digits[..8], &digits[8..14])
+    } else {
+        digits
+    }
+}
+
+/// Sanitize a string into a filesystem-safe slug.
+fn slugify(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+        .chars()
+        .take(32)
+        .collect()
+}
+
+/// Add a single in-memory file to the tar stream.
+fn add_file_to_tar<W: Write>(
+    tar: &mut tar::Builder<W>,
+    path: &str,
+    contents: &[u8],
+) -> std::io::Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_path(path)?;
+    header.set_size(contents.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    tar.append(&header, contents)
+}
+
+/// Copy log files into the tar. Best-effort: missing files are silently
+/// skipped (a debug bundle from a headless test harness without tracing
+/// init is still useful).
+fn add_logs_to_tar<W: Write>(
+    tar: &mut tar::Builder<W>,
+    input: &BundleInput<'_>,
+) -> std::io::Result<()> {
+    let logs_dir = input.config_dir.join("logs");
+    let process_log = logs_dir.join(format!("koda-{}.log", input.current_pid));
+    if let Ok(contents) = std::fs::read(&process_log) {
+        add_file_to_tar(
+            tar,
+            &format!("logs/koda-{}.log", input.current_pid),
+            &contents,
+        )?;
+    }
+    let panic_log = logs_dir.join("panic.log");
+    if let Ok(contents) = std::fs::read(&panic_log) {
+        add_file_to_tar(tar, "logs/panic.log", &contents)?;
+    }
+    Ok(())
+}
+
+/// Build the [`Metadata`] snapshot from inputs + runtime sniffing.
+fn build_metadata(input: &BundleInput<'_>) -> Metadata {
+    Metadata {
+        session_id: input.session_id.to_string(),
+        session_title: input.session_title.map(str::to_string),
+        model: input.model.map(str::to_string),
+        provider: input.provider.map(str::to_string),
+        context_window: input.context_window,
+        totals: compute_totals(input.messages),
+        koda_version: metadata::current_koda_version(),
+        git_sha: metadata::current_git_sha(),
+        started_at: input.session_started_at.map(str::to_string),
+        captured_at: input.captured_at.to_string(),
+        platform: metadata::current_platform(),
+    }
+}
+
+/// One pass over the message slice to compute the at-a-glance counts the
+/// metadata block exposes.
+///
+/// `tool_calls` count: each row's `tool_calls` is a serialized JSON array.
+/// We parse it once per row to count entries (not just "row has any").
+/// This keeps the totals semantically meaningful when an assistant turn
+/// fans out to multiple parallel tool calls.
+fn compute_totals(messages: &[Message]) -> Totals {
+    let mut t = Totals::default();
+    for m in messages {
+        match m.role.as_str() {
+            "user" => t.user_msgs += 1,
+            "assistant" => t.assistant_msgs += 1,
+            _ => {}
+        }
+        if let Some(json_str) = m.tool_calls.as_deref()
+            && let Ok(Value::Array(arr)) = serde_json::from_str::<Value>(json_str)
+        {
+            t.tool_calls += arr.len() as u64;
+        }
+        t.tokens_in += m.prompt_tokens.unwrap_or(0).max(0) as u64;
+        t.tokens_out += m.completion_tokens.unwrap_or(0).max(0) as u64;
+    }
+    t
+}
+
+/// Render the conversation by routing through `history_render` (RFC §D1
+/// — single renderer) and flattening to plain text via `lines_to_text`.
+///
+/// This is the function that makes the bundle's `conversation.md` match
+/// the user's screen byte-for-byte (modulo styling).
+fn render_conversation(messages: &[Message]) -> String {
+    let lines = crate::history_render::render_history_messages(messages);
+    lines_to_text(&lines)
+}
+
+/// Flatten styled `ratatui::Line`s to plain text.
+///
+/// Per RFC §D1, this is THE serializer that lets `history_render`'s
+/// output reach non-TUI surfaces without re-implementing per-tool
+/// formatting. Strips ratatui::Style (color, bold, underline) and joins
+/// every span's content with no separator (spans inside a Line are
+/// already byte-adjacent in the visual flow).
+pub(crate) fn lines_to_text(lines: &[Line<'_>]) -> String {
+    let mut out = String::new();
+    for line in lines {
+        for span in &line.spans {
+            out.push_str(&span.content);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// Dump messages to a `serde_json::Value` for the `messages.json` file.
+///
+/// Format mirrors the DB row shape — the bundle reader's job is to reason
+/// about what koda saw, so flatten as little as possible. `role` is
+/// rendered via `Role::as_str()` since the enum doesn't impl `Serialize`
+/// directly (and lowercase string is the on-disk format anyway).
+/// `tool_calls` is the raw serialized JSON string from the DB — callers
+/// can `JSON.parse` it themselves to inspect.
+fn messages_to_json(messages: &[Message]) -> Value {
+    let array: Vec<Value> = messages
+        .iter()
+        .map(|m| {
+            json!({
+                "id": m.id,
+                "session_id": m.session_id,
+                "role": m.role.as_str(),
+                "content": m.content,
+                "full_content": m.full_content,
+                "tool_calls": m.tool_calls,
+                "tool_call_id": m.tool_call_id,
+                "created_at": m.created_at,
+                "prompt_tokens": m.prompt_tokens,
+                "completion_tokens": m.completion_tokens,
+                "cache_read_tokens": m.cache_read_tokens,
+                "cache_creation_tokens": m.cache_creation_tokens,
+                "thinking_tokens": m.thinking_tokens,
+                "thinking_content": m.thinking_content,
+            })
+        })
+        .collect();
+    json!({ "messages": array })
+}
+
+/// Filter and render the current process's env vars per RFC §D5.
+fn render_env() -> String {
+    let filtered = env_filter::filter(std::env::vars());
+    env_filter::render(&filtered)
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use lines_to_text as _ensure_pub_visible;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use koda_core::persistence::Message;
+    use ratatui::text::Span;
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "koda-debug-bundle-test-{label}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn fixture_message(id: i64, role: koda_core::persistence::Role, content: &str) -> Message {
+        Message {
+            id,
+            session_id: "sess-1".to_string(),
+            role,
+            content: Some(content.to_string()),
+            full_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+            prompt_tokens: Some(100),
+            completion_tokens: Some(50),
+            cache_read_tokens: None,
+            cache_creation_tokens: None,
+            thinking_tokens: None,
+            thinking_content: None,
+            created_at: Some("2026-04-30T10:00:00Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn lines_to_text_strips_styling_preserves_content() {
+        let line1 = Line::from(vec![
+            Span::styled(
+                "hello ",
+                ratatui::style::Style::default().fg(ratatui::style::Color::Red),
+            ),
+            Span::raw("world"),
+        ]);
+        let line2 = Line::from("second line");
+        let text = lines_to_text(&[line1, line2]);
+        assert_eq!(text, "hello world\nsecond line\n");
+    }
+
+    #[test]
+    fn lines_to_text_empty_input() {
+        let text = lines_to_text(&[]);
+        assert_eq!(text, "");
+    }
+
+    #[test]
+    fn slugify_sanitizes_aggressively() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("foo!@#bar"), "foo-bar");
+        assert_eq!(slugify("---leading-trailing---"), "leading-trailing");
+        assert_eq!(slugify(""), "");
+        assert_eq!(slugify("正常 unicode"), "unicode"); // non-ASCII drops to dashes, then trims
+        // Length cap.
+        let long = "a".repeat(100);
+        assert_eq!(slugify(&long).len(), 32);
+    }
+
+    #[test]
+    fn compact_timestamp_strips_iso_separators() {
+        assert_eq!(compact_timestamp("2026-04-30T22:48:43Z"), "20260430-224843");
+        // Subsecond fractions: extra digits flow into the time slot beyond 6,
+        // which we discard since the function format is exactly DATE-HHMMSS.
+        // Trailing fraction digits are dropped silently.
+        assert_eq!(
+            compact_timestamp("2026-04-30T22:48:43.123Z"),
+            "20260430-224843"
+        );
+        // Degraded input — just collect what digits there are.
+        assert_eq!(compact_timestamp("2026-04"), "202604");
+    }
+
+    #[test]
+    fn bundle_filename_uses_slug_and_timestamp() {
+        let messages: Vec<Message> = vec![];
+        let config_dir = temp_dir("filename");
+        let output_dir = temp_dir("filename-out");
+        let input = BundleInput {
+            session_id: "abc",
+            session_title: Some("Fix the WaitTask bug"),
+            session_started_at: None,
+            model: None,
+            provider: None,
+            context_window: None,
+            messages: &messages,
+            config_dir: &config_dir,
+            current_pid: 1234,
+            captured_at: "2026-04-30T22:48:43Z",
+            output_dir: &output_dir,
+        };
+        let name = bundle_filename(&input);
+        assert!(name.starts_with("koda-debug-20260430-224843-"));
+        assert!(name.contains("fix-the-waittask-bug"));
+        assert!(name.ends_with(".tar.gz"));
+    }
+
+    #[test]
+    fn bundle_filename_falls_back_when_title_missing() {
+        let messages: Vec<Message> = vec![];
+        let config_dir = temp_dir("noslug");
+        let output_dir = temp_dir("noslug-out");
+        let input = BundleInput {
+            session_id: "abc",
+            session_title: None,
+            session_started_at: None,
+            model: None,
+            provider: None,
+            context_window: None,
+            messages: &messages,
+            config_dir: &config_dir,
+            current_pid: 1234,
+            captured_at: "2026-04-30T22:48:43Z",
+            output_dir: &output_dir,
+        };
+        let name = bundle_filename(&input);
+        assert!(name.contains("-session.tar.gz"));
+    }
+
+    #[test]
+    fn compute_totals_walks_messages_once() {
+        use koda_core::persistence::Role;
+        let messages = vec![
+            fixture_message(1, Role::User, "hello"),
+            fixture_message(2, Role::Assistant, "hi back"),
+            fixture_message(3, Role::User, "another"),
+            fixture_message(4, Role::System, "ignored in counts"),
+        ];
+        let totals = compute_totals(&messages);
+        assert_eq!(totals.user_msgs, 2);
+        assert_eq!(totals.assistant_msgs, 1);
+        assert_eq!(totals.tool_calls, 0);
+        assert_eq!(totals.tokens_in, 400); // 4 * 100
+        assert_eq!(totals.tokens_out, 200); // 4 * 50
+    }
+
+    #[test]
+    fn messages_to_json_round_trips_required_fields() {
+        use koda_core::persistence::Role;
+        let messages = vec![fixture_message(1, Role::User, "hello")];
+        let value = messages_to_json(&messages);
+        let arr = value["messages"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["id"], 1);
+        assert_eq!(arr[0]["role"], "user");
+        assert_eq!(arr[0]["content"], "hello");
+        assert_eq!(arr[0]["prompt_tokens"], 100);
+        assert_eq!(arr[0]["completion_tokens"], 50);
+    }
+    /// Integration test: produce a real bundle, untar it (in memory),
+    /// verify every documented file is present and well-formed.
+    #[test]
+    fn write_bundle_produces_complete_tarball() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let messages = vec![
+            fixture_message(1, koda_core::persistence::Role::User, "Hello koda"),
+            fixture_message(
+                2,
+                koda_core::persistence::Role::Assistant,
+                "Hi! What can I help with?",
+            ),
+        ];
+        let config_dir = temp_dir("integration-cfg");
+        let output_dir = temp_dir("integration-out");
+
+        // Seed a fake log file so we exercise the log-copy path.
+        std::fs::create_dir_all(config_dir.join("logs")).unwrap();
+        std::fs::write(
+            config_dir.join("logs").join(format!("koda-{}.log", 9999)),
+            b"INFO koda starting up\nINFO session created\n",
+        )
+        .unwrap();
+
+        let input = BundleInput {
+            session_id: "test-session-id",
+            session_title: Some("Integration test bundle"),
+            session_started_at: Some("2026-04-30T10:00:00Z"),
+            model: Some("test-model"),
+            provider: Some("test-provider"),
+            context_window: Some(200_000),
+            messages: &messages,
+            config_dir: &config_dir,
+            current_pid: 9999,
+            captured_at: "2026-04-30T11:00:00Z",
+            output_dir: &output_dir,
+        };
+
+        let bundle_path = write_bundle(&input).expect("bundle write should succeed");
+        assert!(bundle_path.exists(), "bundle file not created");
+        assert!(bundle_path.extension().map(|e| e == "gz").unwrap_or(false));
+
+        // Untar in memory and collect every entry.
+        let file = std::fs::File::open(&bundle_path).unwrap();
+        let gz = GzDecoder::new(file);
+        let mut archive = tar::Archive::new(gz);
+        let mut found: std::collections::HashMap<String, Vec<u8>> = Default::default();
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().display().to_string();
+            let mut buf = Vec::new();
+            entry.read_to_end(&mut buf).unwrap();
+            found.insert(path, buf);
+        }
+
+        // Every documented file must be present.
+        for required in [
+            "README.md",
+            "metadata.json",
+            "conversation.md",
+            "messages.json",
+            "env.txt",
+            "logs/koda-9999.log",
+        ] {
+            assert!(
+                found.contains_key(required),
+                "bundle missing required file: {required} (have: {:?})",
+                found.keys().collect::<Vec<_>>()
+            );
+        }
+
+        // panic.log should be ABSENT (we didn't seed one).
+        assert!(
+            !found.contains_key("logs/panic.log"),
+            "panic.log appeared but no source file was seeded"
+        );
+
+        // Spot-check content well-formedness.
+        let metadata: Value =
+            serde_json::from_slice(&found["metadata.json"]).expect("metadata.json valid JSON");
+        assert_eq!(metadata["session_id"], "test-session-id");
+        assert_eq!(metadata["totals"]["user_msgs"], 1);
+        assert_eq!(metadata["totals"]["assistant_msgs"], 1);
+
+        let messages_dump: Value =
+            serde_json::from_slice(&found["messages.json"]).expect("messages.json valid JSON");
+        assert_eq!(messages_dump["messages"].as_array().unwrap().len(), 2);
+
+        let conversation = String::from_utf8(found["conversation.md"].clone()).unwrap();
+        assert!(
+            !conversation.is_empty(),
+            "conversation.md should not be empty"
+        );
+
+        let log = String::from_utf8(found["logs/koda-9999.log"].clone()).unwrap();
+        assert!(log.contains("koda starting up"));
+
+        // Bundle filename must include slug + timestamp.
+        let name = bundle_path.file_name().unwrap().to_string_lossy();
+        assert!(name.starts_with("koda-debug-20260430-110000-"));
+        assert!(name.contains("integration-test-bundle"));
+    }
+
+    #[test]
+    fn write_bundle_with_panic_log_includes_it() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let messages: Vec<Message> = vec![];
+        let config_dir = temp_dir("panic-cfg");
+        let output_dir = temp_dir("panic-out");
+        std::fs::create_dir_all(config_dir.join("logs")).unwrap();
+        std::fs::write(
+            config_dir.join("logs").join("panic.log"),
+            b"--- panic at 2026-04-30T11:00:00Z ---\nthread 'main' panicked\n",
+        )
+        .unwrap();
+
+        let input = BundleInput {
+            session_id: "p",
+            session_title: None,
+            session_started_at: None,
+            model: None,
+            provider: None,
+            context_window: None,
+            messages: &messages,
+            config_dir: &config_dir,
+            current_pid: 1,
+            captured_at: "2026-04-30T11:00:00Z",
+            output_dir: &output_dir,
+        };
+        let path = write_bundle(&input).unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        let gz = GzDecoder::new(file);
+        let mut archive = tar::Archive::new(gz);
+        let mut found_panic = false;
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let p = entry.path().unwrap().display().to_string();
+            if p == "logs/panic.log" {
+                found_panic = true;
+                let mut buf = String::new();
+                entry.read_to_string(&mut buf).unwrap();
+                assert!(buf.contains("panicked"));
+            }
+        }
+        assert!(found_panic, "panic.log seeded but missing from bundle");
+    }
+
+    #[test]
+    fn write_bundle_succeeds_with_no_logs_dir() {
+        // Headless / fresh-config-dir case: log copying is best-effort,
+        // bundle still ships.
+        let messages: Vec<Message> = vec![];
+        let config_dir = temp_dir("nologs-cfg"); // empty
+        let output_dir = temp_dir("nologs-out");
+        let input = BundleInput {
+            session_id: "n",
+            session_title: None,
+            session_started_at: None,
+            model: None,
+            provider: None,
+            context_window: None,
+            messages: &messages,
+            config_dir: &config_dir,
+            current_pid: 1,
+            captured_at: "2026-04-30T11:00:00Z",
+            output_dir: &output_dir,
+        };
+        let path = write_bundle(&input).expect("bundle should write even with no logs");
+        assert!(path.exists());
+    }
+}

--- a/koda-cli/src/debug_bundle/readme.rs
+++ b/koda-cli/src/debug_bundle/readme.rs
@@ -6,7 +6,7 @@ use super::metadata::Metadata;
 ///
 /// Per RFC #1167: "what's in the bundle, opened first by humans" — so
 /// this is intentionally orientation material, not a polished doc.
-/// Optimised for "I just untarred this in 10 seconds, now what?"
+/// Optimised for "I just unzipped this in 10 seconds, now what?"
 pub(super) fn render(meta: &Metadata) -> String {
     let mut out = String::new();
     out.push_str("# Koda debug bundle\n\n");

--- a/koda-cli/src/debug_bundle/readme.rs
+++ b/koda-cli/src/debug_bundle/readme.rs
@@ -1,0 +1,179 @@
+//! Generate the bundle README.md, opened first by humans cracking it open.
+
+use super::metadata::Metadata;
+
+/// Build the README that ships at the top level of every debug bundle.
+///
+/// Per RFC #1167: "what's in the bundle, opened first by humans" — so
+/// this is intentionally orientation material, not a polished doc.
+/// Optimised for "I just untarred this in 10 seconds, now what?"
+pub(super) fn render(meta: &Metadata) -> String {
+    let mut out = String::new();
+    out.push_str("# Koda debug bundle\n\n");
+    out.push_str(&format!("Captured at: {}\n", meta.captured_at));
+    out.push_str(&format!("Session ID:  {}\n", meta.session_id));
+    if let Some(title) = &meta.session_title {
+        out.push_str(&format!("Session:     {title}\n"));
+    }
+    out.push_str(&format!("Koda version: {}\n", meta.koda_version));
+    if let Some(sha) = &meta.git_sha {
+        out.push_str(&format!("Git SHA:      {sha}\n"));
+    }
+    if let Some(model) = &meta.model {
+        out.push_str(&format!("Model:        {model}\n"));
+    }
+    if let Some(provider) = &meta.provider {
+        out.push_str(&format!("Provider:     {provider}\n"));
+    }
+    out.push_str(&format!(
+        "Platform:     {}/{}",
+        meta.platform.os, meta.platform.arch
+    ));
+    if let Some(term) = &meta.platform.term {
+        out.push_str(&format!(" ({term})"));
+    }
+    out.push('\n');
+
+    out.push_str(
+        r#"
+## What's in this bundle
+
+Read in this order if you're a human debugging:
+
+1. **`README.md`** — you are here.
+2. **`metadata.json`** — session/runtime context at a glance. Open this
+   first to know what you're looking at.
+3. **`conversation.md`** — the conversation as it appeared on the user's
+   screen. Faithful to the live TUI render — same per-tool formatting,
+   same status icons, same preview lines. Strip-styled to plain text so
+   any text editor can read it.
+4. **`messages.json`** — the raw DB dump of every message row. The
+   model's-eye view of the session. Consult when `conversation.md`
+   leaves a question unanswered ("did the model actually see X?").
+5. **`logs/koda-<PID>.log`** — the full per-process tracing log for the
+   koda invocation that wrote this bundle. Look here for engine events
+   (sub-agent spawn, tool dispatch, retry, cancel) and warnings.
+6. **`logs/panic.log`** (if present) — forensic record of any panics
+   captured during the lifetime of THIS koda config dir. Not just this
+   session — the panic log is shared across all koda processes that
+   share `~/.config/koda/`. Filter by timestamp if you need to scope to
+   one session. Absent file means no panics ever recorded.
+7. **`env.txt`** — environment variables filtered through a hardcoded
+   allowlist. Credentials are length-redacted (the question "is
+   $OPENAI_API_KEY set?" is debuggable; the value is not in the bundle).
+   Most user/path env vars are omitted entirely to avoid corp-ID leakage.
+
+## What's NOT in this bundle
+
+- The koda config file (`~/.config/koda/config.toml`) — may contain
+  provider URLs or other deployment-sensitive info. Re-run with
+  `--config` if reproduction needs a config tweak.
+- The session database file itself — `messages.json` is the relevant
+  slice. The DB has every other session you've ever run.
+- Files referenced via `@file` attachments — those were inlined into
+  the messages at the time and appear in `conversation.md` /
+  `messages.json` already.
+
+## Sharing this bundle
+
+Bundles are designed to be shareable with colleagues OR pasted into
+another LLM for second-opinion debugging. The redaction policy assumes
+either consumer is acceptable. **Re-check `env.txt` before sharing
+externally** — some allowlisted vars (e.g. `KODA_*` deploy hints) might
+still be sensitive in your specific deployment.
+"#,
+    );
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::metadata::{Platform, Totals};
+    use super::*;
+
+    fn fixture_meta() -> Metadata {
+        Metadata {
+            session_id: "abc-123".to_string(),
+            session_title: Some("test session".to_string()),
+            model: Some("claude-sonnet-4-6".to_string()),
+            provider: Some("anthropic".to_string()),
+            context_window: Some(200_000),
+            totals: Totals::default(),
+            koda_version: "0.2.25".to_string(),
+            git_sha: Some("deadbeef".to_string()),
+            started_at: Some("2026-04-30T10:00:00Z".to_string()),
+            captured_at: "2026-04-30T11:00:00Z".to_string(),
+            platform: Platform {
+                os: "macos".to_string(),
+                arch: "aarch64".to_string(),
+                term: Some("xterm-256color".to_string()),
+            },
+        }
+    }
+
+    #[test]
+    fn header_includes_session_and_version() {
+        let readme = render(&fixture_meta());
+        assert!(readme.contains("# Koda debug bundle"));
+        assert!(readme.contains("abc-123"));
+        assert!(readme.contains("0.2.25"));
+        assert!(readme.contains("test session"));
+        assert!(readme.contains("claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn optional_fields_omitted_when_absent() {
+        let mut meta = fixture_meta();
+        meta.session_title = None;
+        meta.git_sha = None;
+        meta.model = None;
+        meta.provider = None;
+
+        let readme = render(&meta);
+        assert!(!readme.contains("Session:    "), "session title leaked");
+        assert!(!readme.contains("Git SHA:    "), "git sha leaked");
+        assert!(!readme.contains("Model:      "), "model leaked");
+        assert!(!readme.contains("Provider:   "), "provider leaked");
+        // Required fields still present.
+        assert!(readme.contains("abc-123"));
+        assert!(readme.contains("0.2.25"));
+    }
+
+    #[test]
+    fn lists_all_documented_files() {
+        let readme = render(&fixture_meta());
+        // Every file in the RFC bundle spec must be mentioned in the
+        // readme so consumers know what they're looking at.
+        for expected in [
+            "README.md",
+            "metadata.json",
+            "conversation.md",
+            "messages.json",
+            "logs/koda-",
+            "panic.log",
+            "env.txt",
+        ] {
+            assert!(
+                readme.contains(expected),
+                "README missing reference to {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn warns_about_external_sharing() {
+        let readme = render(&fixture_meta());
+        // Guardrail: a future refactor that strips the sharing warning
+        // would be a real privacy regression. We pin two non-adjacent
+        // phrases so the test fails loudly if the section is removed,
+        // but tolerates re-flowing the line breaks for readability.
+        assert!(
+            readme.contains("Re-check"),
+            "external-sharing warning trigger phrase removed"
+        );
+        assert!(
+            readme.contains("externally"),
+            "external-sharing warning recipient phrase removed"
+        );
+    }
+}

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod app;
 pub(crate) mod builtin_skills;
 pub(crate) mod clipboard;
 pub(crate) mod completer;
+pub(crate) mod debug_bundle;
 pub(crate) mod diff_render;
 pub(crate) mod frame_requester;
 pub(crate) mod headless;

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -284,6 +284,11 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
 
+        "/debug-bundle" => {
+            handle_debug_bundle(buffer, session, config).await;
+            SlashAction::Continue
+        }
+
         "/mcp" => {
             dispatch_mcp(buffer, session, agent, arg).await;
             SlashAction::Continue
@@ -853,6 +858,101 @@ async fn handle_export(
             tui_output::err_msg(buffer, format!("Could not write {path}: {e}"));
         }
     }
+}
+
+/// `/debug-bundle` — write a self-contained `.tar.gz` debug artifact to
+/// `~/.config/koda/debug-bundles/`.
+///
+/// See [`crate::debug_bundle`] module docs for the bundle layout, design
+/// rationale, and security policy. This handler's job is solely to
+/// translate the live session into a [`debug_bundle::BundleInput`] and
+/// surface success/failure to the TUI.
+async fn handle_debug_bundle(
+    buffer: &mut ScrollBuffer,
+    session: &koda_core::session::KodaSession,
+    config: &KodaConfig,
+) {
+    use crate::debug_bundle::{BundleInput, write_bundle};
+
+    // Load the same data /export uses — messages from DB, plus session info
+    // for the metadata header.
+    let messages = match session.db.load_all_messages(&session.id).await {
+        Ok(m) => m,
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Could not load messages: {e}"));
+            return;
+        }
+    };
+
+    let (session_title, session_started_at): (Option<String>, Option<String>) = match session
+        .db
+        .list_sessions(200, std::path::Path::new("/"))
+        .await
+    {
+        Ok(sessions) => {
+            let found = sessions.into_iter().find(|s| s.id == session.id);
+            (
+                found.as_ref().and_then(|s| s.title.clone()),
+                found.map(|s| s.created_at),
+            )
+        }
+        Err(_) => (None, None),
+    };
+
+    let config_dir = match koda_core::db::config_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Could not resolve config dir: {e}"));
+            return;
+        }
+    };
+    let output_dir = config_dir.join("debug-bundles");
+
+    let captured_at = chrono_like_now_iso();
+
+    let input = BundleInput {
+        session_id: &session.id,
+        session_title: session_title.as_deref(),
+        session_started_at: session_started_at.as_deref(),
+        model: Some(config.model.as_str()),
+        provider: Some(session.provider.provider_name()),
+        context_window: None, // PR α: not surfacing yet; PR β can wire from provider
+        messages: &messages,
+        config_dir: &config_dir,
+        current_pid: std::process::id(),
+        captured_at: &captured_at,
+        output_dir: &output_dir,
+    };
+
+    match write_bundle(&input) {
+        Ok(path) => {
+            tui_output::ok_msg(
+                buffer,
+                format!("Wrote debug bundle \u{2192} {}", path.display()),
+            );
+        }
+        Err(e) => {
+            tui_output::err_msg(buffer, format!("Could not write debug bundle: {e}"));
+        }
+    }
+}
+
+/// Best-effort RFC-3339 "now" using the shared [`crate::util::utc_now`]
+/// helper (per #818, hand-rolled date math is banned in koda-cli).
+///
+/// Format: `YYYY-MM-DDTHH:MM:SSZ` (UTC). Used for `captured_at` in the
+/// debug bundle metadata + bundle filename.
+fn chrono_like_now_iso() -> String {
+    let dt = crate::util::utc_now();
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        dt.year(),
+        dt.month() as u8,
+        dt.day(),
+        dt.hour(),
+        dt.minute(),
+        dt.second(),
+    )
 }
 
 /// Validate a user-supplied `/export <path>` destination.

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -860,7 +860,7 @@ async fn handle_export(
     }
 }
 
-/// `/debug-bundle` — write a self-contained `.tar.gz` debug artifact to
+/// `/debug-bundle` — write a self-contained `.zip` debug artifact to
 /// `~/.config/koda/debug-bundles/`.
 ///
 /// See [`crate::debug_bundle`] module docs for the bundle layout, design


### PR DESCRIPTION
First of four PRs implementing RFC #1167 (renderer unification). This PR is **strictly additive** — no existing surface changes, no breaking changes. `/export` continues to work identically. Future PR δ aliases `/export` → `/debug-bundle` and deletes ~1100 LoC of `transcript.rs`.

## What this adds

A new slash command, `/debug-bundle`, that writes a self-contained `.zip` to `~/.config/koda/debug-bundles/koda-debug-{YYYYMMDD-HHMMSS}-{slug}.zip` capturing everything a debugger (human or LLM) needs to reason about a session without machine access.

### Bundle layout

| File | Source |
|---|---|
| `README.md` | Orientation, opened first by humans |
| `conversation.md` | `history_render::render_history_messages` → `lines_to_text` (single-renderer path: byte-for-byte same render the live TUI uses) |
| `messages.json` | Raw DB rows, faithful model's-eye view |
| `metadata.json` | session id/title/model/provider/totals/version/etc |
| `env.txt` | Allowlist-filtered env vars (RFC §D5) |
| `logs/koda-{PID}.log` | Full per-process tracing log |
| `logs/panic.log` | If exists, full file (else absent) |

## Why these design choices aren't options

- **`.zip` over `.tar.gz`.** Random access is the killer agent-friendly property: a zip's central directory at the tail makes reading one entry O(entry), not O(bundle). For our consumer profile (LLM agents poking at one file at a time during debugging, claude.ai/chatgpt UI uploads, Windows users browsing in Explorer), this matters. The compression delta on sub-MB text bundles is meaningless. Pinned by a `by_name()` random-access assertion in the integration test.
- **Allowlist > denylist for env vars (§D5).** New API key vendors leak by default under denylist; allowlist is safe-by-default. Credentials are length-redacted ("is `OPENAI_API_KEY` set?" is the debug question; the actual value is not in the bundle).
- **No runtime config knobs.** To extend the env allowlist, edit source and rebuild. Minimal surface area = no foot-guns from users opting into leaking their own credentials.
- **`history_render` is THE single source of truth (§D1).** `conversation.md` routes through `render_history_messages` → `lines_to_text`, eliminating the divergence that the v0.2.21–v0.2.24 audit cycle filed bugs about (#1162, #1164, #1165).
- **Logs copied verbatim (§D4), not tailed.** Each koda invocation gets its own log; the bundle takes the whole thing.
- **Lives in PARALLEL with `/export`.** No breaking change. Future PR δ does the migration.

## Test coverage

| Layer | Count |
|---|---|
| `env_filter` unit tests (allowlist/redact/drop semantics) | 11 |
| `metadata` unit tests (JSON round-trip, optionals, version sanity) | 4 |
| `readme` unit tests (file-list completeness, sharing-warning guardrail) | 4 |
| `mod.rs` unit tests (slugify, timestamp, totals, JSON shape) | 8 |
| **Integration tests** (real .zip produced + unzipped + random-access by_name verified) | **2** |
| **Total new tests** | **31** |

Existing 551 `koda-cli` lib tests still passing. Clean clippy. Release build succeeds.

## Files

```
koda-cli/src/debug_bundle/mod.rs         676 LoC  (orchestrator + writer + tests)
koda-cli/src/debug_bundle/env_filter.rs  288 LoC
koda-cli/src/debug_bundle/metadata.rs    220 LoC
koda-cli/src/debug_bundle/readme.rs      179 LoC
                                       ─────
                                       1363 LoC (~380 are tests)
```

`mod.rs` is slightly over our 600-line guideline; ~380 of those lines are tests and the remaining source is cohesive bundle orchestration. Splitting purely to hit the line count would hurt cohesion (Zen rule). Happy to revisit if a natural seam emerges in PR β/γ/δ.

`tui_commands.rs` grew by ~100 LoC (handler + ISO-now helper). It's now 1313 lines (was 1213). Already over 600 — file split is tracked in #1144 and explicitly out of scope here.

## Manual verification

- ✅ `cargo build -p koda-cli` — clean
- ✅ `cargo test -p koda-cli --lib` — 551/551 passing (was 520/520; +31 new)
- ✅ `cargo clippy -p koda-cli --lib --tests` — 0 warnings
- ✅ `cargo build -p koda-cli --release` — succeeds
- ✅ `/help` autocompletion auto-includes `/debug-bundle` (driven by `completer.rs` table)

## Commits in this PR

1. `feat(debug-bundle): add /debug-bundle slash command (RFC #1167 PR α)` — initial implementation with tar.gz
2. `refactor(debug-bundle): switch bundle format from tar.gz to zip` — switched to zip for random-access (this conversation: <https://github.com/lijunzh/koda/pull/1170>)

## Next PRs in the epic

- **PR β** — `tracing::error!` breadcrumb in panic hook (~5 LoC) so panics show up in `koda-{PID}.log`, making the bundle's logs section more useful.
- **PR γ** — `/logs` slash command (~50 LoC) to surface log paths inside the TUI.
- **PR δ** — Migrate `/export` to alias `/debug-bundle`, delete `transcript.rs` (~1100 LoC net deletion).

Refs: #1167
