### PR TITLE
Live bg-agent activity feed: BgChildActivity event + ForwardingBgSink (#1201 B)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -170,6 +170,32 @@ pub fn engine_event_to_acp(
             ))
         }
 
+        // (#1201 B) Live activity from inside a running bg agent.
+        // ACP doesn't have a typed bg-child-activity notification, so
+        // we fall through to the same `[bg task N] ...` text-chunk
+        // shape used by `BgTaskUpdate` above. The full structured
+        // payload (with `kind: tool_start` / `tool_end` / `info`) is
+        // still on the wire for any future typed mapping.
+        EngineEvent::BgChildActivity { task_id, kind, .. } => {
+            let body = match kind {
+                koda_core::engine::event::BgChildActivityKind::ToolStart { summary, .. } => {
+                    format!("\u{1f527} {summary}")
+                }
+                koda_core::engine::event::BgChildActivityKind::ToolEnd { tool_name, success } => {
+                    let icon = if *success { "\u{2713}" } else { "\u{2717}" };
+                    format!("{icon} {tool_name}")
+                }
+                koda_core::engine::event::BgChildActivityKind::Info { message } => message.clone(),
+            };
+            let cb = acp::ContentBlock::Text(acp::TextContent::new(format!(
+                "[bg task {task_id}] {body}"
+            )));
+            Some(acp::SessionNotification::new(
+                session_id.to_string(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(cb)),
+            ))
+        }
+
         // (#1077 Phase A) TodoWrite lifecycle. Surfaces every accepted
         // change so ACP IDEs can render a checklist (with diff-driven
         // animation if they care). The diff (added / changed /

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -295,6 +295,26 @@ impl EngineSink for HeadlessSink {
                 };
                 eprintln!("\x1b[2m  [bg task {task_id}] {summary}\x1b[0m");
             }
+            // (#1201 B) Live activity from inside a bg agent. Render
+            // dimly indented under the parent feed so a tailing script
+            // sees "  [bg task 7]   \u{1f527} Read src/auth.rs" without
+            // having to wait for the post-completion drain.
+            EngineEvent::BgChildActivity { task_id, kind, .. } => {
+                let line = match kind {
+                    koda_core::engine::event::BgChildActivityKind::ToolStart {
+                        summary, ..
+                    } => format!("\u{1f527} {summary}"),
+                    koda_core::engine::event::BgChildActivityKind::ToolEnd {
+                        tool_name,
+                        success,
+                    } => {
+                        let icon = if success { "\u{2713}" } else { "\u{2717}" };
+                        format!("{icon} {tool_name}")
+                    }
+                    koda_core::engine::event::BgChildActivityKind::Info { message } => message,
+                };
+                eprintln!("\x1b[2m  [bg task {task_id}] {line}\x1b[0m");
+            }
             // (#1077 Phase A) TodoWrite lifecycle in headless: render a
             // dim one-liner with diff counts so a script tailing stdout
             // sees "todos: +2 ~1 -0 (5 total)" on every accepted change.

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -297,6 +297,46 @@ impl TuiRenderer {
                 // that want diff-driven animation. Same future-cleanup
                 // path as BgTaskUpdate.
             }
+            // (#1201 B) Live activity from inside a running bg agent.
+            // Pre-this-arm a 30-second tool inside a bg agent looked
+            // identical to a 30-second hang — only the post-completion
+            // narrative trace surfaced "what it did". This arm renders
+            // each child activity event as a dim inline line in the
+            // scroll buffer, prefixed with the bg task id so the user
+            // can correlate it with the spawn line and the bg-task
+            // panel.
+            //
+            // Phase B2 (follow-up) will replace this with a proper
+            // Gemini-style activity block that collapses on completion;
+            // for now the inline-line render gets us the live signal
+            // without committing to a panel layout.
+            EngineEvent::BgChildActivity { task_id, kind, .. } => {
+                let body = match kind {
+                    koda_core::engine::event::BgChildActivityKind::ToolStart {
+                        summary, ..
+                    } => format!("\u{1f527} {summary}"),
+                    koda_core::engine::event::BgChildActivityKind::ToolEnd {
+                        tool_name,
+                        success,
+                    } => {
+                        let icon = if success { "\u{2713}" } else { "\u{2717}" };
+                        format!("{icon} {tool_name}")
+                    }
+                    koda_core::engine::event::BgChildActivityKind::Info { message } => {
+                        // BufferingSink-style info lines already carry
+                        // their own indentation/emoji — forward as-is
+                        // so visual hierarchy survives.
+                        message
+                    }
+                };
+                tui_output::emit_line(
+                    buffer,
+                    Line::from(vec![
+                        Span::styled(format!("  [bg {task_id}] "), DIM),
+                        Span::styled(body, DIM),
+                    ]),
+                );
+            }
             EngineEvent::ActionBlocked {
                 tool_name: _,
                 detail,

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -336,6 +336,30 @@ impl BgStatusEmitter {
         });
     }
 
+    /// Forward a live activity event from inside the bg agent up to
+    /// the parent's sink.
+    ///
+    /// **#1201 B**: paired with [`crate::engine::sink::ForwardingBgSink`],
+    /// which decorates the bg agent's `BufferingSink` and calls this
+    /// method whenever an interesting child event happens (tool
+    /// start/end, info line). The event lands on the same registry
+    /// queue as `BgTaskUpdate`, so the inference loop's existing
+    /// drain in [`crate::inference`] forwards it to whatever sink
+    /// is active (TUI / headless / ACP) without further plumbing.
+    ///
+    /// Cheap: a single mutex acquisition + `VecDeque::push_back`,
+    /// the same cost as [`Self::send`]. The activity feed runs at
+    /// roughly tool-call frequency — not hot enough for any of this
+    /// to register in a profile.
+    pub fn send_activity(&self, kind: crate::engine::event::BgChildActivityKind) {
+        self.registry
+            .push_status_event(EngineEvent::BgChildActivity {
+                task_id: self.task_id,
+                spawner: self.spawner,
+                kind,
+            });
+    }
+
     /// Current status (read from the watch channel). Useful for
     /// terminal-disambiguation logic (e.g. "was this a cancel or a
     /// real error?") without taking the registry lock.
@@ -1822,5 +1846,45 @@ mod tests {
         let reg = BgAgentRegistry::new();
         let drained = reg.drain_status_events();
         assert!(drained.is_empty());
+    }
+
+    /// #1201 B: `BgStatusEmitter::send_activity` must push events
+    /// onto the *same* registry queue that `BgStatusEmitter::send`
+    /// uses, with the emitter's `task_id` and `spawner` baked in.
+    /// This pins the wire-up so the inference loop's existing drain
+    /// in `inference.rs` picks up activity events without any extra
+    /// plumbing.
+    #[tokio::test]
+    async fn send_activity_queues_bg_child_activity_with_task_id() {
+        let registry = new_shared();
+        let (status_tx, _status_rx) = tokio::sync::watch::channel(AgentStatus::Pending);
+        let emitter = BgStatusEmitter::new(42, Some(7), status_tx, registry.clone());
+
+        emitter.send_activity(crate::engine::event::BgChildActivityKind::ToolStart {
+            tool_name: "Read".into(),
+            summary: "Read foo.txt".into(),
+        });
+        emitter.send_activity(crate::engine::event::BgChildActivityKind::Info {
+            message: "\u{26a1} cache hit".into(),
+        });
+
+        let drained = registry.drain_status_events();
+        assert_eq!(drained.len(), 2);
+        assert!(matches!(
+            &drained[0],
+            EngineEvent::BgChildActivity {
+                task_id: 42,
+                spawner: Some(7),
+                kind: crate::engine::event::BgChildActivityKind::ToolStart { tool_name, .. }
+            } if tool_name == "Read"
+        ));
+        assert!(matches!(
+            &drained[1],
+            EngineEvent::BgChildActivity {
+                task_id: 42,
+                spawner: Some(7),
+                kind: crate::engine::event::BgChildActivityKind::Info { message }
+            } if message.contains("cache hit")
+        ));
     }
 }

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -1854,7 +1854,7 @@ mod tests {
     /// This pins the wire-up so the inference loop's existing drain
     /// in `inference.rs` picks up activity events without any extra
     /// plumbing.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn send_activity_queues_bg_child_activity_with_task_id() {
         let registry = new_shared();
         let (status_tx, _status_rx) = tokio::sync::watch::channel(AgentStatus::Pending);

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -155,6 +155,38 @@ pub enum EngineEvent {
         status: crate::bg_agent::AgentStatus,
     },
 
+    /// Live activity from inside a running background sub-agent.
+    ///
+    /// **#1201 B**: pre-this-event the parent's TUI had no live signal
+    /// from inside a bg agent — only `BgTaskUpdate` heartbeats
+    /// (`Running { iter: N }`), which tell you "still going" but not
+    /// "doing what". The narrative trace shipped via `BufferingSink`
+    /// only surfaced at result-injection time.
+    ///
+    /// `BgChildActivity` is the live tap: each interesting event
+    /// inside the bg agent (tool start/end, info line) fans out to
+    /// the parent's sink as soon as it happens, so the parent's TUI
+    /// can render a Gemini-style activity feed under the bg-task's
+    /// spawn cell. The post-completion narrative trace via
+    /// `BufferingSink` is still emitted (and is still authoritative
+    /// for the persisted transcript) — this event is purely for
+    /// real-time UX.
+    ///
+    /// Same routing as `BgTaskUpdate`: pushed onto the registry's
+    /// status-event queue by [`crate::bg_agent::BgStatusEmitter::send_activity`]
+    /// and drained by the inference loop, so every client surface
+    /// (TUI / headless / ACP) sees the same stream.
+    BgChildActivity {
+        /// Matches the `task_id` from `BgTaskUpdate` for the same
+        /// running bg task.
+        task_id: u32,
+        /// Sub-agent invocation id of the spawner, or `None` for
+        /// top-level-spawned bg tasks. Mirrors `BgTaskUpdate.spawner`.
+        spawner: Option<u32>,
+        /// What just happened inside the bg agent.
+        kind: BgChildActivityKind,
+    },
+
     // ── Approval flow ─────────────────────────────────────────────────
     /// The engine needs user approval before executing a tool.
     ///
@@ -306,6 +338,58 @@ pub enum EngineEvent {
     /// Error message.
     Error {
         /// The error message.
+        message: String,
+    },
+}
+
+/// What kind of activity happened inside a running background sub-agent.
+///
+/// **#1201 B**: deliberately a small, fixed set rather than "forward
+/// every `EngineEvent`". The parent's TUI is rendering a *summary*
+/// of child activity, not replaying the child's full event stream;
+/// most events (streaming text deltas, thinking deltas, status
+/// updates) would be noise at this granularity.
+///
+/// Wire format is `snake_case` with an internal `kind` tag, matching
+/// the convention for [`TurnEndReason`] and
+/// [`crate::bg_agent::AgentStatus`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BgChildActivityKind {
+    /// The child started a tool call.
+    ///
+    /// `summary` is a pre-truncated one-line description suitable
+    /// for direct render (e.g. `"Read src/auth.rs"`, `"Bash cargo
+    /// test"`). Computed at emit time so every client renders the
+    /// same string without having to know the per-tool argument
+    /// schema.
+    ToolStart {
+        /// Tool name (matches `EngineEvent::ToolCallStart.name`).
+        tool_name: String,
+        /// Pre-truncated one-line summary suitable for direct render.
+        summary: String,
+    },
+    /// The child's tool call completed.
+    ///
+    /// Output is intentionally NOT included — it can be arbitrarily
+    /// large and the parent's TUI is rendering a feed, not a
+    /// transcript. The model's narrative trace via `BufferingSink`
+    /// remains the authoritative record.
+    ToolEnd {
+        /// Tool name (matches `EngineEvent::ToolCallStart.name`).
+        tool_name: String,
+        /// Whether the tool succeeded. Best-effort classification
+        /// at the emit site by inspecting the result string for an
+        /// error-marker prefix; not load-bearing for correctness.
+        success: bool,
+    },
+    /// An informational line from inside the child.
+    ///
+    /// These pass through verbatim from `EngineEvent::Info` so the
+    /// child agent's own status messages (cache hit, microcompact
+    /// fired, etc.) surface in the parent's feed.
+    Info {
+        /// The info line, rendered as-is.
         message: String,
     },
 }
@@ -696,5 +780,74 @@ mod tests {
             let roundtripped: TurnEndReason = serde_json::from_str(&json).unwrap();
             assert_eq!(reason, roundtripped);
         }
+    }
+
+    /// #1201 B: BgChildActivity must roundtrip cleanly so ACP / headless
+    /// clients see the same wire shape as the in-process TUI. Tests all
+    /// three kinds and the `BgChildActivity` envelope.
+    #[test]
+    fn test_bg_child_activity_roundtrip() {
+        let kinds = vec![
+            BgChildActivityKind::ToolStart {
+                tool_name: "Read".into(),
+                summary: "Read src/auth.rs".into(),
+            },
+            BgChildActivityKind::ToolEnd {
+                tool_name: "Bash".into(),
+                success: true,
+            },
+            BgChildActivityKind::ToolEnd {
+                tool_name: "Edit".into(),
+                success: false,
+            },
+            BgChildActivityKind::Info {
+                message: "  \u{26a1} cache hit".into(),
+            },
+        ];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).unwrap();
+            let roundtripped: BgChildActivityKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(kind, roundtripped);
+        }
+
+        // Envelope event — tests the outer EngineEvent serialization
+        // including the snake_case type tag ("bg_child_activity").
+        let event = EngineEvent::BgChildActivity {
+            task_id: 7,
+            spawner: Some(3),
+            kind: BgChildActivityKind::ToolStart {
+                tool_name: "Grep".into(),
+                summary: "Grep TODO src/".into(),
+            },
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(
+            json.contains("\"type\":\"bg_child_activity\""),
+            "envelope must use snake_case type tag for ACP / headless clients"
+        );
+        assert!(
+            json.contains("\"kind\":\"tool_start\""),
+            "inner kind must use snake_case tag"
+        );
+        let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            deserialized,
+            EngineEvent::BgChildActivity {
+                task_id: 7,
+                spawner: Some(3),
+                ..
+            }
+        ));
+
+        // Top-level-spawned bg task — spawner is None.
+        let top_level = EngineEvent::BgChildActivity {
+            task_id: 1,
+            spawner: None,
+            kind: BgChildActivityKind::Info {
+                message: "hello".into(),
+            },
+        };
+        let json = serde_json::to_string(&top_level).unwrap();
+        let _: EngineEvent = serde_json::from_str(&json).unwrap();
     }
 }

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -137,6 +137,175 @@ impl EngineSink for BufferingSink {
     }
 }
 
+// ── ForwardingBgSink (#1201 B) ──────────────────────────
+
+/// A decorator around [`BufferingSink`] that *also* forwards select
+/// events as [`crate::engine::event::EngineEvent::BgChildActivity`]
+/// up to the parent's sink via the bg-task's status emitter.
+///
+/// **#1201 B**: pre-this-decorator the parent's TUI had zero live
+/// signal from inside a running bg agent — only `BgTaskUpdate`
+/// heartbeats (`Running { iter: N }`), which tell you "still going"
+/// but not "doing what". The narrative trace from `BufferingSink`
+/// only surfaced at result-injection time, so a 30-second tool call
+/// inside a bg agent looked identical to a 30-second hang.
+///
+/// `ForwardingBgSink` is the live tap. For each event interesting
+/// enough to surface in the parent's feed, it builds a
+/// [`crate::engine::event::BgChildActivityKind`] and pushes it onto
+/// the registry's status-event queue via
+/// [`crate::bg_agent::BgStatusEmitter::send_activity`]. The
+/// inference loop's existing drain in `inference.rs` forwards the
+/// resulting `BgChildActivity` event to whatever sink is active
+/// (TUI / headless / ACP) without further plumbing.
+///
+/// **The narrative trace is preserved.** Every event that hits this
+/// sink is also forwarded to the inner `BufferingSink`, so the
+/// authoritative post-completion trace (drained at result-injection
+/// time and persisted to the transcript) is unchanged. Live and
+/// post-completion are deliberately two separate channels:
+/// - Live (`BgChildActivity`) is for real-time UX; events are
+///   ephemeral and may be coalesced or dropped by the renderer.
+/// - Post-completion (the `BufferingSink::take_lines` dump) is the
+///   load-bearing record — it's what the model sees in the result
+///   message and what the transcript exporter persists.
+///
+/// ## Sink wrapping order
+///
+/// `PersistingSink` wraps `ForwardingBgSink` wraps `BufferingSink`.
+/// Persistence sees every event first (so the transcript captures
+/// `SubAgentEvent` rows in real time), then forwarding fans out to
+/// the parent's queue, then buffering captures the line for the
+/// post-completion drain.
+pub struct ForwardingBgSink {
+    inner: BufferingSink,
+    emitter: crate::bg_agent::BgStatusEmitter,
+}
+
+impl ForwardingBgSink {
+    /// Wrap a `BufferingSink` and forward live activity through the
+    /// emitter. The emitter is cheap to clone (two `Arc`s and a
+    /// `watch::Sender`); pass a clone and keep the original for the
+    /// terminal-status sends in `run_bg_agent`.
+    pub fn new(inner: BufferingSink, emitter: crate::bg_agent::BgStatusEmitter) -> Self {
+        Self { inner, emitter }
+    }
+
+    /// Drain the inner buffering sink. Same semantics as
+    /// [`BufferingSink::take_lines`] — the buffer is empty after
+    /// this returns. Only the post-completion narrative is drained
+    /// here; live `BgChildActivity` events have already been
+    /// forwarded individually as they happened.
+    pub fn take_lines(&self) -> Vec<String> {
+        self.inner.take_lines()
+    }
+}
+
+impl EngineSink for ForwardingBgSink {
+    fn emit(&self, event: EngineEvent) {
+        // Forward the *live* signal first while we still own the
+        // event by reference. Dropping a delta on the floor here
+        // (e.g. an unknown future variant) is silently fine — the
+        // post-completion trace via the inner BufferingSink remains
+        // authoritative.
+        match &event {
+            EngineEvent::ToolCallStart { name, args, .. } => {
+                self.emitter
+                    .send_activity(crate::engine::event::BgChildActivityKind::ToolStart {
+                        tool_name: name.clone(),
+                        summary: summarize_tool_call(name, args),
+                    });
+            }
+            EngineEvent::ToolCallResult { name, output, .. } => {
+                // Best-effort success classification: tool dispatchers
+                // prefix failed results with "Error:" or "❌". Cheap
+                // string sniff — the live feed only uses this for an
+                // icon hint, not for any control-flow decision.
+                let success = !looks_like_tool_error(output);
+                self.emitter
+                    .send_activity(crate::engine::event::BgChildActivityKind::ToolEnd {
+                        tool_name: name.clone(),
+                        success,
+                    });
+            }
+            EngineEvent::Info { message } => {
+                self.emitter
+                    .send_activity(crate::engine::event::BgChildActivityKind::Info {
+                        message: message.clone(),
+                    });
+            }
+            // Streaming text, thinking, status, approval, etc. are
+            // intentionally not forwarded — too noisy for a feed,
+            // duplicative with the result oneshot, or already covered
+            // by `BgTaskUpdate` heartbeats.
+            _ => {}
+        }
+        // Forward to the inner buffering sink for the post-completion
+        // narrative trace.
+        self.inner.emit(event);
+    }
+}
+
+/// Build a one-line summary of a tool call for the live activity
+/// feed. Output is rendered as-is by clients, so trim hard.
+///
+/// Per-tool special cases live here so every client sees the same
+/// string without having to know each tool's argument schema. New
+/// tools fall through to a generic `"<name> <truncated args>"`.
+fn summarize_tool_call(name: &str, args: &serde_json::Value) -> String {
+    /// Per-line cap. The activity feed is rendered inline under the
+    /// bg-task spawn cell where horizontal real estate is tight.
+    const MAX_LEN: usize = 80;
+
+    let body = match name {
+        "Read" | "Edit" | "Write" | "Delete" => args
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        "Bash" => args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        "Grep" => {
+            let pattern = args.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            let path = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
+            Some(format!("{pattern} {path}"))
+        }
+        "InvokeAgent" => args
+            .get("agent")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        _ => None,
+    };
+
+    let body = body.unwrap_or_default();
+    let combined = if body.is_empty() {
+        name.to_string()
+    } else {
+        format!("{name} {body}")
+    };
+
+    if combined.chars().count() <= MAX_LEN {
+        combined
+    } else {
+        // Char-aware truncation — byte slicing would explode on
+        // multi-byte chars in tool args (paths, commit messages, etc.).
+        let truncated: String = combined.chars().take(MAX_LEN.saturating_sub(1)).collect();
+        format!("{truncated}\u{2026}")
+    }
+}
+
+/// Best-effort "did this tool result indicate failure" check.
+///
+/// Tool dispatchers in `tools/` produce result strings, not Result
+/// enums, so this is the only signal available at the sink. Used
+/// purely for a render hint (success vs error icon) — callers must
+/// not depend on this for correctness.
+fn looks_like_tool_error(output: &str) -> bool {
+    let head = output.trim_start();
+    head.starts_with("Error:") || head.starts_with("\u{274c}")
+}
+
 // ── PersistingSink (#1108 P1b/P2a) ───────────────────────────────
 
 /// A decorator that persists `Info` and `BgTaskUpdate` events to the
@@ -509,5 +678,217 @@ mod tests {
     fn buffering_sink_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<BufferingSink>();
+    }
+
+    // ── ForwardingBgSink (#1201 B) ────────────────────
+
+    /// Build a [`crate::bg_agent::BgStatusEmitter`] hooked up to a
+    /// real registry so we can drain forwarded events. The registry
+    /// is the load-bearing piece — it's what the inference loop
+    /// drains in production, so testing through it (rather than
+    /// against a mock emitter) catches wire-up regressions.
+    fn make_test_emitter(
+        task_id: u32,
+    ) -> (
+        std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+        crate::bg_agent::BgStatusEmitter,
+    ) {
+        let registry = crate::bg_agent::new_shared();
+        let (status_tx, _status_rx) =
+            tokio::sync::watch::channel(crate::bg_agent::AgentStatus::Pending);
+        let emitter =
+            crate::bg_agent::BgStatusEmitter::new(task_id, None, status_tx, registry.clone());
+        (registry, emitter)
+    }
+
+    #[test]
+    fn forwarding_bg_sink_emits_tool_start_and_end_to_registry() {
+        let (registry, emitter) = make_test_emitter(7);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "t1".into(),
+            name: "Read".into(),
+            args: serde_json::json!({"path": "src/auth.rs"}),
+            is_sub_agent: false,
+        });
+        sink.emit(EngineEvent::ToolCallResult {
+            id: "t1".into(),
+            name: "Read".into(),
+            output: "<file contents>".into(),
+        });
+
+        let drained = registry.drain_status_events();
+        assert_eq!(
+            drained.len(),
+            2,
+            "each interesting event should fan out exactly one BgChildActivity"
+        );
+        assert!(matches!(
+            &drained[0],
+            EngineEvent::BgChildActivity {
+                task_id: 7,
+                kind: crate::engine::event::BgChildActivityKind::ToolStart { tool_name, summary },
+                ..
+            } if tool_name == "Read" && summary.contains("src/auth.rs")
+        ));
+        assert!(matches!(
+            &drained[1],
+            EngineEvent::BgChildActivity {
+                kind: crate::engine::event::BgChildActivityKind::ToolEnd { tool_name, success: true },
+                ..
+            } if tool_name == "Read"
+        ));
+    }
+
+    #[test]
+    fn forwarding_bg_sink_classifies_tool_errors() {
+        let (registry, emitter) = make_test_emitter(1);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        sink.emit(EngineEvent::ToolCallResult {
+            id: "t1".into(),
+            name: "Bash".into(),
+            output: "Error: command not found".into(),
+        });
+        let drained = registry.drain_status_events();
+        assert!(matches!(
+            &drained[0],
+            EngineEvent::BgChildActivity {
+                kind: crate::engine::event::BgChildActivityKind::ToolEnd { success: false, .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn forwarding_bg_sink_preserves_buffering_for_post_completion_drain() {
+        // The whole point of the decorator is "live AND buffered" —
+        // dropping the inner buffer would silently break the
+        // model-facing narrative trace. This test pins that.
+        let (_registry, emitter) = make_test_emitter(1);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "t1".into(),
+            name: "Read".into(),
+            args: serde_json::json!({"path": "foo"}),
+            is_sub_agent: false,
+        });
+        sink.emit(EngineEvent::Info {
+            message: "  \u{26a1} cache hit".into(),
+        });
+
+        let lines = sink.take_lines();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("Read"));
+        assert!(lines[1].contains("cache hit"));
+    }
+
+    #[test]
+    fn forwarding_bg_sink_drops_streaming_text() {
+        // Streaming text is forwarded neither live nor to the buffer:
+        // the model's final output already crosses the result oneshot,
+        // so capturing it here would duplicate it AND spam the parent
+        // feed with per-token noise.
+        let (registry, emitter) = make_test_emitter(1);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        sink.emit(EngineEvent::TextDelta {
+            text: "hello".into(),
+        });
+        sink.emit(EngineEvent::ThinkingDelta {
+            text: "reasoning".into(),
+        });
+        sink.emit(EngineEvent::TextDone);
+
+        assert!(registry.drain_status_events().is_empty());
+        assert!(sink.take_lines().is_empty());
+    }
+
+    #[test]
+    fn forwarding_bg_sink_summarizes_known_tool_args() {
+        // Per-tool special cases live inside the sink so every client
+        // renders the same summary string. Pin the contracts the TUI
+        // depends on — if the summary format changes, the activity
+        // feed render needs to update too.
+        let (registry, emitter) = make_test_emitter(1);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        // Bash: command
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "a".into(),
+            name: "Bash".into(),
+            args: serde_json::json!({"command": "cargo test"}),
+            is_sub_agent: false,
+        });
+        // Grep: pattern + path
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "b".into(),
+            name: "Grep".into(),
+            args: serde_json::json!({"pattern": "TODO", "path": "src/"}),
+            is_sub_agent: false,
+        });
+        // InvokeAgent: agent name
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "c".into(),
+            name: "InvokeAgent".into(),
+            args: serde_json::json!({"agent": "reviewer", "prompt": "x"}),
+            is_sub_agent: false,
+        });
+
+        let drained = registry.drain_status_events();
+        let summaries: Vec<String> = drained
+            .iter()
+            .filter_map(|e| match e {
+                EngineEvent::BgChildActivity {
+                    kind: crate::engine::event::BgChildActivityKind::ToolStart { summary, .. },
+                    ..
+                } => Some(summary.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(summaries.len(), 3);
+        assert!(summaries[0].contains("cargo test"), "got: {}", summaries[0]);
+        assert!(
+            summaries[1].contains("TODO") && summaries[1].contains("src/"),
+            "got: {}",
+            summaries[1]
+        );
+        assert!(summaries[2].contains("reviewer"), "got: {}", summaries[2]);
+    }
+
+    #[test]
+    fn forwarding_bg_sink_truncates_long_summaries() {
+        // Summaries land in tight horizontal real estate (inline
+        // under the bg-task spawn cell). A 5KB commit message in the
+        // args must not blow up the feed.
+        let (registry, emitter) = make_test_emitter(1);
+        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+
+        let long_cmd = "x".repeat(500);
+        sink.emit(EngineEvent::ToolCallStart {
+            id: "a".into(),
+            name: "Bash".into(),
+            args: serde_json::json!({"command": long_cmd}),
+            is_sub_agent: false,
+        });
+
+        let drained = registry.drain_status_events();
+        let summary = match &drained[0] {
+            EngineEvent::BgChildActivity {
+                kind: crate::engine::event::BgChildActivityKind::ToolStart { summary, .. },
+                ..
+            } => summary.clone(),
+            _ => panic!("expected ToolStart"),
+        };
+        assert!(summary.chars().count() <= 80);
+        assert!(summary.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn forwarding_bg_sink_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ForwardingBgSink>();
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -179,7 +179,18 @@ async fn run_bg_agent(
     // result oneshot and gets surfaced to the user at
     // result-injection time. See `engine::sink::BufferingSink` for
     // the capture rules.
-    let buffering_sink = crate::engine::sink::BufferingSink::new();
+    //
+    // #1201 B: wrap the buffering sink in a `ForwardingBgSink` so
+    // every interesting event is *also* forwarded live as a
+    // `BgChildActivity` to the parent's sink (via the registry's
+    // status-event queue, drained by the inference loop). Pre-this
+    // wrapper a 30-second tool inside a bg agent looked identical
+    // to a 30-second hang — only the post-completion drain showed
+    // what happened.
+    let buffering_sink = crate::engine::sink::ForwardingBgSink::new(
+        crate::engine::sink::BufferingSink::new(),
+        emitter.clone(),
+    );
     let nested_bg = crate::bg_agent::new_shared();
 
     // Override background=false to prevent infinite spawn — a bg agent


### PR DESCRIPTION
Closes the **B bullet** of #1201 (live activity feed from inside bg agents). Issue stays open for **B2 polish** (Gemini-style block + collapse-on-completion) and **A2 / Bonus**.

## TL;DR

A 30-second tool call inside a bg agent used to look identical to a 30-second hang. Now every interesting child event surfaces live in the parent's TUI / headless / ACP within ~one event-loop tick, while the post-completion narrative trace remains unchanged.

## Architecture

```
   bg agent's inference loop emits EngineEvent
                 │
                 ▼
   ┌─────────────────────────────┐
   │   ForwardingBgSink (NEW)    │ ◀── extends BufferingSink
   │                             │
   │  ┌─────────────────────┐    │
   │  │  forward as         │    │   live tap
   │  │  BgChildActivity    │────┼──▶ via emitter ──▶ registry queue
   │  │  via emitter        │    │
   │  └─────────────────────┘    │
   │                             │
   │  delegate to inner          │   post-completion trace
   │  BufferingSink ─────────────┼──▶ take_lines() at result inject
   └─────────────────────────────┘

   parent inference loop drains registry queue once per iter
                 │
                 ▼
   parent sink (TUI / headless / ACP) renders BgChildActivity
```

The two channels are deliberately separate:
- **Live** (`BgChildActivity`) is for real-time UX; ephemeral, may be coalesced or dropped by future renderers
- **Post-completion** (`take_lines`) is the load-bearing record — what the model sees in the result message and what the transcript exporter persists

## What changed

| File | Lines | What |
|---|---|---|
| `koda-core/src/engine/event.rs` | +153 | New `BgChildActivity` event variant + `BgChildActivityKind` enum (`ToolStart`, `ToolEnd`, `Info`) + roundtrip tests |
| `koda-core/src/bg_agent.rs` | +64 | `BgStatusEmitter::send_activity()` queues activity events on the same registry queue as `BgTaskUpdate`; integration test |
| `koda-core/src/engine/sink.rs` | +381 | `ForwardingBgSink` decorator + `summarize_tool_call` (per-tool special cases) + 7 sink tests |
| `koda-core/src/sub_agent_dispatch.rs` | +13 | One-line wiring: `BufferingSink` → `ForwardingBgSink::new(BufferingSink::new(), emitter.clone())` |
| `koda-cli/src/tui_render.rs` | +40 | Dim inline render with `[bg N]` prefix + tool icons (🔧 / ✓ / ✗) |
| `koda-cli/src/headless.rs` | +20 | Mirror of TUI line via `eprintln!` for tailing scripts |
| `koda-cli/src/acp_adapter.rs` | +26 | Falls through to `BgTaskUpdate`'s `[bg task N] ...` text-chunk shape |

## Per-tool summary contracts

Lives in `summarize_tool_call` so every client renders the same string. Char-aware truncation to 80 chars with ellipsis (`…`).

| Tool | Summary |
|---|---|
| `Read` / `Edit` / `Write` / `Delete` | path |
| `Bash` | command |
| `Grep` | `{pattern} {path}` |
| `InvokeAgent` | agent name |
| (anything else) | tool name only |

## Tests

11 new tests across two files, all passing:

| Test | Layer | Pins |
|---|---|---|
| `event::test_bg_child_activity_roundtrip` | wire | snake_case envelope + kind tags |
| `bg_agent::send_activity_queues_bg_child_activity_with_task_id` | emitter | task_id + spawner correctness |
| `sink::forwarding_bg_sink_emits_tool_start_and_end_to_registry` | sink↔registry | end-to-end via real registry |
| `sink::forwarding_bg_sink_classifies_tool_errors` | sink | success=false on `Error:` prefix |
| `sink::forwarding_bg_sink_preserves_buffering_for_post_completion_drain` | invariant | inner buffer untouched (load-bearing) |
| `sink::forwarding_bg_sink_drops_streaming_text` | filter | TextDelta neither forwarded nor buffered |
| `sink::forwarding_bg_sink_summarizes_known_tool_args` | summary | per-tool contracts |
| `sink::forwarding_bg_sink_truncates_long_summaries` | safety | 80-char cap survives 500-char input |
| `sink::forwarding_bg_sink_is_send_sync` | type | safe for `tokio::spawn` |

## Verification

```
cargo test -p koda-core --lib   → 1167/1167 (was 1158, +9)
cargo test -p koda-cli --lib    → 591/591
cargo clippy --workspace --all-targets -- -D warnings → clean
cargo fmt --all                 → clean
```

## Out of scope (still tracked in #1201)

- **B2 polish** — Gemini-style activity *block* that collapses to one-line summary on bg-agent completion. Current PR is an inline-line render that gets the live signal without committing to a panel layout.
- **A2** — truly async `WaitTask` (deeper refactor)
- **Bonus** — live-refresh `/agents` panel