### PR TITLE
Fix Ctrl+C cancel cascade for background agents (#1200)

### DIFF
--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -135,6 +135,90 @@ pub(crate) fn handle_cancel_background_task(
     }
 }
 
+/// Cancel every active background agent and SIGTERM every running
+/// background process. Used by the global Ctrl+C path so users have
+/// a single keystroke to stop *all* background work — see issue #1200.
+///
+/// Counts only entries that are still running/pending; already-finished
+/// snapshots are skipped so we don't spam "Cancelled 0" messages when
+/// the registries are full of completed (not-yet-reaped) entries.
+///
+/// Returns `(agents_cancelled, processes_killed)` so callers can decide
+/// whether to emit a "nothing to do" message or fall through to
+/// alternate Ctrl+C behaviour (e.g. textarea clear at idle).
+pub(crate) fn cancel_all_bg_work(
+    buffer: &mut ScrollBuffer,
+    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_processes: &koda_core::tools::bg_process::BgRegistry,
+) -> (usize, usize) {
+    use koda_core::bg_agent::AgentStatus;
+
+    // Collect ids first so we don't hold the registry lock across
+    // `.cancel()` (which itself takes the lock). Snapshot is cheap
+    // — copies are bounded by the small number of bg tasks.
+    let agent_ids: Vec<u32> = bg_agents
+        .snapshot()
+        .into_iter()
+        .filter(|s| matches!(s.status, AgentStatus::Pending | AgentStatus::Running { .. }))
+        .map(|s| s.task_id)
+        .collect();
+    let proc_ids: Vec<u32> = bg_processes
+        .snapshot()
+        .into_iter()
+        .filter(|s| {
+            matches!(
+                s.status,
+                koda_core::tools::bg_process::BgProcessStatus::Running
+            )
+        })
+        .map(|s| s.pid)
+        .collect();
+
+    let agents_cancelled = agent_ids.iter().filter(|id| bg_agents.cancel(**id)).count();
+    let processes_killed = proc_ids
+        .iter()
+        .filter(|pid| bg_processes.kill(**pid))
+        .count();
+
+    if agents_cancelled + processes_killed > 0 {
+        let parts: Vec<String> = [
+            (agents_cancelled > 0).then(|| format!("{agents_cancelled} agent(s)")),
+            (processes_killed > 0).then(|| format!("{processes_killed} process(es)")),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+        tui_output::warn_msg(
+            buffer,
+            format!("\u{26d4} Cancelled {} background work", parts.join(" + ")),
+        );
+    }
+
+    (agents_cancelled, processes_killed)
+}
+
+/// Snapshot count of *active* bg work (running agents + tracked
+/// processes). Used by the idle Ctrl+C path to decide whether to
+/// cancel bg work or fall back to the textarea-clear behaviour.
+pub(crate) fn active_bg_count(
+    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_processes: &koda_core::tools::bg_process::BgRegistry,
+) -> usize {
+    use koda_core::bg_agent::AgentStatus;
+    use koda_core::tools::bg_process::BgProcessStatus;
+    let active_agents = bg_agents
+        .snapshot()
+        .into_iter()
+        .filter(|s| matches!(s.status, AgentStatus::Pending | AgentStatus::Running { .. }))
+        .count();
+    let active_procs = bg_processes
+        .snapshot()
+        .into_iter()
+        .filter(|s| matches!(s.status, BgProcessStatus::Running))
+        .count();
+    active_agents + active_procs
+}
+
 /// Format a `Duration` as a compact age string for the `/agents` table.
 ///
 /// - `< 60s`  → `"Ns"` (e.g. `"5s"`)
@@ -558,6 +642,131 @@ mod tests {
         assert!(
             text.contains("Usage:") && text.contains("agent:") && text.contains("process:"),
             "None id should render a Usage: line with both prefixes, got: {text}"
+        );
+    }
+
+    // ── cancel_all_bg_work / active_bg_count (#1200) ─────────────────
+
+    /// Empty registries: `cancel_all_bg_work` returns (0, 0) and
+    /// emits no message. The buffer must stay clean so the idle
+    /// Ctrl+C path can fall through to its textarea-clear behaviour
+    /// without leaving a phantom "cancelled 0" line in scrollback.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_all_bg_work_empty_is_silent() {
+        let mut buf = ScrollBuffer::new(64);
+        let reg = BgAgentRegistry::new();
+        let procs = BgRegistry::new();
+        let (a, p) = cancel_all_bg_work(&mut buf, &reg, &procs);
+        assert_eq!((a, p), (0, 0));
+        assert!(
+            buffer_text(&buf).is_empty(),
+            "empty registries must not emit a status line"
+        );
+    }
+
+    /// Multiple running agents are all cancelled in one call and
+    /// each `BgAgentReservation::cancel` token observes the cascade.
+    /// This is the in-process equivalent of "user hit Ctrl+C and
+    /// every bg agent should die".
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_all_bg_work_cancels_every_running_agent() {
+        let mut buf = ScrollBuffer::new(64);
+        let reg = BgAgentRegistry::new();
+        let procs = BgRegistry::new();
+
+        let (_id1, _tx1, status1, observer1) = register_entry(&reg, "explore", "prompt 1");
+        let (_id2, _tx2, status2, observer2) = register_entry(&reg, "task", "prompt 2");
+        // Bring them out of Pending so they show up as Running in
+        // the snapshot filter.
+        status1.send(AgentStatus::Running { iter: 1 }).unwrap();
+        status2.send(AgentStatus::Running { iter: 1 }).unwrap();
+
+        let (a, p) = cancel_all_bg_work(&mut buf, &reg, &procs);
+        assert_eq!((a, p), (2, 0));
+        assert!(observer1.is_cancelled(), "agent 1 should observe cascade");
+        assert!(observer2.is_cancelled(), "agent 2 should observe cascade");
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("Cancelled") && text.contains("2 agent(s)"),
+            "summary line should report agent count, got: {text}"
+        );
+    }
+
+    /// Mixed registries: agents + processes get cancelled and the
+    /// summary line names both kinds. We use a real `sleep 60`
+    /// child so `BgRegistry::kill` exercises its real SIGTERM path,
+    /// not a stubbed one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_all_bg_work_handles_agents_and_processes() {
+        let mut buf = ScrollBuffer::new(64);
+        let reg = BgAgentRegistry::new();
+        let procs = BgRegistry::new();
+
+        let (_id, _tx, status, observer) = register_entry(&reg, "explore", "hi");
+        status.send(AgentStatus::Running { iter: 1 }).unwrap();
+        let _pid = spawn_sleep_in_registry(&procs);
+
+        let (a, p) = cancel_all_bg_work(&mut buf, &reg, &procs);
+        assert_eq!((a, p), (1, 1));
+        assert!(observer.is_cancelled());
+        let text = buffer_text(&buf);
+        assert!(
+            text.contains("1 agent(s)") && text.contains("1 process(es)"),
+            "summary should mention both kinds, got: {text}"
+        );
+    }
+
+    /// Already-completed agents are skipped — we don't want Ctrl+C
+    /// to spam "cancelled" for entries that finished naturally and
+    /// just haven't been reaped yet.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_all_bg_work_skips_completed_entries() {
+        let mut buf = ScrollBuffer::new(64);
+        let reg = BgAgentRegistry::new();
+        let procs = BgRegistry::new();
+
+        let (_id, tx, status, observer) = register_entry(&reg, "explore", "hi");
+        // Drive to Completed terminal state.
+        status
+            .send(AgentStatus::Completed {
+                summary: "done".to_string(),
+            })
+            .unwrap();
+        // Send a result so the entry looks fully resolved.
+        let _ = tx.send(Ok(("done".to_string(), vec![])));
+
+        let (a, p) = cancel_all_bg_work(&mut buf, &reg, &procs);
+        assert_eq!((a, p), (0, 0));
+        assert!(
+            !observer.is_cancelled(),
+            "completed entries must not have their cancel token fired"
+        );
+        assert!(buffer_text(&buf).is_empty());
+    }
+
+    /// `active_bg_count` matches what the idle Ctrl+C handler will
+    /// see when deciding whether to cancel bg work or fall through
+    /// to the textarea-clear path. Counts must exclude completed
+    /// entries (same filter as `cancel_all_bg_work`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn active_bg_count_excludes_completed() {
+        let reg = BgAgentRegistry::new();
+        let procs = BgRegistry::new();
+        assert_eq!(active_bg_count(&reg, &procs), 0);
+
+        let (_id1, _tx1, s1, _obs1) = register_entry(&reg, "a", "p1");
+        s1.send(AgentStatus::Running { iter: 1 }).unwrap();
+        let (_id2, tx2, s2, _obs2) = register_entry(&reg, "b", "p2");
+        s2.send(AgentStatus::Completed {
+            summary: "x".to_string(),
+        })
+        .unwrap();
+        let _ = tx2.send(Ok(("x".to_string(), vec![])));
+
+        assert_eq!(
+            active_bg_count(&reg, &procs),
+            1,
+            "only the running agent should count"
         );
     }
 }

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -118,12 +118,46 @@ impl TuiContext {
                 self.history_down();
             }
             (KeyCode::Esc, _) => {
-                self.textarea.set_text_clearing_elements("");
-                self.history_idx = None;
+                // #1200: Esc at idle with no editor content is a
+                // "stop everything" gesture. If bg work exists,
+                // cancel it. Otherwise behave as before (clear editor).
+                if self.textarea.text().trim().is_empty()
+                    && crate::tui_bg_tasks::active_bg_count(
+                        &self.session.bg_agents,
+                        &self.agent.tools.bg_registry,
+                    ) > 0
+                {
+                    crate::tui_bg_tasks::cancel_all_bg_work(
+                        &mut self.scroll_buffer,
+                        &self.session.bg_agents,
+                        &self.agent.tools.bg_registry,
+                    );
+                } else {
+                    self.textarea.set_text_clearing_elements("");
+                    self.history_idx = None;
+                }
             }
             (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
-                self.textarea.set_text_clearing_elements("");
-                self.history_idx = None;
+                // #1200: same logic as Esc — idle Ctrl+C cancels bg
+                // work when the editor is empty, else clears the editor.
+                // Two-step UX (type, then Ctrl+C) preserves the muscle
+                // memory while giving Ctrl+C a meaningful idle action
+                // when bg agents/processes are running.
+                if self.textarea.text().trim().is_empty()
+                    && crate::tui_bg_tasks::active_bg_count(
+                        &self.session.bg_agents,
+                        &self.agent.tools.bg_registry,
+                    ) > 0
+                {
+                    crate::tui_bg_tasks::cancel_all_bg_work(
+                        &mut self.scroll_buffer,
+                        &self.session.bg_agents,
+                        &self.agent.tools.bg_registry,
+                    );
+                } else {
+                    self.textarea.set_text_clearing_elements("");
+                    self.history_idx = None;
+                }
             }
             (KeyCode::Char('d'), m) if m.contains(KeyModifiers::CONTROL) => {
                 if self.textarea.text().to_string().trim().is_empty() {

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -78,7 +78,14 @@ impl TuiContext {
         cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     ) -> anyhow::Result<()> {
         let cli_sink = crate::sink::CliSink::channel(ui_tx.clone());
-        let cancel_token = self.session.cancel.clone();
+        // #1200: derive a per-turn child token instead of cloning the
+        // session-lifetime root. This keeps `session.cancel` stable
+        // across turn boundaries so bg agents (which call
+        // `BgAgentRegistry::reserve(&session.cancel, …)`) keep their
+        // cancel-token cascade pointing at a live parent. Cancelling
+        // the child fires only the foreground turn; bg agents are
+        // explicitly cancelled by the Ctrl+C path further down.
+        let cancel_token = self.session.cancel.child_token();
         let db_handle = self.session.db.clone();
 
         self.tui_state = TuiState::Inferring;
@@ -238,6 +245,8 @@ impl TuiContext {
                             &mut self.later_queue,
                             &mut self.paste_blocks,
                             &db_handle,
+                            &bg_agents_for_status,
+                            &agent_for_status.tools.bg_registry,
                         )
                         .await;
                         // Request a redraw to reflect the new state. The
@@ -306,17 +315,26 @@ impl TuiContext {
         }
 
         // Post-turn cleanup
-        self.post_turn_cleanup(ui_rx).await;
+        self.post_turn_cleanup(ui_rx, &cancel_token).await;
         Ok(())
     }
 
     // ── Post-turn cleanup ──────────────────────────────────────
 
-    async fn post_turn_cleanup(&mut self, ui_rx: &mut mpsc::UnboundedReceiver<UiEvent>) {
+    async fn post_turn_cleanup(
+        &mut self,
+        ui_rx: &mut mpsc::UnboundedReceiver<UiEvent>,
+        turn_cancel: &tokio_util::sync::CancellationToken,
+    ) {
         // If the turn was cancelled, clear the later_queue so deferred
         // messages don’t immediately fire a new turn that may block on a
         // single-slot local server (LM Studio, ollama) (#825).
-        if self.session.cancel.is_cancelled() && !self.later_queue.is_empty() {
+        //
+        // #1200: check the per-turn child token, not `session.cancel`.
+        // The session root is now stable across turn boundaries so bg
+        // agents derived from it keep their cancel cascade live; the
+        // child is the one that actually fires on Ctrl+C.
+        if turn_cancel.is_cancelled() && !self.later_queue.is_empty() {
             let n = self.later_queue.len();
             self.later_queue.clear();
             self.scroll_buffer.push(Line::from(vec![
@@ -330,7 +348,12 @@ impl TuiContext {
 
         self.tui_state = TuiState::Idle;
         self.inference_start = None;
-        self.session.cancel = tokio_util::sync::CancellationToken::new();
+        // #1200: do NOT replace `session.cancel`. The session root is
+        // session-lifetime stable now; per-turn cancellation is on a
+        // child token that's dropped when the turn future ends. This
+        // fixes the cascade-broken-across-turns bug where bg agents
+        // reserved during turn N were orphaned the moment turn N
+        // finished and `session.cancel` was swapped out from under them.
 
         // Commit undo snapshots for this turn
         if let Ok(mut undo) = self.agent.tools.undo.lock() {
@@ -451,6 +474,8 @@ async fn handle_crossterm_event_inline(
     later_queue: &mut std::collections::VecDeque<String>,
     paste_blocks: &mut Vec<input::PasteBlock>,
     db: &koda_core::db::Database,
+    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_processes: &koda_core::tools::bg_process::BgRegistry,
 ) {
     use crossterm::event::MouseEventKind;
     match ev {
@@ -498,6 +523,8 @@ async fn handle_crossterm_event_inline(
                 history_idx,
                 later_queue,
                 db,
+                bg_agents,
+                bg_processes,
             )
             .await;
         }
@@ -522,6 +549,8 @@ async fn handle_inference_key_inline(
     history_idx: &mut Option<usize>,
     later_queue: &mut std::collections::VecDeque<String>,
     db: &koda_core::db::Database,
+    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_processes: &koda_core::tools::bg_process::BgRegistry,
 ) {
     // Vim insert-mode Escape (PR 3 of #1178). Same rationale as in
     // `tui_context::events::handle_key`: route bare Esc to the textarea
@@ -724,9 +753,16 @@ async fn handle_inference_key_inline(
         }
         (KeyCode::Esc, _) => {
             cancel_token.cancel();
+            // #1200: Esc/Ctrl+C during inference also stops any bg
+            // work spawned in this session. Without this, the
+            // foreground turn aborts but bg agents/processes keep
+            // running in the dark — confusing the user who just
+            // asked for everything to stop.
+            crate::tui_bg_tasks::cancel_all_bg_work(scroll_buffer, bg_agents, bg_processes);
         }
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
             cancel_token.cancel();
+            crate::tui_bg_tasks::cancel_all_bg_work(scroll_buffer, bg_agents, bg_processes);
         }
         // Ctrl+U: clear the later_queue (deferred messages) without cancelling inference.
         (KeyCode::Char('u'), m) if m.contains(KeyModifiers::CONTROL) => {


### PR DESCRIPTION
Closes #1200.

Implements **Option C** from the issue: stable session-lifetime cancel root + idle Ctrl+C cancels bg work.

## What changed

### A) Stable `session.cancel` root

Before, `post_turn_cleanup` replaced `session.cancel` with a fresh `CancellationToken` at the end of every turn. Bg agents reserved during turn N held `child_token()` of the **old** token; once the parent was dropped, those children became orphans — no parent could ever cascade cancellation to them, including session shutdown.

Now:
- `run_inference_turn` derives a per-turn **child** via `session.cancel.child_token()` instead of cloning the root.
- Cancelling the child fires only the foreground turn; the session root stays alive for the entire session.
- Bg agents (which call `reserve(&session.cancel, …)`) keep their cancel cascade pointing at a live parent.
- `post_turn_cleanup` checks the per-turn token (passed as a new param) instead of `session.cancel` for the "was this turn cancelled?" decision.
- The `self.session.cancel = CancellationToken::new()` line is gone.

### B) Ctrl+C cancels bg work

New helpers in `tui_bg_tasks.rs`:
- `cancel_all_bg_work(buf, agents, procs) -> (a, p)` — iterates both registries, cancels every `Pending`/`Running` agent and SIGTERMs every `Running` process. Silent on empty (no "cancelled 0" spam). Summary line names both kinds when both are touched.
- `active_bg_count(agents, procs)` — used by the idle path to decide whether to cancel bg work or fall through to textarea-clear.

Wired into:
- **Esc / Ctrl+C during inference**: cancel turn token + call `cancel_all_bg_work`. Threading `bg_agents` and `bg_processes` refs through `handle_crossterm_event_inline` → `handle_inference_key_inline`.
- **Esc / Ctrl+C at idle**: if textarea is empty AND bg work exists → cancel bg work; else clear textarea (preserves muscle memory). Two-step UX (type → Ctrl+C clears editor; type nothing → Ctrl+C cancels bg work).

## Tests

5 new tests in `tui_bg_tasks::tests`:

| Test | Covers |
|---|---|
| `cancel_all_bg_work_empty_is_silent` | no scrollback noise on empty registries |
| `cancel_all_bg_work_cancels_every_running_agent` | cascade observed by every entry's cancel token |
| `cancel_all_bg_work_handles_agents_and_processes` | mixed registries, summary names both kinds (uses real `sleep 60` child) |
| `cancel_all_bg_work_skips_completed_entries` | no false "cancelled" spam for finished entries |
| `active_bg_count_excludes_completed` | idle-path counter matches helper's filter |

All 591 koda-cli lib tests pass + 50 integration tests pass. Clippy + fmt clean.

> Note: `koda-core::context::test_percentage_zero_max` flakes under `cargo test -p koda-core` due to a pre-existing global-state race (uses module-level statics). Passes in isolation. Unrelated to this PR (no context.rs changes).

## Acceptance criteria from #1200

- [x] Ctrl+C from idle cancels all running bg agents (Option B)
- [x] Cascade survives turn boundaries (Option A — session root is stable)
- [x] Ctrl+C during inference cancels foreground turn AND bg agents
- [x] Existing per-turn cancel semantics still work (current turn cleanly aborts, next turn starts fresh — verified by full test suite)
- [x] Tests cover (a) cascade across turn boundary, (b) idle Ctrl+C with N bg agents, (c) idle Ctrl+C with no bg agents still clears textarea (the textarea-clear path is the unchanged `else` arm)

## Out of scope

- The new `/agents` panel (#1191) cancel path was already correct — it goes through `BgAgentRegistry::cancel(task_id)` which fires the per-entry token directly, bypassing the cascade. Untouched here.
- Bg-agent UX feedback during `WaitTask` (no live activity feed) — tracked separately in #1201.

## Future cleanup

The threading of `bg_agents` + `bg_processes` into `handle_inference_key_inline` adds 2 more args to a function that's already `#[allow(clippy::too_many_arguments)]`. Could be cleaned up by introducing a `HandlerCtx` struct in a follow-up — but keeping this PR surgical.