### PR TITLE
feat(composer): masked render for API key entry (PR 6 of #1178)

### DIFF
--- a/koda-cli/src/composer/textarea.rs
+++ b/koda-cli/src/composer/textarea.rs
@@ -88,7 +88,10 @@
 // `vim_mode_label`, `should_handle_vim_insert_escape`) via the `/vim` slash
 // command + status-bar pill + Esc routing. PR 5 wired up named elements
 // (`insert_element`, element-aware rendering, atomic backspace) via the
-// @-mention completion path in `tui_context::events::handle_key`.
+// @-mention completion path in `tui_context::events::handle_key`. PR 6
+// wired up masked render (`render_ref_masked` + `TextAreaState`) via the
+// `PromptMode::WizardInput { mask: true }` branch in `tui_viewport.rs`,
+// used by the API-key entry wizard.
 //
 // Still unused (will go away as each follow-up PR wires them up):
 //   - paste-burst integration glue (PR 3 scope was deferred — mac/linux dev
@@ -98,7 +101,8 @@
 //     because koda's @-mention flow doesn't need stable IDs for later
 //     replacement (cycling Tab clears + reinserts via
 //     `set_text_clearing_elements`)
-//   - masked / highlighted render paths — PR 6 scope
+//   - render_ref_styled / render_ref_styled_with_highlights — future
+//     syntax-highlighted composer scope (PR 7+)
 //   - several vim_normal_keymap fields (operator-pending edge cases not yet
 //     exercised by `input(key)` dispatch in koda's call sites)
 #![allow(dead_code)]
@@ -3519,5 +3523,62 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ── PR 6 of #1178: masked render path ────────────────────────────
+    //
+    // `render_ref_masked` is the display-layer protection for API key
+    // entry. The buffer underneath stays cleartext (the wizard handler
+    // reads it via `text()`); only the rendered glyphs change. These
+    // tests pin both halves of that contract.
+
+    #[test]
+    fn render_ref_masked_replaces_all_visible_chars_with_mask_glyph() {
+        let t = ta_with("sk-secret-api-key-12345");
+        let area = Rect::new(0, 0, 30, 1);
+        let mut state = TextAreaState::default();
+        let mut buf = Buffer::empty(area);
+        t.render_ref_masked(area, &mut buf, &mut state, '*', Style::default());
+
+        // First 23 cells (the secret length) must all be `*`. Cells
+        // beyond the text length stay blank — we only care that NONE
+        // of the original cleartext leaked.
+        let secret_len = "sk-secret-api-key-12345".len();
+        for x in 0..secret_len as u16 {
+            let ch = buf[(area.x + x, area.y)].symbol();
+            assert_eq!(
+                ch, "*",
+                "position {x} leaked the cleartext (got {ch:?}, expected `*`)"
+            );
+        }
+        // Sanity: nothing in the rendered area equals any plaintext char.
+        for x in 0..area.width {
+            let ch = buf[(area.x + x, area.y)].symbol();
+            assert!(
+                ch == "*" || ch == " " || ch.is_empty(),
+                "unexpected glyph {ch:?} at x={x}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_ref_masked_does_not_mutate_underlying_text() {
+        let mut t = ta_with("sk-very-secret");
+        let area = Rect::new(0, 0, 30, 1);
+        let mut state = TextAreaState::default();
+        let mut buf = Buffer::empty(area);
+        t.render_ref_masked(area, &mut buf, &mut state, '*', Style::default());
+        assert_eq!(
+            t.text(),
+            "sk-very-secret",
+            "masked render is display-only; the wizard handler must still\n             read back the cleartext via text()"
+        );
+        // The element list is also untouched (no element is created or
+        // dropped by the render pass).
+        assert!(t.text_elements().is_empty());
+        // And we can still mutate after a masked render — the textarea
+        // remains a fully-functional editable buffer.
+        t.insert_str("-extra");
+        assert_eq!(t.text(), "sk-very-secret-extra");
     }
 }

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -158,7 +158,11 @@ impl TuiContext {
                 format!("API key for {}", ptype)
             };
             self.menu = MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
-            self.prompt_mode = PromptMode::WizardInput { label };
+            // PR 6 of #1178: API key entry is the one masked wizard
+            // path. The textarea renders `*` chars instead of the
+            // actual keystrokes so over-the-shoulder onlookers and
+            // screen recordings don't capture the secret.
+            self.prompt_mode = PromptMode::WizardInput { label, mask: true };
             self.provider_wizard = Some(ProviderWizard::ApiKey {
                 provider_type: ptype,
                 base_url,
@@ -169,6 +173,7 @@ impl TuiContext {
             self.menu = MenuContent::WizardTrail(vec![("Provider".into(), provider_name)]);
             self.prompt_mode = PromptMode::WizardInput {
                 label: format!("{} URL", ptype),
+                mask: false,
             };
             self.provider_wizard = Some(ProviderWizard::Url {
                 provider_type: ptype,
@@ -531,7 +536,9 @@ impl TuiContext {
                         format!("API key for {}", provider_name)
                     };
                     self.menu = MenuContent::WizardTrail(vec![("Key".into(), provider_name)]);
-                    self.prompt_mode = PromptMode::WizardInput { label };
+                    // PR 6 of #1178: second API-key entry path (re-enter
+                    // an existing key from the /key picker). Also masked.
+                    self.prompt_mode = PromptMode::WizardInput { label, mask: true };
                     self.provider_wizard = Some(ProviderWizard::ApiKeyOnly { env_name });
                     self.textarea.set_text_clearing_elements("");
                 }

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -547,6 +547,7 @@ async fn handle_inference_key_inline(
             KeyCode::Char('f') | KeyCode::Char('F') => {
                 *prompt_mode = PromptMode::WizardInput {
                     label: "Feedback".into(),
+                    mask: false,
                 };
                 *menu = MenuContent::WizardTrail(vec![(
                     "Action".into(),
@@ -804,6 +805,7 @@ fn handle_inference_ui_inline(
         }) => {
             *prompt_mode = PromptMode::WizardInput {
                 label: "Answer".into(),
+                mask: false,
             };
             *menu = MenuContent::AskUser {
                 id,

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -114,7 +114,14 @@ pub(crate) enum PromptMode {
     /// Normal chat input: ⚡> █
     Chat,
     /// Wizard text input: label: █
-    WizardInput { label: String },
+    ///
+    /// `mask: true` swaps the textarea render path to
+    /// `render_ref_masked` so the user's keystrokes display as `*` —
+    /// used for API key entry (PR 6 of #1178). The underlying buffer is
+    /// still cleartext (the wizard handler reads it via `textarea.text()`),
+    /// so this is purely a display-layer protection against shoulder-
+    /// surfing / screen recording, not a memory-safety feature.
+    WizardInput { label: String, mask: bool },
 }
 
 /// Provider setup wizard state machine.

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -161,7 +161,23 @@ pub(crate) fn draw_viewport(
         frame.render_widget(placeholder, text_area);
         // Still render the textarea on top so the cursor is drawn.
     }
-    frame.render_widget(textarea, text_area);
+    // PR 6 of #1178: when the active wizard asked for masked input (API
+    // key entry today; future password / token flows tomorrow), use
+    // `render_ref_masked` so glyphs display as `*`. The buffer underneath
+    // is unchanged — read-back via `textarea.text()` still yields the
+    // cleartext secret for the wizard handler to persist.
+    if let PromptMode::WizardInput { mask: true, .. } = prompt_mode {
+        let mut state = crate::composer::textarea::TextAreaState::default();
+        textarea.render_ref_masked(
+            text_area,
+            frame.buffer_mut(),
+            &mut state,
+            '*',
+            Style::default(),
+        );
+    } else {
+        frame.render_widget(textarea, text_area);
+    }
 
     // ── Bottom row: key hint footer (PR 4 of #1178) ────────────────────
     // Replaces the previous flat "───" separator with a single dim row


### PR DESCRIPTION
Wires up the codex-port `render_ref_masked` path so that when a wizard asks for sensitive input (currently the two API-key entry flows under `/key` and `/provider`), the textarea displays `*` glyphs instead of the user's actual keystrokes. Protects against shoulder-surfing, screen recordings, screen-share demos, and pair-programming awkwardness.

The underlying buffer is unchanged \u2014 the wizard handler still reads back the cleartext via `textarea.text()` for keystore persistence. **This is a display-layer protection, not a memory-safety feature.**

## What landed

| Piece | Detail |
|---|---|
| **`PromptMode::WizardInput` extended** | New `mask: bool` field, documented as display-only. All five existing constructors updated: 2x API-key paths \u2192 `mask: true`, URL/Feedback/Answer prompts \u2192 `mask: false`. Existing `matches!(.., WizardInput { .. })` patterns are field-additive-safe (already use `{ .. }` rest pattern). |
| **`tui_viewport.rs` render branch** | When `prompt_mode` matches `WizardInput { mask: true, .. }`, route to `render_ref_masked` with `'*'` glyph + default style; otherwise fall through to the existing `render_widget(textarea, ...)` path. Uses a fresh `TextAreaState::default()` per frame because koda's textarea rendering is stateless from the viewport's POV. |
| **2 new unit tests** | `render_ref_masked_replaces_all_visible_chars_with_mask_glyph` (no plaintext leakage to the rendered buffer) \u00b7 `render_ref_masked_does_not_mutate_underlying_text` (the cleartext stays read-back-able for the wizard handler). |

## dead_code allow refresh

`composer/textarea.rs`: PR 6 added to the wired-up list. Remaining dormant items are styled-render variants (deferred to future syntax-highlighted composer scope, PR 7+), id-based named-element APIs (PR 5 rationale still applies), paste-burst glue (deferred), and operator-pending vim_normal_keymap edge cases.

## Quality gate

```
cargo fmt --all                                  no changes
cargo build -p koda-cli                          0 warnings
cargo clippy --workspace --all-targets \\
     --features koda-core/test-support \\
     -- -D warnings                              clean
cargo test --workspace --features \\
     koda-core/test-support --no-fail-fast       2349 passed, 0 failed,
                                                 15 ignored
```

## Diff at a glance

```
 5 files changed, 99 insertions(+), 6 deletions(-)
```

| File | Change |
|---|---|
| `composer/textarea.rs` | +63/-2 (allow refresh + 2 tests) |
| `tui_context/menus.rs` | +9/-2 (mask: true\u00d72, false\u00d71) |
| `tui_handlers_inference.rs` | +2 (mask: false\u00d72) |
| `tui_types.rs` | +8/-1 (PromptMode field + doc) |
| `tui_viewport.rs` | +17/-1 (masked render branch) |

## Risk surface

- **Display-only, not memory-only**: the cleartext lives in the textarea buffer for the duration of the wizard. A core dump or `tmux capture-pane` on the buffer state would still expose the secret. Hardening this would require dropping cleartext after each keystroke and reconstructing only at submit time \u2014 large refactor; YAGNI for `/key`.
- **Cursor visibility under mask**: cursor still blinks at the right column, which is desirable \u2014 users need to see their typing position even when characters are hidden.
- **Paste-into-masked-textarea is also masked**: matches every other password field on the planet. Accept as expected UX.

## Refs

- Part of epic #1178 (codex bottom_pane adoption)
- Builds on PR 1 (#1179), PR 2 (#1181), PR 3 (#1182), PR 4 (#1183), PR 5 (#1184)
- Closes the priority-queue plan from this session