### PR TITLE
feat(composer): port codex bottom_pane::textarea (foundation, PR 1 of 2) (#1178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Internal — codex textarea port foundation (#1116, #1175, #1178)
+
+Foundation work for swapping `ratatui-textarea` (third-party, MIT) for a
+port of codex's `bottom_pane::textarea` module. **No user-visible change
+in this release** — the new module is wired into the build but no koda
+call site consumes it yet (PR 2 of the staged epic does that swap).
+
+- New `koda-cli/src/composer/` module tree at codex SHA
+  `d55479488e125ef7a0a8584505d839a22eaf6204`:
+  - `key_hint.rs` (verbatim vendor, 285 LoC, 9 tests)
+  - `paste_burst.rs` (verbatim vendor, ~430 LoC, 5 tests)
+  - `text_element.rs` (reduced port, ~155 LoC, 4 tests)
+  - `wrapping.rs` (reduced port, 145 LoC)
+  - `keymap.rs` (koda-OWNED policy layer, ~510 LoC, 4 tests)
+  - `textarea.rs` (verbatim vendor with adaptations, 3,503 LoC, 53 tests)
+- Test gain: +75 tests in the composer suite (cumulative across stages),
+  including +18 vim-mode coverage from the HEAD-aligned re-port.
+- Quality gate: full koda-cli lib suite at **572/572 passing**, full
+  workspace at **2,031/2,031 passing**, zero regressions.
+- Provenance: see file headers for SHA anchor + adaptation lists.
+  Future codex syncs are 3-way merges with d55479 as the upstream base.
+
 ## [0.2.26] - 2026-04-29
 
 The RFC #1167 release. `/export` is gone; `/debug-bundle` takes its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1749,7 @@ dependencies = [
  "futures-util",
  "koda-core",
  "libc",
+ "pretty_assertions",
  "ratatui",
  "ratatui-textarea",
  "regex",
@@ -2410,6 +2417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4797,6 +4814,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,6 +1751,7 @@ dependencies = [
  "signal-hook",
  "syntect",
  "tempfile",
+ "textwrap",
  "time",
  "tokio",
  "tokio-util",
@@ -1758,6 +1759,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "two-face",
+ "unicode-segmentation",
  "unicode-width",
  "zip",
 ]
@@ -3261,6 +3263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3644,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,6 +3993,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/LICENSES/codex-APACHE-2.0
+++ b/LICENSES/codex-APACHE-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 OpenAI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -111,4 +111,9 @@ tokio = { workspace = true, features = ["full", "test-util"] }
 # parallel by default; without this, two tests calling `panic::set_hook`
 # would race and produce flaky results.
 serial_test = "3"
+# Better assert_eq! diff output for ported codex tests (#1178). Used
+# inside `composer/paste_burst.rs` test module; small focused dev-only
+# crate. Worth keeping consistent with codex's testing style as we
+# port more of their composer tests in PR 2 / PR 3.
+pretty_assertions = "1"
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -42,6 +42,15 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm",
 ratatui-textarea = "0.9"
 unicode-width = "0.2"
 
+# Composer port (#1116, #1178): textarea + paste_burst lifted from
+# codex-rs (Apache 2.0). textwrap is used by the ported textarea for
+# soft-wrapping; unicode-segmentation handles grapheme-boundary cursor
+# motion. unicode-segmentation is already transitive (1.13.x); declared
+# direct because we now use it ourselves and transitive contracts are
+# fragile.
+textwrap = "0.16"
+unicode-segmentation = "1.13"
+
 # Terminal-cleanup hardening (#1176): signal handlers + atexit hook so that
 # SIGTERM / SIGINT / SIGHUP / process::exit() restore raw mode + alt-screen +
 # mouse-capture before the process dies. Both are already present transitively

--- a/koda-cli/src/composer/key_hint.rs
+++ b/koda-cli/src/composer/key_hint.rs
@@ -1,3 +1,10 @@
+// Foundation work for #1116/#1175. The vendored symbols below are wired into
+// the build but no koda call site consumes them yet — PR 2 of the staged
+// epic swaps chat_composer.rs from ratatui-textarea to composer::textarea
+// and brings the rest into use. The blanket allow goes away when consumers
+// land.
+#![allow(dead_code)]
+
 //! # Provenance
 //!
 //! Ported verbatim from `codex-rs/tui/src/key_hint.rs` at upstream
@@ -54,7 +61,6 @@ use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
 use ratatui::style::Style;
-use ratatui::style::Stylize;
 use ratatui::text::Span;
 
 #[cfg(test)]

--- a/koda-cli/src/composer/key_hint.rs
+++ b/koda-cli/src/composer/key_hint.rs
@@ -1,34 +1,215 @@
-//! Reduced port of codex's `codex-rs/tui/src/key_hint.rs`.
+//! # Provenance
 //!
-//! ## Provenance
-//!
-//! Selected helpers ported from `codex-rs/tui/src/key_hint.rs` at
-//! upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//! Ported verbatim from `codex-rs/tui/src/key_hint.rs` at upstream
+//! commit `d55479488e125ef7a0a8584505d839a22eaf6204` (codex `main`
+//! as of 2026-05-01).
 //!
 //! Original work: Copyright (c) OpenAI / codex contributors,
 //! licensed under the Apache License, Version 2.0.
-//! See `LICENSES/codex-APACHE-2.0` for the full license text.
+//! See `LICENSES/codex-APACHE-2.0` (vendored at the workspace root)
+//! for the full license text.
 //!
-//! ## What was kept vs dropped
+//! # Adaptations for koda
 //!
-//! - **Kept:** [`is_altgr`]. This is the only key-hint helper used by
-//!   the ported [`super::textarea::TextArea`].
-//! - **Dropped:** `KeyBinding`, the modifier-prefix constants, the
-//!   `From<KeyBinding> for Span` impl. Those are part of codex's hint
-//!   rendering surface (footer, key-binding cheat-sheets) which koda
-//!   doesn't currently use. Easy to port later if we adopt codex's
-//!   hint UI.
+//! None. This module is policy-free key-input primitive code:
+//!
+//! - [`KeyBinding`] (data type wrapping `KeyCode` + `KeyModifiers`)
+//! - [`KeyBindingListExt`] trait (matching logic over `[KeyBinding]`)
+//! - Helper constructors ([`plain`], [`alt`], [`shift`], [`ctrl`],
+//!   [`ctrl_alt`])
+//! - [`is_altgr`], [`has_ctrl_or_alt`] modifier helpers
+//! - [`From<KeyBinding> for Span`] rendering for hint UI
+//!
+//! All of this is pure data-structure / algorithm code with no
+//! koda-vs-codex policy decisions to make. Vendored as-is and synced
+//! with codex on the same cadence as [`super::textarea`] and
+//! [`super::paste_burst`].
+//!
+//! # History within koda
+//!
+//! PR #1178 (this PR) initially landed a 75-LoC reduced port that
+//! exposed only [`is_altgr`] (the one helper our reduced textarea port
+//! at codex SHA `7e8594fc` needed). When we pivoted to a HEAD-aligned
+//! port (codex SHA `d55479`), the upstream textarea grew dependencies
+//! on [`KeyBinding`], [`KeyBindingListExt`], and the helper
+//! constructors. Rather than expand our reduced port piecemeal, we
+//! switched to a full verbatim vendor of `key_hint.rs` so future codex
+//! syncs become a single 3-way merge instead of a hand-curated subset.
+//!
+//! # Original module documentation follows
+//!
+//! ---
+//!
+//! Key binding primitives and input matching for the TUI.
+//!
+//! This module provides `KeyBinding`, the runtime representation of a single
+//! keybinding (key code + modifier set), along with matching logic that handles
+//! cross-terminal inconsistencies in how shifted letters are reported.
+//!
+//! It also supplies rendering helpers that convert bindings into styled
+//! `ratatui::text::Span` values for UI hint display.
 
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
+use ratatui::style::Style;
+use ratatui::style::Stylize;
+use ratatui::text::Span;
 
-/// On Windows the AltGr key is delivered as `CONTROL + ALT`. The
-/// textarea uses this to distinguish "user typed an AltGr-composed
-/// character" (a normal text-insert) from "user pressed Ctrl+Alt+key"
-/// (a chord that should be interpreted as a command).
+#[cfg(test)]
+const ALT_PREFIX: &str = "⌥ + ";
+#[cfg(all(not(test), target_os = "macos"))]
+const ALT_PREFIX: &str = "⌥ + ";
+#[cfg(all(not(test), not(target_os = "macos")))]
+const ALT_PREFIX: &str = "alt + ";
+const CTRL_PREFIX: &str = "ctrl + ";
+const SHIFT_PREFIX: &str = "shift + ";
+
+/// One concrete key event that can trigger a TUI action.
 ///
-/// Unconditionally returns `false` on non-Windows platforms because
-/// no other OS encodes AltGr this way; on Linux/macOS the keyboard
-/// driver delivers the composed character directly.
+/// Matching via `is_press` handles both exact equality and a shifted-letter
+/// compatibility fallback for terminals that report uppercase letters without
+/// the SHIFT modifier flag. This means a binding defined as `shift-a` will
+/// match a terminal event of either `Shift+a` or plain `A`.
+///
+/// This does not model multi-key chords or partial matches; callers that need
+/// sequences must keep that state outside this type.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct KeyBinding {
+    key: KeyCode,
+    modifiers: KeyModifiers,
+}
+
+impl KeyBinding {
+    pub(crate) const fn new(key: KeyCode, modifiers: KeyModifiers) -> Self {
+        Self { key, modifiers }
+    }
+
+    pub fn is_press(&self, event: KeyEvent) -> bool {
+        normalize_shifted_ascii_char(self.key, self.modifiers)
+            == normalize_shifted_ascii_char(event.code, event.modifiers)
+            && (event.kind == KeyEventKind::Press || event.kind == KeyEventKind::Repeat)
+    }
+
+    pub(crate) const fn parts(&self) -> (KeyCode, KeyModifiers) {
+        (self.key, self.modifiers)
+    }
+}
+
+fn normalize_shifted_ascii_char(
+    key: KeyCode,
+    mut modifiers: KeyModifiers,
+) -> (KeyCode, KeyModifiers) {
+    let KeyCode::Char(ch) = key else {
+        return (key, modifiers);
+    };
+    if modifiers.is_empty()
+        && let Some(ctrl_char) = c0_control_char_to_ctrl_char(ch)
+    {
+        return (KeyCode::Char(ctrl_char), KeyModifiers::CONTROL | modifiers);
+    }
+    if ch.is_ascii_uppercase() {
+        modifiers.insert(KeyModifiers::SHIFT);
+        return (KeyCode::Char(ch.to_ascii_lowercase()), modifiers);
+    }
+    (key, modifiers)
+}
+
+fn c0_control_char_to_ctrl_char(ch: char) -> Option<char> {
+    match ch {
+        '\u{0002}' => Some('b'),
+        '\u{0006}' => Some('f'),
+        '\u{000e}' => Some('n'),
+        '\u{0010}' => Some('p'),
+        '\u{0012}' => Some('r'),
+        '\u{0013}' => Some('s'),
+        _ => None,
+    }
+}
+
+/// Matching helpers for one action's keybinding set.
+///
+/// Implementations are expected to treat the slice as alternatives for one
+/// action. They should not interpret order as priority for dispatch; order is
+/// reserved for UI hint selection via `primary_binding`.
+pub(crate) trait KeyBindingListExt {
+    /// True when any binding in this set matches `event`.
+    fn is_pressed(&self, event: KeyEvent) -> bool;
+}
+
+impl KeyBindingListExt for [KeyBinding] {
+    fn is_pressed(&self, event: KeyEvent) -> bool {
+        self.iter().any(|binding| binding.is_press(event))
+    }
+}
+
+pub(crate) const fn plain(key: KeyCode) -> KeyBinding {
+    KeyBinding::new(key, KeyModifiers::NONE)
+}
+
+pub(crate) const fn alt(key: KeyCode) -> KeyBinding {
+    KeyBinding::new(key, KeyModifiers::ALT)
+}
+
+pub(crate) const fn shift(key: KeyCode) -> KeyBinding {
+    KeyBinding::new(key, KeyModifiers::SHIFT)
+}
+
+pub(crate) const fn ctrl(key: KeyCode) -> KeyBinding {
+    KeyBinding::new(key, KeyModifiers::CONTROL)
+}
+
+pub(crate) const fn ctrl_alt(key: KeyCode) -> KeyBinding {
+    KeyBinding::new(key, KeyModifiers::CONTROL.union(KeyModifiers::ALT))
+}
+
+fn modifiers_to_string(modifiers: KeyModifiers) -> String {
+    let mut result = String::new();
+    if modifiers.contains(KeyModifiers::CONTROL) {
+        result.push_str(CTRL_PREFIX);
+    }
+    if modifiers.contains(KeyModifiers::SHIFT) {
+        result.push_str(SHIFT_PREFIX);
+    }
+    if modifiers.contains(KeyModifiers::ALT) {
+        result.push_str(ALT_PREFIX);
+    }
+    result
+}
+
+impl From<KeyBinding> for Span<'static> {
+    fn from(binding: KeyBinding) -> Self {
+        (&binding).into()
+    }
+}
+impl From<&KeyBinding> for Span<'static> {
+    fn from(binding: &KeyBinding) -> Self {
+        let KeyBinding { key, modifiers } = binding;
+        let modifiers = modifiers_to_string(*modifiers);
+        let key = match key {
+            KeyCode::Enter => "enter".to_string(),
+            KeyCode::Char(' ') => "space".to_string(),
+            KeyCode::Up => "↑".to_string(),
+            KeyCode::Down => "↓".to_string(),
+            KeyCode::Left => "←".to_string(),
+            KeyCode::Right => "→".to_string(),
+            KeyCode::PageUp => "pgup".to_string(),
+            KeyCode::PageDown => "pgdn".to_string(),
+            _ => format!("{key}").to_ascii_lowercase(),
+        };
+        Span::styled(format!("{modifiers}{key}"), key_hint_style())
+    }
+}
+
+fn key_hint_style() -> Style {
+    Style::default().dim()
+}
+
+pub(crate) fn has_ctrl_or_alt(mods: KeyModifiers) -> bool {
+    (mods.contains(KeyModifiers::CONTROL) || mods.contains(KeyModifiers::ALT)) && !is_altgr(mods)
+}
+
 #[cfg(windows)]
 #[inline]
 pub(crate) fn is_altgr(mods: KeyModifiers) -> bool {
@@ -46,27 +227,101 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_altgr_is_false_on_non_windows() {
-        // On non-Windows platforms (the CI matrix here), AltGr detection
-        // is a constant `false` regardless of input. Verify the
-        // implementation doesn't accidentally claim true for the
-        // Ctrl+Alt combo, which would break Ctrl+Alt+key chords.
-        #[cfg(not(windows))]
-        {
-            assert!(!is_altgr(KeyModifiers::ALT | KeyModifiers::CONTROL));
-            assert!(!is_altgr(KeyModifiers::NONE));
-            assert!(!is_altgr(KeyModifiers::ALT));
-        }
+    fn is_press_accepts_press_and_repeat_but_rejects_release() {
+        let binding = ctrl(KeyCode::Char('k'));
+        let press = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL);
+        let repeat = KeyEvent {
+            kind: KeyEventKind::Repeat,
+            ..press
+        };
+        let release = KeyEvent {
+            kind: KeyEventKind::Release,
+            ..press
+        };
+        let wrong_modifiers = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
 
-        // On Windows, Ctrl+Alt IS the AltGr signal. Verify the
-        // detection returns true so the textarea treats AltGr-composed
-        // characters as text input, not as a chord.
+        assert!(binding.is_press(press));
+        assert!(binding.is_press(repeat));
+        assert!(!binding.is_press(release));
+        assert!(!binding.is_press(wrong_modifiers));
+    }
+
+    #[test]
+    fn keybinding_list_ext_matches_any_binding() {
+        let bindings = [plain(KeyCode::Char('a')), ctrl(KeyCode::Char('b'))];
+
+        assert!(bindings.is_pressed(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)));
+        assert!(bindings.is_pressed(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL)));
+        assert!(!bindings.is_pressed(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn shifted_letter_binding_matches_uppercase_char_events() {
+        let binding = shift(KeyCode::Char('a'));
+
+        assert!(binding.is_press(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::SHIFT)));
+        assert!(binding.is_press(KeyEvent::new(KeyCode::Char('A'), KeyModifiers::NONE)));
+        assert!(binding.is_press(KeyEvent::new(KeyCode::Char('A'), KeyModifiers::SHIFT)));
+    }
+
+    #[test]
+    fn shift_letter_binding_preserves_other_modifiers_with_uppercase_compat() {
+        let binding = KeyBinding::new(
+            KeyCode::Char('i'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+
+        assert!(binding.is_press(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn shift_letter_binding_does_not_match_plain_lowercase_or_other_uppercase() {
+        let binding = shift(KeyCode::Char('o'));
+
+        assert!(!binding.is_press(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE)));
+        assert!(!binding.is_press(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::NONE)));
+    }
+
+    #[test]
+    fn ctrl_letter_binding_matches_c0_control_char_events() {
+        let binding = ctrl(KeyCode::Char('p'));
+
+        assert!(binding.is_press(KeyEvent::new(KeyCode::Char('\u{0010}'), KeyModifiers::NONE)));
+        assert!(!binding.is_press(KeyEvent::new(KeyCode::Char('\u{0010}'), KeyModifiers::ALT)));
+    }
+
+    #[test]
+    fn history_search_ctrl_bindings_match_c0_control_char_events() {
+        assert!(
+            ctrl(KeyCode::Char('r'))
+                .is_press(KeyEvent::new(KeyCode::Char('\u{0012}'), KeyModifiers::NONE))
+        );
+        assert!(
+            ctrl(KeyCode::Char('s'))
+                .is_press(KeyEvent::new(KeyCode::Char('\u{0013}'), KeyModifiers::NONE))
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_sets_both_modifiers() {
+        assert_eq!(
+            ctrl_alt(KeyCode::Char('v')).parts(),
+            (
+                KeyCode::Char('v'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT
+            )
+        );
+    }
+
+    #[test]
+    fn has_ctrl_or_alt_checks_supported_modifier_combinations() {
+        assert!(!has_ctrl_or_alt(KeyModifiers::NONE));
+        assert!(has_ctrl_or_alt(KeyModifiers::CONTROL));
+        assert!(has_ctrl_or_alt(KeyModifiers::ALT));
+
         #[cfg(windows)]
-        {
-            assert!(is_altgr(KeyModifiers::ALT | KeyModifiers::CONTROL));
-            assert!(!is_altgr(KeyModifiers::ALT));
-            assert!(!is_altgr(KeyModifiers::CONTROL));
-            assert!(!is_altgr(KeyModifiers::NONE));
-        }
+        assert!(!has_ctrl_or_alt(KeyModifiers::CONTROL | KeyModifiers::ALT));
+        #[cfg(not(windows))]
+        assert!(has_ctrl_or_alt(KeyModifiers::CONTROL | KeyModifiers::ALT));
     }
 }

--- a/koda-cli/src/composer/key_hint.rs
+++ b/koda-cli/src/composer/key_hint.rs
@@ -1,0 +1,72 @@
+//! Reduced port of codex's `codex-rs/tui/src/key_hint.rs`.
+//!
+//! ## Provenance
+//!
+//! Selected helpers ported from `codex-rs/tui/src/key_hint.rs` at
+//! upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` for the full license text.
+//!
+//! ## What was kept vs dropped
+//!
+//! - **Kept:** [`is_altgr`]. This is the only key-hint helper used by
+//!   the ported [`super::textarea::TextArea`].
+//! - **Dropped:** `KeyBinding`, the modifier-prefix constants, the
+//!   `From<KeyBinding> for Span` impl. Those are part of codex's hint
+//!   rendering surface (footer, key-binding cheat-sheets) which koda
+//!   doesn't currently use. Easy to port later if we adopt codex's
+//!   hint UI.
+
+use crossterm::event::KeyModifiers;
+
+/// On Windows the AltGr key is delivered as `CONTROL + ALT`. The
+/// textarea uses this to distinguish "user typed an AltGr-composed
+/// character" (a normal text-insert) from "user pressed Ctrl+Alt+key"
+/// (a chord that should be interpreted as a command).
+///
+/// Unconditionally returns `false` on non-Windows platforms because
+/// no other OS encodes AltGr this way; on Linux/macOS the keyboard
+/// driver delivers the composed character directly.
+#[cfg(windows)]
+#[inline]
+pub(crate) fn is_altgr(mods: KeyModifiers) -> bool {
+    mods.contains(KeyModifiers::ALT) && mods.contains(KeyModifiers::CONTROL)
+}
+
+#[cfg(not(windows))]
+#[inline]
+pub(crate) fn is_altgr(_mods: KeyModifiers) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_altgr_is_false_on_non_windows() {
+        // On non-Windows platforms (the CI matrix here), AltGr detection
+        // is a constant `false` regardless of input. Verify the
+        // implementation doesn't accidentally claim true for the
+        // Ctrl+Alt combo, which would break Ctrl+Alt+key chords.
+        #[cfg(not(windows))]
+        {
+            assert!(!is_altgr(KeyModifiers::ALT | KeyModifiers::CONTROL));
+            assert!(!is_altgr(KeyModifiers::NONE));
+            assert!(!is_altgr(KeyModifiers::ALT));
+        }
+
+        // On Windows, Ctrl+Alt IS the AltGr signal. Verify the
+        // detection returns true so the textarea treats AltGr-composed
+        // characters as text input, not as a chord.
+        #[cfg(windows)]
+        {
+            assert!(is_altgr(KeyModifiers::ALT | KeyModifiers::CONTROL));
+            assert!(!is_altgr(KeyModifiers::ALT));
+            assert!(!is_altgr(KeyModifiers::CONTROL));
+            assert!(!is_altgr(KeyModifiers::NONE));
+        }
+    }
+}

--- a/koda-cli/src/composer/keymap.rs
+++ b/koda-cli/src/composer/keymap.rs
@@ -1,0 +1,530 @@
+//! koda-owned keymap policy layer (#1178 stage 5c).
+//!
+//! # Status: koda-OWNED, not vendored
+//!
+//! Unlike its sibling modules in `composer/` (which are
+//! verbatim-or-near-verbatim ports of codex source), this file is
+//! **koda's own implementation** of the keymap surface that
+//! [`super::textarea::TextArea`] (Stage 5d) consumes. The struct shapes
+//! and default-binding data are mirrored from codex so the vendored
+//! textarea compiles without modification, but the file is intentionally
+//! scoped much smaller than codex's:
+//!
+//! ## What we DO provide
+//!
+//! - The 9 keymap structs ([`RuntimeKeymap`], [`AppKeymap`],
+//!   [`ChatKeymap`], [`ComposerKeymap`], [`EditorKeymap`],
+//!   [`VimNormalKeymap`], [`VimOperatorKeymap`], [`PagerKeymap`],
+//!   [`ListKeymap`], [`ApprovalKeymap`]) with the same fields codex
+//!   exposes — so [`super::textarea::TextArea`] (which directly accesses
+//!   `editor.move_down`, `vim_normal.append_line_end`, etc.) builds
+//!   unchanged.
+//!
+//! - [`RuntimeKeymap::defaults()`] returning the built-in defaults
+//!   (mirroring codex's hardcoded `built_in_defaults()`).
+//!
+//! - The [`primary_binding`] helper used by hint-rendering code.
+//!
+//! ## What we DO NOT provide
+//!
+//! Everything below is intentionally omitted because it requires
+//! koda-side product decisions that this PR is not the right place
+//! for. Each becomes its own follow-up issue.
+//!
+//! - **No `from_config(TuiKeymap) -> Result<RuntimeKeymap>`**. Codex
+//!   parses `~/.codex/config.toml` into a `codex_config::types::TuiKeymap`
+//!   then resolves it against defaults with precedence + conflict
+//!   validation. koda has no equivalent config schema yet; wiring one
+//!   up would mean importing or reinventing
+//!   [`KeybindingsSpec`](https://github.com/openai/codex/blob/d55479/codex-rs/config/src/tui_keymap.rs)
+//!   plus serde/schemars derives across two crates. Deferred.
+//!
+//! - **No keybinding string parser**. Codex's `parse_keybinding("ctrl+a")`
+//!   lives at the config-loading boundary; without `from_config`, it has
+//!   no caller here.
+//!
+//! - **No conflict validation** (`validate_unique`, `validate_no_shadow`,
+//!   `validate_no_reserved`). These prevent users from binding the
+//!   same key to multiple actions. Without user config, defaults are
+//!   curated by hand to be conflict-free; we re-derive that as a unit
+//!   test below.
+//!
+//! - **No serde/schemars derives**. The structs are runtime-only; they
+//!   never round-trip through TOML in the current design.
+//!
+//! ## Why mirror codex's struct shape if we're not vendoring?
+//!
+//! Two reasons:
+//!
+//! 1. **Textarea compatibility.** [`super::textarea::TextArea`] (Stage 5d)
+//!    is vendored verbatim and accesses these structs by field name. If
+//!    koda diverged on field naming or grouping, the vendored textarea
+//!    would need patches for every divergence — defeating the whole
+//!    "vendor primitive, own policy" goal of clean future syncs.
+//!
+//! 2. **Sync ergonomics.** When codex adds a new editor action (say,
+//!    `move_paragraph_down`), the vendored textarea will reference it
+//!    via `keymap.editor.move_paragraph_down`. We notice the missing
+//!    field at sync time and decide: add a default to mirror codex, or
+//!    keep our own intentionally-different binding. Either way, the
+//!    decision surface is one struct field, not a refactored API.
+//!
+//! ## Provenance of the default bindings
+//!
+//! The hardcoded values in [`RuntimeKeymap::defaults`] are mirrored
+//! from codex's `built_in_defaults()` at SHA
+//! `d55479488e125ef7a0a8584505d839a22eaf6204`, file
+//! `codex-rs/tui/src/keymap.rs` lines ~531-707. We deliberately match
+//! codex's defaults so users coming from codex have a familiar
+//! experience by default; koda may diverge later as product decisions
+//! warrant.
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` for the full license text.
+
+use super::key_hint;
+use super::key_hint::KeyBinding;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyModifiers;
+
+// ----------------------------------------------------------------------------
+// Struct definitions — shape mirrored from codex `keymap.rs` so vendored
+// textarea.rs (Stage 5d) compiles unchanged.
+// ----------------------------------------------------------------------------
+
+/// Runtime keymap consumed by TUI input handlers.
+///
+/// In codex this is the resolved snapshot after layering user config over
+/// defaults. In koda (currently) there is no user-config layer, so this
+/// is always [`RuntimeKeymap::defaults()`]. Kept as a struct (not a bare
+/// function) so the surface stays codex-compatible for the day we wire
+/// up real config.
+#[derive(Clone, Debug)]
+pub(crate) struct RuntimeKeymap {
+    pub(crate) app: AppKeymap,
+    pub(crate) chat: ChatKeymap,
+    pub(crate) composer: ComposerKeymap,
+    pub(crate) editor: EditorKeymap,
+    pub(crate) vim_normal: VimNormalKeymap,
+    pub(crate) vim_operator: VimOperatorKeymap,
+    pub(crate) pager: PagerKeymap,
+    pub(crate) list: ListKeymap,
+    pub(crate) approval: ApprovalKeymap,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct AppKeymap {
+    pub(crate) open_transcript: Vec<KeyBinding>,
+    pub(crate) open_external_editor: Vec<KeyBinding>,
+    pub(crate) copy: Vec<KeyBinding>,
+    pub(crate) clear_terminal: Vec<KeyBinding>,
+    pub(crate) toggle_vim_mode: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ChatKeymap {
+    pub(crate) decrease_reasoning_effort: Vec<KeyBinding>,
+    pub(crate) increase_reasoning_effort: Vec<KeyBinding>,
+    pub(crate) edit_queued_message: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ComposerKeymap {
+    pub(crate) submit: Vec<KeyBinding>,
+    pub(crate) queue: Vec<KeyBinding>,
+    pub(crate) toggle_shortcuts: Vec<KeyBinding>,
+    pub(crate) history_search_previous: Vec<KeyBinding>,
+    pub(crate) history_search_next: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EditorKeymap {
+    pub(crate) insert_newline: Vec<KeyBinding>,
+    pub(crate) move_left: Vec<KeyBinding>,
+    pub(crate) move_right: Vec<KeyBinding>,
+    pub(crate) move_up: Vec<KeyBinding>,
+    pub(crate) move_down: Vec<KeyBinding>,
+    pub(crate) move_word_left: Vec<KeyBinding>,
+    pub(crate) move_word_right: Vec<KeyBinding>,
+    pub(crate) move_line_start: Vec<KeyBinding>,
+    pub(crate) move_line_end: Vec<KeyBinding>,
+    pub(crate) delete_backward: Vec<KeyBinding>,
+    pub(crate) delete_forward: Vec<KeyBinding>,
+    pub(crate) delete_backward_word: Vec<KeyBinding>,
+    pub(crate) delete_forward_word: Vec<KeyBinding>,
+    pub(crate) kill_line_start: Vec<KeyBinding>,
+    pub(crate) kill_line_end: Vec<KeyBinding>,
+    pub(crate) yank: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VimNormalKeymap {
+    pub(crate) enter_insert: Vec<KeyBinding>,
+    pub(crate) append_after_cursor: Vec<KeyBinding>,
+    pub(crate) append_line_end: Vec<KeyBinding>,
+    pub(crate) insert_line_start: Vec<KeyBinding>,
+    pub(crate) open_line_below: Vec<KeyBinding>,
+    pub(crate) open_line_above: Vec<KeyBinding>,
+    pub(crate) move_left: Vec<KeyBinding>,
+    pub(crate) move_right: Vec<KeyBinding>,
+    pub(crate) move_up: Vec<KeyBinding>,
+    pub(crate) move_down: Vec<KeyBinding>,
+    pub(crate) move_word_forward: Vec<KeyBinding>,
+    pub(crate) move_word_backward: Vec<KeyBinding>,
+    pub(crate) move_word_end: Vec<KeyBinding>,
+    pub(crate) move_line_start: Vec<KeyBinding>,
+    pub(crate) move_line_end: Vec<KeyBinding>,
+    pub(crate) delete_char: Vec<KeyBinding>,
+    pub(crate) delete_to_line_end: Vec<KeyBinding>,
+    pub(crate) yank_line: Vec<KeyBinding>,
+    pub(crate) paste_after: Vec<KeyBinding>,
+    pub(crate) start_delete_operator: Vec<KeyBinding>,
+    pub(crate) start_yank_operator: Vec<KeyBinding>,
+    pub(crate) cancel_operator: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VimOperatorKeymap {
+    pub(crate) delete_line: Vec<KeyBinding>,
+    pub(crate) yank_line: Vec<KeyBinding>,
+    pub(crate) motion_left: Vec<KeyBinding>,
+    pub(crate) motion_right: Vec<KeyBinding>,
+    pub(crate) motion_up: Vec<KeyBinding>,
+    pub(crate) motion_down: Vec<KeyBinding>,
+    pub(crate) motion_word_forward: Vec<KeyBinding>,
+    pub(crate) motion_word_backward: Vec<KeyBinding>,
+    pub(crate) motion_word_end: Vec<KeyBinding>,
+    pub(crate) motion_line_start: Vec<KeyBinding>,
+    pub(crate) motion_line_end: Vec<KeyBinding>,
+    pub(crate) cancel: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PagerKeymap {
+    pub(crate) scroll_up: Vec<KeyBinding>,
+    pub(crate) scroll_down: Vec<KeyBinding>,
+    pub(crate) page_up: Vec<KeyBinding>,
+    pub(crate) page_down: Vec<KeyBinding>,
+    pub(crate) half_page_up: Vec<KeyBinding>,
+    pub(crate) half_page_down: Vec<KeyBinding>,
+    pub(crate) jump_top: Vec<KeyBinding>,
+    pub(crate) jump_bottom: Vec<KeyBinding>,
+    pub(crate) close: Vec<KeyBinding>,
+    pub(crate) close_transcript: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ListKeymap {
+    pub(crate) move_up: Vec<KeyBinding>,
+    pub(crate) move_down: Vec<KeyBinding>,
+    pub(crate) accept: Vec<KeyBinding>,
+    pub(crate) cancel: Vec<KeyBinding>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ApprovalKeymap {
+    pub(crate) open_fullscreen: Vec<KeyBinding>,
+    pub(crate) open_thread: Vec<KeyBinding>,
+    pub(crate) approve: Vec<KeyBinding>,
+    pub(crate) approve_for_session: Vec<KeyBinding>,
+    pub(crate) approve_for_prefix: Vec<KeyBinding>,
+    pub(crate) deny: Vec<KeyBinding>,
+    pub(crate) decline: Vec<KeyBinding>,
+    pub(crate) cancel: Vec<KeyBinding>,
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+/// Returns the first binding from a set, used as the primary UI hint for an
+/// action.
+///
+/// Mirror of codex's `keymap::primary_binding`. Hint-rendering code prefers
+/// this to keep displayed shortcuts concise while preserving the full binding
+/// list for actual input matching.
+#[allow(dead_code)] // used by hint-rendering callers added in PR 2.
+pub(crate) fn primary_binding(bindings: &[KeyBinding]) -> Option<KeyBinding> {
+    bindings.first().copied()
+}
+
+/// Build one [`KeyBinding`] from a terse `kind(args)` form for the defaults
+/// table.
+///
+/// Mirror of codex's private `default_binding!` macro (kept here so the
+/// default-bindings table reads identically to upstream — this is the bulk of
+/// future-sync diffs and we want them line-comparable).
+macro_rules! default_binding {
+    (plain($key:expr)) => {
+        key_hint::plain($key)
+    };
+    (ctrl($key:expr)) => {
+        key_hint::ctrl($key)
+    };
+    (alt($key:expr)) => {
+        key_hint::alt($key)
+    };
+    (shift($key:expr)) => {
+        key_hint::shift($key)
+    };
+    (raw($binding:expr)) => {
+        $binding
+    };
+}
+
+/// Build a `Vec<KeyBinding>` for the defaults table.
+///
+/// Mirror of codex's private `default_bindings!` macro. Same rationale as
+/// [`default_binding!`] above.
+macro_rules! default_bindings {
+    ($($kind:ident($($arg:tt)*)),* $(,)?) => {
+        vec![$(default_binding!($kind($($arg)*))),*]
+    };
+}
+
+// ----------------------------------------------------------------------------
+// RuntimeKeymap defaults
+// ----------------------------------------------------------------------------
+
+impl RuntimeKeymap {
+    /// Built-in defaults.
+    ///
+    /// In koda this is the only way to construct a [`RuntimeKeymap`] until a
+    /// user-config layer lands (deferred follow-up). Mirrors codex's
+    /// `RuntimeKeymap::defaults()` which delegates to a private
+    /// `built_in_defaults()`; we collapse the indirection since we don't have
+    /// a `from_config` path that needs to call the private helper.
+    pub(crate) fn defaults() -> Self {
+        Self {
+            app: AppKeymap {
+                open_transcript: default_bindings![ctrl(KeyCode::Char('t'))],
+                open_external_editor: default_bindings![ctrl(KeyCode::Char('g'))],
+                copy: default_bindings![ctrl(KeyCode::Char('o'))],
+                clear_terminal: default_bindings![ctrl(KeyCode::Char('l'))],
+                toggle_vim_mode: default_bindings![],
+            },
+            chat: ChatKeymap {
+                decrease_reasoning_effort: default_bindings![alt(KeyCode::Char(','))],
+                increase_reasoning_effort: default_bindings![alt(KeyCode::Char('.'))],
+                edit_queued_message: default_bindings![alt(KeyCode::Up), shift(KeyCode::Left)],
+            },
+            composer: ComposerKeymap {
+                submit: default_bindings![plain(KeyCode::Enter)],
+                queue: default_bindings![plain(KeyCode::Tab)],
+                toggle_shortcuts: default_bindings![
+                    plain(KeyCode::Char('?')),
+                    shift(KeyCode::Char('?'))
+                ],
+                history_search_previous: default_bindings![ctrl(KeyCode::Char('r'))],
+                history_search_next: default_bindings![ctrl(KeyCode::Char('s'))],
+            },
+            editor: EditorKeymap {
+                insert_newline: default_bindings![
+                    ctrl(KeyCode::Char('j')),
+                    ctrl(KeyCode::Char('m')),
+                    plain(KeyCode::Enter),
+                    shift(KeyCode::Enter),
+                    alt(KeyCode::Enter)
+                ],
+                move_left: default_bindings![plain(KeyCode::Left), ctrl(KeyCode::Char('b'))],
+                move_right: default_bindings![plain(KeyCode::Right), ctrl(KeyCode::Char('f'))],
+                move_up: default_bindings![plain(KeyCode::Up), ctrl(KeyCode::Char('p'))],
+                move_down: default_bindings![plain(KeyCode::Down), ctrl(KeyCode::Char('n'))],
+                move_word_left: default_bindings![
+                    alt(KeyCode::Char('b')),
+                    raw(KeyBinding::new(KeyCode::Left, KeyModifiers::ALT)),
+                    raw(KeyBinding::new(KeyCode::Left, KeyModifiers::CONTROL))
+                ],
+                move_word_right: default_bindings![
+                    alt(KeyCode::Char('f')),
+                    raw(KeyBinding::new(KeyCode::Right, KeyModifiers::ALT)),
+                    raw(KeyBinding::new(KeyCode::Right, KeyModifiers::CONTROL))
+                ],
+                move_line_start: default_bindings![plain(KeyCode::Home), ctrl(KeyCode::Char('a'))],
+                move_line_end: default_bindings![plain(KeyCode::End), ctrl(KeyCode::Char('e'))],
+                delete_backward: default_bindings![
+                    plain(KeyCode::Backspace),
+                    ctrl(KeyCode::Char('h'))
+                ],
+                delete_forward: default_bindings![plain(KeyCode::Delete), ctrl(KeyCode::Char('d'))],
+                delete_backward_word: default_bindings![
+                    alt(KeyCode::Backspace),
+                    ctrl(KeyCode::Char('w')),
+                    raw(KeyBinding::new(
+                        KeyCode::Char('h'),
+                        KeyModifiers::CONTROL.union(KeyModifiers::ALT),
+                    ))
+                ],
+                delete_forward_word: default_bindings![
+                    alt(KeyCode::Delete),
+                    alt(KeyCode::Char('d'))
+                ],
+                kill_line_start: default_bindings![ctrl(KeyCode::Char('u'))],
+                kill_line_end: default_bindings![ctrl(KeyCode::Char('k'))],
+                yank: default_bindings![ctrl(KeyCode::Char('y'))],
+            },
+            vim_normal: VimNormalKeymap {
+                enter_insert: default_bindings![plain(KeyCode::Char('i')), plain(KeyCode::Insert)],
+                append_after_cursor: default_bindings![plain(KeyCode::Char('a'))],
+                append_line_end: default_bindings![
+                    shift(KeyCode::Char('a')),
+                    plain(KeyCode::Char('A'))
+                ],
+                insert_line_start: default_bindings![
+                    shift(KeyCode::Char('i')),
+                    plain(KeyCode::Char('I'))
+                ],
+                open_line_below: default_bindings![plain(KeyCode::Char('o'))],
+                open_line_above: default_bindings![
+                    shift(KeyCode::Char('o')),
+                    plain(KeyCode::Char('O'))
+                ],
+                move_left: default_bindings![plain(KeyCode::Char('h')), plain(KeyCode::Left)],
+                move_right: default_bindings![plain(KeyCode::Char('l')), plain(KeyCode::Right)],
+                move_up: default_bindings![plain(KeyCode::Char('k')), plain(KeyCode::Up)],
+                move_down: default_bindings![plain(KeyCode::Char('j')), plain(KeyCode::Down)],
+                move_word_forward: default_bindings![plain(KeyCode::Char('w'))],
+                move_word_backward: default_bindings![plain(KeyCode::Char('b'))],
+                move_word_end: default_bindings![plain(KeyCode::Char('e'))],
+                move_line_start: default_bindings![plain(KeyCode::Char('0'))],
+                move_line_end: default_bindings![
+                    plain(KeyCode::Char('$')),
+                    shift(KeyCode::Char('$'))
+                ],
+                delete_char: default_bindings![plain(KeyCode::Char('x'))],
+                delete_to_line_end: default_bindings![
+                    shift(KeyCode::Char('d')),
+                    plain(KeyCode::Char('D'))
+                ],
+                yank_line: default_bindings![shift(KeyCode::Char('y')), plain(KeyCode::Char('Y'))],
+                paste_after: default_bindings![plain(KeyCode::Char('p'))],
+                start_delete_operator: default_bindings![plain(KeyCode::Char('d'))],
+                start_yank_operator: default_bindings![plain(KeyCode::Char('y'))],
+                cancel_operator: default_bindings![plain(KeyCode::Esc)],
+            },
+            vim_operator: VimOperatorKeymap {
+                delete_line: default_bindings![plain(KeyCode::Char('d'))],
+                yank_line: default_bindings![plain(KeyCode::Char('y'))],
+                motion_left: default_bindings![plain(KeyCode::Char('h'))],
+                motion_right: default_bindings![plain(KeyCode::Char('l'))],
+                motion_up: default_bindings![plain(KeyCode::Char('k'))],
+                motion_down: default_bindings![plain(KeyCode::Char('j'))],
+                motion_word_forward: default_bindings![plain(KeyCode::Char('w'))],
+                motion_word_backward: default_bindings![plain(KeyCode::Char('b'))],
+                motion_word_end: default_bindings![plain(KeyCode::Char('e'))],
+                motion_line_start: default_bindings![plain(KeyCode::Char('0'))],
+                motion_line_end: default_bindings![
+                    plain(KeyCode::Char('$')),
+                    shift(KeyCode::Char('$'))
+                ],
+                cancel: default_bindings![plain(KeyCode::Esc)],
+            },
+            pager: PagerKeymap {
+                scroll_up: default_bindings![plain(KeyCode::Up), plain(KeyCode::Char('k'))],
+                scroll_down: default_bindings![plain(KeyCode::Down), plain(KeyCode::Char('j'))],
+                page_up: default_bindings![
+                    plain(KeyCode::PageUp),
+                    shift(KeyCode::Char(' ')),
+                    ctrl(KeyCode::Char('b'))
+                ],
+                page_down: default_bindings![
+                    plain(KeyCode::PageDown),
+                    plain(KeyCode::Char(' ')),
+                    ctrl(KeyCode::Char('f'))
+                ],
+                half_page_up: default_bindings![ctrl(KeyCode::Char('u'))],
+                half_page_down: default_bindings![ctrl(KeyCode::Char('d'))],
+                jump_top: default_bindings![plain(KeyCode::Home)],
+                jump_bottom: default_bindings![plain(KeyCode::End)],
+                close: default_bindings![plain(KeyCode::Char('q')), ctrl(KeyCode::Char('c'))],
+                close_transcript: default_bindings![ctrl(KeyCode::Char('t'))],
+            },
+            list: ListKeymap {
+                move_up: default_bindings![
+                    plain(KeyCode::Up),
+                    ctrl(KeyCode::Char('p')),
+                    plain(KeyCode::Char('k'))
+                ],
+                move_down: default_bindings![
+                    plain(KeyCode::Down),
+                    ctrl(KeyCode::Char('n')),
+                    plain(KeyCode::Char('j'))
+                ],
+                accept: default_bindings![plain(KeyCode::Enter)],
+                cancel: default_bindings![plain(KeyCode::Esc)],
+            },
+            approval: ApprovalKeymap {
+                open_fullscreen: default_bindings![
+                    ctrl(KeyCode::Char('a')),
+                    raw(KeyBinding::new(
+                        KeyCode::Char('a'),
+                        KeyModifiers::CONTROL.union(KeyModifiers::SHIFT),
+                    ))
+                ],
+                open_thread: default_bindings![plain(KeyCode::Char('o'))],
+                approve: default_bindings![plain(KeyCode::Char('y'))],
+                approve_for_session: default_bindings![plain(KeyCode::Char('a'))],
+                approve_for_prefix: default_bindings![plain(KeyCode::Char('p'))],
+                deny: default_bindings![plain(KeyCode::Char('d'))],
+                decline: default_bindings![plain(KeyCode::Esc), plain(KeyCode::Char('n'))],
+                cancel: default_bindings![plain(KeyCode::Char('c'))],
+            },
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sanity: `defaults()` actually populates the editor surface used by the
+    /// vendored textarea (Stage 5d). If a sync drops a field we depend on,
+    /// this test fails before the textarea breaks at a less obvious site.
+    #[test]
+    fn defaults_populate_editor_actions_used_by_textarea() {
+        let km = RuntimeKeymap::defaults();
+        // A representative subset — picked because they're the bindings the
+        // textarea exercises in its vendored test suite.
+        assert!(!km.editor.insert_newline.is_empty());
+        assert!(!km.editor.move_left.is_empty());
+        assert!(!km.editor.move_right.is_empty());
+        assert!(!km.editor.move_up.is_empty());
+        assert!(!km.editor.move_down.is_empty());
+        assert!(!km.editor.delete_backward.is_empty());
+        assert!(!km.editor.kill_line_end.is_empty());
+        assert!(!km.editor.yank.is_empty());
+    }
+
+    /// Sanity: vim-mode defaults are populated. textarea's vim tests
+    /// exercise these.
+    #[test]
+    fn defaults_populate_vim_normal_actions() {
+        let km = RuntimeKeymap::defaults();
+        assert!(!km.vim_normal.enter_insert.is_empty());
+        assert!(!km.vim_normal.append_line_end.is_empty());
+        assert!(!km.vim_normal.move_left.is_empty());
+        assert!(!km.vim_normal.start_delete_operator.is_empty());
+    }
+
+    /// Mirror of codex's `default_copy_binding_is_ctrl_o` — guards against
+    /// accidental drift in a binding users will notice immediately.
+    #[test]
+    fn default_copy_binding_is_ctrl_o() {
+        let km = RuntimeKeymap::defaults();
+        assert_eq!(km.app.copy, vec![key_hint::ctrl(KeyCode::Char('o'))]);
+    }
+
+    /// `primary_binding` returns the first element of a binding list, or
+    /// `None` for empty.
+    #[test]
+    fn primary_binding_returns_first_or_none() {
+        let bindings = vec![key_hint::ctrl(KeyCode::Char('a')), key_hint::ctrl(KeyCode::Char('b'))];
+        assert_eq!(primary_binding(&bindings), Some(key_hint::ctrl(KeyCode::Char('a'))));
+        assert_eq!(primary_binding(&[]), None);
+    }
+}

--- a/koda-cli/src/composer/keymap.rs
+++ b/koda-cli/src/composer/keymap.rs
@@ -1,3 +1,8 @@
+// Foundation work for #1116/#1175 — see the equivalent header note in
+// composer/key_hint.rs for the full rationale. The blanket allow goes away
+// when PR 2 wires up the consumers.
+#![allow(dead_code)]
+
 //! koda-owned keymap policy layer (#1178 stage 5c).
 //!
 //! # Status: koda-OWNED, not vendored
@@ -523,8 +528,14 @@ mod tests {
     /// `None` for empty.
     #[test]
     fn primary_binding_returns_first_or_none() {
-        let bindings = vec![key_hint::ctrl(KeyCode::Char('a')), key_hint::ctrl(KeyCode::Char('b'))];
-        assert_eq!(primary_binding(&bindings), Some(key_hint::ctrl(KeyCode::Char('a'))));
+        let bindings = vec![
+            key_hint::ctrl(KeyCode::Char('a')),
+            key_hint::ctrl(KeyCode::Char('b')),
+        ];
+        assert_eq!(
+            primary_binding(&bindings),
+            Some(key_hint::ctrl(KeyCode::Char('a')))
+        );
         assert_eq!(primary_binding(&[]), None);
     }
 }

--- a/koda-cli/src/composer/mod.rs
+++ b/koda-cli/src/composer/mod.rs
@@ -1,0 +1,24 @@
+//! Composer surface: textarea, paste-burst handling, text elements.
+//!
+//! This module is the in-progress hybrid port of codex's composer
+//! primitives (#1116, #1178). The textarea + paste-burst sub-modules
+//! are lifted from codex (Apache 2.0) with minor adaptation to koda's
+//! crossterm/ratatui versions; the small support types (text_element,
+//! key_hint) are reduced ports keeping only what the textarea needs.
+//!
+//! ## Status
+//!
+//! - **PR 1 (this PR — #1178):** ports the primitives. No behavioral
+//!   change: koda still uses `ratatui-textarea` everywhere; new types
+//!   live alongside as tested-but-unused code.
+//! - **PR 2 (next):** swaps `ratatui-textarea` for [`textarea::TextArea`]
+//!   in the composer surface and drops the dep.
+//! - **PR 3 (after PR 2):** adds slash popup + history navigation
+//!   widgets that orbit the new textarea.
+//!
+//! See #1116 for the full plan.
+
+pub mod key_hint;
+pub mod text_element;
+// TODO(#1178): pub mod paste_burst; — added in Stage 3 of this PR.
+// TODO(#1178): pub mod textarea;    — added in Stage 4 of this PR.

--- a/koda-cli/src/composer/mod.rs
+++ b/koda-cli/src/composer/mod.rs
@@ -22,5 +22,5 @@ pub mod key_hint;
 pub mod keymap;
 pub mod paste_burst;
 pub mod text_element;
-// TODO(#1178): pub mod textarea; — added in stage 5d of this PR.
+pub mod textarea;
 pub mod wrapping;

--- a/koda-cli/src/composer/mod.rs
+++ b/koda-cli/src/composer/mod.rs
@@ -19,6 +19,7 @@
 //! See #1116 for the full plan.
 
 pub mod key_hint;
+pub mod keymap;
 pub mod paste_burst;
 pub mod text_element;
 // TODO(#1178): pub mod textarea; — added in stage 5d of this PR.

--- a/koda-cli/src/composer/mod.rs
+++ b/koda-cli/src/composer/mod.rs
@@ -19,6 +19,6 @@
 //! See #1116 for the full plan.
 
 pub mod key_hint;
+pub mod paste_burst;
 pub mod text_element;
-// TODO(#1178): pub mod paste_burst; — added in Stage 3 of this PR.
 // TODO(#1178): pub mod textarea;    — added in Stage 4 of this PR.

--- a/koda-cli/src/composer/mod.rs
+++ b/koda-cli/src/composer/mod.rs
@@ -21,4 +21,5 @@
 pub mod key_hint;
 pub mod paste_burst;
 pub mod text_element;
-// TODO(#1178): pub mod textarea;    — added in Stage 4 of this PR.
+// TODO(#1178): pub mod textarea; — added in stage 5d of this PR.
+pub mod wrapping;

--- a/koda-cli/src/composer/paste_burst.rs
+++ b/koda-cli/src/composer/paste_burst.rs
@@ -1,7 +1,13 @@
 //! # Provenance
 //!
 //! Ported verbatim from `codex-rs/tui/src/bottom_pane/paste_burst.rs`
-//! at upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//! at upstream commit `d55479488e125ef7a0a8584505d839a22eaf6204`
+//! (codex `main` as of 2026-05-01).
+//!
+//! Verified byte-identical between this SHA and our previous reference
+//! `7e8594fc198615068018b198ab86a9ae0a541dff` (`git diff` returns 0
+//! lines), so the re-stamp is a pure attribution change — no
+//! behavioral diff.
 //!
 //! Original work: Copyright (c) OpenAI / codex contributors,
 //! licensed under the Apache License, Version 2.0.

--- a/koda-cli/src/composer/paste_burst.rs
+++ b/koda-cli/src/composer/paste_burst.rs
@@ -1,3 +1,8 @@
+// Foundation work for #1116/#1175 — see the equivalent header note in
+// composer/key_hint.rs for the full rationale. The blanket allow goes away
+// when PR 2 wires up the consumers.
+#![allow(dead_code)]
+
 //! # Provenance
 //!
 //! Ported verbatim from `codex-rs/tui/src/bottom_pane/paste_burst.rs`

--- a/koda-cli/src/composer/paste_burst.rs
+++ b/koda-cli/src/composer/paste_burst.rs
@@ -1,0 +1,599 @@
+//! # Provenance
+//!
+//! Ported verbatim from `codex-rs/tui/src/bottom_pane/paste_burst.rs`
+//! at upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` (vendored at the workspace root) for
+//! the full license text.
+//!
+//! # Adaptations for koda
+//!
+//! None. This module has zero codex-internal dependencies (only
+//! `std::time::{Duration, Instant}`), so the file is a verbatim copy.
+//! The doc-comment reference to `docs/tui-chat-composer.md` points at
+//! codex's docs and is preserved as the canonical design overview;
+//! koda will add its own integration doc once PR 2 wires this module
+//! into the composer event loop.
+//!
+//! # Original module documentation follows
+//!
+//! ---
+//!
+//! Paste-burst detection for terminals without bracketed paste.
+//!
+//! On some platforms (notably Windows), pastes often arrive as a rapid stream of
+//! `KeyCode::Char` and `KeyCode::Enter` key events rather than as a single "paste" event.
+//! In that mode, the composer needs to:
+//!
+//! - Prevent transient UI side effects (e.g. toggles bound to `?`) from triggering on pasted text.
+//! - Ensure Enter is treated as a newline *inside the paste*, not as "submit the message".
+//! - Avoid flicker caused by inserting a typed prefix and then immediately reclassifying it as
+//!   paste once enough chars have arrived.
+//!
+//! This module provides the `PasteBurst` state machine. `ChatComposer` feeds it only "plain"
+//! character events (no Ctrl/Alt) and uses its decisions to either:
+//!
+//! - briefly hold a first ASCII char (flicker suppression),
+//! - buffer a burst as a single pasted string, or
+//! - let input flow through as normal typing.
+//!
+//! For the higher-level view of how `PasteBurst` integrates with `ChatComposer`, see
+//! `docs/tui-chat-composer.md`.
+//!
+//! # Call Pattern
+//!
+//! `PasteBurst` is a pure state machine: it never mutates the textarea directly. The caller feeds
+//! it events and then applies the chosen action:
+//!
+//! - For each plain `KeyCode::Char`, call [`PasteBurst::on_plain_char`] (ASCII) or
+//!   [`PasteBurst::on_plain_char_no_hold`] (non-ASCII/IME).
+//! - If the decision indicates buffering, the caller appends to `PasteBurst.buffer` via
+//!   [`PasteBurst::append_char_to_buffer`].
+//! - On a UI tick, call [`PasteBurst::flush_if_due`]. If it returns [`FlushResult::Typed`], insert
+//!   that char as normal typing. If it returns [`FlushResult::Paste`], treat the returned string as
+//!   an explicit paste.
+//! - Before applying non-char input (arrow keys, Ctrl/Alt modifiers, etc.), use
+//!   [`PasteBurst::flush_before_modified_input`] to avoid leaving buffered text "stuck", and then
+//!   [`PasteBurst::clear_window_after_non_char`] so subsequent typing does not get grouped into a
+//!   previous burst.
+//!
+//! # State Variables
+//!
+//! This state machine is encoded in a few fields with slightly different meanings:
+//!
+//! - `active`: true while we are still *actively* accepting characters into the current burst.
+//! - `buffer`: accumulated burst text that will eventually flush as a single `Paste(String)`.
+//!   A non-empty buffer is treated as "in burst context" even if `active` has been cleared.
+//! - `pending_first_char`: a single held ASCII char used for flicker suppression. The caller must
+//!   not render this char until it either becomes part of a burst (`BeginBufferFromPending`) or
+//!   flushes as a normal typed char (`FlushResult::Typed`).
+//! - `last_plain_char_time`/`consecutive_plain_char_burst`: the timing/count heuristic for
+//!   "paste-like" streams.
+//! - `burst_window_until`: the Enter suppression window ("Enter inserts newline") that outlives the
+//!   buffer itself.
+//!
+//! # Timing Model
+//!
+//! There are two timeouts:
+//!
+//! - `PASTE_BURST_CHAR_INTERVAL`: maximum delay between consecutive "plain" chars for them to be
+//!   considered part of a single burst. It also bounds how long `pending_first_char` is held.
+//! - `PASTE_BURST_ACTIVE_IDLE_TIMEOUT`: once buffering is active, how long to wait after the last
+//!   char before flushing the accumulated buffer as a paste.
+//!
+//! `flush_if_due()` intentionally uses `>` (not `>=`) when comparing elapsed time, so tests and UI
+//! ticks should cross the threshold by at least 1ms (see `recommended_flush_delay()`).
+//!
+//! # Retro Capture Details
+//!
+//! Retro-capture exists to handle the case where we initially inserted characters as "normal
+//! typing", but later decide that the stream is paste-like. When that happens, we retroactively
+//! remove a prefix of already-inserted text from the textarea and move it into the burst buffer so
+//! the eventual `handle_paste(...)` sees a contiguous pasted string.
+//!
+//! Retro-capture mostly matters on paths that do *not* hold the first character (non-ASCII/IME
+//! input, and retro-grab scenarios). The ASCII path usually prefers
+//! `RetainFirstChar -> BeginBufferFromPending`, which avoids needing retro-capture at all.
+//!
+//! Retro-capture is expressed in terms of characters, not bytes:
+//!
+//! - `CharDecision::BeginBuffer { retro_chars }` uses `retro_chars` as a character count.
+//! - `decide_begin_buffer(now, before_cursor, retro_chars)` turns that into a UTF-8 byte range by
+//!   calling `retro_start_index()`.
+//! - `RetroGrab.start_byte` is a byte index into the `before_cursor` slice; callers must clamp the
+//!   cursor to a char boundary before slicing so `start_byte..cursor` is always valid UTF-8.
+//!
+//! # Clearing vs Flushing
+//!
+//! There are two ways callers end burst handling, and they are not interchangeable:
+//!
+//! - `flush_before_modified_input()` returns the buffered text (and/or a pending first ASCII char)
+//!   so the caller can apply it through the normal paste path before handling an unrelated input.
+//! - `clear_window_after_non_char()` clears the *classification window* so subsequent typing does
+//!   not get grouped into the previous burst. It assumes the caller has already flushed any buffer
+//!   because it clears `last_plain_char_time`, which means `flush_if_due()` will not flush a
+//!   non-empty buffer until another plain char updates the timestamp.
+//!
+//! # States (Conceptually)
+//!
+//! - **Idle**: no buffered text, no pending char.
+//! - **Pending first char**: `pending_first_char` holds one ASCII char for up to
+//!   `PASTE_BURST_CHAR_INTERVAL` while we wait to see if a burst follows.
+//! - **Active buffer**: `active`/`buffer` holds paste-like content until it times out and flushes.
+//! - **Enter suppress window**: `burst_window_until` keeps Enter treated as newline briefly after
+//!   burst activity so multiline pastes stay grouped.
+//!
+//! # ASCII vs Non-ASCII
+//!
+//! - [`PasteBurst::on_plain_char`] may return [`CharDecision::RetainFirstChar`] to hold the first
+//!   ASCII char and avoid flicker.
+//! - [`PasteBurst::on_plain_char_no_hold`] never holds (used for IME/non-ASCII paths), since
+//!   holding a non-ASCII character can feel like dropped input.
+//!
+//! # Contract With `ChatComposer`
+//!
+//! `PasteBurst` does not mutate the UI text buffer on its own. The caller (`ChatComposer`) must
+//! interpret decisions and apply the corresponding UI edits:
+//!
+//! - For each plain ASCII `KeyCode::Char`, call [`PasteBurst::on_plain_char`].
+//!   - [`CharDecision::RetainFirstChar`]: do **not** insert the char into the textarea yet.
+//!   - [`CharDecision::BeginBufferFromPending`]: call [`PasteBurst::append_char_to_buffer`] for the
+//!     current char (the previously-held char is already in the burst buffer).
+//!   - [`CharDecision::BeginBuffer { retro_chars }`]: consider retro-capturing the already-inserted
+//!     prefix by calling [`PasteBurst::decide_begin_buffer`]. If it returns `Some`, remove the
+//!     returned `start_byte..cursor` range from the textarea and then call
+//!     [`PasteBurst::append_char_to_buffer`] for the current char. If it returns `None`, fall back
+//!     to normal insertion.
+//!   - [`CharDecision::BufferAppend`]: call [`PasteBurst::append_char_to_buffer`].
+//!
+//! - For each plain non-ASCII `KeyCode::Char`, call [`PasteBurst::on_plain_char_no_hold`] and then:
+//!   - If it returns `Some(CharDecision::BufferAppend)`, call
+//!     [`PasteBurst::append_char_to_buffer`].
+//!   - If it returns `Some(CharDecision::BeginBuffer { retro_chars })`, call
+//!     [`PasteBurst::decide_begin_buffer`] as above (and if buffering starts, remove the grabbed
+//!     prefix from the textarea and then append the current char to the buffer).
+//!   - If it returns `None`, insert normally.
+//!
+//! - Before applying non-char input (or any input that should not join a burst), call
+//!   [`PasteBurst::flush_before_modified_input`] and pass the returned string (if any) through the
+//!   normal paste path.
+//!
+//! - Periodically (e.g. on a UI tick), call [`PasteBurst::flush_if_due`].
+//!   - [`FlushResult::Typed`]: insert that single char as normal typing.
+//!   - [`FlushResult::Paste`]: treat the returned string as an explicit paste.
+//!
+//! - When a non-plain key is pressed (Ctrl/Alt-modified input, arrows, etc.), callers should use
+//!   [`PasteBurst::clear_window_after_non_char`] to prevent the next keystroke from being
+//!   incorrectly grouped into a previous burst.
+
+use std::time::Duration;
+use std::time::Instant;
+
+// Heuristic thresholds for detecting paste-like input bursts.
+// Detect quickly to avoid showing typed prefix before paste is recognized
+const PASTE_BURST_MIN_CHARS: u16 = 3;
+const PASTE_ENTER_SUPPRESS_WINDOW: Duration = Duration::from_millis(120);
+
+// Maximum delay between consecutive chars to be considered part of a paste burst.
+// Windows terminals (especially VS Code integrated terminal) deliver paste events
+// more slowly than native terminals, so we use a higher threshold there.
+#[cfg(not(windows))]
+const PASTE_BURST_CHAR_INTERVAL: Duration = Duration::from_millis(8);
+#[cfg(windows)]
+const PASTE_BURST_CHAR_INTERVAL: Duration = Duration::from_millis(30);
+
+// Idle timeout before flushing buffered paste content.
+// Slower paste bursts have been observed in Windows environments.
+#[cfg(not(windows))]
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(8);
+#[cfg(windows)]
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(60);
+
+#[derive(Default)]
+pub(crate) struct PasteBurst {
+    last_plain_char_time: Option<Instant>,
+    consecutive_plain_char_burst: u16,
+    burst_window_until: Option<Instant>,
+    buffer: String,
+    active: bool,
+    // Hold first fast char briefly to avoid rendering flicker
+    pending_first_char: Option<(char, Instant)>,
+}
+
+pub(crate) enum CharDecision {
+    /// Start buffering and retroactively capture some already-inserted chars.
+    BeginBuffer { retro_chars: u16 },
+    /// We are currently buffering; append the current char into the buffer.
+    BufferAppend,
+    /// Do not insert/render this char yet; temporarily save the first fast
+    /// char while we wait to see if a paste-like burst follows.
+    RetainFirstChar,
+    /// Begin buffering using the previously saved first char (no retro grab needed).
+    BeginBufferFromPending,
+}
+
+pub(crate) struct RetroGrab {
+    pub start_byte: usize,
+    pub grabbed: String,
+}
+
+pub(crate) enum FlushResult {
+    Paste(String),
+    Typed(char),
+    None,
+}
+
+impl PasteBurst {
+    /// Recommended delay to wait between simulated keypresses (or before
+    /// scheduling a UI tick) so that a pending fast keystroke is flushed
+    /// out of the burst detector as normal typed input.
+    ///
+    /// Primarily used by tests and by the TUI to reliably cross the
+    /// paste-burst timing threshold.
+    pub fn recommended_flush_delay() -> Duration {
+        PASTE_BURST_CHAR_INTERVAL + Duration::from_millis(1)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recommended_active_flush_delay() -> Duration {
+        PASTE_BURST_ACTIVE_IDLE_TIMEOUT + Duration::from_millis(1)
+    }
+
+    /// Entry point: decide how to treat a plain char with current timing.
+    pub fn on_plain_char(&mut self, ch: char, now: Instant) -> CharDecision {
+        self.note_plain_char(now);
+
+        if self.active {
+            self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+            return CharDecision::BufferAppend;
+        }
+
+        // If we already held a first char and receive a second fast char,
+        // start buffering without retro-grabbing (we never rendered the first).
+        if let Some((held, held_at)) = self.pending_first_char
+            && now.duration_since(held_at) <= PASTE_BURST_CHAR_INTERVAL
+        {
+            self.active = true;
+            // take() to clear pending; we already captured the held char above
+            let _ = self.pending_first_char.take();
+            self.buffer.push(held);
+            self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+            return CharDecision::BeginBufferFromPending;
+        }
+
+        if self.consecutive_plain_char_burst >= PASTE_BURST_MIN_CHARS {
+            return CharDecision::BeginBuffer {
+                retro_chars: self.consecutive_plain_char_burst.saturating_sub(1),
+            };
+        }
+
+        // Save the first fast char very briefly to see if a burst follows.
+        self.pending_first_char = Some((ch, now));
+        CharDecision::RetainFirstChar
+    }
+
+    /// Like on_plain_char(), but never holds the first char.
+    ///
+    /// Used for non-ASCII input paths (e.g., IMEs) where holding a character can
+    /// feel like dropped input, while still allowing burst-based paste detection.
+    ///
+    /// Note: This method will only ever return BufferAppend or BeginBuffer.
+    pub fn on_plain_char_no_hold(&mut self, now: Instant) -> Option<CharDecision> {
+        self.note_plain_char(now);
+
+        if self.active {
+            self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+            return Some(CharDecision::BufferAppend);
+        }
+
+        if self.consecutive_plain_char_burst >= PASTE_BURST_MIN_CHARS {
+            return Some(CharDecision::BeginBuffer {
+                retro_chars: self.consecutive_plain_char_burst.saturating_sub(1),
+            });
+        }
+
+        None
+    }
+
+    fn note_plain_char(&mut self, now: Instant) {
+        match self.last_plain_char_time {
+            Some(prev) if now.duration_since(prev) <= PASTE_BURST_CHAR_INTERVAL => {
+                self.consecutive_plain_char_burst =
+                    self.consecutive_plain_char_burst.saturating_add(1)
+            }
+            _ => self.consecutive_plain_char_burst = 1,
+        }
+        self.last_plain_char_time = Some(now);
+    }
+
+    /// Flushes any buffered burst if the inter-key timeout has elapsed.
+    ///
+    /// Returns:
+    ///
+    /// - [`FlushResult::Paste`] when a paste burst was active and buffered text is emitted as one
+    ///   pasted string.
+    /// - [`FlushResult::Typed`] when a single fast first ASCII char was being held (flicker
+    ///   suppression) and no burst followed before the timeout elapsed.
+    /// - [`FlushResult::None`] when the timeout has not elapsed, or there is nothing to flush.
+    pub fn flush_if_due(&mut self, now: Instant) -> FlushResult {
+        let timeout = if self.is_active_internal() {
+            PASTE_BURST_ACTIVE_IDLE_TIMEOUT
+        } else {
+            PASTE_BURST_CHAR_INTERVAL
+        };
+        let timed_out = self
+            .last_plain_char_time
+            .is_some_and(|t| now.duration_since(t) > timeout);
+        if timed_out && self.is_active_internal() {
+            self.active = false;
+            let out = std::mem::take(&mut self.buffer);
+            FlushResult::Paste(out)
+        } else if timed_out {
+            // If we were saving a single fast char and no burst followed,
+            // flush it as normal typed input.
+            if let Some((ch, _at)) = self.pending_first_char.take() {
+                FlushResult::Typed(ch)
+            } else {
+                FlushResult::None
+            }
+        } else {
+            FlushResult::None
+        }
+    }
+
+    /// While bursting: accumulate a newline into the buffer instead of
+    /// submitting the textarea.
+    ///
+    /// Returns true if a newline was appended (we are in a burst context),
+    /// false otherwise.
+    pub fn append_newline_if_active(&mut self, now: Instant) -> bool {
+        if self.is_active() {
+            self.buffer.push('\n');
+            self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Decide if Enter should insert a newline (burst context) vs submit.
+    pub fn newline_should_insert_instead_of_submit(&self, now: Instant) -> bool {
+        let in_burst_window = self.burst_window_until.is_some_and(|until| now <= until);
+        self.is_active() || in_burst_window
+    }
+
+    /// Keep the burst window alive.
+    pub fn extend_window(&mut self, now: Instant) {
+        self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+    }
+
+    /// Begin buffering with retroactively grabbed text.
+    pub fn begin_with_retro_grabbed(&mut self, grabbed: String, now: Instant) {
+        if !grabbed.is_empty() {
+            self.buffer.push_str(&grabbed);
+        }
+        self.active = true;
+        self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+    }
+
+    /// Append a char into the burst buffer.
+    pub fn append_char_to_buffer(&mut self, ch: char, now: Instant) {
+        self.buffer.push(ch);
+        self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+    }
+
+    /// Try to append a char into the burst buffer only if a burst is already active.
+    ///
+    /// Returns true when the char was captured into the existing burst, false otherwise.
+    pub fn try_append_char_if_active(&mut self, ch: char, now: Instant) -> bool {
+        if self.active || !self.buffer.is_empty() {
+            self.append_char_to_buffer(ch, now);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Decide whether to begin buffering by retroactively capturing recent
+    /// chars from the slice before the cursor.
+    ///
+    /// Heuristic: if the retro-grabbed slice contains any whitespace or is
+    /// sufficiently long (>= 16 characters), treat it as paste-like to avoid
+    /// rendering the typed prefix momentarily before the paste is recognized.
+    /// This favors responsiveness and prevents flicker for typical pastes
+    /// (URLs, file paths, multiline text) while not triggering on short words.
+    ///
+    /// Returns Some(RetroGrab) with the start byte and grabbed text when we
+    /// decide to buffer retroactively; otherwise None.
+    pub fn decide_begin_buffer(
+        &mut self,
+        now: Instant,
+        before: &str,
+        retro_chars: usize,
+    ) -> Option<RetroGrab> {
+        let start_byte = retro_start_index(before, retro_chars);
+        let grabbed = before[start_byte..].to_string();
+        let looks_pastey =
+            grabbed.chars().any(char::is_whitespace) || grabbed.chars().count() >= 16;
+        if looks_pastey {
+            // Note: caller is responsible for removing this slice from UI text.
+            self.begin_with_retro_grabbed(grabbed.clone(), now);
+            Some(RetroGrab {
+                start_byte,
+                grabbed,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Before applying modified/non-char input: flush buffered burst immediately.
+    pub fn flush_before_modified_input(&mut self) -> Option<String> {
+        if !self.is_active() {
+            return None;
+        }
+        self.active = false;
+        let mut out = std::mem::take(&mut self.buffer);
+        if let Some((ch, _at)) = self.pending_first_char.take() {
+            out.push(ch);
+        }
+        Some(out)
+    }
+
+    /// Clear only the timing window and any pending first-char.
+    ///
+    /// Does not emit or clear the buffered text itself; callers should have
+    /// already flushed (if needed) via one of the flush methods above.
+    pub fn clear_window_after_non_char(&mut self) {
+        self.consecutive_plain_char_burst = 0;
+        self.last_plain_char_time = None;
+        self.burst_window_until = None;
+        self.active = false;
+        self.pending_first_char = None;
+    }
+
+    /// Returns true if we are in any paste-burst related transient state
+    /// (actively buffering, have a non-empty buffer, or have saved the first
+    /// fast char while waiting for a potential burst).
+    pub fn is_active(&self) -> bool {
+        self.is_active_internal() || self.pending_first_char.is_some()
+    }
+
+    fn is_active_internal(&self) -> bool {
+        self.active || !self.buffer.is_empty()
+    }
+
+    pub fn clear_after_explicit_paste(&mut self) {
+        self.last_plain_char_time = None;
+        self.consecutive_plain_char_burst = 0;
+        self.burst_window_until = None;
+        self.active = false;
+        self.buffer.clear();
+        self.pending_first_char = None;
+    }
+}
+
+pub(crate) fn retro_start_index(before: &str, retro_chars: usize) -> usize {
+    if retro_chars == 0 {
+        return before.len();
+    }
+    before
+        .char_indices()
+        .rev()
+        .nth(retro_chars.saturating_sub(1))
+        .map(|(idx, _)| idx)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    /// Behavior: for ASCII input we "hold" the first fast char briefly. If no burst follows,
+    /// that held char should eventually flush as normal typed input (not as a paste).
+    #[test]
+    fn ascii_first_char_is_held_then_flushes_as_typed() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('a', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        let t1 = t0 + PasteBurst::recommended_flush_delay() + Duration::from_millis(1);
+        assert!(matches!(burst.flush_if_due(t1), FlushResult::Typed('a')));
+        assert!(!burst.is_active());
+    }
+
+    /// Behavior: if two ASCII chars arrive quickly, we should start buffering without ever
+    /// rendering the first one, then flush the whole buffered payload as a paste.
+    #[test]
+    fn ascii_two_fast_chars_start_buffer_from_pending_and_flush_as_paste() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('a', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        let t1 = t0 + Duration::from_millis(1);
+        assert!(matches!(
+            burst.on_plain_char('b', t1),
+            CharDecision::BeginBufferFromPending
+        ));
+        burst.append_char_to_buffer('b', t1);
+
+        let t2 = t1 + PasteBurst::recommended_active_flush_delay() + Duration::from_millis(1);
+        assert!(matches!(
+            burst.flush_if_due(t2),
+            FlushResult::Paste(ref s) if s == "ab"
+        ));
+    }
+
+    /// Behavior: when non-char input is about to be applied, we flush any transient burst state
+    /// immediately (including a single pending ASCII char) so state doesn't leak across inputs.
+    #[test]
+    fn flush_before_modified_input_includes_pending_first_char() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('a', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        assert_eq!(burst.flush_before_modified_input(), Some("a".to_string()));
+        assert!(!burst.is_active());
+    }
+
+    /// Behavior: retro-grab buffering is only enabled when the already-inserted prefix looks
+    /// paste-like (whitespace or "long enough") so short IME bursts don't get misclassified.
+    #[test]
+    fn decide_begin_buffer_only_triggers_for_pastey_prefixes() {
+        let mut burst = PasteBurst::default();
+        let now = Instant::now();
+
+        assert!(
+            burst
+                .decide_begin_buffer(now, "ab", /*retro_chars*/ 2)
+                .is_none()
+        );
+        assert!(!burst.is_active());
+
+        let grab = burst
+            .decide_begin_buffer(now, "a b", /*retro_chars*/ 2)
+            .expect("whitespace should be considered paste-like");
+        assert_eq!(grab.start_byte, 1);
+        assert_eq!(grab.grabbed, " b");
+        assert!(burst.is_active());
+    }
+
+    /// Behavior: after a paste-like burst, we keep an "enter suppression window" alive briefly so
+    /// a slightly-late Enter still inserts a newline instead of submitting.
+    #[test]
+    fn newline_suppression_window_outlives_buffer_flush() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('a', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        let t1 = t0 + Duration::from_millis(1);
+        assert!(matches!(
+            burst.on_plain_char('b', t1),
+            CharDecision::BeginBufferFromPending
+        ));
+        burst.append_char_to_buffer('b', t1);
+
+        let t2 = t1 + PasteBurst::recommended_active_flush_delay() + Duration::from_millis(1);
+        assert!(matches!(burst.flush_if_due(t2), FlushResult::Paste(ref s) if s == "ab"));
+        assert!(!burst.is_active());
+
+        assert!(burst.newline_should_insert_instead_of_submit(t2));
+        let t3 = t1 + PASTE_ENTER_SUPPRESS_WINDOW + Duration::from_millis(1);
+        assert!(!burst.newline_should_insert_instead_of_submit(t3));
+    }
+}

--- a/koda-cli/src/composer/text_element.rs
+++ b/koda-cli/src/composer/text_element.rs
@@ -1,3 +1,8 @@
+// Foundation work for #1116/#1175 — see the equivalent header note in
+// composer/key_hint.rs for the full rationale. The blanket allow goes away
+// when PR 2 wires up the consumers.
+#![allow(dead_code)]
+
 //! Reduced port of codex's `codex-rs/protocol/src/user_input.rs`.
 //!
 //! ## Provenance
@@ -136,20 +141,14 @@ mod tests {
 
     #[test]
     fn text_element_explicit_placeholder_takes_precedence() {
-        let elem = TextElement::new(
-            ByteRange { start: 6, end: 11 },
-            Some("[image]".to_string()),
-        );
+        let elem = TextElement::new(ByteRange { start: 6, end: 11 }, Some("[image]".to_string()));
         let text = "Hello world";
         assert_eq!(elem.placeholder(text), Some("[image]"));
     }
 
     #[test]
     fn text_element_map_range_preserves_placeholder() {
-        let elem = TextElement::new(
-            ByteRange { start: 6, end: 11 },
-            Some("[img]".to_string()),
-        );
+        let elem = TextElement::new(ByteRange { start: 6, end: 11 }, Some("[img]".to_string()));
         let mapped = elem.map_range(|r| ByteRange {
             start: r.start + 10,
             end: r.end + 10,

--- a/koda-cli/src/composer/text_element.rs
+++ b/koda-cli/src/composer/text_element.rs
@@ -1,0 +1,156 @@
+//! Reduced port of codex's `codex-rs/protocol/src/user_input.rs`.
+//!
+//! ## Provenance
+//!
+//! Selected types ported from `codex-rs/protocol/src/user_input.rs` at
+//! upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` (vendored at the workspace root) for
+//! the full license text.
+//!
+//! ## What was kept vs dropped
+//!
+//! - **Kept:** [`ByteRange`], [`TextElement`], [`MAX_USER_INPUT_TEXT_CHARS`].
+//!   These are the primitives the ported [`super::textarea::TextArea`] needs
+//!   to track non-text spans (e.g. image placeholders) embedded in the
+//!   composer buffer.
+//! - **Dropped:** the `UserInput` enum and its protocol-serialization
+//!   derive (`schemars::JsonSchema`, `serde::{Deserialize, Serialize}`,
+//!   `ts_rs::TS`). koda's protocol layer is separate from codex's; we
+//!   only need the in-memory composer types here. Adding those derives
+//!   would drag four crates into `koda-cli` for no current benefit.
+//!
+//! ## Adaptations
+//!
+//! - Removed all `#[derive(Deserialize, Serialize, TS, JsonSchema)]`
+//!   from the ported types.
+//! - Removed the `UserInput` enum entirely (not used by textarea).
+
+use std::ops::Range;
+
+/// Conservative cap so one user message cannot monopolize a large context window.
+///
+/// Ported verbatim from codex; unchanged for koda since the rationale
+/// (model context-window protection) is identical.
+pub const MAX_USER_INPUT_TEXT_CHARS: usize = 1 << 20;
+
+/// A non-text span inside the composer buffer.
+///
+/// Used by [`super::textarea::TextArea`] to track placeholders such as
+/// pasted image references that should be displayed/persisted as a
+/// single logical unit even though they're embedded in the UTF-8 text
+/// stream. Cursor motion across an element treats it as one grapheme;
+/// deletion removes the whole span atomically.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextElement {
+    /// Byte range in the parent `text` buffer that this element occupies.
+    pub byte_range: ByteRange,
+    /// Optional human-readable placeholder for the element, displayed in the UI.
+    placeholder: Option<String>,
+}
+
+impl TextElement {
+    pub fn new(byte_range: ByteRange, placeholder: Option<String>) -> Self {
+        Self {
+            byte_range,
+            placeholder,
+        }
+    }
+
+    /// Returns a copy of this element with a remapped byte range.
+    ///
+    /// The placeholder is preserved as-is; callers must ensure the new range
+    /// still refers to the same logical element (and same placeholder)
+    /// within the new text.
+    pub fn map_range<F>(&self, map: F) -> Self
+    where
+        F: FnOnce(ByteRange) -> ByteRange,
+    {
+        Self {
+            byte_range: map(self.byte_range),
+            placeholder: self.placeholder.clone(),
+        }
+    }
+
+    pub fn set_placeholder(&mut self, placeholder: Option<String>) {
+        self.placeholder = placeholder;
+    }
+
+    /// Returns the placeholder string for this element, falling back to
+    /// the underlying text in the buffer if no explicit placeholder was
+    /// set. Used by the textarea when rendering the element in the
+    /// composer.
+    pub fn placeholder<'a>(&'a self, text: &'a str) -> Option<&'a str> {
+        self.placeholder
+            .as_deref()
+            .or_else(|| text.get(self.byte_range.start..self.byte_range.end))
+    }
+}
+
+/// A byte range within a UTF-8 text buffer.
+///
+/// `start` is inclusive, `end` is exclusive. The range is expected to
+/// align to UTF-8 character boundaries (the textarea ensures this on
+/// insertion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ByteRange {
+    /// Start byte offset (inclusive) within the UTF-8 text buffer.
+    pub start: usize,
+    /// End byte offset (exclusive) within the UTF-8 text buffer.
+    pub end: usize,
+}
+
+impl From<Range<usize>> for ByteRange {
+    fn from(range: Range<usize>) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_range_from_std_range() {
+        let r: ByteRange = (3..7).into();
+        assert_eq!(r.start, 3);
+        assert_eq!(r.end, 7);
+    }
+
+    #[test]
+    fn text_element_placeholder_falls_back_to_buffer_text() {
+        let elem = TextElement::new(ByteRange { start: 6, end: 11 }, None);
+        let text = "Hello world";
+        assert_eq!(elem.placeholder(text), Some("world"));
+    }
+
+    #[test]
+    fn text_element_explicit_placeholder_takes_precedence() {
+        let elem = TextElement::new(
+            ByteRange { start: 6, end: 11 },
+            Some("[image]".to_string()),
+        );
+        let text = "Hello world";
+        assert_eq!(elem.placeholder(text), Some("[image]"));
+    }
+
+    #[test]
+    fn text_element_map_range_preserves_placeholder() {
+        let elem = TextElement::new(
+            ByteRange { start: 6, end: 11 },
+            Some("[img]".to_string()),
+        );
+        let mapped = elem.map_range(|r| ByteRange {
+            start: r.start + 10,
+            end: r.end + 10,
+        });
+        assert_eq!(mapped.byte_range.start, 16);
+        assert_eq!(mapped.byte_range.end, 21);
+        assert_eq!(mapped.placeholder("anything goes here..."), Some("[img]"));
+    }
+}

--- a/koda-cli/src/composer/text_element.rs
+++ b/koda-cli/src/composer/text_element.rs
@@ -3,7 +3,12 @@
 //! ## Provenance
 //!
 //! Selected types ported from `codex-rs/protocol/src/user_input.rs` at
-//! upstream commit `7e8594fc198615068018b198ab86a9ae0a541dff`.
+//! upstream commit `d55479488e125ef7a0a8584505d839a22eaf6204`
+//! (codex `main` as of 2026-05-01).
+//!
+//! Verified byte-identical between this SHA and our previous reference
+//! `7e8594fc198615068018b198ab86a9ae0a541dff` (`git diff` returns 0
+//! lines), so the re-stamp is a pure attribution change.
 //!
 //! Original work: Copyright (c) OpenAI / codex contributors,
 //! licensed under the Apache License, Version 2.0.

--- a/koda-cli/src/composer/textarea.rs
+++ b/koda-cli/src/composer/textarea.rs
@@ -1,3 +1,9 @@
+// Foundation work for #1116/#1175 — see the equivalent header note in
+// composer/key_hint.rs for the full rationale. The blanket allow goes away
+// when PR 2 wires up the consumers (the chat_composer.rs swap from
+// ratatui-textarea to composer::textarea + the popup widgets that orbit it).
+#![allow(dead_code)]
+
 //! # Provenance
 //!
 //! Ported from `codex-rs/tui/src/bottom_pane/textarea.rs` at upstream
@@ -3484,12 +3490,7 @@ mod tests {
 
                 // Stateful render should not panic, and updates scroll
                 let mut sbuf = Buffer::empty(area);
-                ratatui::widgets::StatefulWidget::render(
-                    &ta,
-                    area,
-                    &mut sbuf,
-                    &mut state,
-                );
+                ratatui::widgets::StatefulWidget::render(&ta, area, &mut sbuf, &mut state);
 
                 // After wrapping, desired height equals the number of lines we would render without scroll
                 let total_lines = total_lines as usize;

--- a/koda-cli/src/composer/textarea.rs
+++ b/koda-cli/src/composer/textarea.rs
@@ -1,0 +1,3503 @@
+//! # Provenance
+//!
+//! Ported from `codex-rs/tui/src/bottom_pane/textarea.rs` at upstream
+//! commit `d55479488e125ef7a0a8584505d839a22eaf6204` (codex `main` as
+//! of 2026-05-01).
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` (vendored at the workspace root) for
+//! the full license text.
+//!
+//! # Adaptations for koda
+//!
+//! This is the HEAD-aligned re-port (Stage 5d of #1178). Compared to
+//! the upstream file at `codex-rs/tui/src/bottom_pane/textarea.rs`:
+//!
+//! ## Module-path swaps (we vendor into `composer/` not `tui/`)
+//!
+//! - `use crate::key_hint::*`           → `use super::key_hint::*`
+//!   (our verbatim vendor at `composer/key_hint.rs`)
+//! - `use crate::keymap::{EditorKeymap, RuntimeKeymap, VimNormalKeymap,
+//!    VimOperatorKeymap}` → `use super::keymap::*`
+//!   (our koda-OWNED policy layer at `composer/keymap.rs`; same
+//!   struct/field shape, no config integration)
+//! - `use codex_protocol::user_input::{ByteRange, TextElement}`
+//!   → `use super::text_element::*` (our reduced port at
+//!   `composer/text_element.rs`; same data types, no protocol
+//!   serialization derives)
+//! - `crate::wrapping::wrap_ranges` → `super::wrapping::wrap_ranges`
+//!   (our reduced port at `composer/wrapping.rs`; same 2 helpers,
+//!   none of the URL-aware adaptive wrapping)
+//!
+//! ## ratatui 0.30 API drift (codex is on ratatui 0.29)
+//!
+//! - `WidgetRef` (unstable in 0.26-0.29) was removed in ratatui 0.30.
+//!   Migrated to `Widget` implemented for `&TextArea` (the modern
+//!   pattern; same call-site semantics).
+//! - `StatefulWidgetRef` → `StatefulWidget` for `&TextArea` (same
+//!   story).
+//! - Method signature `fn render_ref(&self, ...)` → `fn render(self, ...)`.
+//!   Inside the body `self` is `&TextArea` (the impl is on the
+//!   reference type), so semantics are identical.
+//! - All test-code `ratatui::widgets::StatefulWidgetRef::render_ref`
+//!   call sites updated to `ratatui::widgets::StatefulWidget::render`,
+//!   ditto `WidgetRef::render_ref` → `Widget::render`.
+//!
+//! ## Test-suite gating
+//!
+//! Codex's `fuzz_textarea_randomized` property test uses `rand` +
+//! `chrono` to drive thousands of randomized edits. Adding both as
+//! dev-deps for one test isn't worth it; the deterministic test suite
+//! covers all the explicit behaviors. The fuzz test is preserved
+//! verbatim under `#[cfg(any())]` (always-false gate) along with the
+//! `rand_grapheme` helper and `use rand::prelude::*;`. Reviving is a
+//! one-line cfg swap once we add the dev-deps.
+//!
+//! ## What's NOT adapted
+//!
+//! Everything else — the editor logic, kill-buffer semantics, vim
+//! mode, soft-wrap, cursor motion, element handling, paste burst
+//! integration — is preserved verbatim from codex. Future codex syncs
+//! against this file should be a 3-way merge anchored at SHA d55479
+//! with our adaptations re-applied.
+//!
+//! # Original module documentation follows
+//!
+//! ---
+//!
+//! The textarea owns editable composer text, placeholder elements, cursor/wrap state, and a
+//! single-entry kill buffer.
+//!
+//! Whole-buffer replacement APIs intentionally rebuild only the visible draft state. They clear
+//! element ranges and derived cursor/wrapping caches, but they keep the kill buffer intact so a
+//! caller can clear or rewrite the draft and still allow `Ctrl+Y` to restore the user's most
+//! recent `Ctrl+K`. This is the contract higher-level composer flows rely on after submit,
+//! slash-command dispatch, and other synthetic clears.
+//!
+//! This module does not implement an Emacs-style multi-entry kill ring. It keeps only the most
+//! recent killed span.
+
+use super::key_hint::KeyBindingListExt;
+use super::key_hint::is_altgr;
+use super::keymap::EditorKeymap;
+use super::keymap::RuntimeKeymap;
+use super::keymap::VimNormalKeymap;
+use super::keymap::VimOperatorKeymap;
+use super::text_element::ByteRange;
+use super::text_element::TextElement as UserTextElement;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::widgets::StatefulWidget;
+use ratatui::widgets::Widget;
+use std::cell::Ref;
+use std::cell::RefCell;
+use std::ops::Range;
+use textwrap::Options;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+const WORD_SEPARATORS: &str = "`~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?";
+
+fn is_word_separator(ch: char) -> bool {
+    WORD_SEPARATORS.contains(ch)
+}
+
+fn split_word_pieces(run: &str) -> Vec<(usize, &str)> {
+    let mut pieces = Vec::new();
+    for (segment_start, segment) in run.split_word_bound_indices() {
+        let mut piece_start = 0;
+        let mut chars = segment.char_indices();
+        let Some((_, first_char)) = chars.next() else {
+            continue;
+        };
+        let mut in_separator = is_word_separator(first_char);
+
+        for (idx, ch) in chars {
+            let is_separator = is_word_separator(ch);
+            if is_separator == in_separator {
+                continue;
+            }
+            pieces.push((segment_start + piece_start, &segment[piece_start..idx]));
+            piece_start = idx;
+            in_separator = is_separator;
+        }
+
+        pieces.push((segment_start + piece_start, &segment[piece_start..]));
+    }
+
+    pieces
+}
+
+#[derive(Debug, Clone)]
+struct TextElement {
+    id: u64,
+    range: Range<usize>,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TextElementSnapshot {
+    pub(crate) id: u64,
+    pub(crate) range: Range<usize>,
+    pub(crate) text: String,
+}
+
+/// `TextArea` is the editable buffer behind the TUI composer.
+///
+/// It owns the raw UTF-8 text, placeholder-like text elements that must move atomically with
+/// edits, cursor/wrapping state for rendering, and a single-entry kill buffer for `Ctrl+K` /
+/// `Ctrl+Y` style editing. Callers may replace the entire visible buffer through
+/// [`Self::set_text_clearing_elements`] or [`Self::set_text_with_elements`] without disturbing the
+/// kill buffer; if they incorrectly assume those methods fully reset editing state, a later yank
+/// will appear to restore stale text from the user's perspective.
+#[derive(Debug)]
+pub(crate) struct TextArea {
+    text: String,
+    cursor_pos: usize,
+    wrap_cache: RefCell<Option<WrapCache>>,
+    preferred_col: Option<usize>,
+    elements: Vec<TextElement>,
+    next_element_id: u64,
+    kill_buffer: String,
+    kill_buffer_kind: KillBufferKind,
+    vim_enabled: bool,
+    vim_mode: VimMode,
+    vim_operator: Option<VimOperator>,
+    editor_keymap: EditorKeymap,
+    vim_normal_keymap: VimNormalKeymap,
+    vim_operator_keymap: VimOperatorKeymap,
+}
+
+#[derive(Debug, Clone)]
+struct WrapCache {
+    width: u16,
+    lines: Vec<Range<usize>>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct TextAreaState {
+    /// Index into wrapped lines of the first visible line.
+    scroll: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VimMode {
+    /// Normal mode routes printable keys to movement, operators, and mode transitions.
+    Normal,
+    /// Insert mode routes input through the regular editor keymap until Escape is pressed.
+    Insert,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KillBufferKind {
+    /// Characterwise kills and yanks paste at the cursor.
+    Characterwise,
+    /// Linewise kills and yanks paste as whole lines below the cursor line.
+    Linewise,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VimOperator {
+    /// Delete the range selected by the next motion or repeated operator key.
+    Delete,
+    /// Copy the range selected by the next motion or repeated operator key.
+    Yank,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VimMotion {
+    /// Move one atomic boundary to the left.
+    Left,
+    /// Move one atomic boundary to the right.
+    Right,
+    /// Move one visual row up, preserving preferred display column.
+    Up,
+    /// Move one visual row down, preserving preferred display column.
+    Down,
+    /// Move to the start of the next word-like run.
+    WordForward,
+    /// Move to the start of the previous word-like run.
+    WordBackward,
+    /// Move to the end of the current or next word-like run.
+    WordEnd,
+    /// Move to the start of the current line.
+    LineStart,
+    /// Move to the end of the current line.
+    LineEnd,
+}
+
+impl TextArea {
+    pub fn new() -> Self {
+        let defaults = RuntimeKeymap::defaults();
+        Self {
+            text: String::new(),
+            cursor_pos: 0,
+            wrap_cache: RefCell::new(None),
+            preferred_col: None,
+            elements: Vec::new(),
+            next_element_id: 1,
+            kill_buffer: String::new(),
+            kill_buffer_kind: KillBufferKind::Characterwise,
+            vim_enabled: false,
+            vim_mode: VimMode::Insert,
+            vim_operator: None,
+            editor_keymap: defaults.editor,
+            vim_normal_keymap: defaults.vim_normal,
+            vim_operator_keymap: defaults.vim_operator,
+        }
+    }
+
+    /// Replace the editor and Vim keymaps used by subsequent text-editing input.
+    ///
+    /// This method intentionally swaps only the keymap caches. It does not
+    /// reinterpret pending input, change Vim mode, move the cursor, or mutate
+    /// the kill buffer, so callers can safely apply a live config update while
+    /// preserving the current draft exactly as typed.
+    pub fn set_keymap_bindings(&mut self, keymap: &RuntimeKeymap) {
+        self.editor_keymap = keymap.editor.clone();
+        self.vim_normal_keymap = keymap.vim_normal.clone();
+        self.vim_operator_keymap = keymap.vim_operator.clone();
+    }
+
+    /// Replace the visible textarea text and clear any existing text elements.
+    ///
+    /// This is the "fresh buffer" path for callers that want plain text with no placeholder
+    /// ranges. It intentionally preserves the current kill buffer, because higher-level flows such
+    /// as submit or slash-command dispatch clear the draft through this method and still want
+    /// `Ctrl+Y` to recover the user's most recent kill.
+    pub fn set_text_clearing_elements(&mut self, text: &str) {
+        self.set_text_inner(text, /*elements*/ None);
+    }
+
+    /// Replace the visible textarea text and rebuild the provided text elements.
+    ///
+    /// As with [`Self::set_text_clearing_elements`], this resets only state derived from the
+    /// visible buffer. The kill buffer survives so callers restoring drafts or external edits do
+    /// not silently discard a pending yank target.
+    pub fn set_text_with_elements(&mut self, text: &str, elements: &[UserTextElement]) {
+        self.set_text_inner(text, Some(elements));
+    }
+
+    fn set_text_inner(&mut self, text: &str, elements: Option<&[UserTextElement]>) {
+        // Stage 1: replace the raw text and keep the cursor in a safe byte range.
+        self.text = text.to_string();
+        self.cursor_pos = self.cursor_pos.clamp(0, self.text.len());
+        // Stage 2: rebuild element ranges from scratch against the new text.
+        self.elements.clear();
+        if let Some(elements) = elements {
+            for elem in elements {
+                let mut start = elem.byte_range.start.min(self.text.len());
+                let mut end = elem.byte_range.end.min(self.text.len());
+                start = self.clamp_pos_to_char_boundary(start);
+                end = self.clamp_pos_to_char_boundary(end);
+                if start >= end {
+                    continue;
+                }
+                let id = self.next_element_id();
+                self.elements.push(TextElement {
+                    id,
+                    range: start..end,
+                    name: None,
+                });
+            }
+            self.elements.sort_by_key(|e| e.range.start);
+        }
+        // Stage 3: clamp the cursor and reset derived state tied to the prior content.
+        // The kill buffer is editing history rather than visible-buffer state, so full-buffer
+        // replacements intentionally leave it alone.
+        self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+        self.wrap_cache.replace(None);
+        self.preferred_col = None;
+    }
+
+    /// Enable or disable modal Vim editing for the textarea.
+    ///
+    /// Enabling always enters normal mode and disabling always returns to
+    /// insert semantics. Pending operators are cleared in both directions so a
+    /// toggle cannot leave the next keypress interpreted as the second half of
+    /// an old `d` or `y` command.
+    pub(crate) fn set_vim_enabled(&mut self, enabled: bool) {
+        self.vim_enabled = enabled;
+        self.vim_operator = None;
+        self.vim_mode = if enabled {
+            VimMode::Normal
+        } else {
+            VimMode::Insert
+        };
+    }
+
+    /// Return whether modal Vim editing is currently enabled.
+    pub(crate) fn is_vim_enabled(&self) -> bool {
+        self.vim_enabled
+    }
+
+    /// Return whether Vim mode is enabled and currently waiting in normal mode.
+    ///
+    /// Composer-level handlers use this to decide whether Up/Down should be
+    /// offered to history navigation only after normal-mode movement reaches a
+    /// text boundary.
+    pub(crate) fn is_vim_normal_mode(&self) -> bool {
+        self.vim_enabled && self.vim_mode == VimMode::Normal
+    }
+
+    /// Return the cursor position that represents the last editable item in Vim normal mode.
+    pub(crate) fn vim_normal_end_cursor(&self) -> usize {
+        if self.text.is_empty() {
+            0
+        } else {
+            self.prev_atomic_boundary(self.text.len())
+        }
+    }
+
+    /// Return whether a Vim operator is waiting for a motion.
+    ///
+    /// This is observable so the composer can avoid stealing the second key of
+    /// `d{motion}` or `y{motion}` for higher-level shortcuts.
+    pub(crate) fn is_vim_operator_pending(&self) -> bool {
+        self.vim_operator.is_some()
+    }
+
+    /// Enter Vim insert mode if modal editing is enabled.
+    ///
+    /// Calling this while Vim is disabled is a no-op, which lets parent
+    /// workflows reset mode after submissions without first branching on the
+    /// current keymap state.
+    pub(crate) fn enter_vim_insert_mode(&mut self) {
+        if self.vim_enabled {
+            self.vim_mode = VimMode::Insert;
+            self.vim_operator = None;
+        }
+    }
+
+    /// Enter Vim normal mode if modal editing is enabled.
+    ///
+    /// This clears any pending operator and preferred vertical column. The
+    /// latter matches normal Vim navigation expectations after leaving insert
+    /// mode; preserving the old column would make the next `j` or `k` jump to a
+    /// stale visual target.
+    pub(crate) fn enter_vim_normal_mode(&mut self) {
+        if self.vim_enabled {
+            self.vim_mode = VimMode::Normal;
+            self.vim_operator = None;
+            self.preferred_col = None;
+        }
+    }
+
+    /// Return whether rapid plain-key bursts should be treated as paste input.
+    ///
+    /// Paste burst detection is disabled in Vim normal mode so a fast sequence
+    /// like `dd` or `yw` remains command input instead of being converted into
+    /// literal text.
+    pub(crate) fn allows_paste_burst(&self) -> bool {
+        !self.vim_enabled || self.vim_mode == VimMode::Insert
+    }
+
+    /// Return whether rendering should use the insert-mode cursor style.
+    pub(crate) fn uses_vim_insert_cursor(&self) -> bool {
+        self.vim_enabled && self.vim_mode == VimMode::Insert
+    }
+
+    /// Return whether Escape should be intercepted before composer-level routing.
+    ///
+    /// In Vim insert mode, Escape is an editing transition rather than a popup
+    /// cancel/backtrack shortcut. Letting the composer handle it first would
+    /// close UI surfaces while leaving the textarea in insert mode.
+    pub(crate) fn should_handle_vim_insert_escape(&self, event: KeyEvent) -> bool {
+        self.vim_enabled
+            && self.vim_mode == VimMode::Insert
+            && event.code == KeyCode::Esc
+            && event.modifiers == KeyModifiers::NONE
+            && matches!(event.kind, KeyEventKind::Press | KeyEventKind::Repeat)
+    }
+
+    /// Return the footer label for the active Vim mode.
+    ///
+    /// `None` means Vim editing is disabled, so callers should omit the mode
+    /// indicator rather than rendering an insert-mode label for normal
+    /// non-modal editing.
+    pub(crate) fn vim_mode_label(&self) -> Option<&'static str> {
+        if !self.vim_enabled {
+            return None;
+        }
+        Some(match self.vim_mode {
+            VimMode::Normal => "Normal",
+            VimMode::Insert => "Insert",
+        })
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn insert_str(&mut self, text: &str) {
+        self.insert_str_at(self.cursor_pos, text);
+    }
+
+    pub fn insert_str_at(&mut self, pos: usize, text: &str) {
+        let pos = self.clamp_pos_for_insertion(pos);
+        self.text.insert_str(pos, text);
+        self.wrap_cache.replace(None);
+        if pos <= self.cursor_pos {
+            self.cursor_pos += text.len();
+        }
+        self.shift_elements(pos, /*removed*/ 0, text.len());
+        self.preferred_col = None;
+    }
+
+    pub fn replace_range(&mut self, range: std::ops::Range<usize>, text: &str) {
+        let range = self.expand_range_to_element_boundaries(range);
+        self.replace_range_raw(range, text);
+    }
+
+    fn replace_range_raw(&mut self, range: std::ops::Range<usize>, text: &str) {
+        assert!(range.start <= range.end);
+        let start = range.start.clamp(0, self.text.len());
+        let end = range.end.clamp(0, self.text.len());
+        let removed_len = end - start;
+        let inserted_len = text.len();
+        if removed_len == 0 && inserted_len == 0 {
+            return;
+        }
+        let diff = inserted_len as isize - removed_len as isize;
+
+        self.text.replace_range(range, text);
+        self.wrap_cache.replace(None);
+        self.preferred_col = None;
+        self.update_elements_after_replace(start, end, inserted_len);
+
+        // Update the cursor position to account for the edit.
+        self.cursor_pos = if self.cursor_pos < start {
+            // Cursor was before the edited range – no shift.
+            self.cursor_pos
+        } else if self.cursor_pos <= end {
+            // Cursor was inside the replaced range – move to end of the new text.
+            start + inserted_len
+        } else {
+            // Cursor was after the replaced range – shift by the length diff.
+            ((self.cursor_pos as isize) + diff) as usize
+        }
+        .min(self.text.len());
+
+        // Ensure cursor is not inside an element
+        self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+    }
+
+    pub fn cursor(&self) -> usize {
+        self.cursor_pos
+    }
+
+    pub fn set_cursor(&mut self, pos: usize) {
+        self.cursor_pos = pos.clamp(0, self.text.len());
+        self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+        self.preferred_col = None;
+    }
+
+    pub fn desired_height(&self, width: u16) -> u16 {
+        self.wrapped_lines(width).len() as u16
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        self.cursor_pos_with_state(area, TextAreaState::default())
+    }
+
+    /// Compute the on-screen cursor position taking scrolling into account.
+    pub fn cursor_pos_with_state(&self, area: Rect, state: TextAreaState) -> Option<(u16, u16)> {
+        let lines = self.wrapped_lines(area.width);
+        let effective_scroll = self.effective_scroll(area.height, &lines, state.scroll);
+        let i = Self::wrapped_line_index_by_start(&lines, self.cursor_pos)?;
+        let ls = &lines[i];
+        let col = self.text[ls.start..self.cursor_pos].width() as u16;
+        let screen_row = i
+            .saturating_sub(effective_scroll as usize)
+            .try_into()
+            .unwrap_or(0);
+        Some((area.x + col, area.y + screen_row))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    fn current_display_col(&self) -> usize {
+        let bol = self.beginning_of_current_line();
+        self.text[bol..self.cursor_pos].width()
+    }
+
+    fn wrapped_line_index_by_start(lines: &[Range<usize>], pos: usize) -> Option<usize> {
+        // partition_point returns the index of the first element for which
+        // the predicate is false, i.e. the count of elements with start <= pos.
+        let idx = lines.partition_point(|r| r.start <= pos);
+        if idx == 0 { None } else { Some(idx - 1) }
+    }
+
+    fn move_to_display_col_on_line(
+        &mut self,
+        line_start: usize,
+        line_end: usize,
+        target_col: usize,
+    ) {
+        let mut width_so_far = 0usize;
+        for (i, g) in self.text[line_start..line_end].grapheme_indices(true) {
+            width_so_far += g.width();
+            if width_so_far > target_col {
+                self.cursor_pos = line_start + i;
+                // Avoid landing inside an element; round to nearest boundary
+                self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+                return;
+            }
+        }
+        self.cursor_pos = line_end;
+        self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+    }
+
+    fn beginning_of_line(&self, pos: usize) -> usize {
+        self.text[..pos].rfind('\n').map(|i| i + 1).unwrap_or(0)
+    }
+    fn beginning_of_current_line(&self) -> usize {
+        self.beginning_of_line(self.cursor_pos)
+    }
+
+    fn first_non_blank_of_current_line(&self) -> usize {
+        let bol = self.beginning_of_current_line();
+        let eol = self.end_of_current_line();
+        self.text[bol..eol]
+            .char_indices()
+            .find_map(|(offset, ch)| (!ch.is_whitespace()).then_some(bol + offset))
+            .unwrap_or(eol)
+    }
+
+    fn end_of_line(&self, pos: usize) -> usize {
+        self.text[pos..]
+            .find('\n')
+            .map(|i| i + pos)
+            .unwrap_or(self.text.len())
+    }
+    fn end_of_current_line(&self) -> usize {
+        self.end_of_line(self.cursor_pos)
+    }
+
+    pub fn input(&mut self, event: KeyEvent) {
+        // Only process key presses or repeats; ignore releases to avoid inserting
+        // characters on key-up events when modifiers are no longer reported.
+        if !matches!(event.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return;
+        }
+        if self.vim_enabled {
+            self.handle_vim_input(event);
+        } else {
+            let keymap = self.editor_keymap.clone();
+            self.input_with_keymap(event, &keymap);
+        }
+    }
+
+    pub fn input_with_keymap(&mut self, event: KeyEvent, keymap: &EditorKeymap) {
+        if keymap.insert_newline.is_pressed(event) {
+            self.insert_str("\n");
+            return;
+        }
+
+        if keymap.delete_backward_word.is_pressed(event) {
+            self.delete_backward_word();
+            return;
+        }
+
+        // Windows AltGr generates ALT|CONTROL. Preserve typed characters for AltGr users
+        // unless a specific shortcut already matched above.
+        if let KeyEvent {
+            code: KeyCode::Char(c),
+            modifiers,
+            ..
+        } = event
+            && is_altgr(modifiers)
+        {
+            self.insert_str(&c.to_string());
+            return;
+        }
+
+        if keymap.delete_backward.is_pressed(event) {
+            self.delete_backward(/*n*/ 1);
+            return;
+        }
+        if keymap.delete_forward_word.is_pressed(event) {
+            self.delete_forward_word();
+            return;
+        }
+        if keymap.delete_forward.is_pressed(event) {
+            self.delete_forward(/*n*/ 1);
+            return;
+        }
+        if keymap.kill_line_start.is_pressed(event) {
+            self.kill_to_beginning_of_line();
+            return;
+        }
+        if keymap.kill_line_end.is_pressed(event) {
+            self.kill_to_end_of_line();
+            return;
+        }
+        if keymap.yank.is_pressed(event) {
+            self.yank();
+            return;
+        }
+        if keymap.move_word_left.is_pressed(event) {
+            self.set_cursor(self.beginning_of_previous_word());
+            return;
+        }
+        if keymap.move_word_right.is_pressed(event) {
+            self.set_cursor(self.end_of_next_word());
+            return;
+        }
+        if keymap.move_left.is_pressed(event) {
+            self.move_cursor_left();
+            return;
+        }
+        if keymap.move_right.is_pressed(event) {
+            self.move_cursor_right();
+            return;
+        }
+        if keymap.move_up.is_pressed(event) {
+            self.move_cursor_up();
+            return;
+        }
+        if keymap.move_down.is_pressed(event) {
+            self.move_cursor_down();
+            return;
+        }
+        if keymap.move_line_start.is_pressed(event) {
+            let move_up_at_bol = matches!(
+                event,
+                KeyEvent {
+                    code: KeyCode::Char('a'),
+                    modifiers: KeyModifiers::CONTROL,
+                    ..
+                }
+            );
+            self.move_cursor_to_beginning_of_line(move_up_at_bol);
+            return;
+        }
+        if keymap.move_line_end.is_pressed(event) {
+            let move_down_at_eol = matches!(
+                event,
+                KeyEvent {
+                    code: KeyCode::Char('e'),
+                    modifiers: KeyModifiers::CONTROL,
+                    ..
+                }
+            );
+            self.move_cursor_to_end_of_line(move_down_at_eol);
+            return;
+        }
+
+        if let KeyEvent {
+            code: KeyCode::Char(c),
+            modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
+            ..
+        } = event
+        {
+            // Insert plain characters (and Shift-modified). Do not insert when ALT is held,
+            // because many terminals map Option/Meta combos to ALT+<char>.
+            if c.is_ascii_control() {
+                return;
+            }
+            self.insert_str(&c.to_string());
+        }
+
+        tracing::debug!("Unhandled key event in TextArea: {:?}", event);
+    }
+
+    fn handle_vim_input(&mut self, event: KeyEvent) {
+        match self.vim_mode {
+            VimMode::Insert => self.handle_vim_insert(event),
+            VimMode::Normal => self.handle_vim_normal(event),
+        }
+    }
+
+    fn handle_vim_insert(&mut self, event: KeyEvent) {
+        if matches!(event.code, KeyCode::Esc) {
+            let bol = self.beginning_of_current_line();
+            if self.cursor_pos > bol {
+                self.cursor_pos = self.prev_atomic_boundary(self.cursor_pos).max(bol);
+            }
+            self.enter_vim_normal_mode();
+            return;
+        }
+        let keymap = self.editor_keymap.clone();
+        self.input_with_keymap(event, &keymap);
+    }
+
+    fn handle_vim_normal(&mut self, event: KeyEvent) {
+        if let Some(op) = self.vim_operator.take() {
+            self.handle_vim_operator(op, event);
+            return;
+        }
+
+        if self.vim_normal_keymap.enter_insert.is_pressed(event) {
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.append_after_cursor.is_pressed(event) {
+            let next = self.next_atomic_boundary(self.cursor_pos);
+            self.set_cursor(next);
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.append_line_end.is_pressed(event) {
+            self.set_cursor(self.end_of_current_line());
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.insert_line_start.is_pressed(event) {
+            self.set_cursor(self.first_non_blank_of_current_line());
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.open_line_below.is_pressed(event) {
+            let eol = self.end_of_current_line();
+            let insert_at = if eol < self.text.len() { eol + 1 } else { eol };
+            self.insert_str_at(insert_at, "\n");
+            let cursor = if eol < self.text.len() {
+                insert_at
+            } else {
+                insert_at + 1
+            };
+            self.set_cursor(cursor);
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.open_line_above.is_pressed(event) {
+            let bol = self.beginning_of_current_line();
+            self.insert_str_at(bol, "\n");
+            self.set_cursor(bol);
+            self.vim_mode = VimMode::Insert;
+            return;
+        }
+        if self.vim_normal_keymap.move_left.is_pressed(event) {
+            self.move_cursor_left();
+            return;
+        }
+        if self.vim_normal_keymap.move_right.is_pressed(event) {
+            self.move_cursor_right();
+            return;
+        }
+        if self.vim_normal_keymap.move_down.is_pressed(event) {
+            self.move_cursor_down();
+            return;
+        }
+        if self.vim_normal_keymap.move_up.is_pressed(event) {
+            self.move_cursor_up();
+            return;
+        }
+        if self.vim_normal_keymap.move_word_forward.is_pressed(event) {
+            self.set_cursor(self.beginning_of_next_word());
+            return;
+        }
+        if self.vim_normal_keymap.move_word_backward.is_pressed(event) {
+            self.set_cursor(self.beginning_of_previous_word());
+            return;
+        }
+        if self.vim_normal_keymap.move_word_end.is_pressed(event) {
+            self.set_cursor(self.vim_word_end_cursor());
+            return;
+        }
+        if self.vim_normal_keymap.move_line_start.is_pressed(event) {
+            self.set_cursor(self.beginning_of_current_line());
+            return;
+        }
+        if self.vim_normal_keymap.move_line_end.is_pressed(event) {
+            self.set_cursor(self.vim_line_end_cursor());
+            return;
+        }
+        if self.vim_normal_keymap.delete_char.is_pressed(event) {
+            self.delete_forward_kill(/*n*/ 1);
+            return;
+        }
+        if self.vim_normal_keymap.delete_to_line_end.is_pressed(event) {
+            self.kill_to_end_of_line();
+            return;
+        }
+        if self.vim_normal_keymap.yank_line.is_pressed(event) {
+            self.yank_current_line();
+            return;
+        }
+        if self.vim_normal_keymap.paste_after.is_pressed(event) {
+            self.paste_after_cursor();
+            return;
+        }
+        if self
+            .vim_normal_keymap
+            .start_delete_operator
+            .is_pressed(event)
+        {
+            self.vim_operator = Some(VimOperator::Delete);
+            return;
+        }
+        if self.vim_normal_keymap.start_yank_operator.is_pressed(event) {
+            self.vim_operator = Some(VimOperator::Yank);
+            return;
+        }
+        if self.vim_normal_keymap.cancel_operator.is_pressed(event) {
+            self.vim_operator = None;
+        }
+    }
+
+    fn handle_vim_operator(&mut self, op: VimOperator, event: KeyEvent) -> bool {
+        if op == VimOperator::Delete && self.vim_operator_keymap.delete_line.is_pressed(event) {
+            self.delete_current_line();
+            return true;
+        }
+        if op == VimOperator::Yank && self.vim_operator_keymap.yank_line.is_pressed(event) {
+            self.yank_current_line();
+            return true;
+        }
+        if self.vim_operator_keymap.cancel.is_pressed(event) {
+            return true;
+        }
+
+        if let Some(motion) = self.vim_motion_for_event(event) {
+            self.apply_vim_operator(op, motion);
+            return true;
+        }
+        false
+    }
+
+    fn vim_motion_for_event(&self, event: KeyEvent) -> Option<VimMotion> {
+        if self.vim_operator_keymap.motion_left.is_pressed(event) {
+            return Some(VimMotion::Left);
+        }
+        if self.vim_operator_keymap.motion_right.is_pressed(event) {
+            return Some(VimMotion::Right);
+        }
+        if self.vim_operator_keymap.motion_down.is_pressed(event) {
+            return Some(VimMotion::Down);
+        }
+        if self.vim_operator_keymap.motion_up.is_pressed(event) {
+            return Some(VimMotion::Up);
+        }
+        if self
+            .vim_operator_keymap
+            .motion_word_forward
+            .is_pressed(event)
+        {
+            return Some(VimMotion::WordForward);
+        }
+        if self
+            .vim_operator_keymap
+            .motion_word_backward
+            .is_pressed(event)
+        {
+            return Some(VimMotion::WordBackward);
+        }
+        if self.vim_operator_keymap.motion_word_end.is_pressed(event) {
+            return Some(VimMotion::WordEnd);
+        }
+        if self.vim_operator_keymap.motion_line_start.is_pressed(event) {
+            return Some(VimMotion::LineStart);
+        }
+        if self.vim_operator_keymap.motion_line_end.is_pressed(event) {
+            return Some(VimMotion::LineEnd);
+        }
+        None
+    }
+
+    fn apply_vim_operator(&mut self, op: VimOperator, motion: VimMotion) {
+        let Some(range) = self.range_for_motion(motion) else {
+            return;
+        };
+        match op {
+            VimOperator::Delete => self.kill_range(range),
+            VimOperator::Yank => self.yank_range(range),
+        }
+    }
+
+    fn range_for_motion(&mut self, motion: VimMotion) -> Option<Range<usize>> {
+        if matches!(motion, VimMotion::Up | VimMotion::Down) {
+            return self.linewise_range_for_vertical_motion(motion);
+        }
+        let start = self.cursor_pos;
+        let target = self.target_for_motion(motion);
+        if start == target {
+            return None;
+        }
+        let (range_start, range_end) = if target < start {
+            (target, start)
+        } else {
+            (start, target)
+        };
+        Some(range_start..range_end)
+    }
+
+    fn linewise_range_for_vertical_motion(&self, motion: VimMotion) -> Option<Range<usize>> {
+        let current = self.current_line_range_with_newline();
+        let range = match motion {
+            VimMotion::Up => {
+                let start = if current.start == 0 {
+                    current.start
+                } else {
+                    self.beginning_of_line(current.start.saturating_sub(1))
+                };
+                start..current.end
+            }
+            VimMotion::Down => {
+                let end = if current.end >= self.text.len() {
+                    current.end
+                } else {
+                    let next_eol = self.end_of_line(current.end);
+                    if next_eol < self.text.len() {
+                        next_eol + 1
+                    } else {
+                        next_eol
+                    }
+                };
+                current.start..end
+            }
+            VimMotion::Left
+            | VimMotion::Right
+            | VimMotion::WordForward
+            | VimMotion::WordBackward
+            | VimMotion::WordEnd
+            | VimMotion::LineStart
+            | VimMotion::LineEnd => return None,
+        };
+        (range.start < range.end).then_some(range)
+    }
+
+    fn target_for_motion(&mut self, motion: VimMotion) -> usize {
+        let original_cursor = self.cursor_pos;
+        let original_preferred = self.preferred_col;
+        match motion {
+            VimMotion::Left => self.move_cursor_left(),
+            VimMotion::Right => self.move_cursor_right(),
+            VimMotion::Up => self.move_cursor_up(),
+            VimMotion::Down => self.move_cursor_down(),
+            VimMotion::WordForward => self.set_cursor(self.beginning_of_next_word()),
+            VimMotion::WordBackward => self.set_cursor(self.beginning_of_previous_word()),
+            VimMotion::WordEnd => self.set_cursor(self.end_of_next_word()),
+            VimMotion::LineStart => self.set_cursor(self.beginning_of_current_line()),
+            VimMotion::LineEnd => self.set_cursor(self.end_of_current_line()),
+        }
+        let target = self.cursor_pos;
+        self.cursor_pos = original_cursor;
+        self.preferred_col = original_preferred;
+        target
+    }
+
+    // ####### Input Functions #######
+    pub fn delete_backward(&mut self, n: usize) {
+        if n == 0 || self.cursor_pos == 0 {
+            return;
+        }
+        let mut target = self.cursor_pos;
+        for _ in 0..n {
+            target = self.prev_atomic_boundary(target);
+            if target == 0 {
+                break;
+            }
+        }
+        self.replace_range(target..self.cursor_pos, "");
+    }
+
+    pub fn delete_forward(&mut self, n: usize) {
+        if n == 0 || self.cursor_pos >= self.text.len() {
+            return;
+        }
+        let mut target = self.cursor_pos;
+        for _ in 0..n {
+            target = self.next_atomic_boundary(target);
+            if target >= self.text.len() {
+                break;
+            }
+        }
+        self.replace_range(self.cursor_pos..target, "");
+    }
+
+    pub fn delete_forward_kill(&mut self, n: usize) {
+        if n == 0 || self.cursor_pos >= self.text.len() {
+            return;
+        }
+        let mut target = self.cursor_pos;
+        for _ in 0..n {
+            target = self.next_atomic_boundary(target);
+            if target >= self.text.len() {
+                break;
+            }
+        }
+        self.kill_range(self.cursor_pos..target);
+    }
+
+    pub fn delete_backward_word(&mut self) {
+        let start = self.beginning_of_previous_word();
+        self.kill_range(start..self.cursor_pos);
+    }
+
+    /// Delete text to the right of the cursor using "word" semantics.
+    ///
+    /// Deletes from the current cursor position through the end of the next word as determined
+    /// by `end_of_next_word()`. Any whitespace (including newlines) between the cursor and that
+    /// word is included in the deletion.
+    pub fn delete_forward_word(&mut self) {
+        let end = self.end_of_next_word();
+        if end > self.cursor_pos {
+            self.kill_range(self.cursor_pos..end);
+        }
+    }
+
+    /// Kill from the cursor to the end of the current logical line.
+    ///
+    /// If the cursor is already at end-of-line and a trailing newline exists, this kills that
+    /// newline so repeated invocations continue making progress. The removed text becomes the next
+    /// yank target and remains available even if a caller later clears or rewrites the visible
+    /// buffer via `set_text_*`.
+    pub fn kill_to_end_of_line(&mut self) {
+        let eol = self.end_of_current_line();
+        let range = if self.cursor_pos == eol {
+            if eol < self.text.len() {
+                Some(self.cursor_pos..eol + 1)
+            } else {
+                None
+            }
+        } else {
+            Some(self.cursor_pos..eol)
+        };
+
+        if let Some(range) = range {
+            self.kill_range(range);
+        }
+    }
+
+    pub fn kill_to_beginning_of_line(&mut self) {
+        let bol = self.beginning_of_current_line();
+        let range = if self.cursor_pos == bol {
+            if bol > 0 { Some(bol - 1..bol) } else { None }
+        } else {
+            Some(bol..self.cursor_pos)
+        };
+
+        if let Some(range) = range {
+            self.kill_range(range);
+        }
+    }
+
+    /// Insert the most recently killed text at the cursor.
+    ///
+    /// This uses the textarea's single-entry kill buffer. Because whole-buffer replacement APIs do
+    /// not clear that buffer, `yank` can restore text after composer-level clears such as submit
+    /// and slash-command dispatch.
+    pub fn yank(&mut self) {
+        if self.kill_buffer.is_empty() {
+            return;
+        }
+        let text = self.kill_buffer.clone();
+        self.insert_str(&text);
+    }
+
+    fn kill_range(&mut self, range: Range<usize>) {
+        self.kill_range_with_kind(range, KillBufferKind::Characterwise);
+    }
+
+    fn kill_line_range(&mut self, range: Range<usize>) {
+        self.kill_range_with_kind(range, KillBufferKind::Linewise);
+    }
+
+    fn kill_range_with_kind(&mut self, range: Range<usize>, kind: KillBufferKind) {
+        let range = self.expand_range_to_element_boundaries(range);
+        if range.start >= range.end {
+            return;
+        }
+
+        let removed = self.text[range.clone()].to_string();
+        if removed.is_empty() {
+            return;
+        }
+
+        self.store_kill_buffer(removed, kind);
+        self.replace_range_raw(range, "");
+    }
+
+    fn yank_range(&mut self, range: Range<usize>) {
+        self.yank_range_with_kind(range, KillBufferKind::Characterwise);
+    }
+
+    fn yank_line_range(&mut self, range: Range<usize>) {
+        self.yank_range_with_kind(range, KillBufferKind::Linewise);
+    }
+
+    fn yank_range_with_kind(&mut self, range: Range<usize>, kind: KillBufferKind) {
+        let range = self.expand_range_to_element_boundaries(range);
+        if range.start >= range.end {
+            return;
+        }
+        let removed = self.text[range].to_string();
+        if removed.is_empty() {
+            return;
+        }
+        self.store_kill_buffer(removed, kind);
+    }
+
+    fn store_kill_buffer(&mut self, text: String, kind: KillBufferKind) {
+        self.kill_buffer = text;
+        self.kill_buffer_kind = kind;
+    }
+
+    fn paste_after_cursor(&mut self) {
+        if self.kill_buffer.is_empty() {
+            return;
+        }
+        if self.kill_buffer_kind == KillBufferKind::Linewise {
+            self.paste_line_after_current_line();
+            return;
+        }
+        let insert_at = self.next_atomic_boundary(self.cursor_pos);
+        self.set_cursor(insert_at);
+        let text = self.kill_buffer.clone();
+        self.insert_str(&text);
+    }
+
+    fn paste_line_after_current_line(&mut self) {
+        let eol = self.end_of_current_line();
+        let insert_at = if eol < self.text.len() { eol + 1 } else { eol };
+        let cursor = if eol < self.text.len() {
+            insert_at
+        } else {
+            insert_at + 1
+        };
+        let text = if eol < self.text.len() {
+            if self.kill_buffer.ends_with('\n') {
+                self.kill_buffer.clone()
+            } else {
+                format!("{}\n", self.kill_buffer)
+            }
+        } else {
+            format!("\n{}", self.kill_buffer.trim_end_matches('\n'))
+        };
+        self.insert_str_at(insert_at, &text);
+        self.set_cursor(cursor.min(self.text.len()));
+    }
+
+    fn yank_current_line(&mut self) {
+        let range = self.current_line_range_with_newline();
+        self.yank_line_range(range);
+    }
+
+    fn delete_current_line(&mut self) {
+        let range = self.current_line_range_with_newline();
+        self.kill_line_range(range);
+    }
+
+    fn current_line_range_with_newline(&self) -> Range<usize> {
+        let bol = self.beginning_of_current_line();
+        let eol = self.end_of_current_line();
+        let end = if eol < self.text.len() { eol + 1 } else { eol };
+        bol..end
+    }
+
+    /// Move the cursor left by a single grapheme cluster.
+    pub fn move_cursor_left(&mut self) {
+        self.cursor_pos = self.prev_atomic_boundary(self.cursor_pos);
+        self.preferred_col = None;
+    }
+
+    /// Move the cursor right by a single grapheme cluster.
+    pub fn move_cursor_right(&mut self) {
+        self.cursor_pos = self.next_atomic_boundary(self.cursor_pos);
+        self.preferred_col = None;
+    }
+
+    pub fn move_cursor_up(&mut self) {
+        // If we have a wrapping cache, prefer navigating across wrapped (visual) lines.
+        if let Some((target_col, maybe_line)) = {
+            let cache_ref = self.wrap_cache.borrow();
+            if let Some(cache) = cache_ref.as_ref() {
+                let lines = &cache.lines;
+                if let Some(idx) = Self::wrapped_line_index_by_start(lines, self.cursor_pos) {
+                    let cur_range = &lines[idx];
+                    let target_col = self
+                        .preferred_col
+                        .unwrap_or_else(|| self.text[cur_range.start..self.cursor_pos].width());
+                    if idx > 0 {
+                        let prev = &lines[idx - 1];
+                        let line_start = prev.start;
+                        let line_end = prev.end.saturating_sub(1);
+                        Some((target_col, Some((line_start, line_end))))
+                    } else {
+                        Some((target_col, None))
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } {
+            // We had wrapping info. Apply movement accordingly.
+            match maybe_line {
+                Some((line_start, line_end)) => {
+                    if self.preferred_col.is_none() {
+                        self.preferred_col = Some(target_col);
+                    }
+                    self.move_to_display_col_on_line(line_start, line_end, target_col);
+                    return;
+                }
+                None => {
+                    // Already at first visual line -> move to start
+                    self.cursor_pos = 0;
+                    self.preferred_col = None;
+                    return;
+                }
+            }
+        }
+
+        // Fallback to logical line navigation if we don't have wrapping info yet.
+        if let Some(prev_nl) = self.text[..self.cursor_pos].rfind('\n') {
+            let target_col = match self.preferred_col {
+                Some(c) => c,
+                None => {
+                    let c = self.current_display_col();
+                    self.preferred_col = Some(c);
+                    c
+                }
+            };
+            let prev_line_start = self.text[..prev_nl].rfind('\n').map(|i| i + 1).unwrap_or(0);
+            let prev_line_end = prev_nl;
+            self.move_to_display_col_on_line(prev_line_start, prev_line_end, target_col);
+        } else {
+            self.cursor_pos = 0;
+            self.preferred_col = None;
+        }
+    }
+
+    pub fn move_cursor_down(&mut self) {
+        // If we have a wrapping cache, prefer navigating across wrapped (visual) lines.
+        if let Some((target_col, move_to_last)) = {
+            let cache_ref = self.wrap_cache.borrow();
+            if let Some(cache) = cache_ref.as_ref() {
+                let lines = &cache.lines;
+                if let Some(idx) = Self::wrapped_line_index_by_start(lines, self.cursor_pos) {
+                    let cur_range = &lines[idx];
+                    let target_col = self
+                        .preferred_col
+                        .unwrap_or_else(|| self.text[cur_range.start..self.cursor_pos].width());
+                    if idx + 1 < lines.len() {
+                        let next = &lines[idx + 1];
+                        let line_start = next.start;
+                        let line_end = next.end.saturating_sub(1);
+                        Some((target_col, Some((line_start, line_end))))
+                    } else {
+                        Some((target_col, None))
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } {
+            match move_to_last {
+                Some((line_start, line_end)) => {
+                    if self.preferred_col.is_none() {
+                        self.preferred_col = Some(target_col);
+                    }
+                    self.move_to_display_col_on_line(line_start, line_end, target_col);
+                    return;
+                }
+                None => {
+                    // Already on last visual line -> move to end
+                    self.cursor_pos = self.text.len();
+                    self.preferred_col = None;
+                    return;
+                }
+            }
+        }
+
+        // Fallback to logical line navigation if we don't have wrapping info yet.
+        let target_col = match self.preferred_col {
+            Some(c) => c,
+            None => {
+                let c = self.current_display_col();
+                self.preferred_col = Some(c);
+                c
+            }
+        };
+        if let Some(next_nl) = self.text[self.cursor_pos..]
+            .find('\n')
+            .map(|i| i + self.cursor_pos)
+        {
+            let next_line_start = next_nl + 1;
+            let next_line_end = self.text[next_line_start..]
+                .find('\n')
+                .map(|i| i + next_line_start)
+                .unwrap_or(self.text.len());
+            self.move_to_display_col_on_line(next_line_start, next_line_end, target_col);
+        } else {
+            self.cursor_pos = self.text.len();
+            self.preferred_col = None;
+        }
+    }
+
+    pub fn move_cursor_to_beginning_of_line(&mut self, move_up_at_bol: bool) {
+        let bol = self.beginning_of_current_line();
+        if move_up_at_bol && self.cursor_pos == bol {
+            self.set_cursor(self.beginning_of_line(self.cursor_pos.saturating_sub(1)));
+        } else {
+            self.set_cursor(bol);
+        }
+        self.preferred_col = None;
+    }
+
+    pub fn move_cursor_to_end_of_line(&mut self, move_down_at_eol: bool) {
+        let eol = self.end_of_current_line();
+        if move_down_at_eol && self.cursor_pos == eol {
+            let next_pos = (self.cursor_pos.saturating_add(1)).min(self.text.len());
+            self.set_cursor(self.end_of_line(next_pos));
+        } else {
+            self.set_cursor(eol);
+        }
+    }
+
+    // ===== Text elements support =====
+
+    pub fn element_payloads(&self) -> Vec<String> {
+        self.elements
+            .iter()
+            .filter_map(|e| self.text.get(e.range.clone()).map(str::to_string))
+            .collect()
+    }
+
+    pub fn text_elements(&self) -> Vec<UserTextElement> {
+        self.elements
+            .iter()
+            .map(|e| {
+                let placeholder = self.text.get(e.range.clone()).map(str::to_string);
+                UserTextElement::new(
+                    ByteRange {
+                        start: e.range.start,
+                        end: e.range.end,
+                    },
+                    placeholder,
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn text_element_snapshots(&self) -> Vec<TextElementSnapshot> {
+        self.elements
+            .iter()
+            .filter_map(|element| {
+                self.text
+                    .get(element.range.clone())
+                    .map(|text| TextElementSnapshot {
+                        id: element.id,
+                        range: element.range.clone(),
+                        text: text.to_string(),
+                    })
+            })
+            .collect()
+    }
+
+    pub(crate) fn element_id_for_exact_range(&self, range: Range<usize>) -> Option<u64> {
+        self.elements
+            .iter()
+            .find(|element| element.range == range)
+            .map(|element| element.id)
+    }
+
+    /// Renames a single text element in-place, keeping it atomic.
+    ///
+    /// Use this when the element payload is an identifier (e.g. a placeholder) that must be
+    /// updated without converting the element back into normal text.
+    pub fn replace_element_payload(&mut self, old: &str, new: &str) -> bool {
+        let Some(idx) = self
+            .elements
+            .iter()
+            .position(|e| self.text.get(e.range.clone()) == Some(old))
+        else {
+            return false;
+        };
+
+        let range = self.elements[idx].range.clone();
+        let start = range.start;
+        let end = range.end;
+        if start > end || end > self.text.len() {
+            return false;
+        }
+
+        let removed_len = end - start;
+        let inserted_len = new.len();
+        let diff = inserted_len as isize - removed_len as isize;
+
+        self.text.replace_range(range, new);
+        self.wrap_cache.replace(None);
+        self.preferred_col = None;
+
+        // Update the modified element's range.
+        self.elements[idx].range = start..(start + inserted_len);
+
+        // Shift element ranges that occur after the replaced element.
+        if diff != 0 {
+            for (j, e) in self.elements.iter_mut().enumerate() {
+                if j == idx {
+                    continue;
+                }
+                if e.range.end <= start {
+                    continue;
+                }
+                if e.range.start >= end {
+                    e.range.start = ((e.range.start as isize) + diff) as usize;
+                    e.range.end = ((e.range.end as isize) + diff) as usize;
+                    continue;
+                }
+
+                // Elements should not partially overlap each other; degrade gracefully by
+                // snapping anything intersecting the replaced range to the new bounds.
+                e.range.start = start.min(e.range.start);
+                e.range.end = (start + inserted_len).max(e.range.end.saturating_add_signed(diff));
+            }
+        }
+
+        // Update the cursor position to account for the edit.
+        self.cursor_pos = if self.cursor_pos < start {
+            self.cursor_pos
+        } else if self.cursor_pos <= end {
+            start + inserted_len
+        } else {
+            ((self.cursor_pos as isize) + diff) as usize
+        };
+        self.cursor_pos = self.clamp_pos_to_nearest_boundary(self.cursor_pos);
+
+        // Keep element ordering deterministic.
+        self.elements.sort_by_key(|e| e.range.start);
+
+        true
+    }
+
+    pub fn insert_element(&mut self, text: &str) -> u64 {
+        let start = self.clamp_pos_for_insertion(self.cursor_pos);
+        self.insert_str_at(start, text);
+        let end = start + text.len();
+        let id = self.add_element(start..end);
+        // Place cursor at end of inserted element
+        self.set_cursor(end);
+        id
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn insert_named_element(&mut self, text: &str, id: String) {
+        let start = self.clamp_pos_for_insertion(self.cursor_pos);
+        self.insert_str_at(start, text);
+        let end = start + text.len();
+        self.add_element_with_id(start..end, Some(id));
+        // Place cursor at end of inserted element
+        self.set_cursor(end);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn replace_element_by_id(&mut self, id: &str, text: &str) -> bool {
+        if let Some(idx) = self
+            .elements
+            .iter()
+            .position(|e| e.name.as_deref() == Some(id))
+        {
+            let range = self.elements[idx].range.clone();
+            self.replace_range_raw(range, text);
+            self.elements.retain(|e| e.name.as_deref() != Some(id));
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Update the element's text in place, preserving its id so callers can
+    /// update it again later (e.g. recording -> transcribing -> final).
+    #[allow(dead_code)]
+    pub fn update_named_element_by_id(&mut self, id: &str, text: &str) -> bool {
+        if let Some(elem_idx) = self
+            .elements
+            .iter()
+            .position(|e| e.name.as_deref() == Some(id))
+        {
+            let old_range = self.elements[elem_idx].range.clone();
+            let start = old_range.start;
+            self.replace_range_raw(old_range, text);
+            // After replace_range_raw, the old element entry was removed if fully overlapped.
+            // Re-add an updated element with the same id and new range.
+            let new_end = start + text.len();
+            self.add_element_with_id(start..new_end, Some(id.to_string()));
+            true
+        } else {
+            false
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn named_element_range(&self, id: &str) -> Option<std::ops::Range<usize>> {
+        self.elements
+            .iter()
+            .find(|e| e.name.as_deref() == Some(id))
+            .map(|e| e.range.clone())
+    }
+
+    fn add_element_with_id(&mut self, range: Range<usize>, name: Option<String>) -> u64 {
+        let id = self.next_element_id();
+        let elem = TextElement { id, range, name };
+        self.elements.push(elem);
+        self.elements.sort_by_key(|e| e.range.start);
+        id
+    }
+
+    fn add_element(&mut self, range: Range<usize>) -> u64 {
+        self.add_element_with_id(range, /*name*/ None)
+    }
+
+    /// Mark an existing text range as an atomic element without changing the text.
+    ///
+    /// This is used to convert already-typed tokens (like `/plan`) into elements
+    /// so they render and edit atomically. Overlapping or duplicate ranges are ignored.
+    pub fn add_element_range(&mut self, range: Range<usize>) -> Option<u64> {
+        let start = self.clamp_pos_to_char_boundary(range.start.min(self.text.len()));
+        let end = self.clamp_pos_to_char_boundary(range.end.min(self.text.len()));
+        if start >= end {
+            return None;
+        }
+        if self
+            .elements
+            .iter()
+            .any(|e| e.range.start == start && e.range.end == end)
+        {
+            return None;
+        }
+        if self
+            .elements
+            .iter()
+            .any(|e| start < e.range.end && end > e.range.start)
+        {
+            return None;
+        }
+        let id = self.add_element(start..end);
+        Some(id)
+    }
+
+    pub fn remove_element_range(&mut self, range: Range<usize>) -> bool {
+        let start = self.clamp_pos_to_char_boundary(range.start.min(self.text.len()));
+        let end = self.clamp_pos_to_char_boundary(range.end.min(self.text.len()));
+        if start >= end {
+            return false;
+        }
+        let len_before = self.elements.len();
+        self.elements
+            .retain(|elem| elem.range.start != start || elem.range.end != end);
+        len_before != self.elements.len()
+    }
+
+    fn next_element_id(&mut self) -> u64 {
+        let id = self.next_element_id;
+        self.next_element_id = self.next_element_id.saturating_add(1);
+        id
+    }
+    fn find_element_containing(&self, pos: usize) -> Option<usize> {
+        self.elements
+            .iter()
+            .position(|e| pos > e.range.start && pos < e.range.end)
+    }
+
+    fn clamp_pos_to_char_boundary(&self, pos: usize) -> usize {
+        let pos = pos.min(self.text.len());
+        if self.text.is_char_boundary(pos) {
+            return pos;
+        }
+        let mut prev = pos;
+        while prev > 0 && !self.text.is_char_boundary(prev) {
+            prev -= 1;
+        }
+        let mut next = pos;
+        while next < self.text.len() && !self.text.is_char_boundary(next) {
+            next += 1;
+        }
+        if pos.saturating_sub(prev) <= next.saturating_sub(pos) {
+            prev
+        } else {
+            next
+        }
+    }
+
+    fn clamp_pos_to_nearest_boundary(&self, pos: usize) -> usize {
+        let pos = self.clamp_pos_to_char_boundary(pos);
+        if let Some(idx) = self.find_element_containing(pos) {
+            let e = &self.elements[idx];
+            let dist_start = pos.saturating_sub(e.range.start);
+            let dist_end = e.range.end.saturating_sub(pos);
+            if dist_start <= dist_end {
+                self.clamp_pos_to_char_boundary(e.range.start)
+            } else {
+                self.clamp_pos_to_char_boundary(e.range.end)
+            }
+        } else {
+            pos
+        }
+    }
+
+    fn clamp_pos_for_insertion(&self, pos: usize) -> usize {
+        let pos = self.clamp_pos_to_char_boundary(pos);
+        // Do not allow inserting into the middle of an element
+        if let Some(idx) = self.find_element_containing(pos) {
+            let e = &self.elements[idx];
+            // Choose closest edge for insertion
+            let dist_start = pos.saturating_sub(e.range.start);
+            let dist_end = e.range.end.saturating_sub(pos);
+            if dist_start <= dist_end {
+                self.clamp_pos_to_char_boundary(e.range.start)
+            } else {
+                self.clamp_pos_to_char_boundary(e.range.end)
+            }
+        } else {
+            pos
+        }
+    }
+
+    fn expand_range_to_element_boundaries(&self, mut range: Range<usize>) -> Range<usize> {
+        // Expand to include any intersecting elements fully
+        loop {
+            let mut changed = false;
+            for e in &self.elements {
+                if e.range.start < range.end && e.range.end > range.start {
+                    let new_start = range.start.min(e.range.start);
+                    let new_end = range.end.max(e.range.end);
+                    if new_start != range.start || new_end != range.end {
+                        range.start = new_start;
+                        range.end = new_end;
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        range
+    }
+
+    fn shift_elements(&mut self, at: usize, removed: usize, inserted: usize) {
+        // Generic shift: for pure insert, removed = 0; for delete, inserted = 0.
+        let end = at + removed;
+        let diff = inserted as isize - removed as isize;
+        // Remove elements fully deleted by the operation and shift the rest
+        self.elements
+            .retain(|e| !(e.range.start >= at && e.range.end <= end));
+        for e in &mut self.elements {
+            if e.range.end <= at {
+                // before edit
+            } else if e.range.start >= end {
+                // after edit
+                e.range.start = ((e.range.start as isize) + diff) as usize;
+                e.range.end = ((e.range.end as isize) + diff) as usize;
+            } else {
+                // Overlap with element but not fully contained (shouldn't happen when using
+                // element-aware replace, but degrade gracefully by snapping element to new bounds)
+                let new_start = at.min(e.range.start);
+                let new_end = at + inserted.max(e.range.end.saturating_sub(end));
+                e.range.start = new_start;
+                e.range.end = new_end;
+            }
+        }
+    }
+
+    fn update_elements_after_replace(&mut self, start: usize, end: usize, inserted_len: usize) {
+        self.shift_elements(start, end.saturating_sub(start), inserted_len);
+    }
+
+    fn prev_atomic_boundary(&self, pos: usize) -> usize {
+        if pos == 0 {
+            return 0;
+        }
+        // If currently at an element end or inside, jump to start of that element.
+        if let Some(idx) = self
+            .elements
+            .iter()
+            .position(|e| pos > e.range.start && pos <= e.range.end)
+        {
+            return self.elements[idx].range.start;
+        }
+        let mut gc = unicode_segmentation::GraphemeCursor::new(pos, self.text.len(), false);
+        match gc.prev_boundary(&self.text, 0) {
+            Ok(Some(b)) => {
+                if let Some(idx) = self.find_element_containing(b) {
+                    self.elements[idx].range.start
+                } else {
+                    b
+                }
+            }
+            Ok(None) => 0,
+            Err(_) => pos.saturating_sub(1),
+        }
+    }
+
+    fn next_atomic_boundary(&self, pos: usize) -> usize {
+        if pos >= self.text.len() {
+            return self.text.len();
+        }
+        // If currently at an element start or inside, jump to end of that element.
+        if let Some(idx) = self
+            .elements
+            .iter()
+            .position(|e| pos >= e.range.start && pos < e.range.end)
+        {
+            return self.elements[idx].range.end;
+        }
+        let mut gc = unicode_segmentation::GraphemeCursor::new(pos, self.text.len(), false);
+        match gc.next_boundary(&self.text, 0) {
+            Ok(Some(b)) => {
+                if let Some(idx) = self.find_element_containing(b) {
+                    self.elements[idx].range.end
+                } else {
+                    b
+                }
+            }
+            Ok(None) => self.text.len(),
+            Err(_) => pos.saturating_add(1),
+        }
+    }
+
+    pub(crate) fn beginning_of_previous_word(&self) -> usize {
+        let prefix = &self.text[..self.cursor_pos];
+        let Some((first_non_ws_idx, ch)) = prefix
+            .char_indices()
+            .rev()
+            .find(|&(_, ch)| !ch.is_whitespace())
+        else {
+            return 0;
+        };
+        let run_start = prefix[..first_non_ws_idx]
+            .char_indices()
+            .rev()
+            .find(|&(_, ch)| ch.is_whitespace())
+            .map_or(0, |(idx, ch)| idx + ch.len_utf8());
+        let run_end = first_non_ws_idx + ch.len_utf8();
+        let pieces = split_word_pieces(&prefix[run_start..run_end]);
+        let mut pieces = pieces.into_iter().rev().peekable();
+        let Some((piece_start, piece)) = pieces.next() else {
+            return run_start;
+        };
+        let mut start = run_start + piece_start;
+
+        if piece.chars().all(is_word_separator) {
+            while let Some((idx, piece)) = pieces.peek() {
+                if !piece.chars().all(is_word_separator) {
+                    break;
+                }
+                start = run_start + *idx;
+                pieces.next();
+            }
+        }
+
+        self.adjust_pos_out_of_elements(start, /*prefer_start*/ true)
+    }
+
+    pub(crate) fn end_of_next_word(&self) -> usize {
+        let suffix = &self.text[self.cursor_pos..];
+        let Some(first_non_ws) = suffix.find(|ch: char| !ch.is_whitespace()) else {
+            return self.text.len();
+        };
+        let run = &suffix[first_non_ws..];
+        let run = &run[..run.find(char::is_whitespace).unwrap_or(run.len())];
+        let mut pieces = split_word_pieces(run).into_iter().peekable();
+        let Some((start, piece)) = pieces.next() else {
+            return self.cursor_pos + first_non_ws;
+        };
+        let word_start = self.cursor_pos + first_non_ws + start;
+        let mut end = word_start + piece.len();
+        if piece.chars().all(is_word_separator) {
+            while let Some((idx, piece)) = pieces.peek() {
+                if !piece.chars().all(is_word_separator) {
+                    break;
+                }
+                end = self.cursor_pos + first_non_ws + *idx + piece.len();
+                pieces.next();
+            }
+        }
+
+        self.adjust_pos_out_of_elements(end, /*prefer_start*/ false)
+    }
+
+    fn vim_word_end_cursor(&self) -> usize {
+        let end = self.end_of_next_word();
+        if end > self.cursor_pos {
+            self.prev_atomic_boundary(end)
+        } else {
+            end
+        }
+    }
+
+    fn vim_line_end_cursor(&self) -> usize {
+        let bol = self.beginning_of_current_line();
+        let eol = self.end_of_current_line();
+        if eol > bol {
+            self.prev_atomic_boundary(eol).max(bol)
+        } else {
+            eol
+        }
+    }
+
+    pub(crate) fn beginning_of_next_word(&self) -> usize {
+        let Some(first_non_ws) = self.text[self.cursor_pos..].find(|c: char| !c.is_whitespace())
+        else {
+            return self.text.len();
+        };
+        let word_start = self.cursor_pos + first_non_ws;
+        if word_start != self.cursor_pos {
+            return self.adjust_pos_out_of_elements(word_start, /*prefer_start*/ true);
+        }
+        let end = self.end_of_next_word();
+        if end >= self.text.len() {
+            return self.text.len();
+        }
+        let Some(next_non_ws) = self.text[end..].find(|c: char| !c.is_whitespace()) else {
+            return self.text.len();
+        };
+        self.adjust_pos_out_of_elements(end + next_non_ws, /*prefer_start*/ true)
+    }
+
+    fn adjust_pos_out_of_elements(&self, pos: usize, prefer_start: bool) -> usize {
+        if let Some(idx) = self.find_element_containing(pos) {
+            let e = &self.elements[idx];
+            if prefer_start {
+                e.range.start
+            } else {
+                e.range.end
+            }
+        } else {
+            pos
+        }
+    }
+
+    #[expect(clippy::unwrap_used)]
+    fn wrapped_lines(&self, width: u16) -> Ref<'_, Vec<Range<usize>>> {
+        // Ensure cache is ready (potentially mutably borrow, then drop)
+        {
+            let mut cache = self.wrap_cache.borrow_mut();
+            let needs_recalc = match cache.as_ref() {
+                Some(c) => c.width != width,
+                None => true,
+            };
+            if needs_recalc {
+                let lines = super::wrapping::wrap_ranges(
+                    &self.text,
+                    Options::new(width as usize).wrap_algorithm(textwrap::WrapAlgorithm::FirstFit),
+                );
+                *cache = Some(WrapCache { width, lines });
+            }
+        }
+
+        let cache = self.wrap_cache.borrow();
+        Ref::map(cache, |c| &c.as_ref().unwrap().lines)
+    }
+
+    /// Calculate the scroll offset that should be used to satisfy the
+    /// invariants given the current area size and wrapped lines.
+    ///
+    /// - Cursor is always on screen.
+    /// - No scrolling if content fits in the area.
+    fn effective_scroll(
+        &self,
+        area_height: u16,
+        lines: &[Range<usize>],
+        current_scroll: u16,
+    ) -> u16 {
+        let total_lines = lines.len() as u16;
+        if area_height >= total_lines {
+            return 0;
+        }
+
+        // Where is the cursor within wrapped lines? Prefer assigning boundary positions
+        // (where pos equals the start of a wrapped line) to that later line.
+        let cursor_line_idx =
+            Self::wrapped_line_index_by_start(lines, self.cursor_pos).unwrap_or(0) as u16;
+
+        let max_scroll = total_lines.saturating_sub(area_height);
+        let mut scroll = current_scroll.min(max_scroll);
+
+        // Ensure cursor is visible within [scroll, scroll + area_height)
+        if cursor_line_idx < scroll {
+            scroll = cursor_line_idx;
+        } else if cursor_line_idx >= scroll + area_height {
+            scroll = cursor_line_idx + 1 - area_height;
+        }
+        scroll
+    }
+}
+
+impl Widget for &TextArea {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let lines = self.wrapped_lines(area.width);
+        self.render_lines(area, buf, &lines, 0..lines.len(), Style::default(), &[]);
+    }
+}
+
+impl StatefulWidget for &TextArea {
+    type State = TextAreaState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let lines = self.wrapped_lines(area.width);
+        let scroll = self.effective_scroll(area.height, &lines, state.scroll);
+        state.scroll = scroll;
+
+        let start = scroll as usize;
+        let end = (scroll + area.height).min(lines.len() as u16) as usize;
+        self.render_lines(area, buf, &lines, start..end, Style::default(), &[]);
+    }
+}
+
+impl TextArea {
+    pub(crate) fn render_ref_masked(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut TextAreaState,
+        mask_char: char,
+        base_style: Style,
+    ) {
+        let lines = self.wrapped_lines(area.width);
+        let scroll = self.effective_scroll(area.height, &lines, state.scroll);
+        state.scroll = scroll;
+
+        let start = scroll as usize;
+        let end = (scroll + area.height).min(lines.len() as u16) as usize;
+        self.render_lines_masked(area, buf, &lines, start..end, mask_char, base_style);
+    }
+
+    /// Render the textarea with an explicit `base_style` applied to every cell,
+    /// used by the Zellij code path to override inherited terminal styles.
+    pub(crate) fn render_ref_styled(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut TextAreaState,
+        base_style: Style,
+    ) {
+        let lines = self.wrapped_lines(area.width);
+        let scroll = self.effective_scroll(area.height, &lines, state.scroll);
+        state.scroll = scroll;
+
+        let start = scroll as usize;
+        let end = (scroll + area.height).min(lines.len() as u16) as usize;
+        self.render_lines(area, buf, &lines, start..end, base_style, &[]);
+    }
+
+    /// Render the textarea with `base_style` plus additional render-only highlight ranges.
+    ///
+    /// Highlight ranges are byte ranges in `self.text`. They affect only the buffer rendering and
+    /// do not mutate the editable text, cursor, element metadata, or wrapping cache.
+    pub(crate) fn render_ref_styled_with_highlights(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        state: &mut TextAreaState,
+        base_style: Style,
+        highlights: &[(Range<usize>, Style)],
+    ) {
+        let lines = self.wrapped_lines(area.width);
+        let scroll = self.effective_scroll(area.height, &lines, state.scroll);
+        state.scroll = scroll;
+
+        let start = scroll as usize;
+        let end = (scroll + area.height).min(lines.len() as u16) as usize;
+        self.render_lines(area, buf, &lines, start..end, base_style, highlights);
+    }
+
+    fn render_lines(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        lines: &[Range<usize>],
+        range: std::ops::Range<usize>,
+        base_style: Style,
+        highlights: &[(Range<usize>, Style)],
+    ) {
+        for (row, idx) in range.enumerate() {
+            let r = &lines[idx];
+            let y = area.y + row as u16;
+            let line_range = r.start..r.end - 1;
+            buf.set_style(Rect::new(area.x, y, area.width, 1), base_style);
+            // Draw base line with the provided style.
+            buf.set_string(area.x, y, &self.text[line_range.clone()], base_style);
+
+            // Overlay styled segments for elements that intersect this line.
+            for elem in &self.elements {
+                // Compute overlap with displayed slice.
+                let overlap_start = elem.range.start.max(line_range.start);
+                let overlap_end = elem.range.end.min(line_range.end);
+                if overlap_start >= overlap_end {
+                    continue;
+                }
+                let styled = &self.text[overlap_start..overlap_end];
+                let x_off = self.text[line_range.start..overlap_start].width() as u16;
+                let style = base_style.fg(ratatui::style::Color::Cyan);
+                buf.set_string(area.x + x_off, y, styled, style);
+            }
+
+            // Overlay render-only highlight ranges last so transient search highlighting remains
+            // visible even when it intersects attachment placeholders or other styled elements.
+            for (highlight_range, style) in highlights {
+                let overlap_start = highlight_range.start.max(line_range.start);
+                let overlap_end = highlight_range.end.min(line_range.end);
+                if overlap_start >= overlap_end {
+                    continue;
+                }
+                let highlighted = &self.text[overlap_start..overlap_end];
+                let x_off = self.text[line_range.start..overlap_start].width() as u16;
+                buf.set_string(area.x + x_off, y, highlighted, *style);
+            }
+        }
+    }
+
+    fn render_lines_masked(
+        &self,
+        area: Rect,
+        buf: &mut Buffer,
+        lines: &[Range<usize>],
+        range: std::ops::Range<usize>,
+        mask_char: char,
+        base_style: Style,
+    ) {
+        for (row, idx) in range.enumerate() {
+            let r = &lines[idx];
+            let y = area.y + row as u16;
+            let line_range = r.start..r.end - 1;
+            buf.set_style(Rect::new(area.x, y, area.width, 1), base_style);
+            let masked = self.text[line_range.clone()]
+                .chars()
+                .map(|_| mask_char)
+                .collect::<String>();
+            buf.set_string(area.x, y, &masked, base_style);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // koda adaptation: `super::key_hint` from inside `mod tests` resolves
+    // to `composer::textarea::key_hint` (which doesn't exist). The codex
+    // original uses `crate::key_hint` since their layout is `tui::key_hint`.
+    // We use the explicit absolute path here for clarity.
+    use crate::composer::key_hint;
+    // crossterm types are intentionally not imported here to avoid unused warnings
+    use pretty_assertions::assert_eq;
+
+    // koda adaptation: codex's `fuzz_textarea_randomized` property test uses
+    // `rand` + `chrono` for thousands of randomized edits. We don't carry
+    // those dev-deps yet (#1178). Both this `use` and the helper + test
+    // below are gated under `#[cfg(any())]` (Rust idiom for always-false)
+    // so the verbatim codex code is preserved for trivial revival — just
+    // swap the cfg and add the dev-deps.
+    #[cfg(any())]
+    use rand::prelude::*;
+
+    #[cfg(any())]
+    fn rand_grapheme(rng: &mut rand::rngs::StdRng) -> String {
+        let r: u8 = rng.random_range(0..100);
+        match r {
+            0..=4 => "\n".to_string(),
+            5..=12 => " ".to_string(),
+            13..=35 => (rng.random_range(b'a'..=b'z') as char).to_string(),
+            36..=45 => (rng.random_range(b'A'..=b'Z') as char).to_string(),
+            46..=52 => (rng.random_range(b'0'..=b'9') as char).to_string(),
+            53..=65 => {
+                // Some emoji (wide graphemes)
+                let choices = ["👍", "😊", "🐍", "🚀", "🧪", "🌟"];
+                choices[rng.random_range(0..choices.len())].to_string()
+            }
+            66..=75 => {
+                // CJK wide characters
+                let choices = ["漢", "字", "測", "試", "你", "好", "界", "编", "码"];
+                choices[rng.random_range(0..choices.len())].to_string()
+            }
+            76..=85 => {
+                // Combining mark sequences
+                let base = ["e", "a", "o", "n", "u"][rng.random_range(0..5)];
+                let marks = ["\u{0301}", "\u{0308}", "\u{0302}", "\u{0303}"];
+                format!("{base}{}", marks[rng.random_range(0..marks.len())])
+            }
+            86..=92 => {
+                // Some non-latin single codepoints (Greek, Cyrillic, Hebrew)
+                let choices = ["Ω", "β", "Ж", "ю", "ש", "م", "ह"];
+                choices[rng.random_range(0..choices.len())].to_string()
+            }
+            _ => {
+                // ZWJ sequences (single graphemes but multi-codepoint)
+                let choices = [
+                    "👩\u{200D}💻", // woman technologist
+                    "👨\u{200D}💻", // man technologist
+                    "🏳️\u{200D}🌈", // rainbow flag
+                ];
+                choices[rng.random_range(0..choices.len())].to_string()
+            }
+        }
+    }
+
+    fn ta_with(text: &str) -> TextArea {
+        let mut t = TextArea::new();
+        t.insert_str(text);
+        t
+    }
+
+    #[test]
+    fn insert_and_replace_update_cursor_and_text() {
+        // insert helpers
+        let mut t = ta_with("hello");
+        t.set_cursor(/*pos*/ 5);
+        t.insert_str("!");
+        assert_eq!(t.text(), "hello!");
+        assert_eq!(t.cursor(), 6);
+
+        t.insert_str_at(/*pos*/ 0, "X");
+        assert_eq!(t.text(), "Xhello!");
+        assert_eq!(t.cursor(), 7);
+
+        // Insert after the cursor should not move it
+        t.set_cursor(/*pos*/ 1);
+        let end = t.text().len();
+        t.insert_str_at(end, "Y");
+        assert_eq!(t.text(), "Xhello!Y");
+        assert_eq!(t.cursor(), 1);
+
+        // replace_range cases
+        // 1) cursor before range
+        let mut t = ta_with("abcd");
+        t.set_cursor(/*pos*/ 1);
+        t.replace_range(2..3, "Z");
+        assert_eq!(t.text(), "abZd");
+        assert_eq!(t.cursor(), 1);
+
+        // 2) cursor inside range
+        let mut t = ta_with("abcd");
+        t.set_cursor(/*pos*/ 2);
+        t.replace_range(1..3, "Q");
+        assert_eq!(t.text(), "aQd");
+        assert_eq!(t.cursor(), 2);
+
+        // 3) cursor after range with shifted by diff
+        let mut t = ta_with("abcd");
+        t.set_cursor(/*pos*/ 4);
+        t.replace_range(0..1, "AA");
+        assert_eq!(t.text(), "AAbcd");
+        assert_eq!(t.cursor(), 5);
+    }
+
+    #[test]
+    fn insert_str_at_clamps_to_char_boundary() {
+        let mut t = TextArea::new();
+        t.insert_str("你");
+        t.set_cursor(/*pos*/ 0);
+        t.insert_str_at(/*pos*/ 1, "A");
+        assert_eq!(t.text(), "A你");
+        assert_eq!(t.cursor(), 1);
+    }
+
+    #[test]
+    fn set_text_clamps_cursor_to_char_boundary() {
+        let mut t = TextArea::new();
+        t.insert_str("abcd");
+        t.set_cursor(/*pos*/ 1);
+        t.set_text_clearing_elements("你");
+        assert_eq!(t.cursor(), 0);
+        t.insert_str("a");
+        assert_eq!(t.text(), "a你");
+    }
+
+    #[test]
+    fn delete_backward_and_forward_edges() {
+        let mut t = ta_with("abc");
+        t.set_cursor(/*pos*/ 1);
+        t.delete_backward(/*n*/ 1);
+        assert_eq!(t.text(), "bc");
+        assert_eq!(t.cursor(), 0);
+
+        // deleting backward at start is a no-op
+        t.set_cursor(/*pos*/ 0);
+        t.delete_backward(/*n*/ 1);
+        assert_eq!(t.text(), "bc");
+        assert_eq!(t.cursor(), 0);
+
+        // forward delete removes next grapheme
+        t.set_cursor(/*pos*/ 1);
+        t.delete_forward(/*n*/ 1);
+        assert_eq!(t.text(), "b");
+        assert_eq!(t.cursor(), 1);
+
+        // forward delete at end is a no-op
+        t.set_cursor(t.text().len());
+        t.delete_forward(/*n*/ 1);
+        assert_eq!(t.text(), "b");
+    }
+
+    #[test]
+    fn delete_forward_deletes_element_at_left_edge() {
+        let mut t = TextArea::new();
+        t.insert_str("a");
+        t.insert_element("<element>");
+        t.insert_str("b");
+
+        let elem_start = t.elements[0].range.start;
+        t.set_cursor(elem_start);
+        t.delete_forward(/*n*/ 1);
+
+        assert_eq!(t.text(), "ab");
+        assert_eq!(t.cursor(), elem_start);
+    }
+
+    #[test]
+    fn vim_insert_and_escape() {
+        let mut t = TextArea::new();
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "h");
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), 0);
+    }
+
+    #[test]
+    fn vim_insert_key_enters_insert_mode() {
+        let mut t = TextArea::new();
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Insert, KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "h");
+        assert_eq!(t.vim_mode_label(), Some("Insert"));
+    }
+
+    #[test]
+    fn vim_normal_arrow_keys_move_cursor() {
+        let mut t = ta_with("ab\ncd");
+        t.set_cursor(/*pos*/ 1);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 2);
+
+        t.input(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 5);
+
+        t.input(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 4);
+
+        t.input(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 1);
+    }
+
+    #[test]
+    fn vim_escape_from_insert_at_start_does_not_underflow() {
+        let mut t = TextArea::new();
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), 0);
+    }
+
+    #[test]
+    fn vim_escape_from_insert_at_line_start_stays_on_line() {
+        let mut t = ta_with("one\ntwo");
+        t.set_cursor(/*pos*/ "one\n".len());
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), "one\n".len());
+    }
+
+    #[test]
+    fn vim_escape_moves_by_grapheme_boundary() {
+        let mut t = ta_with("👍👍");
+        t.set_cursor(t.text().len());
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), "👍".len());
+    }
+
+    #[test]
+    fn vim_escape_respects_atomic_element_boundary() {
+        let mut t = TextArea::new();
+        t.insert_str("a");
+        t.insert_element("<element>");
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), 1);
+    }
+
+    #[test]
+    fn vim_shift_i_enters_insert_at_first_non_blank_with_shift_only_binding() {
+        let mut t = ta_with("hello\n  world");
+        t.vim_normal_keymap.insert_line_start = vec![key_hint::shift(KeyCode::Char('i'))];
+        t.set_cursor(/*pos*/ "hello\n  wor".len());
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Insert"));
+        assert_eq!(t.cursor(), "hello\n  ".len());
+    }
+
+    #[test]
+    fn vim_shift_a_enters_insert_at_line_end_with_shift_only_binding() {
+        let mut t = ta_with("hello\nworld");
+        t.vim_normal_keymap.append_line_end = vec![key_hint::shift(KeyCode::Char('a'))];
+        t.set_cursor(/*pos*/ 8);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('A'), KeyModifiers::NONE));
+
+        assert_eq!(t.vim_mode_label(), Some("Insert"));
+        assert_eq!(t.cursor(), 11);
+    }
+
+    #[test]
+    fn vim_shift_o_opens_line_above_with_shift_only_binding() {
+        let mut t = ta_with("hello\nworld");
+        t.vim_normal_keymap.open_line_above = vec![key_hint::shift(KeyCode::Char('o'))];
+        t.set_cursor(/*pos*/ 8);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('O'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "hello\n\nworld");
+        assert_eq!(t.vim_mode_label(), Some("Insert"));
+        assert_eq!(t.cursor(), 6);
+    }
+
+    #[test]
+    fn vim_o_opens_line_below_on_inserted_line() {
+        let mut t = ta_with("one\ntwo");
+        t.set_cursor(/*pos*/ 1);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "one\n\ntwo");
+        assert_eq!(t.vim_mode_label(), Some("Insert"));
+        assert_eq!(t.cursor(), "one\n".len());
+    }
+
+    #[test]
+    fn vim_delete_word() {
+        let mut t = ta_with("hello world");
+        t.set_cursor(/*pos*/ 0);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "world");
+        assert_eq!(t.kill_buffer, "hello ");
+    }
+
+    #[test]
+    fn vim_operator_invalid_motion_is_consumed() {
+        let mut t = ta_with("hello");
+        t.set_cursor(/*pos*/ 0);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE));
+        assert!(t.is_vim_operator_pending());
+
+        t.input(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "hello");
+        assert_eq!(t.vim_mode_label(), Some("Normal"));
+        assert_eq!(t.cursor(), 0);
+        assert!(!t.is_vim_operator_pending());
+    }
+
+    #[test]
+    fn vim_e_lands_on_word_end_character() {
+        let mut t = ta_with("abc");
+        t.set_cursor(/*pos*/ 0);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
+
+        assert_eq!(t.cursor(), 2);
+
+        t.input(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "ab");
+        assert_eq!(t.kill_buffer, "c");
+    }
+
+    #[test]
+    fn vim_dollar_lands_on_line_end_character() {
+        let mut t = ta_with("abc\n123");
+        t.set_cursor(/*pos*/ 1);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('$'), KeyModifiers::NONE));
+
+        assert_eq!(t.cursor(), 2);
+
+        t.input(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "ab\n123");
+        assert_eq!(t.kill_buffer, "c");
+    }
+
+    #[test]
+    fn vim_linewise_yank_pastes_below_current_line() {
+        let mut t = ta_with("abc\n123\nxyz");
+        t.set_cursor(/*pos*/ 1);
+        t.set_vim_enabled(/*enabled*/ true);
+
+        t.input(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+        t.input(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE));
+
+        assert_eq!(t.text(), "abc\nabc\n123\nxyz");
+        assert_eq!(t.cursor(), "abc\n".len());
+        assert_eq!(t.kill_buffer, "abc\n");
+        assert_eq!(t.kill_buffer_kind, KillBufferKind::Linewise);
+    }
+
+    #[test]
+    fn delete_backward_word_and_kill_line_variants() {
+        // delete backward word at end removes the whole previous word
+        let mut t = ta_with("hello   world  ");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "hello   ");
+        assert_eq!(t.cursor(), 8);
+
+        // From inside a word, delete from word start to cursor
+        let mut t = ta_with("foo bar");
+        t.set_cursor(/*pos*/ 6); // inside "bar" (after 'a')
+        t.delete_backward_word();
+        assert_eq!(t.text(), "foo r");
+        assert_eq!(t.cursor(), 4);
+
+        // From end, delete the last word only
+        let mut t = ta_with("foo bar");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "foo ");
+        assert_eq!(t.cursor(), 4);
+
+        // kill_to_end_of_line when not at EOL
+        let mut t = ta_with("abc\ndef");
+        t.set_cursor(/*pos*/ 1); // on first line, middle
+        t.kill_to_end_of_line();
+        assert_eq!(t.text(), "a\ndef");
+        assert_eq!(t.cursor(), 1);
+
+        // kill_to_end_of_line when at EOL deletes newline
+        let mut t = ta_with("abc\ndef");
+        t.set_cursor(/*pos*/ 3); // EOL of first line
+        t.kill_to_end_of_line();
+        assert_eq!(t.text(), "abcdef");
+        assert_eq!(t.cursor(), 3);
+
+        // kill_to_beginning_of_line from middle of line
+        let mut t = ta_with("abc\ndef");
+        t.set_cursor(/*pos*/ 5); // on second line, after 'e'
+        t.kill_to_beginning_of_line();
+        assert_eq!(t.text(), "abc\nef");
+
+        // kill_to_beginning_of_line at beginning of non-first line removes the previous newline
+        let mut t = ta_with("abc\ndef");
+        t.set_cursor(/*pos*/ 4); // beginning of second line
+        t.kill_to_beginning_of_line();
+        assert_eq!(t.text(), "abcdef");
+        assert_eq!(t.cursor(), 3);
+    }
+
+    #[test]
+    fn delete_forward_word_variants() {
+        let mut t = ta_with("hello   world ");
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "   world ");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with("hello   world ");
+        t.set_cursor(/*pos*/ 1);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "h   world ");
+        assert_eq!(t.cursor(), 1);
+
+        let mut t = ta_with("hello   world");
+        t.set_cursor(t.text().len());
+        t.delete_forward_word();
+        assert_eq!(t.text(), "hello   world");
+        assert_eq!(t.cursor(), t.text().len());
+
+        let mut t = ta_with("foo   \nbar");
+        t.set_cursor(/*pos*/ 3);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "foo");
+        assert_eq!(t.cursor(), 3);
+
+        let mut t = ta_with("foo\nbar");
+        t.set_cursor(/*pos*/ 3);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "foo");
+        assert_eq!(t.cursor(), 3);
+
+        let mut t = ta_with("hello   world ");
+        t.set_cursor(t.text().len() + 10);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "hello   world ");
+        assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn delete_forward_word_handles_atomic_elements() {
+        let mut t = TextArea::new();
+        t.insert_element("<element>");
+        t.insert_str(" tail");
+
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), " tail");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = TextArea::new();
+        t.insert_str("   ");
+        t.insert_element("<element>");
+        t.insert_str(" tail");
+
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), " tail");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = TextArea::new();
+        t.insert_str("prefix ");
+        t.insert_element("<element>");
+        t.insert_str(" tail");
+
+        // cursor in the middle of the element, delete_forward_word deletes the element
+        let elem_range = t.elements[0].range.clone();
+        t.cursor_pos = elem_range.start + (elem_range.len() / 2);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "prefix  tail");
+        assert_eq!(t.cursor(), elem_range.start);
+    }
+
+    #[test]
+    fn delete_backward_word_respects_word_separators() {
+        let mut t = ta_with("path/to/file");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "path/to/");
+        assert_eq!(t.cursor(), t.text().len());
+
+        t.delete_backward_word();
+        assert_eq!(t.text(), "path/to");
+        assert_eq!(t.cursor(), t.text().len());
+
+        let mut t = ta_with("foo/ ");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "foo");
+        assert_eq!(t.cursor(), 3);
+
+        let mut t = ta_with("foo /");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "foo ");
+        assert_eq!(t.cursor(), 4);
+    }
+
+    #[test]
+    fn delete_forward_word_respects_word_separators() {
+        let mut t = ta_with("path/to/file");
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "/to/file");
+        assert_eq!(t.cursor(), 0);
+
+        t.delete_forward_word();
+        assert_eq!(t.text(), "to/file");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with("/ foo");
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), " foo");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with(" /foo");
+        t.set_cursor(/*pos*/ 0);
+        t.delete_forward_word();
+        assert_eq!(t.text(), "foo");
+        assert_eq!(t.cursor(), 0);
+    }
+
+    #[test]
+    fn yank_restores_last_kill() {
+        let mut t = ta_with("hello");
+        t.set_cursor(/*pos*/ 0);
+        t.kill_to_end_of_line();
+        assert_eq!(t.text(), "");
+        assert_eq!(t.cursor(), 0);
+
+        t.yank();
+        assert_eq!(t.text(), "hello");
+        assert_eq!(t.cursor(), 5);
+
+        let mut t = ta_with("hello world");
+        t.set_cursor(t.text().len());
+        t.delete_backward_word();
+        assert_eq!(t.text(), "hello ");
+        assert_eq!(t.cursor(), 6);
+
+        t.yank();
+        assert_eq!(t.text(), "hello world");
+        assert_eq!(t.cursor(), 11);
+
+        let mut t = ta_with("hello");
+        t.set_cursor(/*pos*/ 5);
+        t.kill_to_beginning_of_line();
+        assert_eq!(t.text(), "");
+        assert_eq!(t.cursor(), 0);
+
+        t.yank();
+        assert_eq!(t.text(), "hello");
+        assert_eq!(t.cursor(), 5);
+    }
+
+    #[test]
+    fn kill_buffer_persists_across_set_text() {
+        let mut t = ta_with("restore me");
+        t.set_cursor(/*pos*/ 0);
+        t.kill_to_end_of_line();
+        assert!(t.text().is_empty());
+
+        t.set_text_clearing_elements("/diff");
+        t.set_text_clearing_elements("");
+        t.yank();
+
+        assert_eq!(t.text(), "restore me");
+        assert_eq!(t.cursor(), "restore me".len());
+    }
+
+    #[test]
+    fn cursor_left_and_right_handle_graphemes() {
+        let mut t = ta_with("a👍b");
+        t.set_cursor(t.text().len());
+
+        t.move_cursor_left(); // before 'b'
+        let after_first_left = t.cursor();
+        t.move_cursor_left(); // before '👍'
+        let after_second_left = t.cursor();
+        t.move_cursor_left(); // before 'a'
+        let after_third_left = t.cursor();
+
+        assert!(after_first_left < t.text().len());
+        assert!(after_second_left < after_first_left);
+        assert!(after_third_left < after_second_left);
+
+        // Move right back to end safely
+        t.move_cursor_right();
+        t.move_cursor_right();
+        t.move_cursor_right();
+        assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn control_b_and_f_move_cursor() {
+        let mut t = ta_with("abcd");
+        t.set_cursor(/*pos*/ 1);
+
+        t.input(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        assert_eq!(t.cursor(), 2);
+
+        t.input(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        assert_eq!(t.cursor(), 1);
+    }
+
+    #[test]
+    fn control_b_f_fallback_control_chars_move_cursor() {
+        let mut t = ta_with("abcd");
+        t.set_cursor(/*pos*/ 2);
+
+        // Simulate terminals that send C0 control chars without CONTROL modifier.
+        // ^B (U+0002) should move left
+        t.input(KeyEvent::new(KeyCode::Char('\u{0002}'), KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 1);
+
+        // ^F (U+0006) should move right
+        t.input(KeyEvent::new(KeyCode::Char('\u{0006}'), KeyModifiers::NONE));
+        assert_eq!(t.cursor(), 2);
+    }
+
+    #[test]
+    fn c0_control_chars_respect_unbound_editor_movement() {
+        let mut t = ta_with("a\nb");
+        t.set_cursor(/*pos*/ 2);
+        let mut keymap = RuntimeKeymap::defaults().editor;
+        keymap.move_up.clear();
+
+        t.input_with_keymap(
+            KeyEvent::new(KeyCode::Char('\u{0010}'), KeyModifiers::NONE),
+            &keymap,
+        );
+
+        assert_eq!(t.cursor(), 2);
+    }
+
+    #[test]
+    fn c0_control_chars_respect_remapped_editor_movement() {
+        let mut t = ta_with("a\nb");
+        t.set_cursor(/*pos*/ 0);
+        let mut keymap = RuntimeKeymap::defaults().editor;
+        keymap.move_up.clear();
+        keymap.move_down = vec![key_hint::ctrl(KeyCode::Char('p'))];
+
+        t.input_with_keymap(
+            KeyEvent::new(KeyCode::Char('\u{0010}'), KeyModifiers::NONE),
+            &keymap,
+        );
+
+        assert_eq!(t.cursor(), 2);
+    }
+
+    #[test]
+    fn delete_backward_word_alt_keys() {
+        // Test the custom Alt+Ctrl+h binding
+        let mut t = ta_with("hello world");
+        t.set_cursor(t.text().len()); // cursor at the end
+        t.input(KeyEvent::new(
+            KeyCode::Char('h'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert_eq!(t.text(), "hello ");
+        assert_eq!(t.cursor(), 6);
+
+        // Test the standard Alt+Backspace binding
+        let mut t = ta_with("hello world");
+        t.set_cursor(t.text().len()); // cursor at the end
+        t.input(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT));
+        assert_eq!(t.text(), "hello ");
+        assert_eq!(t.cursor(), 6);
+    }
+
+    #[test]
+    fn delete_backward_word_handles_narrow_no_break_space() {
+        let mut t = ta_with("32\u{202F}AM");
+        t.set_cursor(t.text().len());
+        t.input(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT));
+        pretty_assertions::assert_eq!(t.text(), "32\u{202F}");
+        pretty_assertions::assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn delete_forward_word_with_without_alt_modifier() {
+        let mut t = ta_with("hello world");
+        t.set_cursor(/*pos*/ 0);
+        t.input(KeyEvent::new(KeyCode::Delete, KeyModifiers::ALT));
+        assert_eq!(t.text(), " world");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with("hello");
+        t.set_cursor(/*pos*/ 0);
+        t.input(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE));
+        assert_eq!(t.text(), "ello");
+        assert_eq!(t.cursor(), 0);
+    }
+
+    #[test]
+    fn delete_forward_word_alt_d() {
+        let mut t = ta_with("hello world");
+        t.set_cursor(/*pos*/ 6);
+        t.input(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::ALT));
+        pretty_assertions::assert_eq!(t.text(), "hello ");
+        pretty_assertions::assert_eq!(t.cursor(), 6);
+    }
+
+    #[test]
+    fn control_h_backspace() {
+        // Test Ctrl+H as backspace
+        let mut t = ta_with("12345");
+        t.set_cursor(/*pos*/ 3); // cursor after '3'
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "1245");
+        assert_eq!(t.cursor(), 2);
+
+        // Test Ctrl+H at beginning (should be no-op)
+        t.set_cursor(/*pos*/ 0);
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "1245");
+        assert_eq!(t.cursor(), 0);
+
+        // Test Ctrl+H at end
+        t.set_cursor(t.text().len());
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "124");
+        assert_eq!(t.cursor(), 3);
+    }
+
+    #[cfg_attr(not(windows), ignore = "AltGr modifier only applies on Windows")]
+    #[test]
+    fn altgr_ctrl_alt_char_inserts_literal() {
+        let mut t = ta_with("");
+        t.input(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert_eq!(t.text(), "c");
+        assert_eq!(t.cursor(), 1);
+    }
+
+    #[test]
+    fn cursor_vertical_movement_across_lines_and_bounds() {
+        let mut t = ta_with("short\nloooooooooong\nmid");
+        // Place cursor on second line, column 5
+        let second_line_start = 6; // after first '\n'
+        t.set_cursor(second_line_start + 5);
+
+        // Move up: target column preserved, clamped by line length
+        t.move_cursor_up();
+        assert_eq!(t.cursor(), 5); // first line has len 5
+
+        // Move up again goes to start of text
+        t.move_cursor_up();
+        assert_eq!(t.cursor(), 0);
+
+        // Move down: from start to target col tracked
+        t.move_cursor_down();
+        // On first move down, we should land on second line, at col 0 (target col remembered as 0)
+        let pos_after_down = t.cursor();
+        assert!(pos_after_down >= second_line_start);
+
+        // Move down again to third line; clamp to its length
+        t.move_cursor_down();
+        let third_line_start = t.text().find("mid").unwrap();
+        let third_line_end = third_line_start + 3;
+        assert!(t.cursor() >= third_line_start && t.cursor() <= third_line_end);
+
+        // Moving down at last line jumps to end
+        t.move_cursor_down();
+        assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn home_end_and_emacs_style_home_end() {
+        let mut t = ta_with("one\ntwo\nthree");
+        // Position at middle of second line
+        let second_line_start = t.text().find("two").unwrap();
+        t.set_cursor(second_line_start + 1);
+
+        t.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ false);
+        assert_eq!(t.cursor(), second_line_start);
+
+        // Ctrl-A behavior: if at BOL, go to beginning of previous line
+        t.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ true);
+        assert_eq!(t.cursor(), 0); // beginning of first line
+
+        // Move to EOL of first line
+        t.move_cursor_to_end_of_line(/*move_down_at_eol*/ false);
+        assert_eq!(t.cursor(), 3);
+
+        // Ctrl-E: if at EOL, go to end of next line
+        t.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
+        // end of second line ("two") is right before its '\n'
+        let end_second_nl = t.text().find("\nthree").unwrap();
+        assert_eq!(t.cursor(), end_second_nl);
+    }
+
+    #[test]
+    fn end_of_line_or_down_at_end_of_text() {
+        let mut t = ta_with("one\ntwo");
+        // Place cursor at absolute end of the text
+        t.set_cursor(t.text().len());
+        // Should remain at end without panicking
+        t.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
+        assert_eq!(t.cursor(), t.text().len());
+
+        // Also verify behavior when at EOL of a non-final line:
+        let eol_first_line = 3; // index of '\n' in "one\ntwo"
+        t.set_cursor(eol_first_line);
+        t.move_cursor_to_end_of_line(/*move_down_at_eol*/ true);
+        assert_eq!(t.cursor(), t.text().len()); // moves to end of next (last) line
+    }
+
+    #[test]
+    fn word_navigation_helpers() {
+        let t = ta_with("  alpha  beta   gamma");
+        let mut t = t; // make mutable for set_cursor
+        // Put cursor after "alpha"
+        let after_alpha = t.text().find("alpha").unwrap() + "alpha".len();
+        t.set_cursor(after_alpha);
+        assert_eq!(t.beginning_of_previous_word(), 2); // skip initial spaces
+
+        // Put cursor at start of beta
+        let beta_start = t.text().find("beta").unwrap();
+        t.set_cursor(beta_start);
+        assert_eq!(t.end_of_next_word(), beta_start + "beta".len());
+
+        // If at end, end_of_next_word returns len
+        t.set_cursor(t.text().len());
+        assert_eq!(t.end_of_next_word(), t.text().len());
+    }
+
+    #[test]
+    fn word_navigation_cjk_each_char_is_boundary() {
+        let text = "你好世界";
+        let mut t = ta_with(text);
+
+        t.set_cursor(/*pos*/ text.len());
+        assert_eq!(t.beginning_of_previous_word(), 9);
+
+        t.set_cursor(/*pos*/ 9);
+        assert_eq!(t.beginning_of_previous_word(), 6);
+
+        t.set_cursor(/*pos*/ 6);
+        assert_eq!(t.beginning_of_previous_word(), 3);
+
+        t.set_cursor(/*pos*/ 3);
+        assert_eq!(t.beginning_of_previous_word(), 0);
+    }
+
+    #[test]
+    fn word_navigation_cjk_forward() {
+        let text = "你好世界";
+        let mut t = ta_with(text);
+
+        t.set_cursor(/*pos*/ 0);
+        assert_eq!(t.end_of_next_word(), 3);
+
+        t.set_cursor(/*pos*/ 3);
+        assert_eq!(t.end_of_next_word(), 6);
+
+        t.set_cursor(/*pos*/ 6);
+        assert_eq!(t.end_of_next_word(), 9);
+
+        t.set_cursor(/*pos*/ 9);
+        assert_eq!(t.end_of_next_word(), 12);
+    }
+
+    #[test]
+    fn word_navigation_mixed_ascii_cjk() {
+        let text = "hello你好";
+        let mut t = ta_with(text);
+
+        t.set_cursor(/*pos*/ 0);
+        assert_eq!(t.end_of_next_word(), 5);
+
+        t.set_cursor(/*pos*/ 5);
+        assert_eq!(t.end_of_next_word(), 8);
+
+        t.set_cursor(/*pos*/ text.len());
+        assert_eq!(t.beginning_of_previous_word(), 8);
+
+        t.set_cursor(/*pos*/ 8);
+        assert_eq!(t.beginning_of_previous_word(), 5);
+
+        t.set_cursor(/*pos*/ 5);
+        assert_eq!(t.beginning_of_previous_word(), 0);
+    }
+
+    #[test]
+    fn word_navigation_preserves_separator_breaks_within_unicode_segments() {
+        let mut t = ta_with("can't 32.3 foo.bar");
+
+        t.set_cursor(/*pos*/ 5);
+        assert_eq!(t.beginning_of_previous_word(), 4);
+
+        t.set_cursor(/*pos*/ 4);
+        assert_eq!(t.beginning_of_previous_word(), 3);
+
+        t.set_cursor(/*pos*/ 10);
+        assert_eq!(t.beginning_of_previous_word(), 9);
+
+        t.set_cursor(/*pos*/ 18);
+        assert_eq!(t.beginning_of_previous_word(), 15);
+    }
+
+    #[test]
+    fn wrapping_and_cursor_positions() {
+        let mut t = ta_with("hello world here");
+        let area = Rect::new(0, 0, 6, 10); // width 6 -> wraps words
+        // desired height counts wrapped lines
+        assert!(t.desired_height(area.width) >= 3);
+
+        // Place cursor in "world"
+        let world_start = t.text().find("world").unwrap();
+        t.set_cursor(world_start + 3);
+        let (_x, y) = t.cursor_pos(area).unwrap();
+        assert_eq!(y, 1); // world should be on second wrapped line
+
+        // With state and small height, cursor is mapped onto visible row
+        let mut state = TextAreaState::default();
+        let small_area = Rect::new(0, 0, 6, 1);
+        // First call: cursor not visible -> effective scroll ensures it is
+        let (_x, y) = t.cursor_pos_with_state(small_area, state).unwrap();
+        assert_eq!(y, 0);
+
+        // Render with state to update actual scroll value
+        let mut buf = Buffer::empty(small_area);
+        ratatui::widgets::StatefulWidget::render(&t, small_area, &mut buf, &mut state);
+        // After render, state.scroll should be adjusted so cursor row fits
+        let effective_lines = t.desired_height(small_area.width);
+        assert!(state.scroll < effective_lines);
+    }
+
+    #[test]
+    fn render_highlights_apply_style_without_mutating_text() {
+        let t = ta_with("hello world");
+        let area = Rect::new(0, 0, 20, 1);
+        let mut state = TextAreaState::default();
+        let mut buf = Buffer::empty(area);
+        let highlight_style = Style::default().add_modifier(ratatui::style::Modifier::REVERSED);
+
+        t.render_ref_styled_with_highlights(
+            area,
+            &mut buf,
+            &mut state,
+            Style::default(),
+            &[(6..11, highlight_style)],
+        );
+
+        assert_eq!(t.text(), "hello world");
+        assert!(
+            !buf[(0, 0)]
+                .style()
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED)
+        );
+        assert!(
+            buf[(6, 0)]
+                .style()
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED)
+        );
+        assert!(
+            buf[(10, 0)]
+                .style()
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED)
+        );
+    }
+
+    #[test]
+    fn cursor_pos_with_state_basic_and_scroll_behaviors() {
+        // Case 1: No wrapping needed, height fits — scroll ignored, y maps directly.
+        let mut t = ta_with("hello world");
+        t.set_cursor(/*pos*/ 3);
+        let area = Rect::new(2, 5, 20, 3);
+        // Even if an absurd scroll is provided, when content fits the area the
+        // effective scroll is 0 and the cursor position matches cursor_pos.
+        let bad_state = TextAreaState { scroll: 999 };
+        let (x1, y1) = t.cursor_pos(area).unwrap();
+        let (x2, y2) = t.cursor_pos_with_state(area, bad_state).unwrap();
+        assert_eq!((x2, y2), (x1, y1));
+
+        // Case 2: Cursor below the current window — y should be clamped to the
+        // bottom row (area.height - 1) after adjusting effective scroll.
+        let mut t = ta_with("one two three four five six");
+        // Force wrapping to many visual lines.
+        let wrap_width = 4;
+        let _ = t.desired_height(wrap_width);
+        // Put cursor somewhere near the end so it's definitely below the first window.
+        t.set_cursor(t.text().len().saturating_sub(2));
+        let small_area = Rect::new(0, 0, wrap_width, 2);
+        let state = TextAreaState { scroll: 0 };
+        let (_x, y) = t.cursor_pos_with_state(small_area, state).unwrap();
+        assert_eq!(y, small_area.y + small_area.height - 1);
+
+        // Case 3: Cursor above the current window — y should be top row (0)
+        // when the provided scroll is too large.
+        let mut t = ta_with("alpha beta gamma delta epsilon zeta");
+        let wrap_width = 5;
+        let lines = t.desired_height(wrap_width);
+        // Place cursor near start so an excessive scroll moves it to top row.
+        t.set_cursor(/*pos*/ 1);
+        let area = Rect::new(0, 0, wrap_width, 3);
+        let state = TextAreaState {
+            scroll: lines.saturating_mul(2),
+        };
+        let (_x, y) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!(y, area.y);
+    }
+
+    #[test]
+    fn wrapped_navigation_across_visual_lines() {
+        let mut t = ta_with("abcdefghij");
+        // Force wrapping at width 4: lines -> ["abcd", "efgh", "ij"]
+        let _ = t.desired_height(/*width*/ 4);
+
+        // From the very start, moving down should go to the start of the next wrapped line (index 4)
+        t.set_cursor(/*pos*/ 0);
+        t.move_cursor_down();
+        assert_eq!(t.cursor(), 4);
+
+        // Cursor at boundary index 4 should be displayed at start of second wrapped line
+        t.set_cursor(/*pos*/ 4);
+        let area = Rect::new(0, 0, 4, 10);
+        let (x, y) = t.cursor_pos(area).unwrap();
+        assert_eq!((x, y), (0, 1));
+
+        // With state and small height, cursor should be visible at row 0, col 0
+        let small_area = Rect::new(0, 0, 4, 1);
+        let state = TextAreaState::default();
+        let (x, y) = t.cursor_pos_with_state(small_area, state).unwrap();
+        assert_eq!((x, y), (0, 0));
+
+        // Place cursor in the middle of the second wrapped line ("efgh"), at 'g'
+        t.set_cursor(/*pos*/ 6);
+        // Move up should go to same column on previous wrapped line -> index 2 ('c')
+        t.move_cursor_up();
+        assert_eq!(t.cursor(), 2);
+
+        // Move down should return to same position on the next wrapped line -> back to index 6 ('g')
+        t.move_cursor_down();
+        assert_eq!(t.cursor(), 6);
+
+        // Move down again should go to third wrapped line. Target col is 2, but the line has len 2 -> clamp to end
+        t.move_cursor_down();
+        assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn cursor_pos_with_state_after_movements() {
+        let mut t = ta_with("abcdefghij");
+        // Wrap width 4 -> visual lines: abcd | efgh | ij
+        let _ = t.desired_height(/*width*/ 4);
+        let area = Rect::new(0, 0, 4, 2);
+        let mut state = TextAreaState::default();
+        let mut buf = Buffer::empty(area);
+
+        // Start at beginning
+        t.set_cursor(/*pos*/ 0);
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x, y) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x, y), (0, 0));
+
+        // Move down to second visual line; should be at bottom row (row 1) within 2-line viewport
+        t.move_cursor_down();
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x, y) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x, y), (0, 1));
+
+        // Move down to third visual line; viewport scrolls and keeps cursor on bottom row
+        t.move_cursor_down();
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x, y) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x, y), (0, 1));
+
+        // Move up to second visual line; with current scroll, it appears on top row
+        t.move_cursor_up();
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x, y) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x, y), (0, 0));
+
+        // Column preservation across moves: set to col 2 on first line, move down
+        t.set_cursor(/*pos*/ 2);
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x0, y0) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x0, y0), (2, 0));
+        t.move_cursor_down();
+        ratatui::widgets::StatefulWidget::render(&t, area, &mut buf, &mut state);
+        let (x1, y1) = t.cursor_pos_with_state(area, state).unwrap();
+        assert_eq!((x1, y1), (2, 1));
+    }
+
+    #[test]
+    fn wrapped_navigation_with_newlines_and_spaces() {
+        // Include spaces and an explicit newline to exercise boundaries
+        let mut t = ta_with("word1  word2\nword3");
+        // Width 6 will wrap "word1  " and then "word2" before the newline
+        let _ = t.desired_height(/*width*/ 6);
+
+        // Put cursor on the second wrapped line before the newline, at column 1 of "word2"
+        let start_word2 = t.text().find("word2").unwrap();
+        t.set_cursor(start_word2 + 1);
+
+        // Up should go to first wrapped line, column 1 -> index 1
+        t.move_cursor_up();
+        assert_eq!(t.cursor(), 1);
+
+        // Down should return to the same visual column on "word2"
+        t.move_cursor_down();
+        assert_eq!(t.cursor(), start_word2 + 1);
+
+        // Down again should cross the logical newline to the next visual line ("word3"), clamped to its length if needed
+        t.move_cursor_down();
+        let start_word3 = t.text().find("word3").unwrap();
+        assert!(t.cursor() >= start_word3 && t.cursor() <= start_word3 + "word3".len());
+    }
+
+    #[test]
+    fn wrapped_navigation_with_wide_graphemes() {
+        // Four thumbs up, each of display width 2, with width 3 to force wrapping inside grapheme boundaries
+        let mut t = ta_with("👍👍👍👍");
+        let _ = t.desired_height(/*width*/ 3);
+
+        // Put cursor after the second emoji (which should be on first wrapped line)
+        t.set_cursor("👍👍".len());
+
+        // Move down should go to the start of the next wrapped line (same column preserved but clamped)
+        t.move_cursor_down();
+        // We expect to land somewhere within the third emoji or at the start of it
+        let pos_after_down = t.cursor();
+        assert!(pos_after_down >= "👍👍".len());
+
+        // Moving up should take us back to the original position
+        t.move_cursor_up();
+        assert_eq!(t.cursor(), "👍👍".len());
+    }
+
+    // koda adaptation: see the cfg(any()) note above `use rand::prelude::*;`
+    // — this property test is gated out pending a follow-up to add rand+chrono
+    // dev-deps. Verbatim codex test preserved below for revival.
+    #[cfg(any())]
+    #[test]
+    fn fuzz_textarea_randomized() {
+        // Deterministic seed for reproducibility
+        // Seed the RNG based on the current day in Pacific Time (PST/PDT). This
+        // keeps the fuzz test deterministic within a day while still varying
+        // day-to-day to improve coverage.
+        let pst_today_seed: u64 = (chrono::Utc::now() - chrono::Duration::hours(8))
+            .date_naive()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp() as u64;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(pst_today_seed);
+
+        for _case in 0..500 {
+            let mut ta = TextArea::new();
+            let mut state = TextAreaState::default();
+            // Track element payloads we insert. Payloads use characters '[' and ']' which
+            // are not produced by rand_grapheme(), avoiding accidental collisions.
+            let mut elem_texts: Vec<String> = Vec::new();
+            let mut next_elem_id: usize = 0;
+            // Start with a random base string
+            let base_len = rng.random_range(0..30);
+            let mut base = String::new();
+            for _ in 0..base_len {
+                base.push_str(&rand_grapheme(&mut rng));
+            }
+            ta.set_text_clearing_elements(&base);
+            // Choose a valid char boundary for initial cursor
+            let mut boundaries: Vec<usize> = vec![0];
+            boundaries.extend(ta.text().char_indices().map(|(i, _)| i).skip(1));
+            boundaries.push(ta.text().len());
+            let init = boundaries[rng.random_range(0..boundaries.len())];
+            ta.set_cursor(init);
+
+            let mut width: u16 = rng.random_range(1..=12);
+            let mut height: u16 = rng.random_range(1..=4);
+
+            for _step in 0..60 {
+                // Mostly stable width/height, occasionally change
+                if rng.random_bool(0.1) {
+                    width = rng.random_range(1..=12);
+                }
+                if rng.random_bool(0.1) {
+                    height = rng.random_range(1..=4);
+                }
+
+                // Pick an operation
+                match rng.random_range(0..18) {
+                    0 => {
+                        // insert small random string at cursor
+                        let len = rng.random_range(0..6);
+                        let mut s = String::new();
+                        for _ in 0..len {
+                            s.push_str(&rand_grapheme(&mut rng));
+                        }
+                        ta.insert_str(&s);
+                    }
+                    1 => {
+                        // replace_range with small random slice
+                        let mut b: Vec<usize> = vec![0];
+                        b.extend(ta.text().char_indices().map(|(i, _)| i).skip(1));
+                        b.push(ta.text().len());
+                        let i1 = rng.random_range(0..b.len());
+                        let i2 = rng.random_range(0..b.len());
+                        let (start, end) = if b[i1] <= b[i2] {
+                            (b[i1], b[i2])
+                        } else {
+                            (b[i2], b[i1])
+                        };
+                        let insert_len = rng.random_range(0..=4);
+                        let mut s = String::new();
+                        for _ in 0..insert_len {
+                            s.push_str(&rand_grapheme(&mut rng));
+                        }
+                        let before = ta.text().len();
+                        // If the chosen range intersects an element, replace_range will expand to
+                        // element boundaries, so the naive size delta assertion does not hold.
+                        let intersects_element = elem_texts.iter().any(|payload| {
+                            if let Some(pstart) = ta.text().find(payload) {
+                                let pend = pstart + payload.len();
+                                pstart < end && pend > start
+                            } else {
+                                false
+                            }
+                        });
+                        ta.replace_range(start..end, &s);
+                        if !intersects_element {
+                            let after = ta.text().len();
+                            assert_eq!(
+                                after as isize,
+                                before as isize + (s.len() as isize) - ((end - start) as isize)
+                            );
+                        }
+                    }
+                    2 => ta.delete_backward(rng.random_range(0..=3)),
+                    3 => ta.delete_forward(rng.random_range(0..=3)),
+                    4 => ta.delete_backward_word(),
+                    5 => ta.kill_to_beginning_of_line(),
+                    6 => ta.kill_to_end_of_line(),
+                    7 => ta.move_cursor_left(),
+                    8 => ta.move_cursor_right(),
+                    9 => ta.move_cursor_up(),
+                    10 => ta.move_cursor_down(),
+                    11 => ta.move_cursor_to_beginning_of_line(/*move_up_at_bol*/ true),
+                    12 => ta.move_cursor_to_end_of_line(/*move_down_at_eol*/ true),
+                    13 => {
+                        // Insert an element with a unique sentinel payload
+                        let payload =
+                            format!("[[EL#{}:{}]]", next_elem_id, rng.random_range(1000..9999));
+                        next_elem_id += 1;
+                        ta.insert_element(&payload);
+                        elem_texts.push(payload);
+                    }
+                    14 => {
+                        // Try inserting inside an existing element (should clamp to boundary)
+                        if let Some(payload) = elem_texts.choose(&mut rng).cloned()
+                            && let Some(start) = ta.text().find(&payload)
+                        {
+                            let end = start + payload.len();
+                            if end - start > 2 {
+                                let pos = rng.random_range(start + 1..end - 1);
+                                let ins = rand_grapheme(&mut rng);
+                                ta.insert_str_at(pos, &ins);
+                            }
+                        }
+                    }
+                    15 => {
+                        // Replace a range that intersects an element -> whole element should be replaced
+                        if let Some(payload) = elem_texts.choose(&mut rng).cloned()
+                            && let Some(start) = ta.text().find(&payload)
+                        {
+                            let end = start + payload.len();
+                            // Create an intersecting range [start-δ, end-δ2)
+                            let mut s = start.saturating_sub(rng.random_range(0..=2));
+                            let mut e = (end + rng.random_range(0..=2)).min(ta.text().len());
+                            // Align to char boundaries to satisfy String::replace_range contract
+                            let txt = ta.text();
+                            while s > 0 && !txt.is_char_boundary(s) {
+                                s -= 1;
+                            }
+                            while e < txt.len() && !txt.is_char_boundary(e) {
+                                e += 1;
+                            }
+                            if s < e {
+                                // Small replacement text
+                                let mut srep = String::new();
+                                for _ in 0..rng.random_range(0..=2) {
+                                    srep.push_str(&rand_grapheme(&mut rng));
+                                }
+                                ta.replace_range(s..e, &srep);
+                            }
+                        }
+                    }
+                    16 => {
+                        // Try setting the cursor to a position inside an element; it should clamp out
+                        if let Some(payload) = elem_texts.choose(&mut rng).cloned()
+                            && let Some(start) = ta.text().find(&payload)
+                        {
+                            let end = start + payload.len();
+                            if end - start > 2 {
+                                let pos = rng.random_range(start + 1..end - 1);
+                                ta.set_cursor(pos);
+                            }
+                        }
+                    }
+                    _ => {
+                        // Jump to word boundaries
+                        if rng.random_bool(0.5) {
+                            let p = ta.beginning_of_previous_word();
+                            ta.set_cursor(p);
+                        } else {
+                            let p = ta.end_of_next_word();
+                            ta.set_cursor(p);
+                        }
+                    }
+                }
+
+                // Sanity invariants
+                assert!(ta.cursor() <= ta.text().len());
+
+                // Element invariants
+                for payload in &elem_texts {
+                    if let Some(start) = ta.text().find(payload) {
+                        let end = start + payload.len();
+                        // 1) Text inside elements matches the initially set payload
+                        assert_eq!(&ta.text()[start..end], payload);
+                        // 2) Cursor is never strictly inside an element
+                        let c = ta.cursor();
+                        assert!(
+                            c <= start || c >= end,
+                            "cursor inside element: {start}..{end} at {c}"
+                        );
+                    }
+                }
+
+                // Render and compute cursor positions; ensure they are in-bounds and do not panic
+                let area = Rect::new(0, 0, width, height);
+                // Stateless render into an area tall enough for all wrapped lines
+                let total_lines = ta.desired_height(width);
+                let full_area = Rect::new(0, 0, width, total_lines.max(1));
+                let mut buf = Buffer::empty(full_area);
+                ratatui::widgets::Widget::render(&ta, full_area, &mut buf);
+
+                // cursor_pos: x must be within width when present
+                let _ = ta.cursor_pos(area);
+
+                // cursor_pos_with_state: always within viewport rows
+                let (_x, _y) = ta
+                    .cursor_pos_with_state(area, state)
+                    .unwrap_or((area.x, area.y));
+
+                // Stateful render should not panic, and updates scroll
+                let mut sbuf = Buffer::empty(area);
+                ratatui::widgets::StatefulWidget::render(
+                    &ta,
+                    area,
+                    &mut sbuf,
+                    &mut state,
+                );
+
+                // After wrapping, desired height equals the number of lines we would render without scroll
+                let total_lines = total_lines as usize;
+                // state.scroll must not exceed total_lines when content fits within area height
+                if (height as usize) >= total_lines {
+                    assert_eq!(state.scroll, 0);
+                }
+            }
+        }
+    }
+}

--- a/koda-cli/src/composer/wrapping.rs
+++ b/koda-cli/src/composer/wrapping.rs
@@ -1,0 +1,145 @@
+//! Reduced port of codex's `codex-rs/tui/src/wrapping.rs`.
+//!
+//! ## Provenance
+//!
+//! Selected helpers ported from `codex-rs/tui/src/wrapping.rs` at upstream
+//! commit `d55479488e125ef7a0a8584505d839a22eaf6204` (codex `main` as of
+//! 2026-05-01).
+//!
+//! Verified byte-identical between this SHA and our previous reference
+//! `7e8594fc198615068018b198ab86a9ae0a541dff` (`git diff` returns 0
+//! lines), so the re-stamp is a pure attribution change.
+//!
+//! Original work: Copyright (c) OpenAI / codex contributors,
+//! licensed under the Apache License, Version 2.0.
+//! See `LICENSES/codex-APACHE-2.0` for the full license text.
+//!
+//! ## What was kept vs dropped
+//!
+//! - **Kept:** [`wrap_ranges`] and its helper [`map_owned_wrapped_line_to_range`].
+//!   These are the only wrapping primitives [`super::textarea::TextArea`]
+//!   needs to drive its cursor-position math.
+//! - **Dropped:** all the URL-aware adaptive wrapping (~1,300 LoC of
+//!   codex's `wrapping.rs`). koda's history-render path uses different
+//!   wrapping logic (`koda-cli/src/history_render.rs`) and the URL
+//!   helpers there are not needed inside the composer's textarea
+//!   (which renders user-typed input, not agent output). If we later
+//!   want URL-aware wrapping in the composer, we can port more.
+//! - **Dropped:** `wrap_ranges_trim` (used by codex but not by the
+//!   textarea sub-module; would be dead code here).
+
+use std::ops::Range;
+use textwrap::Options;
+
+/// Returns byte-ranges into `text` for each wrapped line, including
+/// trailing whitespace and a +1 sentinel byte. Used by the textarea
+/// cursor-position logic.
+///
+/// The sentinel byte is critical: without it, a cursor at the END of a
+/// wrapped line wouldn't have a valid byte position to point at, and
+/// the textarea couldn't distinguish "cursor at end of line N" from
+/// "cursor at start of line N+1" in the soft-wrapped representation.
+pub(crate) fn wrap_ranges<'a, O>(text: &str, width_or_options: O) -> Vec<Range<usize>>
+where
+    O: Into<Options<'a>>,
+{
+    let opts = width_or_options.into();
+    let mut lines: Vec<Range<usize>> = Vec::new();
+    let mut cursor = 0usize;
+    for (line_index, line) in textwrap::wrap(text, &opts).iter().enumerate() {
+        match line {
+            std::borrow::Cow::Borrowed(slice) => {
+                // SAFETY: `slice` is a sub-slice of `text` (Cow::Borrowed
+                // implies same allocation), so the offset_from is well-defined.
+                let start = unsafe { slice.as_ptr().offset_from(text.as_ptr()) as usize };
+                let end = start + slice.len();
+                let trailing_spaces = text[end..].chars().take_while(|c| *c == ' ').count();
+                lines.push(start..end + trailing_spaces + 1);
+                cursor = end + trailing_spaces;
+            }
+            std::borrow::Cow::Owned(slice) => {
+                let synthetic_prefix = if line_index == 0 {
+                    opts.initial_indent
+                } else {
+                    opts.subsequent_indent
+                };
+                let mapped = map_owned_wrapped_line_to_range(text, cursor, slice, synthetic_prefix);
+                let trailing_spaces = text[mapped.end..].chars().take_while(|c| *c == ' ').count();
+                lines.push(mapped.start..mapped.end + trailing_spaces + 1);
+                cursor = mapped.end + trailing_spaces;
+            }
+        }
+    }
+    lines
+}
+
+/// Maps an owned (materialized) wrapped line back to a byte range in `text`.
+///
+/// `textwrap` returns `Cow::Owned` when it inserts a hyphenation penalty
+/// character (typically `-`) that does not exist in the source. This
+/// function walks the owned string character-by-character against the
+/// source, skipping trailing penalty chars, and returns the
+/// corresponding source byte range starting from `cursor`.
+fn map_owned_wrapped_line_to_range(
+    text: &str,
+    cursor: usize,
+    wrapped: &str,
+    synthetic_prefix: &str,
+) -> Range<usize> {
+    let wrapped = if synthetic_prefix.is_empty() {
+        wrapped
+    } else {
+        wrapped.strip_prefix(synthetic_prefix).unwrap_or(wrapped)
+    };
+
+    let mut start = cursor;
+    while start < text.len() && !wrapped.starts_with(' ') {
+        let Some(ch) = text[start..].chars().next() else {
+            break;
+        };
+        if ch != ' ' {
+            break;
+        }
+        start += ch.len_utf8();
+    }
+
+    let mut end = start;
+    let mut saw_source_char = false;
+    let mut chars = wrapped.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if end < text.len() {
+            let Some(src) = text[end..].chars().next() else {
+                unreachable!("checked end < text.len()");
+            };
+            if ch == src {
+                end += src.len_utf8();
+                saw_source_char = true;
+                continue;
+            }
+        }
+
+        // textwrap can materialize owned lines when penalties are inserted.
+        // The default penalty is a trailing '-'; it does not correspond to
+        // source bytes, so we skip it while keeping byte ranges in source text.
+        if ch == '-' && chars.peek().is_none() {
+            continue;
+        }
+
+        // Non-source chars can be synthesized by textwrap in owned output
+        // (e.g. non-space indent prefixes). Keep going and map the source bytes
+        // we can confidently match instead of crashing the app.
+        if !saw_source_char {
+            continue;
+        }
+
+        tracing::warn!(
+            wrapped = %wrapped,
+            cursor,
+            end,
+            "wrap_ranges: could not fully map owned line; returning partial source range"
+        );
+        break;
+    }
+
+    start..end
+}

--- a/koda-cli/src/composer/wrapping.rs
+++ b/koda-cli/src/composer/wrapping.rs
@@ -1,3 +1,8 @@
+// Foundation work for #1116/#1175 — see the equivalent header note in
+// composer/key_hint.rs for the full rationale. The blanket allow goes away
+// when PR 2 wires up the consumers.
+#![allow(dead_code)]
+
 //! Reduced port of codex's `codex-rs/tui/src/wrapping.rs`.
 //!
 //! ## Provenance

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -22,6 +22,7 @@ pub(crate) mod app;
 pub(crate) mod builtin_skills;
 pub(crate) mod clipboard;
 pub(crate) mod completer;
+pub(crate) mod composer;
 pub(crate) mod debug_bundle;
 pub(crate) mod diff_render;
 pub(crate) mod frame_requester;


### PR DESCRIPTION
# #1178 — Port codex `bottom_pane::textarea` (foundation, PR 1 of 2)

Foundation work for replacing our `ratatui-textarea` (third-party MIT crate) with a port of codex's `bottom_pane::textarea` module. **No user-visible change in this PR** — the new `composer/` module tree is wired into the build but no koda call site consumes it yet. PR 2 (per the staged epic in #1116/#1175) does the `chat_composer.rs` swap.

Refs #1116, #1175, #1178.

---

## Why a separate "foundation" PR

The whole textarea family (textarea + paste-burst + key-hint + keymap + wrapping + text-element) is ~5,000 LoC of upstream code. Landing it in one PR alongside the `chat_composer.rs` consumer swap would be a 7,000+ LoC diff that's effectively un-reviewable. Splitting at the "module exists but isn't consumed" boundary gives reviewers two surfaces:

1. **This PR**: does the port look right? Are the adaptations minimal and well-documented? Does the test suite carry over?
2. **PR 2 (next)**: does the consumer swap behave identically to the old `ratatui-textarea` flow?

Each surface is independently reviewable.

## The architectural pivot mid-PR: "vendor primitive, own policy"

Halfway through this PR we hit a design fork that's worth flagging up front because **commit history shows the journey**:

- **Original plan** (Stages 1-3): minimum-primitives port at codex SHA `7e8594fc`. Reduced ports of every dependency, hand-curated subset of every helper.
- **Discovered problem**: codex's HEAD textarea (SHA `d55479`) had moved +758 LoC since `7e8594fc`, including a configurable-keymap refactor and full vim modal editing. The reduced-port approach would have to expand for every new symbol upstream introduces.
- **Pivot** (Stages 5a-5e): re-anchor at HEAD, distinguish **vendored primitives** (verbatim, anchored at SHA, future syncs are 3-way merges) from **koda-owned policy** (mirror codex's struct shapes for sync ergonomics, but scope smaller because we don't need user-config integration yet).

The 7-stage commit map below is laid out so each commit is a clean checkpoint of that journey.

---

## Module structure landed

```
koda-cli/src/composer/
├── mod.rs          (declares the 6 sub-modules)
├── key_hint.rs     ← VENDORED   verbatim   285 LoC   9 tests
├── paste_burst.rs  ← VENDORED   verbatim   ~430 LoC  5 tests
├── text_element.rs ← VENDORED   reduced    ~155 LoC  4 tests
├── wrapping.rs     ← VENDORED   reduced    145 LoC
├── keymap.rs       ← OWNED      koda-policy ~510 LoC 4 tests
└── textarea.rs     ← VENDORED   verbatim+adaptations 3,503 LoC 53 tests
```

**Distinction matters:**

- 5 of 6 files are **vendored** at codex SHA `d55479488e125ef7a0a8584505d839a22eaf6204`. They're policy-free primitive code (data structures, algorithms, key matching). Future codex syncs are 3-way merges anchored at this SHA. Each file's header documents the SHA + the adaptation list so the merge is mechanical.
- 1 of 6 files (`keymap.rs`) is **koda-owned**. The struct shapes mirror codex (so the vendored textarea compiles unchanged) but the file scope is ~5x smaller than codex's because we omit user-config integration (TOML loading, conflict validation, serde derives). Those become their own RFC when koda gains a config schema.

## Adaptations to the vendored textarea (full list in the file header)

### Module-path swaps (we vendor into `composer/`, codex uses `tui/`)

```
crate::key_hint           → super::key_hint        (verbatim vendor)
crate::keymap             → super::keymap          (koda-OWNED)
codex_protocol::user_input → super::text_element   (reduced vendor)
crate::wrapping           → super::wrapping        (reduced vendor)
```

### ratatui 0.30 API drift (codex on 0.29)

- `WidgetRef` (removed in 0.30) → `Widget` for `&TextArea`
- `StatefulWidgetRef` (removed) → `StatefulWidget` for `&TextArea`
- `fn render_ref(&self, ...)` → `fn render(self, ...)` (semantics identical: `self` is `&TextArea` since impl is on the reference type)
- All test-code call sites updated symmetrically

### Test path fix

Inside `#[cfg(test)] mod tests`, `super::key_hint` resolves to `composer::textarea::key_hint` (which doesn't exist). Changed to `crate::composer::key_hint`. Codex's original works because their layout is `tui::key_hint` so `super` resolves correctly there.

### Test gating

`fuzz_textarea_randomized` + `rand_grapheme` + `use rand::prelude::*;` gated under `#[cfg(any())]` (always-false). Codex uses `rand` + `chrono` for thousands of randomized property-test edits; not worth two dev-deps for one test. Verbatim code preserved for trivial revival (one-line cfg swap once we add the dev-deps).

### Per-module `#![allow(dead_code)]`

Vendored modules are intentionally full of unconsumed public symbols at this stage — that's the foundation property. Each of the 6 sub-modules opens with:

```rust
// Foundation work for #1116/#1175. The vendored symbols below are wired into
// the build but no koda call site consumes them yet — PR 2 of the staged
// epic swaps chat_composer.rs from ratatui-textarea to composer::textarea
// and brings the rest into use. The blanket allow goes away when consumers
// land.
#![allow(dead_code)]
```

Scoped per-file so removing the allow in PR 2 is one diff per module and the lint naturally re-engages.

---

## Stage map (7 commits, each a clean checkpoint)

| Stage | Commit | What landed |
|---|---|---|
| 1+2 | `1372963` | port `text_element` + reduced `key_hint` primitives |
| 3 | `9bdbcdb` | port `paste_burst.rs` verbatim |
| 5a | `1d8473c` | `wrapping.rs` + re-stamp 3 ports to SHA `d55479` |
| 5b | `e324c81` | full vendor of `key_hint.rs` (75 → 285 LoC) |
| 5c | `94529a6` | koda-OWNED `keymap.rs` policy layer |
| 5d | `9c4b895` | port `textarea.rs` at HEAD (the capstone) |
| 5e | `ae465c7` | CHANGELOG + clippy hygiene + workspace gates |

**Note on stage numbering**: Stage 4 (textarea port at the older SHA `7e8594fc`) was tested during exploration but never landed as its own commit. That work was superseded in-flight by the HEAD pivot to SHA `d55479` after the design discussion described above. The numbering preserves the journey honestly.

## Quality gates

| Gate | Result |
|---|---|
| `cargo fmt --all` | ✅ clean |
| `cargo clippy -p koda-cli --lib --tests -- -D warnings` | ✅ clean |
| `cargo build --workspace` | ✅ clean |
| `cargo test -p koda-cli --lib composer` | ✅ **75/75 passing** (1 ignored = fuzz) |
| `cargo test -p koda-cli --lib` | ✅ **572/572 passing** |
| `cargo test --workspace --lib` | ✅ **2,031/2,031 passing** |
| **Regressions** | **ZERO** |

## Test gain vs the stale midpoint at SHA `7e8594fc`

- Was: 35 textarea tests, 50 composer-suite total
- Now: 53 textarea tests, **75 composer-suite total** (+25 tests)
- Big new coverage: vim modal editing (normal mode + operator-pending), configurable-keymap refactor

## What's NOT in this PR (deferred to PR 2)

- Swap `chat_composer.rs` from `ratatui-textarea` to `composer::textarea`
- Bring up the popup widgets that orbit the new textarea (autocomplete, slash-menu, approval modal — the things that consume `ListKeymap` / `ApprovalKeymap`)
- Drop the `ratatui-textarea` dependency once unused
- Remove the per-module `dead_code` allows added here

Doing those swaps in this PR would balloon the diff well past the "each commit is a clean, reviewable checkpoint" line we've been holding.

## Provenance

- **Anchor SHA**: `d55479488e125ef7a0a8584505d839a22eaf6204` (codex `main` as of 2026-05-01)
- **License**: codex is Apache-2.0; vendored at `LICENSES/codex-APACHE-2.0` at workspace root
- **Future syncs**: 3-way merge against this SHA with the per-file adaptation lists as the patch set
