### PR TITLE
feat(panic-hook): tracing::error! breadcrumb so /debug-bundle logs are self-correlating (RFC #1167 PR β)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   cross-platform UX. Lives in parallel with `/export`; future PRs
   unify them per RFC #1167. (#1167 — PR α)
 
+### Changed
+
+- **Panic hook now emits a `tracing::error!` breadcrumb** before
+  writing `panic.log`. The breadcrumb — a single-line
+  `thread '<name>' panicked at <location>: <message>` mirroring the
+  rustc default format — lands in the per-process tracing log
+  (`koda-{PID}.log`). When both files end up in a `/debug-bundle`,
+  the panic is now correlatable with the surrounding tracing context
+  via wall-clock timestamp, instead of sitting in `panic.log`
+  isolated from the events leading up to it. (RFC #1167 — PR β)
+
 ## [0.2.25] - 2026-04-30
 
 Background-tasks UX release. 5 PRs since v0.2.24 reshape `WaitTask` into

--- a/koda-cli/src/panic_log.rs
+++ b/koda-cli/src/panic_log.rs
@@ -105,24 +105,38 @@ pub fn write_panic_log(info: &PanicHookInfo<'_>) {
     let _ = file.flush();
 }
 
-/// Format a panic record into `writer`. Pure function for unit testing.
+/// Single-line summary fields extracted from a [`PanicHookInfo`].
 ///
-/// Separated from [`write_panic_log`] so the formatting can be exercised
-/// without touching the filesystem or the global panic hook.
-pub(crate) fn write_panic_record<W: Write>(
-    writer: &mut W,
-    info: &PanicHookInfo<'_>,
-    timestamp: &str,
-    version: &str,
-) {
+/// Used in two places:
+///   1. [`write_panic_record`] formats this into the multi-line
+///      `panic.log` record (with backtrace).
+///   2. [`panic_breadcrumb`] formats this into a single line for
+///      `tracing::error!` so the per-process tracing log
+///      (`koda-{PID}.log`) gets a correlatable breadcrumb —
+///      i.e. when something goes wrong, the bundle's `logs/` has
+///      both the surrounding context (tracing log) AND the panic
+///      itself (panic.log) sharing the same wall-clock timestamp.
+///
+/// All fields are owned `String`s so the struct can outlive the
+/// `PanicHookInfo` borrow if a caller needs to defer formatting.
+pub(crate) struct PanicSummary {
+    pub thread: String,
+    pub location: String,
+    pub message: String,
+}
+
+/// Extract the human-readable summary fields from a panic hook payload.
+///
+/// Pure function (no I/O, no logging) so it's safe to call from inside
+/// any panic hook implementation. Conventional payload types (`&str`
+/// from `panic!("...")`, `String` from `panic!("{}", ...)`) are
+/// downcast; anything else degrades to a placeholder.
+pub(crate) fn panic_summary(info: &PanicHookInfo<'_>) -> PanicSummary {
     let location = info
         .location()
         .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
         .unwrap_or_else(|| "(unknown)".to_string());
 
-    // PanicHookInfo::payload() carries the panic argument. The conventional
-    // payload types are &str (from `panic!("...")`) and String (from
-    // `panic!("{}", ...)`). Anything else falls back to a placeholder.
     let message = info
         .payload()
         .downcast_ref::<&str>()
@@ -134,6 +148,40 @@ pub(crate) fn write_panic_record<W: Write>(
         .name()
         .unwrap_or("<unnamed>")
         .to_string();
+
+    PanicSummary {
+        thread,
+        location,
+        message,
+    }
+}
+
+/// Format a panic into a single-line breadcrumb suitable for
+/// `tracing::error!`. Pure function, no allocations beyond the result.
+///
+/// Format: `thread '<name>' panicked at <location>: <message>`
+///
+/// This deliberately mirrors the rustc default panic message so logs
+/// scraped by humans grep the same way they would for a normal panic.
+pub(crate) fn panic_breadcrumb(info: &PanicHookInfo<'_>) -> String {
+    let s = panic_summary(info);
+    format!(
+        "thread '{}' panicked at {}: {}",
+        s.thread, s.location, s.message
+    )
+}
+
+/// Format a panic record into `writer`. Pure function for unit testing.
+///
+/// Separated from [`write_panic_log`] so the formatting can be exercised
+/// without touching the filesystem or the global panic hook.
+pub(crate) fn write_panic_record<W: Write>(
+    writer: &mut W,
+    info: &PanicHookInfo<'_>,
+    timestamp: &str,
+    version: &str,
+) {
+    let summary = panic_summary(info);
 
     // Backtrace is only useful when RUST_BACKTRACE is enabled; otherwise
     // capture() returns an unresolved/disabled marker. Record explicitly
@@ -153,9 +201,9 @@ pub(crate) fn write_panic_record<W: Write>(
     );
     let _ = writeln!(writer, "[{timestamp}] PANIC");
     let _ = writeln!(writer, "version:    koda {version}");
-    let _ = writeln!(writer, "location:   {location}");
-    let _ = writeln!(writer, "thread:     {thread}");
-    let _ = writeln!(writer, "message:    {message}");
+    let _ = writeln!(writer, "location:   {}", summary.location);
+    let _ = writeln!(writer, "thread:     {}", summary.thread);
+    let _ = writeln!(writer, "message:    {}", summary.message);
     let _ = writeln!(writer, "backtrace:");
     for line in backtrace_str.lines() {
         let _ = writeln!(writer, "  {line}");
@@ -282,6 +330,69 @@ mod tests {
         // Buffer ends with a delimiter line (sanity that we're appending
         // a complete record, not a half one).
         assert!(formatted.trim_end().ends_with('='), "trailing delimiter");
+    }
+
+    /// Captured `(thread, location, message)` triple from
+    /// `panic_summary` for the breadcrumb tests below.
+    static CAPTURED_SUMMARY: Mutex<Option<(String, String, String)>> = Mutex::new(None);
+    static CAPTURED_BREADCRUMB: Mutex<Option<String>> = Mutex::new(None);
+
+    #[test]
+    #[serial]
+    fn panic_summary_extracts_thread_location_and_message() {
+        *CAPTURED_SUMMARY.lock().unwrap() = None;
+        let saved = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let s = panic_summary(info);
+            *CAPTURED_SUMMARY.lock().unwrap() = Some((s.thread, s.location, s.message));
+        }));
+        let _ = std::panic::catch_unwind(|| {
+            panic!("summary test panic");
+        });
+        std::panic::set_hook(saved);
+
+        let (thread, location, message) =
+            CAPTURED_SUMMARY.lock().unwrap().clone().expect("hook ran");
+        assert!(!thread.is_empty(), "thread name populated");
+        // Location is `file:line:col` — should mention this very file.
+        assert!(
+            location.contains("panic_log.rs"),
+            "location points at panic site, got: {location}"
+        );
+        assert_eq!(message, "summary test panic");
+    }
+
+    #[test]
+    #[serial]
+    fn panic_breadcrumb_renders_single_line_in_rustc_format() {
+        *CAPTURED_BREADCRUMB.lock().unwrap() = None;
+        let saved = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            *CAPTURED_BREADCRUMB.lock().unwrap() = Some(panic_breadcrumb(info));
+        }));
+        let _ = std::panic::catch_unwind(|| {
+            panic!("breadcrumb test panic");
+        });
+        std::panic::set_hook(saved);
+
+        let line = CAPTURED_BREADCRUMB
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("hook ran");
+        // Single line, no embedded newlines (this is the property that
+        // makes it suitable for tracing::error! — a multi-line message
+        // would break log parsers and grep workflows).
+        assert!(
+            !line.contains('\n'),
+            "breadcrumb must be single line, got: {line:?}"
+        );
+        // Mirrors rustc's default panic message format so humans grep
+        // it the same way.
+        assert!(line.starts_with("thread '"), "got: {line}");
+        assert!(line.contains("' panicked at "), "got: {line}");
+        assert!(line.contains("breadcrumb test panic"), "got: {line}");
+        assert!(line.contains("panic_log.rs"), "got: {line}");
     }
 
     #[test]

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -592,7 +592,16 @@ fn install_panic_hook(restore: fn()) {
     std::panic::set_hook(Box::new(move |info| {
         // Best-effort: ignore errors here, we're already failing.
         restore();
-        // Forensic breadcrumb for post-mortem debugging (#1122). Wrapped
+        // Forensic breadcrumb in the per-process tracing log
+        // (`koda-{PID}.log`). The panic.log written below has the
+        // multi-line record + backtrace; this single line is what
+        // makes the panic correlatable with surrounding tracing
+        // events when both files end up in a /debug-bundle
+        // (RFC #1167 §D3). If the global subscriber isn't installed
+        // (headless tests, very early panics), tracing::error! is a
+        // no-op — safe.
+        tracing::error!("{}", crate::panic_log::panic_breadcrumb(info));
+        // Forensic record for post-mortem debugging (#1122). Wrapped
         // in a `let _ =` chain inside the helper so any I/O error here
         // cannot turn into panic-in-panic-hook.
         crate::panic_log::write_panic_log(info);


### PR DESCRIPTION
Second of four PRs implementing RFC #1167. Tiny, surgical change. **PR α (#1170) merged 30 minutes ago** delivered `/debug-bundle`; this PR makes the bundle's `logs/` section actually useful when something has crashed.

## The problem

Before this change, when koda panicked:

- ✅ `~/.config/koda/logs/panic.log` got a multi-line forensic record (location + thread + message + backtrace)
- ❌ `~/.config/koda/logs/koda-{PID}.log` (per-process tracing log) had **zero record of the panic**

A debugger reading `koda-{PID}.log` would see normal activity, then nothing — no signal at all that the process died. To correlate "what was happening right before the crash" with "the crash itself" you had to mentally splice two files together by wall-clock timestamp. Painful.

When both files end up in a `/debug-bundle` (PR α), the human/LLM consumer hits this same wall.

## The fix

Panic hook now emits a single `tracing::error!` line **before** writing `panic.log`:

```text
ERROR thread 'main' panicked at koda-cli/src/foo.rs:42:13: oh no
```

Format mirrors rustc's default panic message exactly so existing human grep workflows just work. The line lands in `koda-{PID}.log` via the global tracing subscriber. Now the bundle's `logs/` directory is self-correlating.

## Implementation

| Change | LoC |
|---|---|
| `panic_log.rs`: extract `PanicSummary { thread, location, message }` + `panic_summary()` helper (used by both `write_panic_record` and the new breadcrumb — eliminates duplicated `downcast<&str/String>` logic) | +50 / -16 |
| `panic_log.rs`: add `panic_breadcrumb(info) -> String` (pure function, formats summary into rustc-style single line) | +14 |
| `tui_viewport.rs::install_panic_hook`: add `tracing::error!` call between `restore()` and `write_panic_log()` | +9 / -2 |
| `panic_log.rs` tests: 2 new (`panic_summary_extracts_*`, `panic_breadcrumb_renders_single_line_in_rustc_format`) | +66 |
| `CHANGELOG.md`: Changed entry | +13 |

**Net diff:** +147 / -16. Slightly bigger than the "5 LoC" estimate I gave earlier — most of the extra LoC is the DRY refactor (`PanicSummary` extraction, eliminating duplication that would have grown when adding the second consumer) + the two new tests.

## Order matters in the panic hook

```rust
std::panic::set_hook(Box::new(move |info| {
    restore();                                           // 1. terminal first (so error isn't
                                                         //    clobbered by alt-screen teardown)
    tracing::error!("{}", panic_log::panic_breadcrumb(info));  // 2. tracing log
    panic_log::write_panic_log(info);                    // 3. panic.log
    original(info);                                      // 4. chain (default backtrace etc.)
}));
```

If the global tracing subscriber isn't installed (headless tests, very early panics before app startup), `tracing::error!` is a no-op — safe.

## Test coverage

- ✅ `panic_summary_extracts_thread_location_and_message` — pure unit test using `catch_unwind` + capture-via-`static Mutex<Option<...>>` pattern (same as the existing `write_panic_record_*` test)
- ✅ `panic_breadcrumb_renders_single_line_in_rustc_format` — asserts no embedded newlines (the property that makes it tracing-suitable) + rustc-format prefix structure

Both gated with `#[serial]` since `panic::set_hook` is global state.

## Manual verification

- ✅ `cargo test -p koda-cli --lib` — 553/553 passing (was 551 + 2 new)
- ✅ `cargo clippy -p koda-cli --lib --tests` — 0 warnings
- ✅ Full panic-hook-chain integrity tests in `tui_viewport::panic_hook_tests` still pass (no regression to #1119/#1120 fix)

## Next PRs in the epic

- **PR γ** — `/logs` slash command (~50 LoC) to surface log paths inside the TUI.
- **PR δ** — Migrate `/export` to alias `/debug-bundle`, delete `transcript.rs` (~1100 LoC net deletion).

Refs: #1167
