### PR TITLE
hotfix(tui-context/events): restore `use super::*;` in `mod tests` (merge-skew from #1189 + #1190)

### DIFF
--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -575,7 +575,14 @@ fn clamp_to_char_boundary(s: &str, mut idx: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    // ── History DB persistence ────────────────────────────────
+    // Bring file-private helpers (`plain_char`, `is_plain_insertable_char`,
+    // `clamp_to_char_boundary`) into scope. Lost in the merge skew between
+    // #1189 (added paste_burst tests using these helpers) and #1190
+    // (composer extraction, which moved the history-nav tests out of
+    // this module — carrying the `use super::*` with them).
+    use super::*;
+
+    // ── History DB persistence ───────────────────────────────────
     //
     // Pure index-math tests live in `crate::composer::history_nav` (#1187).
     // What stays here is the integration with `koda_core::db::Database`,


### PR DESCRIPTION
## 🚨 What's broken

Running `cargo test --workspace` on `main` (after #1189 + #1190 both landed) fails with **17 `E0425` errors**:

```
error[E0425]: cannot find function `plain_char` in this scope
error[E0425]: cannot find function `is_plain_insertable_char` in this scope
error[E0425]: cannot find function `clamp_to_char_boundary` in this scope
... (×17 total)
```

The lib itself compiles; only `cargo test --lib` for `koda-cli` is broken.

## Root cause: classic merge skew

| PR | Touched | Effect on `mod tests` |
|---|---|---|
| **#1190** (composer extraction) | Moved history-nav tests OUT of the file → carried the `use super::*;` import with them | Lost the import |
| **#1189** (paste_burst wiring) | Added 6 new tests at the bottom that rely on file-private helpers | Now references unresolved symbols |

Both PRs touched `koda-cli/src/tui_context/events.rs` in **non-overlapping line regions**, so neither PR's CI saw the breakage. It only manifests with both merges combined.

This is exactly the failure mode our merge of #1190 right after #1189 risked — and unfortunately the GitHub auto-merge "both still mergeable" check doesn't catch this class of latent skew.

## The fix

One-line addition () plus a 7-line comment explaining the regression so future-us doesn't reintroduce it:

```rust
#[cfg(test)]
mod tests {
    // Bring file-private helpers (`plain_char`, `is_plain_insertable_char`,
    // `clamp_to_char_boundary`) into scope. Lost in the merge skew between
    // #1189 (added paste_burst tests using these helpers) and #1190
    // (composer extraction, which moved the history-nav tests out of
    // this module — carrying the `use super::*` with them).
    use super::*;
    ...
}
```

## Validation

| Gate | Result |
|---|---|
| `cargo test --workspace` | ✅ **2359/2359 passing** (was 0 buildable before) |
| `cargo test -p koda-cli --lib` | ✅ 582/582 passing |
| `cargo test -p koda-core --lib` | ✅ 1138/1138 passing |
| `cargo clippy -p koda-cli --all-targets --features koda-core/test-support -- -D warnings` | ✅ clean |
| `cargo fmt --all -- --check` | ✅ clean |

## Why this should land FAST

- Blocks `cargo test --workspace` on main (CI red on every PR until this lands)
- Blocks the in-flight #1159 PR work (can't run workspace tests for validation)
- 1 line of actual change + tests document themselves

## Process improvement (for the audit-dust prevention rule)

Future merges of two PRs touching the same file (even in non-overlapping regions) should run `cargo test --workspace` against the **merged HEAD** before the second PR's auto-merge fires. The current `mergeable: CLEAN` check is necessary but not sufficient — non-syntactic semantic conflicts (like missing imports for newly-added test code) slip through.

🐶 — code