### PR TITLE
ci: harden bubblewrap install against Azure Ubuntu mirror flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,25 @@ jobs:
       - name: Set up Linux sandbox (bubblewrap)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y bubblewrap
+          # Hardened install: Azure Ubuntu mirrors (azure.archive.ubuntu.com)
+          # periodically fail DNS resolution from GH Actions runners, blocking
+          # CI on a transient infra issue unrelated to the change under test.
+          # Retry with exponential backoff up to 5 times (max ~2.5 min) before
+          # giving up. See https://github.com/lijunzh/koda/pull/1179 for the
+          # failure mode that motivated this.
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get install -y bubblewrap; then
+              echo "bubblewrap installed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::apt-get install bubblewrap failed after 5 attempts (Azure mirror unreachable?)"
+              exit 1
+            fi
+            delay=$((15 * attempt))
+            echo "::warning::apt-get install attempt $attempt/5 failed; retrying in ${delay}s"
+            sleep $delay
+          done
           # Enable unprivileged user namespaces so bwrap can sandbox.
           # GH Actions runners disable this by default.
           sudo sysctl -w kernel.unprivileged_userns_clone=1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,7 +41,21 @@ jobs:
       - name: Set up Linux sandbox (bubblewrap)
         if: runner.os == 'Linux' && steps.install.outcome == 'success'
         run: |
-          sudo apt-get install -y bubblewrap
+          # See ci.yml for the rationale on the retry loop — same Azure
+          # mirror flake protection.
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get install -y bubblewrap; then
+              echo "bubblewrap installed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::apt-get install bubblewrap failed after 5 attempts (Azure mirror unreachable?)"
+              exit 1
+            fi
+            delay=$((15 * attempt))
+            echo "::warning::apt-get install attempt $attempt/5 failed; retrying in ${delay}s"
+            sleep $delay
+          done
           sudo sysctl -w kernel.unprivileged_userns_clone=1
           if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,21 @@ jobs:
       - name: Set up Linux sandbox (bubblewrap)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install -y bubblewrap
+          # See ci.yml for the rationale on the retry loop — same Azure
+          # mirror flake protection.
+          for attempt in 1 2 3 4 5; do
+            if sudo apt-get install -y bubblewrap; then
+              echo "bubblewrap installed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::apt-get install bubblewrap failed after 5 attempts (Azure mirror unreachable?)"
+              exit 1
+            fi
+            delay=$((15 * attempt))
+            echo "::warning::apt-get install attempt $attempt/5 failed; retrying in ${delay}s"
+            sleep $delay
+          done
           sudo sysctl -w kernel.unprivileged_userns_clone=1
           if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0


### PR DESCRIPTION
Wraps the apt-get install of bubblewrap in a 5-attempt retry loop with linear backoff (max ~2.5 min total) in all 3 workflow files that install it.

## Why

PR #1179 has hit **three consecutive failures** of `Test (ubuntu-latest)`, all with the same signature:

```
E: Failed to fetch ... bubblewrap_0.9.0-1ubuntu0.1_amd64.deb
   Temporary failure resolving 'azure.archive.ubuntu.com'
##[error]Process completed with exit code 100.
```

The Azure Ubuntu mirror periodically goes unreachable from GH Actions runners. Three reruns over ~15 min all failed at the same step \u2014 it's a persistent infrastructure outage, not a flake. Without retry logic, any PR trying to merge during the outage window is wedged.

## Loop design

- 5 attempts, 0/15/30/45/60s linear backoff
- Workflow annotations (`::warning::`, `::error::`) show retries in the GH UI
- Hard-fails on attempt 5 \u2014 no silent skips
- Comment in ci.yml documents the rationale; coverage.yml + release.yml reference it

## Files changed

- `.github/workflows/ci.yml` (Test job, Linux runners)
- `.github/workflows/coverage.yml` (coverage job)
- `.github/workflows/release.yml` (release-test job)

## Quality gate

YAML validated with `yaml.safe_load`. No koda code paths touched.

## Refs

Unblocks #1179 (codex textarea port foundation), which is currently stuck waiting for this Azure outage to end.