### PR TITLE
fix(#1216): Gemini-style cancel cascade + Esc/Ctrl+C UX overhaul

### DIFF
--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -73,7 +73,7 @@ pub async fn run_headless(
         .await?;
 
     let cli_sink = HeadlessSink::new(cmd_tx);
-    let cancel = session.cancel.clone();
+    let cancel = session.cancel_token();
     let result = tokio::select! {
         r = session.run_turn(
             &config,

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -331,10 +331,7 @@ async fn handle_new_session(
     )
     .await;
 
-    state.active = Some(ActiveSession {
-        session,
-        cmd_tx,
-    });
+    state.active = Some(ActiveSession { session, cmd_tx });
 
     let response = acp::NewSessionResponse::new(session_id);
     let resp = wrap_response(id, acp::AgentResponse::NewSessionResponse(response));

--- a/koda-cli/src/server.rs
+++ b/koda-cli/src/server.rs
@@ -53,13 +53,11 @@ use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 
 /// An active prompt session with its running task handle.
 struct ActiveSession {
     session: KodaSession,
     cmd_tx: mpsc::Sender<EngineCommand>,
-    cancel: CancellationToken,
 }
 
 /// Server state shared across the event loop.
@@ -255,7 +253,11 @@ async fn handle_notification(raw: &serde_json::Value, state: &mut ServerState) {
     if let Ok(acp::ClientNotification::CancelNotification(_cancel)) = decoded
         && let Some(ref active) = state.active
     {
-        active.cancel.cancel();
+        // #1216: Gemini-style cascade. `interrupt` fires the current
+        // session-root token (cancels the in-flight turn + every bg
+        // agent + every nested derivative) and atomically swaps in a
+        // fresh root, so the next NewPromptRequest starts clean.
+        active.session.interrupt();
     }
 }
 
@@ -319,7 +321,6 @@ async fn handle_new_session(
     };
 
     let (cmd_tx, _cmd_rx) = mpsc::channel::<EngineCommand>(32);
-    let cancel = CancellationToken::new();
 
     let session = KodaSession::new(
         session_id.clone(),
@@ -333,7 +334,6 @@ async fn handle_new_session(
     state.active = Some(ActiveSession {
         session,
         cmd_tx,
-        cancel,
     });
 
     let response = acp::NewSessionResponse::new(session_id);
@@ -381,9 +381,10 @@ async fn handle_prompt(
         return;
     }
 
-    // Create a fresh cancel token for this prompt
-    active.cancel = CancellationToken::new();
-    active.session.cancel = active.cancel.clone();
+    // #1216: no per-prompt cancel-token swap needed. The session's
+    // own `interrupt()` (called by CancelNotification) does the
+    // cascade-and-swap atomically, so by the time we reach here
+    // `session.cancel_token()` is already a fresh, un-fired root.
 
     // Create new cmd channel for this prompt
     let (cmd_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(32);

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -4,6 +4,12 @@
 
 use super::*;
 
+/// #1216: Window after the first idle Ctrl+C in which a second
+/// Ctrl+C confirms exit. Long enough for muscle-memory "oops, I
+/// didn't mean to quit" pauses, short enough that an unrelated
+/// Ctrl+C minutes later won't accidentally exit.
+pub(crate) const QUIT_ARM_WINDOW: std::time::Duration = std::time::Duration::from_millis(1500);
+
 impl TuiContext {
     pub(crate) async fn handle_idle_event(&mut self, ev: Event) -> anyhow::Result<bool> {
         match ev {
@@ -118,47 +124,85 @@ impl TuiContext {
                 self.history_down();
             }
             (KeyCode::Esc, _) => {
-                // #1200: Esc at idle with no editor content is a
-                // "stop everything" gesture. If bg work exists,
-                // cancel it. Otherwise behave as before (clear editor).
-                if self.textarea.text().trim().is_empty()
-                    && crate::tui_bg_tasks::active_bg_count(
-                        &self.session.bg_agents,
-                        &self.agent.tools.bg_registry,
-                    ) > 0
+                // #1216: Esc is the *contextual* cancel — dismiss
+                // the thing you're in. Popup-Esc is already handled
+                // upstream by `handle_menu_key`, so by the time we
+                // reach this arm there's no popup. Priority order:
+                //
+                //   1. Composer has text → clear it (typical "oops,
+                //      let me start over" gesture).
+                //   2. Bg work is running → session-wide cascade
+                //      (Gemini-style: kill everything below us).
+                //   3. Otherwise → no-op (Esc on a blank composer
+                //      with nothing running is genuinely nothing
+                //      to do; we don't arm quit on Esc — that's
+                //      Ctrl+C's job, see below).
+                //
+                // Any Esc resets the quit-arm because the user is
+                // clearly steering, not asking to exit.
+                self.quit_armed_at = None;
+                if !self.textarea.text().trim().is_empty() {
+                    self.textarea.set_text_clearing_elements("");
+                    self.history_idx = None;
+                } else if crate::tui_bg_tasks::active_bg_count(
+                    &self.session.bg_agents,
+                    &self.agent.tools.bg_registry,
+                ) > 0
                 {
+                    self.session.interrupt();
                     crate::tui_bg_tasks::cancel_all_bg_work(
                         &mut self.scroll_buffer,
                         &self.session.bg_agents,
                         &self.agent.tools.bg_registry,
                         &mut self.bg_activity,
                     );
-                } else {
-                    self.textarea.set_text_clearing_elements("");
-                    self.history_idx = None;
                 }
             }
             (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
-                // #1200: same logic as Esc — idle Ctrl+C cancels bg
-                // work when the editor is empty, else clears the editor.
-                // Two-step UX (type, then Ctrl+C) preserves the muscle
-                // memory while giving Ctrl+C a meaningful idle action
-                // when bg agents/processes are running.
-                if self.textarea.text().trim().is_empty()
-                    && crate::tui_bg_tasks::active_bg_count(
-                        &self.session.bg_agents,
-                        &self.agent.tools.bg_registry,
-                    ) > 0
-                {
+                // #1216: Ctrl+C is the *hard interrupt* — the Unix
+                // "abort / get me out" gesture. Priority order:
+                //
+                //   1. Bg work is running → session-wide cascade.
+                //      Reset quit-arm: the user is clearly using
+                //      Ctrl+C as cancel, not as quit-confirm.
+                //   2. Composer has text → clear it. Same reset.
+                //   3. Empty composer + no bg → arm quit on first
+                //      press, confirm on second within QUIT_ARM_WINDOW.
+                //      Matches codex/claude-code/gemini-cli muscle
+                //      memory: a single Ctrl+C never silently exits.
+                let bg_alive = crate::tui_bg_tasks::active_bg_count(
+                    &self.session.bg_agents,
+                    &self.agent.tools.bg_registry,
+                ) > 0;
+                let composer_dirty = !self.textarea.text().trim().is_empty();
+                if bg_alive {
+                    self.quit_armed_at = None;
+                    self.session.interrupt();
                     crate::tui_bg_tasks::cancel_all_bg_work(
                         &mut self.scroll_buffer,
                         &self.session.bg_agents,
                         &self.agent.tools.bg_registry,
                         &mut self.bg_activity,
                     );
-                } else {
+                } else if composer_dirty {
+                    self.quit_armed_at = None;
                     self.textarea.set_text_clearing_elements("");
                     self.history_idx = None;
+                } else {
+                    let now = std::time::Instant::now();
+                    let confirmed = self
+                        .quit_armed_at
+                        .map(|t| now.duration_since(t) <= QUIT_ARM_WINDOW)
+                        .unwrap_or(false);
+                    if confirmed {
+                        self.should_quit = true;
+                    } else {
+                        self.quit_armed_at = Some(now);
+                        crate::tui_output::dim_msg(
+                            &mut self.scroll_buffer,
+                            "\u{26a0}  Press Ctrl+C again within 1.5s to exit (or Ctrl+D)".to_string(),
+                        );
+                    }
                 }
             }
             (KeyCode::Char('d'), m) if m.contains(KeyModifiers::CONTROL) => {

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -200,7 +200,8 @@ impl TuiContext {
                         self.quit_armed_at = Some(now);
                         crate::tui_output::dim_msg(
                             &mut self.scroll_buffer,
-                            "\u{26a0}  Press Ctrl+C again within 1.5s to exit (or Ctrl+D)".to_string(),
+                            "\u{26a0}  Press Ctrl+C again within 1.5s to exit (or Ctrl+D)"
+                                .to_string(),
                         );
                     }
                 }

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -73,6 +73,13 @@ pub(crate) struct TuiContext {
     pub later_queue: VecDeque<String>,
     pub pending_command: Option<String>,
     pub should_quit: bool,
+    /// #1216: Ctrl+C-arm timestamp. When the user presses Ctrl+C at
+    /// idle with nothing to interrupt (empty composer, no bg work),
+    /// we *don't* exit immediately — that's a one-keystroke loss of
+    /// session state, easy to fat-finger. Instead we record the press
+    /// here and show a hint; a second Ctrl+C within
+    /// [`QUIT_ARM_WINDOW`] confirms exit. Reset on any other action.
+    pub quit_armed_at: Option<std::time::Instant>,
     pub silent_compact_deferred: bool,
     pub inference_start: Option<std::time::Instant>,
     /// Context window usage percentage (0-100), updated via EngineEvent::ContextUsage.
@@ -382,6 +389,7 @@ impl TuiContext {
             later_queue: VecDeque::new(),
             pending_command: None,
             should_quit: false,
+            quit_armed_at: None,
             silent_compact_deferred: false,
             inference_start: None,
             context_pct: 0,

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -85,7 +85,7 @@ impl TuiContext {
         // cancel-token cascade pointing at a live parent. Cancelling
         // the child fires only the foreground turn; bg agents are
         // explicitly cancelled by the Ctrl+C path further down.
-        let cancel_token = self.session.cancel.child_token();
+        let cancel_token = self.session.cancel_token().child_token();
         let db_handle = self.session.db.clone();
 
         self.tui_state = TuiState::Inferring;

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -547,7 +547,7 @@ async fn handle_crossterm_event_inline(
         Event::Key(key) => {
             handle_inference_key_inline(
                 key,
-                &session_cancel,
+                session_cancel,
                 cmd_tx,
                 scroll_buffer,
                 menu,

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -86,6 +86,14 @@ impl TuiContext {
         // the child fires only the foreground turn; bg agents are
         // explicitly cancelled by the Ctrl+C path further down.
         let cancel_token = self.session.cancel_token().child_token();
+        // #1216: clone the cloneable session-cancel handle BEFORE the
+        // run_turn future borrows `&mut self.session`. The Esc/Ctrl+C
+        // arm of the inference loop's select! needs to call
+        // `session.interrupt()` mid-turn for the Gemini-style cascade,
+        // but it can't reach `self.session` while the turn future
+        // holds a mutable borrow. The handle is internally `Arc`-backed
+        // so this clone is cheap and aliases the same root.
+        let session_cancel = self.session.cancel_handle();
         let db_handle = self.session.db.clone();
 
         self.tui_state = TuiState::Inferring;
@@ -248,7 +256,7 @@ impl TuiContext {
                     SelectArm::Crossterm(ev) => {
                         handle_crossterm_event_inline(
                             ev,
-                            &cancel_token,
+                            &session_cancel,
                             cmd_tx,
                             &mut self.scroll_buffer,
                             self.history_area_height as usize,
@@ -487,7 +495,7 @@ impl TuiContext {
 #[allow(clippy::too_many_arguments)]
 async fn handle_crossterm_event_inline(
     ev: Event,
-    cancel_token: &tokio_util::sync::CancellationToken,
+    session_cancel: &koda_core::session::SessionCancel,
     cmd_tx: &mpsc::Sender<EngineCommand>,
     scroll_buffer: &mut ScrollBuffer,
     hist_h: usize,
@@ -539,7 +547,7 @@ async fn handle_crossterm_event_inline(
         Event::Key(key) => {
             handle_inference_key_inline(
                 key,
-                cancel_token,
+                &session_cancel,
                 cmd_tx,
                 scroll_buffer,
                 menu,
@@ -566,7 +574,7 @@ async fn handle_crossterm_event_inline(
 #[allow(clippy::too_many_arguments)]
 async fn handle_inference_key_inline(
     key: crossterm::event::KeyEvent,
-    cancel_token: &tokio_util::sync::CancellationToken,
+    session_cancel: &koda_core::session::SessionCancel,
     cmd_tx: &mpsc::Sender<EngineCommand>,
     scroll_buffer: &mut ScrollBuffer,
     menu: &mut MenuContent,
@@ -783,12 +791,18 @@ async fn handle_inference_key_inline(
             }
         }
         (KeyCode::Esc, _) => {
-            cancel_token.cancel();
-            // #1200: Esc/Ctrl+C during inference also stops any bg
-            // work spawned in this session. Without this, the
-            // foreground turn aborts but bg agents/processes keep
-            // running in the dark — confusing the user who just
-            // asked for everything to stop.
+            // #1216: Gemini-style cascade. `session.interrupt()` fires
+            // the session-lifetime cancel root — collapsing the
+            // per-turn `cancel_token` (it's a child), every bg agent's
+            // per-task cancel (also children), and every nested bg
+            // agent transitively — then atomically swaps in a fresh
+            // root so the next turn isn't born cancelled.
+            //
+            // We still call `cancel_all_bg_work` for its `mark_cancelling`
+            // side effect (flips overlay icons red instantly so the user
+            // gets visual feedback even before the underlying status
+            // transition propagates through the watch channel).
+            session_cancel.interrupt();
             crate::tui_bg_tasks::cancel_all_bg_work(
                 scroll_buffer,
                 bg_agents,
@@ -797,7 +811,11 @@ async fn handle_inference_key_inline(
             );
         }
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
-            cancel_token.cancel();
+            // Same cascade as Esc — during inference both keys are
+            // intentional aliases. The asymmetry shows up at idle
+            // (Esc dismisses popups, Ctrl+C arms quit), see the idle
+            // handler in `tui_context::events`.
+            session_cancel.interrupt();
             crate::tui_bg_tasks::cancel_all_bg_work(
                 scroll_buffer,
                 bg_agents,

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -37,6 +37,7 @@ use anyhow::Result;
 use koda_sandbox::{BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
+use parking_lot::RwLock;
 use tokio_util::sync::CancellationToken;
 
 /// Cached parse of [`DEFAULT_DEV_ALLOWLIST`].
@@ -75,8 +76,22 @@ pub struct KodaSession {
     pub provider: Box<dyn LlmProvider>,
     /// Current trust mode (Plan / Safe / Auto).
     pub mode: TrustMode,
-    /// Cancellation token for graceful shutdown.
-    pub cancel: CancellationToken,
+    /// Session-lifetime cancellation root (#1216).
+    ///
+    /// Wrapped in [`RwLock`] so an `Esc`/`Ctrl+C` Gemini-style cascade
+    /// can fire the current token (collapsing every per-turn child and
+    /// every bg-agent child) **and** atomically swap in a fresh root
+    /// before the next turn starts. Without the swap, a tokio
+    /// [`CancellationToken`] stays cancelled forever once fired —
+    /// every subsequent `child_token()` would be born already-cancelled
+    /// and the session would be permanently poisoned.
+    ///
+    /// Read via [`Self::cancel_token`] (cheap clone of current root).
+    /// Fired via [`Self::interrupt`] (cascade + swap, single atomic op).
+    /// Direct field access is intentionally private — every external
+    /// site must go through one of those two doors so the swap
+    /// invariant is impossible to violate.
+    cancel: RwLock<CancellationToken>,
     /// File lifecycle tracker — tracks files created by Koda (#465).
     pub file_tracker: FileTracker,
     /// Whether the session title has already been set (first-message guard).
@@ -234,7 +249,7 @@ impl KodaSession {
             db,
             provider,
             mode,
-            cancel: CancellationToken::new(),
+            cancel: RwLock::new(CancellationToken::new()),
             file_tracker,
             title_set: false,
             proxy,
@@ -252,6 +267,35 @@ impl KodaSession {
     /// Emits `TurnStart` and `TurnEnd` lifecycle events. The loop-cap prompt is handled via `EngineEvent::LoopCapReached` / `EngineCommand::LoopDecision`
     /// through the `cmd_rx` channel.
     ///
+    /// Returns a clone of the **current** session-lifetime cancel token (#1216).
+    ///
+    /// Use this anywhere the legacy `self.cancel.clone()` was reached for.
+    /// Hides the [`RwLock`] indirection from callers and keeps the
+    /// swap-on-interrupt invariant invisible at call sites.
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.read().clone()
+    }
+
+    /// Cascade-cancel everything in this session and arm a fresh root (#1216).
+    ///
+    /// Fires the *current* root token — which propagates to every
+    /// outstanding child: the live per-turn token (#1208), every bg
+    /// agent's per-task token (#1200), nested bg agents, anything
+    /// downstream that derived via [`CancellationToken::child_token`]
+    /// off of [`Self::cancel_token`]. Then atomically swaps in a
+    /// brand-new root so the *next* `run_turn` (and any bg agent it
+    /// later spawns) starts from a clean, un-fired token.
+    ///
+    /// This is the Gemini-style cascade primitive: one call kills the
+    /// whole tree, and the session remains usable for follow-up turns.
+    /// See issue #1216 for the design discussion vs Codex (per-thread)
+    /// and Claude Code (explicit two-tier) alternatives.
+    pub fn interrupt(&self) {
+        let mut guard = self.cancel.write();
+        guard.cancel();
+        *guard = CancellationToken::new();
+    }
+
     /// # Per-turn cancellation (#1208)
     ///
     /// `turn_cancel` lets callers (notably the TUI) wire Ctrl+C / Esc to a
@@ -315,7 +359,7 @@ impl KodaSession {
             // can stop *just this turn* with Ctrl+C without nuking the
             // session-lifetime token bg agents share. Headless / server /
             // tests pass `None` and keep the legacy session-token behaviour.
-            cancel: turn_cancel.unwrap_or_else(|| self.cancel.clone()),
+            cancel: turn_cancel.unwrap_or_else(|| self.cancel_token()),
             cmd_rx,
             file_tracker: &mut self.file_tracker,
             bg_agents: &self.bg_agents,
@@ -324,7 +368,9 @@ impl KodaSession {
         .await;
 
         let reason = match &result {
-            Ok(()) if self.cancel.is_cancelled() => crate::engine::event::TurnEndReason::Cancelled,
+            Ok(()) if self.cancel_token().is_cancelled() => {
+                crate::engine::event::TurnEndReason::Cancelled
+            }
             Ok(()) => crate::engine::event::TurnEndReason::Complete,
             Err(e) => crate::engine::event::TurnEndReason::Error {
                 message: e.to_string(),

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -35,9 +35,9 @@ use crate::trust::TrustMode;
 
 use anyhow::Result;
 use koda_sandbox::{BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
+use parking_lot::RwLock;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
-use parking_lot::RwLock;
 use tokio_util::sync::CancellationToken;
 
 /// Cloneable, session-detached handle to the session-lifetime cancel root (#1216).
@@ -57,8 +57,20 @@ pub struct SessionCancel {
     inner: Arc<RwLock<CancellationToken>>,
 }
 
+impl Default for SessionCancel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionCancel {
-    fn new() -> Self {
+    /// Construct a fresh, never-cancelled root.
+    ///
+    /// Used by [`KodaSession::new`] for production sessions and by
+    /// integration tests that need to inject a known handle into a
+    /// struct-literal `KodaSession` (so they can drive
+    /// [`Self::interrupt`] from the test harness).
+    pub fn new() -> Self {
         Self {
             inner: Arc::new(RwLock::new(CancellationToken::new())),
         }
@@ -128,7 +140,31 @@ pub struct KodaSession {
     /// Direct field access is intentionally private — every external
     /// site must go through one of those two doors so the swap
     /// invariant is impossible to violate.
-    cancel: SessionCancel,
+    /// Session-lifetime cancellation root (#1216).
+    ///
+    /// Wraps an [`Arc<RwLock<CancellationToken>>`] so an `Esc`/`Ctrl+C`
+    /// Gemini-style cascade can fire the current token (collapsing
+    /// every per-turn child and every bg-agent child) **and** atomically
+    /// swap in a fresh root before the next turn starts. Without the
+    /// swap, a tokio [`CancellationToken`] stays cancelled forever once
+    /// fired — every subsequent `child_token()` would be born
+    /// already-cancelled and the session would be permanently poisoned.
+    ///
+    /// The `Arc` indirection lets [`Self::cancel_handle`] hand out a
+    /// cloneable [`SessionCancel`] that survives outside the
+    /// `&mut self` borrow window held by long-lived futures (the TUI
+    /// keeps one across `run_turn` so Esc/Ctrl+C can still call
+    /// [`SessionCancel::interrupt`] mid-turn).
+    ///
+    /// # Invariant (enforced by convention)
+    ///
+    /// Production code reads via [`Self::cancel_token`] and fires via
+    /// [`Self::interrupt`] — never poke at the inner token directly.
+    /// The field is `pub` only because integration tests in
+    /// `koda-core/tests/` need to inject a known root via struct-
+    /// literal construction; bypassing `interrupt()` in non-test code
+    /// breaks the swap invariant and permanently poisons the session.
+    pub cancel: SessionCancel,
     /// File lifecycle tracker — tracks files created by Koda (#465).
     pub file_tracker: FileTracker,
     /// Whether the session title has already been set (first-message guard).
@@ -390,6 +426,17 @@ impl KodaSession {
             format!("{}{mcp_section}", self.agent.system_prompt)
         };
 
+        // #1216: snapshot the effective cancel token *before* handing
+        // it to the inference loop. After the loop finishes we need to
+        // know "did the cancellation that drove this turn happen?" —
+        // but `self.cancel_token()` post-turn returns a *fresh* token
+        // if [`Self::interrupt`] fired during the turn (the swap is
+        // the whole point of #1216). Without snapshotting, every
+        // interrupt-driven cancellation would be misreported as
+        // `TurnEnd::Complete`. Caller-supplied per-turn tokens (#1208)
+        // don't have this problem (they're not swapped) but we capture
+        // uniformly for symmetry.
+        let effective_cancel = turn_cancel.clone().unwrap_or_else(|| self.cancel_token());
         let result = crate::inference::inference_loop(InferenceContext {
             project_root: &self.agent.project_root,
             config,
@@ -406,7 +453,7 @@ impl KodaSession {
             // can stop *just this turn* with Ctrl+C without nuking the
             // session-lifetime token bg agents share. Headless / server /
             // tests pass `None` and keep the legacy session-token behaviour.
-            cancel: turn_cancel.unwrap_or_else(|| self.cancel_token()),
+            cancel: effective_cancel.clone(),
             cmd_rx,
             file_tracker: &mut self.file_tracker,
             bg_agents: &self.bg_agents,
@@ -415,7 +462,7 @@ impl KodaSession {
         .await;
 
         let reason = match &result {
-            Ok(()) if self.cancel_token().is_cancelled() => {
+            Ok(()) if effective_cancel.is_cancelled() => {
                 crate::engine::event::TurnEndReason::Cancelled
             }
             Ok(()) => crate::engine::event::TurnEndReason::Complete,
@@ -475,5 +522,102 @@ mod b22_tests {
         // out `&'static Filter` across threads. Pin it.
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<koda_sandbox::Filter>();
+    }
+}
+
+#[cfg(test)]
+mod cancel_handle_tests {
+    //! #1216 — [`SessionCancel`] regression tests.
+    //!
+    //! These pin the Gemini-style cascade primitive's contract:
+    //!
+    //! 1. `interrupt()` fires the current root (cascade to children).
+    //! 2. `interrupt()` swaps in a fresh root (subsequent `current()`
+    //!    returns an UN-cancelled token — the session is reusable).
+    //! 3. The cloneable handle aliases the same `Arc` so an `interrupt()`
+    //!    on a clone is observed by every other clone (this is what
+    //!    lets the TUI key handler interrupt across the `&mut self.session`
+    //!    borrow held by the `run_turn` future).
+    use super::SessionCancel;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn interrupt_fires_current_root_cascading_to_children() {
+        let h = SessionCancel::new();
+        let child = h.current().child_token();
+        let grandchild = child.child_token();
+        assert!(!child.is_cancelled());
+        assert!(!grandchild.is_cancelled());
+
+        h.interrupt();
+        // tokio::CancellationToken cascade is synchronous on `cancel()`,
+        // so children observe immediately on the next poll.
+        assert!(child.is_cancelled(), "child must observe cascade");
+        assert!(grandchild.is_cancelled(), "grandchild must observe cascade");
+    }
+
+    #[tokio::test]
+    async fn interrupt_swaps_in_fresh_root_so_session_stays_usable() {
+        let h = SessionCancel::new();
+        let pre = h.current();
+        h.interrupt();
+        assert!(pre.is_cancelled(), "old root must be fired");
+        let post = h.current();
+        assert!(
+            !post.is_cancelled(),
+            "new root must be un-cancelled (else next turn is born dead)"
+        );
+        // And further children of the new root are independent of the old.
+        let new_child = post.child_token();
+        assert!(!new_child.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cloned_handles_share_underlying_arc() {
+        let h1 = SessionCancel::new();
+        let h2 = h1.clone();
+        let child_via_h1 = h1.current().child_token();
+
+        // Interrupt on the *clone* must cascade to children derived
+        // from the original — this is the key invariant that lets
+        // the TUI's detached handle interrupt mid-turn.
+        h2.interrupt();
+        assert!(
+            child_via_h1.is_cancelled(),
+            "clone's interrupt must fire the shared root"
+        );
+
+        // And after the swap, both handles see the same fresh root.
+        let a = h1.current();
+        let b = h2.current();
+        assert!(!a.is_cancelled());
+        assert!(!b.is_cancelled());
+        // Firing through h1 cancels b's snapshot too (same root).
+        h1.interrupt();
+        assert!(a.is_cancelled());
+        assert!(b.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn interrupt_unblocks_a_waiter_within_a_few_ms() {
+        // Exercises the same race that powers the WaitTask escape
+        // hatch: a future awaiting `cancel.cancelled()` must wake up
+        // promptly when interrupt fires from another task.
+        let h = SessionCancel::new();
+        let token = h.current();
+        let h_for_fire = h.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            h_for_fire.interrupt();
+        });
+        let started = std::time::Instant::now();
+        tokio::time::timeout(Duration::from_secs(1), token.cancelled())
+            .await
+            .expect("must wake within 1s");
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "must wake promptly, took {elapsed:?}"
+        );
     }
 }

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -541,7 +541,7 @@ mod cancel_handle_tests {
     use super::SessionCancel;
     use std::time::Duration;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn interrupt_fires_current_root_cascading_to_children() {
         let h = SessionCancel::new();
         let child = h.current().child_token();
@@ -556,7 +556,7 @@ mod cancel_handle_tests {
         assert!(grandchild.is_cancelled(), "grandchild must observe cascade");
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn interrupt_swaps_in_fresh_root_so_session_stays_usable() {
         let h = SessionCancel::new();
         let pre = h.current();
@@ -572,7 +572,7 @@ mod cancel_handle_tests {
         assert!(!new_child.is_cancelled());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cloned_handles_share_underlying_arc() {
         let h1 = SessionCancel::new();
         let h2 = h1.clone();
@@ -598,7 +598,7 @@ mod cancel_handle_tests {
         assert!(b.is_cancelled());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn interrupt_unblocks_a_waiter_within_a_few_ms() {
         // Exercises the same race that powers the WaitTask escape
         // hatch: a future awaiting `cancel.cancelled()` must wake up

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -40,6 +40,43 @@ use tokio::sync::mpsc;
 use parking_lot::RwLock;
 use tokio_util::sync::CancellationToken;
 
+/// Cloneable, session-detached handle to the session-lifetime cancel root (#1216).
+///
+/// Holds an `Arc<RwLock<CancellationToken>>` alias of the same root
+/// owned by [`KodaSession`] — so a clone can be passed across borrow
+/// boundaries (notably the TUI's `&mut self.session` window held by a
+/// pinned `run_turn` future) and still drive [`Self::interrupt`].
+///
+/// Two operations:
+/// - [`Self::current`]: snapshot of the *current* root token. Use this
+///   anywhere you'd previously called `session.cancel.clone()`.
+/// - [`Self::interrupt`]: fire-and-swap, identical semantics to
+///   [`KodaSession::interrupt`].
+#[derive(Clone)]
+pub struct SessionCancel {
+    inner: Arc<RwLock<CancellationToken>>,
+}
+
+impl SessionCancel {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(CancellationToken::new())),
+        }
+    }
+
+    /// Clone of the current root. See [`KodaSession::cancel_token`].
+    pub fn current(&self) -> CancellationToken {
+        self.inner.read().clone()
+    }
+
+    /// Fire current root + swap in a fresh one. See [`KodaSession::interrupt`].
+    pub fn interrupt(&self) {
+        let mut guard = self.inner.write();
+        guard.cancel();
+        *guard = CancellationToken::new();
+    }
+}
+
 /// Cached parse of [`DEFAULT_DEV_ALLOWLIST`].
 ///
 /// **#1022 B22**: pre-fix, `Filter::new(DEFAULT_DEV_ALLOWLIST).expect(…)`
@@ -91,7 +128,7 @@ pub struct KodaSession {
     /// Direct field access is intentionally private — every external
     /// site must go through one of those two doors so the swap
     /// invariant is impossible to violate.
-    cancel: RwLock<CancellationToken>,
+    cancel: SessionCancel,
     /// File lifecycle tracker — tracks files created by Koda (#465).
     pub file_tracker: FileTracker,
     /// Whether the session title has already been set (first-message guard).
@@ -249,7 +286,7 @@ impl KodaSession {
             db,
             provider,
             mode,
-            cancel: RwLock::new(CancellationToken::new()),
+            cancel: SessionCancel::new(),
             file_tracker,
             title_set: false,
             proxy,
@@ -273,7 +310,19 @@ impl KodaSession {
     /// Hides the [`RwLock`] indirection from callers and keeps the
     /// swap-on-interrupt invariant invisible at call sites.
     pub fn cancel_token(&self) -> CancellationToken {
-        self.cancel.read().clone()
+        self.cancel.current()
+    }
+
+    /// Cloneable handle to the cancel root for cross-borrow use (#1216).
+    ///
+    /// Returns a [`SessionCancel`] backed by the same `Arc` as the
+    /// session's own field. The TUI clones this *before* the
+    /// `run_turn` future borrows `&mut self.session`, so the
+    /// Esc/Ctrl+C key handler can still call
+    /// [`SessionCancel::interrupt`] mid-turn without the borrow
+    /// checker getting in the way.
+    pub fn cancel_handle(&self) -> SessionCancel {
+        self.cancel.clone()
     }
 
     /// Cascade-cancel everything in this session and arm a fresh root (#1216).
@@ -291,9 +340,7 @@ impl KodaSession {
     /// See issue #1216 for the design discussion vs Codex (per-thread)
     /// and Claude Code (explicit two-tier) alternatives.
     pub fn interrupt(&self) {
-        let mut guard = self.cancel.write();
-        guard.cancel();
-        *guard = CancellationToken::new();
+        self.cancel.interrupt();
     }
 
     /// # Per-turn cancellation (#1208)

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -261,6 +261,7 @@ pub(crate) async fn execute_one_tool(
             bg_agents,
             &tools.bg_registry,
             caller_spawner,
+            &cancel,
         )
         .await;
         (r.output, r.success, r.full_output)

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -41,6 +41,7 @@ use crate::providers::ToolDefinition;
 use serde_json::{Value, json};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 use crate::bg_agent::{
     AgentStatus, BgAgentRegistry, BgAgentResult, BgTaskSnapshot, CancelOutcome, WaitOutcome,
@@ -359,11 +360,12 @@ pub async fn execute(
     bg_agents: &Arc<BgAgentRegistry>,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
+    cancel: &CancellationToken,
 ) -> ToolResult {
     match tool_name {
         "ListBackgroundTasks" => execute_list(bg_agents, bg_processes, caller_spawner),
         "CancelTask" => execute_cancel(arguments, bg_agents, bg_processes, caller_spawner),
-        "WaitTask" => execute_wait(arguments, bg_agents, bg_processes, caller_spawner).await,
+        "WaitTask" => execute_wait(arguments, bg_agents, bg_processes, caller_spawner, cancel).await,
         other => err(format!(
             "bg_task_tools::execute called with unknown tool '{other}' \
              (router bug — should have matched in tool_dispatch)"
@@ -437,6 +439,7 @@ async fn execute_wait(
     bg_agents: &Arc<BgAgentRegistry>,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
+    cancel: &CancellationToken,
 ) -> ToolResult {
     let args: Value = match serde_json::from_str(arguments) {
         Ok(v) => v,
@@ -483,7 +486,7 @@ async fn execute_wait(
     // not 120s.
     let futures = task_ids
         .iter()
-        .map(|id| wait_one_task(id.clone(), bg_agents, bg_processes, caller_spawner, timeout));
+        .map(|id| wait_one_task(id.clone(), bg_agents, bg_processes, caller_spawner, timeout, cancel));
     let task_results: Vec<Value> = futures_util::future::join_all(futures).await;
 
     // Roll up status counts so the model can branch on "all done" /
@@ -519,6 +522,7 @@ async fn wait_one_task(
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
     timeout: Duration,
+    cancel: &CancellationToken,
 ) -> Value {
     let task_id = match parse_task_id(&task_id_str) {
         Ok(t) => t,
@@ -530,18 +534,34 @@ async fn wait_one_task(
             });
         }
     };
+    // #1216: race the registry wait against the master cancel token.
+    // Pre-#1216 the master inference would block here for the full
+    // `timeout` (default 5min, max 24h) waiting for a wedged bg agent
+    // to notice its own cancel. Now Esc/Ctrl+C unwinds the master in
+    // microseconds even if the bg agent is itself parked inside an
+    // unresponsive tool call (e.g. a giant Read or a nested WaitTask).
+    // The bg agent's own cancel still fires via the CancellationToken
+    // parent→child cascade fired by `session.interrupt()`; we just
+    // don't wait for it to finish unwinding before reporting back.
     match task_id {
         TaskId::Agent(n) => {
-            let outcome = bg_agents
-                .wait_for_completion(n, caller_spawner, timeout)
-                .await;
-            agent_wait_to_value(&task_id_str, outcome)
+            tokio::select! {
+                outcome = bg_agents.wait_for_completion(n, caller_spawner, timeout) => {
+                    agent_wait_to_value(&task_id_str, outcome)
+                }
+                _ = cancel.cancelled() => agent_wait_to_value(&task_id_str, WaitOutcome::Cancelled),
+            }
         }
         TaskId::Process(n) => {
-            let outcome = bg_processes
-                .wait_for_exit_as_caller(n, caller_spawner, timeout)
-                .await;
-            process_wait_to_value(&task_id_str, outcome)
+            tokio::select! {
+                outcome = bg_processes.wait_for_exit_as_caller(n, caller_spawner, timeout) => {
+                    process_wait_to_value(&task_id_str, outcome)
+                }
+                _ = cancel.cancelled() => json!({
+                    "task_id": task_id_str,
+                    "status": "cancelled",
+                }),
+            }
         }
     }
 }
@@ -617,6 +637,14 @@ fn process_wait_to_value(task_id_str: &str, outcome: ProcessWaitOutcome) -> Valu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Fresh, never-cancelled token for tests that don't care about
+    /// the master cancel path. Returns a value (not a clone) so each
+    /// call site has an independent root — nothing in these tests
+    /// shares cancellation state across cases.
+    fn no_cancel() -> CancellationToken {
+        CancellationToken::new()
+    }
 
     #[test]
     fn definitions_returns_three_tools_with_expected_names() {
@@ -768,7 +796,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_list_returns_empty_array_when_no_tasks() {
         let (agents, processes) = fresh_registries();
-        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
         assert!(r.success);
         assert_eq!(r.output, "[]");
     }
@@ -780,7 +808,7 @@ mod tests {
         let (agents, processes) = fresh_registries();
         let (id, _tx, _, _) = agents.register_test_with_status("explore", "map repo", None);
 
-        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
         assert!(r.success);
         let arr: Value = serde_json::from_str(&r.output).unwrap();
         let arr = arr.as_array().unwrap();
@@ -800,11 +828,11 @@ mod tests {
         agents.register_test_with_status("a", "top", None);
         agents.register_test_with_status("b", "sub", Some(7));
 
-        let top = execute("ListBackgroundTasks", "{}", &agents, &processes, None).await;
+        let top = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
         let arr: Value = serde_json::from_str(&top.output).unwrap();
         assert_eq!(arr.as_array().unwrap().len(), 1, "top sees only its own");
 
-        let sub = execute("ListBackgroundTasks", "{}", &agents, &processes, Some(7)).await;
+        let sub = execute("ListBackgroundTasks", "{}", &agents, &processes, Some(7), &no_cancel()).await;
         let arr: Value = serde_json::from_str(&sub.output).unwrap();
         assert_eq!(arr.as_array().unwrap().len(), 1, "sub sees only its own");
     }
@@ -822,6 +850,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(r.success, "got: {}", r.output);
@@ -840,6 +869,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(!r.success);
@@ -858,6 +888,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(!r.success);
@@ -872,7 +903,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_rejects_malformed_json() {
         let (agents, processes) = fresh_registries();
-        let r = execute("CancelTask", "not-json", &agents, &processes, None).await;
+        let r = execute("CancelTask", "not-json", &agents, &processes, None, &no_cancel()).await;
         assert!(!r.success);
         assert!(r.output.contains("invalid JSON"), "got: {}", r.output);
     }
@@ -880,7 +911,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_rejects_missing_task_id() {
         let (agents, processes) = fresh_registries();
-        let r = execute("CancelTask", "{}", &agents, &processes, None).await;
+        let r = execute("CancelTask", "{}", &agents, &processes, None, &no_cancel()).await;
         assert!(!r.success);
         assert!(r.output.contains("missing required"), "got: {}", r.output);
     }
@@ -906,6 +937,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(r.success, "got: {}", r.output);
@@ -940,6 +972,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(r.success);
@@ -978,6 +1011,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(
@@ -992,6 +1026,61 @@ mod tests {
         assert_eq!(payload["summary"]["cancelled"], 1);
         // Consumed — entry removed from registry.
         assert_eq!(agents.snapshot().len(), 0);
+    }
+
+    /// #1216: master-cancel race. Pre-fix, when the bg agent was
+    /// wedged inside its own tool call (no terminal status arriving),
+    /// `WaitTask` blocked the master inference for the full timeout
+    /// (default 5min, max 24h). Esc/Ctrl+C couldn't reach it. The
+    /// fix threads a `cancel: &CancellationToken` through `execute`
+    /// and races it against `wait_for_completion` inside
+    /// `wait_one_task`.
+    ///
+    /// This test simulates that wedge: a registered bg agent that
+    /// NEVER transitions to terminal status. We fire the master
+    /// cancel token mid-wait and assert WaitTask returns within
+    /// well under the requested 5s timeout with `status: cancelled`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_wait_unblocks_immediately_on_master_cancel() {
+        let (agents, processes) = fresh_registries();
+        // Register but do NOT push a terminal status — simulates a
+        // bg agent stuck inside an unresponsive tool call. We hold
+        // `_tx`, `_status_tx`, `_observer` so the registry entry
+        // stays "running" for the entire call.
+        let (id, _tx, _status_tx, _observer) =
+            agents.register_test_with_status("wedged", "x", None);
+
+        let cancel = CancellationToken::new();
+        let cancel_for_fire = cancel.clone();
+
+        // Fire the master cancel after a short delay so we can prove
+        // WaitTask is the one observing the token (not racing into
+        // the timeout path).
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            cancel_for_fire.cancel();
+        });
+
+        let started = std::time::Instant::now();
+        let r = execute(
+            "WaitTask",
+            &json!({ "task_ids": [format!("agent:{id}")], "timeout_secs": 5 }).to_string(),
+            &agents,
+            &processes,
+            None,
+            &cancel,
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "WaitTask must unblock on master cancel, not wait out the 5s timeout (took {elapsed:?})"
+        );
+        assert!(r.success, "WaitTask payload must still parse: {}", r.output);
+        let payload: Value = serde_json::from_str(&r.output).unwrap();
+        assert_eq!(payload["tasks"][0]["status"], "cancelled");
+        assert_eq!(payload["summary"]["cancelled"], 1);
     }
 
     /// #1157 — the headline feature: N parallel sub-agents land in
@@ -1024,6 +1113,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(r.success, "got: {}", r.output);
@@ -1082,6 +1172,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(r.success, "top-level call must succeed: {}", r.output);
@@ -1112,6 +1203,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(!r.success);
@@ -1130,6 +1222,7 @@ mod tests {
             &agents,
             &processes,
             None,
+            &no_cancel(),
         )
         .await;
         assert!(!r.success);
@@ -1143,7 +1236,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_unknown_tool_name_returns_error() {
         let (agents, processes) = fresh_registries();
-        let r = execute("NotAToolWeKnow", "{}", &agents, &processes, None).await;
+        let r = execute("NotAToolWeKnow", "{}", &agents, &processes, None, &no_cancel()).await;
         assert!(!r.success);
         assert!(r.output.contains("unknown tool"));
     }

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -365,7 +365,9 @@ pub async fn execute(
     match tool_name {
         "ListBackgroundTasks" => execute_list(bg_agents, bg_processes, caller_spawner),
         "CancelTask" => execute_cancel(arguments, bg_agents, bg_processes, caller_spawner),
-        "WaitTask" => execute_wait(arguments, bg_agents, bg_processes, caller_spawner, cancel).await,
+        "WaitTask" => {
+            execute_wait(arguments, bg_agents, bg_processes, caller_spawner, cancel).await
+        }
         other => err(format!(
             "bg_task_tools::execute called with unknown tool '{other}' \
              (router bug — should have matched in tool_dispatch)"
@@ -484,9 +486,16 @@ async fn execute_wait(
     // finishes (or times out) — NOT the sum of per-task latencies.
     // For 4 sub-agents each averaging 30s, this is 30s total wall time,
     // not 120s.
-    let futures = task_ids
-        .iter()
-        .map(|id| wait_one_task(id.clone(), bg_agents, bg_processes, caller_spawner, timeout, cancel));
+    let futures = task_ids.iter().map(|id| {
+        wait_one_task(
+            id.clone(),
+            bg_agents,
+            bg_processes,
+            caller_spawner,
+            timeout,
+            cancel,
+        )
+    });
     let task_results: Vec<Value> = futures_util::future::join_all(futures).await;
 
     // Roll up status counts so the model can branch on "all done" /
@@ -796,7 +805,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_list_returns_empty_array_when_no_tasks() {
         let (agents, processes) = fresh_registries();
-        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
+        let r = execute(
+            "ListBackgroundTasks",
+            "{}",
+            &agents,
+            &processes,
+            None,
+            &no_cancel(),
+        )
+        .await;
         assert!(r.success);
         assert_eq!(r.output, "[]");
     }
@@ -808,7 +825,15 @@ mod tests {
         let (agents, processes) = fresh_registries();
         let (id, _tx, _, _) = agents.register_test_with_status("explore", "map repo", None);
 
-        let r = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
+        let r = execute(
+            "ListBackgroundTasks",
+            "{}",
+            &agents,
+            &processes,
+            None,
+            &no_cancel(),
+        )
+        .await;
         assert!(r.success);
         let arr: Value = serde_json::from_str(&r.output).unwrap();
         let arr = arr.as_array().unwrap();
@@ -828,11 +853,27 @@ mod tests {
         agents.register_test_with_status("a", "top", None);
         agents.register_test_with_status("b", "sub", Some(7));
 
-        let top = execute("ListBackgroundTasks", "{}", &agents, &processes, None, &no_cancel()).await;
+        let top = execute(
+            "ListBackgroundTasks",
+            "{}",
+            &agents,
+            &processes,
+            None,
+            &no_cancel(),
+        )
+        .await;
         let arr: Value = serde_json::from_str(&top.output).unwrap();
         assert_eq!(arr.as_array().unwrap().len(), 1, "top sees only its own");
 
-        let sub = execute("ListBackgroundTasks", "{}", &agents, &processes, Some(7), &no_cancel()).await;
+        let sub = execute(
+            "ListBackgroundTasks",
+            "{}",
+            &agents,
+            &processes,
+            Some(7),
+            &no_cancel(),
+        )
+        .await;
         let arr: Value = serde_json::from_str(&sub.output).unwrap();
         assert_eq!(arr.as_array().unwrap().len(), 1, "sub sees only its own");
     }
@@ -903,7 +944,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_rejects_malformed_json() {
         let (agents, processes) = fresh_registries();
-        let r = execute("CancelTask", "not-json", &agents, &processes, None, &no_cancel()).await;
+        let r = execute(
+            "CancelTask",
+            "not-json",
+            &agents,
+            &processes,
+            None,
+            &no_cancel(),
+        )
+        .await;
         assert!(!r.success);
         assert!(r.output.contains("invalid JSON"), "got: {}", r.output);
     }
@@ -1236,7 +1285,15 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_unknown_tool_name_returns_error() {
         let (agents, processes) = fresh_registries();
-        let r = execute("NotAToolWeKnow", "{}", &agents, &processes, None, &no_cancel()).await;
+        let r = execute(
+            "NotAToolWeKnow",
+            "{}",
+            &agents,
+            &processes,
+            None,
+            &no_cancel(),
+        )
+        .await;
         assert!(!r.success);
         assert!(r.output.contains("unknown tool"));
     }

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -21,7 +21,7 @@ use koda_core::{
         client::{McpClient, McpClientStatus},
         config::{McpServerConfig, McpTransport},
     },
-    session::KodaSession,
+    session::{KodaSession, SessionCancel},
     tools::ToolRegistry,
     trust::TrustMode,
 };
@@ -29,7 +29,6 @@ use koda_test_utils::{ChatMessage, Env, MockProvider, MockResponse, TestSink};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{RwLock, mpsc};
-use tokio_util::sync::CancellationToken;
 
 /// Stub config for tests — transport details don't matter because we use
 /// `set_status_for_test` / `set_instructions_for_test` to bypass the real
@@ -58,10 +57,10 @@ async fn make_session_with_mcp(
     mcp_manager: McpManager,
 ) -> (
     KodaSession,
-    CancellationToken,
+    SessionCancel,
     Arc<Mutex<Vec<Vec<ChatMessage>>>>,
 ) {
-    let cancel = CancellationToken::new();
+    let cancel = SessionCancel::new();
     let tools = ToolRegistry::new(env.root.clone(), env.config.max_context_tokens);
 
     // Attach the MCP manager BEFORE wrapping in Arc — this matches the

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -9,7 +9,7 @@ use koda_core::{
     engine::{EngineCommand, EngineEvent, event::TurnEndReason},
     persistence::Persistence,
     providers::{LlmResponse, ModelInfo},
-    session::KodaSession,
+    session::{KodaSession, SessionCancel},
     tools::ToolRegistry,
     trust::TrustMode,
 };
@@ -27,11 +27,8 @@ use tokio_util::sync::CancellationToken;
 /// Bypasses `KodaSession::new()` (which calls `create_provider` internally)
 /// so tests can supply a pre-configured MockProvider.  A fresh ToolRegistry
 /// is created each call because ToolRegistry does not implement Clone.
-async fn make_session(
-    env: &Env,
-    provider: Box<dyn LlmProvider>,
-) -> (KodaSession, CancellationToken) {
-    let cancel = CancellationToken::new();
+async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession, SessionCancel) {
+    let cancel = SessionCancel::new();
     let tools = ToolRegistry::new(env.root.clone(), env.config.max_context_tokens);
 
     let agent = Arc::new(koda_core::agent::KodaAgent {
@@ -189,7 +186,7 @@ async fn session_cancellation_produces_turn_end_cancelled() {
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {
         let _ = entered_rx.await;
-        cancel_clone.cancel();
+        cancel_clone.interrupt();
     });
 
     let sink = TestSink::new();
@@ -291,7 +288,7 @@ async fn session_turn_cancel_token_stops_inference() {
     // The whole point of #1208: cancel the *per-turn* token, NOT
     // session.cancel — then assert the turn still ends, AND
     // session.cancel is still alive afterwards (so bg agents survive).
-    let turn_cancel = tokio_util::sync::CancellationToken::new();
+    let turn_cancel = CancellationToken::new();
     let turn_cancel_clone = turn_cancel.clone();
     tokio::spawn(async move {
         let _ = entered_rx.await;
@@ -326,7 +323,7 @@ async fn session_turn_cancel_token_stops_inference() {
         "per-turn token should remain in the cancelled state"
     );
     assert!(
-        !session_cancel.is_cancelled(),
+        !session_cancel.current().is_cancelled(),
         "session.cancel must NOT be fired when only the per-turn token cancels \
          (this is the whole #1208 fix — bg agents survive across cancelled turns)"
     );


### PR DESCRIPTION
Closes #1216.

## Problem

Esc/Ctrl+C wedges when master inference is parked in WaitTask while bg agents are running. The per-turn cancel token cascade (#1208) doesn't reach bg-agent children, and the bg-agent cancel registry doesn't cascade upward to the foreground turn.

## Solution: Gemini-style single-root cascade

Introduce a session-lifetime cancel root with **fire-and-swap** semantics:
- One `interrupt()` call cancels the current root (cascading to every child: per-turn token, per-bg-agent tokens, nested derivatives) **and atomically swaps in a fresh un-cancelled root** so the session stays usable.
- Cloneable `SessionCancel` handle survives outside `&mut self.session` borrows (TUI grabs one before `run_turn` borrows the session, then fires from the key handler).

## Phases

- **Phase 1**: `KodaSession::interrupt()` + `cancel_token()` cascade primitive
- **Phase 2**: thread cancel into `bg_task_tools` so WaitTask unblocks on Esc
- **Phase 3**: TUI Esc/Ctrl+C asymmetry + Gemini cascade hookup
  - Inference: both Esc + Ctrl+C call `session.interrupt()` (cascade)
  - Idle Esc: contextual cancel (composer → bg → no-op)
  - Idle Ctrl+C: hard interrupt + 1.5s quit-arm (matches codex/claude-code/gemini-cli muscle memory; never silently exits on a single press)
- **Phase 4**: 4 cascade regression tests + run_turn snapshot fix + clippy gate

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` ✅ clean
- 2091 lib tests pass
- All 25 integration test binaries pass individually
- `session_cancellation_produces_turn_end_cancelled` (existing test) caught a real bug in run_turn's post-turn cancel check — fixed by snapshotting the effective cancel token at entry (after interrupt() swaps the root, the live token is fresh and reports false)