### PR TITLE
refactor: rename Bg{Child,Activity}* → Child{Agent,}* (PR-A0 of #1232 §1)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -180,16 +180,21 @@ pub fn engine_event_to_acp(
         // shape used by `BgTaskUpdate` above. The full structured
         // payload (with `kind: tool_start` / `tool_end` / `info`) is
         // still on the wire for any future typed mapping.
-        EngineEvent::BgChildActivity { task_id, kind, .. } => {
+        EngineEvent::ChildAgentActivity { task_id, kind, .. } => {
             let body = match kind {
-                koda_core::engine::event::BgChildActivityKind::ToolStart { summary, .. } => {
+                koda_core::engine::event::ChildAgentActivityKind::ToolStart { summary, .. } => {
                     format!("\u{1f527} {summary}")
                 }
-                koda_core::engine::event::BgChildActivityKind::ToolEnd { tool_name, success } => {
+                koda_core::engine::event::ChildAgentActivityKind::ToolEnd {
+                    tool_name,
+                    success,
+                } => {
                     let icon = if *success { "\u{2713}" } else { "\u{2717}" };
                     format!("{icon} {tool_name}")
                 }
-                koda_core::engine::event::BgChildActivityKind::Info { message } => message.clone(),
+                koda_core::engine::event::ChildAgentActivityKind::Info { message } => {
+                    message.clone()
+                }
                 // Forward-compat: future activity kinds render as a
                 // generic line so ACP IDEs see something (#1224).
                 _ => "(activity)".to_string(),

--- a/koda-cli/src/child_activity.rs
+++ b/koda-cli/src/child_activity.rs
@@ -1,11 +1,11 @@
 //! Live tracker for background-work activity (#1210).
 //!
 //! Stateful counterpart to the pure-render
-//! [`crate::widgets::bg_activity_overlay`] widget. Absorbs
-//! `BgChildActivity` and `BgTaskUpdate` engine events into a
+//! [`crate::widgets::child_activity_overlay`] widget. Absorbs
+//! `ChildAgentActivity` and `BgTaskUpdate` engine events into a
 //! per-task last-activity map, then projects (alongside the engine's
 //! `BgAgentRegistry` + `BgRegistry` snapshots) into a flat list of
-//! [`crate::widgets::bg_activity_overlay::ActivityRow`]s the widget
+//! [`crate::widgets::child_activity_overlay::ActivityRow`]s the widget
 //! can render.
 //!
 //! ## Why a separate module
@@ -19,12 +19,12 @@
 //!
 //! ## Lifecycle
 //!
-//! 1. Construct empty (`BgActivityTracker::default()`) at TUI start.
-//! 2. On every `EngineEvent::BgChildActivity`, call
-//!    [`BgActivityTracker::record_activity`].
+//! 1. Construct empty (`ChildActivityTracker::default()`) at TUI start.
+//! 2. On every `EngineEvent::ChildAgentActivity`, call
+//!    [`ChildActivityTracker::record_activity`].
 //! 3. On every `EngineEvent::BgTaskUpdate`, call
-//!    [`BgActivityTracker::record_status`].
-//! 4. Each frame, call [`BgActivityTracker::build_rows`] with the
+//!    [`ChildActivityTracker::record_status`].
+//! 4. Each frame, call [`ChildActivityTracker::build_rows`] with the
 //!    current registry snapshots to get visible rows + total count.
 //!
 //! Pruning is implicit: rows are derived from the registry snapshot,
@@ -32,15 +32,15 @@
 //! drops them. The tracker's internal map is bounded by registry
 //! membership at projection time (see `build_rows`).
 
-use crate::widgets::bg_activity_overlay::{ActivityRow, ActivityStatus, MAX_VISIBLE};
+use crate::widgets::child_activity_overlay::{ActivityRow, ActivityStatus, MAX_VISIBLE};
 use koda_core::bg_agent::{AgentStatus, BgTaskSnapshot};
-use koda_core::engine::event::BgChildActivityKind;
+use koda_core::engine::event::ChildAgentActivityKind;
 use koda_core::tools::bg_process::{BgProcessSnapshot, BgProcessStatus};
 use std::collections::HashMap;
 use std::time::Duration;
 
 /// Per-task last-known activity description. Populated from
-/// `BgChildActivity` events. Bounded by registry membership: rows
+/// `ChildAgentActivity` events. Bounded by registry membership: rows
 /// for task ids no longer in the agent registry are dropped at
 /// projection time.
 #[derive(Debug, Clone)]
@@ -54,7 +54,7 @@ struct LastActivity {
 /// Stateful tracker. Cheap to construct; carry one as a field on
 /// `TuiContext`.
 #[derive(Debug, Clone, Default)]
-pub struct BgActivityTracker {
+pub struct ChildActivityTracker {
     /// Latest activity per agent task_id. Process tasks have no
     /// activity stream (they're shells, not LLM agents) — their
     /// "activity" is the static command string from
@@ -67,13 +67,13 @@ pub struct BgActivityTracker {
     cancelling: std::collections::HashSet<u32>,
 }
 
-impl BgActivityTracker {
-    /// Absorb a `BgChildActivity` event. Idempotent — re-recording
+impl ChildActivityTracker {
+    /// Absorb a `ChildAgentActivity` event. Idempotent — re-recording
     /// the same activity overwrites the previous entry.
-    pub fn record_activity(&mut self, task_id: u32, kind: &BgChildActivityKind) {
+    pub fn record_activity(&mut self, task_id: u32, kind: &ChildAgentActivityKind) {
         let description = match kind {
-            BgChildActivityKind::ToolStart { summary, .. } => summary.clone(),
-            BgChildActivityKind::ToolEnd { tool_name, success } => {
+            ChildAgentActivityKind::ToolStart { summary, .. } => summary.clone(),
+            ChildAgentActivityKind::ToolEnd { tool_name, success } => {
                 // ToolEnd would normally be a no-op (we want to keep
                 // showing the most recent ToolStart, not "Read foo
                 // ✓"), but if it's a *failure* we surface that so the
@@ -85,7 +85,7 @@ impl BgActivityTracker {
                 }
                 format!("{tool_name} \u{2717}")
             }
-            BgChildActivityKind::Info { message } => message.clone(),
+            ChildAgentActivityKind::Info { message } => message.clone(),
             // Forward-compat: future activity kinds are dropped from
             // the live overlay until we know how to render them. Same
             // shape as the success ToolEnd case above (#1224).
@@ -114,7 +114,7 @@ impl BgActivityTracker {
 
     /// Project current state + registry snapshots into renderable
     /// rows. Returns `(visible_rows, total_count)` matching the
-    /// widget's `BgActivityOverlay::new` signature.
+    /// widget's `ChildActivityOverlay::new` signature.
     ///
     /// Sort order: agents first (sorted by task_id ascending, so the
     /// fan-out spawn order is preserved), then processes (sorted by
@@ -251,7 +251,7 @@ fn format_age(d: Duration) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use koda_core::engine::event::BgChildActivityKind;
+    use koda_core::engine::event::ChildAgentActivityKind;
 
     fn agent(task_id: u32, name: &str, age_secs: u64, status: AgentStatus) -> BgTaskSnapshot {
         BgTaskSnapshot::for_testing(
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn empty_tracker_with_empty_registry_yields_no_rows() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let (rows, total) = t.build_rows(&[], &[]);
         assert!(rows.is_empty());
         assert_eq!(total, 0);
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn running_agent_without_recorded_activity_renders_with_no_activity() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let snap = vec![agent(1, "explore", 5, AgentStatus::Running { iter: 1 })];
         let (rows, total) = t.build_rows(&snap, &[]);
         assert_eq!(total, 1);
@@ -296,10 +296,10 @@ mod tests {
 
     #[test]
     fn tool_start_event_populates_activity() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolStart {
+            &ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "Read src/auth.rs".into(),
             },
@@ -311,17 +311,17 @@ mod tests {
 
     #[test]
     fn tool_end_success_does_not_overwrite_last_tool_start() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolStart {
+            &ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "Read foo.rs".into(),
             },
         );
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolEnd {
+            &ChildAgentActivityKind::ToolEnd {
                 tool_name: "Read".into(),
                 success: true,
             },
@@ -334,17 +334,17 @@ mod tests {
 
     #[test]
     fn tool_end_failure_surfaces_failure_marker() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolStart {
+            &ChildAgentActivityKind::ToolStart {
                 tool_name: "Bash".into(),
                 summary: "Bash cargo test".into(),
             },
         );
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolEnd {
+            &ChildAgentActivityKind::ToolEnd {
                 tool_name: "Bash".into(),
                 success: false,
             },
@@ -360,17 +360,17 @@ mod tests {
 
     #[test]
     fn info_event_overrides_previous_activity() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.record_activity(
             1,
-            &BgChildActivityKind::ToolStart {
+            &ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "Read foo.rs".into(),
             },
         );
         t.record_activity(
             1,
-            &BgChildActivityKind::Info {
+            &ChildAgentActivityKind::Info {
                 message: "Cache hit, skipping".into(),
             },
         );
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn terminal_agents_are_excluded_from_overlay() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let snap = vec![
             agent(1, "explore", 5, AgentStatus::Running { iter: 2 }),
             agent(
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn cancelling_marker_flips_status_color() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.mark_cancelling(7);
         let snap = vec![agent(7, "explore", 5, AgentStatus::Running { iter: 2 })];
         let (rows, _) = t.build_rows(&snap, &[]);
@@ -418,10 +418,10 @@ mod tests {
 
     #[test]
     fn stale_tracker_entries_pruned_when_registry_drops_task() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         t.record_activity(
             42,
-            &BgChildActivityKind::ToolStart {
+            &ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "stale".into(),
             },
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn agents_sorted_before_processes_in_render_order() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let agents = vec![
             agent(2, "verify", 2, AgentStatus::Running { iter: 1 }),
             agent(1, "explore", 4, AgentStatus::Running { iter: 1 }),
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn overflow_total_exceeds_visible_when_more_than_max_visible() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let agents: Vec<_> = (0..(MAX_VISIBLE as u32 + 4))
             .map(|i| agent(i, &format!("ag{i}"), 1, AgentStatus::Running { iter: 1 }))
             .collect();
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn process_row_uses_command_as_activity() {
-        let mut t = BgActivityTracker::default();
+        let mut t = ChildActivityTracker::default();
         let procs = vec![process(123, "cargo test --release", 4)];
         let (rows, _) = t.build_rows(&[], &procs);
         assert_eq!(rows.len(), 1);

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -304,19 +304,19 @@ impl EngineSink for HeadlessSink {
             // dimly indented under the parent feed so a tailing script
             // sees "  [bg task 7]   \u{1f527} Read src/auth.rs" without
             // having to wait for the post-completion drain.
-            EngineEvent::BgChildActivity { task_id, kind, .. } => {
+            EngineEvent::ChildAgentActivity { task_id, kind, .. } => {
                 let line = match kind {
-                    koda_core::engine::event::BgChildActivityKind::ToolStart {
+                    koda_core::engine::event::ChildAgentActivityKind::ToolStart {
                         summary, ..
                     } => format!("\u{1f527} {summary}"),
-                    koda_core::engine::event::BgChildActivityKind::ToolEnd {
+                    koda_core::engine::event::ChildAgentActivityKind::ToolEnd {
                         tool_name,
                         success,
                     } => {
                         let icon = if success { "\u{2713}" } else { "\u{2717}" };
                         format!("{icon} {tool_name}")
                     }
-                    koda_core::engine::event::BgChildActivityKind::Info { message } => message,
+                    koda_core::engine::event::ChildAgentActivityKind::Info { message } => message,
                     // Forward-compat: future activity kinds render as
                     // a generic line (#1224).
                     _ => "(activity)".to_string(),

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -19,8 +19,8 @@ compile_error!(
 pub(crate) mod acp_adapter;
 pub(crate) mod ansi_parse;
 pub(crate) mod app;
-pub(crate) mod bg_activity;
 pub(crate) mod builtin_skills;
+pub(crate) mod child_activity;
 pub(crate) mod clipboard;
 pub(crate) mod completer;
 pub(crate) mod composer;

--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -87,7 +87,7 @@ pub(crate) fn handle_cancel_background_task(
     buffer: &mut ScrollBuffer,
     bg_agents: &koda_core::bg_agent::BgAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
     task_id: Option<TaskId>,
 ) {
     let Some(id) = task_id else {
@@ -106,7 +106,7 @@ pub(crate) fn handle_cancel_background_task(
                 // doesn't transition to Cancelled until the inference
                 // loop next checks the token — could be a few hundred
                 // ms — and that lag without feedback feels broken.
-                bg_activity.mark_cancelling(n);
+                child_activity.mark_cancelling(n);
                 tui_output::ok_msg(
                     buffer,
                     format!("Cancellation requested for agent:{n}. Result will inject shortly."),
@@ -153,7 +153,7 @@ pub(crate) fn cancel_all_bg_work(
     buffer: &mut ScrollBuffer,
     bg_agents: &koda_core::bg_agent::BgAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) -> (usize, usize) {
     use koda_core::bg_agent::AgentStatus;
 
@@ -187,7 +187,7 @@ pub(crate) fn cancel_all_bg_work(
                 // immediate feedback (#1210); the registry status
                 // transition to Cancelled lags by an inference
                 // iteration.
-                bg_activity.mark_cancelling(**id);
+                child_activity.mark_cancelling(**id);
             }
             cancelled
         })
@@ -337,7 +337,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
             Some(TaskId::Agent(task_id)),
         );
 
@@ -367,7 +367,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
             Some(TaskId::Process(pid)),
         );
 
@@ -394,7 +394,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
             Some(TaskId::Agent(999)),
         );
         let text = buffer_text(&buf);
@@ -415,7 +415,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
             Some(TaskId::Process(999_999)),
         );
         let text = buffer_text(&buf);
@@ -438,7 +438,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
             None,
         );
         let text = buffer_text(&buf);
@@ -463,7 +463,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
         );
         assert_eq!((a, p), (0, 0));
         assert!(
@@ -493,7 +493,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
         );
         assert_eq!((a, p), (2, 0));
         assert!(observer1.is_cancelled(), "agent 1 should observe cascade");
@@ -523,7 +523,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
         );
         assert_eq!((a, p), (1, 1));
         assert!(observer.is_cancelled());
@@ -557,7 +557,7 @@ mod tests {
             &mut buf,
             &reg,
             &procs,
-            &mut crate::bg_activity::BgActivityTracker::default(),
+            &mut crate::child_activity::ChildActivityTracker::default(),
         );
         assert_eq!((a, p), (0, 0));
         assert!(

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -46,7 +46,7 @@ pub async fn handle_slash_command(
     agent: &Arc<KodaAgent>,
     pending_command: &mut Option<String>,
     menu: &mut crate::tui_types::MenuContent,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) -> SlashAction {
     let parts: Vec<&str> = input.splitn(2, ' ').collect();
     let cmd = parts[0];
@@ -176,7 +176,7 @@ pub async fn handle_slash_command(
 
         // #1210 deleted the legacy `/agents` interactive panel; live
         // bg-agent + bg-process state now flows through the always-on
-        // `widgets::bg_activity_overlay` rendered above the status bar.
+        // `widgets::child_activity_overlay` rendered above the status bar.
         // The model-facing `ListBackgroundTasks` tool keeps the same
         // dump shape for in-context introspection — `/agents` was the
         // user-facing surface for the same data and is redundant.
@@ -196,7 +196,7 @@ pub async fn handle_slash_command(
                 buffer,
                 &session.bg_agents,
                 &agent.tools.bg_registry,
-                bg_activity,
+                child_activity,
                 parsed,
             );
             SlashAction::Continue

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -154,7 +154,7 @@ impl TuiContext {
                         &mut self.scroll_buffer,
                         &self.session.bg_agents,
                         &self.agent.tools.bg_registry,
-                        &mut self.bg_activity,
+                        &mut self.child_activity,
                     );
                 }
             }
@@ -182,7 +182,7 @@ impl TuiContext {
                         &mut self.scroll_buffer,
                         &self.session.bg_agents,
                         &self.agent.tools.bg_registry,
-                        &mut self.bg_activity,
+                        &mut self.child_activity,
                     );
                 } else if composer_dirty {
                     self.quit_armed_at = None;

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -126,11 +126,11 @@ pub(crate) struct TuiContext {
     pub draw_rx: crate::frame_requester::DrawNotifyRx,
 
     /// Live activity tracker for bg agents + processes (#1210).
-    /// Absorbs `BgChildActivity` / `BgTaskUpdate` events into a per-task
+    /// Absorbs `ChildAgentActivity` / `BgTaskUpdate` events into a per-task
     /// last-seen map; projected each frame into the
-    /// `widgets::bg_activity_overlay` rendered above the status bar.
-    /// See [`crate::bg_activity::BgActivityTracker`].
-    pub bg_activity: crate::bg_activity::BgActivityTracker,
+    /// `widgets::child_activity_overlay` rendered above the status bar.
+    /// See [`crate::child_activity::ChildActivityTracker`].
+    pub child_activity: crate::child_activity::ChildActivityTracker,
 }
 
 /// Outcome of dispatching a single command.
@@ -408,7 +408,7 @@ impl TuiContext {
             project_root,
             frame_requester,
             draw_rx,
-            bg_activity: crate::bg_activity::BgActivityTracker::default(),
+            child_activity: crate::child_activity::ChildActivityTracker::default(),
         })
     }
 
@@ -461,8 +461,8 @@ impl TuiContext {
         // redundant the moment the live surface exists (#1210).
         let agent_snaps = self.session.bg_agents.snapshot();
         let process_snaps = self.agent.tools.bg_registry.snapshot();
-        let (bg_activity_rows, bg_activity_total) =
-            self.bg_activity.build_rows(&agent_snaps, &process_snaps);
+        let (child_activity_rows, child_activity_total) =
+            self.child_activity.build_rows(&agent_snaps, &process_snaps);
 
         let mut history_rect = None;
         if let Err(e) = self.terminal.draw(|f| {
@@ -483,8 +483,8 @@ impl TuiContext {
                 selection,
                 mcp_info,
                 &project_root,
-                &bg_activity_rows,
-                bg_activity_total,
+                &child_activity_rows,
+                child_activity_total,
             ));
         }) {
             tracing::debug!("draw skipped: {e}");
@@ -668,7 +668,7 @@ impl TuiContext {
             &self.agent,
             &mut self.pending_command,
             &mut self.menu,
-            &mut self.bg_activity,
+            &mut self.child_activity,
         )
         .await;
 

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -219,8 +219,8 @@ impl TuiContext {
                         // is doing right now, and the cancel keybindings.
                         let agent_snaps = bg_agents_for_status.snapshot();
                         let process_snaps = agent_for_status.tools.bg_registry.snapshot();
-                        let (bg_activity_rows, bg_activity_total) =
-                            self.bg_activity.build_rows(&agent_snaps, &process_snaps);
+                        let (child_activity_rows, child_activity_total) =
+                            self.child_activity.build_rows(&agent_snaps, &process_snaps);
                         let queue_total = self.later_queue.len();
                         let queue_preview: Vec<String> = self
                             .later_queue
@@ -248,8 +248,8 @@ impl TuiContext {
                                 self.mouse_selection.as_ref(),
                                 mcp_info,
                                 &self.project_root,
-                                &bg_activity_rows,
-                                bg_activity_total,
+                                &child_activity_rows,
+                                child_activity_total,
                             );
                         });
                     }
@@ -273,7 +273,7 @@ impl TuiContext {
                             &db_handle,
                             &bg_agents_for_status,
                             &agent_for_status.tools.bg_registry,
-                            &mut self.bg_activity,
+                            &mut self.child_activity,
                         )
                         .await;
                         // Request a redraw to reflect the new state. The
@@ -297,7 +297,7 @@ impl TuiContext {
                             &mut self.menu,
                             &mut self.prompt_mode,
                             &mut self.renderer,
-                            &mut self.bg_activity,
+                            &mut self.child_activity,
                         );
                         // Bounded drain — at most MAX_DRAIN extra events per
                         // iteration so we yield back to the select for input
@@ -319,7 +319,7 @@ impl TuiContext {
                                 &mut self.menu,
                                 &mut self.prompt_mode,
                                 &mut self.renderer,
-                                &mut self.bg_activity,
+                                &mut self.child_activity,
                             );
                         });
                         // One coalesced redraw per drain batch — not per
@@ -402,8 +402,8 @@ impl TuiContext {
             // during post-turn drain — a fan-out agent emitting a
             // ToolStart milliseconds before the turn future resolves
             // would otherwise vanish from the overlay forever (#1210).
-            if let EngineEvent::BgChildActivity { task_id, kind, .. } = &e {
-                self.bg_activity.record_activity(*task_id, kind);
+            if let EngineEvent::ChildAgentActivity { task_id, kind, .. } = &e {
+                self.child_activity.record_activity(*task_id, kind);
             }
             self.renderer.render_to_buffer(e, &mut self.scroll_buffer);
         }
@@ -512,7 +512,7 @@ async fn handle_crossterm_event_inline(
     db: &koda_core::db::Database,
     bg_agents: &koda_core::bg_agent::BgAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) {
     use crossterm::event::MouseEventKind;
     match ev {
@@ -562,7 +562,7 @@ async fn handle_crossterm_event_inline(
                 db,
                 bg_agents,
                 bg_processes,
-                bg_activity,
+                child_activity,
             )
             .await;
         }
@@ -589,7 +589,7 @@ async fn handle_inference_key_inline(
     db: &koda_core::db::Database,
     bg_agents: &koda_core::bg_agent::BgAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) {
     // Vim insert-mode Escape (PR 3 of #1178). Same rationale as in
     // `tui_context::events::handle_key`: route bare Esc to the textarea
@@ -838,7 +838,7 @@ async fn handle_inference_key_inline(
                 scroll_buffer,
                 bg_agents,
                 bg_processes,
-                bg_activity,
+                child_activity,
             );
         }
         (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
@@ -851,7 +851,7 @@ async fn handle_inference_key_inline(
                 scroll_buffer,
                 bg_agents,
                 bg_processes,
-                bg_activity,
+                child_activity,
             );
         }
         // Ctrl+U: clear the later_queue (deferred messages) without cancelling inference.
@@ -939,7 +939,7 @@ fn handle_inference_ui_inline(
     menu: &mut MenuContent,
     prompt_mode: &mut PromptMode,
     renderer: &mut crate::tui_render::TuiRenderer,
-    bg_activity: &mut crate::bg_activity::BgActivityTracker,
+    child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) {
     match ui_event {
         UiEvent::Engine(EngineEvent::AskUserRequest {
@@ -1002,12 +1002,12 @@ fn handle_inference_ui_inline(
         UiEvent::Engine(event) => {
             // Tap bg-activity events into the live tracker BEFORE the
             // renderer no-ops them (#1207 dropped scroll output for
-            // BgChildActivity; #1210 routes them to the activity
+            // ChildAgentActivity; #1210 routes them to the activity
             // overlay instead). Done here so every fall-through engine
             // event passes through the same tap point — no risk of a
             // future variant-specific arm bypassing it.
-            if let EngineEvent::BgChildActivity { task_id, kind, .. } = &event {
-                bg_activity.record_activity(*task_id, kind);
+            if let EngineEvent::ChildAgentActivity { task_id, kind, .. } = &event {
+                child_activity.record_activity(*task_id, kind);
             }
             renderer.render_to_buffer(event, buffer);
         }

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -284,7 +284,7 @@ impl TuiRenderer {
             | EngineEvent::LoopCapReached { .. }
             | EngineEvent::BgTaskUpdate { .. }
             | EngineEvent::TodoUpdate { .. }
-            | EngineEvent::BgChildActivity { .. } => {
+            | EngineEvent::ChildAgentActivity { .. } => {
                 // Handled by the event loop, not the renderer.
                 // (#1076) BgTaskUpdate is routed to the bg-task panel,
                 // which still reads from the registry snapshot for its
@@ -295,7 +295,7 @@ impl TuiRenderer {
                 // the structured event is for ACP / headless clients
                 // that want diff-driven animation. Same future-cleanup
                 // path as BgTaskUpdate.
-                // (#1201 B2) BgChildActivity is dropped from TUI
+                // (#1201 B2) ChildAgentActivity is dropped from TUI
                 // scrollback render. The B1 inline-line render
                 // (`[bg N] 🔧 Read foo.rs` per event) was redundant
                 // with the post-completion `✅ Background agent X
@@ -441,7 +441,7 @@ fn render_tool_output(
     // ListBackgroundTasks (#1209) — same JSON-soup problem as WaitTask;
     // the model calls this to peek at running bg work and we owe the
     // user a per-task render with the same icon vocabulary as the
-    // live `bg_activity_overlay` instead of a one-line JSON dump.
+    // live `child_activity_overlay` instead of a one-line JSON dump.
     if name == "ListBackgroundTasks"
         && let Some(lines) = crate::wait_task_format::try_render_list_bg_tasks_lines(output)
     {
@@ -930,7 +930,7 @@ mod tests {
         assert_eq!(collapse_blank_lines("\n\n\n\n"), "\n");
     }
 
-    // ── #1201 B2: BgChildActivity is a TUI no-op ────────────────────────────
+    // ── #1201 B2: ChildAgentActivity is a TUI no-op ────────────────────────────
     //
     // The B1 PR rendered each child activity event as a dim inline
     // line in the scroll buffer. That turned out redundant with the
@@ -945,28 +945,29 @@ mod tests {
     // accidentally re-introduce the noise.
     #[test]
     fn bg_child_activity_does_not_push_lines_to_scroll_buffer() {
-        use koda_core::engine::event::{BgChildActivityKind, EngineEvent};
+        use koda_core::engine::event::{ChildAgentActivityKind, EngineEvent};
 
         let mut renderer = TuiRenderer::new();
         let mut buffer = ScrollBuffer::new(2500);
 
         for kind in [
-            BgChildActivityKind::ToolStart {
+            ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "src/main.rs".into(),
             },
-            BgChildActivityKind::ToolEnd {
+            ChildAgentActivityKind::ToolEnd {
                 tool_name: "Read".into(),
                 success: true,
             },
-            BgChildActivityKind::Info {
+            ChildAgentActivityKind::Info {
                 message: "  \u{1f4cc} note".into(),
             },
         ] {
             renderer.render_to_buffer(
-                EngineEvent::BgChildActivity {
+                EngineEvent::ChildAgentActivity {
                     task_id: 7,
                     spawner: None,
+                    is_background: true,
                     kind,
                 },
                 &mut buffer,
@@ -976,7 +977,7 @@ mod tests {
         assert_eq!(
             buffer.len(),
             0,
-            "BgChildActivity must not push to scrollback (#1201 B2); \
+            "ChildAgentActivity must not push to scrollback (#1201 B2); \
              post-completion `✅ ... completed` Info line is the durable record"
         );
     }

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -47,10 +47,10 @@ pub(crate) fn draw_viewport(
     project_root: &std::path::Path,
     // #1210: pre-built rows for the live bg-activity overlay rendered
     // above the status bar. Slice is already truncated to MAX_VISIBLE;
-    // `bg_activity_total` is the un-truncated count, used for the
+    // `child_activity_total` is the un-truncated count, used for the
     // "+ N more" overflow hint.
-    bg_activity_rows: &[crate::widgets::bg_activity_overlay::ActivityRow],
-    bg_activity_total: usize,
+    child_activity_rows: &[crate::widgets::child_activity_overlay::ActivityRow],
+    child_activity_total: usize,
 ) -> ratatui::layout::Rect {
     let area = frame.area();
 
@@ -93,8 +93,10 @@ pub(crate) fn draw_viewport(
     // Bg-activity overlay height (#1210): 0 when no live work; mirrors
     // QueuePreview's collapse-when-empty pattern so the chrome reflows
     // automatically as fan-out agents come and go.
-    let bg_activity_height =
-        crate::widgets::bg_activity_overlay::BgActivityOverlay::height_for(bg_activity_total);
+    let child_activity_height =
+        crate::widgets::child_activity_overlay::ChildActivityOverlay::height_for(
+            child_activity_total,
+        );
 
     // Layout: History | TopSep | Input | BotSep | Status | Queue? | Menu
     //
@@ -113,19 +115,19 @@ pub(crate) fn draw_viewport(
         top_sep_row,
         input_rows,
         bot_sep_row,
-        bg_activity_row,
+        child_activity_row,
         status_row,
         queue_preview_row,
         menu_area,
     ] = Layout::vertical([
-        Constraint::Min(1),                       // history: fill remaining space
-        Constraint::Length(1),                    // top separator (─────)
-        Constraint::Length(input_height),         // input textarea
-        Constraint::Length(1),                    // bottom separator (─────)
-        Constraint::Length(bg_activity_height),   // #1210 live bg-activity overlay (0 when empty)
-        Constraint::Length(1),                    // status bar
-        Constraint::Length(queue_preview_height), // later_queue preview (0 when empty)
-        Constraint::Length(menu_height),          // dropdown menu (0 when inactive)
+        Constraint::Min(1),                        // history: fill remaining space
+        Constraint::Length(1),                     // top separator (─────)
+        Constraint::Length(input_height),          // input textarea
+        Constraint::Length(1),                     // bottom separator (─────)
+        Constraint::Length(child_activity_height), // #1210 live bg-activity overlay (0 when empty)
+        Constraint::Length(1),                     // status bar
+        Constraint::Length(queue_preview_height),  // later_queue preview (0 when empty)
+        Constraint::Length(menu_height),           // dropdown menu (0 when inactive)
     ])
     .areas(area);
 
@@ -243,13 +245,13 @@ pub(crate) fn draw_viewport(
     // study (#1210) showed claude_code/gemini-cli surface the
     // equivalent in the same band, and that's where users expect
     // it.
-    if bg_activity_height > 0 {
+    if child_activity_height > 0 {
         frame.render_widget(
-            crate::widgets::bg_activity_overlay::BgActivityOverlay::new(
-                bg_activity_rows,
-                bg_activity_total,
+            crate::widgets::child_activity_overlay::ChildActivityOverlay::new(
+                child_activity_rows,
+                child_activity_total,
             ),
-            bg_activity_row,
+            child_activity_row,
         );
     }
 

--- a/koda-cli/src/wait_task_format.rs
+++ b/koda-cli/src/wait_task_format.rs
@@ -53,7 +53,7 @@ pub fn wait_status_icon(status: &str) -> &'static str {
         "forbidden" => "\u{1F512}",  // 🔒
         "parse_error" => "\u{26A0}", // ⚠
         // ListBackgroundTasks-specific statuses (#1209). Glyph choice
-        // matches `bg_activity_overlay`'s status palette so the live
+        // matches `child_activity_overlay`'s status palette so the live
         // overlay and the tool-result render speak the same icon
         // vocabulary.
         "pending" => "\u{25D0}", // ◐ — half-filled circle
@@ -286,7 +286,7 @@ pub fn try_render_list_bg_tasks_lines(payload: &str) -> Option<Vec<Line<'static>
 
         // Status suffix shows the raw status word (with optional exit
         // code for processes) plus age. Format mirrors the live
-        // `bg_activity_overlay` so eye sweeps between live + history
+        // `child_activity_overlay` so eye sweeps between live + history
         // see the same tail.
         let status_tail = match exit_code {
             Some(code) => format!("({status} {code}, {age_secs}s)"),

--- a/koda-cli/src/widgets/child_activity_overlay.rs
+++ b/koda-cli/src/widgets/child_activity_overlay.rs
@@ -41,7 +41,7 @@
 //!   covers the field-standard surface area without rebuilding the
 //!   `/agents` modal panel that #1210 deletes.
 //! - Does NOT auto-refresh — caller drives a redraw on each
-//!   `BgChildActivity` / `BgTaskUpdate` event (already wired via
+//!   `ChildAgentActivity` / `BgTaskUpdate` event (already wired via
 //!   `frame_requester`).
 
 use ratatui::{
@@ -105,7 +105,7 @@ pub enum ActivityStatus {
 ///
 /// Construction is cheap (borrows the row slice + total). Pass to
 /// [`ratatui::Frame::render_widget`].
-pub struct BgActivityOverlay<'a> {
+pub struct ChildActivityOverlay<'a> {
     /// Visible rows (already truncated to [`MAX_VISIBLE`] by caller).
     rows: &'a [ActivityRow],
     /// Total live work count (may exceed `rows.len()`); drives
@@ -113,7 +113,7 @@ pub struct BgActivityOverlay<'a> {
     total: usize,
 }
 
-impl<'a> BgActivityOverlay<'a> {
+impl<'a> ChildActivityOverlay<'a> {
     /// Construct an overlay for the given visible row slice.
     ///
     /// `rows.len() <= MAX_VISIBLE` is the caller's invariant; this
@@ -137,7 +137,7 @@ impl<'a> BgActivityOverlay<'a> {
     }
 }
 
-impl Widget for BgActivityOverlay<'_> {
+impl Widget for ChildActivityOverlay<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         // Reserve space for the leading "  ICON LABEL  AGE  · " prefix.
         // Worked example: "  " (2) + icon+space (2 cells: emoji is
@@ -253,10 +253,10 @@ mod tests {
     use super::*;
 
     fn render(rows: &[ActivityRow], total: usize, width: u16) -> Vec<String> {
-        let height = BgActivityOverlay::height_for(total).max(1);
+        let height = ChildActivityOverlay::height_for(total).max(1);
         let area = Rect::new(0, 0, width, height);
         let mut buf = Buffer::empty(area);
-        BgActivityOverlay::new(rows, total).render(area, &mut buf);
+        ChildActivityOverlay::new(rows, total).render(area, &mut buf);
         (0..height)
             .map(|y| {
                 (0..width)
@@ -280,19 +280,19 @@ mod tests {
 
     #[test]
     fn height_zero_when_no_work() {
-        assert_eq!(BgActivityOverlay::height_for(0), 0);
+        assert_eq!(ChildActivityOverlay::height_for(0), 0);
     }
 
     #[test]
     fn height_one_row_includes_hint() {
         // 1 body row + 1 hint = 2
-        assert_eq!(BgActivityOverlay::height_for(1), 2);
+        assert_eq!(ChildActivityOverlay::height_for(1), 2);
     }
 
     #[test]
     fn height_capped_at_max_visible_plus_hint() {
         assert_eq!(
-            BgActivityOverlay::height_for(MAX_VISIBLE + 10),
+            ChildActivityOverlay::height_for(MAX_VISIBLE + 10),
             (MAX_VISIBLE + 1) as u16
         );
     }

--- a/koda-cli/src/widgets/mod.rs
+++ b/koda-cli/src/widgets/mod.rs
@@ -4,7 +4,7 @@
 //! logic (`build_*_lines` functions). The generic [`dropdown::DropdownState`]
 //! provides shared navigation (up/down/scroll/filter) so menus stay DRY.
 
-pub mod bg_activity_overlay;
+pub mod child_activity_overlay;
 pub mod dropdown;
 pub mod file_menu;
 pub mod model_menu;

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -380,7 +380,7 @@ mod tests {
 
     // (#1158's bg-pill tests removed in #1210 along with the pill
     // itself; the live bg-activity overlay is covered by
-    // `widgets::bg_activity_overlay::tests` and `bg_activity::tests`.)
+    // `widgets::child_activity_overlay::tests` and `child_activity::tests`.)
 
     /// Vim segment is hidden when the textarea reports `None`
     /// (vim editing disabled). PR 3 of #1178.

--- a/koda-core/src/bg_agent.rs
+++ b/koda-core/src/bg_agent.rs
@@ -370,7 +370,7 @@ impl BgStatusEmitter {
     /// Forward a live activity event from inside the bg agent up to
     /// the parent's sink.
     ///
-    /// **#1201 B**: paired with [`crate::engine::sink::ForwardingBgSink`],
+    /// **#1201 B**: paired with [`crate::engine::sink::ForwardingChildSink`],
     /// which decorates the bg agent's `BufferingSink` and calls this
     /// method whenever an interesting child event happens (tool
     /// start/end, info line). The event lands on the same registry
@@ -382,11 +382,15 @@ impl BgStatusEmitter {
     /// the same cost as [`Self::send`]. The activity feed runs at
     /// roughly tool-call frequency — not hot enough for any of this
     /// to register in a profile.
-    pub fn send_activity(&self, kind: crate::engine::event::BgChildActivityKind) {
+    pub fn send_activity(&self, kind: crate::engine::event::ChildAgentActivityKind) {
         self.registry
-            .push_status_event(EngineEvent::BgChildActivity {
+            .push_status_event(EngineEvent::ChildAgentActivity {
                 task_id: self.task_id,
                 spawner: self.spawner,
+                // PR-A0 of #1232: hardcoded `true` because every emit
+                // site today is a bg agent. PR-A wires up a fg path
+                // that passes `false` here.
+                is_background: true,
                 kind,
             });
     }
@@ -1891,11 +1895,11 @@ mod tests {
         let (status_tx, _status_rx) = tokio::sync::watch::channel(AgentStatus::Pending);
         let emitter = BgStatusEmitter::new(42, Some(7), status_tx, registry.clone());
 
-        emitter.send_activity(crate::engine::event::BgChildActivityKind::ToolStart {
+        emitter.send_activity(crate::engine::event::ChildAgentActivityKind::ToolStart {
             tool_name: "Read".into(),
             summary: "Read foo.txt".into(),
         });
-        emitter.send_activity(crate::engine::event::BgChildActivityKind::Info {
+        emitter.send_activity(crate::engine::event::ChildAgentActivityKind::Info {
             message: "\u{26a1} cache hit".into(),
         });
 
@@ -1903,18 +1907,20 @@ mod tests {
         assert_eq!(drained.len(), 2);
         assert!(matches!(
             &drained[0],
-            EngineEvent::BgChildActivity {
+            EngineEvent::ChildAgentActivity {
                 task_id: 42,
                 spawner: Some(7),
-                kind: crate::engine::event::BgChildActivityKind::ToolStart { tool_name, .. }
+                is_background: true,
+                kind: crate::engine::event::ChildAgentActivityKind::ToolStart { tool_name, .. }
             } if tool_name == "Read"
         ));
         assert!(matches!(
             &drained[1],
-            EngineEvent::BgChildActivity {
+            EngineEvent::ChildAgentActivity {
                 task_id: 42,
                 spawner: Some(7),
-                kind: crate::engine::event::BgChildActivityKind::Info { message }
+                is_background: true,
+                kind: crate::engine::event::ChildAgentActivityKind::Info { message }
             } if message.contains("cache hit")
         ));
     }

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -156,7 +156,8 @@ pub enum EngineEvent {
         status: crate::bg_agent::AgentStatus,
     },
 
-    /// Live activity from inside a running background sub-agent.
+    /// Live activity from inside a running child agent (foreground or
+    /// background sub-agent).
     ///
     /// **#1201 B**: pre-this-event the parent's TUI had no live signal
     /// from inside a bg agent — only `BgTaskUpdate` heartbeats
@@ -164,28 +165,46 @@ pub enum EngineEvent {
     /// "doing what". The narrative trace shipped via `BufferingSink`
     /// only surfaced at result-injection time.
     ///
-    /// `BgChildActivity` is the live tap: each interesting event
-    /// inside the bg agent (tool start/end, info line) fans out to
-    /// the parent's sink as soon as it happens, so the parent's TUI
-    /// can render a Gemini-style activity feed under the bg-task's
+    /// **PR-A0 of #1232 § 1**: renamed from `BgChildActivity`. The
+    /// underlying mechanism is identical — pushed onto the registry's
+    /// status-event queue and forwarded to the active sink — but the
+    /// type name no longer pretends bg is the only valid source.
+    /// Foreground sub-agent routing through this event is the actual
+    /// behavior change in PR-A; PR-A0 is just the rename so the type
+    /// stops lying. Today every emit site still passes
+    /// `is_background: true`.
+    ///
+    /// Wire format (`"type":"bg_child_activity"`) is preserved via
+    /// `#[serde(rename)]` so ACP / headless clients keep parsing the
+    /// same envelope. PR-A will revisit the wire tag once fg actually
+    /// flows through here.
+    ///
+    /// `ChildAgentActivity` is the live tap: each interesting event
+    /// inside the child agent (tool start/end, info line) fans out
+    /// to the parent's sink as soon as it happens, so the parent's
+    /// TUI can render a Gemini-style activity feed under the child's
     /// spawn cell. The post-completion narrative trace via
     /// `BufferingSink` is still emitted (and is still authoritative
     /// for the persisted transcript) — this event is purely for
     /// real-time UX.
-    ///
-    /// Same routing as `BgTaskUpdate`: pushed onto the registry's
-    /// status-event queue by [`crate::bg_agent::BgStatusEmitter::send_activity`]
-    /// and drained by the inference loop, so every client surface
-    /// (TUI / headless / ACP) sees the same stream.
-    BgChildActivity {
+    #[serde(rename = "bg_child_activity")]
+    ChildAgentActivity {
         /// Matches the `task_id` from `BgTaskUpdate` for the same
-        /// running bg task.
+        /// running task. For foreground sub-agents (PR-A) this will
+        /// be a synthetic id assigned at dispatch time.
         task_id: u32,
         /// Sub-agent invocation id of the spawner, or `None` for
-        /// top-level-spawned bg tasks. Mirrors `BgTaskUpdate.spawner`.
+        /// top-level-spawned tasks. Mirrors `BgTaskUpdate.spawner`.
         spawner: Option<u32>,
-        /// What just happened inside the bg agent.
-        kind: BgChildActivityKind,
+        /// `true` if the child runs as a background task (today: all
+        /// emit sites). `false` reserved for foreground sub-agents
+        /// in PR-A. Wire-default is `true` so older clients that
+        /// never received this field deserialize as the historical
+        /// behavior.
+        #[serde(default = "default_is_background_true")]
+        is_background: bool,
+        /// What just happened inside the child agent.
+        kind: ChildAgentActivityKind,
     },
 
     // ── Approval flow ─────────────────────────────────────────────────
@@ -357,7 +376,7 @@ pub enum EngineEvent {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum BgChildActivityKind {
+pub enum ChildAgentActivityKind {
     /// The child started a tool call.
     ///
     /// `summary` is a pre-truncated one-line description suitable
@@ -394,6 +413,14 @@ pub enum BgChildActivityKind {
         /// The info line, rendered as-is.
         message: String,
     },
+}
+
+/// Serde default for the `is_background` field on
+/// [`EngineEvent::ChildAgentActivity`]. Returns `true` so older wire
+/// payloads that pre-date the field deserialize as the historical
+/// behavior (every emit was from a bg agent before PR-A).
+fn default_is_background_true() -> bool {
+    true
 }
 
 /// Why an inference turn ended.
@@ -785,40 +812,44 @@ mod tests {
         }
     }
 
-    /// #1201 B: BgChildActivity must roundtrip cleanly so ACP / headless
-    /// clients see the same wire shape as the in-process TUI. Tests all
-    /// three kinds and the `BgChildActivity` envelope.
+    /// #1201 B + PR-A0 of #1232: ChildAgentActivity must roundtrip
+    /// cleanly so ACP / headless clients see the same wire shape as
+    /// the in-process TUI. Tests all three kinds, the envelope, and
+    /// the wire-tag preservation (still `bg_child_activity` for back
+    /// compat).
     #[test]
-    fn test_bg_child_activity_roundtrip() {
+    fn test_child_agent_activity_roundtrip() {
         let kinds = vec![
-            BgChildActivityKind::ToolStart {
+            ChildAgentActivityKind::ToolStart {
                 tool_name: "Read".into(),
                 summary: "Read src/auth.rs".into(),
             },
-            BgChildActivityKind::ToolEnd {
+            ChildAgentActivityKind::ToolEnd {
                 tool_name: "Bash".into(),
                 success: true,
             },
-            BgChildActivityKind::ToolEnd {
+            ChildAgentActivityKind::ToolEnd {
                 tool_name: "Edit".into(),
                 success: false,
             },
-            BgChildActivityKind::Info {
+            ChildAgentActivityKind::Info {
                 message: "  \u{26a1} cache hit".into(),
             },
         ];
         for kind in kinds {
             let json = serde_json::to_string(&kind).unwrap();
-            let roundtripped: BgChildActivityKind = serde_json::from_str(&json).unwrap();
+            let roundtripped: ChildAgentActivityKind = serde_json::from_str(&json).unwrap();
             assert_eq!(kind, roundtripped);
         }
 
         // Envelope event — tests the outer EngineEvent serialization
-        // including the snake_case type tag ("bg_child_activity").
-        let event = EngineEvent::BgChildActivity {
+        // including the preserved snake_case type tag
+        // ("bg_child_activity") and the new is_background field.
+        let event = EngineEvent::ChildAgentActivity {
             task_id: 7,
             spawner: Some(3),
-            kind: BgChildActivityKind::ToolStart {
+            is_background: true,
+            kind: ChildAgentActivityKind::ToolStart {
                 tool_name: "Grep".into(),
                 summary: "Grep TODO src/".into(),
             },
@@ -826,31 +857,49 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(
             json.contains("\"type\":\"bg_child_activity\""),
-            "envelope must use snake_case type tag for ACP / headless clients"
+            "envelope must preserve historical wire tag for ACP / headless clients"
         );
         assert!(
             json.contains("\"kind\":\"tool_start\""),
             "inner kind must use snake_case tag"
         );
+        assert!(
+            json.contains("\"is_background\":true"),
+            "is_background must serialize on the wire so future fg emits are distinguishable"
+        );
         let deserialized: EngineEvent = serde_json::from_str(&json).unwrap();
         assert!(matches!(
             deserialized,
-            EngineEvent::BgChildActivity {
+            EngineEvent::ChildAgentActivity {
                 task_id: 7,
                 spawner: Some(3),
+                is_background: true,
                 ..
             }
         ));
 
-        // Top-level-spawned bg task — spawner is None.
-        let top_level = EngineEvent::BgChildActivity {
+        // Top-level-spawned task — spawner is None.
+        let top_level = EngineEvent::ChildAgentActivity {
             task_id: 1,
             spawner: None,
-            kind: BgChildActivityKind::Info {
+            is_background: true,
+            kind: ChildAgentActivityKind::Info {
                 message: "hello".into(),
             },
         };
         let json = serde_json::to_string(&top_level).unwrap();
         let _: EngineEvent = serde_json::from_str(&json).unwrap();
+
+        // Back-compat: a payload from before is_background existed
+        // must still deserialize, defaulting is_background to true.
+        let legacy_json = r#"{"type":"bg_child_activity","task_id":2,"spawner":null,"kind":{"kind":"info","message":"legacy"}}"#;
+        let legacy: EngineEvent = serde_json::from_str(legacy_json).unwrap();
+        assert!(matches!(
+            legacy,
+            EngineEvent::ChildAgentActivity {
+                is_background: true,
+                ..
+            }
+        ));
     }
 }

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -137,10 +137,10 @@ impl EngineSink for BufferingSink {
     }
 }
 
-// ── ForwardingBgSink (#1201 B) ──────────────────────────
+// ── ForwardingChildSink (#1201 B) ──────────────────────────
 
 /// A decorator around [`BufferingSink`] that *also* forwards select
-/// events as [`crate::engine::event::EngineEvent::BgChildActivity`]
+/// events as [`crate::engine::event::EngineEvent::ChildAgentActivity`]
 /// up to the parent's sink via the bg-task's status emitter.
 ///
 /// **#1201 B**: pre-this-decorator the parent's TUI had zero live
@@ -150,13 +150,13 @@ impl EngineSink for BufferingSink {
 /// only surfaced at result-injection time, so a 30-second tool call
 /// inside a bg agent looked identical to a 30-second hang.
 ///
-/// `ForwardingBgSink` is the live tap. For each event interesting
+/// `ForwardingChildSink` is the live tap. For each event interesting
 /// enough to surface in the parent's feed, it builds a
-/// [`crate::engine::event::BgChildActivityKind`] and pushes it onto
+/// [`crate::engine::event::ChildAgentActivityKind`] and pushes it onto
 /// the registry's status-event queue via
 /// [`crate::bg_agent::BgStatusEmitter::send_activity`]. The
 /// inference loop's existing drain in `inference.rs` forwards the
-/// resulting `BgChildActivity` event to whatever sink is active
+/// resulting `ChildAgentActivity` event to whatever sink is active
 /// (TUI / headless / ACP) without further plumbing.
 ///
 /// **The narrative trace is preserved.** Every event that hits this
@@ -164,7 +164,7 @@ impl EngineSink for BufferingSink {
 /// authoritative post-completion trace (drained at result-injection
 /// time and persisted to the transcript) is unchanged. Live and
 /// post-completion are deliberately two separate channels:
-/// - Live (`BgChildActivity`) is for real-time UX; events are
+/// - Live (`ChildAgentActivity`) is for real-time UX; events are
 ///   ephemeral and may be coalesced or dropped by the renderer.
 /// - Post-completion (the `BufferingSink::take_lines` dump) is the
 ///   load-bearing record — it's what the model sees in the result
@@ -172,17 +172,17 @@ impl EngineSink for BufferingSink {
 ///
 /// ## Sink wrapping order
 ///
-/// `PersistingSink` wraps `ForwardingBgSink` wraps `BufferingSink`.
+/// `PersistingSink` wraps `ForwardingChildSink` wraps `BufferingSink`.
 /// Persistence sees every event first (so the transcript captures
 /// `SubAgentEvent` rows in real time), then forwarding fans out to
 /// the parent's queue, then buffering captures the line for the
 /// post-completion drain.
-pub struct ForwardingBgSink {
+pub struct ForwardingChildSink {
     inner: BufferingSink,
     emitter: crate::bg_agent::BgStatusEmitter,
 }
 
-impl ForwardingBgSink {
+impl ForwardingChildSink {
     /// Wrap a `BufferingSink` and forward live activity through the
     /// emitter. The emitter is cheap to clone (two `Arc`s and a
     /// `watch::Sender`); pass a clone and keep the original for the
@@ -194,14 +194,14 @@ impl ForwardingBgSink {
     /// Drain the inner buffering sink. Same semantics as
     /// [`BufferingSink::take_lines`] — the buffer is empty after
     /// this returns. Only the post-completion narrative is drained
-    /// here; live `BgChildActivity` events have already been
+    /// here; live `ChildAgentActivity` events have already been
     /// forwarded individually as they happened.
     pub fn take_lines(&self) -> Vec<String> {
         self.inner.take_lines()
     }
 }
 
-impl EngineSink for ForwardingBgSink {
+impl EngineSink for ForwardingChildSink {
     fn emit(&self, event: EngineEvent) {
         // Forward the *live* signal first while we still own the
         // event by reference. Dropping a delta on the floor here
@@ -210,11 +210,12 @@ impl EngineSink for ForwardingBgSink {
         // authoritative.
         match &event {
             EngineEvent::ToolCallStart { name, args, .. } => {
-                self.emitter
-                    .send_activity(crate::engine::event::BgChildActivityKind::ToolStart {
+                self.emitter.send_activity(
+                    crate::engine::event::ChildAgentActivityKind::ToolStart {
                         tool_name: name.clone(),
                         summary: summarize_tool_call(name, args),
-                    });
+                    },
+                );
             }
             EngineEvent::ToolCallResult { name, output, .. } => {
                 // Best-effort success classification: tool dispatchers
@@ -223,14 +224,14 @@ impl EngineSink for ForwardingBgSink {
                 // icon hint, not for any control-flow decision.
                 let success = !looks_like_tool_error(output);
                 self.emitter
-                    .send_activity(crate::engine::event::BgChildActivityKind::ToolEnd {
+                    .send_activity(crate::engine::event::ChildAgentActivityKind::ToolEnd {
                         tool_name: name.clone(),
                         success,
                     });
             }
             EngineEvent::Info { message } => {
                 self.emitter
-                    .send_activity(crate::engine::event::BgChildActivityKind::Info {
+                    .send_activity(crate::engine::event::ChildAgentActivityKind::Info {
                         message: message.clone(),
                     });
             }
@@ -680,7 +681,7 @@ mod tests {
         assert_send_sync::<BufferingSink>();
     }
 
-    // ── ForwardingBgSink (#1201 B) ────────────────────
+    // ── ForwardingChildSink (#1201 B) ────────────────────
 
     /// Build a [`crate::bg_agent::BgStatusEmitter`] hooked up to a
     /// real registry so we can drain forwarded events. The registry
@@ -702,9 +703,9 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_bg_sink_emits_tool_start_and_end_to_registry() {
+    fn forwarding_child_sink_emits_tool_start_and_end_to_registry() {
         let (registry, emitter) = make_test_emitter(7);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         sink.emit(EngineEvent::ToolCallStart {
             id: "t1".into(),
@@ -722,29 +723,29 @@ mod tests {
         assert_eq!(
             drained.len(),
             2,
-            "each interesting event should fan out exactly one BgChildActivity"
+            "each interesting event should fan out exactly one ChildAgentActivity"
         );
         assert!(matches!(
             &drained[0],
-            EngineEvent::BgChildActivity {
+            EngineEvent::ChildAgentActivity {
                 task_id: 7,
-                kind: crate::engine::event::BgChildActivityKind::ToolStart { tool_name, summary },
+                kind: crate::engine::event::ChildAgentActivityKind::ToolStart { tool_name, summary },
                 ..
             } if tool_name == "Read" && summary.contains("src/auth.rs")
         ));
         assert!(matches!(
             &drained[1],
-            EngineEvent::BgChildActivity {
-                kind: crate::engine::event::BgChildActivityKind::ToolEnd { tool_name, success: true },
+            EngineEvent::ChildAgentActivity {
+                kind: crate::engine::event::ChildAgentActivityKind::ToolEnd { tool_name, success: true },
                 ..
             } if tool_name == "Read"
         ));
     }
 
     #[test]
-    fn forwarding_bg_sink_classifies_tool_errors() {
+    fn forwarding_child_sink_classifies_tool_errors() {
         let (registry, emitter) = make_test_emitter(1);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         sink.emit(EngineEvent::ToolCallResult {
             id: "t1".into(),
@@ -754,20 +755,20 @@ mod tests {
         let drained = registry.drain_status_events();
         assert!(matches!(
             &drained[0],
-            EngineEvent::BgChildActivity {
-                kind: crate::engine::event::BgChildActivityKind::ToolEnd { success: false, .. },
+            EngineEvent::ChildAgentActivity {
+                kind: crate::engine::event::ChildAgentActivityKind::ToolEnd { success: false, .. },
                 ..
             }
         ));
     }
 
     #[test]
-    fn forwarding_bg_sink_preserves_buffering_for_post_completion_drain() {
+    fn forwarding_child_sink_preserves_buffering_for_post_completion_drain() {
         // The whole point of the decorator is "live AND buffered" —
         // dropping the inner buffer would silently break the
         // model-facing narrative trace. This test pins that.
         let (_registry, emitter) = make_test_emitter(1);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         sink.emit(EngineEvent::ToolCallStart {
             id: "t1".into(),
@@ -786,13 +787,13 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_bg_sink_drops_streaming_text() {
+    fn forwarding_child_sink_drops_streaming_text() {
         // Streaming text is forwarded neither live nor to the buffer:
         // the model's final output already crosses the result oneshot,
         // so capturing it here would duplicate it AND spam the parent
         // feed with per-token noise.
         let (registry, emitter) = make_test_emitter(1);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         sink.emit(EngineEvent::TextDelta {
             text: "hello".into(),
@@ -807,13 +808,13 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_bg_sink_summarizes_known_tool_args() {
+    fn forwarding_child_sink_summarizes_known_tool_args() {
         // Per-tool special cases live inside the sink so every client
         // renders the same summary string. Pin the contracts the TUI
         // depends on — if the summary format changes, the activity
         // feed render needs to update too.
         let (registry, emitter) = make_test_emitter(1);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         // Bash: command
         sink.emit(EngineEvent::ToolCallStart {
@@ -841,8 +842,8 @@ mod tests {
         let summaries: Vec<String> = drained
             .iter()
             .filter_map(|e| match e {
-                EngineEvent::BgChildActivity {
-                    kind: crate::engine::event::BgChildActivityKind::ToolStart { summary, .. },
+                EngineEvent::ChildAgentActivity {
+                    kind: crate::engine::event::ChildAgentActivityKind::ToolStart { summary, .. },
                     ..
                 } => Some(summary.clone()),
                 _ => None,
@@ -859,12 +860,12 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_bg_sink_truncates_long_summaries() {
+    fn forwarding_child_sink_truncates_long_summaries() {
         // Summaries land in tight horizontal real estate (inline
         // under the bg-task spawn cell). A 5KB commit message in the
         // args must not blow up the feed.
         let (registry, emitter) = make_test_emitter(1);
-        let sink = ForwardingBgSink::new(BufferingSink::new(), emitter);
+        let sink = ForwardingChildSink::new(BufferingSink::new(), emitter);
 
         let long_cmd = "x".repeat(500);
         sink.emit(EngineEvent::ToolCallStart {
@@ -876,8 +877,8 @@ mod tests {
 
         let drained = registry.drain_status_events();
         let summary = match &drained[0] {
-            EngineEvent::BgChildActivity {
-                kind: crate::engine::event::BgChildActivityKind::ToolStart { summary, .. },
+            EngineEvent::ChildAgentActivity {
+                kind: crate::engine::event::ChildAgentActivityKind::ToolStart { summary, .. },
                 ..
             } => summary.clone(),
             _ => panic!("expected ToolStart"),
@@ -887,8 +888,8 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_bg_sink_is_send_sync() {
+    fn forwarding_child_sink_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<ForwardingBgSink>();
+        assert_send_sync::<ForwardingChildSink>();
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -180,14 +180,14 @@ async fn run_bg_agent(
     // result-injection time. See `engine::sink::BufferingSink` for
     // the capture rules.
     //
-    // #1201 B: wrap the buffering sink in a `ForwardingBgSink` so
+    // #1201 B: wrap the buffering sink in a `ForwardingChildSink` so
     // every interesting event is *also* forwarded live as a
-    // `BgChildActivity` to the parent's sink (via the registry's
+    // `ChildAgentActivity` to the parent's sink (via the registry's
     // status-event queue, drained by the inference loop). Pre-this
     // wrapper a 30-second tool inside a bg agent looked identical
     // to a 30-second hang — only the post-completion drain showed
     // what happened.
-    let buffering_sink = crate::engine::sink::ForwardingBgSink::new(
+    let buffering_sink = crate::engine::sink::ForwardingChildSink::new(
         crate::engine::sink::BufferingSink::new(),
         emitter.clone(),
     );


### PR DESCRIPTION
## Summary

Pure mechanical rename with one tiny semantic addition (a new `is_background: bool` field). **Zero runtime behavior change. Wire format preserved.**

This is **PR-A0 of #1232 §1** — preparatory cleanup so the actual feature work in PR-A (route foreground sub-agent activity through the same overlay event) ships as a pure semantic change with no naming distractions.

## Why

Today `BgChildActivity` only fires for background sub-agents. PR-A will route foreground sub-agent activity through the same event so the master TUI gets live feedback during fg sub-agent calls (currently invisible — the user-visible *"no communication on sub-agent activity"* complaint from #1232 §1).

Once fg flows through, the `Bg*` prefix becomes a lie. PR-A0 fixes the naming first so PR-A is purely semantic and reviewers don't have to disentangle "what's a rename" from "what's a behavior change" in the same diff.

## Renames

**Engine layer (`koda-core`):**

| Old | New |
|---|---|
| `EngineEvent::BgChildActivity` | `EngineEvent::ChildAgentActivity` |
| `enum BgChildActivityKind` | `enum ChildAgentActivityKind` |
| `struct ForwardingBgSink` | `struct ForwardingChildSink` |

**CLI layer (`koda-cli`):**

| Old | New |
|---|---|
| `bg_activity.rs` | `child_activity.rs` |
| `widgets/bg_activity_overlay.rs` | `widgets/child_activity_overlay.rs` |
| `struct BgActivityTracker` | `struct ChildActivityTracker` |
| `struct BgActivityOverlay` | `struct ChildActivityOverlay` |
| field/var name `bg_activity` | `child_activity` |

## New field: `is_background: bool`

`ChildAgentActivity` gains an `is_background: bool` field. Today every emit site is a bg agent and hardcodes `true`; PR-A wires up the fg path that will pass `false`.

Making the distinction explicit in the **data** (rather than implicit in the type **name**) lets future consumers filter ("show me only blocking work") without resurrecting a type split.

## Wire-format preservation

The variant carries `#[serde(rename = "bg_child_activity")]` so the JSON envelope tag stays `"type":"bg_child_activity"` for ACP / headless clients. Old payloads that lack `is_background` deserialize via a serde-default helper (`default_is_background_true`) that returns `true`, matching historical behavior.

A new back-compat test asserts:
- Serialization preserves the historical `"type":"bg_child_activity"` tag
- `is_background` round-trips cleanly
- Legacy JSON (without `is_background`) deserializes with `is_background == true`

PR-A will revisit the wire tag once fg actually flows through.

## Naming rationale

"**Child**" was chosen over alternatives:
- ❌ `SubAgent*` — overloaded with the dispatch path (`sub_agent_dispatch.rs`, `execute_sub_agent`)
- ❌ `Agent*` — too broad; readers might think master-agent's own activity belongs here
- ✅ `Child*` — matches existing tracing vocabulary (`child_token`, `child_sink`, span names) and precisely captures "agents that are children of the master inference loop"

## What stays named `Bg*`

Genuinely bg-only types keep their prefix:

```
BgAgentRegistry, BgAgentReservation, BgAgentEntry, BgAgentResult,
BgPayload, BgStatusEmitter, BgTaskUpdate, BgTaskSnapshot,
BgRegistry, BgProcessStatus, BgProcessSnapshot, BgEntry
```

These are the bg-task lifecycle (registry, reservation, payload, etc.) — they exist *because* the work runs out-of-band of the inference loop. Renaming would be wrong.

## Verification

- ✅ `cargo build` (workspace): clean
- ✅ `cargo test --workspace --lib`: **2,120 tests, 0 failures**
- ✅ `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- ✅ `cargo fmt --all`: clean
- ✅ Pre-push hook (fmt + clippy): passes

## Diff stats

`19 files changed, 288 insertions(+), 224 deletions(-)`

Mostly mechanical renames + a small block of new test code (back-compat deserialization).

## Out of scope for this PR (lands in PR-A)

- Routing fg sub-agent activity through the new event
- Changing the wire tag from `bg_child_activity` to `child_agent_activity` (deferred until fg actually flows through, so it's one CHANGELOG entry)
- Making `InvokeAgent.background` a required field (also #1232 §2)

Closes part of #1232 §1 (preparatory rename only).
