### PR TITLE
test(tui_render): wiring assertions for WaitTask pretty branches (closes #1169)

### DIFF
--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -978,4 +978,82 @@ mod tests {
              post-completion `✅ ... completed` Info line is the durable record"
         );
     }
+
+    // ── WaitTask / ListBackgroundTasks pretty-render wiring ──────────────────
+    //
+    // The `render_tool_output` dispatch has two opt-in branches that route
+    // these tools through `wait_task_format` instead of the generic
+    // line-by-line dump. The formatter has 9 unit tests; these two tests
+    // cover the *wiring*: that the live TUI path actually invokes the
+    // formatter and surfaces its output to the scroll buffer. Without
+    // them, a one-character typo in the dispatch (e.g. `"WaitTasks"`
+    // vs `"WaitTask"`) would silently fall through to raw-JSON dump and
+    // only get caught visually. Closes the qa-expert finding from #1169.
+
+    #[test]
+    fn wait_task_branch_emits_pretty_lines_not_raw_json() {
+        let payload = json!({
+            "tasks": [{
+                "task_id": "agent:7",
+                "status": "completed",
+                "agent_name": "explore",
+                "output": "Found three call sites.",
+            }],
+            "summary": { "completed": 1, "total": 1 },
+        })
+        .to_string();
+
+        let lines = render_tool("WaitTask", json!({}), &payload);
+        let joined: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+
+        // Pretty branch ran: header + completion icon + agent name + preview.
+        assert!(
+            joined.contains("1 task(s) gathered"),
+            "missing pretty header — formatter wiring broken: {joined:?}"
+        );
+        assert!(joined.contains("\u{2705}"), "missing ✅ completion icon");
+        assert!(joined.contains("explore"), "missing agent name");
+        assert!(
+            joined.contains("Found three call sites."),
+            "missing output preview"
+        );
+
+        // Raw JSON keys must NOT leak through — that would mean the
+        // dispatch fell through to the generic line-by-line path.
+        assert!(
+            !joined.contains("\"task_id\":") && !joined.contains("\"agent_name\":"),
+            "raw JSON leaked — pretty branch did not fire: {joined:?}"
+        );
+    }
+
+    #[test]
+    fn list_bg_tasks_branch_emits_pretty_lines_not_raw_json() {
+        let payload = json!([{
+            "task_id": "agent:3",
+            "status": "running",
+            "age_secs": 12,
+            "description": "verify the fix",
+        }])
+        .to_string();
+
+        let lines = render_tool("ListBackgroundTasks", json!({}), &payload);
+        let joined: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+
+        assert!(
+            joined.contains("1 background task(s)"),
+            "missing pretty header — formatter wiring broken: {joined:?}"
+        );
+        assert!(joined.contains("verify the fix"), "missing description");
+
+        assert!(
+            !joined.contains("\"task_id\":") && !joined.contains("\"age_secs\":"),
+            "raw JSON leaked — pretty branch did not fire: {joined:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Closes #1169 — the v0.2.25 P3 audit-findings bundle that's been carried through two release cycles per its own aging rule. Adds the lone remaining cheap-to-action item (a wiring test for the WaitTask / ListBackgroundTasks pretty-render branches) and audits the disposition of the other six items.

## What this PR does

Adds two ~30-line wiring tests to `koda-cli/src/tui_render.rs`:

- `wait_task_branch_emits_pretty_lines_not_raw_json`
- `list_bg_tasks_branch_emits_pretty_lines_not_raw_json`

Both drive the full `TuiRenderer` → `ScrollBuffer` pipeline with a representative tool payload and assert (a) the pretty-formatter output reached the buffer (header text, status icon, agent name, preview present), AND (b) raw JSON keys (`"task_id":`, `"agent_name":`, `"age_secs":`) did NOT leak through. The latter is the regression-protection point: a one-character typo in the `render_tool_output` dispatch (e.g. `"WaitTasks"` vs `"WaitTask"`) would silently fall through to the generic line-by-line raw-JSON dump and previously only get caught visually.

## Disposition of the other six P3 items

Verified each item's current state in the source. **5 of 7 already self-resolved** during the v0.2.26 + v0.2.27 carry-period — strong real-world signal that the koda-release skill's audit-dust prevention rule (P3 items go in a bundle, not standalone, and age out after 2 cycles) is working as intended.

| # | Item | Disposition | Evidence |
|---|---|---|---|
| 1 | `"asynchronous"` category for koda-cli | ✅ **Already done** | `koda-cli/Cargo.toml:12` lists it |
| 2a | `#[must_use]` on `wait_status_icon` | ✅ **Already done** | `koda-cli/src/wait_task_format.rs:46` |
| 2b | `#[must_use]` on `first_meaningful_line` | ✅ **Already done** | `koda-cli/src/wait_task_format.rs:76` |
| 2c | `#[must_use]` on `try_render_wait_task_lines` | ✅ **Already done** | `koda-cli/src/wait_task_format.rs:122` |
| 2d | `#[must_use]` on `StatusBar::with_bg_counts` | 🪦 **Function deleted** | refactored away in #1213 (always-on bg overlay supersedes the status-bar pill) |
| 3 | `SECURITY.md` placeholder address | ✅ **Already done** | `SECURITY.md` now points to GitHub Security Advisory only; no placeholder remains |
| 6 | `tui_render` WaitTask wiring test | ✅ **This PR** | added two wiring tests |
| 4 | `cargo-audit` cache in CI | ⏸️ **Defer — no driver** | 30s/run is not annoying anyone; speculative tooling adoption per audit-dust rule |
| 5 | `cargo audit --deny warnings` | ⏸️ **Defer — no CVE driver** | item description itself: "no concrete CVE driving this" |
| 7 | PR template for release smoke list | ⏸️ **Defer — no demand** | process change with no requesters; can be filed standalone if a future release-prep miss makes it concrete |

The three deferred items don't escalate well in a bundle (they're policy-shaped, not bug-shaped). Per the issue's own triage rule — "if an item sits here for two release cycles without action, close it" — they're closed with this PR. If any escalates later (e.g. a real CVE makes `--deny warnings` urgent), the right move is filing a fresh standalone P1, not reanimating this bundle.

## Verification

- `cargo test -p koda-cli --lib tui_render::tests` — 21/21 pass (19 prior + 2 new)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p koda-cli --all-targets --features koda-core/test-support -- -D warnings` — clean

## Why this matters for the upcoming release

Clears the only carried-over tracking issue before the v0.3.0 release prep. With this merged, the open-issue tracker is down to genuine forward-looking work (#1175 capability milestone, #1163 foreground-rendering RFC, #1150 daemon epic, #1144 design-debt refactor, #663 dream feature) — no maintenance debt blocking the release cut.

## Closes

- Closes #1169
