### PR TITLE
feat(composer): key hint footer below input (PR 4 of #1178)

### DIFF
--- a/koda-cli/src/composer/key_hint.rs
+++ b/koda-cli/src/composer/key_hint.rs
@@ -55,13 +55,13 @@
 //! It also supplies rendering helpers that convert bindings into styled
 //! `ratatui::text::Span` values for UI hint display.
 
-// PR 2 of #1178 swapped the consumers (chat handlers + viewport) to use this
-// module, but the codex-port surface includes advanced features (vim mode
-// toggle, paste-burst detection, named/highlighted elements, masked render,
-// key hints) that are scoped for PR 3+. The unused-warnings will go away as
-// each follow-up PR wires them up; until then, allow them at the module
-// level so the faithful port can land without piecemeal #[allow] tags.
-#![allow(dead_code)]
+// PR 4 of #1178 wired this module's `KeyBinding`, helper constructors
+// (`plain`/`shift`/`ctrl`), and `From<&KeyBinding> for Span` rendering into
+// the new key-hint footer (`widgets/key_hints.rs`). The remaining surface
+// (`alt`, `ctrl_alt`, `parts`, `has_ctrl_or_alt`) is unused by koda today
+// but preserved verbatim from the codex port so the next sync stays a
+// trivial diff. Per-item `#[allow(dead_code)]` rather than a module-level
+// blanket so newly-dead code becomes a warning we have to acknowledge.
 
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -105,6 +105,7 @@ impl KeyBinding {
             && (event.kind == KeyEventKind::Press || event.kind == KeyEventKind::Repeat)
     }
 
+    #[allow(dead_code)] // Codex-port surface preserved for sync parity (#1178); not used by koda yet.
     pub(crate) const fn parts(&self) -> (KeyCode, KeyModifiers) {
         (self.key, self.modifiers)
     }
@@ -173,6 +174,7 @@ pub(crate) const fn ctrl(key: KeyCode) -> KeyBinding {
     KeyBinding::new(key, KeyModifiers::CONTROL)
 }
 
+#[allow(dead_code)] // Codex-port surface preserved for sync parity (#1178); not used by koda yet.
 pub(crate) const fn ctrl_alt(key: KeyCode) -> KeyBinding {
     KeyBinding::new(key, KeyModifiers::CONTROL.union(KeyModifiers::ALT))
 }
@@ -219,6 +221,7 @@ fn key_hint_style() -> Style {
     Style::default().dim()
 }
 
+#[allow(dead_code)] // Codex-port surface preserved for sync parity (#1178); not used by koda yet.
 pub(crate) fn has_ctrl_or_alt(mods: KeyModifiers) -> bool {
     (mods.contains(KeyModifiers::CONTROL) || mods.contains(KeyModifiers::ALT)) && !is_altgr(mods)
 }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -163,13 +163,14 @@ pub(crate) fn draw_viewport(
     }
     frame.render_widget(textarea, text_area);
 
-    // ── Bottom separator ────────────────────────────────
-    let bot_width = bot_sep_row.width as usize;
+    // ── Bottom row: key hint footer (PR 4 of #1178) ────────────────────
+    // Replaces the previous flat "───" separator with a single dim row
+    // of `key verb` hints (`enter send · shift+enter newline · ...`).
+    // Same height (1 row), but turns dead-space chrome into discoverable
+    // shortcuts. `KeyHints::render` reads `area.width` itself and drops
+    // items from the right on narrow terminals — no width threading needed.
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            "\u{2500}".repeat(bot_width),
-            Style::default().fg(Color::Rgb(124, 111, 100)),
-        ))),
+        crate::widgets::key_hints::KeyHints::default_set(),
         bot_sep_row,
     );
 

--- a/koda-cli/src/widgets/key_hints.rs
+++ b/koda-cli/src/widgets/key_hints.rs
@@ -1,0 +1,205 @@
+//! Single-row key-hint footer rendered between the input textarea and the
+//! status bar. Surfaces the most-used keybindings so first-time users don't
+//! have to read docs to discover Tab-completion, Shift+Enter newlines, etc.
+//!
+//! # Why this exists (PR 4 of #1178)
+//!
+//! Before this widget, the row below the input was a flat
+//! `─────────────────` separator — pure visual chrome with no information
+//! value. The codex `composer::key_hint` port (PR 1 of #1178) gave us a
+//! `From<KeyBinding> for Span` impl that styles a key as a dim
+//! `lowercase+modifier` token (e.g. `ctrl+c`, `shift+enter`). This widget
+//! pairs each rendered key with a one-word verb and joins them with `·`
+//! separators, replacing the dead-space separator with discoverable hints.
+//!
+//! # Truncation behavior
+//!
+//! Hints are rendered left-to-right. When the available width is narrower
+//! than the full set, items are dropped from the right one at a time until
+//! the remaining set fits. This keeps the high-priority items (`enter`,
+//! `shift+enter`) visible on narrow terminals and gracefully degrades on
+//! 80-column screens.
+//!
+//! # What is *not* in here
+//!
+//! - Vim-mode-aware hints: when `/vim` is active, `i a o` (enter INSERT)
+//!   and `esc` (back to NORMAL) become the most relevant bindings. That
+//!   reactivity is intentional follow-up scope; v1 ships a static set so
+//!   the rendering is dead-simple and the discovery win is immediate.
+//! - User-configurable hints: the set is hard-coded against
+//!   `composer::keymap::EditorKeymap::defaults()`. If a future PR adds a
+//!   user-keymap config, this widget should rebuild from that instead of
+//!   hard-coding the bindings.
+
+use crate::composer::key_hint::{KeyBinding, ctrl, plain, shift};
+use crossterm::event::KeyCode;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget};
+
+/// Single (key-binding, verb) hint pair.
+///
+/// `verb` is the imperative action (e.g. `"send"`, `"newline"`) shown
+/// dimmed-grey next to the key token.
+#[derive(Debug, Clone, Copy)]
+pub struct Hint {
+    pub key: KeyBinding,
+    pub verb: &'static str,
+}
+
+impl Hint {
+    pub const fn new(key: KeyBinding, verb: &'static str) -> Self {
+        Self { key, verb }
+    }
+}
+
+/// Footer widget rendering an ordered list of [`Hint`]s on one row.
+///
+/// Build with [`KeyHints::default_set`] for the standard koda set, or
+/// `KeyHints { items }` directly for tests / custom callers.
+pub struct KeyHints {
+    items: Vec<Hint>,
+}
+
+impl KeyHints {
+    /// The standard koda hint set (6 items, ~85-100 visual columns).
+    ///
+    /// Order is by priority — narrow terminals truncate from the right,
+    /// so the most-essential hints (`enter`, `shift+enter`) live first.
+    /// Bindings mirror `composer::keymap::EditorKeymap::defaults()` for
+    /// the textarea-internal items and koda's own dispatch for the rest
+    /// (`tab` → completer, `esc` → menu cancel, `↑↓` → history, `ctrl+c`
+    /// → quit).
+    pub fn default_set() -> Self {
+        Self {
+            items: vec![
+                Hint::new(plain(KeyCode::Enter), "send"),
+                Hint::new(shift(KeyCode::Enter), "newline"),
+                Hint::new(plain(KeyCode::Tab), "complete"),
+                Hint::new(plain(KeyCode::Esc), "menu"),
+                Hint::new(plain(KeyCode::Up), "history"),
+                Hint::new(ctrl(KeyCode::Char('c')), "quit"),
+            ],
+        }
+    }
+}
+
+impl Widget for KeyHints {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let spans = build_hint_spans(&self.items, area.width as usize);
+        Paragraph::new(Line::from(spans)).render(area, buf);
+    }
+}
+
+/// Build the styled spans for a hint row, dropping items from the right
+/// until the rendered width fits in `max_width` columns.
+///
+/// Layout per item: `<key-span> <verb-span>` joined by ` · ` separators.
+/// The verb is dimmed slightly less than the key so the eye lands on the
+/// action first, then the chord.
+fn build_hint_spans(items: &[Hint], max_width: usize) -> Vec<Span<'static>> {
+    if items.is_empty() || max_width == 0 {
+        return Vec::new();
+    }
+    // Iteratively drop from the right until the rendered width fits.
+    // Cheap O(n²) — n is always ≤ 6 in practice; not worth a smarter algo.
+    for take in (1..=items.len()).rev() {
+        let spans = render_n(items, take);
+        let width: usize = spans.iter().map(|s| s.width()).sum();
+        if width <= max_width {
+            return spans;
+        }
+    }
+    // Even the first item alone doesn't fit — render it anyway and let
+    // the Paragraph clip. Better than an empty footer that hides the
+    // whole feature on narrow terminals.
+    render_n(items, 1)
+}
+
+/// Render exactly `n` items as `key verb · key verb · ...` spans.
+fn render_n(items: &[Hint], n: usize) -> Vec<Span<'static>> {
+    let verb_style = Style::default().fg(Color::Rgb(140, 140, 140));
+    let sep_style = Style::default().fg(Color::Rgb(80, 80, 80));
+    let mut spans = Vec::with_capacity(n * 4);
+    for (i, hint) in items.iter().take(n).enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" \u{00b7} ", sep_style));
+        }
+        spans.push(Span::from(hint.key));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(hint.verb, verb_style));
+    }
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rendered width fits any `max_width >= total_width(default_set)`.
+    #[test]
+    fn default_set_fits_when_width_is_generous() {
+        let items = KeyHints::default_set().items;
+        let spans = build_hint_spans(&items, 200);
+        let width: usize = spans.iter().map(|s| s.width()).sum();
+        assert!(
+            width <= 200,
+            "default set must fit in 200 cols (got {width})"
+        );
+        assert_eq!(
+            spans.iter().filter(|s| s.content == " \u{00b7} ").count(),
+            items.len() - 1,
+            "n items \u{2192} n-1 separators",
+        );
+    }
+
+    /// On narrow terminals, items drop from the right; `enter send`
+    /// (the highest-priority hint) survives.
+    #[test]
+    fn narrow_terminal_drops_low_priority_items_first() {
+        let items = KeyHints::default_set().items;
+        let spans = build_hint_spans(&items, 30);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            text.contains("enter") && text.contains("send"),
+            "highest-priority hint must survive narrow render: {text}"
+        );
+        assert!(
+            !text.contains("ctrl+c"),
+            "lowest-priority hint must be dropped on 30-col terminal: {text}"
+        );
+    }
+
+    /// Zero width yields no spans (don't crash on degenerate input).
+    #[test]
+    fn zero_width_returns_empty() {
+        let items = KeyHints::default_set().items;
+        assert!(build_hint_spans(&items, 0).is_empty());
+    }
+
+    /// Empty hint list renders nothing regardless of width.
+    #[test]
+    fn empty_items_returns_empty() {
+        assert!(build_hint_spans(&[], 200).is_empty());
+    }
+
+    /// End-to-end Widget render path: rendered buffer contains all verbs
+    /// when the area is wide enough.
+    #[test]
+    fn widget_render_writes_all_verbs_into_buffer() {
+        let area = Rect::new(0, 0, 120, 1);
+        let mut buf = Buffer::empty(area);
+        KeyHints::default_set().render(area, &mut buf);
+        let text: String = (0..area.width)
+            .map(|x| buf.cell((x, 0)).map(|c| c.symbol()).unwrap_or(" "))
+            .collect();
+        for verb in ["send", "newline", "complete", "menu", "history", "quit"] {
+            assert!(
+                text.contains(verb),
+                "rendered footer must contain {verb:?}: {text}"
+            );
+        }
+    }
+}

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod dropdown;
 pub mod file_menu;
+pub mod key_hints;
 pub mod model_menu;
 pub mod provider_menu;
 pub mod queue_preview;


### PR DESCRIPTION
Replaces the dead-space `\u2500\u2500\u2500\u2500\u2500` separator below the input textarea with a single-row key-hint footer that surfaces the most-used bindings:

```
enter send \u00b7 shift + enter newline \u00b7 tab complete \u00b7 esc menu \u00b7 \u2191 history \u00b7 ctrl + c quit
```

Same height as the old separator (1 row), but turns visual chrome into discoverable shortcuts. First-time users no longer have to read docs to learn that Tab completes paths, Shift+Enter inserts a newline, or that the up arrow walks command history.

## What landed

| Piece | Detail |
|---|---|
| **New widget** `koda-cli/src/widgets/key_hints.rs` | `Hint { key, verb }` data type + `KeyHints` collection + `Widget` impl. `KeyHints::default_set()` returns the standard 6-hint koda set. ~205 LoC including module doc + 5 unit tests. |
| **Truncation** | Items render left-to-right; rightmost items are dropped one at a time when row width is too narrow (cheap O(n\u00b2); n \u2264 6 in practice). Highest-priority hints (`enter send`, `shift+enter newline`) survive on narrow terminals. |
| **Visual style** | Reuses the codex-port `composer::key_hint::From<KeyBinding> for Span` impl, so keys render as dim `lowercase+modifier` tokens. Verbs use a slightly lighter grey to draw the eye to the action first. |
| **Wired into `tui_viewport.rs`** | Replaces 5-line bottom-separator Paragraph render with a single `frame.render_widget(KeyHints::default_set(), bot_sep_row)` call. |

## dead_code allow cleanup

The module-level `#![allow(dead_code)]` on `composer/key_hint.rs` is **gone**. 4 of 7 dormant items are now consumed (`KeyBinding`, `plain`, `shift`, `ctrl`, `From<KeyBinding> for Span`). The remaining 3 (`parts`, `ctrl_alt`, `has_ctrl_or_alt`) get per-item `#[allow(dead_code)]` tags with sync-parity rationale. Future newly-dead code will warn instead of silently growing.

## Quality gate

```
cargo fmt --all                                  no changes
cargo build -p koda-cli                          0 warnings
cargo clippy --workspace --all-targets \\
     --features koda-core/test-support \\
     -- -D warnings                              clean
cargo test --workspace --features \\
     koda-core/test-support --no-fail-fast       2344 passed, 0 failed,
                                                 15 ignored
```

5 new tests covering: full-set fits in 200 cols, narrow terminal drops low-priority items, zero-width / empty-input degenerate cases don't panic, end-to-end Widget render writes verbs into buffer.

## Diff at a glance

```
 4 files changed, 223 insertions(+), 13 deletions(-)
```

| File | Change |
|---|---|
| `composer/key_hint.rs` | +9/-8 (drop module allow, add 3 per-item) |
| `tui_viewport.rs` | +6/-7 (replace separator render) |
| `widgets/key_hints.rs` | +207 (new widget + 5 tests) |
| `widgets/mod.rs` | +1 (mod entry) |

## Risk surface

- **Static hint set, not vim-aware**: when `/vim` is enabled and the user is in NORMAL mode, the hints `enter send` / `shift+enter newline` are misleading (vim NORMAL doesn't insert chars). Vim-mode-aware hints (e.g. show `i a o \u2192 INSERT` and `esc` when in NORMAL) is intentional follow-up scope; v1 keeps rendering dead-simple.
- **No user-keymap awareness**: hints are hard-coded against `EditorKeymap::defaults()`. A future user-configurable keymap PR would need to rebuild from the active config.
- **Narrow-terminal truncation**: on terminals < ~25 cols the row may show only the first hint clipped. Acceptable \u2014 koda's other widgets degrade on \u00ab30-col terminals.

## Refs

- Part of epic #1178 (codex bottom_pane adoption)
- Builds on PR 1 (#1179 \u2014 textarea + key_hint port), PR 2 (#1181 \u2014 consumer swap), PR 3 (#1182 \u2014 vim mode wire-up)
- Next up: PR 5 \u2014 named elements / @-mention completer