### PR TITLE
fix(trust): classify TodoWrite as ReadOnly (#1212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`TodoWrite` no longer requires approval and is no longer blocked in Plan mode** (#1212). The tool was misclassified as `LocalMutation` alongside `Write`/`Edit`/`MemoryWrite`, which made `koda-core::trust` gate it as `NeedsConfirmation` in Safe and `Blocked` in Plan — breaking the very tool that is supposed to be the canonical planning surface. `TodoWrite` only mutates Koda-owned session state (the in-memory todo list), not the user's files, so it is now classified as `ReadOnly` and auto-approves in every trust mode. Tests in `trust.rs` and `tool_wiring_test.rs`, plus the `tools/mod.rs` doc table and `docs/src/tools.md`, were updated to match.
+
 ### Removed
 
 - **Interactive `/agents` panel and `/agents` slash command** (#1210, supersedes #1191). The dedicated bg-task surface (`MenuContent::BgAgentsPanel` from #1199 and the original flat-text `/agents` dump from #996) was redundant once the always-on **bg-activity overlay** above the status bar landed in #1210: the overlay shows every running sub-agent + shell process, what each is doing right now, and the cancel keybindings, with no slash-command needed. `/cancel <id>` and the `ListBackgroundTasks` LLM tool are unchanged. The status-bar bg-task pill (#1158 b) was also dropped for the same reason. Net: −1132 LoC.

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -18,7 +18,7 @@ within the project sandbox are auto-approved.
 | `Think` | Internal | Extended reasoning step (no side effects) |
 | `MemoryRead` | Read-only | Read from project or global memory |
 | `MemoryWrite` | Mutating | Append a fact to a memory file |
-| `TodoWrite` | Mutating | Update the session task list |
+| `TodoWrite` | Read-only | Update the session task list (Koda-owned state, no FS impact) |
 | `RecallContext` | Read-only | Search session history for past context |
 | `ListSkills` | Read-only | List available skills |
 | `ActivateSkill` | Internal | Load a skill's instructions into context |
@@ -33,9 +33,9 @@ within the project sandbox are auto-approved.
 
 | Category | Tools | Plan | Safe | Auto |
 |----------|-------|------|------|------|
-| Read-only | Read, Grep, Glob, ListFiles, WebFetch, WebSearch, RecallContext | ✅ Auto | ✅ Auto | ✅ Auto |
+| Read-only | Read, Grep, Glob, ListFiles, WebFetch, WebSearch, RecallContext, TodoWrite | ✅ Auto | ✅ Auto | ✅ Auto |
 | Internal | Think, ActivateSkill | ✅ Auto | ✅ Auto | ✅ Auto |
-| Mutations | Write, Edit, MemoryWrite, TodoWrite | ❌ Deny | ⏸ Prompt | ✅ Auto |
+| Mutations | Write, Edit, MemoryWrite | ❌ Deny | ⏸ Prompt | ✅ Auto |
 | Destructive | Delete | ❌ Deny | ⏸ Prompt | ✅ Auto |
 | Agent calls | InvokeAgent | ✅ Auto | ✅ Auto | ✅ Auto |
 | Background tasks | ListBackgroundTasks, CancelTask, WaitTask | ✅ Auto | ✅ Auto | ✅ Auto |

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -21,7 +21,7 @@
 //! | **ListAgents** | `agent` | ReadOnly | List available sub-agents |
 //! | **MemoryRead** | `memory` | ReadOnly | Read project/global memory |
 //! | **MemoryWrite** | `memory` | LocalMutation | Save facts to memory |
-//! | **TodoWrite** | `todo` | LocalMutation | Update task list |
+//! | **TodoWrite** | `todo` | ReadOnly | Update session task list (no FS impact) |
 //! | **AskUser** | `ask_user` | ReadOnly | Ask the user a question |
 //! | **ActivateSkill** | `skills` | ReadOnly | Load a skill's instructions |
 //! | **ListSkills** | `skills` | ReadOnly | List available skills |
@@ -75,9 +75,13 @@ pub enum ToolEffect {
 /// annotations.
 pub fn classify_tool(name: &str) -> ToolEffect {
     match name {
-        // Pure reads — zero side-effects
+        // Pure reads — zero side-effects.
+        // `TodoWrite` lives here because it only mutates Koda's own session
+        // state (the in-memory todo list), not the user's files or shell. From
+        // a user-impact perspective it's read-only; gating it behind approval
+        // breaks Plan-mode planning entirely (#1212).
         "Read" | "List" | "Grep" | "Glob" | "MemoryRead" | "ListAgents" | "ListSkills"
-        | "ActivateSkill" | "RecallContext" | "AskUser" => ToolEffect::ReadOnly,
+        | "ActivateSkill" | "RecallContext" | "AskUser" | "TodoWrite" => ToolEffect::ReadOnly,
 
         // Remote actions — side-effects on remote services only
         "WebFetch" => ToolEffect::ReadOnly,    // GET-only fetch
@@ -92,7 +96,7 @@ pub fn classify_tool(name: &str) -> ToolEffect {
         "ListBackgroundTasks" | "CancelTask" | "WaitTask" => ToolEffect::ReadOnly,
 
         // Local mutations — write to filesystem or local state
-        "Write" | "Edit" | "MemoryWrite" | "TodoWrite" => ToolEffect::LocalMutation,
+        "Write" | "Edit" | "MemoryWrite" => ToolEffect::LocalMutation,
 
         // Bash — default to LocalMutation; refined by classify_bash_command()
         "Bash" => ToolEffect::LocalMutation,

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -637,6 +637,9 @@ mod tests {
         "WebSearch",
         "ListSkills",
         "ActivateSkill",
+        // TodoWrite mutates Koda-owned session state only — no FS impact —
+        // so it must auto-approve in every trust mode (#1212).
+        "TodoWrite",
     ];
 
     #[test]
@@ -654,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_plan_blocks_all_writes() {
-        for tool in ["Write", "Edit", "Delete", "MemoryWrite", "TodoWrite"] {
+        for tool in ["Write", "Edit", "Delete", "MemoryWrite"] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), TrustMode::Plan, None),
                 ToolApproval::Blocked,
@@ -665,7 +668,7 @@ mod tests {
 
     #[test]
     fn test_safe_confirms_writes() {
-        for tool in ["Write", "Edit", "Delete", "MemoryWrite", "TodoWrite"] {
+        for tool in ["Write", "Edit", "Delete", "MemoryWrite"] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), TrustMode::Safe, None),
                 ToolApproval::NeedsConfirmation,
@@ -683,7 +686,7 @@ mod tests {
         } else {
             ToolApproval::NeedsConfirmation
         };
-        for tool in ["Write", "Edit", "TodoWrite"] {
+        for tool in ["Write", "Edit"] {
             assert_eq!(
                 check_tool(tool, &serde_json::json!({}), TrustMode::Auto, None),
                 expected,

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -115,6 +115,11 @@ fn test_classify_tool_covers_all_tools_explicitly() {
         ("WebFetch", ToolEffect::ReadOnly),
         ("WebSearch", ToolEffect::ReadOnly),
         ("InvokeAgent", ToolEffect::ReadOnly),
+        // TodoWrite mutates Koda-owned session state (the in-memory todo
+        // list), not the user's filesystem. From a user-impact view it's
+        // ReadOnly; classifying it as a mutation broke Plan-mode planning
+        // entirely (#1212).
+        ("TodoWrite", ToolEffect::ReadOnly),
         // Background-task management (#996 Layer 2). All three are
         // ReadOnly: List is a pure read; Cancel/Wait signal but don't
         // write files — idempotent control of work the model already
@@ -127,7 +132,6 @@ fn test_classify_tool_covers_all_tools_explicitly() {
         ("Edit", ToolEffect::LocalMutation),
         ("Bash", ToolEffect::LocalMutation),
         ("MemoryWrite", ToolEffect::LocalMutation),
-        ("TodoWrite", ToolEffect::LocalMutation),
         // Destructive
         ("Delete", ToolEffect::Destructive),
     ]


### PR DESCRIPTION
## Summary

Closes #1212.

`TodoWrite` was misclassified as `ToolEffect::LocalMutation` alongside `Write`/`Edit`/`MemoryWrite`. Because `koda-core::trust` gates approvals off `ToolEffect`, this propagated to every trust mode:

- **Plan** → `Blocked` — broke the very tool that's supposed to be the canonical planning surface (#1080, #1081, #621).
- **Safe** → `NeedsConfirmation` — every plan tick prompted the user.
- **Auto** → `AutoApprove` only when sandbox available; otherwise `NeedsConfirmation`.

`TodoWrite` only mutates Koda-owned session state (the in-memory todo list), not the user's files or shell. From a user-impact view it's read-only, so this PR reclassifies it as `ReadOnly` and lets it auto-approve in every trust mode.

## Changes

- **`koda-core/src/tools/mod.rs`** — move `TodoWrite` from the `LocalMutation` arm into the `ReadOnly` arm; update the doc table; add a comment explaining the user-impact rationale.
- **`koda-core/src/trust.rs`** — drop `TodoWrite` from the Plan/Safe/Auto mutation test loops; add it to `READ_ONLY_TOOLS` so `test_read_tools_always_approved` now covers it.
- **`koda-core/tests/tool_wiring_test.rs`** — flip the expected `ToolEffect` to `ReadOnly`.
- **`docs/src/tools.md`** — update the per-tool table and the per-mode approval matrix.
- **`CHANGELOG.md`** — add an `Unreleased` → `Fixed` entry.

## Tests

```
cargo test -p koda-core --lib                 # 1172 passed
cargo test -p koda-core --test tool_wiring_test  # 5 passed
cargo test -p koda-core --doc tools           # 5 passed
cargo clippy -p koda-core --all-targets       # clean
```

## Out of scope

`MemoryWrite` has the same shape (writes to a Koda-owned store, not user files) and is probably the same bug, but the issue calls it out as worth a separate discussion. Not touching it here.