### PR TITLE
feat(composer): wire up vim mode (PR 3 of #1178)

### DIFF
--- a/koda-cli/src/completer.rs
+++ b/koda-cli/src/completer.rs
@@ -59,6 +59,7 @@ pub const SLASH_COMMANDS: &[(&str, &str, Option<&str>)] = &[
     ("/skills", "List available skills (search with query)", None),
     ("/undo", "Undo last turn's file changes", None),
     ("/verbose", "Toggle full tool output", None),
+    ("/vim", "Toggle vim-mode editing in the input", None),
 ];
 
 /// Unified Tab-completion for slash commands and @file paths.

--- a/koda-cli/src/composer/textarea.rs
+++ b/koda-cli/src/composer/textarea.rs
@@ -84,11 +84,18 @@
 //! recent killed span.
 
 // PR 2 of #1178 swapped the consumers (chat handlers + viewport) to use this
-// module, but the codex-port surface includes advanced features (vim mode
-// toggle, paste-burst detection, named/highlighted elements, masked render,
-// key hints) that are scoped for PR 3+. The unused-warnings will go away as
-// each follow-up PR wires them up; until then, allow them at the module
-// level so the faithful port can land without piecemeal #[allow] tags.
+// module. PR 3 wired up vim-mode (`set_vim_enabled`, `is_vim_enabled`,
+// `vim_mode_label`, `should_handle_vim_insert_escape`) via the `/vim` slash
+// command + status-bar pill + Esc routing.
+//
+// Still unused (will go away as each follow-up PR wires them up):
+//   - paste-burst integration glue (PR 3 scope was deferred — mac/linux dev
+//     focus, niche value for legacy Windows ConHost only)
+//   - named-element APIs (`insert_named_element`, `replace_element_payload`,
+//     etc.) — PR 5 scope (@ -mention completer + image attachments)
+//   - masked / highlighted render paths — PR 6 scope
+//   - several vim_normal_keymap fields (operator-pending edge cases not yet
+//     exercised by `input(key)` dispatch in koda's call sites)
 #![allow(dead_code)]
 
 use super::key_hint::KeyBindingListExt;

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -68,6 +68,19 @@ impl TuiContext {
             return Ok(consumed);
         }
 
+        // Vim insert-mode Escape: route to the textarea so it transitions to
+        // NORMAL mode. Without this short-circuit, the bare-Esc match arm
+        // below (or the inference-loop's Esc-cancels-inference handler)
+        // would consume the keystroke and the textarea would stay in INSERT,
+        // making vim mode feel broken. PR 3 of #1178; the textarea owns the
+        // "is this an insert-mode Esc that I should handle?" predicate so
+        // we never need to mirror the vim_enabled/vim_mode state outside
+        // the textarea.
+        if self.textarea.should_handle_vim_insert_escape(key) {
+            self.textarea.input(key);
+            return Ok(true);
+        }
+
         match (key.code, key.modifiers) {
             (KeyCode::Enter, m) if m.contains(KeyModifiers::ALT) => {
                 self.textarea.insert_str("\n");
@@ -150,7 +163,7 @@ impl TuiContext {
             _ => {
                 self.history_idx = None;
                 self.completer.reset();
-                self.textarea.input_with_keymap(key, &self.keymap.editor);
+                self.textarea.input(key);
                 self.update_reactive_menu();
             }
         }

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -51,10 +51,6 @@ pub(crate) struct TuiContext {
     // ── UI state ────────────────────────────────────────────
     pub terminal: Term,
     pub textarea: TextArea,
-    /// Resolved keymap (defaults for now; user-config layer is a follow-up).
-    /// Threaded into input handlers so the textarea's `input_with_keymap` can
-    /// consult `editor` bindings instead of hard-coding key matches inline.
-    pub keymap: RuntimeKeymap,
     pub renderer: TuiRenderer,
     pub scroll_buffer: ScrollBuffer,
     pub crossterm_events: EventStream,
@@ -251,9 +247,15 @@ impl TuiContext {
         // the textarea in `tui_viewport::draw_viewport` so we don't depend on
         // ratatui-textarea's placeholder feature (codex doesn't have an
         // equivalent at the textarea level).
+        //
+        // Keymap (PR 3): construct defaults and hand them to the textarea so
+        // its internal `input(key)` dispatcher routes to the editor / vim /
+        // vim-operator handlers correctly. The textarea owns its own clone of
+        // the keymap from this point on; TuiContext does not need to keep a
+        // copy. Future PRs that need the keymap (e.g. the key-hint footer)
+        // can either ask the textarea for it or rebuild defaults on the fly.
         let mut textarea = TextArea::new();
-        let keymap = RuntimeKeymap::defaults();
-        textarea.set_keymap_bindings(&keymap);
+        textarea.set_keymap_bindings(&RuntimeKeymap::defaults());
 
         let mut renderer = TuiRenderer::new();
         renderer.model = config.model.clone();
@@ -334,7 +336,6 @@ impl TuiContext {
         Ok(Self {
             terminal,
             textarea,
-            keymap,
             renderer,
             scroll_buffer: {
                 let mut buf = ScrollBuffer::new(2500);
@@ -567,6 +568,26 @@ impl TuiContext {
     }
 
     async fn dispatch_slash(&mut self, input: &str) -> CommandOutcome {
+        if input.trim() == "/vim" {
+            // Toggle vim-mode editing on the textarea (PR 3 of #1178).
+            // The textarea owns the mode flag; we just flip it and emit
+            // a confirmation line so the user sees the change in scrollback.
+            // The status-bar `VIM:NORMAL` / `VIM:INSERT` pill (rendered in
+            // `tui_viewport::draw_viewport`) reflects the current mode on
+            // the next frame.
+            let now_on = !self.textarea.is_vim_enabled();
+            self.textarea.set_vim_enabled(now_on);
+            let msg = if now_on {
+                "\u{1f43b} Vim mode: ON \u{2014} Esc \u{2192} NORMAL, i/a/o \u{2192} INSERT."
+            } else {
+                "\u{1f43b} Vim mode: OFF."
+            };
+            self.scroll_buffer.push(Line::from(Span::styled(
+                msg,
+                Style::default().fg(Color::Cyan),
+            )));
+            return CommandOutcome::Handled;
+        }
         if input.trim() == "/model" {
             self.open_model_picker().await;
             return CommandOutcome::Handled;

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -231,7 +231,6 @@ impl TuiContext {
                             &mut self.prompt_mode,
                             &mut self.pending_approval_id,
                             &mut self.textarea,
-                            &self.keymap,
                             &self.shared_mode,
                             &mut self.completer,
                             &mut self.history,
@@ -445,7 +444,6 @@ async fn handle_crossterm_event_inline(
     prompt_mode: &mut PromptMode,
     pending_approval_id: &mut Option<String>,
     textarea: &mut crate::composer::textarea::TextArea,
-    keymap: &crate::composer::keymap::RuntimeKeymap,
     shared_mode: &koda_core::trust::SharedTrustMode,
     completer: &mut crate::completer::InputCompleter,
     history: &mut Vec<String>,
@@ -494,7 +492,6 @@ async fn handle_crossterm_event_inline(
                 prompt_mode,
                 pending_approval_id,
                 textarea,
-                keymap,
                 shared_mode,
                 completer,
                 history,
@@ -519,7 +516,6 @@ async fn handle_inference_key_inline(
     prompt_mode: &mut PromptMode,
     pending_approval_id: &mut Option<String>,
     textarea: &mut crate::composer::textarea::TextArea,
-    keymap: &crate::composer::keymap::RuntimeKeymap,
     shared_mode: &koda_core::trust::SharedTrustMode,
     completer: &mut crate::completer::InputCompleter,
     history: &mut Vec<String>,
@@ -527,6 +523,17 @@ async fn handle_inference_key_inline(
     later_queue: &mut std::collections::VecDeque<String>,
     db: &koda_core::db::Database,
 ) {
+    // Vim insert-mode Escape (PR 3 of #1178). Same rationale as in
+    // `tui_context::events::handle_key`: route bare Esc to the textarea
+    // for the INSERT → NORMAL transition before the inference-loop's
+    // "Esc cancels inference" handler grabs it. The textarea decides via
+    // `should_handle_vim_insert_escape` so this file does not need to
+    // know whether vim is enabled.
+    if textarea.should_handle_vim_insert_escape(key) {
+        textarea.input(key);
+        return;
+    }
+
     // Approval hotkeys
     if let MenuContent::Approval { id, .. } = menu {
         let approval_id = id.clone();
@@ -616,7 +623,7 @@ async fn handle_inference_key_inline(
                 }
             }
             _ => {
-                textarea.input_with_keymap(key, &keymap.editor);
+                textarea.input(key);
             }
         }
         return;
@@ -658,7 +665,7 @@ async fn handle_inference_key_inline(
                 }
             }
             _ => {
-                textarea.input_with_keymap(key, &keymap.editor);
+                textarea.input(key);
             }
         }
         return;
@@ -751,7 +758,7 @@ async fn handle_inference_key_inline(
                     ),
                 ]));
             } else {
-                textarea.input_with_keymap(key, &keymap.editor);
+                textarea.input(key);
             }
         }
         (KeyCode::Tab, KeyModifiers::NONE) => {
@@ -763,7 +770,7 @@ async fn handle_inference_key_inline(
         }
         _ => {
             completer.reset();
-            textarea.input_with_keymap(key, &keymap.editor);
+            textarea.input(key);
         }
     }
 }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -208,6 +208,10 @@ pub(crate) fn draw_viewport(
     if bg_agents > 0 || bg_processes > 0 {
         sb = sb.with_bg_counts(bg_agents, bg_processes);
     }
+    // Vim-mode pill (PR 3 of #1178). The textarea returns `None` when
+    // vim editing is disabled, which makes `with_vim_label` a no-op —
+    // non-vim users never see the segment.
+    sb = sb.with_vim_label(textarea.vim_mode_label());
     frame.render_widget(sb, status_row);
 
     // ── Menu overlay (below status bar) ───────────────

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -43,6 +43,12 @@ pub struct StatusBar<'a> {
     /// from the launch confirmation.
     bg_agents: usize,
     bg_processes: usize,
+    /// Vim mode label (e.g. "NORMAL", "INSERT", "OPERATOR-PENDING").
+    /// `None` hides the segment entirely (vim editing disabled).
+    /// Sourced from `composer::textarea::TextArea::vim_mode_label()`
+    /// which the status-bar caller passes in via [`with_vim_label`].
+    /// Added in PR 3 of #1178 (vim mode wire-up).
+    vim_label: Option<&'a str>,
 }
 
 /// Stats from the most recent inference turn.
@@ -72,6 +78,7 @@ impl<'a> StatusBar<'a> {
             mcp_info: None,
             bg_agents: 0,
             bg_processes: 0,
+            vim_label: None,
         }
     }
 
@@ -119,6 +126,17 @@ impl<'a> StatusBar<'a> {
     pub fn with_bg_counts(mut self, agents: usize, processes: usize) -> Self {
         self.bg_agents = agents;
         self.bg_processes = processes;
+        self
+    }
+
+    /// Set the active vim-mode label (NORMAL / INSERT / OPERATOR-PENDING).
+    ///
+    /// `None` (or any call site that doesn't invoke this) hides the segment
+    /// entirely — vim editing is opt-in, so users who don't toggle it never
+    /// see VIM clutter in the status bar. PR 3 of #1178; sourced from
+    /// `composer::textarea::TextArea::vim_mode_label()`.
+    pub fn with_vim_label(mut self, label: Option<&'a str>) -> Self {
+        self.vim_label = label;
         self
     }
 }
@@ -247,6 +265,21 @@ impl Widget for StatusBar<'_> {
                 Style::default().fg(ctx_color),
             ),
         ]);
+
+        // Vim mode pill (PR 3 of #1178). Hidden when vim editing is
+        // disabled (the textarea returns `None` from `vim_mode_label()`),
+        // so non-vim users never see this segment. Magenta to make the
+        // mode visually distinct from the trust-mode segment.
+        if let Some(label) = self.vim_label {
+            spans.push(Span::styled(
+                "\u{2502}",
+                Style::default().fg(Color::Rgb(60, 60, 60)),
+            ));
+            spans.push(Span::styled(
+                format!(" VIM:{label} "),
+                Style::default().fg(Color::Magenta),
+            ));
+        }
 
         // MCP server indicator (hidden when no servers configured)
         if let Some(mcp) = self.mcp_info {
@@ -627,6 +660,31 @@ mod tests {
             buf.cell((cell_x, 0)).unwrap().fg,
             Color::Cyan,
             "bg pill must render in cyan (in-flight palette)"
+        );
+    }
+
+    /// Vim segment is hidden when the textarea reports `None`
+    /// (vim editing disabled). PR 3 of #1178.
+    #[test]
+    fn vim_segment_hidden_when_label_is_none() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_vim_label(None);
+        let out = render_bar(bar, 200);
+        assert!(
+            !out.contains("VIM"),
+            "vim segment must not render when label is None: {out}"
+        );
+    }
+
+    /// Vim segment renders the label when set. Covers the
+    /// `with_vim_label(Some(...))` happy path used by `tui_viewport`
+    /// when the textarea is in a vim mode.
+    #[test]
+    fn vim_segment_renders_label_when_some() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_vim_label(Some("NORMAL"));
+        let out = render_bar(bar, 200);
+        assert!(
+            out.contains("VIM:NORMAL"),
+            "vim pill must render label: {out}"
         );
     }
 }


### PR DESCRIPTION
Activates the vim-mode editing surface that the codex `bottom_pane::textarea` port has shipped (dormant) since PR 1. Adds a runtime toggle, status-bar indicator, and Esc routing so vim users can use modal editing in the chat input. Vim editing is OFF by default; non-vim users see zero behavior change.

## What landed

| Piece | Detail |
|---|---|
| **Runtime toggle** | New `/vim` slash command flips `textarea.set_vim_enabled(...)`. In-memory only \u2014 persisting to `KodaConfig` is a deliberate non-goal (avoids cascading through agent-JSON migration / defaults). |
| **Status-bar pill** | New `StatusBar::with_vim_label(Option<&str>)` builder; `tui_viewport` passes `textarea.vim_mode_label()`. Magenta `VIM:NORMAL` / `VIM:INSERT` / `VIM:OPERATOR-PENDING` segment. Hidden when vim editing is off (textarea returns `None`). |
| **Esc routing** | `textarea.should_handle_vim_insert_escape(key)` intercepts at the top of `handle_key` (events.rs) and `handle_inference_key_inline` (tui_handlers_inference.rs). Bare Esc in INSERT mode transitions to NORMAL via `textarea.input(key)` instead of cancelling inference / closing menus. NORMAL-mode Esc still falls through (preserves \"Esc cancels\" muscle memory). |
| **Completer** | `/vim` registered in the slash command list so Tab-completion + slash menu surface it. |

## Bonus simplification

PR 2 wired the chat handlers to `textarea.input_with_keymap(key, &keymap.editor)`, which **bypasses vim routing** \u2014 `input_with_keymap` always uses the editor keymap regardless of `vim_enabled`. The correct entry point is `textarea.input(key)`, which internally checks `vim_enabled` and dispatches to the vim handler or the editor keymap (both owned by the textarea after `set_keymap_bindings`).

Refactored 5 call sites + dropped the `keymap: RuntimeKeymap` parameter from inference-handler signatures + dropped the `keymap` field from `TuiContext`. YAGNI cleanup that fell naturally out of using the right API. The textarea is now the sole owner of its keymap copy.

## Per-module dead_code allow

Updated the `#![allow(dead_code)]` comment on `composer/textarea.rs` to reflect what's now wired (vim toggle, mode label, Esc predicate) vs still dormant (paste-burst glue, named-element APIs, masked render, several operator-pending vim keymap edge cases). Module-level allow stays \u2014 PR 5/6 peel it back as they wire features.

## Quality gate

```
cargo fmt --all                                  no changes
cargo build -p koda-cli                          0 warnings
cargo clippy --workspace --all-targets \\
     --features koda-core/test-support \\
     -- -D warnings                              clean
cargo test --workspace --features \\
     koda-core/test-support --no-fail-fast       2337 passed, 0 failed,
                                                 15 ignored
```

Two new `StatusBar` unit tests cover `with_vim_label(None)` (segment hidden) and `with_vim_label(Some(\"NORMAL\"))` (pill renders).

## Diff at a glance

```
 7 files changed, 132 insertions(+), 21 deletions(-)
```

| File | Change |
|---|---|
| `completer.rs` | +1 (`/vim` registry entry) |
| `composer/textarea.rs` | +14/-3 (allow comment refresh) |
| `tui_context/events.rs` | +14/-1 (Esc intercept) |
| `tui_context/mod.rs` | +29/-6 (`/vim` handler, drop `keymap` field) |
| `tui_handlers_inference.rs` | +14/-9 (Esc intercept, drop `keymap` param) |
| `tui_viewport.rs` | +4 (`with_vim_label` call) |
| `widgets/status_bar.rs` | +56/-2 (vim field + builder + 2 tests) |

## Risk surface

- **NORMAL-mode Esc still cancels inference**: deliberate \u2014 keeps non-vim shortcut working. Vim users typically only hit Esc to exit INSERT (which IS intercepted). Operator-pending cancel-via-Esc is not yet handled.
- **In-memory toggle**: vim mode resets to OFF at startup. Sticky-across-sessions is intentional follow-up scope.
- **Status bar real estate**: adds one segment (~13 chars). On narrow terminals the existing truncation heuristics drop the bg-counts segment first.

## Refs

- Part of epic #1178 (codex bottom_pane adoption)
- Builds on PR 1 (#1179 \u2014 textarea port) and PR 2 (#1181 \u2014 consumer swap)
- Next up: PR 4 \u2014 key hint footer