### PR TITLE
feat(composer): @-mention named-element wiring (PR 5 of #1178)

### DIFF
--- a/koda-cli/src/composer/text_element.rs
+++ b/koda-cli/src/composer/text_element.rs
@@ -43,6 +43,16 @@
 // key hints) that are scoped for PR 3+. The unused-warnings will go away as
 // each follow-up PR wires them up; until then, allow them at the module
 // level so the faithful port can land without piecemeal #[allow] tags.
+
+// PR 5 of #1178 wired the textarea's `insert_element` / element-aware
+// rendering into koda's @-mention completion path, which exercises the
+// `TextElement` struct + `ByteRange` type alias from this module via the
+// textarea's internal use of them. The remaining surface
+// (`MAX_USER_INPUT_TEXT_CHARS`, `map_range`, `set_placeholder`,
+// `placeholder`) is preserved verbatim from the codex port for sync
+// parity — the next codex resync stays a trivial diff. Module-level
+// allow rather than per-item because most of the file is sync-parity
+// surface; per-item would add 4+ tags to a 167-line file for no gain.
 #![allow(dead_code)]
 
 use std::ops::Range;

--- a/koda-cli/src/composer/textarea.rs
+++ b/koda-cli/src/composer/textarea.rs
@@ -86,13 +86,18 @@
 // PR 2 of #1178 swapped the consumers (chat handlers + viewport) to use this
 // module. PR 3 wired up vim-mode (`set_vim_enabled`, `is_vim_enabled`,
 // `vim_mode_label`, `should_handle_vim_insert_escape`) via the `/vim` slash
-// command + status-bar pill + Esc routing.
+// command + status-bar pill + Esc routing. PR 5 wired up named elements
+// (`insert_element`, element-aware rendering, atomic backspace) via the
+// @-mention completion path in `tui_context::events::handle_key`.
 //
 // Still unused (will go away as each follow-up PR wires them up):
 //   - paste-burst integration glue (PR 3 scope was deferred — mac/linux dev
 //     focus, niche value for legacy Windows ConHost only)
-//   - named-element APIs (`insert_named_element`, `replace_element_payload`,
-//     etc.) — PR 5 scope (@ -mention completer + image attachments)
+//   - id-based named-element APIs (`insert_named_element`,
+//     `replace_element_by_id`) — PR 5 used the simpler `insert_element`
+//     because koda's @-mention flow doesn't need stable IDs for later
+//     replacement (cycling Tab clears + reinserts via
+//     `set_text_clearing_elements`)
 //   - masked / highlighted render paths — PR 6 scope
 //   - several vim_normal_keymap fields (operator-pending edge cases not yet
 //     exercised by `input(key)` dispatch in koda's call sites)

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -155,8 +155,39 @@ impl TuiContext {
             (KeyCode::Tab, KeyModifiers::NONE) => {
                 let current = self.textarea.text().to_string();
                 if let Some(completed) = self.completer.complete(&current) {
-                    self.textarea.set_text_clearing_elements("");
-                    self.textarea.insert_str(&completed);
+                    // Detect @-mention completion (PR 5 of #1178). The
+                    // completer's `find_last_at_token` rule matches an `@`
+                    // at start-of-input or after whitespace, and the
+                    // returned text is `"{prefix}@{path}"` with the
+                    // mention always reaching the end (no trailing space).
+                    // When that pattern fires, insert the mention as a
+                    // codex-port named element so:
+                    //   - it renders cyan (textarea.render_lines overlays
+                    //     element ranges automatically),
+                    //   - one Backspace deletes the entire path atomically
+                    //     (textarea.delete_backward snaps to atomic
+                    //     boundaries),
+                    //   - cycling Tab presses re-create the element with
+                    //     the next match (set_text_clearing_elements +
+                    //     insert_element naturally replaces the previous
+                    //     element — no manual cleanup needed).
+                    // Falls back to the plain insert_str path for slash
+                    // commands and `/model <name>` completions.
+                    if let Some(at_pos) = crate::completer::find_last_at_token(&completed) {
+                        let (prefix, mention) = completed.split_at(at_pos);
+                        self.textarea.set_text_clearing_elements(prefix);
+                        // Defensive: place cursor at end of prefix so the
+                        // mention is appended (not inserted at the textarea's
+                        // last cursor position, which `set_text_inner` only
+                        // clamps to text length — it never moves backward to
+                        // the end on its own when the previous cursor was
+                        // already inside the new shorter prefix).
+                        self.textarea.set_cursor(prefix.len());
+                        self.textarea.insert_element(mention);
+                    } else {
+                        self.textarea.set_text_clearing_elements("");
+                        self.textarea.insert_str(&completed);
+                    }
                     self.completer.reset();
                 }
             }
@@ -467,5 +498,99 @@ mod tests {
 
         let loaded = db.history_load().await.unwrap();
         assert!(loaded.is_empty());
+    }
+
+    // ── @-mention named-element wiring (PR 5 of #1178) ───────────────────
+    //
+    // Tests the textarea-side behavior the Tab handler relies on without
+    // spinning up a full `TuiContext`. The handler does:
+    //   if let Some(at_pos) = find_last_at_token(&completed) {
+    //       let (prefix, mention) = completed.split_at(at_pos);
+    //       textarea.set_text_clearing_elements(prefix);
+    //       textarea.insert_element(mention);
+    //   }
+    // Each test exercises a different invariant of that flow.
+
+    use crate::completer::find_last_at_token;
+    use crate::composer::textarea::TextArea;
+
+    /// Simulates the Tab handler's @-mention branch end-to-end, returning
+    /// the resulting textarea so tests can assert on text + element state.
+    fn simulate_at_mention_completion(prefix: &str, mention: &str) -> TextArea {
+        let completed = format!("{prefix}{mention}");
+        let at_pos = find_last_at_token(&completed)
+            .expect("test fixture must include an @-token in the completed text");
+        let (split_prefix, split_mention) = completed.split_at(at_pos);
+        let mut ta = TextArea::new();
+        ta.set_text_clearing_elements(split_prefix);
+        ta.set_cursor(split_prefix.len());
+        ta.insert_element(split_mention);
+        ta
+    }
+
+    /// After Tab on `explain @src/m\t` the textarea text equals the full
+    /// completion AND the `@src/main.rs` portion is registered as exactly
+    /// one named element. This is the core PR 5 invariant.
+    #[test]
+    fn at_mention_completion_creates_one_element_for_the_path() {
+        let ta = simulate_at_mention_completion("explain ", "@src/main.rs");
+        assert_eq!(ta.text(), "explain @src/main.rs");
+        let elements = ta.text_elements();
+        assert_eq!(
+            elements.len(),
+            1,
+            "exactly one element must wrap the @-mention"
+        );
+        let elem = &elements[0];
+        assert_eq!(
+            &ta.text()[elem.byte_range.start..elem.byte_range.end],
+            "@src/main.rs",
+            "element range must cover the full @-mention including the @"
+        );
+    }
+
+    /// Cycling Tab (e.g. `main.rs` → `lib.rs`) replaces the previous
+    /// element rather than accumulating two. The handler clears the
+    /// textarea via `set_text_clearing_elements` before inserting the new
+    /// mention, which by design drops all prior elements.
+    #[test]
+    fn cycling_at_mention_completion_replaces_previous_element() {
+        let mut ta = simulate_at_mention_completion("explain ", "@src/main.rs");
+        // Second Tab cycles to a different file — simulate by re-running the
+        // same handler logic on the fresh "completed" string.
+        let completed = "explain @src/lib.rs";
+        let at_pos = find_last_at_token(completed).unwrap();
+        let (prefix, mention) = completed.split_at(at_pos);
+        ta.set_text_clearing_elements(prefix);
+        ta.set_cursor(prefix.len());
+        ta.insert_element(mention);
+
+        assert_eq!(ta.text(), "explain @src/lib.rs");
+        let elements = ta.text_elements();
+        assert_eq!(elements.len(), 1, "cycling must replace, not accumulate");
+        assert_eq!(
+            &ta.text()[elements[0].byte_range.start..elements[0].byte_range.end],
+            "@src/lib.rs"
+        );
+    }
+
+    /// One Backspace at end-of-element deletes the entire `@path` span
+    /// atomically (the codex-port `delete_backward` snaps to atomic
+    /// boundaries, of which an element start is one). This is the
+    /// user-visible UX win that motivated PR 5: no more 12 backspaces
+    /// to undo a long file path.
+    #[test]
+    fn one_backspace_deletes_entire_at_mention_atomically() {
+        let mut ta = simulate_at_mention_completion("explain ", "@src/main.rs");
+        ta.delete_backward(1);
+        assert_eq!(
+            ta.text(),
+            "explain ",
+            "single backspace must wipe the whole @-mention element"
+        );
+        assert!(
+            ta.text_elements().is_empty(),
+            "deleting the element must also remove it from the element list"
+        );
     }
 }


### PR DESCRIPTION
Activates the codex `bottom_pane::textarea` named-element APIs by routing Tab-completed @-mentions through `insert_element` instead of plain `insert_str`. Three concrete UX wins fall out automatically:

1. **Atomic deletion**: one Backspace at the end of an @-mention now deletes the entire path span. Previously, removing `@some/long/file/path.rs` took 24 backspaces. Now it takes 1.
2. **Visual distinction**: the textarea's element-aware render (`render_lines`, line 2047+) overlays element ranges in cyan, so @-mentions stand out from surrounding free-form text.
3. **Stable across edits**: typing text before/after a mention shifts the element's byte range automatically; the element stays a single logical unit until explicitly deleted.

## What landed

| Piece | Detail |
|---|---|
| **Tab handler change** in `tui_context/events.rs` | When `completer.complete()` returns text containing an @-token (detected via the existing `find_last_at_token` helper), split at the @ and call `set_text_clearing_elements(prefix)` \u2192 `set_cursor(prefix.len())` \u2192 `insert_element(mention)`. Falls back to `insert_str` for slash commands and `/model <name>` completions. |
| **Defensive cursor reposition** | `set_text_clearing_elements` clamps cursor to new text length but never moves it forward \u2014 if the previous cursor sat inside the new shorter prefix, the element would have been inserted mid-prefix. Now we explicitly `set_cursor(prefix.len())` before inserting. Caught by the test fixture; production was probably fine but defense-in-depth is cheap. |
| **3 new unit tests** | `at_mention_completion_creates_one_element_for_the_path` \u00b7 `cycling_at_mention_completion_replaces_previous_element` \u00b7 `one_backspace_deletes_entire_at_mention_atomically`. Cover the core flow, cycling Tab behavior, and the headline atomic-delete win. |

## dead_code allow refresh

- `composer/text_element.rs`: module-level allow comment refreshed; remaining items are sync-parity surface.
- `composer/textarea.rs`: PR 5 added to the wired-up list. `insert_element` now consumed; id-based variants (`insert_named_element`, `replace_element_by_id`) still dormant \u2014 koda's flow doesn't need stable IDs.

## Quality gate

```
cargo fmt --all                                  no changes
cargo build -p koda-cli                          0 warnings
cargo clippy --workspace --all-targets \\
     --features koda-core/test-support \\
     -- -D warnings                              clean
cargo test --workspace --features \\
     koda-core/test-support --no-fail-fast       2347 passed, 0 failed,
                                                 15 ignored
```

## Diff at a glance

```
 3 files changed, 145 insertions(+), 5 deletions(-)
```

| File | Change |
|---|---|
| `composer/text_element.rs` | +10 (allow comment refresh) |
| `composer/textarea.rs` | +11/-3 (allow comment refresh) |
| `tui_context/events.rs` | +124/-2 (Tab handler + 3 tests) |

## Risk surface

- **Earlier @-mentions lose element status on next Tab**: `set_text_clearing_elements` drops ALL elements before inserting the new one. So if you @-mention three files and Tab on the fourth, the first three become plain text. v2 should preserve prior elements via `set_text_with_elements` + a rebuild loop. Out of scope here \u2014 atomic-delete + visual-styling is the headline win; multi-mention preservation is iterative.
- **No color fallback**: cyan overlay is invisible on monochrome terminals, but atomic delete still works. Acceptable degradation.
- **Auto-generated element IDs are discarded**: if a future feature needs to find/replace specific elements, it should switch to `insert_named_element` with meaningful IDs. YAGNI for now.

## Refs

- Part of epic #1178 (codex bottom_pane adoption)
- Builds on PR 1 (#1179), PR 2 (#1181), PR 3 (#1182), PR 4 (#1183)
- Last planned PR in the priority queue: PR 6 \u2014 masked render