### PR TITLE
fix(session): per-turn cancel cascades through inference loop (closes #1208)

### DIFF
--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -80,6 +80,7 @@ pub async fn run_headless(
             pending_images,
             &cli_sink,
             &mut cmd_rx,
+            None,
         ) => r,
         _ = tokio::signal::ctrl_c() => {
             cancel.cancel();

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -442,7 +442,7 @@ async fn handle_prompt(
     let config = state.config.clone();
     let result = active
         .session
-        .run_turn(&config, None, &sink, &mut cmd_rx)
+        .run_turn(&config, None, &sink, &mut cmd_rx, None)
         .await;
 
     // Drop the sink so the streaming task finishes

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -103,9 +103,16 @@ impl TuiContext {
 
         // Run the inference turn as a pinned future
         {
-            let turn = self
-                .session
-                .run_turn(&self.config, pending_images, &cli_sink, cmd_rx);
+            let turn = self.session.run_turn(
+                &self.config,
+                pending_images,
+                &cli_sink,
+                cmd_rx,
+                // #1208: pass the per-turn child token so Ctrl+C / Esc
+                // stops *this* turn without firing session.cancel
+                // (which bg agents derive from — see #1200).
+                Some(cancel_token.clone()),
+            );
             tokio::pin!(turn);
 
             // Rotate which select arm is preferred each iteration so neither

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -251,12 +251,23 @@ impl KodaSession {
     ///
     /// Emits `TurnStart` and `TurnEnd` lifecycle events. The loop-cap prompt is handled via `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`
     /// through the `cmd_rx` channel.
+    ///
+    /// # Per-turn cancellation (#1208)
+    ///
+    /// `turn_cancel` lets callers (notably the TUI) wire Ctrl+C / Esc to a
+    /// **per-turn** child token that, when fired, stops the inference loop
+    /// without cancelling the session-lifetime `self.cancel` (which bg agents
+    /// derive from — see #1200 for why session.cancel must stay stable across
+    /// turns). When `None`, the inference loop falls back to `self.cancel`,
+    /// which preserves the pre-#1208 behaviour every test, the headless
+    /// driver, and the ACP server already rely on.
     pub async fn run_turn(
         &mut self,
         config: &KodaConfig,
         pending_images: Option<Vec<ImageData>>,
         sink: &dyn EngineSink,
         cmd_rx: &mut mpsc::Receiver<EngineCommand>,
+        turn_cancel: Option<CancellationToken>,
     ) -> Result<()> {
         let turn_id = uuid::Uuid::new_v4().to_string();
         sink.emit(crate::engine::EngineEvent::TurnStart {
@@ -300,7 +311,11 @@ impl KodaSession {
             pending_images,
             mode: self.mode,
             sink,
-            cancel: self.cancel.clone(),
+            // #1208: prefer the caller-supplied per-turn cancel so the TUI
+            // can stop *just this turn* with Ctrl+C without nuking the
+            // session-lifetime token bg agents share. Headless / server /
+            // tests pass `None` and keep the legacy session-token behaviour.
+            cancel: turn_cancel.unwrap_or_else(|| self.cancel.clone()),
             cmd_rx,
             file_tracker: &mut self.file_tracker,
             bg_agents: &self.bg_agents,

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -146,7 +146,7 @@ async fn mcp_instructions_reach_provider_in_live_turn() {
     let sink = TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await
         .expect("turn should succeed");
 
@@ -190,7 +190,7 @@ async fn no_mcp_manager_means_no_mcp_block_in_prompt() {
     let sink = TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await
         .expect("turn should succeed");
 
@@ -223,7 +223,7 @@ async fn connected_server_without_instructions_is_omitted() {
     let sink = TestSink::new();
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
     session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await
         .expect("turn should succeed");
 
@@ -265,7 +265,7 @@ async fn server_connected_after_agent_built_still_appears_in_next_turn() {
 
     // Turn 1: no MCP, no block.
     session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await
         .expect("turn 1 should succeed");
     {
@@ -288,7 +288,7 @@ async fn server_connected_after_agent_built_still_appears_in_next_turn() {
     // Queue a follow-up user message and run turn 2.
     env.insert_user_message("anything new?").await;
     session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await
         .expect("turn 2 should succeed");
 

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -86,7 +86,7 @@ async fn session_run_turn_emits_turn_start_and_end() {
     let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
 
     let result = session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await;
     assert!(
         result.is_ok(),
@@ -197,7 +197,7 @@ async fn session_cancellation_produces_turn_end_cancelled() {
 
     let start = std::time::Instant::now();
     let result = session
-        .run_turn(&env.config, None, &sink, &mut cmd_rx)
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
         .await;
 
     let elapsed = start.elapsed();
@@ -231,6 +231,107 @@ async fn session_cancellation_produces_turn_end_cancelled() {
     );
 }
 
+/// **#1208 regression.** A per-turn cancel token (the `turn_cancel`
+/// argument added so the TUI can fire Ctrl+C without nuking
+/// `session.cancel`, which bg agents derive from — see #1200) must
+/// stop the inference loop just like the session-token path does.
+///
+/// Without the wiring, firing the per-turn child token left the
+/// inference loop spinning because it was checking `session.cancel`
+/// instead. The bug surfaced as: bg sub-agents stopped, master turn
+/// kept running, model retried by spawning more bg agents.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn session_turn_cancel_token_stops_inference() {
+    let env = Env::new().await;
+    env.insert_user_message("hello").await;
+
+    // Same hanging-provider trick as `session_cancellation_produces_turn_end_cancelled`:
+    // signal once we're inside the LLM call, then sleep so the test
+    // drives the cancel deterministically.
+    struct HangingProvider {
+        entered: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for HangingProvider {
+        async fn chat(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &koda_core::config::ModelSettings,
+        ) -> Result<LlmResponse> {
+            unreachable!()
+        }
+        async fn chat_stream(
+            &self,
+            _: &[ChatMessage],
+            _: &[ToolDefinition],
+            _: &koda_core::config::ModelSettings,
+        ) -> Result<koda_core::providers::stream_collector::SseCollector> {
+            if let Some(tx) = self.entered.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            unreachable!()
+        }
+        async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+            Ok(vec![])
+        }
+        fn provider_name(&self) -> &str {
+            "hanging"
+        }
+    }
+
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let provider = HangingProvider {
+        entered: std::sync::Mutex::new(Some(entered_tx)),
+    };
+    let (mut session, session_cancel) = make_session(&env, Box::new(provider)).await;
+
+    // The whole point of #1208: cancel the *per-turn* token, NOT
+    // session.cancel — then assert the turn still ends, AND
+    // session.cancel is still alive afterwards (so bg agents survive).
+    let turn_cancel = tokio_util::sync::CancellationToken::new();
+    let turn_cancel_clone = turn_cancel.clone();
+    tokio::spawn(async move {
+        let _ = entered_rx.await;
+        turn_cancel_clone.cancel();
+    });
+
+    let sink = TestSink::new();
+    let (_, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+
+    let start = std::time::Instant::now();
+    let result = session
+        .run_turn(
+            &env.config,
+            None,
+            &sink,
+            &mut cmd_rx,
+            Some(turn_cancel.clone()),
+        )
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_ok(),
+        "per-turn cancellation should be graceful, not an error"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "per-turn cancel should unblock inference quickly, took {elapsed:?}"
+    );
+    assert!(
+        turn_cancel.is_cancelled(),
+        "per-turn token should remain in the cancelled state"
+    );
+    assert!(
+        !session_cancel.is_cancelled(),
+        "session.cancel must NOT be fired when only the per-turn token cancels \
+         (this is the whole #1208 fix — bg agents survive across cancelled turns)"
+    );
+}
+
 /// Messages from two separate `run_turn()` calls on the same session must
 /// both appear in the DB afterward.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -247,7 +348,7 @@ async fn session_persists_messages_across_two_turns() {
     let sink1 = TestSink::new();
     let (_, mut cmd_rx1) = mpsc::channel::<EngineCommand>(1);
     session1
-        .run_turn(&env.config, None, &sink1, &mut cmd_rx1)
+        .run_turn(&env.config, None, &sink1, &mut cmd_rx1, None)
         .await
         .expect("turn 1 should succeed");
 
@@ -275,7 +376,7 @@ async fn session_persists_messages_across_two_turns() {
     let sink2 = TestSink::new();
     let (_, mut cmd_rx2) = mpsc::channel::<EngineCommand>(1);
     session2
-        .run_turn(&env.config, None, &sink2, &mut cmd_rx2)
+        .run_turn(&env.config, None, &sink2, &mut cmd_rx2, None)
         .await
         .expect("turn 2 should succeed");
 


### PR DESCRIPTION
## What

Fixes #1208. A single Ctrl+C / Esc now stops both the bg sub-agents *and* the master inference loop.

## Root cause (recap)

The TUI builds a per-turn child token off `session.cancel`:

```rust
let cancel_token = self.session.cancel.child_token();  // line 88
```

…and fires it on Ctrl+C / Esc. But `inference_loop` was checking `session.cancel` (the parent), and **child→parent does not cascade**, so cancellation was invisible to the loop. Net effect: bg sub-agents stopped, master turn kept spinning, model would re-spawn the agents.

We can't just have the TUI fire `session.cancel` itself — #1200 deliberately keeps it session-lifetime stable so bg agents derived from it survive normal turn ends.

## Fix

`KodaSession::run_turn` gains an optional `turn_cancel: Option<CancellationToken>`:

- `Some(token)` → use it as the inference loop's cancel; cancelling it stops *just this turn*, leaves `session.cancel` alive (bg agents survive).
- `None` → falls back to `self.cancel.clone()` (preserves every test, the headless driver, and the ACP server with zero churn).

The TUI passes `Some(cancel_token.clone())` — same per-turn child it already owns — so all the existing cancel-handling code (`cancel_all_bg_work`, `mark_cancelling`, `/cancel`, Esc cancel-all) keeps working unchanged.

## Tests

New regression test `session_turn_cancel_token_stops_inference` (in `koda-core/tests/session_test.rs`) asserts both halves of the contract:

- Per-turn cancel actually stops the inference loop (turn ends fast)
- `session.cancel` is **NOT** touched (so bg agents survive — the whole reason we threaded a separate token instead of just firing `session.cancel`)

```
$ cargo test -p koda-core --test session_test
test session_turn_cancel_token_stops_inference ... ok
test session_cancellation_produces_turn_end_cancelled ... ok
test session_run_turn_emits_turn_start_and_end ... ok
test session_persists_messages_across_two_turns ... ok
```

Plus full `cargo clippy --workspace --all-targets -- -D warnings` ✅.

## Files touched

```
koda-cli/src/headless.rs                           |   1 +
koda-cli/src/server.rs                             |   2 +-
koda-cli/src/tui_handlers_inference.rs             |  13 +-
koda-core/src/session.rs                           |  17 +-
koda-core/tests/mcp_instructions_bootstrap_test.rs |  10 +-
koda-core/tests/session_test.rs                    | 109 ++++-
6 files, +138 / -14
```

## Discovered via

Field-testing #1213 (always-on bg-activity overlay).
