### PR TITLE
Discourage immediate WaitTask after bg-agent spawn (#1201 A1)

### DIFF
--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -44,6 +44,10 @@ EXECUTION MODES (pick one per call):
   isolated workspace, so parallel write-agents cannot trample each other.
 - Background (background=true): returns immediately. Results inject as a
   user message on the next iteration. Use for long-running independent work.
+  After spawning, KEEP WORKING — do other useful things and let the result
+  inject naturally. Do NOT immediately call WaitTask; that defeats the
+  point of backgrounding (turns the whole pattern back into a blocking call
+  and silences the parent for the duration).
 - Forked context (agent_name='fork'): inherits your full conversation
   history. Useful when the sub-agent needs everything you've already loaded.
 
@@ -86,8 +90,19 @@ Key rules:
                         "description": "Run in background and return immediately (default: false). \
                             Results are drained and injected as a user message at the start of \
                             the next iteration — NOT mid-iteration. The bg agent inherits the \
-                            parent's trust + sandbox at spawn time and is cancelled on Ctrl+C. \
-                            Use for independent long-running tasks that don't block your current work."
+                            parent's trust + sandbox at spawn time and is cancelled on Ctrl+C.\n\n\
+                            **After spawning, keep working.** The whole point of background \
+                            mode is that you do other useful things (file edits, follow-up \
+                            searches, summarizing progress for the user) while the agent runs. \
+                            Results inject automatically on a future iteration via auto-drain \
+                            — you do NOT need to call `WaitTask` to receive them. Calling \
+                            `WaitTask` immediately after the spawn turns the background dispatch \
+                            back into a blocking call and silences the parent for the duration; \
+                            only do that when you genuinely have no other work to make progress \
+                            on (e.g. the next step strictly depends on this agent's output and \
+                            no parallel work is possible).\n\n\
+                            Use for independent long-running tasks that don't block your \
+                            current work."
                     }
                 },
                 "required": ["prompt"]
@@ -383,6 +398,42 @@ mod tests {
         assert!(
             bg_desc.contains("next iteration"),
             "background param must explain drain-on-next-iteration timing"
+        );
+    }
+
+    /// #1201 A1: nudge the model away from "spawn bg agent → immediately
+    /// WaitTask". That pattern silences the parent for the entire wait
+    /// and turns the non-blocking dispatch back into a blocking call.
+    /// The mode bullet AND the per-param description must both push back.
+    #[test]
+    fn test_invoke_agent_description_discourages_immediate_wait_task() {
+        let defs = definitions();
+        let desc = &defs[0].description;
+        // The top-level Background mode bullet must mention WaitTask
+        // explicitly so the model sees the anti-pattern named.
+        assert!(
+            desc.contains("WaitTask"),
+            "top-level Background mode bullet must reference WaitTask by \
+             name so the model can recognize the anti-pattern (#1201 A1)"
+        );
+        // Per-param description must reinforce the same nudge — the model
+        // tends to look at the parameter doc when deciding *how* to use
+        // a tool, not the broader prose.
+        let bg_desc = defs[0]
+            .parameters
+            .pointer("/properties/background/description")
+            .and_then(|v| v.as_str())
+            .expect("background param must have a description");
+        assert!(
+            bg_desc.contains("WaitTask"),
+            "background param description must reference WaitTask so the \
+             nudge appears next to the parameter the model is setting \
+             (#1201 A1)"
+        );
+        assert!(
+            bg_desc.contains("auto-drain"),
+            "background param description must name the auto-drain path \
+             so the model knows results arrive without WaitTask (#1201 A1)"
         );
     }
 

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -160,7 +160,20 @@ pub fn definitions() -> Vec<ToolDefinition> {
                 wait this long', not 'check back quickly' — for sub-agent tasks (multi-iteration \
                 inference) prefer 120-300 s; the default suits short shell-process waits. The \
                 same `timeout_secs` applies to every task in the request (per-task, not total). \
-                Default {default}s, max {max}s.",
+                Default {default}s, max {max}s.\n\n\
+                **When NOT to call WaitTask.** Background sub-agents and processes drain \
+                automatically: completed tasks inject as a user message at the start of the \
+                next iteration. So if you've just spawned bg work and have ANY other useful \
+                work to do (more file edits, follow-up searches, summarizing progress for the \
+                user, even \"acknowledge the spawn and stop\"), do that instead and let the \
+                result arrive on its own. Calling WaitTask immediately after a bg spawn turns \
+                the parallel/non-blocking pattern back into a serial blocking call — the \
+                parent's TUI goes silent for the entire duration with no per-tool feedback \
+                from the child. Only call WaitTask when (a) the next step you'd take strictly \
+                depends on this task's result and you cannot make progress without it, (b) \
+                you're at the end of your work and need the result to finalize the user-facing \
+                reply, or (c) you're rendezvousing on N parallel agents you fanned out earlier \
+                and you've already exhausted other work.",
                 default = WAIT_TASK_DEFAULT_TIMEOUT_SECS,
                 max = WAIT_TASK_MAX_TIMEOUT_SECS,
             ),
@@ -624,6 +637,41 @@ mod tests {
         assert!(
             required.is_none() || required.unwrap().as_array().unwrap().is_empty(),
             "ListBackgroundTasks must take no required args"
+        );
+    }
+
+    /// #1201 A1: WaitTask description must actively push back against the
+    /// "spawn bg agent → immediately WaitTask" anti-pattern. Pinning the
+    /// load-bearing concepts so future "tighter wording" passes don't
+    /// silently drop the nudge.
+    #[test]
+    fn wait_task_description_discourages_immediate_post_spawn_call() {
+        let defs = definitions();
+        let wait = defs.iter().find(|d| d.name == "WaitTask").unwrap();
+        let desc = &wait.description;
+        // The auto-drain alternative must be named — the model needs to
+        // know there's a passive way to receive bg results so it can
+        // confidently skip WaitTask.
+        assert!(
+            desc.contains("drain"),
+            "WaitTask description must mention auto-drain so the model knows \
+             results arrive on the next iteration without an explicit wait \
+             (#1201 A1)"
+        );
+        // The anti-pattern must be named explicitly so the model can
+        // recognize it in its own output, not just inferred from prose.
+        assert!(
+            desc.contains("immediately") || desc.contains("immediate"),
+            "WaitTask description must call out the immediate-post-spawn \
+             anti-pattern by name (#1201 A1)"
+        );
+        // The consequence (silent parent / blocking) must be stated so
+        // the model understands WHY this is bad, not just THAT it's bad.
+        assert!(
+            desc.contains("blocking") || desc.contains("silent"),
+            "WaitTask description must explain the cost of immediate \
+             waiting (parent goes silent / blocks) so the model has a \
+             reason to avoid it (#1201 A1)"
         );
     }
 


### PR DESCRIPTION
Closes the **A1 bullet** of #1201. (Issue stays open for B + Bonus.)

## TL;DR

Tool descriptions now actively push the model away from the "spawn bg agent → immediately WaitTask" anti-pattern. Two files, ~80 lines of description copy + 2 pinning tests. Cheap, low-risk, immediate UX win.

## The anti-pattern this fixes

When the model writes:

```json
InvokeAgent { background: true, prompt: "..." }
WaitTask { task_ids: ["agent:1"], timeout_secs: 300 }
```

…in the same iteration (or back-to-back), the parent's inference loop `await`s on `WaitTask`. The TUI shows a single `WaitTasks` tool-header line and **goes silent for up to 300 s** with no streaming, no thoughts, no per-tool breadcrumbs. The whole point of backgrounding is wasted.

The auto-drain path (`bg_agent.rs:567 drain_completed`) already injects completed bg results as a user message at the start of each iteration — the model just doesn't know it can rely on that and skip the explicit wait.

## Changes

### `InvokeAgent` — `tools/agent.rs`

Two reinforcing edits so the nudge appears wherever the model looks:

1. **Top-level "Background" mode bullet** ends with: *"After spawning, KEEP WORKING — do other useful things and let the result inject naturally. Do NOT immediately call WaitTask; that defeats the point of backgrounding (turns the whole pattern back into a blocking call and silences the parent for the duration)."*

2. **Per-param `background` description** gets a new paragraph spelling out the auto-drain alternative explicitly: results inject automatically, you don't need to call `WaitTask`, and only do so when you genuinely have no other parallel work.

Both reference `WaitTask` **by name** so the model can recognize the anti-pattern in its own output (not just infer from prose).

### `WaitTask` — `tools/bg_task_tools.rs`

Added a new **"When NOT to call WaitTask"** paragraph at the end that:

- Names the auto-drain alternative
- Calls out the immediate-post-spawn anti-pattern explicitly
- States the cost: *"the parent's TUI goes silent for the entire duration with no per-tool feedback from the child"*
- Lists the 3 legitimate use cases:
  - **(a)** strict data dependency on this task
  - **(b)** end-of-work finalization
  - **(c)** rendezvous on N parallel agents you fanned out earlier

The existing "prefer WaitTask over a polling loop" guidance is preserved — `WaitTask` is still the right call for many cases. The new text is **additive**: "and here's when NOT to use it".

## Tests

Two new tests pin the load-bearing **concepts** (not exact wording — that lets future "tighter wording" passes refactor freely without silently dropping the nudge):

| Test | Asserts |
|---|---|
| `agent::tests::test_invoke_agent_description_discourages_immediate_wait_task` | Mode bullet AND param description both reference `WaitTask` + `auto-drain` |
| `bg_task_tools::tests::wait_task_description_discourages_immediate_post_spawn_call` | New paragraph names `drain` + `immediate` + (`blocking` or `silent`) |

## Verification

```
cargo test -p koda-core --lib    → 1158/1158 passed (was 1156, added 2)
cargo test -p koda-cli --lib     → 591/591 passed
cargo clippy --workspace -- -D warnings → clean
cargo fmt --all → clean
```

## Why this works (without B yet)

The model reads tool descriptions on every turn. Even a passive prompt-engineering nudge moves behavior — Codex, Claude Code, and Gemini CLI all rely on description-level steering for similar non-blocking patterns. We get most of the bg-agent UX win immediately, and `B` (live activity feed) becomes a polish layer instead of a load-bearing fix.

## Out of scope (still tracked in #1201)

- **B**: live activity feed during wait (Gemini-style inline streaming) — bigger PR (event shape + plumbing + renderer)
- **A2**: truly async `WaitTask` — deeper refactor, lower bang-for-buck
- **Bonus**: live-refresh `/agents` panel