### PR TITLE
feat(tui): interactive /agents panel with cancel (closes #1191)

### DIFF
--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -65,116 +65,9 @@ use crate::scroll_buffer::ScrollBuffer;
 use crate::tui_output;
 use koda_core::tools::bg_task_tools::TaskId;
 use ratatui::style::Modifier;
-use ratatui::text::{Line, Span};
+use ratatui::text::Span;
 
-use tui_output::{BOLD, CYAN, DIM};
-
-/// Render `/agents` — a compact unified table of every currently-pending
-/// background task. Reads
-/// [`koda_core::bg_agent::BgAgentRegistry::snapshot`] and
-/// [`koda_core::tools::bg_process::BgRegistry::snapshot`] (both sync,
-/// no async). Empty registries render an explicit "No background tasks."
-/// line so the user knows the command worked rather than wondering
-/// if `/agents` silently failed.
-///
-/// Process snapshots are taken *after* a [`reap`] call so freshly-exited
-/// processes show their final status instead of stale `Running`.
-///
-/// [`reap`]: koda_core::tools::bg_process::BgRegistry::reap
-pub(crate) fn handle_list_background_tasks(
-    buffer: &mut ScrollBuffer,
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
-    bg_processes: &koda_core::tools::bg_process::BgRegistry,
-) {
-    // Refresh process statuses so users see the latest exit codes
-    // rather than stale `Running` entries. Mirrors what the LLM-tool
-    // path does in `bg_task_tools::execute_list`.
-    bg_processes.reap();
-
-    let agent_snaps = bg_agents.snapshot();
-    let process_snaps = bg_processes.snapshot();
-
-    tui_output::blank(buffer);
-    tui_output::emit_line(buffer, Line::styled("  \u{1f43e} Background tasks", BOLD));
-    tui_output::blank(buffer);
-
-    if agent_snaps.is_empty() && process_snaps.is_empty() {
-        tui_output::dim_msg(buffer, "No background tasks.".into());
-        tui_output::blank(buffer);
-        tui_output::dim_msg(
-            buffer,
-            "Ask Koda to launch one with `background: true` in InvokeAgent or Bash.".into(),
-        );
-        return;
-    }
-
-    // ── Column widths ─────────────────────────────────────────────
-    //
-    // ID column holds prefixed ids like `agent:9999` or `process:65535`,
-    // so we size to the longest actual id rather than a fixed 4.
-    // NAME column shows agent name OR process command head; pad to
-    // the longest with a sane minimum of 8.
-    let id_strings: Vec<String> = agent_snaps
-        .iter()
-        .map(|s| format!("agent:{}", s.task_id))
-        .chain(process_snaps.iter().map(|s| format!("process:{}", s.pid)))
-        .collect();
-    let id_col = id_strings.iter().map(|s| s.len()).max().unwrap_or(8).max(8);
-
-    let name_col = agent_snaps
-        .iter()
-        .map(|s| s.agent_name.len())
-        .chain(process_snaps.iter().map(|s| command_head(&s.command).len()))
-        .max()
-        .unwrap_or(8)
-        .max(8);
-
-    // Header.
-    tui_output::emit_line(
-        buffer,
-        Line::from(vec![Span::styled(
-            format!(
-                "  {:<id_col$}  {:<name_col$}  {:<6}  STATUS",
-                "ID", "NAME", "AGE"
-            ),
-            DIM,
-        )]),
-    );
-
-    // Render agent rows first (they're the more common case for now),
-    // then process rows. Ordering inside each group is registry order
-    // (ascending task_id / pid).
-    for snap in &agent_snaps {
-        let id = format!("agent:{}", snap.task_id);
-        let mut spans = vec![Span::raw(format!(
-            "  {:<id_col$}  {:<name_col$}  {:<6}  ",
-            id,
-            snap.agent_name,
-            format_age(snap.age),
-        ))];
-        spans.extend(agent_status_spans(&snap.status));
-        tui_output::emit_line(buffer, Line::from(spans));
-    }
-
-    for snap in &process_snaps {
-        let id = format!("process:{}", snap.pid);
-        let name = command_head(&snap.command);
-        let mut spans = vec![Span::raw(format!(
-            "  {:<id_col$}  {:<name_col$}  {:<6}  ",
-            id,
-            name,
-            format_age(snap.age),
-        ))];
-        spans.extend(process_status_spans(&snap.status));
-        tui_output::emit_line(buffer, Line::from(spans));
-    }
-
-    tui_output::blank(buffer);
-    tui_output::dim_msg(
-        buffer,
-        "Use `/cancel agent:<id>` or `/cancel process:<id>` to stop one.".into(),
-    );
-}
+use tui_output::{CYAN, DIM};
 
 /// Render `/cancel <id>`. Routes to the right registry based on the
 /// parsed [`TaskId`]:
@@ -253,7 +146,11 @@ pub(crate) fn handle_cancel_background_task(
 /// `"2m"`. Matches user intent ("how many full Xs has it been
 /// running?") better than rounding to nearest, and avoids the
 /// confusing `"60s"` -> `"1m"` jitter at the boundary.
-fn format_age(d: std::time::Duration) -> String {
+///
+/// Made `pub(crate)` so the interactive bg-agents panel
+/// (`widgets::bg_agents_panel`, #1191) can reuse the same age format
+/// the flat `/agents` view used to use — visual consistency.
+pub(crate) fn format_age(d: std::time::Duration) -> String {
     let secs = d.as_secs();
     if secs < 60 {
         format!("{secs}s")
@@ -273,9 +170,12 @@ fn format_age(d: std::time::Duration) -> String {
 /// we only want enough to identify the process. We strip everything
 /// after the first 24 chars and append an ellipsis. Whitespace inside
 /// the head is preserved so `cargo test` reads naturally.
+///
+/// Made `pub(crate)` (along with [`command_head`] below) for reuse by
+/// `widgets::bg_agents_panel` (#1191).
 const COMMAND_HEAD_CHARS: usize = 24;
 
-fn command_head(cmd: &str) -> String {
+pub(crate) fn command_head(cmd: &str) -> String {
     let trimmed = cmd.trim();
     if trimmed.chars().count() <= COMMAND_HEAD_CHARS {
         trimmed.to_string()
@@ -288,7 +188,11 @@ fn command_head(cmd: &str) -> String {
 /// Color-coded status icon + label for bg **agents**, matching Codex's
 /// `multi_agents::status_summary_spans` palette: cyan running, green
 /// completed, red errored, dim cancelled / pending.
-fn agent_status_spans(status: &koda_core::bg_agent::AgentStatus) -> Vec<Span<'static>> {
+///
+/// Made `pub(crate)` for reuse by `widgets::bg_agents_panel` (#1191) —
+/// the interactive panel and the legacy flat printer must agree on
+/// the icon/color/text vocabulary.
+pub(crate) fn agent_status_spans(status: &koda_core::bg_agent::AgentStatus) -> Vec<Span<'static>> {
     use koda_core::bg_agent::AgentStatus;
     match status {
         AgentStatus::Pending => vec![Span::styled("\u{25d0} Pending", CYAN)],
@@ -338,7 +242,9 @@ fn agent_status_spans(status: &koda_core::bg_agent::AgentStatus) -> Vec<Span<'st
 /// - `Exited { code: Some(c) }` where c≠0 → `✗ Exited (c)` (red)
 /// - `Exited { code: None }` → `✗ Exited (signal)` (red) — POSIX returns
 ///   no code for signal-killed processes
-fn process_status_spans(
+///
+/// Made `pub(crate)` for reuse by `widgets::bg_agents_panel` (#1191).
+pub(crate) fn process_status_spans(
     status: &koda_core::tools::bg_process::BgProcessStatus,
 ) -> Vec<Span<'static>> {
     use koda_core::tools::bg_process::BgProcessStatus;
@@ -365,9 +271,11 @@ fn process_status_spans(
 /// `/agents` table. Codex uses 80 graphemes
 /// (`COLLAB_AGENT_RESPONSE_PREVIEW_GRAPHEMES`); we use 60 to keep
 /// rows readable on a 100-col terminal after the ID/NAME/AGE prefix.
+///
+/// Made `pub(crate)` for reuse by `widgets::bg_agents_panel` (#1191).
 const PREVIEW_CHARS: usize = 60;
 
-fn summary_preview(s: &str) -> String {
+pub(crate) fn summary_preview(s: &str) -> String {
     // Collapse all whitespace runs (including newlines and tabs) to
     // a single space — mirrors Codex's `split_whitespace().join(" ")`.
     // Without this, embedded newlines wreck the table layout.
@@ -554,152 +462,6 @@ mod tests {
     #[test]
     fn summary_preview_short_passes_through() {
         assert_eq!(summary_preview("all good"), "all good");
-    }
-
-    // ── handle_list_background_tasks ───────────────────────────────────────────────
-
-    /// Both registries empty: render the explicit "No background
-    /// tasks." line. Without it the user might wonder if `/agents`
-    /// is broken.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_empty_renders_explicit_message() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-        assert!(
-            text.contains("No background tasks."),
-            "empty registries should render explicit empty-state line, got: {text}"
-        );
-    }
-
-    /// Populated agent registry: every task surfaces with its
-    /// **prefixed** id (`agent:N`), agent name, and the Pending
-    /// status icon. Pinning the row content keeps the slash command's
-    /// contract stable across refactors.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_renders_each_pending_agent_with_prefix() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        let (id_a, _tx_a, _stx_a, _cancel_a) = register_entry(&reg, "explore", "map repo");
-        let (id_b, _tx_b, _stx_b, _cancel_b) = register_entry(&reg, "verify", "check tests");
-
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-
-        // Both ids must appear with the `agent:` prefix — bare numerics
-        // would be ambiguous now that processes share the table.
-        assert!(text.contains(&format!("agent:{id_a}")));
-        assert!(text.contains(&format!("agent:{id_b}")));
-        assert!(text.contains("explore"));
-        assert!(text.contains("verify"));
-        assert!(
-            text.contains("Pending"),
-            "Pending status label missing, got: {text}"
-        );
-    }
-
-    /// Status writes via the watch channel are reflected in the
-    /// rendered output. This is the contract that lets `/agents`
-    /// show live state — if it ever stales, the slash command
-    /// becomes useless.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_reflects_running_status() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        let (_id, _tx, status_tx, _cancel) = register_entry(&reg, "explore", "x");
-
-        // Flip Pending → Running { iter: 7 } before the snapshot.
-        status_tx.send(AgentStatus::Running { iter: 7 }).unwrap();
-
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-        assert!(
-            text.contains("Running"),
-            "expected 'Running' label, got: {text}"
-        );
-        // iter > 0 surfaces the per-iter detail.
-        assert!(
-            text.contains("iter 7"),
-            "expected per-iter detail when iter > 0, got: {text}"
-        );
-    }
-
-    /// Layer-0 placeholder semantics: `Running { iter: 0 }` means
-    /// "started but no per-iter info yet" — don't render a misleading
-    /// `"iter 0"`. Layer 4 (#1058) populated the field for bg agents.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_hides_iter_zero_placeholder() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        let (_id, _tx, status_tx, _cancel) = register_entry(&reg, "explore", "x");
-
-        status_tx.send(AgentStatus::Running { iter: 0 }).unwrap();
-
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-        assert!(text.contains("Running"));
-        assert!(
-            !text.contains("iter 0"),
-            "iter 0 should not render the per-iter detail (it's a Layer-0 placeholder), got: {text}"
-        );
-    }
-
-    /// Phase F: process registry rows surface alongside agent rows,
-    /// each with the `process:` prefix. We spawn a real `sleep 60`
-    /// so the snapshot reads from a live entry and we can
-    /// later kill it in cleanup.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_renders_processes_with_prefix() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        let pid = spawn_sleep_in_registry(&procs);
-
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-
-        assert!(
-            text.contains(&format!("process:{pid}")),
-            "process row missing or unprefixed, got: {text}"
-        );
-        // The command head should appear — at least the `sleep` prefix.
-        assert!(
-            text.contains("sleep"),
-            "expected command head 'sleep' in row, got: {text}"
-        );
-        // Status is live: should be Running when we just spawned.
-        assert!(
-            text.contains("Running"),
-            "freshly-spawned process should report Running, got: {text}"
-        );
-
-        // Cleanup so we don't leak a child past the test.
-        procs.kill(pid);
-    }
-
-    /// Phase F: agents and processes share one table. With both
-    /// registries populated we should see both prefixes in the
-    /// output — neither registry should crowd the other out.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn list_background_tasks_unifies_both_registries() {
-        let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
-        let procs = BgRegistry::new();
-        let (agent_id, _tx, _stx, _c) = register_entry(&reg, "explore", "x");
-        let pid = spawn_sleep_in_registry(&procs);
-
-        handle_list_background_tasks(&mut buf, &reg, &procs);
-        let text = buffer_text(&buf);
-
-        assert!(text.contains(&format!("agent:{agent_id}")));
-        assert!(text.contains(&format!("process:{pid}")));
-
-        procs.kill(pid);
     }
 
     // ── handle_cancel_background_task ──────────────────────────────────────────────

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -173,13 +173,22 @@ pub async fn handle_slash_command(
             SlashAction::Continue
         }
 
-        // #996 Layers 1+F — unified runtime task surface. `/agents` (plural)
-        // lists running tasks; `/agent` (singular) lists sub-agent definitions.
+        // #996 Layers 1+F + #1191 Candidate 2 — unified runtime task
+        // surface. `/agents` (plural) opens an INTERACTIVE panel
+        // (`MenuContent::BgAgentsPanel`); `/agent` (singular) lists
+        // sub-agent definitions inline.
+        //
+        // The panel replaces the legacy flat-text dump from
+        // `tui_bg_tasks::handle_list_background_tasks`. Snapshots are
+        // captured here at open-time — see
+        // `widgets::bg_agents_panel` for the snapshot-semantics
+        // rationale (frozen until reopen, simple > complex per Zen).
         "/agents" => {
-            crate::tui_bg_tasks::handle_list_background_tasks(
-                buffer,
-                &session.bg_agents,
-                &agent.tools.bg_registry,
+            agent.tools.bg_registry.reap();
+            let agents = session.bg_agents.snapshot();
+            let processes = agent.tools.bg_registry.snapshot();
+            *menu = crate::tui_types::MenuContent::BgAgentsPanel(
+                crate::widgets::bg_agents_panel::BgAgentsPanelState::new(agents, processes),
             );
             SlashAction::Continue
         }

--- a/koda-cli/src/tui_context/menus.rs
+++ b/koda-cli/src/tui_context/menus.rs
@@ -356,6 +356,88 @@ impl TuiContext {
             return Some(true);
         }
 
+        // Interactive `/agents` panel (#1191 Candidate 2). Owns its
+        // own state machine (List / Detail / ConfirmCancel) and full
+        // keyboard surface — we consume EVERY keypress while the panel
+        // is open so stray keys don't leak into the textarea behind it.
+        // Cancellation is fired live against the registries; status
+        // does not auto-refresh until the panel is reopened (per the
+        // snapshot-semantics doc on `BgAgentsPanelState`).
+        if let MenuContent::BgAgentsPanel(state) = &mut self.menu {
+            use crate::widgets::bg_agents_panel::{BgPanelMode, BgPanelRow};
+            match (state.mode, key.code) {
+                // ── List mode ──────────────────────────────────────
+                (BgPanelMode::List, KeyCode::Up) => state.up(),
+                (BgPanelMode::List, KeyCode::Down) => state.down(),
+                (BgPanelMode::List, KeyCode::Enter) => state.toggle_detail(),
+                (BgPanelMode::List, KeyCode::Char('c')) => state.request_cancel(),
+                (BgPanelMode::List, KeyCode::Esc | KeyCode::Char('q')) => {
+                    self.menu = MenuContent::None;
+                }
+                // ── Detail mode ────────────────────────────────────
+                (BgPanelMode::Detail, KeyCode::Enter) => state.toggle_detail(),
+                (BgPanelMode::Detail, KeyCode::Char('c')) => state.request_cancel(),
+                (BgPanelMode::Detail, KeyCode::Esc | KeyCode::Char('q')) => {
+                    let _ = state.back();
+                }
+                // ── Confirm-cancel mode ────────────────────────────
+                (BgPanelMode::ConfirmCancel, KeyCode::Char('y' | 'Y')) => {
+                    // Snapshot the selected row to a local before we
+                    // mutate self.menu / self.session — dropping the
+                    // borrow on state lets us call &-taking registry
+                    // methods without a borrow-checker fight.
+                    let target = state.selected().cloned();
+                    let _ = state.back();
+                    if let Some(row) = target {
+                        match row {
+                            BgPanelRow::Agent(snap) => {
+                                if self.session.bg_agents.cancel(snap.task_id) {
+                                    crate::tui_output::ok_msg(
+                                        &mut self.scroll_buffer,
+                                        format!(
+                                            "Cancellation requested for agent:{}. Result will inject shortly.",
+                                            snap.task_id
+                                        ),
+                                    );
+                                } else {
+                                    crate::tui_output::warn_msg(
+                                        &mut self.scroll_buffer,
+                                        format!(
+                                            "agent:{} no longer running (already finished or cancelled).",
+                                            snap.task_id
+                                        ),
+                                    );
+                                }
+                            }
+                            BgPanelRow::Process(snap) => {
+                                if self.agent.tools.bg_registry.kill(snap.pid) {
+                                    crate::tui_output::ok_msg(
+                                        &mut self.scroll_buffer,
+                                        format!(
+                                            "SIGTERM sent to process:{}. It should exit shortly.",
+                                            snap.pid
+                                        ),
+                                    );
+                                } else {
+                                    crate::tui_output::warn_msg(
+                                        &mut self.scroll_buffer,
+                                        format!("process:{} no longer running.", snap.pid),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+                (BgPanelMode::ConfirmCancel, KeyCode::Char('n' | 'N') | KeyCode::Esc) => {
+                    let _ = state.back();
+                }
+                // Any other key in any mode: swallow silently so the
+                // textarea behind the panel doesn't pick it up.
+                _ => {}
+            }
+            return Some(true);
+        }
+
         // Purge confirmation: only y/n/Esc are meaningful.
         if let MenuContent::PurgeConfirm { min_age_days, .. } = &self.menu {
             let days = *min_age_days;
@@ -422,6 +504,13 @@ impl TuiContext {
             MenuContent::Key(dd) => nav!(dd),
             MenuContent::Session(dd) => nav!(dd),
             MenuContent::File { dropdown: dd, .. } => nav!(dd),
+            MenuContent::BgAgentsPanel(state) => {
+                if dir < 0 {
+                    state.up()
+                } else {
+                    state.down()
+                }
+            }
             MenuContent::Approval { .. }
             | MenuContent::AskUser { .. }
             | MenuContent::LoopCap
@@ -607,6 +696,7 @@ impl TuiContext {
             | MenuContent::HistorySearch { .. }
             | MenuContent::WizardTrail(_)
             | MenuContent::ShortcutsOverlay
+            | MenuContent::BgAgentsPanel(_)
             | MenuContent::None => {}
         }
         self.menu = MenuContent::None;

--- a/koda-cli/src/tui_types.rs
+++ b/koda-cli/src/tui_types.rs
@@ -103,6 +103,11 @@ pub enum MenuContent {
     /// active; dismissed by `?` again, `Esc`, or any other key.
     /// Content is built by [`crate::widgets::shortcuts_overlay`].
     ShortcutsOverlay,
+    /// Interactive `/agents` panel (#1191 Candidate 2). Replaces the
+    /// flat-text `/agents` dump with a list/detail/cancel state
+    /// machine. Owns its own row snapshots; the renderer lives in
+    /// [`crate::widgets::bg_agents_panel`].
+    BgAgentsPanel(crate::widgets::bg_agents_panel::BgAgentsPanelState),
 }
 
 impl MenuContent {

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -83,6 +83,7 @@ pub(crate) fn draw_viewport(
         MenuContent::ShortcutsOverlay => {
             crate::widgets::shortcuts_overlay::overlay_height(area.width)
         }
+        MenuContent::BgAgentsPanel(state) => crate::widgets::bg_agents_panel::visible_height(state),
     };
 
     // Queue preview height: 0 when idle / queue empty.
@@ -501,6 +502,9 @@ fn render_menu(frame: &mut ratatui::Frame, menu: &MenuContent, menu_area: ratatu
         MenuContent::ShortcutsOverlay => {
             let lines = crate::widgets::shortcuts_overlay::build_overlay_lines(menu_area.width);
             frame.render_widget(Paragraph::new(lines), menu_area);
+        }
+        MenuContent::BgAgentsPanel(state) => {
+            crate::widgets::bg_agents_panel::render(state, menu_area, frame.buffer_mut());
         }
         MenuContent::None => {}
     }

--- a/koda-cli/src/widgets/bg_agents_panel.rs
+++ b/koda-cli/src/widgets/bg_agents_panel.rs
@@ -1,0 +1,659 @@
+//! Interactive `/agents` panel — list/detail/cancel state machine for
+//! the unified background-tasks surface (#1191 Candidate 2).
+//!
+//! Replaces the flat-text dump previously emitted by
+//! [`crate::tui_bg_tasks::handle_list_background_tasks`]. Field-study
+//! comparison (issue #1198) showed Codex / Claude Code / Gemini CLI all
+//! converge on an *interactive* surface for background work — none stay
+//! text-only. This widget adopts Claude Code's footer-pill → list →
+//! detail dialog pattern because it matches what koda already has
+//! (status pill + unified bg list + dropdown infra).
+//!
+//! ## State machine
+//!
+//! ```text
+//!     ┌──────────┐  Enter   ┌────────┐
+//!     │   List   │─────────▶│ Detail │
+//!     │          │◀─────────│        │
+//!     └──────────┘   Esc    └────────┘
+//!          │ ▲
+//!        c │ │ y/n/Esc
+//!          ▼ │
+//!   ┌──────────────┐
+//!   │ ConfirmCancel│
+//!   └──────────────┘
+//! ```
+//!
+//! - `↑`/`↓`        navigate selection (List mode only)
+//! - `Enter`        toggle Detail for the selected row
+//! - `c`            request cancel for the selected row
+//! - `y`            confirm cancel (ConfirmCancel mode)
+//! - `n` / `Esc`    abort cancel (ConfirmCancel mode)
+//! - `Esc` / `q`    back/dismiss (Detail back to List; List closes panel)
+//!
+//! ## Snapshot semantics
+//!
+//! State captures a snapshot of agent + process registries at panel-open
+//! time and **does not auto-refresh** while the panel is open. This
+//! matches the slash-menu and shortcuts-overlay pattern in koda — open
+//! menus show frozen content. A future iteration can layer push-refresh
+//! on top of `EngineEvent::BgTaskUpdate`; deferred to keep this PR
+//! focused (Zen of Python: simple is better than complex).
+//!
+//! Cancellation does live-mutate the registries (since it must), but the
+//! panel doesn't observe the resulting status change until the user
+//! reopens the panel. That's an acceptable v1 quirk — the typical
+//! workflow is "cancel and walk away", not "cancel and watch".
+
+use crate::tui_bg_tasks::{
+    agent_status_spans, command_head, format_age, process_status_spans, summary_preview,
+};
+use crate::tui_output::{BOLD, CYAN, DIM, GREEN, RED, WARM_ACCENT};
+use koda_core::bg_agent::BgTaskSnapshot;
+use koda_core::tools::bg_process::BgProcessSnapshot;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Widget, Wrap};
+
+// ── Row model ──────────────────────────────────────────────────────────
+//
+// Agents and processes have different snapshot types but render identically
+// in the panel. Wrap them in one enum so the renderer / navigation logic
+// has a single iteration target — DRY trumps preserving the type split.
+
+/// One row in the panel — either a background agent or a background
+/// shell process. Both types render the same column shape (id, name,
+/// age, status), and detail mode varies only in what extra fields are
+/// shown.
+#[derive(Debug, Clone)]
+pub enum BgPanelRow {
+    Agent(BgTaskSnapshot),
+    Process(BgProcessSnapshot),
+}
+
+impl BgPanelRow {
+    /// Display id with type prefix: `agent:N` or `process:PID`.
+    pub fn display_id(&self) -> String {
+        match self {
+            BgPanelRow::Agent(s) => format!("agent:{}", s.task_id),
+            BgPanelRow::Process(s) => format!("process:{}", s.pid),
+        }
+    }
+
+    /// Display name — agent role for agents, command head for processes.
+    pub fn display_name(&self) -> String {
+        match self {
+            BgPanelRow::Agent(s) => s.agent_name.clone(),
+            BgPanelRow::Process(s) => command_head(&s.command),
+        }
+    }
+
+    /// Wall-clock age string (e.g. `5m`).
+    pub fn display_age(&self) -> String {
+        match self {
+            BgPanelRow::Agent(s) => format_age(s.age),
+            BgPanelRow::Process(s) => format_age(s.age),
+        }
+    }
+
+    /// Status label spans (icon + colored text).
+    pub fn status_spans(&self) -> Vec<Span<'static>> {
+        match self {
+            BgPanelRow::Agent(s) => agent_status_spans(&s.status),
+            BgPanelRow::Process(s) => process_status_spans(&s.status),
+        }
+    }
+}
+
+// ── State ──────────────────────────────────────────────────────────────
+
+/// What the panel is currently showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BgPanelMode {
+    /// List of all bg tasks; arrow keys select.
+    List,
+    /// Expanded detail of the selected task (full prompt / summary / error).
+    Detail,
+    /// `[y]/[n]` confirmation before firing the cancel.
+    ConfirmCancel,
+}
+
+/// Panel state. Owned by `MenuContent::BgAgentsPanel(...)` for the
+/// duration of the popup.
+#[derive(Debug, Clone)]
+pub struct BgAgentsPanelState {
+    /// Unified row list captured at panel-open time. Agents come first,
+    /// then processes — same ordering the legacy flat printer used
+    /// (registry order within each group).
+    pub rows: Vec<BgPanelRow>,
+    /// Index of the highlighted row. Always in `0..rows.len()` when
+    /// `!rows.is_empty()`; meaningless and ignored when `rows.is_empty()`.
+    pub selection: usize,
+    /// Current display mode.
+    pub mode: BgPanelMode,
+}
+
+impl BgAgentsPanelState {
+    /// Build panel state from current registry snapshots. Both lists
+    /// are concatenated in the order the legacy `/agents` flat dump
+    /// used (agents first, processes second).
+    pub fn new(agents: Vec<BgTaskSnapshot>, processes: Vec<BgProcessSnapshot>) -> Self {
+        let mut rows: Vec<BgPanelRow> = agents.into_iter().map(BgPanelRow::Agent).collect();
+        rows.extend(processes.into_iter().map(BgPanelRow::Process));
+        Self {
+            rows,
+            selection: 0,
+            mode: BgPanelMode::List,
+        }
+    }
+
+    /// `true` when there's nothing to show. The renderer uses this
+    /// to draw the empty-state message instead of the table.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Move selection up by 1 (List mode only); wraps at the top.
+    /// No-op when empty.
+    pub fn up(&mut self) {
+        if !self.rows.is_empty() && self.mode == BgPanelMode::List {
+            self.selection = if self.selection == 0 {
+                self.rows.len() - 1
+            } else {
+                self.selection - 1
+            };
+        }
+    }
+
+    /// Move selection down by 1 (List mode only); wraps at the bottom.
+    /// No-op when empty.
+    pub fn down(&mut self) {
+        if !self.rows.is_empty() && self.mode == BgPanelMode::List {
+            self.selection = (self.selection + 1) % self.rows.len();
+        }
+    }
+
+    /// Toggle Detail mode for the selected row. Pressing Enter in
+    /// Detail mode goes back to List.
+    pub fn toggle_detail(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.mode = match self.mode {
+            BgPanelMode::List => BgPanelMode::Detail,
+            BgPanelMode::Detail => BgPanelMode::List,
+            // ConfirmCancel doesn't toggle to detail — Enter in
+            // ConfirmCancel is a no-op (use y/n explicitly).
+            BgPanelMode::ConfirmCancel => BgPanelMode::ConfirmCancel,
+        };
+    }
+
+    /// Open the cancel confirmation for the selected row. No-op if
+    /// empty or already in ConfirmCancel.
+    pub fn request_cancel(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        if self.mode != BgPanelMode::ConfirmCancel {
+            self.mode = BgPanelMode::ConfirmCancel;
+        }
+    }
+
+    /// Back out one mode level: Detail/ConfirmCancel → List. Returns
+    /// `true` when state actually changed (caller treats this as
+    /// "consumed the key"); `false` from List mode (caller should
+    /// close the whole panel).
+    pub fn back(&mut self) -> bool {
+        match self.mode {
+            BgPanelMode::Detail | BgPanelMode::ConfirmCancel => {
+                self.mode = BgPanelMode::List;
+                true
+            }
+            BgPanelMode::List => false,
+        }
+    }
+
+    /// The currently-selected row, if any.
+    pub fn selected(&self) -> Option<&BgPanelRow> {
+        self.rows.get(self.selection)
+    }
+}
+
+// ── Rendering ──────────────────────────────────────────────────────────
+
+/// Total visible row count for the panel — used by the viewport layout
+/// to size the menu_area Rect. Includes header + list/detail body +
+/// hint footer.
+pub fn visible_height(state: &BgAgentsPanelState) -> u16 {
+    if state.is_empty() {
+        // header (1) + blank (1) + "no tasks" (1) + blank (1) + hint (1) = 5
+        return 5;
+    }
+    match state.mode {
+        BgPanelMode::List => {
+            // header (1) + column header (1) + N rows + blank (1) + hint (1)
+            (4 + state.rows.len() as u16).min(20)
+        }
+        BgPanelMode::Detail => {
+            // header (1) + ID line (1) + status line (1) + blank (1)
+            // + body (up to 8 wrapped lines) + blank (1) + hint (1)
+            13
+        }
+        BgPanelMode::ConfirmCancel => {
+            // header (1) + question (1) + blank (1) + hint (1) = 4
+            4
+        }
+    }
+}
+
+/// Render the panel into `area`. The widget is responsible for its own
+/// header/footer; the caller (`tui_viewport`) just provides the Rect
+/// and the buffer.
+pub fn render(state: &BgAgentsPanelState, area: Rect, buf: &mut Buffer) {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header — always shown, mode-aware so the user knows where they are.
+    let header = match state.mode {
+        BgPanelMode::List => format!(" 🐾 Background tasks ({})", state.rows.len()),
+        BgPanelMode::Detail => " 🐾 Background tasks — detail".to_string(),
+        BgPanelMode::ConfirmCancel => " 🐾 Background tasks — confirm cancel".to_string(),
+    };
+    lines.push(Line::from(Span::styled(header, BOLD)));
+
+    if state.is_empty() {
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("  No background tasks.", DIM)));
+        lines.push(Line::default());
+        lines.push(Line::from(Span::styled("  esc/q close", DIM)));
+        Paragraph::new(lines).render(area, buf);
+        return;
+    }
+
+    match state.mode {
+        BgPanelMode::List => render_list(state, &mut lines),
+        BgPanelMode::Detail => render_detail(state, &mut lines),
+        BgPanelMode::ConfirmCancel => render_confirm(state, &mut lines),
+    }
+
+    Paragraph::new(lines)
+        .wrap(Wrap { trim: false })
+        .render(area, buf);
+}
+
+fn render_list(state: &BgAgentsPanelState, lines: &mut Vec<Line<'static>>) {
+    // Column widths sized to the longest actual id/name (min 8 each).
+    let id_col = state
+        .rows
+        .iter()
+        .map(|r| r.display_id().len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+    let name_col = state
+        .rows
+        .iter()
+        .map(|r| r.display_name().len())
+        .max()
+        .unwrap_or(8)
+        .max(8);
+
+    lines.push(Line::from(Span::styled(
+        format!(
+            "  {:<id_col$}  {:<name_col$}  {:<6}  STATUS",
+            "ID", "NAME", "AGE"
+        ),
+        DIM,
+    )));
+
+    for (i, row) in state.rows.iter().enumerate() {
+        let is_sel = i == state.selection;
+        let cursor = if is_sel { "▶ " } else { "  " };
+        let prefix_style = if is_sel {
+            WARM_ACCENT
+        } else {
+            Style::default()
+        };
+        let mut spans = vec![
+            Span::styled(cursor, prefix_style),
+            Span::styled(
+                format!(
+                    "{:<id_col$}  {:<name_col$}  {:<6}  ",
+                    row.display_id(),
+                    row.display_name(),
+                    row.display_age(),
+                ),
+                if is_sel {
+                    Style::default().add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                },
+            ),
+        ];
+        spans.extend(row.status_spans());
+        lines.push(Line::from(spans));
+    }
+
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "  ↑↓ navigate  enter detail  c cancel  esc/q close",
+        DIM,
+    )));
+}
+
+fn render_detail(state: &BgAgentsPanelState, lines: &mut Vec<Line<'static>>) {
+    let Some(row) = state.selected() else {
+        return;
+    };
+
+    // ID line.
+    lines.push(Line::from(vec![
+        Span::styled("  ", Style::default()),
+        Span::styled(row.display_id(), CYAN.add_modifier(Modifier::BOLD)),
+        Span::styled("  ", Style::default()),
+        Span::styled(row.display_name(), Style::default()),
+        Span::styled(format!("  ({})", row.display_age()), DIM),
+    ]));
+
+    // Status line.
+    let mut status_line = vec![Span::styled("  Status: ", DIM)];
+    status_line.extend(row.status_spans());
+    lines.push(Line::from(status_line));
+
+    lines.push(Line::default());
+
+    // Body — type-specific detail content.
+    match row {
+        BgPanelRow::Agent(snap) => {
+            lines.push(Line::from(Span::styled("  Prompt:", DIM)));
+            // Show the prompt verbatim — it's what the parent delegated.
+            // Wrap is applied at render time by Paragraph::wrap so we
+            // don't pre-truncate here.
+            lines.push(Line::from(Span::raw(format!("  {}", snap.prompt))));
+            // If completed/errored, also show the summary/error.
+            use koda_core::bg_agent::AgentStatus;
+            match &snap.status {
+                AgentStatus::Completed { summary } if !summary.is_empty() => {
+                    lines.push(Line::default());
+                    lines.push(Line::from(Span::styled("  Result:", DIM)));
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", summary_preview(summary)),
+                        GREEN,
+                    )));
+                }
+                AgentStatus::Errored { error } if !error.is_empty() => {
+                    lines.push(Line::default());
+                    lines.push(Line::from(Span::styled("  Error:", DIM)));
+                    lines.push(Line::from(Span::styled(
+                        format!("  {}", summary_preview(error)),
+                        RED,
+                    )));
+                }
+                _ => {}
+            }
+        }
+        BgPanelRow::Process(snap) => {
+            lines.push(Line::from(Span::styled("  Command:", DIM)));
+            lines.push(Line::from(Span::raw(format!("  {}", snap.command))));
+        }
+    }
+
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "  enter back  c cancel  esc back",
+        DIM,
+    )));
+}
+
+fn render_confirm(state: &BgAgentsPanelState, lines: &mut Vec<Line<'static>>) {
+    let Some(row) = state.selected() else {
+        return;
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  Cancel ", DIM),
+        Span::styled(row.display_id(), CYAN.add_modifier(Modifier::BOLD)),
+        Span::styled(" (", DIM),
+        Span::styled(row.display_name(), Style::default()),
+        Span::styled(")?", DIM),
+    ]));
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "  [y] confirm   [n]/esc abort",
+        DIM,
+    )));
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! Panel state-machine + render smoke tests.
+    //!
+    //! `BgTaskSnapshot` and `BgProcessSnapshot` are `#[non_exhaustive]`,
+    //! so we can't construct them by literal. Instead we drive the real
+    //! [`BgAgentRegistry`] API to mint genuine snapshots — same pattern
+    //! the [`crate::tui_bg_tasks`] tests use. We don't exercise process
+    //! rows here (would need to spawn a real child); process rendering
+    //! is covered transitively by [`crate::tui_bg_tasks`]'s formatter
+    //! tests since `BgPanelRow::Process` just delegates.
+
+    use super::*;
+    use koda_core::bg_agent::{AgentStatus, BgAgentRegistry};
+    use tokio::sync::watch;
+    use tokio_util::sync::CancellationToken;
+
+    /// Reserve + attach a real entry on the registry and return its
+    /// task_id. Mirrors [`crate::tui_bg_tasks`]'s `register_entry` but
+    /// trimmed to what the panel tests need (we don't care about the
+    /// returned senders — the registry holds them).
+    ///
+    /// Allows overriding the live status by sending on the returned
+    /// status sender before snapshotting (so tests can exercise
+    /// Running/Completed/Errored render paths).
+    fn register(
+        reg: &BgAgentRegistry,
+        agent_name: &str,
+        prompt: &str,
+    ) -> (u32, watch::Sender<AgentStatus>) {
+        let parent = CancellationToken::new();
+        let r = reg.reserve(&parent, None);
+        let task_id = r.task_id;
+        let status_tx = r.status_tx;
+        let noop = tokio::spawn(async {});
+        // Same shape as `tui_bg_tasks::tests::register_entry` — see
+        // that helper's docstring for the spawner=None rationale.
+        reg.attach(
+            task_id,
+            agent_name,
+            prompt,
+            r.rx,
+            r.cancel,
+            r.status_rx,
+            None,
+            None,
+            noop,
+        );
+        (task_id, status_tx)
+    }
+
+    /// Build a panel state from a registry's current snapshot. Tiny
+    /// helper to keep each test focused on the assertion, not the
+    /// fixture plumbing.
+    fn panel_from(reg: &BgAgentRegistry) -> BgAgentsPanelState {
+        BgAgentsPanelState::new(reg.snapshot(), vec![])
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_state_renders_no_tasks() {
+        let state = BgAgentsPanelState::new(vec![], vec![]);
+        assert!(state.is_empty());
+        assert_eq!(visible_height(&state), 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn new_concatenates_agents_then_processes() {
+        let reg = BgAgentRegistry::new();
+        let (id1, _) = register(&reg, "explore", "x");
+        let (id2, _) = register(&reg, "verify", "y");
+        let state = panel_from(&reg);
+        assert_eq!(state.rows.len(), 2);
+        assert_eq!(state.rows[0].display_id(), format!("agent:{id1}"));
+        assert_eq!(state.rows[1].display_id(), format!("agent:{id2}"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn navigation_wraps_at_both_ends() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        register(&reg, "b", "y");
+        let mut state = panel_from(&reg);
+        assert_eq!(state.selection, 0);
+        state.up(); // wrap to last
+        assert_eq!(state.selection, 1);
+        state.down(); // wrap back to first
+        assert_eq!(state.selection, 0);
+        state.down();
+        assert_eq!(state.selection, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn navigation_noop_in_detail_mode() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        register(&reg, "b", "y");
+        let mut state = panel_from(&reg);
+        state.toggle_detail();
+        assert_eq!(state.mode, BgPanelMode::Detail);
+        state.down();
+        assert_eq!(state.selection, 0, "selection must not move in detail mode");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn toggle_detail_round_trips() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        let mut state = panel_from(&reg);
+        assert_eq!(state.mode, BgPanelMode::List);
+        state.toggle_detail();
+        assert_eq!(state.mode, BgPanelMode::Detail);
+        state.toggle_detail();
+        assert_eq!(state.mode, BgPanelMode::List);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn request_cancel_sets_confirm_mode() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        let mut state = panel_from(&reg);
+        state.request_cancel();
+        assert_eq!(state.mode, BgPanelMode::ConfirmCancel);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn back_returns_false_from_list_to_signal_panel_close() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        let mut state = panel_from(&reg);
+        assert!(
+            !state.back(),
+            "List back should return false (panel closes)"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn back_returns_true_from_detail() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        let mut state = panel_from(&reg);
+        state.toggle_detail();
+        assert!(state.back());
+        assert_eq!(state.mode, BgPanelMode::List);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn back_returns_true_from_confirm() {
+        let reg = BgAgentRegistry::new();
+        register(&reg, "a", "x");
+        let mut state = panel_from(&reg);
+        state.request_cancel();
+        assert!(state.back());
+        assert_eq!(state.mode, BgPanelMode::List);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn empty_state_navigation_is_safe() {
+        let mut state = BgAgentsPanelState::new(vec![], vec![]);
+        // None of these should panic on an empty list.
+        state.up();
+        state.down();
+        state.toggle_detail();
+        state.request_cancel();
+        assert_eq!(state.mode, BgPanelMode::List);
+        assert_eq!(state.selection, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn visible_height_grows_with_rows_in_list_mode() {
+        let reg_one = BgAgentRegistry::new();
+        register(&reg_one, "a", "x");
+        let one = panel_from(&reg_one);
+
+        let reg_three = BgAgentRegistry::new();
+        register(&reg_three, "a", "x");
+        register(&reg_three, "b", "y");
+        register(&reg_three, "c", "z");
+        let three = panel_from(&reg_three);
+
+        assert!(visible_height(&three) > visible_height(&one));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn visible_height_caps_at_20_for_huge_lists() {
+        let reg = BgAgentRegistry::new();
+        for i in 0..50 {
+            register(&reg, &format!("a{i}"), "x");
+        }
+        let state = panel_from(&reg);
+        assert_eq!(visible_height(&state), 20);
+    }
+
+    /// Visual smoke: render a multi-status panel into a fixed buffer
+    /// and assert key strings appear. Cheap regression net for "did
+    /// the column layout silently break".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_render_smoke() {
+        let reg = BgAgentRegistry::new();
+        let (id1, status1) = register(&reg, "explore", "map repo");
+        register(&reg, "verify", "check tests");
+        // Bump one task to Running so the smoke covers the colored
+        // status path, not just Pending.
+        let _ = status1.send(AgentStatus::Running { iter: 3 });
+
+        let state = panel_from(&reg);
+        let area = Rect::new(0, 0, 80, visible_height(&state));
+        let mut buf = Buffer::empty(area);
+        render(&state, area, &mut buf);
+
+        let text: String = (0..buf.area.height)
+            .map(|y| {
+                (0..buf.area.width)
+                    .map(|x| buf[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            text.contains("Background tasks (2)"),
+            "header missing:\n{text}"
+        );
+        assert!(
+            text.contains(&format!("agent:{id1}")),
+            "agent row missing:\n{text}"
+        );
+        assert!(text.contains("explore"), "agent name missing:\n{text}");
+        assert!(text.contains("verify"), "second agent missing:\n{text}");
+        assert!(text.contains("↑↓ navigate"), "footer hint missing:\n{text}");
+    }
+}

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -4,6 +4,7 @@
 //! logic (`build_*_lines` functions). The generic [`dropdown::DropdownState`]
 //! provides shared navigation (up/down/scroll/filter) so menus stay DRY.
 
+pub mod bg_agents_panel;
 pub mod dropdown;
 pub mod file_menu;
 pub mod model_menu;


### PR DESCRIPTION
## Summary

Replaces the legacy flat-text `/agents` dump with an interactive list/detail/cancel panel.

## Behavior
- **List mode**: ↑↓ navigate, Enter → detail, `c` → cancel-confirm, Esc/q → close
- **Detail mode**: shows full snapshot for selected row; Enter/Esc → back, `c` → cancel
- **Confirm-cancel mode**: y → fire cancellation (cooperative for sub-agents, SIGTERM for processes), n/Esc → back
- Snapshots are **frozen** at open-time per Zen 'simple is better than complex' — reopen to refresh

## Files
- **new** `widgets/bg_agents_panel.rs` — state machine + renderer (~430 LoC + ~230 LoC tests)
- `tui_types.rs` — new `MenuContent::BgAgentsPanel` variant
- `tui_viewport.rs` — render + height delegation
- `tui_context/menus.rs` — keypress state machine (consumes every key while panel open)
- `tui_commands.rs` — `/agents` opens panel instead of dumping text
- `tui_bg_tasks.rs` — slimmed by 282 lines (legacy flat dump retired)

## Quality gates
- ✅ `cargo fmt --check` clean
- ✅ `cargo clippy --all-targets --all-features` clean
- ✅ 586 tests pass

Closes #1191