### PR TITLE
fix(tui): pretty-render ListBackgroundTasks tool result (closes #1209)

### DIFF
--- a/koda-cli/src/history_render.rs
+++ b/koda-cli/src/history_render.rs
@@ -206,6 +206,16 @@ fn render_tool_result(lines: &mut Vec<Line<'static>>, msg: &Message, tool_name: 
         return;
     }
 
+    // ListBackgroundTasks (#1209) — same JSON-soup problem; render
+    // with the same per-task helper so resumed history matches the
+    // live `tui_render` output verbatim.
+    if tool_name == "ListBackgroundTasks"
+        && let Some(rendered) = crate::wait_task_format::try_render_list_bg_tasks_lines(content)
+    {
+        lines.extend(rendered);
+        return;
+    }
+
     let total_lines = content.lines().count();
 
     let content_style = match classify_tool(tool_name) {

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -436,6 +436,19 @@ fn render_tool_output(
         return;
     }
 
+    // ListBackgroundTasks (#1209) — same JSON-soup problem as WaitTask;
+    // the model calls this to peek at running bg work and we owe the
+    // user a per-task render with the same icon vocabulary as the
+    // live `bg_activity_overlay` instead of a one-line JSON dump.
+    if name == "ListBackgroundTasks"
+        && let Some(lines) = crate::wait_task_format::try_render_list_bg_tasks_lines(output)
+    {
+        for line in lines {
+            tui_output::emit_line(buffer, line);
+        }
+        return;
+    }
+
     // Collapse consecutive blank lines (3+ → 1) to reduce visual noise,
     // especially from WebFetch HTML-to-text conversion.
     let collapsed = collapse_blank_lines(output);

--- a/koda-cli/src/wait_task_format.rs
+++ b/koda-cli/src/wait_task_format.rs
@@ -33,6 +33,16 @@ use crate::tui_output::{BOLD, DIM, TOOL_PREFIX};
 /// added to the engine must land here as well — the catch-all `❔`
 /// makes the omission visible in rendered output rather than failing
 /// silently.
+///
+/// Covers the union of statuses emitted by **both** `WaitTask` (the
+/// original consumer) and `ListBackgroundTasks` (#1209 added the latter):
+///
+/// - `WaitTask` outcomes: `completed`, `timed_out`, `cancelled`,
+///   `not_found`, `forbidden`, `parse_error`.
+/// - `ListBackgroundTasks` agent statuses: `pending`, `running`,
+///   `completed`, `cancelled`, `errored`.
+/// - `ListBackgroundTasks` process statuses: `running`, `exited`,
+///   `killed`.
 #[must_use]
 pub fn wait_status_icon(status: &str) -> &'static str {
     match status {
@@ -42,7 +52,16 @@ pub fn wait_status_icon(status: &str) -> &'static str {
         "not_found" => "\u{2753}",   // ❓
         "forbidden" => "\u{1F512}",  // 🔒
         "parse_error" => "\u{26A0}", // ⚠
-        _ => "\u{2754}",             // ❔
+        // ListBackgroundTasks-specific statuses (#1209). Glyph choice
+        // matches `bg_activity_overlay`'s status palette so the live
+        // overlay and the tool-result render speak the same icon
+        // vocabulary.
+        "pending" => "\u{25D0}", // ◐ — half-filled circle
+        "running" => "\u{25B6}", // ▶ — play / in-flight
+        "errored" => "\u{2717}", // ✗ — cross
+        "exited" => "\u{2713}",  // ✓ — check (clean exit)
+        "killed" => "\u{26D4}",  // ⛔ — same as cancelled (also user-initiated stop)
+        _ => "\u{2754}",         // ❔ — catch-all (visible omission)
     }
 }
 
@@ -195,6 +214,102 @@ pub fn try_render_wait_task_lines(payload: &str) -> Option<Vec<Line<'static>>> {
     Some(lines)
 }
 
+/// Render a `ListBackgroundTasks` JSON payload (#1209).
+///
+/// Shape contract (see `koda-core::tools::bg_task_tools`):
+///
+/// ```json
+/// [
+///   {
+///     "task_id": "agent:1",
+///     "task_type": "agent" | "process",
+///     "description": "<agent_name>: <prompt>" | "<command>",
+///     "status": "pending"|"running"|"completed"|"cancelled"|"errored"
+///             | "running"|"exited"|"killed",
+///     "age_secs": 12,
+///     "exit_code": 0   // optional, processes only
+///   },
+///   ...
+/// ]
+/// ```
+///
+/// Empty arrays render as a single "no background tasks" line so the
+/// model's tool call still leaves a visible trace in history rather
+/// than vanishing. Any other shape mismatch returns `None` so the
+/// caller falls back to the generic raw render — we never want to
+/// drop content silently.
+///
+/// Output shape (matches the `WaitTask` renderer's per-task style):
+///
+/// ```text
+///   │ 3 background task(s)
+///   │   ▶ agent:1  explore: scan koda-core/src for ToolEffect (running, 12s)
+///   │   ◐ agent:2  verify: confirm render (pending, 3s)
+///   │   ⛔ process:5821  cargo test --workspace (killed, 45s)
+/// ```
+#[must_use]
+pub fn try_render_list_bg_tasks_lines(payload: &str) -> Option<Vec<Line<'static>>> {
+    let v: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let tasks = v.as_array()?;
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    // Header. Empty-array case still emits a header so a `ListBackgroundTasks`
+    // call with zero results is visible in history rather than rendering
+    // as nothing-at-all (which would look like a broken tool).
+    let header = if tasks.is_empty() {
+        "no background tasks".to_string()
+    } else {
+        format!("{} background task(s)", tasks.len())
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  \u{2502} ", TOOL_PREFIX),
+        Span::styled(header, BOLD),
+    ]));
+
+    let dim_italic = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::ITALIC);
+
+    for task in tasks {
+        let task_id = task.get("task_id").and_then(|v| v.as_str()).unwrap_or("?");
+        let status = task.get("status").and_then(|v| v.as_str()).unwrap_or("?");
+        let age_secs = task.get("age_secs").and_then(|v| v.as_u64()).unwrap_or(0);
+        let description = task
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| first_meaningful_line(s, TUI_PREVIEW_CHARS))
+            .unwrap_or_default();
+        let exit_code = task.get("exit_code").and_then(|v| v.as_i64());
+
+        let icon = wait_status_icon(status);
+
+        // Status suffix shows the raw status word (with optional exit
+        // code for processes) plus age. Format mirrors the live
+        // `bg_activity_overlay` so eye sweeps between live + history
+        // see the same tail.
+        let status_tail = match exit_code {
+            Some(code) => format!("({status} {code}, {age_secs}s)"),
+            None => format!("({status}, {age_secs}s)"),
+        };
+
+        let mut spans: Vec<Span<'static>> = vec![
+            Span::styled("  \u{2502} ", TOOL_PREFIX),
+            Span::raw(format!("  {icon} ")),
+            Span::styled(task_id.to_string(), BOLD),
+        ];
+        if !description.is_empty() {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(description, dim_italic));
+        }
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(status_tail, DIM));
+        lines.push(Line::from(spans));
+    }
+
+    Some(lines)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +432,103 @@ mod tests {
         let row: String = lines[1].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(!row.contains("\u{2014} "), "no dangling em-dash: {row}");
         assert!(row.contains("agent:1"), "task id still present: {row}");
+    }
+
+    // --- ListBackgroundTasks renderer (#1209) ------------------------------
+
+    fn collect(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn list_bg_tasks_renders_mixed_agent_and_process() {
+        let payload = serde_json::json!([
+            {
+                "task_id": "agent:1",
+                "task_type": "agent",
+                "description": "explore: scan koda-core/src for ToolEffect",
+                "status": "running",
+                "age_secs": 12,
+            },
+            {
+                "task_id": "agent:2",
+                "task_type": "agent",
+                "description": "verify: confirm render",
+                "status": "pending",
+                "age_secs": 3,
+            },
+            {
+                "task_id": "process:5821",
+                "task_type": "process",
+                "description": "cargo test --workspace",
+                "status": "killed",
+                "age_secs": 45,
+            },
+        ]);
+        let lines = try_render_list_bg_tasks_lines(&payload.to_string()).expect("renders");
+        let all = collect(&lines);
+
+        // Header summarises count
+        assert!(
+            all.contains("3 background task(s)"),
+            "header missing: {all}"
+        );
+
+        // Each task id present
+        for id in ["agent:1", "agent:2", "process:5821"] {
+            assert!(all.contains(id), "task id {id} missing: {all}");
+        }
+
+        // Status icons (running, pending, killed)
+        assert!(all.contains("\u{25B6}"), "running icon ▶ missing: {all}");
+        assert!(all.contains("\u{25D0}"), "pending icon ◐ missing: {all}");
+        assert!(all.contains("\u{26D4}"), "killed icon ⛔ missing: {all}");
+
+        // Status tail with age
+        assert!(all.contains("(running, 12s)"), "status tail missing: {all}");
+        assert!(all.contains("(killed, 45s)"), "status tail missing: {all}");
+    }
+
+    #[test]
+    fn list_bg_tasks_includes_exit_code_when_present() {
+        let payload = serde_json::json!([
+            {
+                "task_id": "process:1",
+                "task_type": "process",
+                "description": "cargo build",
+                "status": "exited",
+                "age_secs": 7,
+                "exit_code": 0,
+            },
+        ]);
+        let lines = try_render_list_bg_tasks_lines(&payload.to_string()).expect("renders");
+        let all = collect(&lines);
+        assert!(all.contains("(exited 0, 7s)"), "exit code missing: {all}");
+        assert!(all.contains("\u{2713}"), "exited icon ✓ missing: {all}");
+    }
+
+    #[test]
+    fn list_bg_tasks_renders_empty_array_visibly() {
+        // The model can call this tool when nothing's running.
+        // The user must still see *something* in history rather than
+        // the line silently disappearing.
+        let lines = try_render_list_bg_tasks_lines("[]").expect("renders");
+        let all = collect(&lines);
+        assert!(
+            all.contains("no background tasks"),
+            "empty-state header missing: {all}"
+        );
+        assert_eq!(lines.len(), 1, "empty state is exactly one line");
+    }
+
+    #[test]
+    fn list_bg_tasks_returns_none_for_non_array() {
+        // Non-array payload — fall back to generic render path.
+        assert!(try_render_list_bg_tasks_lines("{}").is_none());
+        assert!(try_render_list_bg_tasks_lines("not json").is_none());
     }
 }


### PR DESCRIPTION
## What

Fixes #1209. `ListBackgroundTasks` tool results now pretty-print as a per-task summary instead of dumping the entire JSON array as one giant compact line.

## Before

```
  │ [{"task_id":"agent:1","task_type":"agent","description":"explore: scan koda-core/src for…","status":"running","age_secs":12},{"task_id":"agent:2",…}]
```

## After

```
  │ 3 background task(s)
  │   ▶ agent:1  explore: scan koda-core/src for ToolEffect (running, 12s)
  │   ◐ agent:2  verify: confirm render (pending, 3s)
  │   ⛔ process:5821  cargo test --workspace (killed, 45s)
```

Same icon vocabulary as the live `bg_activity_overlay` (#1213) so the user's eye sees the same glyphs in both surfaces.

## Fix

1. **Extend `wait_task_format::wait_status_icon`** to cover the `ListBackgroundTasks` status set: `pending` (◐), `running` (▶), `errored` (✗), `exited` (✓), `killed` (⛔). Doc comment now lists the union of statuses both `WaitTask` and `ListBackgroundTasks` emit so the catch-all glyph stays a tripwire for future status additions.

2. **Add `try_render_list_bg_tasks_lines`** that parses the top-level JSON array shape, emits a header (`"N background task(s)"` or `"no background tasks"` for the empty case so the call still leaves a visible trace), then one styled line per task with icon, `task_id`, description, and `(status, age_secs[, exit_code])` tail.

3. **Wire the renderer into both surfaces**:
   - `koda-cli/src/tui_render.rs::render_tool_output` (live)
   - `koda-cli/src/history_render.rs::render_tool_result` (resumed history)

   Mirroring the existing `WaitTask` special-case exactly so the live + resumed render paths stay byte-identical (the same SRP discipline that #1167 / wait_task_format established).

## Tests

Four new unit tests in `wait_task_format::tests`:

- Mixed agent/process tasks render distinct icons + tails (3 tasks, 3 distinct glyphs, ages, status words)
- `exit_code` field surfaces for processes (`(exited 0, 7s)`)
- Empty arrays render the `"no background tasks"` empty-state header (single line, never silent)
- Non-array payloads return `None` so the caller's generic-render fallback still saves the raw content

```
$ cargo test -p koda-cli --lib wait_task_format
test result: ok. 13 passed; 0 failed; 0 ignored
```

Plus full `cargo clippy --workspace --all-targets -- -D warnings` ✅.

## Layering note

Pretty-printing happens entirely in the **TUI presentation layer**. `koda-core`'s tool result stays JSON (machine-readable for the model + ACP/headless consumers). Same SRP discipline #1191's bg-agent UX invariant table established: never bake presentation choices into engine-layer JSON.

## Files touched

```
koda-cli/src/history_render.rs   |  10 ++
koda-cli/src/tui_render.rs       |  13 +++
koda-cli/src/wait_task_format.rs | 215 +++++++++++++++++++++++++++-
3 files, +237 / -1
```

## Discovered via

Field-testing #1213 (always-on bg-activity overlay).
