### PR TITLE
chore: release v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.26] - 2026-04-29
+
+The RFC #1167 release. `/export` is gone; `/debug-bundle` takes its
+place with a richer self-contained `.zip` artifact (conversation,
+raw messages, metadata, allowlist-filtered env, and per-process
+tracing logs). Panic-hook breadcrumbs make the bundled logs
+self-correlating. Net workspace deletion across the three landing
+PRs: **−677 LoC** — the new feature is smaller than the code it
+replaces.
+
+### Behaviour change — `/export` removed, `/debug-bundle` is the export path
+
+- **`/export` and the `transcript.rs` module are gone.** Any user
+  workflow that relied on `/export <file.md>` to dump a session
+  transcript must switch to `/debug-bundle`. The new artifact is a
+  `.zip` (not a `.md`) and contains the conversation rendered via the
+  same `history_render` pipeline as the live TUI — byte-for-byte
+  identical to what was on screen. See
+  [`commands.md#debug-bundle`](./docs/src/commands.md#debug-bundle)
+  for the full bundle layout, env-var redaction policy, and usage
+  examples. (RFC #1167 — PR δ — #1172)
+- **`KODA_TRANSCRIPT_HYPERLINKS` and `KODA_EXPORT_VERBOSE` env vars
+  are gone.** Both controlled `/export` formatting; setting them is
+  now a silent no-op. Remove them from your shell rc files.
+  Documented under `### Removed` below.
+
 ### Added
 
 - **`/debug-bundle` slash command** — writes a self-contained `.zip`
@@ -17,8 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   length-redacted), and `logs/` (full per-process tracing log + panic
   log if any). Format chosen for random-access reads (LLM debugging
   poke-one-file workflows are O(file) instead of O(bundle)) and broad
-  cross-platform UX. Lives in parallel with `/export`; future PRs
-  unify them per RFC #1167. (#1167 — PR α)
+  cross-platform UX. Replaces the legacy `/export` command (see
+  Removed below) per RFC #1167. (#1167 — PR α)
 
 ### Changed
 
@@ -44,6 +70,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   surfaces `~/.config/koda/logs/latest` for raw-log discoverability
   (replacing the originally-planned dedicated `/logs` slash command;
   YAGNI).
+- **Env vars `KODA_TRANSCRIPT_HYPERLINKS` and `KODA_EXPORT_VERBOSE`**
+  removed alongside `/export`. Both controlled formatting of the
+  removed transcript exporter. Setting either is now a silent no-op.
+  Migration: remove from shell rc files; `/debug-bundle` has no
+  equivalent flags because its output is structured (zip + JSON +
+  Markdown) rather than a single concatenated stream.
 
 ## [0.2.25] - 2026-04-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.2.25)
+10. Sync version with workspace (currently 0.2.26)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/src/commands.md
+++ b/docs/src/commands.md
@@ -224,34 +224,89 @@ Defaults to the most recent response (`n=1`).
 Reads from the full session DB, so compacted (summarised) responses are
 included in the count. A one-line preview is shown in the confirmation.
 
-## `/export [<file.md>]`
+## `/debug-bundle`
 
-Exports the full session transcript as a Markdown document.
-
-```text
-/export                    ← auto-named file in the current directory
-/export notes/session.md   ← write to a specific relative path
-```
-
-Paths must be relative to the current directory. Absolute paths and `..`
-traversal are rejected.
-
-When no path is given, the filename is derived from the first user message
-and the current UTC time:
+Writes a self-contained `.zip` artifact capturing everything a debugger
+(human or LLM) needs to reason about the current session. Replaces the
+`/export` command removed in v0.2.26 (RFC #1167).
 
 ```text
-koda-20260410-143022-refactor-the-auth-module.md
+/debug-bundle
 ```
 
-The transcript includes all user messages, assistant responses, and a
-summary of every tool call. System prompts are excluded.
+The bundle is written to:
 
-Sub-agent invocations are folded under the parent `InvokeAgent` tool
-call: the parent's tool-result block contains the full sub-agent trace
-(messages and tool calls) indented as a nested transcript section. The
-folding is driven by `session_events.parent_tool_call_id` in the
-session DB, so re-exporting an old session also reflects the
-hierarchy.
+```text
+~/.config/koda/debug-bundles/koda-debug-{timestamp}-{slug}.zip
+```
+
+where `{slug}` is derived from the first user message. The success
+message prints the full path and a hint to the raw log directory:
+
+```text
+Wrote debug bundle → /Users/you/.config/koda/debug-bundles/koda-debug-20260429-082303-fix-the-auth-bug.zip
+  raw logs: /Users/you/.config/koda/logs/latest
+```
+
+### Bundle layout
+
+| File | What's in it |
+|---|---|
+| `README.md` | Human-orientation: what each file is, when to share, the env-var redaction caveat |
+| `conversation.md` | Full session rendered via the same `history_render` pipeline as the live TUI — byte-for-byte identical to what you saw on screen |
+| `messages.json` | Raw per-message DB rows (role, content, tool calls, tool results) |
+| `metadata.json` | Session ID, title, started-at, model, provider, current PID, capture timestamp |
+| `env.txt` | Allowlist-filtered environment variables (see below) |
+| `logs/koda-{PID}.log` | Full per-process tracing log captured by the active session |
+| `logs/panic.log` | Present only if the session encountered a panic; mirrors `~/.config/koda/logs/panic.log` |
+
+The `.zip` format was chosen for **random-access reads** — LLM debugging
+workflows that poke at one file at a time pay O(file) instead of
+O(bundle), and the artifact opens cleanly in Finder Quick Look,
+Windows Explorer, and any unzip CLI.
+
+### Environment-variable redaction
+
+`env.txt` is filtered through an **allowlist by default** in
+`koda-cli/src/debug_bundle/env_filter.rs`. The filter has three
+categories:
+
+- **Pass through verbatim**: `KODA_*`, `RUST_*`, `LC_*`, `LANG`,
+  `TERM`, `SHELL`, `PATH`, proxy vars (`HTTP_PROXY` / `HTTPS_PROXY` /
+  `NO_PROXY`).
+- **Length-redact**: known credential vars (`OPENAI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, `GEMINI_API_KEY`, etc.) appear
+  as `<redacted, N bytes>` so their *presence* is visible to the
+  debugger but the *value* never leaks.
+- **Drop entirely**: PII (`HOME`, `USER`, `PWD`, `LOGNAME`) and any
+  unknown variable. Defaulting unknown to *drop* protects against
+  unanticipated future credential names.
+
+There is **no runtime opt-in to disable this filter**. Embedding raw
+`std::env::vars()` in a sharable artifact is a foot-gun even with
+opt-in flags; the bundle README also reminds you to re-check `env.txt`
+before sharing externally.
+
+### When to use it
+
+- Reporting a bug to the koda issue tracker — attach the `.zip` so
+  maintainers see your exact session, panic context, and runtime
+  environment.
+- Asking another LLM (Claude, ChatGPT, Gemini) to help debug a koda
+  session — the model can `unzip` and read `conversation.md` directly.
+- Capturing a known-bad state for later analysis (the timestamped
+  filename + slug make bundles trivially sortable).
+
+### Self-correlating logs (v0.2.26)
+
+When a panic occurs, the panic hook now emits a `tracing::error!`
+breadcrumb in rustc's default format (`thread '<name>' panicked at
+<location>: <message>`) **before** writing `panic.log`. The breadcrumb
+lands in the per-process tracing log, so within a `/debug-bundle` the
+`logs/panic.log` and `logs/koda-{PID}.log` are correlatable by
+wall-clock timestamp — no more orphan panic files disconnected from
+the events that led up to them.
+
 
 ## `/verbose [on|off]`
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -54,29 +54,26 @@ priority over global config:
 
 ## Display
 
-Koda's TUI ships ANSI-colored syntax highlighting and OSC 8 hyperlinks by
-default — both have one-flag escape hatches for environments where the
-output looks awful (monochrome themes, non-OSC-8-aware terminals that
-leak escape bytes, etc.).
+Koda's TUI ships ANSI-colored syntax highlighting by default. Disable
+with one flag for environments where the output looks awful (monochrome
+themes, non-RGB-aware terminals).
 
 | Env var | Default | Disable with |
 |---------|---------|--------------|
 | `KODA_SYNTAX_HIGHLIGHT` | on | `off`, `0`, `false`, or `no` |
-| `KODA_TRANSCRIPT_HYPERLINKS` | on | `off`, `0`, `false`, or `no` |
-| `KODA_EXPORT_VERBOSE` | off | (set to `1`, `true`, `yes`, or `on` to enable) |
 
 - **`KODA_SYNTAX_HIGHLIGHT`** controls TUI syntax highlighting for
   `Read`, `Bash` headers, and inline code. Disable for monochrome
   terminals or terminals where ANSI-RGB output looks washed out.
   Memoized on first call — restart koda after changing.
-- **`KODA_TRANSCRIPT_HYPERLINKS`** controls markdown-style hyperlinks
-  in `/copy` and `/export` output. Disable if you paste transcripts
-  into a viewer that mangles `[text](file:///abs/path)` syntax.
-- **`KODA_EXPORT_VERBOSE`** restores per-iteration sub-agent
-  heartbeat lines (`Running (Nx)`) in `/export` output. Off by
-  default (since v0.2.25) so transcripts focus on terminal task
-  outcomes; enable when debugging heartbeat aggregation or
-  long-running sub-agents that never seem to terminate.
 
-Both flags accept the same negative values; everything else (including
-empty string and `on`) keeps the feature enabled.
+The negative values above (`off`, `0`, `false`, `no`) are
+case-insensitive; everything else (including empty string and `on`)
+keeps the feature enabled.
+
+> **Removed in v0.2.26**: `KODA_TRANSCRIPT_HYPERLINKS` and
+> `KODA_EXPORT_VERBOSE` previously controlled `/export` output
+> formatting. Both were removed alongside `/export` itself when RFC
+> #1167 collapsed transcript export into [`/debug-bundle`](commands.md#debug-bundle).
+> Setting either var is now a silent no-op; remove them from your
+> shell rc files.

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -14,7 +14,7 @@ Each crash appends a delimited block:
 ```
 ======================================================================
 [2026-04-29T20:55:32Z] PANIC
-version:    koda 0.2.25
+version:    koda 0.2.26
 location:   koda-core/src/foo.rs:42:8
 thread:     <unnamed>
 message:    assertion failed: x > 0

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.2.25"
+version = "0.2.26"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.2.25" }
+koda-core = { path = "../koda-core", version = "0.2.26" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
@@ -83,7 +83,7 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.2.25", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.2.26", features = ["test-support"] }
 serde_json = { workspace = true }
 # tokio's `test-util` feature enables `#[tokio::test(start_paused = true)]` so
 # frame_requester tests can manipulate the clock deterministically without

--- a/koda-cli/tests/regression_test.rs
+++ b/koda-cli/tests/regression_test.rs
@@ -108,7 +108,7 @@ mod completions {
     ];
 
     /// Commands that should NOT appear in completions.
-    const REMOVED_COMMANDS: &[&str] = &["/key", "/transcript"];
+    const REMOVED_COMMANDS: &[&str] = &["/key", "/transcript", "/export"];
 
     #[test]
     fn test_expected_commands_present() {

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.2.25"
+version = "0.2.26"
 edition.workspace = true
 rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.2.25" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.2.26" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.2.25"
+version = "0.2.26"
 edition.workspace = true
 rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"


### PR DESCRIPTION
The RFC #1167 release. Three feature PRs landed since v0.2.25, all closing the epic to replace `/export` with `/debug-bundle`:

| Commit | PR | Role |
|---|---|---|
| `d08aeff` | [#1170](https://github.com/lijunzh/koda/pull/1170) | feat(debug-bundle): `/debug-bundle` slash command writing `.zip` artifacts (PR α) |
| `7838364` | [#1171](https://github.com/lijunzh/koda/pull/1171) | feat(panic-hook): `tracing::error!` breadcrumb so `/debug-bundle` logs are self-correlating (PR β) |
| `99bfee2` | [#1172](https://github.com/lijunzh/koda/pull/1172) | refactor(transcript): delete `/export` and `transcript.rs` entirely (PR δ) |

(PR γ — a dedicated `/logs` slash command — was dropped on YAGNI grounds; replaced by a 1-line raw-logs hint in `/debug-bundle`'s success message. See [issue #1167](https://github.com/lijunzh/koda/issues/1167) for the full retrospective.)

**Net workspace deletion across the three landing PRs: −677 LoC.** The new feature is smaller than the code it replaces.

## Behaviour changes (breaking)

### `/export` is gone

Any user workflow relying on `/export <file.md>` to dump a session transcript must switch to `/debug-bundle`. The new artifact is a `.zip` (not a `.md`) containing the conversation rendered via the same `history_render` pipeline as the live TUI — byte-for-byte identical to what was on screen, plus `messages.json`, `metadata.json`, allowlist-filtered `env.txt`, and per-process tracing logs.

### Two env vars removed

`KODA_TRANSCRIPT_HYPERLINKS` and `KODA_EXPORT_VERBOSE` are gone alongside `/export`. Setting either is now a silent no-op. Users should remove them from shell rc files. `/debug-bundle` has no equivalent flags because its output is structured (zip + JSON + Markdown) rather than a single concatenated stream.

## Version bumps

- `koda-core` 0.2.25 → 0.2.26 (+ `koda-sandbox` path-dep version pin)
- `koda-cli` 0.2.25 → 0.2.26 (+ both `koda-core` path-dep version pins)
- `koda-sandbox` 0.2.25 → 0.2.26
- `Cargo.lock` regenerated via `cargo check --workspace`
- `koda-test-utils` stays at 0.1.0 (independent versioning)

## Sub-agent audit findings (Phase 2)

| Agent | Outcome |
|---|---|
| `code-reviewer` | **3 P1 + 1 P2 + 4 P3 findings** — all P1/P2 **fixed in this PR**. The P1s were doc blockers: `commands.md` still documented `/export`, `configuration.md` advertised the dead env vars, and `/debug-bundle` had zero docs. Without this catch the release would have shipped with broken user-facing docs. |
| `qa-expert` | **Ship it** — no findings. Contributed a 7-item manual smoke list (live-session secret leak audit, panic correlation end-to-end, RUST_BACKTRACE toggle behaviour, filename-collision edge case, Quick Look sanity, large-session size sanity, Unix permission verification) for pre-release manual testing. |
| `rust-programmer` | Agent invocation timed out (httpx ReadError). Rao fmt --all --check`, `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings`, `cargo doc --workspace --no-deps RUSTDOCFLAGS=-Dwarnings` directly — all clean. |
| `security-auditor` | Agent invocation timed out (httpx ReadTimeout). Defhe `Security Audit` CI job, which passed on all three source PRs (#1170, #1171, #1172). The new file-writing surface (`debug_bundle/`) was hand-reviewed by `code-reviewer` who praised the env_filter allowlist-by-default + length-redaction + KODA_/RUST_/LC_ prefix scoping + `pii_corp_id_dropped_entirely` test (which hardcodes the Walmart corp ID as a leakage assertion). |

## P1 fixes applied in this PR er and above the version bump)

1. **`docs/src/commands.md`**: replaced the dead `/export [<file.md>]` section with a complete `/debug-bundle` writeup covering bundle layout (README/conversation/messages/metadata/env/logs), env-var redaction policy (allowlist / length-redact / drop), the random-access-reads rationale for choosing zip over tar.gz, when to use it (bug reports / LLM debugging / known-bad-state capture), and the v0.2.26 self-correlating-logs feature.
2. **`docs/src/configuration.md`**: removed the dead env vars table rows and bullets; added a clear "Removed in v0.2.26" callout pointing readers to `/debug-bundle`.
3. **`docs/src/troubleshooting.md`**: bumped sample `koda --version` output in the panic.log layout example.
4. **`koda-cli/tests/regression_test.rs`** (P2): added `/export` to `REMOVED_COMMANDS` so any future regression that re-introduces the slash command gets caught at CI time.
5. **`CHANGELOG.md` Added blurb tightened**: was "Lives in parallel with `/export`; future PRs unify them" (which contradicts the same release's `### Removed` block deleting `/export`); now reads "Replaces the legacy `/export` command (see Removed below) per RFC #1167."

## Quality gates

- ✅ `cargo fmt --all --check` clean
- ✅ `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` clean
- ✅ `cargo test -p koda-cli --lib` 495/495 passing
- ✅ `cargo test -p koda-cli --test regression_test` 20/20 passing
- ✅ `cargo doc --workspace --no-deps` clean (`RUSTDOCFLAGS=-Dwarnings`)

## Manual smoke recommendations from `qa-expert` (do before tagging)

1. Live secret-leak audit: launch koda with real `OPENAI_API_KEY`, run `/debug-bundle`, `grep -i "sk-\|ghp_\|api03" env.txt` → must return zero matches.
2. Panic correlation E2E: trigger a deliberate panic, run `/debug-bundle`, confirm `logs/panic.log` and `logs/koda-{PID}.log` carry timestamps within the same second.
3. `RUST_BACKTRACE` toggle: confirm the bundle's `panic.log` says either real frames or the `(disabled — re-run with RUST_BACKTRACE=1)` message.
4. Filename collision: fire `/debug-bundle` twice within a second; confirm no overwrite or panic.
5. macOS Quick Look + `unzip -l`: confirm no path-traversal warnings.
6. Long-session size: 200+ message session → bundle should be single-digit MB.
7. Unix permissions: `~/.config/koda/logs` should be `0700`, `panic.log` should be `0600`.

## Deferred items

No P1 / P2 items deferred — all caught + fixed inline. The P3-bundle items from the audit (CHANGELOG blurb tightening already applied; the `_ensure_pub_visible` shim in `debug_bundle/mod.rs:339` for cleanup; the stale `context_window: None` TODO in `tui_commands.rs:805`; pre-existing `/key` still in `SLASH_COMMANDS`) are tracker noise per the audit-dust prevention rule and are not being filed as separate issues.

Closes [RFC #1167](https://github.com/lijunzh/koda/issues/1167) (already closed; this PR ships the version bump that makes the work releasable).
