### PR TITLE
fix(bg-agent): persist completion as Role::Tool keyed on parent tool_call_id (closes #1159)

### DIFF
--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -575,7 +575,14 @@ fn clamp_to_char_boundary(s: &str, mut idx: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    // ── History DB persistence ────────────────────────────────
+    // Bring file-private helpers (`plain_char`, `is_plain_insertable_char`,
+    // `clamp_to_char_boundary`) into scope. Lost in the merge skew between
+    // #1189 (added paste_burst tests using these helpers) and #1190
+    // (composer extraction, which moved the history-nav tests out of
+    // this module — carrying the `use super::*` with them).
+    use super::*;
+
+    // ── History DB persistence ───────────────────────────────────
     //
     // Pure index-math tests live in `crate::composer::history_nav` (#1187).
     // What stays here is the integration with `koda_core::db::Database`,

--- a/koda-core/src/db/queries.rs
+++ b/koda-core/src/db/queries.rs
@@ -125,6 +125,76 @@ pub(crate) fn prune_whitespace_only_messages(messages: &mut Vec<Message>) {
     });
 }
 
+/// Dedupe `Role::Tool` rows that share a `tool_call_id`, keeping only the
+/// **latest** (highest `id` — our `created_at` proxy since both are
+/// monotonic per session) for each id.
+///
+/// # Why
+///
+/// (#1159) Background sub-agents now emit a `Role::Tool` row at completion
+/// keyed on the parent `InvokeAgent`'s `tool_call_id`. The original
+/// dispatch-turn write (the synchronous "Background agent X started
+/// (agent:N)..." stub returned by `InvokeAgent`) is *also* a `Role::Tool`
+/// row with the same `tool_call_id`. Sending both to a provider violates
+/// the `tool_use_id` ↔ `tool_result_id` 1:1 invariant that Anthropic
+/// enforces (and that OpenAI/Gemini handle via last-write-wins anyway).
+///
+/// This pass is a logical "update via append" — we keep every row in the
+/// DB for transcript fidelity (debug bundles, `/copy`, etc. see the full
+/// history via `load_all_messages`) but the model only sees the latest
+/// status per call when its context is loaded for the next turn.
+///
+/// # Algorithm
+///
+/// O(n) two-pass. Pass 1 collects the max `id` per `tool_call_id` for
+/// `Role::Tool` rows. Pass 2 retains a `Role::Tool` row only if it is the
+/// max-id row for its id (or has no `tool_call_id`, which is impossible
+/// for valid Tool rows but defended against). Non-Tool rows are untouched.
+pub(crate) fn dedupe_tool_results_by_call_id(messages: &mut Vec<Message>) {
+    if messages.is_empty() {
+        return;
+    }
+
+    // Pass 1: max id per tool_call_id, restricted to Role::Tool rows.
+    let mut latest_id_for: std::collections::HashMap<String, i64> =
+        std::collections::HashMap::new();
+    for msg in messages.iter() {
+        if msg.role == Role::Tool
+            && let Some(call_id) = msg.tool_call_id.as_deref()
+        {
+            latest_id_for
+                .entry(call_id.to_string())
+                .and_modify(|cur| {
+                    if msg.id > *cur {
+                        *cur = msg.id;
+                    }
+                })
+                .or_insert(msg.id);
+        }
+    }
+
+    // Early-out: every Role::Tool row was already unique-by-call_id.
+    if latest_id_for.is_empty() {
+        return;
+    }
+
+    // Pass 2: retain non-Tool rows + the latest Tool row per call_id.
+    messages.retain(|msg| {
+        if msg.role != Role::Tool {
+            return true;
+        }
+        let Some(call_id) = msg.tool_call_id.as_deref() else {
+            // Defensive: a Tool row with no tool_call_id is malformed but
+            // we don't drop it here — `prune_mismatched_tool_calls` will
+            // handle it on a subsequent pass if needed.
+            return true;
+        };
+        latest_id_for
+            .get(call_id)
+            .is_none_or(|&max_id| msg.id == max_id)
+    });
+}
+
 // ── Interrupted turn detection (#594) ─────────────────────────────────────
 
 /// Inspect the tail of a message history to detect an interrupted turn.
@@ -355,6 +425,9 @@ impl Persistence for Database {
     /// - Mismatched tool_use / tool_result pairs are pruned (#428)
     /// - Null-content assistant messages with no tool calls are dropped (#594)
     /// - Whitespace-only assistant messages are dropped (#594)
+    /// - Duplicate `Role::Tool` rows sharing a `tool_call_id` are deduped
+    ///   to the latest write (#1159 — background sub-agent completion
+    ///   updates the original `InvokeAgent` tool_result via append).
     async fn load_context(&self, session_id: &str) -> Result<Vec<Message>> {
         let mut messages: Vec<Message> = sqlx::query_as::<_, MessageRow>(
             "SELECT id, session_id, role, content, full_content, tool_calls, tool_call_id,
@@ -377,6 +450,7 @@ impl Persistence for Database {
         prune_mismatched_tool_calls(&mut messages); // (#428)
         prune_null_content_messages(&mut messages); // (#594)
         prune_whitespace_only_messages(&mut messages); // (#594)
+        dedupe_tool_results_by_call_id(&mut messages); // (#1159)
 
         Ok(messages)
     }

--- a/koda-core/src/db/tests.rs
+++ b/koda-core/src/db/tests.rs
@@ -6,7 +6,8 @@
 
 use super::queries::prune_mismatched_tool_calls;
 use super::queries::{
-    detect_interruption, prune_null_content_messages, prune_whitespace_only_messages,
+    dedupe_tool_results_by_call_id, detect_interruption, prune_null_content_messages,
+    prune_whitespace_only_messages,
 };
 use crate::db::Database;
 use crate::persistence::{InterruptionKind, Message, Persistence, Role};
@@ -438,6 +439,239 @@ fn test_prune_mismatched_tool_calls_unit() {
     prune_mismatched_tool_calls(&mut msgs);
     assert_eq!(msgs.len(), 3, "complete pair should be preserved");
     assert!(msgs[1].tool_calls.is_some());
+}
+
+// ── #1159: dedupe_tool_results_by_call_id ─────────────────────────────────
+
+/// Helper: build a `Message` with an explicit `id`. Mirrors the helper in
+/// `test_prune_mismatched_tool_calls_unit` but sets `id` so we can
+/// exercise the "latest by id" semantics.
+fn msg_with_id(id: i64, role: &str, content: Option<&str>, tool_call_id: Option<&str>) -> Message {
+    Message {
+        id,
+        session_id: String::new(),
+        role: role.parse().unwrap_or(Role::User),
+        content: content.map(Into::into),
+        full_content: None,
+        tool_calls: None,
+        tool_call_id: tool_call_id.map(Into::into),
+        prompt_tokens: None,
+        completion_tokens: None,
+        cache_read_tokens: None,
+        cache_creation_tokens: None,
+        thinking_tokens: None,
+        thinking_content: None,
+        created_at: None,
+    }
+}
+
+#[test]
+fn dedupe_empty_input_is_noop() {
+    let mut msgs: Vec<Message> = vec![];
+    dedupe_tool_results_by_call_id(&mut msgs);
+    assert!(msgs.is_empty());
+}
+
+#[test]
+fn dedupe_no_tool_rows_is_noop() {
+    let mut msgs = vec![
+        msg_with_id(1, "user", Some("hi"), None),
+        msg_with_id(2, "assistant", Some("hello"), None),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+    assert_eq!(msgs.len(), 2);
+}
+
+#[test]
+fn dedupe_unique_call_ids_preserved() {
+    let mut msgs = vec![
+        msg_with_id(1, "tool", Some("result for tc1"), Some("tc1")),
+        msg_with_id(2, "tool", Some("result for tc2"), Some("tc2")),
+        msg_with_id(3, "tool", Some("result for tc3"), Some("tc3")),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+    assert_eq!(msgs.len(), 3, "unique call_ids must all survive");
+}
+
+#[test]
+fn dedupe_keeps_latest_for_same_call_id() {
+    // The bg-agent scenario: dispatch-turn stub (id=2) then async
+    // completion (id=5) sharing the parent InvokeAgent's tool_call_id.
+    let mut msgs = vec![
+        msg_with_id(1, "user", Some("please explore"), None),
+        msg_with_id(2, "tool", Some("started (agent:1)"), Some("tc1")),
+        msg_with_id(3, "assistant", Some("working on it"), None),
+        msg_with_id(5, "tool", Some("[completed] Found 3 issues"), Some("tc1")),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+
+    assert_eq!(msgs.len(), 3, "the dispatch-turn stub must be dropped");
+    let tool = msgs.iter().find(|m| m.role == Role::Tool).unwrap();
+    assert_eq!(
+        tool.id, 5,
+        "only the latest tool_result for tc1 should remain"
+    );
+    assert!(
+        tool.content.as_deref().unwrap().contains("Found 3 issues"),
+        "latest content must be preserved"
+    );
+}
+
+#[test]
+fn dedupe_handles_many_call_ids_independently() {
+    // Mixed: tc1 has 2 writes, tc2 has 3 writes, tc3 has 1 write.
+    let mut msgs = vec![
+        msg_with_id(1, "tool", Some("tc1 stub"), Some("tc1")),
+        msg_with_id(2, "tool", Some("tc2 stub"), Some("tc2")),
+        msg_with_id(3, "tool", Some("tc3 only"), Some("tc3")),
+        msg_with_id(4, "tool", Some("tc1 final"), Some("tc1")),
+        msg_with_id(5, "tool", Some("tc2 mid"), Some("tc2")),
+        msg_with_id(6, "tool", Some("tc2 final"), Some("tc2")),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+
+    assert_eq!(
+        msgs.len(),
+        3,
+        "one tool_result per unique call_id should remain"
+    );
+    let by_call_id: std::collections::HashMap<&str, &str> = msgs
+        .iter()
+        .filter_map(|m| {
+            Some((
+                m.tool_call_id.as_deref()?,
+                m.content.as_deref().unwrap_or(""),
+            ))
+        })
+        .collect();
+    assert_eq!(by_call_id.get("tc1"), Some(&"tc1 final"));
+    assert_eq!(by_call_id.get("tc2"), Some(&"tc2 final"));
+    assert_eq!(by_call_id.get("tc3"), Some(&"tc3 only"));
+}
+
+#[test]
+fn dedupe_preserves_non_tool_rows_around_dupes() {
+    let mut msgs = vec![
+        msg_with_id(1, "system", Some("sys prompt"), None),
+        msg_with_id(2, "user", Some("do the thing"), None),
+        msg_with_id(3, "tool", Some("stub"), Some("tc1")),
+        msg_with_id(4, "assistant", Some("i delegated"), None),
+        msg_with_id(5, "tool", Some("final"), Some("tc1")),
+        msg_with_id(6, "user", Some("thanks"), None),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+
+    assert_eq!(msgs.len(), 5, "only the duplicate Tool stub should drop");
+    let roles: Vec<Role> = msgs.iter().map(|m| m.role.clone()).collect();
+    assert_eq!(
+        roles,
+        vec![
+            Role::System,
+            Role::User,
+            Role::Assistant,
+            Role::Tool,
+            Role::User,
+        ]
+    );
+}
+
+#[test]
+fn dedupe_tool_row_without_call_id_is_kept() {
+    // Defensive: a malformed Tool row with no tool_call_id should not be
+    // dropped by this pass (other passes handle malformed rows).
+    let mut msgs = vec![
+        msg_with_id(1, "tool", Some("orphan"), None),
+        msg_with_id(2, "tool", Some("keyed"), Some("tc1")),
+    ];
+    dedupe_tool_results_by_call_id(&mut msgs);
+    assert_eq!(msgs.len(), 2, "orphan Tool row is kept (not our concern)");
+}
+
+/// End-to-end through `load_context`: simulates the real bg-agent flow.
+///
+/// (#1159) Sequence: user prompt → assistant calls InvokeAgent(tc1) →
+/// dispatch-turn stub tool_result(tc1) → assistant works on something else
+/// → async drain writes a second tool_result(tc1) on completion. The
+/// model on its next turn should see ONLY the completion, not the stub.
+#[tokio::test]
+async fn dedupe_via_load_context_keeps_only_latest_bg_completion() {
+    let (db, _tmp) = setup().await;
+    let session = db.create_session("default", _tmp.path()).await.unwrap();
+
+    // Turn 1: user asks, assistant invokes a bg sub-agent.
+    db.insert_message(
+        &session,
+        &Role::User,
+        Some("please explore"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let mid = db
+        .insert_message(
+            &session,
+            &Role::Assistant,
+            Some("I'll spawn an explorer"),
+            Some(r#"[{"id":"tc1","name":"InvokeAgent","arguments":"{}"}]"#),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    db.mark_message_complete(mid).await.unwrap();
+
+    // Synchronous dispatch result: "started (agent:1)" stub keyed on tc1.
+    db.insert_tool_message_with_full(
+        &session,
+        "Background agent 'explore' started (agent:1). Results will be injected when complete.",
+        "tc1",
+        "Background agent 'explore' started (agent:1). Results will be injected when complete.",
+    )
+    .await
+    .unwrap();
+
+    // (Imagine the assistant did other work here.)
+
+    // Async drain: completion writes a SECOND tool_result keyed on tc1.
+    db.insert_tool_message_with_full(
+        &session,
+        "[Background agent 'explore' completed]\nOriginal task: explore\nResult:\nFound 3 issues.",
+        "tc1",
+        "[Background agent 'explore' completed]\nOriginal task: explore\nResult:\nFound 3 issues.",
+    )
+    .await
+    .unwrap();
+
+    let msgs = db.load_context(&session).await.unwrap();
+
+    let tool_rows: Vec<&Message> = msgs.iter().filter(|m| m.role == Role::Tool).collect();
+    assert_eq!(
+        tool_rows.len(),
+        1,
+        "only the latest tool_result for tc1 should reach the provider context, got {tool_rows:#?}"
+    );
+    let surviving = tool_rows[0];
+    assert_eq!(surviving.tool_call_id.as_deref(), Some("tc1"));
+    assert!(
+        surviving.content.as_deref().unwrap().contains("completed"),
+        "the completion content should win, not the stub"
+    );
+    assert!(
+        !surviving.content.as_deref().unwrap().contains("started"),
+        "the dispatch-turn stub must NOT be the surviving row"
+    );
+
+    // The full transcript (load_all_messages) preserves both rows for
+    // debug-bundle / forensic use.
+    let all = db.load_all_messages(&session).await.unwrap();
+    let all_tool_rows: Vec<&Message> = all.iter().filter(|m| m.role == Role::Tool).collect();
+    assert_eq!(
+        all_tool_rows.len(),
+        2,
+        "load_all_messages must preserve full history (both stub and completion)"
+    );
 }
 
 #[tokio::test]

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -758,8 +758,37 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                     }
                 }
             }
-            db.insert_message(session_id, &Role::User, Some(&injection), None, None, None)
+            // #1159: write the completion as a `Role::Tool` row keyed on the
+            // parent's `InvokeAgent` tool_call_id, NOT as a synthetic
+            // `Role::User` message.
+            //
+            // Why the change:
+            //   - Pre-fix, completed bg-agent results landed as fake user
+            //     turns, polluting the parent's context and breaking the
+            //     `tool_use_id` ↔ `tool_result_id` pairing invariant that
+            //     providers (especially Anthropic) prefer.
+            //   - The `InvokeAgent` dispatch already emitted a synchronous
+            //     "started (agent:N)" tool_result on the dispatch turn.
+            //     This second tool_result with the *same* `tool_call_id`
+            //     overwrites that stub at read time via
+            //     `dedupe_tool_results_by_call_id` in `load_context`
+            //     (logical update via append + dedupe).
+            //
+            // Fallback: tests that bypass the dispatch path have no
+            // `parent_tool_call_id` — keep the old user-message shape
+            // for those callers so existing test fixtures don't break.
+            if let Some(parent_call_id) = bg_result.parent_tool_call_id.as_deref() {
+                db.insert_tool_message_with_full(
+                    session_id,
+                    &injection,
+                    parent_call_id,
+                    &injection,
+                )
                 .await?;
+            } else {
+                db.insert_message(session_id, &Role::User, Some(&injection), None, None, None)
+                    .await?;
+            }
         }
 
         // Drain any `QueueNext` inputs the client sent during the previous


### PR DESCRIPTION
## Closes #1159

Background sub-agent completions now write a real `Role::Tool` row keyed on the parent `InvokeAgent`'s `tool_call_id`, instead of a fake `Role::User` message.

## ⚠️ Stacked on #1192

This PR includes a cherry-picked commit from #1192 (the merge-skew hotfix). When #1192 lands, the cherry-pick will auto-resolve away on rebase. **Do not merge this PR until #1192 lands first.**

## Problem (the bug we're closing)

Pre-fix, when a bg sub-agent completed asynchronously, the drain code wrote the result like this:

```rust
db.insert_message(session_id, &Role::User, Some(&injection), None, None, None).await?;
```

Three concrete harms:

1. **Pollution of conversation history.** The model sees a 'user' say things the actual user never typed. Looks like role-confusion to the model and to anyone reading transcripts.
2. **Provider invariant violation.** Anthropic enforces `tool_use_id` ↔ `tool_result_id` 1:1 — when a bg-agent's parent `InvokeAgent` had a synchronous "started (agent:N)" `tool_result`, the completion arriving as a `User` message left the bg-agent's tool_call dangling forever (no second result).
3. **Transcript ambiguity.** `/copy`, debug bundles, and markdown exports couldn't reliably attribute who said what.

## Fix (two coordinated changes, both in `koda-core`)

### Change 1 — `koda-core/src/inference.rs` (~30 lines)

Bg-agent drain handler now writes `Role::Tool` keyed on `parent_tool_call_id`:

```rust
if let Some(parent_call_id) = bg_result.parent_tool_call_id.as_deref() {
    db.insert_tool_message_with_full(
        session_id,
        &injection,
        parent_call_id,
        &injection,
    ).await?;
} else {
    // Fallback for test fixtures bypassing dispatch
    db.insert_message(session_id, &Role::User, Some(&injection), None, None, None).await?;
}
```

### Change 2 — `koda-core/src/db/queries.rs` (~75 lines + wired into `load_context`)

New `dedupe_tool_results_by_call_id` pass that keeps only the **latest** `Role::Tool` row per `tool_call_id` (highest `id` wins, since `id` is monotonic per-session).

Why this is needed: the dispatch turn already wrote a synchronous `Role::Tool` row (the "Background agent X started (agent:N)..." stub) with the same `tool_call_id`. Without dedupe, providers would see two `tool_results` for one `tool_use`. With dedupe, the model on its next turn sees ONLY the completion — which is the logical "update via append" pattern from event-sourced systems.

The full transcript (`load_all_messages`) keeps both rows for forensic debugging.

## Why this is safe (provider-by-provider)

| Provider | Pre-fix behavior | Post-fix behavior | Net |
|---|---|---|---|
| **Anthropic** | Threw `invalid_request_error` when bg completion landed as User after a stub | Receives one tool_result per tool_use_id (invariant satisfied) | ✅ fixes a crash class |
| **OpenAI** | Lenient last-write-wins on duplicate `tool_call_id`; saw the fake user msg | Receives one tool_result, no fake user | ✅ fewer tokens, cleaner |
| **Gemini** | function-response normalizer handles ordering | One fewer item to normalize | ✅ strictly better |

## Pruning order matters (and is correct)

`load_context` runs sanitization passes in this order (with the new addition):

```
prune_mismatched_tool_calls  // (#428)
prune_null_content_messages  // (#594)
prune_whitespace_only_messages  // (#594)
dedupe_tool_results_by_call_id  // (#1159) ← new
```

The existing prune uses `HashSet<String>` for both call_ids and return_ids — it collapses our two `Role::Tool` rows into one entry, so symmetric_difference passes ✅. No false-positive prunes. Dedupe THEN runs, keeping only the latest.

## Test coverage (+8 tests, 0 deletions)

| Test | What it locks in |
|---|---|
| `dedupe_empty_input_is_noop` | Empty input doesn't crash |
| `dedupe_no_tool_rows_is_noop` | Skips work when nothing applies |
| `dedupe_unique_call_ids_preserved` | Doesn't drop rows that are already unique |
| `dedupe_keeps_latest_for_same_call_id` | The bg-agent core scenario: stub then completion |
| `dedupe_handles_many_call_ids_independently` | Mixed duplicates per-id, independent buckets |
| `dedupe_preserves_non_tool_rows_around_dupes` | System/User/Assistant rows untouched |
| `dedupe_tool_row_without_call_id_is_kept` | Defensive: orphan Tool rows survive (other passes handle them) |
| `dedupe_via_load_context_keeps_only_latest_bg_completion` | **End-to-end**: live SQLite, full bg-agent flow, asserts both `load_context` (1 Tool row) AND `load_all_messages` (2 Tool rows for forensic value) |

## Validation gates

| Gate | Result |
|---|---|
| `cargo test --workspace` | ✅ **2367/2367 passing** (baseline 2359 + 8 new) |
| `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` | ✅ clean |
| `cargo fmt --all -- --check` | ✅ clean |
| Total diff | +339 / -2, 3 files (well under our 600-line file budget) |

## What this PR is **not**

- Not a UX change. The TUI continues to render `Role::Tool` rows the same way it always has (via `history_render::render_tool_result` → `tool_header` + `tool_history`). The fix is invisible to users except that:
  - Anthropic users stop hitting the dangling-tool_use crash
  - All users get a cleaner conversation history (no fake user turns)

- Not a bg-agent UX overhaul. Four candidate UX improvements (interactive `/agents` view, completion popup, clickable status pill, compose hint line) are filed as **#1191** for a future epic.

- Not touching the textarea, composer, or any TUI primitive. The bg-agent layering invariant (engine in `koda-core`, presentation in `koda-cli`, **nothing** in textarea/composer) is preserved by design.

🐶 — code