### PR TITLE
refactor: generalize Bg* registry to ChildAgentRegistry (PR-A0.5 of #1232)

### DIFF
--- a/koda-cli/src/acp_adapter.rs
+++ b/koda-cli/src/acp_adapter.rs
@@ -141,22 +141,22 @@ pub fn engine_event_to_acp(
         // a short `[bg task N] kind` line that ACP-aware IDEs can
         // either show inline or filter on the `[bg task N]` prefix.
         // The full structured payload is still on the wire for any
-        // future typed mapping — see `EngineEvent::BgTaskUpdate`.
-        EngineEvent::BgTaskUpdate {
+        // future typed mapping — see `EngineEvent::ChildTaskUpdate`.
+        EngineEvent::ChildTaskUpdate {
             task_id, status, ..
         } => {
             let summary = match status {
-                koda_core::bg_agent::AgentStatus::Pending => "pending".to_string(),
-                koda_core::bg_agent::AgentStatus::Running { iter } => {
+                koda_core::child_agent::AgentStatus::Pending => "pending".to_string(),
+                koda_core::child_agent::AgentStatus::Running { iter } => {
                     if *iter == 0 {
                         "running (starting)".to_string()
                     } else {
                         format!("running (iter {iter})")
                     }
                 }
-                koda_core::bg_agent::AgentStatus::Cancelled => "cancelled".to_string(),
-                koda_core::bg_agent::AgentStatus::Completed { .. } => "completed".to_string(),
-                koda_core::bg_agent::AgentStatus::Errored { error } => {
+                koda_core::child_agent::AgentStatus::Cancelled => "cancelled".to_string(),
+                koda_core::child_agent::AgentStatus::Completed { .. } => "completed".to_string(),
+                koda_core::child_agent::AgentStatus::Errored { error } => {
                     let snippet: String = error.chars().take(80).collect();
                     format!("errored: {snippet}")
                 }
@@ -177,7 +177,7 @@ pub fn engine_event_to_acp(
         // (#1201 B) Live activity from inside a running bg agent.
         // ACP doesn't have a typed bg-child-activity notification, so
         // we fall through to the same `[bg task N] ...` text-chunk
-        // shape used by `BgTaskUpdate` above. The full structured
+        // shape used by `ChildTaskUpdate` above. The full structured
         // payload (with `kind: tool_start` / `tool_end` / `info`) is
         // still on the wire for any future typed mapping.
         EngineEvent::ChildAgentActivity { task_id, kind, .. } => {
@@ -217,7 +217,7 @@ pub fn engine_event_to_acp(
         // here. IDEs that want richer rendering can scan the
         // tool-result stream for `TodoWrite` outputs (the formatted
         // list lives there); the goal of this notification is parity
-        // with `BgTaskUpdate` ("a transition happened, here's the
+        // with `ChildTaskUpdate` ("a transition happened, here's the
         // gist"), not to be the sole source of render data.
         EngineEvent::TodoUpdate { items, diff } => {
             let cb = acp::ContentBlock::Text(acp::TextContent::new(format!(
@@ -534,14 +534,15 @@ mod tests {
     // #1076: bg-task lifecycle must reach ACP clients as session
     // notifications.  Pre-fix the TUI was the only client that saw
     // bg status because it polled the registry directly; now every
-    // transition flows through `EngineEvent::BgTaskUpdate` and lands
+    // transition flows through `EngineEvent::ChildTaskUpdate` and lands
     // here as a text chunk an ACP-aware IDE can render or filter.
     #[test]
     fn test_bg_task_update_running_iter_zero_renders_starting() {
-        let event = EngineEvent::BgTaskUpdate {
+        let event = EngineEvent::ChildTaskUpdate {
             task_id: 5,
             spawner: None,
-            status: koda_core::bg_agent::AgentStatus::Running { iter: 0 },
+            is_background: true,
+            status: koda_core::child_agent::AgentStatus::Running { iter: 0 },
         };
         let notif = engine_event_to_acp(&event, "s1").expect("must produce notification");
         match notif.update {
@@ -558,10 +559,11 @@ mod tests {
 
     #[test]
     fn test_bg_task_update_renders_iter_count() {
-        let event = EngineEvent::BgTaskUpdate {
+        let event = EngineEvent::ChildTaskUpdate {
             task_id: 12,
             spawner: Some(7),
-            status: koda_core::bg_agent::AgentStatus::Running { iter: 4 },
+            is_background: true,
+            status: koda_core::child_agent::AgentStatus::Running { iter: 4 },
         };
         let notif = engine_event_to_acp(&event, "s1").unwrap();
         let acp::SessionUpdate::AgentMessageChunk(chunk) = notif.update else {
@@ -580,25 +582,26 @@ mod tests {
         // Pending is included because it's the initial reservation
         // state — some clients may want to show "queued".
         let cases = [
-            (koda_core::bg_agent::AgentStatus::Pending, "pending"),
-            (koda_core::bg_agent::AgentStatus::Cancelled, "cancelled"),
+            (koda_core::child_agent::AgentStatus::Pending, "pending"),
+            (koda_core::child_agent::AgentStatus::Cancelled, "cancelled"),
             (
-                koda_core::bg_agent::AgentStatus::Completed {
+                koda_core::child_agent::AgentStatus::Completed {
                     summary: "all good".into(),
                 },
                 "completed",
             ),
             (
-                koda_core::bg_agent::AgentStatus::Errored {
+                koda_core::child_agent::AgentStatus::Errored {
                     error: "boom".into(),
                 },
                 "errored",
             ),
         ];
         for (status, marker) in cases {
-            let event = EngineEvent::BgTaskUpdate {
+            let event = EngineEvent::ChildTaskUpdate {
                 task_id: 1,
                 spawner: None,
+                is_background: true,
                 status,
             };
             let notif = engine_event_to_acp(&event, "s1").unwrap();

--- a/koda-cli/src/child_activity.rs
+++ b/koda-cli/src/child_activity.rs
@@ -2,9 +2,9 @@
 //!
 //! Stateful counterpart to the pure-render
 //! [`crate::widgets::child_activity_overlay`] widget. Absorbs
-//! `ChildAgentActivity` and `BgTaskUpdate` engine events into a
+//! `ChildAgentActivity` and `ChildTaskUpdate` engine events into a
 //! per-task last-activity map, then projects (alongside the engine's
-//! `BgAgentRegistry` + `BgRegistry` snapshots) into a flat list of
+//! `ChildAgentRegistry` + `BgRegistry` snapshots) into a flat list of
 //! [`crate::widgets::child_activity_overlay::ActivityRow`]s the widget
 //! can render.
 //!
@@ -22,7 +22,7 @@
 //! 1. Construct empty (`ChildActivityTracker::default()`) at TUI start.
 //! 2. On every `EngineEvent::ChildAgentActivity`, call
 //!    [`ChildActivityTracker::record_activity`].
-//! 3. On every `EngineEvent::BgTaskUpdate`, call
+//! 3. On every `EngineEvent::ChildTaskUpdate`, call
 //!    [`ChildActivityTracker::record_status`].
 //! 4. Each frame, call [`ChildActivityTracker::build_rows`] with the
 //!    current registry snapshots to get visible rows + total count.
@@ -33,7 +33,7 @@
 //! membership at projection time (see `build_rows`).
 
 use crate::widgets::child_activity_overlay::{ActivityRow, ActivityStatus, MAX_VISIBLE};
-use koda_core::bg_agent::{AgentStatus, BgTaskSnapshot};
+use koda_core::child_agent::{AgentStatus, ChildTaskSnapshot};
 use koda_core::engine::event::ChildAgentActivityKind;
 use koda_core::tools::bg_process::{BgProcessSnapshot, BgProcessStatus};
 use std::collections::HashMap;
@@ -129,7 +129,7 @@ impl ChildActivityTracker {
     /// fan-out → drain cycles.
     pub fn build_rows(
         &mut self,
-        agents: &[BgTaskSnapshot],
+        agents: &[ChildTaskSnapshot],
         processes: &[BgProcessSnapshot],
     ) -> (Vec<ActivityRow>, usize) {
         // ── Prune stale tracker entries (registry has dropped these tasks) ──
@@ -253,8 +253,8 @@ mod tests {
     use super::*;
     use koda_core::engine::event::ChildAgentActivityKind;
 
-    fn agent(task_id: u32, name: &str, age_secs: u64, status: AgentStatus) -> BgTaskSnapshot {
-        BgTaskSnapshot::for_testing(
+    fn agent(task_id: u32, name: &str, age_secs: u64, status: AgentStatus) -> ChildTaskSnapshot {
+        ChildTaskSnapshot::for_testing(
             task_id,
             name.to_string(),
             "x".into(),

--- a/koda-cli/src/headless.rs
+++ b/koda-cli/src/headless.rs
@@ -275,21 +275,23 @@ impl EngineSink for HeadlessSink {
             // running (iter 3)" instead of nothing. The full result
             // payload is still injected at completion via the
             // `drain_completed` path — this is just live progress.
-            EngineEvent::BgTaskUpdate {
+            EngineEvent::ChildTaskUpdate {
                 task_id, status, ..
             } => {
                 let summary = match status {
-                    koda_core::bg_agent::AgentStatus::Pending => "pending".to_string(),
-                    koda_core::bg_agent::AgentStatus::Running { iter } => {
+                    koda_core::child_agent::AgentStatus::Pending => "pending".to_string(),
+                    koda_core::child_agent::AgentStatus::Running { iter } => {
                         if iter == 0 {
                             "running (starting)".to_string()
                         } else {
                             format!("running (iter {iter})")
                         }
                     }
-                    koda_core::bg_agent::AgentStatus::Cancelled => "cancelled".to_string(),
-                    koda_core::bg_agent::AgentStatus::Completed { .. } => "completed".to_string(),
-                    koda_core::bg_agent::AgentStatus::Errored { error } => {
+                    koda_core::child_agent::AgentStatus::Cancelled => "cancelled".to_string(),
+                    koda_core::child_agent::AgentStatus::Completed { .. } => {
+                        "completed".to_string()
+                    }
+                    koda_core::child_agent::AgentStatus::Errored { error } => {
                         let snippet: String = error.chars().take(80).collect();
                         format!("errored: {snippet}")
                     }

--- a/koda-cli/src/tui_bg_tasks.rs
+++ b/koda-cli/src/tui_bg_tasks.rs
@@ -4,7 +4,7 @@
 //! ## Overview
 //!
 //! `/agents` lists every currently-tracked background task — both
-//! background sub-agents from [`koda_core::bg_agent::BgAgentRegistry`]
+//! background sub-agents from [`koda_core::child_agent::ChildAgentRegistry`]
 //! (spawned via `InvokeAgent { background: true }`) and background
 //! shell processes from [`koda_core::tools::bg_process::BgRegistry`]
 //! (spawned via `Bash { background: true }`). They share a single
@@ -68,7 +68,7 @@ use koda_core::tools::bg_task_tools::TaskId;
 /// Render `/cancel <id>`. Routes to the right registry based on the
 /// parsed [`TaskId`]:
 ///
-/// - [`TaskId::Agent`] → [`BgAgentRegistry::cancel`]
+/// - [`TaskId::Agent`] → [`ChildAgentRegistry::cancel`]
 /// - [`TaskId::Process`] → [`BgRegistry::kill`] (sends SIGTERM)
 ///
 /// Both registries' cancel paths are idempotent (PR #1041's
@@ -81,11 +81,11 @@ use koda_core::tools::bg_task_tools::TaskId;
 /// than at the parser layer (see `ReplAction::CancelBackgroundTask`'s
 /// docstring for the rationale).
 ///
-/// [`BgAgentRegistry::cancel`]: koda_core::bg_agent::BgAgentRegistry::cancel
+/// [`ChildAgentRegistry::cancel`]: koda_core::child_agent::ChildAgentRegistry::cancel
 /// [`BgRegistry::kill`]: koda_core::tools::bg_process::BgRegistry::kill
 pub(crate) fn handle_cancel_background_task(
     buffer: &mut ScrollBuffer,
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_agents: &koda_core::child_agent::ChildAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
     child_activity: &mut crate::child_activity::ChildActivityTracker,
     task_id: Option<TaskId>,
@@ -151,11 +151,11 @@ pub(crate) fn handle_cancel_background_task(
 /// alternate Ctrl+C behaviour (e.g. textarea clear at idle).
 pub(crate) fn cancel_all_bg_work(
     buffer: &mut ScrollBuffer,
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_agents: &koda_core::child_agent::ChildAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
     child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) -> (usize, usize) {
-    use koda_core::bg_agent::AgentStatus;
+    use koda_core::child_agent::AgentStatus;
 
     // Collect ids first so we don't hold the registry lock across
     // `.cancel()` (which itself takes the lock). Snapshot is cheap
@@ -218,10 +218,10 @@ pub(crate) fn cancel_all_bg_work(
 /// processes). Used by the idle Ctrl+C path to decide whether to
 /// cancel bg work or fall back to the textarea-clear behaviour.
 pub(crate) fn active_bg_count(
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_agents: &koda_core::child_agent::ChildAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
 ) -> usize {
-    use koda_core::bg_agent::AgentStatus;
+    use koda_core::child_agent::AgentStatus;
     use koda_core::tools::bg_process::BgProcessStatus;
     let active_agents = bg_agents
         .snapshot()
@@ -239,7 +239,7 @@ pub(crate) fn active_bg_count(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use koda_core::bg_agent::{AgentStatus, BgAgentRegistry, BgPayload};
+    use koda_core::child_agent::{AgentStatus, BgPayload, ChildAgentRegistry};
     use koda_core::tools::bg_process::BgRegistry;
     use tokio::sync::{oneshot, watch};
     use tokio_util::sync::CancellationToken;
@@ -259,7 +259,7 @@ mod tests {
             .join("\n")
     }
 
-    /// Build a registered bg-agent entry using only `BgAgentRegistry`'s
+    /// Build a registered bg-agent entry using only `ChildAgentRegistry`'s
     /// **public** API. We can't use the in-crate `register_test*`
     /// helpers because they're `#[cfg(test)]`-gated to `koda-core`
     /// itself — those gates make them invisible to other crates'
@@ -270,7 +270,7 @@ mod tests {
     /// `JoinHandle` we attach is a noop spawn — enough to satisfy
     /// `AbortOnDropHandle` without burning a tokio worker on real work.
     fn register_entry(
-        reg: &BgAgentRegistry,
+        reg: &ChildAgentRegistry,
         agent_name: &str,
         prompt: &str,
     ) -> (
@@ -283,7 +283,7 @@ mod tests {
         // Phase A1 of #996 added a `spawner: Option<u32>` to both
         // reserve() and attach(). The TUI test harness only ever
         // exercises the top-level path, so `None` is the right value.
-        let r = reg.reserve(&parent, None);
+        let r = reg.reserve(&parent, None, true);
         let task_id = r.task_id;
         let tx = r.tx;
         let status_tx = r.status_tx;
@@ -297,6 +297,7 @@ mod tests {
             r.cancel,
             r.status_rx,
             None,
+            true,
             None,
             noop,
         );
@@ -329,7 +330,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_agent_id_reports_success_and_fires_token() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         let (task_id, _tx, _status_tx, observer) = register_entry(&reg, "explore", "x");
 
@@ -359,7 +360,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_process_id_kills_and_reports_success() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         let pid = spawn_sleep_in_registry(&procs);
 
@@ -388,7 +389,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_agent_id_reports_helpful_error() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         handle_cancel_background_task(
             &mut buf,
@@ -409,7 +410,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_process_id_reports_helpful_error() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         handle_cancel_background_task(
             &mut buf,
@@ -432,7 +433,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_none_id_renders_usage_with_both_prefixes() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         handle_cancel_background_task(
             &mut buf,
@@ -457,7 +458,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_all_bg_work_empty_is_silent() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         let (a, p) = cancel_all_bg_work(
             &mut buf,
@@ -473,13 +474,13 @@ mod tests {
     }
 
     /// Multiple running agents are all cancelled in one call and
-    /// each `BgAgentReservation::cancel` token observes the cascade.
+    /// each `ChildAgentReservation::cancel` token observes the cascade.
     /// This is the in-process equivalent of "user hit Ctrl+C and
     /// every bg agent should die".
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_all_bg_work_cancels_every_running_agent() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
 
         let (_id1, _tx1, status1, observer1) = register_entry(&reg, "explore", "prompt 1");
@@ -512,7 +513,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_all_bg_work_handles_agents_and_processes() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
 
         let (_id, _tx, status, observer) = register_entry(&reg, "explore", "hi");
@@ -540,7 +541,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_all_bg_work_skips_completed_entries() {
         let mut buf = ScrollBuffer::new(64);
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
 
         let (_id, tx, status, observer) = register_entry(&reg, "explore", "hi");
@@ -573,7 +574,7 @@ mod tests {
     /// entries (same filter as `cancel_all_bg_work`).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn active_bg_count_excludes_completed() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let procs = BgRegistry::new();
         assert_eq!(active_bg_count(&reg, &procs), 0);
 

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -126,7 +126,7 @@ pub(crate) struct TuiContext {
     pub draw_rx: crate::frame_requester::DrawNotifyRx,
 
     /// Live activity tracker for bg agents + processes (#1210).
-    /// Absorbs `ChildAgentActivity` / `BgTaskUpdate` events into a per-task
+    /// Absorbs `ChildAgentActivity` / `ChildTaskUpdate` events into a per-task
     /// last-seen map; projected each frame into the
     /// `widgets::child_activity_overlay` rendered above the status bar.
     /// See [`crate::child_activity::ChildActivityTracker`].

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -81,7 +81,7 @@ impl TuiContext {
         // #1200: derive a per-turn child token instead of cloning the
         // session-lifetime root. This keeps `session.cancel` stable
         // across turn boundaries so bg agents (which call
-        // `BgAgentRegistry::reserve(&session.cancel, …)`) keep their
+        // `ChildAgentRegistry::reserve(&session.cancel, …)`) keep their
         // cancel-token cascade pointing at a live parent. Cancelling
         // the child fires only the foreground turn; bg agents are
         // explicitly cancelled by the Ctrl+C path further down.
@@ -510,7 +510,7 @@ async fn handle_crossterm_event_inline(
     later_queue: &mut std::collections::VecDeque<String>,
     paste_blocks: &mut Vec<input::PasteBlock>,
     db: &koda_core::db::Database,
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_agents: &koda_core::child_agent::ChildAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
     child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) {
@@ -587,7 +587,7 @@ async fn handle_inference_key_inline(
     history_idx: &mut Option<usize>,
     later_queue: &mut std::collections::VecDeque<String>,
     db: &koda_core::db::Database,
-    bg_agents: &koda_core::bg_agent::BgAgentRegistry,
+    bg_agents: &koda_core::child_agent::ChildAgentRegistry,
     bg_processes: &koda_core::tools::bg_process::BgRegistry,
     child_activity: &mut crate::child_activity::ChildActivityTracker,
 ) {

--- a/koda-cli/src/tui_render.rs
+++ b/koda-cli/src/tui_render.rs
@@ -282,11 +282,11 @@ impl TuiRenderer {
             | EngineEvent::TurnStart { .. }
             | EngineEvent::TurnEnd { .. }
             | EngineEvent::LoopCapReached { .. }
-            | EngineEvent::BgTaskUpdate { .. }
+            | EngineEvent::ChildTaskUpdate { .. }
             | EngineEvent::TodoUpdate { .. }
             | EngineEvent::ChildAgentActivity { .. } => {
                 // Handled by the event loop, not the renderer.
-                // (#1076) BgTaskUpdate is routed to the bg-task panel,
+                // (#1076) ChildTaskUpdate is routed to the bg-task panel,
                 // which still reads from the registry snapshot for its
                 // primary render. Future cleanup may have it consume
                 // the event stream directly and drop the polling.
@@ -294,7 +294,7 @@ impl TuiRenderer {
                 // todo-list panel from the tool-result message stream;
                 // the structured event is for ACP / headless clients
                 // that want diff-driven animation. Same future-cleanup
-                // path as BgTaskUpdate.
+                // path as ChildTaskUpdate.
                 // (#1201 B2) ChildAgentActivity is dropped from TUI
                 // scrollback render. The B1 inline-line render
                 // (`[bg N] 🔧 Read foo.rs` per event) was redundant

--- a/koda-cli/src/widgets/child_activity_overlay.rs
+++ b/koda-cli/src/widgets/child_activity_overlay.rs
@@ -41,7 +41,7 @@
 //!   covers the field-standard surface area without rebuilding the
 //!   `/agents` modal panel that #1210 deletes.
 //! - Does NOT auto-refresh — caller drives a redraw on each
-//!   `ChildAgentActivity` / `BgTaskUpdate` event (already wired via
+//!   `ChildAgentActivity` / `ChildTaskUpdate` event (already wired via
 //!   `frame_requester`).
 
 use ratatui::{
@@ -62,7 +62,7 @@ use ratatui::{
 pub const MAX_VISIBLE: usize = 5;
 
 /// One row of background work to render. Pre-formatted; this widget
-/// does not know about `BgTaskSnapshot` or `BgProcessSnapshot`. The
+/// does not know about `ChildTaskSnapshot` or `BgProcessSnapshot`. The
 /// caller (event handler in `tui_context`) does the formatting and
 /// hands a flat list down.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/koda-core/src/child_agent.rs
+++ b/koda-core/src/child_agent.rs
@@ -7,7 +7,7 @@
 //! ## Lifecycle
 //!
 //! 1. **Spawn**: `InvokeAgent { background: true }` creates a tokio task
-//! 2. **Track**: the task handle + metadata are stored in `BgAgentRegistry`
+//! 2. **Track**: the task handle + metadata are stored in `ChildAgentRegistry`
 //! 3. **Poll**: before each inference call, the loop calls `drain_completed()`
 //! 4. **Inject**: completed results are appended as user messages
 //! 5. **Cleanup**: on registry drop, all pending task handles are aborted —
@@ -125,7 +125,7 @@ pub enum AgentStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 #[must_use = "a snapshot is only useful if you read its fields"]
-pub struct BgTaskSnapshot {
+pub struct ChildTaskSnapshot {
     /// Monotonic id assigned at `reserve()` time. Stable for the
     /// lifetime of the task; reused across snapshots.
     pub task_id: u32,
@@ -140,11 +140,25 @@ pub struct BgTaskSnapshot {
     pub age: Duration,
     /// Latest value from the task's `watch::Receiver<AgentStatus>`.
     pub status: AgentStatus,
+    /// `true` if this entry represents a background sub-agent
+    /// (auto-drains its result on a future iteration), `false` for
+    /// foreground sub-agents (parent awaits inline).
+    ///
+    /// **PR-A0.5 of #1232**: added when the registry was generalized
+    /// from bg-only to host both fg and bg child agents. Today every
+    /// constructor still passes `true`; PR-A wires up the fg path
+    /// that registers entries with `false`.
+    ///
+    /// Consumers that want a bg-only view (e.g. the `/agents`
+    /// overlay's "truly backgrounded" filter) should check this
+    /// field rather than assuming presence in the registry implies
+    /// background.
+    pub is_background: bool,
     /// Sub-agent task that spawned this bg-agent. `None` = top-level
     /// (the user's main conversation).
     ///
     /// **#996 Layer 2 / Model D**: tracked so that when a sub-agent
-    /// exits, [`BgAgentRegistry::cancel_for_spawner`] can fire the
+    /// exits, [`ChildAgentRegistry::cancel_for_spawner`] can fire the
     /// cancel token on every bg-agent it left behind. Mirrors
     /// Claude Code's `agentId` field on `LocalShellTaskState`
     /// (`prevents 10-day fake-logs.sh zombies`).
@@ -155,13 +169,13 @@ pub struct BgTaskSnapshot {
     pub spawner: Option<u32>,
 }
 
-impl BgTaskSnapshot {
+impl ChildTaskSnapshot {
     /// Test-only constructor for downstream crates (e.g. `koda-cli`
     /// renderer tests). The `#[non_exhaustive]` attribute on the
     /// struct forbids brace-init from outside this crate; this
     /// helper preserves that invariant for production code while
     /// still letting renderer-layer tests build fixtures without
-    /// spinning up a full `BgAgentRegistry` + `tokio::spawn`.
+    /// spinning up a full `ChildAgentRegistry` + `tokio::spawn`.
     ///
     /// Hidden from rustdoc (`#[doc(hidden)]`) so it doesn't pollute
     /// the public surface; intentional opt-out of API stability.
@@ -180,6 +194,37 @@ impl BgTaskSnapshot {
             prompt,
             age,
             status,
+            // PR-A0.5 of #1232: legacy test fixtures predate the fg/bg
+            // split, so default to `true` to match historical behavior
+            // (every test agent today is a bg agent). Tests that need
+            // to assert fg behavior should use `for_testing_fg`.
+            is_background: true,
+            spawner,
+        }
+    }
+
+    /// Test-only constructor for foreground child-agent fixtures.
+    /// Same shape as [`Self::for_testing`] but with `is_background`
+    /// flipped to `false`. Added in PR-A0.5 of #1232 so PR-A's
+    /// fg-routing tests can assert overlay behavior under the new
+    /// `is_background == false` path without resurrecting the
+    /// brace-init bypass that `#[non_exhaustive]` forbids.
+    #[doc(hidden)]
+    pub fn for_testing_fg(
+        task_id: u32,
+        agent_name: String,
+        prompt: String,
+        age: std::time::Duration,
+        status: AgentStatus,
+        spawner: Option<u32>,
+    ) -> Self {
+        Self {
+            task_id,
+            agent_name,
+            prompt,
+            age,
+            status,
+            is_background: false,
             spawner,
         }
     }
@@ -244,13 +289,13 @@ pub struct BgAgentResult {
 /// completes (B3 of #1022). Also holds the per-task
 /// [`CancellationToken`] so future per-task cancel commands
 /// (`/cancel <id>` — see #996) have a hook to fire.
-struct BgAgentEntry {
+struct ChildAgentEntry {
     agent_name: String,
     prompt: String,
     rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
     /// Per-task cancel — derived as a `child_token()` of the parent
     /// session's token at spawn time. Firing this token (via
-    /// [`BgAgentRegistry::cancel`] for #996, or via the registry-drop
+    /// [`ChildAgentRegistry::cancel`] for #996, or via the registry-drop
     /// path) causes the in-flight bg agent to observe `is_cancelled()`
     /// on its next loop iteration.
     cancel: CancellationToken,
@@ -260,8 +305,11 @@ struct BgAgentEntry {
     /// When the task was attached. Used to compute `age` in snapshots.
     started_at: Instant,
     /// Sub-agent task that spawned this bg-agent. `None` = top-level.
-    /// **#996 Layer 2 / Model D** — see [`BgTaskSnapshot::spawner`].
+    /// **#996 Layer 2 / Model D** — see [`ChildTaskSnapshot::spawner`].
     spawner: Option<u32>,
+    /// `true` for background agents, `false` for foreground. Surfaced
+    /// via the snapshot's `is_background` field. PR-A0.5 of #1232.
+    is_background: bool,
     /// **#1108 P2a**: parent's `InvokeAgent` tool_call_id. Stored at
     /// reserve time, surfaced via [`BgAgentResult::parent_tool_call_id`]
     /// at drain time. `None` only for legacy `attach()`-based tests.
@@ -279,17 +327,17 @@ struct BgAgentEntry {
 ///
 /// Shared via `Arc` between the inference loop (which drains results)
 /// and the tool dispatch (which spawns agents).
-pub struct BgAgentRegistry {
-    pending: Mutex<HashMap<u32, BgAgentEntry>>,
+pub struct ChildAgentRegistry {
+    pending: Mutex<HashMap<u32, ChildAgentEntry>>,
     next_id: Mutex<u32>,
-    /// Queue of `EngineEvent::BgTaskUpdate` events produced by
-    /// [`BgStatusEmitter::send`]. Drained by the inference loop
+    /// Queue of `EngineEvent::ChildTaskUpdate` events produced by
+    /// [`ChildStatusEmitter::send`]. Drained by the inference loop
     /// alongside [`Self::drain_completed`] and forwarded to the
     /// active `EngineSink`.
     ///
     /// **#1076**: closes the engine/UI boundary leak — prior to this
     /// queue, bg-task status only reached the TUI by the TUI grabbing
-    /// `Arc<BgAgentRegistry>` directly out of `KodaSession` and
+    /// `Arc<ChildAgentRegistry>` directly out of `KodaSession` and
     /// polling `snapshot()`. ACP / headless clients saw nothing.
     /// Routing through `EngineEvent` puts every client surface on
     /// the same channel.
@@ -314,15 +362,16 @@ pub struct BgAgentRegistry {
 /// Both clones share the same `watch::Sender` and `Arc<registry>`,
 /// so every `.send()` reaches both fan-out targets.
 #[derive(Clone)]
-pub struct BgStatusEmitter {
+pub struct ChildStatusEmitter {
     task_id: u32,
     spawner: Option<u32>,
+    is_background: bool,
     status_tx: watch::Sender<AgentStatus>,
-    registry: Arc<BgAgentRegistry>,
+    registry: Arc<ChildAgentRegistry>,
 }
 
-impl BgStatusEmitter {
-    /// Construct from the parts handed back by [`BgAgentRegistry::reserve`].
+impl ChildStatusEmitter {
+    /// Construct from the parts handed back by [`ChildAgentRegistry::reserve`].
     ///
     /// The registry `Arc` is held for the lifetime of the bg agent,
     /// which is fine: the inference loop already keeps an `Arc` on
@@ -332,12 +381,14 @@ impl BgStatusEmitter {
     pub fn new(
         task_id: u32,
         spawner: Option<u32>,
+        is_background: bool,
         status_tx: watch::Sender<AgentStatus>,
-        registry: Arc<BgAgentRegistry>,
+        registry: Arc<ChildAgentRegistry>,
     ) -> Self {
         Self {
             task_id,
             spawner,
+            is_background,
             status_tx,
             registry,
         }
@@ -350,21 +401,23 @@ impl BgStatusEmitter {
     ///    see the new state on the next read — no behavior change).
     /// 2. The registry's event queue, drained by the inference loop
     ///    and forwarded to the active `EngineSink` (so the TUI / ACP
-    ///    / headless clients all see the same `BgTaskUpdate` event).
+    ///    / headless clients all see the same `ChildTaskUpdate` event).
     ///
     /// `watch::Sender::send` only fails if every receiver was dropped,
     /// which means the registry entry is gone — in that case the queue
     /// push is harmless (it'll be drained and ignored by clients that
     /// don't recognize the task id). We deliberately don't gate the
     /// queue push on the watch send result so a racing reap doesn't
-    /// swallow the terminal `BgTaskUpdate`.
+    /// swallow the terminal `ChildTaskUpdate`.
     pub fn send(&self, status: AgentStatus) {
         let _ = self.status_tx.send(status.clone());
-        self.registry.push_status_event(EngineEvent::BgTaskUpdate {
-            task_id: self.task_id,
-            spawner: self.spawner,
-            status,
-        });
+        self.registry
+            .push_status_event(EngineEvent::ChildTaskUpdate {
+                task_id: self.task_id,
+                spawner: self.spawner,
+                is_background: self.is_background,
+                status,
+            });
     }
 
     /// Forward a live activity event from inside the bg agent up to
@@ -374,7 +427,7 @@ impl BgStatusEmitter {
     /// which decorates the bg agent's `BufferingSink` and calls this
     /// method whenever an interesting child event happens (tool
     /// start/end, info line). The event lands on the same registry
-    /// queue as `BgTaskUpdate`, so the inference loop's existing
+    /// queue as `ChildTaskUpdate`, so the inference loop's existing
     /// drain in [`crate::inference`] forwards it to whatever sink
     /// is active (TUI / headless / ACP) without further plumbing.
     ///
@@ -410,7 +463,7 @@ impl BgStatusEmitter {
     }
 }
 
-/// Reservation slot returned by [`BgAgentRegistry::reserve`].
+/// Reservation slot returned by [`ChildAgentRegistry::reserve`].
 ///
 /// The two-phase pattern (`reserve` → spawn → `attach`) lets the
 /// dispatcher hand the oneshot sender into the spawned future
@@ -419,7 +472,7 @@ impl BgStatusEmitter {
 /// `child_token()` of the parent's cancel — fires either when the
 /// parent fires (cascade) or when this slot is individually cancelled
 /// (future per-task `/cancel <id>` UX, #996).
-pub struct BgAgentReservation {
+pub struct ChildAgentReservation {
     /// Monotonically-assigned task ID. Surfaces in user-facing
     /// messages (`Background agent 'foo' started (agent:7)`) and
     /// keys the per-task `/cancel <id>` UX (#996).
@@ -427,7 +480,7 @@ pub struct BgAgentReservation {
     /// Sender half of the result oneshot. Move into the spawned
     /// future so it can deliver `Ok(output)` / `Err(message)`.
     pub tx: oneshot::Sender<Result<BgPayload, BgPayload>>,
-    /// Receiver half. Move back into the registry via [`BgAgentRegistry::attach`]
+    /// Receiver half. Move back into the registry via [`ChildAgentRegistry::attach`]
     /// so `drain_completed()` can poll it.
     pub rx: oneshot::Receiver<Result<BgPayload, BgPayload>>,
     /// Per-task cancel token. Cloned for the spawned future
@@ -439,17 +492,28 @@ pub struct BgAgentReservation {
     /// the sole writer; it transitions through
     /// [`AgentStatus::Pending`] → `Running` → terminal.
     pub status_tx: watch::Sender<AgentStatus>,
-    /// Status receiver — hand back to the registry via [`BgAgentRegistry::attach`]
+    /// Status receiver — hand back to the registry via [`ChildAgentRegistry::attach`]
     /// so `snapshot()` and `/agents` can read the current state without
     /// touching the spawn site.
     pub status_rx: watch::Receiver<AgentStatus>,
     /// Sub-agent task id of the spawner, or `None` for the top-level
-    /// loop. Carried verbatim to [`BgAgentRegistry::attach`] so the
+    /// loop. Carried verbatim to [`ChildAgentRegistry::attach`] so the
     /// entry knows who spawned it (Model D cleanup-on-exit).
     pub spawner: Option<u32>,
+    /// `true` if this reservation is for a background sub-agent
+    /// (auto-drains its result on a future iteration), `false` for
+    /// foreground sub-agents (parent awaits inline).
+    ///
+    /// **PR-A0.5 of #1232**: added when the registry was generalized
+    /// from bg-only to host both fg and bg child agents. The flag is
+    /// carried into [`ChildAgentRegistry::attach`] so the registry
+    /// entry's snapshots and the [`EngineEvent::ChildTaskUpdate`]
+    /// events emitted by [`ChildStatusEmitter::send`] both reflect
+    /// the same source-of-truth value.
+    pub is_background: bool,
 }
 
-impl BgAgentRegistry {
+impl ChildAgentRegistry {
     /// Create an empty registry.
     pub fn new() -> Self {
         Self {
@@ -460,7 +524,7 @@ impl BgAgentRegistry {
     }
 
     /// Push an event onto the status queue. Called by
-    /// [`BgStatusEmitter::send`]; not part of the public API.
+    /// [`ChildStatusEmitter::send`]; not part of the public API.
     pub(crate) fn push_status_event(&self, event: EngineEvent) {
         self.events.lock().push_back(event);
     }
@@ -497,13 +561,14 @@ impl BgAgentRegistry {
         &self,
         parent_cancel: &CancellationToken,
         spawner: Option<u32>,
-    ) -> BgAgentReservation {
+        is_background: bool,
+    ) -> ChildAgentReservation {
         let (tx, rx) = oneshot::channel();
         let (status_tx, status_rx) = watch::channel(AgentStatus::Pending);
         let mut id = self.next_id.lock();
         let task_id = *id;
         *id += 1;
-        BgAgentReservation {
+        ChildAgentReservation {
             task_id,
             tx,
             rx,
@@ -511,6 +576,7 @@ impl BgAgentRegistry {
             status_tx,
             status_rx,
             spawner,
+            is_background,
         }
     }
 
@@ -541,12 +607,13 @@ impl BgAgentRegistry {
         cancel: CancellationToken,
         status_rx: watch::Receiver<AgentStatus>,
         spawner: Option<u32>,
+        is_background: bool,
         parent_tool_call_id: Option<String>,
         handle: tokio::task::JoinHandle<()>,
     ) {
         self.pending.lock().insert(
             reservation_id,
-            BgAgentEntry {
+            ChildAgentEntry {
                 agent_name: agent_name.to_string(),
                 prompt: prompt.to_string(),
                 rx,
@@ -554,6 +621,7 @@ impl BgAgentRegistry {
                 status_rx,
                 started_at: Instant::now(),
                 spawner,
+                is_background,
                 parent_tool_call_id,
                 _handle: AbortOnDropHandle::new(handle),
             },
@@ -606,7 +674,7 @@ impl BgAgentRegistry {
         let noop = tokio::spawn(async {});
         self.pending.lock().insert(
             task_id,
-            BgAgentEntry {
+            ChildAgentEntry {
                 agent_name: agent_name.to_string(),
                 prompt: prompt.to_string(),
                 rx,
@@ -614,6 +682,9 @@ impl BgAgentRegistry {
                 status_rx,
                 started_at: Instant::now(),
                 spawner,
+                // Test-only entries default to bg-true (legacy behavior).
+                // PR-A0.5 of #1232.
+                is_background: true,
                 parent_tool_call_id: None,
                 _handle: AbortOnDropHandle::new(noop),
             },
@@ -719,17 +790,18 @@ impl BgAgentRegistry {
     /// **Unscoped**: returns every task regardless of spawner. Used by
     /// the TUI `/agents` command (humans want the global view) and as
     /// the engine of [`Self::snapshot_for_caller`] (which filters).
-    pub fn snapshot(&self) -> Vec<BgTaskSnapshot> {
+    pub fn snapshot(&self) -> Vec<ChildTaskSnapshot> {
         let guard = self.pending.lock();
         let now = Instant::now();
         let mut out: Vec<_> = guard
             .iter()
-            .map(|(id, entry)| BgTaskSnapshot {
+            .map(|(id, entry)| ChildTaskSnapshot {
                 task_id: *id,
                 agent_name: entry.agent_name.clone(),
                 prompt: entry.prompt.clone(),
                 age: now.saturating_duration_since(entry.started_at),
                 status: entry.status_rx.borrow().clone(),
+                is_background: entry.is_background,
                 spawner: entry.spawner,
             })
             .collect();
@@ -747,7 +819,7 @@ impl BgAgentRegistry {
     /// Strict equality — a sub-agent does NOT see sibling sub-agents'
     /// tasks, and the top-level does NOT see sub-agents' tasks via the
     /// LLM (the TUI's `/agents` command remains the global view).
-    pub fn snapshot_for_caller(&self, caller_spawner: Option<u32>) -> Vec<BgTaskSnapshot> {
+    pub fn snapshot_for_caller(&self, caller_spawner: Option<u32>) -> Vec<ChildTaskSnapshot> {
         self.snapshot()
             .into_iter()
             .filter(|s| s.spawner == caller_spawner)
@@ -817,7 +889,7 @@ impl BgAgentRegistry {
     }
 }
 
-/// Outcome of [`BgAgentRegistry::cancel_as_caller`].
+/// Outcome of [`ChildAgentRegistry::cancel_as_caller`].
 ///
 /// Mirrors HTTP-ish status codes so the LLM-tool layer can produce
 /// useful error messages without inspecting registry internals.
@@ -842,7 +914,7 @@ pub enum CancelOutcome {
     Forbidden,
 }
 
-/// Outcome of [`BgAgentRegistry::wait_for_completion`].
+/// Outcome of [`ChildAgentRegistry::wait_for_completion`].
 ///
 /// Encodes the four resolutions of a `WaitTask` call. The LLM-tool
 /// layer translates each into a serialised payload the model receives.
@@ -867,7 +939,7 @@ pub enum WaitOutcome {
     /// task is still in `pending` and may still complete on its own.
     /// Carries the most-recent status snapshot so the model can
     /// decide whether to wait again or move on.
-    TimedOut(BgTaskSnapshot),
+    TimedOut(ChildTaskSnapshot),
     /// No task with that id, or caller's spawner doesn't match.
     /// Same `Forbidden`/`NotFound` distinction as [`CancelOutcome`].
     NotFound,
@@ -875,7 +947,7 @@ pub enum WaitOutcome {
     Forbidden,
 }
 
-impl BgAgentRegistry {
+impl ChildAgentRegistry {
     /// Block until a single task reaches a terminal state, or until
     /// `timeout` elapses. The tool layer is the sole caller; humans
     /// use `/cancel` (synchronous) and the auto-drain path.
@@ -1011,7 +1083,7 @@ impl BgAgentRegistry {
 /// Returns when the current value is already terminal OR after a
 /// `changed()` event lands a terminal value. Yields control on
 /// every iteration so the timeout future in
-/// [`BgAgentRegistry::wait_for_completion`] gets a chance to fire.
+/// [`ChildAgentRegistry::wait_for_completion`] gets a chance to fire.
 async fn wait_for_terminal_status(mut rx: watch::Receiver<AgentStatus>) {
     loop {
         let is_terminal = matches!(
@@ -1031,13 +1103,13 @@ async fn wait_for_terminal_status(mut rx: watch::Receiver<AgentStatus>) {
     }
 }
 
-impl Default for BgAgentRegistry {
+impl Default for ChildAgentRegistry {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Drop for BgAgentRegistry {
+impl Drop for ChildAgentRegistry {
     /// Abort every still-pending bg task on registry drop.
     ///
     /// `AbortOnDropHandle::drop` does the work — this impl exists
@@ -1055,7 +1127,7 @@ impl Drop for BgAgentRegistry {
         if !map.is_empty() {
             tracing::debug!(
                 count = map.len(),
-                "BgAgentRegistry dropped with pending tasks; aborting"
+                "ChildAgentRegistry dropped with pending tasks; aborting"
             );
         }
         // Map drops here → each entry's `AbortOnDropHandle` aborts
@@ -1064,8 +1136,8 @@ impl Drop for BgAgentRegistry {
 }
 
 /// Wrap in Arc for sharing between inference loop and tool dispatch.
-pub fn new_shared() -> Arc<BgAgentRegistry> {
-    Arc::new(BgAgentRegistry::new())
+pub fn new_shared() -> Arc<ChildAgentRegistry> {
+    Arc::new(ChildAgentRegistry::new())
 }
 
 #[cfg(test)]
@@ -1076,7 +1148,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn register_and_complete() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (task_id, tx) = reg.register_test("explore", "find all tests");
         assert_eq!(task_id, 1);
         assert_eq!(reg.pending_count(), 1);
@@ -1097,7 +1169,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_only_completed() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id1, tx1) = reg.register_test("task", "build");
         let (_id2, _tx2) = reg.register_test("explore", "search");
 
@@ -1111,7 +1183,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn dropped_sender_reports_cancelled() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("task", "build");
         drop(tx); // simulate task panic/cancel
 
@@ -1123,7 +1195,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn error_result() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("verify", "check");
         tx.send(Err(("test failures".to_string(), Vec::new())))
             .unwrap();
@@ -1143,7 +1215,7 @@ mod tests {
     /// so this test pins the round-trip end-to-end.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn events_propagate_through_drain_for_success() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("explore", "map repo");
         let trace = vec![
             "  \u{1f527} Read".to_string(),
@@ -1169,7 +1241,7 @@ mod tests {
     /// debuggable one.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn events_propagate_through_drain_for_failure() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("build", "compile");
         let trace = vec![
             "  \u{1f527} Bash".to_string(),
@@ -1189,7 +1261,7 @@ mod tests {
     /// that's an explicitly-empty Vec rather than uninitialized.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancelled_task_has_empty_event_trace() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("flaky", "x");
         drop(tx); // simulate panic / abort
         let results = reg.drain_completed();
@@ -1209,9 +1281,9 @@ mod tests {
     /// were dropped. That's the leak we're fixing.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn registry_drop_aborts_pending_tasks() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let parent = CancellationToken::new();
-        let reservation = reg.reserve(&parent, None);
+        let reservation = reg.reserve(&parent, None, true);
         let task_id = reservation.task_id;
         let cancel_for_task = reservation.cancel.clone();
         let tx = reservation.tx;
@@ -1245,6 +1317,7 @@ mod tests {
             cancel_for_entry,
             status_rx,
             None,
+            true,
             None,
             handle,
         );
@@ -1270,10 +1343,10 @@ mod tests {
     /// `reserve`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancel_cascades_to_reserved_child() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let parent = CancellationToken::new();
-        let r1 = reg.reserve(&parent, None);
-        let r2 = reg.reserve(&parent, None);
+        let r1 = reg.reserve(&parent, None, true);
+        let r2 = reg.reserve(&parent, None, true);
 
         assert!(!r1.cancel.is_cancelled());
         assert!(!r2.cancel.is_cancelled());
@@ -1300,7 +1373,7 @@ mod tests {
     /// true *and* the underlying token actually fires.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_known_task_fires_token() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (task_id, _tx, _status_tx, observer) =
             reg.register_test_with_status("explore", "map repo", None);
 
@@ -1318,7 +1391,7 @@ mod tests {
     /// surface this to the user as "no such task".
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_unknown_task_returns_false() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         assert!(
             !reg.cancel(999),
             "cancel of an unknown id should be a no-op returning false"
@@ -1331,7 +1404,7 @@ mod tests {
     /// in `pending`; a third call after drain returns false.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_is_idempotent_while_pending() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (task_id, _tx, _status_tx, _observer) =
             reg.register_test_with_status("explore", "x", None);
 
@@ -1347,7 +1420,7 @@ mod tests {
     /// because no spawned future has flipped it yet.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_lists_pending_tasks_in_id_order() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id_a, _tx_a) = reg.register_test("explore", "map");
         let (id_b, _tx_b) = reg.register_test("verify", "check");
 
@@ -1371,7 +1444,7 @@ mod tests {
     /// and live `/agents -v` (Layer 1) reflect transitions immediately.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_reflects_status_writes() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (task_id, _tx, status_tx, _cancel) =
             reg.register_test_with_status("explore", "map", None);
 
@@ -1406,7 +1479,7 @@ mod tests {
     /// prevents underflow if the system clock jumps backwards).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_age_is_monotonic() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, _tx) = reg.register_test("explore", "x");
 
         let age1 = reg.snapshot()[0].age;
@@ -1423,7 +1496,7 @@ mod tests {
     /// background agents."
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_empty_registry_is_empty_vec() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         assert!(reg.snapshot().is_empty());
     }
 
@@ -1434,7 +1507,7 @@ mod tests {
     /// 30 s" UX is implemented at the *display* layer, not here.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_drops_drained_tasks() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_id, tx) = reg.register_test("explore", "x");
         assert_eq!(reg.snapshot().len(), 1);
 
@@ -1454,7 +1527,7 @@ mod tests {
     /// visibility is exactly zero — the Model E isolation guarantee.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_for_caller_filters_by_spawner() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (top_id, _tx, _, _) = reg.register_test_with_status("a", "top", None);
         let (sub_a_id, _tx, _, _) = reg.register_test_with_status("b", "sub-a", Some(7));
         let (_sub_b_id, _tx, _, _) = reg.register_test_with_status("c", "sub-b", Some(9));
@@ -1474,7 +1547,7 @@ mod tests {
     /// `cancel_as_caller` enforces the Model E permission rule.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_as_caller_returns_forbidden_for_other_spawner() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id, _tx, _, observer) = reg.register_test_with_status("x", "y", Some(7));
 
         // Wrong caller — not the top-level (None != Some(7)) and not a peer.
@@ -1500,7 +1573,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_as_caller_returns_not_found_for_unknown_id() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         assert_eq!(reg.cancel_as_caller(999, None), CancelOutcome::NotFound);
     }
 
@@ -1508,7 +1581,7 @@ mod tests {
     /// and leaves siblings + top-level alone. The cleanup-on-exit hook.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancel_for_spawner_kills_only_matching_children() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (_top, _, _, top_obs) = reg.register_test_with_status("top", "t", None);
         let (_a1, _, _, a1_obs) = reg.register_test_with_status("a1", "x", Some(7));
         let (_a2, _, _, a2_obs) = reg.register_test_with_status("a2", "y", Some(7));
@@ -1533,7 +1606,7 @@ mod tests {
     /// (so a subsequent `drain_completed` can't double-inject).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_consumes_completed_task() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id, tx, status_tx, _) = reg.register_test_with_status("explore", "map", Some(3));
 
         // Fire the result, then transition status to terminal so the
@@ -1568,7 +1641,7 @@ mod tests {
     /// entry in the registry so a later drain still works.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_timeout_preserves_entry() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id, _tx, status_tx, _) = reg.register_test_with_status("slow", "x", None);
 
         // Move to Running so the snapshot test below can verify the
@@ -1593,7 +1666,7 @@ mod tests {
     /// as `cancel_as_caller`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_forbidden_for_other_spawner() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id, _tx, _, _) = reg.register_test_with_status("x", "y", Some(5));
 
         let outcome = reg
@@ -1617,7 +1690,7 @@ mod tests {
     /// up surfaces as `Cancelled` (oneshot closed without sending).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_cancelled_when_sender_dropped() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let (id, tx, status_tx, _) = reg.register_test_with_status("x", "y", None);
 
         // Drop the sender (simulates task panic / abort), then push
@@ -1634,7 +1707,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_returns_not_found_for_unknown_id() {
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let outcome = reg
             .wait_for_completion(999, None, Duration::from_millis(10))
             .await;
@@ -1659,7 +1732,7 @@ mod tests {
     /// sends reliably triggers the old race.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn wait_for_completion_handles_status_then_yield_then_payload() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let (id, tx, status_tx, _observer) =
             reg.register_test_with_status("explore", "map repo", None);
 
@@ -1693,33 +1766,34 @@ mod tests {
         }
     }
 
-    // ── #1076: BgStatusEmitter → sink fan-out ───────────────────────────────
+    // ── #1076: ChildStatusEmitter → sink fan-out ───────────────────────────────
 
     /// Helper: build an emitter wired to the given registry, mirroring
     /// the production construction in `sub_agent_dispatch::execute_sub_agent`.
     fn emitter_for(
-        reg: &Arc<BgAgentRegistry>,
+        reg: &Arc<ChildAgentRegistry>,
         task_id: u32,
         spawner: Option<u32>,
-    ) -> BgStatusEmitter {
+    ) -> ChildStatusEmitter {
         let (tx, _rx) = watch::channel(AgentStatus::Pending);
-        BgStatusEmitter::new(task_id, spawner, tx, reg.clone())
+        ChildStatusEmitter::new(task_id, spawner, true, tx, reg.clone())
     }
 
-    fn extract(event: &EngineEvent) -> (u32, Option<u32>, &AgentStatus) {
+    fn extract(event: &EngineEvent) -> (u32, Option<u32>, bool, &AgentStatus) {
         match event {
-            EngineEvent::BgTaskUpdate {
+            EngineEvent::ChildTaskUpdate {
                 task_id,
                 spawner,
+                is_background,
                 status,
-            } => (*task_id, *spawner, status),
-            other => panic!("expected BgTaskUpdate, got {other:?}"),
+            } => (*task_id, *spawner, *is_background, status),
+            other => panic!("expected ChildTaskUpdate, got {other:?}"),
         }
     }
 
     #[test]
     fn emitter_send_queues_engine_event_on_registry() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let emitter = emitter_for(&reg, 7, Some(42));
 
         // Initial: queue is empty.
@@ -1731,7 +1805,7 @@ mod tests {
         emitter.send(AgentStatus::Running { iter: 0 });
         let drained = reg.drain_status_events();
         assert_eq!(drained.len(), 1, "single send must produce one event");
-        let (id, spawner, status) = extract(&drained[0]);
+        let (id, spawner, _is_bg, status) = extract(&drained[0]);
         assert_eq!(id, 7);
         assert_eq!(spawner, Some(42));
         assert!(matches!(status, AgentStatus::Running { iter: 0 }));
@@ -1739,7 +1813,7 @@ mod tests {
 
     #[test]
     fn emitter_drain_is_fifo_and_clears_queue() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let emitter = emitter_for(&reg, 1, None);
 
         emitter.send(AgentStatus::Running { iter: 0 });
@@ -1758,7 +1832,7 @@ mod tests {
         let iters: Vec<_> = drained
             .iter()
             .filter_map(|e| match e {
-                EngineEvent::BgTaskUpdate {
+                EngineEvent::ChildTaskUpdate {
                     status: AgentStatus::Running { iter },
                     ..
                 } => Some(*iter),
@@ -1769,7 +1843,7 @@ mod tests {
 
         // Last event is the terminal Completed.
         assert!(matches!(
-            extract(&drained[3]).2,
+            extract(&drained[3]).3,
             AgentStatus::Completed { .. }
         ));
 
@@ -1786,9 +1860,9 @@ mod tests {
         // Sink fan-out (queue) is for the inference-loop → EngineSink
         // path.  Both targets must see every transition or `/agents`
         // and the TUI/ACP/headless clients will disagree on state.
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let (tx, mut rx) = watch::channel(AgentStatus::Pending);
-        let emitter = BgStatusEmitter::new(3, None, tx, reg.clone());
+        let emitter = ChildStatusEmitter::new(3, None, true, tx, reg.clone());
 
         emitter.send(AgentStatus::Running { iter: 5 });
 
@@ -1801,7 +1875,7 @@ mod tests {
         let drained = reg.drain_status_events();
         assert_eq!(drained.len(), 1);
         assert!(matches!(
-            extract(&drained[0]).2,
+            extract(&drained[0]).3,
             AgentStatus::Running { iter: 5 }
         ));
     }
@@ -1814,9 +1888,9 @@ mod tests {
         // the same per-task watch channel — otherwise terminal
         // states could land on a different queue than the heartbeats
         // and clients would see Running forever.
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let (tx, _rx) = watch::channel(AgentStatus::Pending);
-        let a = BgStatusEmitter::new(11, Some(2), tx, reg.clone());
+        let a = ChildStatusEmitter::new(11, Some(2), true, tx, reg.clone());
         let b = a.clone();
 
         a.send(AgentStatus::Running { iter: 1 });
@@ -1833,7 +1907,7 @@ mod tests {
 
     #[test]
     fn agent_status_round_trips_through_serde() {
-        // `EngineEvent::BgTaskUpdate` is the wire format for ACP /
+        // `EngineEvent::ChildTaskUpdate` is the wire format for ACP /
         // headless / future transports.  All `AgentStatus` variants
         // must survive a serde round-trip or the boundary leak fix
         // creates a new boundary leak (engine emits, transport drops
@@ -1850,21 +1924,24 @@ mod tests {
                 error: "boom".into(),
             },
         ] {
-            let event = EngineEvent::BgTaskUpdate {
+            let event = EngineEvent::ChildTaskUpdate {
                 task_id: 1,
                 spawner: Some(2),
+                is_background: true,
                 status: status.clone(),
             };
             let json = serde_json::to_string(&event).expect("serialize");
             let back: EngineEvent = serde_json::from_str(&json).expect("deserialize");
             match back {
-                EngineEvent::BgTaskUpdate {
+                EngineEvent::ChildTaskUpdate {
                     task_id,
                     spawner,
+                    is_background,
                     status: round_tripped,
                 } => {
                     assert_eq!(task_id, 1);
                     assert_eq!(spawner, Some(2));
+                    assert!(is_background, "is_background must round-trip true");
                     assert_eq!(round_tripped, status, "json round-trip lost data: {json}");
                 }
                 other => panic!("round-trip changed variant: {other:?}"),
@@ -1878,13 +1955,13 @@ mod tests {
         // iteration; the no-bg-task case must be cheap and yield
         // an empty Vec without any allocations forced by mistakes
         // in the queue type (e.g. `Some(VecDeque::new())`).
-        let reg = BgAgentRegistry::new();
+        let reg = ChildAgentRegistry::new();
         let drained = reg.drain_status_events();
         assert!(drained.is_empty());
     }
 
-    /// #1201 B: `BgStatusEmitter::send_activity` must push events
-    /// onto the *same* registry queue that `BgStatusEmitter::send`
+    /// #1201 B: `ChildStatusEmitter::send_activity` must push events
+    /// onto the *same* registry queue that `ChildStatusEmitter::send`
     /// uses, with the emitter's `task_id` and `spawner` baked in.
     /// This pins the wire-up so the inference loop's existing drain
     /// in `inference.rs` picks up activity events without any extra
@@ -1893,7 +1970,7 @@ mod tests {
     async fn send_activity_queues_bg_child_activity_with_task_id() {
         let registry = new_shared();
         let (status_tx, _status_rx) = tokio::sync::watch::channel(AgentStatus::Pending);
-        let emitter = BgStatusEmitter::new(42, Some(7), status_tx, registry.clone());
+        let emitter = ChildStatusEmitter::new(42, Some(7), true, status_tx, registry.clone());
 
         emitter.send_activity(crate::engine::event::ChildAgentActivityKind::ToolStart {
             tool_name: "Read".into(),

--- a/koda-core/src/db/mod.rs
+++ b/koda-core/src/db/mod.rs
@@ -263,7 +263,7 @@ impl Database {
         .await?;
 
         // Session events (#1108 P1b/P2a): non-message engine events that
-        // matter for debugging — `EngineEvent::Info`, `BgTaskUpdate`, and
+        // matter for debugging — `EngineEvent::Info`, `ChildTaskUpdate`, and
         // sub-agent inner-trace lines. Pre-#1108 these were sink-only and
         // never reached the transcript export, leaving the reader unable
         // to tell what a bg sub-agent was doing during its wait window.

--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -129,38 +129,52 @@ pub enum EngineEvent {
         diff: crate::tools::todo::TodoDiff,
     },
 
-    // ── Background sub-agent lifecycle ────────────────────────────────
-    /// A background sub-agent's status changed.
+    // ── Child sub-agent lifecycle ──────────────────────────────────
+    /// A child sub-agent's status changed.
     ///
-    /// Emitted on every transition through [`crate::bg_agent::AgentStatus`]
+    /// Emitted on every transition through [`crate::child_agent::AgentStatus`]
     /// (`Pending` → `Running { iter }` → terminal). Drained from the
     /// registry's status queue inside the inference loop alongside
-    /// [`crate::bg_agent::BgAgentRegistry::drain_completed`], so any sink
+    /// [`crate::child_agent::ChildAgentRegistry::drain_completed`], so any sink
     /// (CLI / TUI / headless / ACP) sees the same event stream without
     /// having to poll the registry directly.
     ///
     /// Closes the engine/UI boundary leak documented in #1076 — prior to
-    /// this variant the TUI was the only client that could see live bg
+    /// this variant the TUI was the only client that could see live
     /// status because it shared the process and grabbed
-    /// `Arc<BgAgentRegistry>` straight out of `KodaSession`.
-    BgTaskUpdate {
+    /// `Arc<ChildAgentRegistry>` straight out of `KodaSession`.
+    ///
+    /// **PR-A0.5 of #1232**: renamed from `BgTaskUpdate`. The wire tag
+    /// (`"type":"bg_task_update"`) is preserved via `#[serde(rename)]`
+    /// so ACP / headless clients keep parsing the same envelope. The
+    /// new `is_background` field defaults to `true` on legacy payloads
+    /// for the same reason.
+    #[serde(rename = "bg_task_update")]
+    ChildTaskUpdate {
         /// Monotonic id assigned at `reserve()` time, stable for the
         /// lifetime of the task.
         task_id: u32,
         /// Sub-agent invocation id of the spawner, or `None` if the
         /// task was launched from the top-level loop. See
-        /// [`crate::bg_agent::BgTaskSnapshot::spawner`].
+        /// [`crate::child_agent::ChildTaskSnapshot::spawner`].
         spawner: Option<u32>,
+        /// `true` if this is a background sub-agent (auto-drains its
+        /// result on a future iteration), `false` for foreground
+        /// sub-agents (parent awaits inline). Wire-default is `true`
+        /// so older clients that never received this field
+        /// deserialize as the historical bg-only behavior.
+        #[serde(default = "default_is_background_true")]
+        is_background: bool,
         /// New status. Includes `Running { iter }` heartbeats so
         /// clients can render iteration progress without polling.
-        status: crate::bg_agent::AgentStatus,
+        status: crate::child_agent::AgentStatus,
     },
 
     /// Live activity from inside a running child agent (foreground or
     /// background sub-agent).
     ///
     /// **#1201 B**: pre-this-event the parent's TUI had no live signal
-    /// from inside a bg agent — only `BgTaskUpdate` heartbeats
+    /// from inside a bg agent — only `ChildTaskUpdate` heartbeats
     /// (`Running { iter: N }`), which tell you "still going" but not
     /// "doing what". The narrative trace shipped via `BufferingSink`
     /// only surfaced at result-injection time.
@@ -189,12 +203,12 @@ pub enum EngineEvent {
     /// real-time UX.
     #[serde(rename = "bg_child_activity")]
     ChildAgentActivity {
-        /// Matches the `task_id` from `BgTaskUpdate` for the same
+        /// Matches the `task_id` from `ChildTaskUpdate` for the same
         /// running task. For foreground sub-agents (PR-A) this will
         /// be a synthetic id assigned at dispatch time.
         task_id: u32,
         /// Sub-agent invocation id of the spawner, or `None` for
-        /// top-level-spawned tasks. Mirrors `BgTaskUpdate.spawner`.
+        /// top-level-spawned tasks. Mirrors `ChildTaskUpdate.spawner`.
         spawner: Option<u32>,
         /// `true` if the child runs as a background task (today: all
         /// emit sites). `false` reserved for foreground sub-agents
@@ -372,7 +386,7 @@ pub enum EngineEvent {
 ///
 /// Wire format is `snake_case` with an internal `kind` tag, matching
 /// the convention for [`TurnEndReason`] and
-/// [`crate::bg_agent::AgentStatus`].
+/// [`crate::child_agent::AgentStatus`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -144,7 +144,7 @@ impl EngineSink for BufferingSink {
 /// up to the parent's sink via the bg-task's status emitter.
 ///
 /// **#1201 B**: pre-this-decorator the parent's TUI had zero live
-/// signal from inside a running bg agent — only `BgTaskUpdate`
+/// signal from inside a running bg agent — only `ChildTaskUpdate`
 /// heartbeats (`Running { iter: N }`), which tell you "still going"
 /// but not "doing what". The narrative trace from `BufferingSink`
 /// only surfaced at result-injection time, so a 30-second tool call
@@ -154,7 +154,7 @@ impl EngineSink for BufferingSink {
 /// enough to surface in the parent's feed, it builds a
 /// [`crate::engine::event::ChildAgentActivityKind`] and pushes it onto
 /// the registry's status-event queue via
-/// [`crate::bg_agent::BgStatusEmitter::send_activity`]. The
+/// [`crate::child_agent::ChildStatusEmitter::send_activity`]. The
 /// inference loop's existing drain in `inference.rs` forwards the
 /// resulting `ChildAgentActivity` event to whatever sink is active
 /// (TUI / headless / ACP) without further plumbing.
@@ -179,7 +179,7 @@ impl EngineSink for BufferingSink {
 /// post-completion drain.
 pub struct ForwardingChildSink {
     inner: BufferingSink,
-    emitter: crate::bg_agent::BgStatusEmitter,
+    emitter: crate::child_agent::ChildStatusEmitter,
 }
 
 impl ForwardingChildSink {
@@ -187,7 +187,7 @@ impl ForwardingChildSink {
     /// emitter. The emitter is cheap to clone (two `Arc`s and a
     /// `watch::Sender`); pass a clone and keep the original for the
     /// terminal-status sends in `run_bg_agent`.
-    pub fn new(inner: BufferingSink, emitter: crate::bg_agent::BgStatusEmitter) -> Self {
+    pub fn new(inner: BufferingSink, emitter: crate::child_agent::ChildStatusEmitter) -> Self {
         Self { inner, emitter }
     }
 
@@ -238,7 +238,7 @@ impl EngineSink for ForwardingChildSink {
             // Streaming text, thinking, status, approval, etc. are
             // intentionally not forwarded — too noisy for a feed,
             // duplicative with the result oneshot, or already covered
-            // by `BgTaskUpdate` heartbeats.
+            // by `ChildTaskUpdate` heartbeats.
             _ => {}
         }
         // Forward to the inner buffering sink for the post-completion
@@ -309,7 +309,7 @@ fn looks_like_tool_error(output: &str) -> bool {
 
 // ── PersistingSink (#1108 P1b/P2a) ───────────────────────────────
 
-/// A decorator that persists `Info` and `BgTaskUpdate` events to the
+/// A decorator that persists `Info` and `ChildTaskUpdate` events to the
 /// `session_events` table before forwarding to an inner sink.
 ///
 /// Pre-#1108 these events were sink-only and never reached the DB,
@@ -343,7 +343,7 @@ pub struct PersistingSink<'a> {
 }
 
 impl<'a> PersistingSink<'a> {
-    /// Wrap an inner sink. The decorator persists Info/BgTaskUpdate
+    /// Wrap an inner sink. The decorator persists Info/ChildTaskUpdate
     /// events as a side effect; everything else passes through
     /// untouched.
     pub fn new(
@@ -386,7 +386,7 @@ impl EngineSink for PersistingSink<'_> {
         // Branch on whether this is a sub-agent context. Sub-agents
         // need a richer event set persisted (the inner trace) so the
         // parent transcript can show what they did. Top-level only
-        // needs Info / BgTaskUpdate — tool calls there are already
+        // needs Info / ChildTaskUpdate — tool calls there are already
         // in `messages.tool_calls`.
         if self.parent_tool_call_id.is_some() {
             // Sub-agent: persist the same set BufferingSink renders
@@ -422,7 +422,7 @@ impl EngineSink for PersistingSink<'_> {
                 EngineEvent::Info { message } => {
                     self.persist(sek::INFO, message.clone());
                 }
-                EngineEvent::BgTaskUpdate { .. } => {
+                EngineEvent::ChildTaskUpdate { .. } => {
                     if let Ok(json) = serde_json::to_string(&event) {
                         self.persist(sek::BG_TASK_UPDATE, json);
                     }
@@ -683,7 +683,7 @@ mod tests {
 
     // ── ForwardingChildSink (#1201 B) ────────────────────
 
-    /// Build a [`crate::bg_agent::BgStatusEmitter`] hooked up to a
+    /// Build a [`crate::child_agent::ChildStatusEmitter`] hooked up to a
     /// real registry so we can drain forwarded events. The registry
     /// is the load-bearing piece — it's what the inference loop
     /// drains in production, so testing through it (rather than
@@ -691,14 +691,19 @@ mod tests {
     fn make_test_emitter(
         task_id: u32,
     ) -> (
-        std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
-        crate::bg_agent::BgStatusEmitter,
+        std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
+        crate::child_agent::ChildStatusEmitter,
     ) {
-        let registry = crate::bg_agent::new_shared();
+        let registry = crate::child_agent::new_shared();
         let (status_tx, _status_rx) =
-            tokio::sync::watch::channel(crate::bg_agent::AgentStatus::Pending);
-        let emitter =
-            crate::bg_agent::BgStatusEmitter::new(task_id, None, status_tx, registry.clone());
+            tokio::sync::watch::channel(crate::child_agent::AgentStatus::Pending);
+        let emitter = crate::child_agent::ChildStatusEmitter::new(
+            task_id,
+            None,
+            true,
+            status_tx,
+            registry.clone(),
+        );
         (registry, emitter)
     }
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -605,7 +605,7 @@ pub struct InferenceContext<'a> {
     /// so bg agents survive across turns; this is just a borrow into
     /// the loop. Drained at the top of every iteration to inject
     /// completed bg results into the conversation.
-    pub bg_agents: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    pub bg_agents: &'a std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     /// Cross-turn sub-agent result cache (#1022 B12). Owned by [`crate::session::KodaSession`].
     /// Generation-based invalidation on mutating tool calls is
     /// honored uniformly via `crate::tool_dispatch::execute_one_tool`.
@@ -635,7 +635,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     } = ctx;
 
     // #1108 P1b: wrap the user-facing sink with `PersistingSink` so
-    // every `Info` / `BgTaskUpdate` event lands in `session_events`
+    // every `Info` / `ChildTaskUpdate` event lands in `session_events`
     // for the markdown transcript export. Pre-#1108 these were
     // sink-only and disappeared once the user closed the TUI.
     let _persisting_sink = crate::engine::sink::PersistingSink::new(
@@ -655,7 +655,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     // #1022 B12: `bg_agents` and `sub_agent_cache` now live on
     // `KodaSession` and are borrowed in via `InferenceContext`. Local
     // construction here was the root cause of the cross-turn drop bug:
-    // when this function returned, the `Arc<BgAgentRegistry>` dropped,
+    // when this function returned, the `Arc<ChildAgentRegistry>` dropped,
     // every still-pending bg task was aborted by `AbortOnDropHandle`,
     // and the result was lost. Owning on the session means the
     // registry survives across turns and the next call drains anything
@@ -686,7 +686,7 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
     loop {
         // #1076: forward queued bg-task status transitions to the sink
         // before processing anything else. Drained from the same
-        // `Arc<BgAgentRegistry>` that owns `drain_completed`, so the
+        // `Arc<ChildAgentRegistry>` that owns `drain_completed`, so the
         // ordering is: status transitions first (so clients see
         // `Running { iter: N }` heartbeats), then completed-result
         // injection (so the model gets the final output as a user

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -58,7 +58,7 @@ pub mod bash_path_lint;
 /// Bash command safety classification — ReadOnly, LocalMutation, Destructive.
 pub mod bash_safety;
 /// Background sub-agent registry — tracks and drains async agent results.
-pub mod bg_agent;
+pub mod child_agent;
 /// Context compaction — summarise old messages to reclaim token budget.
 pub mod compact;
 /// Global configuration: provider, model, model settings, CLI flags.

--- a/koda-core/src/persistence.rs
+++ b/koda-core/src/persistence.rs
@@ -116,7 +116,7 @@ pub struct Message {
 pub mod session_event_kind {
     /// `EngineEvent::Info` — payload is the message text.
     pub const INFO: &str = "info";
-    /// `EngineEvent::BgTaskUpdate` — payload is JSON
+    /// `EngineEvent::ChildTaskUpdate` — payload is JSON
     /// `{"task_id": u32, "spawner": Option<u32>, "status": AgentStatus}`.
     pub const BG_TASK_UPDATE: &str = "bg_task_update";
     /// One line of a sub-agent's `BufferingSink` trace — payload is
@@ -389,7 +389,7 @@ pub trait Persistence: Send + Sync {
     /// `Some(call_id)` only for sub-agent events so the renderer can
     /// fold them under the parent's `InvokeAgent` tool result.
     ///
-    /// Hot-path: called from every `EngineEvent::Info`/`BgTaskUpdate`
+    /// Hot-path: called from every `EngineEvent::Info`/`ChildTaskUpdate`
     /// emission via [`crate::engine::sink::PersistingSink`]. Failures
     /// are logged but never propagated — a DB hiccup must not crash
     /// the inference loop.

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -23,7 +23,7 @@
 //! (e.g., main REPL + background sub-agents) without shared mutable state.
 
 use crate::agent::KodaAgent;
-use crate::bg_agent::{self, BgAgentRegistry};
+use crate::child_agent::{self, ChildAgentRegistry};
 use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
@@ -220,7 +220,7 @@ pub struct KodaSession {
     /// registry into the recursive `execute_sub_agent` call (so
     /// nested `InvokeAgent { background: true }` registers in the
     /// caller-visible slot, not a fresh per-call one).
-    pub bg_agents: Arc<BgAgentRegistry>,
+    pub bg_agents: Arc<ChildAgentRegistry>,
 
     /// Cross-turn sub-agent result cache (#1022 B12).
     ///
@@ -330,7 +330,7 @@ impl KodaSession {
             // #1022 B12: registry + cache live on the session so bg
             // agents survive across turns and the cache yields
             // cross-turn hits.
-            bg_agents: bg_agent::new_shared(),
+            bg_agents: child_agent::new_shared(),
             sub_agent_cache: SubAgentCache::new(),
         }
     }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -98,9 +98,9 @@ pub(crate) fn next_invocation_id() -> u32 {
 /// with its own `BgRegistry`, which `Drop`-SIGTERMs everything when
 /// the registry goes out of scope. That handles shell orphans for
 /// free; this struct only needs to deal with the *shared*
-/// `BgAgentRegistry`.
+/// `ChildAgentRegistry`.
 struct InvocationCleanup<'a> {
-    bg: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg: &'a std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     invocation_id: u32,
 }
 
@@ -134,7 +134,7 @@ async fn run_bg_agent(
     sub_agent_cache: SubAgentCache,
     parent_session: String,
     tx: tokio::sync::oneshot::Sender<
-        Result<crate::bg_agent::BgPayload, crate::bg_agent::BgPayload>,
+        Result<crate::child_agent::BgPayload, crate::child_agent::BgPayload>,
     >,
     // B2 of #1022: parent's cancel token, threaded as a `child_token()`
     // so a Ctrl-C in the parent loop cancels the bg agent.
@@ -151,7 +151,7 @@ async fn run_bg_agent(
     // Layer 0 of #996 + #1076: status fan-out helper. Drives the
     // per-task `watch::Sender<AgentStatus>` (read by `/agents` and
     // the status-bar pill via `snapshot()`) AND queues an
-    // `EngineEvent::BgTaskUpdate` on the registry so the inference
+    // `EngineEvent::ChildTaskUpdate` on the registry so the inference
     // loop can forward it to the active `EngineSink`. Pre-#1076 this
     // was a raw `watch::Sender` and only the TUI (which polled the
     // registry directly) saw transitions; now every client surface
@@ -159,16 +159,16 @@ async fn run_bg_agent(
     //
     // `send` failures on the underlying watch are silently absorbed
     // by the emitter — the only way that fails is if the registry
-    // entry was reaped, in which case the queued `BgTaskUpdate` is
+    // entry was reaped, in which case the queued `ChildTaskUpdate` is
     // harmless extra signal that clients can ignore.
-    emitter: crate::bg_agent::BgStatusEmitter,
+    emitter: crate::child_agent::ChildStatusEmitter,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
     // `execute_sub_agent` updates this to `iter: 1..=20` as it progresses
     // (Layer 4, #1058). `iter: 0` is intentional here — it signals
     // "started, first iteration pending".
-    emitter.send(crate::bg_agent::AgentStatus::Running { iter: 0 });
+    emitter.send(crate::child_agent::AgentStatus::Running { iter: 0 });
 
     let (_, mut cmd_rx) = mpsc::channel(1);
     // #1022 B9: bg agents used to run with `NullSink`, so every
@@ -191,7 +191,7 @@ async fn run_bg_agent(
         crate::engine::sink::BufferingSink::new(),
         emitter.clone(),
     );
-    let nested_bg = crate::bg_agent::new_shared();
+    let nested_bg = crate::child_agent::new_shared();
 
     // Override background=false to prevent infinite spawn — a bg agent
     // that itself emitted `InvokeAgent { background: true }` would
@@ -256,7 +256,7 @@ async fn run_bg_agent(
     // drained sees the terminal state, not stale `Running`.
     match &result {
         Ok(output) => {
-            emitter.send(crate::bg_agent::AgentStatus::Completed {
+            emitter.send(crate::child_agent::AgentStatus::Completed {
                 // `summary` is currently the full output — truncation
                 // is the display layer's job (Codex pattern: see
                 // `COLLAB_AGENT_RESPONSE_PREVIEW_GRAPHEMES`).
@@ -269,9 +269,9 @@ async fn run_bg_agent(
             // the token: if it fired, the user-visible reason is
             // "Cancelled", not the inner error string.
             let status = if cancel_for_status.is_cancelled() {
-                crate::bg_agent::AgentStatus::Cancelled
+                crate::child_agent::AgentStatus::Cancelled
             } else {
-                crate::bg_agent::AgentStatus::Errored {
+                crate::child_agent::AgentStatus::Errored {
                     error: e.to_string(),
                 }
             };
@@ -306,7 +306,7 @@ pub(crate) fn execute_sub_agent<'a>(
     parent_cache: Option<crate::tools::FileReadCache>,
     sub_agent_cache: &'a SubAgentCache,
     parent_session_id: &'a str,
-    bg_agents: &'a std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &'a std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     // Phase 5 PR-4 of #934: parent's effective sandbox policy. The
     // child policy is composed onto this so the child can only narrow,
     // never widen — see [`koda_sandbox::SandboxPolicy::compose`] for
@@ -321,13 +321,13 @@ pub(crate) fn execute_sub_agent<'a>(
     // tags any bg work the child itself spawns.
     parent_spawner: Option<u32>,
     // Layer 4 of #996 + #1076: live iteration heartbeat.  Pass the
-    // bg-agent's `BgStatusEmitter` so each loop iteration can push
+    // bg-agent's `ChildStatusEmitter` so each loop iteration can push
     // `Running { iter }` to BOTH the registry's per-task watch
     // channel (`/agents`, status-bar pill) AND the engine event
     // queue (`EngineSink` → TUI / ACP / headless).  Foreground
     // sub-agents pass `None` — they have no status channel because
     // they're not tracked in the registry at all.
-    emitter: Option<crate::bg_agent::BgStatusEmitter>,
+    emitter: Option<crate::child_agent::ChildStatusEmitter>,
     // **#1108 P2a**: parent's `InvokeAgent` tool_call_id. Recorded on
     // the bg-agent reservation so the inference loop's drain handler
     // can persist the bg agent's narrative trace to `session_events`
@@ -389,7 +389,11 @@ pub(crate) fn execute_sub_agent<'a>(
             // bg sub-agent itself were to be cancelled-on-parent-exit,
             // but the registry's parent->bg cancel-token cascade
             // already handles that case.
-            let reservation = bg_agents.reserve(&cancel, parent_spawner);
+            // PR-A0.5 of #1232: pass `is_background: true` here —
+            // this dispatch path is the bg-only spawn site (the
+            // `tokio::spawn` + auto-drain mechanism). PR-A wires a
+            // separate fg registration path that passes `false`.
+            let reservation = bg_agents.reserve(&cancel, parent_spawner, true);
             let task_id = reservation.task_id;
             let bg_cancel = reservation.cancel.clone();
             let bg_tx = reservation.tx;
@@ -397,7 +401,7 @@ pub(crate) fn execute_sub_agent<'a>(
             let entry_cancel = reservation.cancel;
             // Layer 0 of #996 + #1076: bundle the watch sender, the
             // task id, the spawner id, and an `Arc` on the registry
-            // into a `BgStatusEmitter`.  The emitter fans out every
+            // into a `ChildStatusEmitter`.  The emitter fans out every
             // `.send(...)` to BOTH the per-task watch channel (read
             // by `snapshot()` / `/agents`) AND the registry's event
             // queue (drained by the inference loop and forwarded to
@@ -405,9 +409,12 @@ pub(crate) fn execute_sub_agent<'a>(
             // engine/UI boundary leak: the TUI no longer needs to
             // poll the registry directly to render live status, and
             // ACP / headless gain visibility for free.
-            let emitter = crate::bg_agent::BgStatusEmitter::new(
+            let emitter = crate::child_agent::ChildStatusEmitter::new(
                 task_id,
                 parent_spawner,
+                // PR-A0.5 of #1232: bg path — emitter tags every
+                // `ChildTaskUpdate` with `is_background: true`.
+                true,
                 reservation.status_tx,
                 bg_agents.clone(),
             );
@@ -452,6 +459,10 @@ pub(crate) fn execute_sub_agent<'a>(
                 entry_cancel,
                 entry_status_rx,
                 parent_spawner,
+                // PR-A0.5 of #1232: bg path — stamp the entry as
+                // background so snapshots and the `/agents` overlay
+                // can keep filtering bg-only when they want.
+                true,
                 parent_tool_call_id.map(str::to_string),
                 handle,
             );
@@ -840,7 +851,7 @@ pub(crate) fn execute_sub_agent<'a>(
             // sends: if the receiver is gone, the user can't see the
             // update and we don't want noise.
             if let Some(ref e) = emitter {
-                e.send(crate::bg_agent::AgentStatus::Running { iter });
+                e.send(crate::child_agent::AgentStatus::Running { iter });
             }
             // Respect parent cancellation (#286)
             if cancel.is_cancelled() {
@@ -1415,12 +1426,12 @@ mod b21_tests {
 #[cfg(test)]
 mod invocation_cleanup_tests {
     use super::InvocationCleanup;
-    use crate::bg_agent::BgAgentRegistry;
+    use crate::child_agent::ChildAgentRegistry;
     use std::sync::Arc;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_cancels_entries_tagged_with_matching_spawner() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         // Tag two bg entries with our invocation id. The 4th tuple
         // element is a clone of the entry's cancel token — we use it
         // as an observer to detect the guard firing the cancel.
@@ -1450,7 +1461,7 @@ mod invocation_cleanup_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_leaves_entries_with_different_spawner_alone() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         // Mix: one tagged with our id, one with a sibling's, one with None.
         let (_id_mine, _tx_m, _status_tx_m, cancel_mine) =
             reg.register_test_with_status("a", "mine", Some(7));
@@ -1480,7 +1491,7 @@ mod invocation_cleanup_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drop_with_no_matching_entries_is_noop() {
-        let reg = Arc::new(BgAgentRegistry::new());
+        let reg = Arc::new(ChildAgentRegistry::new());
         let (_id, _tx, _status_tx, cancel) = reg.register_test_with_status("a", "x", Some(99));
 
         // Cleanup for an invocation that never spawned anything —

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -242,7 +242,7 @@ pub(crate) async fn execute_one_tool(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     caller_spawner: Option<u32>,
 ) -> (String, String, bool, Option<String>) {
     let (result, success, full_output) = if matches!(
@@ -251,7 +251,7 @@ pub(crate) async fn execute_one_tool(
     ) {
         // Layer 2 of #996 — background-task management tools.
         //
-        // These need the `Arc<BgAgentRegistry>` (not held by the
+        // These need the `Arc<ChildAgentRegistry>` (not held by the
         // ToolRegistry) plus the caller's spawner identity (now
         // threaded as `caller_spawner`), so they can't go through
         // the generic `tools.execute()` path.
@@ -320,7 +320,7 @@ pub(crate) async fn execute_one_tool(
             caller_spawner,
             // Layer 4 of #996 + #1076: foreground sub-agents are not
             // tracked in the bg-agent registry, so there is no
-            // `BgStatusEmitter` to fan out per-iteration heartbeats
+            // `ChildStatusEmitter` to fan out per-iteration heartbeats
             // to. Pass `None` to skip the per-iteration emit.
             None,
             // #1108 P2a: pass the InvokeAgent tool_call_id so any
@@ -374,7 +374,7 @@ async fn validate_then_execute_one_tool(
     sink: &dyn crate::engine::EngineSink,
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     caller_spawner: Option<u32>,
 ) -> (String, String, bool, Option<String>) {
     let parsed_args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
@@ -427,7 +427,7 @@ pub(crate) async fn execute_tools_parallel(
     cancel: CancellationToken,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     caller_spawner: Option<u32>,
 ) -> Result<()> {
     let count = tool_calls.len();
@@ -506,7 +506,7 @@ pub(crate) async fn execute_tools_split_batch(
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     caller_spawner: Option<u32>,
 ) -> Result<()> {
     // Partition into parallelizable vs sequential
@@ -633,7 +633,7 @@ pub(crate) async fn execute_tools_sequential(
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::bg_agent::BgAgentRegistry>,
+    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     caller_spawner: Option<u32>,
 ) -> Result<()> {
     for tc in tool_calls {

--- a/koda-core/src/tools/bg_process.rs
+++ b/koda-core/src/tools/bg_process.rs
@@ -35,7 +35,7 @@
 //! the session are keyed by PID. The registry is `Mutex`-protected since
 //! the spawning thread, the reaper, and the cleanup path all touch it.
 
-use crate::bg_agent::CancelOutcome;
+use crate::child_agent::CancelOutcome;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -43,7 +43,7 @@ use tokio::process::Child;
 
 /// Outcome of [`BgRegistry::wait_for_exit_as_caller`].
 ///
-/// Mirrors [`crate::bg_agent::WaitOutcome`] but carries process-specific
+/// Mirrors [`crate::child_agent::WaitOutcome`] but carries process-specific
 /// terminal info (exit code) instead of an agent result. The two enums
 /// stay separate because they really are different things — forcing one
 /// to wear the other's shape would mean optionalizing fields that aren't
@@ -197,7 +197,7 @@ impl BgRegistry {
     }
 
     /// Scoped snapshot for the `ListBackgroundTasks` LLM tool. Same
-    /// Model E rule as [`crate::bg_agent::BgAgentRegistry::snapshot_for_caller`]:
+    /// Model E rule as [`crate::child_agent::ChildAgentRegistry::snapshot_for_caller`]:
     /// strict spawner equality, `None == None`.
     pub fn snapshot_for_caller(&self, caller_spawner: Option<u32>) -> Vec<BgProcessSnapshot> {
         self.snapshot()
@@ -270,7 +270,7 @@ impl BgRegistry {
     }
 
     /// Scoped kill for the `CancelTask` LLM tool. Same Model E rule
-    /// as [`crate::bg_agent::BgAgentRegistry::cancel_as_caller`].
+    /// as [`crate::child_agent::ChildAgentRegistry::cancel_as_caller`].
     pub fn kill_as_caller(&self, pid: u32, caller_spawner: Option<u32>) -> CancelOutcome {
         let mut guard = self.inner.lock().unwrap();
         let Some(entry) = guard.get_mut(&pid) else {

--- a/koda-core/src/tools/bg_task_tools.rs
+++ b/koda-core/src/tools/bg_task_tools.rs
@@ -17,7 +17,7 @@
 //! shell processes apart at a glance:
 //!
 //! - `agent:N`   — bg-agent task (the `task_id` from
-//!   [`crate::bg_agent::BgAgentRegistry::reserve`]).
+//!   [`crate::child_agent::ChildAgentRegistry::reserve`]).
 //! - `process:N` — bg shell process (the OS PID from
 //!   [`crate::tools::bg_process::BgRegistry::insert`]).
 //!
@@ -30,11 +30,11 @@
 //! Each tool is filtered to the caller's own tasks: top-level sees
 //! only top-level-spawned, sub-agent N sees only its own. Cross-spawner
 //! cancel/wait returns a `Forbidden` error. This is enforced at the
-//! [`BgAgentRegistry`] / [`BgRegistry`] layer; the tool layer just
+//! [`ChildAgentRegistry`] / [`BgRegistry`] layer; the tool layer just
 //! produces a useful message when it sees `CancelOutcome::Forbidden`
 //! / `WaitOutcome::Forbidden`.
 //!
-//! [`BgAgentRegistry`]: crate::bg_agent::BgAgentRegistry
+//! [`ChildAgentRegistry`]: crate::child_agent::ChildAgentRegistry
 //! [`BgRegistry`]: crate::tools::bg_process::BgRegistry
 
 use crate::providers::ToolDefinition;
@@ -43,8 +43,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-use crate::bg_agent::{
-    AgentStatus, BgAgentRegistry, BgAgentResult, BgTaskSnapshot, CancelOutcome, WaitOutcome,
+use crate::child_agent::{
+    AgentStatus, BgAgentResult, CancelOutcome, ChildAgentRegistry, ChildTaskSnapshot, WaitOutcome,
 };
 use crate::tools::ToolResult;
 use crate::tools::bg_process::{
@@ -276,7 +276,7 @@ pub fn clamp_wait_timeout_secs(requested: Option<u32>) -> u32 {
 // Dispatch entry point for the three Layer-2 tools. Called from
 // `tool_dispatch::execute_one_tool` when `tool_name` matches; never
 // goes through `ToolRegistry::execute()` because we need the
-// `Arc<BgAgentRegistry>` (not stored on the registry) and the caller's
+// `Arc<ChildAgentRegistry>` (not stored on the registry) and the caller's
 // spawner identity (only known at the dispatch layer).
 
 /// Render an [`AgentStatus`] as the lower-case status string we
@@ -302,7 +302,7 @@ fn process_status_str(s: &BgProcessStatus) -> &'static str {
     }
 }
 
-fn agent_snapshot_to_json(s: &BgTaskSnapshot) -> Value {
+fn agent_snapshot_to_json(s: &ChildTaskSnapshot) -> Value {
     json!({
         "task_id": format!("agent:{}", s.task_id),
         "task_type": "agent",
@@ -357,7 +357,7 @@ fn ok(value: Value) -> ToolResult {
 pub async fn execute(
     tool_name: &str,
     arguments: &str,
-    bg_agents: &Arc<BgAgentRegistry>,
+    bg_agents: &Arc<ChildAgentRegistry>,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
     cancel: &CancellationToken,
@@ -376,7 +376,7 @@ pub async fn execute(
 }
 
 fn execute_list(
-    bg_agents: &BgAgentRegistry,
+    bg_agents: &ChildAgentRegistry,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
 ) -> ToolResult {
@@ -399,7 +399,7 @@ fn execute_list(
 
 fn execute_cancel(
     arguments: &str,
-    bg_agents: &BgAgentRegistry,
+    bg_agents: &ChildAgentRegistry,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
 ) -> ToolResult {
@@ -438,7 +438,7 @@ fn execute_cancel(
 
 async fn execute_wait(
     arguments: &str,
-    bg_agents: &Arc<BgAgentRegistry>,
+    bg_agents: &Arc<ChildAgentRegistry>,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
     cancel: &CancellationToken,
@@ -527,7 +527,7 @@ async fn execute_wait(
 /// doesn't blow away the results of the other N-1.
 async fn wait_one_task(
     task_id_str: String,
-    bg_agents: &Arc<BgAgentRegistry>,
+    bg_agents: &Arc<ChildAgentRegistry>,
     bg_processes: &BgRegistry,
     caller_spawner: Option<u32>,
     timeout: Duration,
@@ -797,8 +797,8 @@ mod tests {
 
     // ── execute() dispatch tests ─────────────────────────────────────────────────────
 
-    fn fresh_registries() -> (Arc<BgAgentRegistry>, BgRegistry) {
-        (Arc::new(BgAgentRegistry::new()), BgRegistry::new())
+    fn fresh_registries() -> (Arc<ChildAgentRegistry>, BgRegistry) {
+        (Arc::new(ChildAgentRegistry::new()), BgRegistry::new())
     }
 
     /// `ListBackgroundTasks` on empty registries returns `[]`, success.
@@ -878,7 +878,7 @@ mod tests {
         assert_eq!(arr.as_array().unwrap().len(), 1, "sub sees only its own");
     }
 
-    /// `CancelTask` routes `agent:N` to BgAgentRegistry and reports
+    /// `CancelTask` routes `agent:N` to ChildAgentRegistry and reports
     /// success in the structured payload.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn execute_cancel_succeeds_for_owned_agent_task() {

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -128,7 +128,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         cancel,
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
-        bg_agents: &koda_core::bg_agent::new_shared(),
+        bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -1,7 +1,7 @@
 //! E2E tests: sub-agent invocation and caching.
 
 use koda_core::{
-    bg_agent::AgentStatus, engine::EngineEvent, persistence::Persistence, runtime_env,
+    child_agent::AgentStatus, engine::EngineEvent, persistence::Persistence, runtime_env,
 };
 use koda_test_utils::{ENV_MUTEX, Env, MockProvider, MockResponse};
 use std::time::Duration;
@@ -480,14 +480,14 @@ async fn bg_agent_iter_counter_advances_via_status_channel() {
     let bg_updates: Vec<&AgentStatus> = bg_events
         .iter()
         .filter_map(|ev| match ev {
-            EngineEvent::BgTaskUpdate { status, .. } => Some(status),
+            EngineEvent::ChildTaskUpdate { status, .. } => Some(status),
             _ => None,
         })
         .collect();
 
     assert!(
         !bg_updates.is_empty(),
-        "expected at least one BgTaskUpdate event; bg_events ({} total): {bg_events:#?}",
+        "expected at least one ChildTaskUpdate event; bg_events ({} total): {bg_events:#?}",
         bg_events.len()
     );
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -172,7 +172,7 @@ async fn test_provider_error_emits_error_event() {
         cancel: CancellationToken::new(),
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
-        bg_agents: &koda_core::bg_agent::new_shared(),
+        bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;
@@ -296,7 +296,7 @@ async fn test_cancel_during_streaming() {
         cancel,
         cmd_rx: &mut cmd_rx,
         file_tracker: &mut file_tracker,
-        bg_agents: &koda_core::bg_agent::new_shared(),
+        bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
     })
     .await;

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -102,7 +102,7 @@ async fn make_session_with_mcp(
         title_set: false,
         proxy: None,
         socks5_proxy: None,
-        bg_agents: koda_core::bg_agent::new_shared(),
+        bg_agents: koda_core::child_agent::new_shared(),
         sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
     };
     (session, cancel, recorded)

--- a/koda-core/tests/persisting_sink_test.rs
+++ b/koda-core/tests/persisting_sink_test.rs
@@ -3,12 +3,12 @@
 //! ## What this file guards
 //!
 //! `PersistingSink` (`koda-core/src/engine/sink.rs`) is the
-//! decorator that writes `Info` / `BgTaskUpdate` / sub-agent-trace
+//! decorator that writes `Info` / `ChildTaskUpdate` / sub-agent-trace
 //! events into the `session_events` table on the way to the
 //! user-facing sink. The routing decision is a single branch:
 //!
 //! - `parent_tool_call_id == None` → top-level event, persist `Info`
-//!   and `BgTaskUpdate`.
+//!   and `ChildTaskUpdate`.
 //! - `parent_tool_call_id == Some(call_id)` → sub-agent event,
 //!   persist a richer set (`Info`, `ToolCallStart`, `ApprovalRequest`,
 //!   `AskUserRequest`) and stamp every row with `call_id` so the
@@ -140,20 +140,21 @@ async fn top_level_info_event_persists_with_null_parent() {
     );
 }
 
-/// Top-level `BgTaskUpdate` events persist with `kind = bg_task_update`
+/// Top-level `ChildTaskUpdate` events persist with `kind = bg_task_update`
 /// and a JSON-encoded payload (so the renderer can deserialize the
 /// `AgentStatus` back into the original variant).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn top_level_bg_task_update_persists_as_json_with_null_parent() {
-    use koda_core::bg_agent::AgentStatus;
+    use koda_core::child_agent::AgentStatus;
 
     let (_tmp, db, session_id) = fresh_db().await;
     let inner = TestSink::new();
     let sink = PersistingSink::new(&inner, db.clone(), session_id.clone(), None);
 
-    let event = EngineEvent::BgTaskUpdate {
+    let event = EngineEvent::ChildTaskUpdate {
         task_id: 42,
         spawner: None,
+        is_background: true,
         status: AgentStatus::Running { iter: 7 },
     };
     sink.emit(event);
@@ -180,7 +181,7 @@ async fn top_level_bg_task_update_persists_as_json_with_null_parent() {
     assert_eq!(parsed["status"]["iter"], 7, "full payload: {parsed}");
 }
 
-/// Sanity: events that aren't on the `Info` / `BgTaskUpdate` allowlist
+/// Sanity: events that aren't on the `Info` / `ChildTaskUpdate` allowlist
 /// do NOT create rows in the top-level routing path. If `TextDelta`
 /// started persisting we'd flood the table on every streaming token —
 /// regression guard for that explicit bug shape.
@@ -209,7 +210,7 @@ async fn top_level_passes_through_non_persistable_events_without_db_writes() {
     let events = db.load_session_events(&session_id).await.unwrap();
     assert!(
         events.is_empty(),
-        "top-level routing must only persist Info/BgTaskUpdate; \
+        "top-level routing must only persist Info/ChildTaskUpdate; \
          got rows for non-allowlisted events: {events:?}"
     );
 
@@ -359,11 +360,11 @@ async fn sub_agent_ask_user_request_persists_truncated() {
     );
 }
 
-/// Sub-agent routing must NOT persist `BgTaskUpdate` (that's a
+/// Sub-agent routing must NOT persist `ChildTaskUpdate` (that's a
 /// top-level concept). Tests the negative side of the asymmetry.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sub_agent_does_not_persist_bg_task_update() {
-    use koda_core::bg_agent::AgentStatus;
+    use koda_core::child_agent::AgentStatus;
 
     let (_tmp, db, session_id) = fresh_db().await;
     let inner = TestSink::new();
@@ -374,9 +375,10 @@ async fn sub_agent_does_not_persist_bg_task_update() {
         Some("parent-4".into()),
     );
 
-    sink.emit(EngineEvent::BgTaskUpdate {
+    sink.emit(EngineEvent::ChildTaskUpdate {
         task_id: 1,
         spawner: Some(99),
+        is_background: true,
         status: AgentStatus::Pending,
     });
 
@@ -387,7 +389,7 @@ async fn sub_agent_does_not_persist_bg_task_update() {
     let events = db.load_session_events(&session_id).await.unwrap();
     assert!(
         events.is_empty(),
-        "BgTaskUpdate must not persist on the sub-agent path; got: {events:?}"
+        "ChildTaskUpdate must not persist on the sub-agent path; got: {events:?}"
     );
 
     // Inner sink still saw the event — forwarding is unconditional.

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -59,7 +59,7 @@ async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession
         title_set: false,
         proxy: None,
         socks5_proxy: None,
-        bg_agents: koda_core::bg_agent::new_shared(),
+        bg_agents: koda_core::child_agent::new_shared(),
         sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
     };
     (session, cancel)

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -5,7 +5,7 @@
 
 use koda_core::persistence::Persistence;
 use koda_core::{
-    bg_agent::BgAgentRegistry,
+    child_agent::ChildAgentRegistry,
     config::{KodaConfig, ProviderType},
     db::{Database, Role},
     engine::{EngineCommand, EngineEvent, sink::TestSink},
@@ -45,9 +45,9 @@ pub struct Env {
     /// Background agent registry shared across inference calls.
     ///
     /// Tests that spawn background sub-agents can poll this for
-    /// live status snapshots, or call [`BgAgentRegistry::subscribe`]
+    /// live status snapshots, or call [`ChildAgentRegistry::subscribe`]
     /// to get a watch receiver for a specific task.
-    pub bg_agents: Arc<BgAgentRegistry>,
+    pub bg_agents: Arc<ChildAgentRegistry>,
 }
 
 /// Builder for [`Env`] — customise provider, context window, agent name, etc.
@@ -125,7 +125,7 @@ impl EnvBuilder {
             config,
             tools,
             trust: self.trust,
-            bg_agents: koda_core::bg_agent::new_shared(),
+            bg_agents: koda_core::child_agent::new_shared(),
         }
     }
 }
@@ -296,14 +296,14 @@ impl Env {
         (result, sink.events())
     }
 
-    /// Collect every `BgTaskUpdate` event a background sub-agent will
+    /// Collect every `ChildTaskUpdate` event a background sub-agent will
     /// emit, regardless of which side of the parent's `inference_loop`
     /// drained them.
     ///
     /// **Why this helper exists** (#1109, PR #1113):
     ///
-    /// `BgTaskUpdate` events flow through a single-consumer queue
-    /// inside [`BgAgentRegistry`]. The parent's `inference_loop`
+    /// `ChildTaskUpdate` events flow through a single-consumer queue
+    /// inside [`ChildAgentRegistry`]. The parent's `inference_loop`
     /// drains them on every iteration and forwards to the sink. A
     /// test that asserts on these events is racing the parent for
     /// the same queue:
@@ -323,19 +323,19 @@ impl Env {
     ///
     /// * `events_from_run_inference` — the `Vec<EngineEvent>`
     ///   returned by [`Self::run_inference`] (or any of its
-    ///   variants). `BgTaskUpdate` events are filtered out; other
+    ///   variants). `ChildTaskUpdate` events are filtered out; other
     ///   event types are ignored.
     /// * `terminal_timeout` — how long to keep polling
-    ///   [`BgAgentRegistry::drain_status_events`] waiting for a
+    ///   [`ChildAgentRegistry::drain_status_events`] waiting for a
     ///   terminal status (`Completed`, `Errored`, `Cancelled`). Use
     ///   a generous bound (e.g. 10s) — on a healthy machine the
     ///   helper returns in single-digit milliseconds.
     ///
     /// # Returns
     ///
-    /// `Ok(events)` if a terminal `BgTaskUpdate` was observed within
+    /// `Ok(events)` if a terminal `ChildTaskUpdate` was observed within
     /// `terminal_timeout`, where `events` contains every
-    /// `BgTaskUpdate` from both sources in arrival order (sink-side
+    /// `ChildTaskUpdate` from both sources in arrival order (sink-side
     /// events first, then queue-drained events).
     ///
     /// `Err(events)` if the timeout elapsed without a terminal
@@ -350,7 +350,7 @@ impl Env {
     ///     .await
     ///     .expect("bg task never reached terminal state");
     /// assert!(bg_events.iter().any(|e| matches!(
-    ///     e, EngineEvent::BgTaskUpdate {
+    ///     e, EngineEvent::ChildTaskUpdate {
     ///         status: AgentStatus::Completed { .. }, ..
     ///     }
     /// )));
@@ -362,7 +362,7 @@ impl Env {
     ) -> Result<Vec<EngineEvent>, Vec<EngineEvent>> {
         let mut bg_events: Vec<EngineEvent> = events_from_run_inference
             .into_iter()
-            .filter(|ev| matches!(ev, EngineEvent::BgTaskUpdate { .. }))
+            .filter(|ev| matches!(ev, EngineEvent::ChildTaskUpdate { .. }))
             .collect();
 
         let deadline = tokio::time::Instant::now() + terminal_timeout;
@@ -381,7 +381,7 @@ impl Env {
     }
 }
 
-/// Returns `true` if `ev` is a [`EngineEvent::BgTaskUpdate`] in a
+/// Returns `true` if `ev` is a [`EngineEvent::ChildTaskUpdate`] in a
 /// terminal status (`Completed`, `Errored`, or `Cancelled`).
 ///
 /// Extracted as a free function so [`Env::collect_bg_events_after`]
@@ -389,10 +389,10 @@ impl Env {
 /// `AgentStatus` has additional non-terminal variants we must not
 /// mistakenly treat as final.
 fn is_terminal_bg_update(ev: &EngineEvent) -> bool {
-    use koda_core::bg_agent::AgentStatus;
+    use koda_core::child_agent::AgentStatus;
     matches!(
         ev,
-        EngineEvent::BgTaskUpdate {
+        EngineEvent::ChildTaskUpdate {
             status: AgentStatus::Completed { .. }
                 | AgentStatus::Errored { .. }
                 | AgentStatus::Cancelled,


### PR DESCRIPTION
## Summary

Generalize the bg-only sub-agent registry to host **both fg and bg** child agents, matching the architectural consensus across **Codex / Claude Code / Gemini CLI**. Pure rename + new `is_background: bool` field plumbed through the registry, snapshot, reservation, emitter, and event types.

**Zero runtime behavior change.** Every constructor still passes `true`. PR-A wires up the fg path that passes `false`.

## Why this PR exists (and revises PR-A0)

PR-A0 kept `Bg*` names for the registry types on the theory that *"the registry is bg-only by design."* A competitive review of Codex, Claude Code, and Gemini CLI showed all three ship a **single unified registry** with fg/bg as a runtime flag (or in Gemini's case, no bg distinction at all):

| Product | Bg sub-agents? | One registry? | fg/bg in render path? | "Bg" type names? |
|---|---|---|---|---|
| **Codex** | ✅ all async, `wait` blocks | ✅ `AgentRegistry` | ❌ unified | ❌ none |
| **Claude Code** | ✅ `run_in_background: true` | ✅ shared flow | ❌ `isAsync` is a prop | ❌ none |
| **Gemini CLI** | ❌ doesn't exist | ✅ `AgentRegistry` | ❌ only sub-agents | ❌ none |
| **Koda (after PR-A0)** | ✅ `background: true` | ❌ `BgAgentRegistry` only | ✅ separate (fg invisible!) | ✅ `Bg*` everywhere |
| **Koda (this PR)** | ✅ `background: true` | ✅ `ChildAgentRegistry` | ❌ `is_background` flag | ❌ unified |

**Three-for-three vote for unified registry.** Koda now matches.

PR-A's overlay-attribution work needs fg sub-agents to appear in the same registry that powers `/agents`. Splitting fg and bg into parallel registries (option M from the planning doc) would have duplicated ~250 LoC of lifecycle/snapshot/cleanup machinery for no benefit beyond preserving PR-A0's naming choice. Generalizing the existing registry (option L) is structurally cleaner and aligns with industry consensus.

## Renames

**File:**
| Old | New |
|---|---|
| `koda-core/src/bg_agent.rs` | `koda-core/src/child_agent.rs` |

**Types** (registry / snapshot / lifecycle — both fg and bg):
| Old | New |
|---|---|
| `pub struct BgAgentRegistry` | `pub struct ChildAgentRegistry` |
| `struct BgAgentEntry` | `struct ChildAgentEntry` |
| `pub struct BgAgentReservation` | `pub struct ChildAgentReservation` |
| `pub struct BgStatusEmitter` | `pub struct ChildStatusEmitter` |
| `pub struct BgTaskSnapshot` | `pub struct ChildTaskSnapshot` |
| `EngineEvent::BgTaskUpdate` | `EngineEvent::ChildTaskUpdate` |

**Module path:** `koda_core::bg_agent::*` → `koda_core::child_agent::*`

## What stays `Bg*`

Genuinely bg-only machinery keeps its prefix — these don't have a foreground analog:

| Type | Why it stays |
|---|---|
| `pub type BgPayload` | Auto-injected result tuple. Fg sub-agents return their string via the parent's `await` directly; no payload struct needed. |
| `pub struct BgAgentResult` | Terminal result with payload. Fg sub-agents have no terminal result event; the parent gets the string from `execute_sub_agent`. |

Plus the entirely separate **bg shell-process** types in `tools/bg_process.rs` (`BgRegistry`, `BgEntry`, `BgProcessStatus`, `BgProcessSnapshot`) — these are for `Bash { background: true }`, not sub-agents.

## New field: `is_background: bool`

Plumbed through every layer:

```rust
pub struct ChildAgentReservation { ..., pub is_background: bool }
pub struct ChildTaskSnapshot     { ..., pub is_background: bool }
EngineEvent::ChildTaskUpdate     { ..., is_background: bool, ... }
struct ChildAgentEntry           { ..., is_background: bool, ... }
struct ChildStatusEmitter        { ..., is_background: bool, ... }
```

Today every constructor passes `true`. The field exists so PR-A can register fg sub-agents with `false` without touching any of these type signatures again.

## Wire-format preservation

`EngineEvent::ChildTaskUpdate` carries `#[serde(rename = "bg_task_update")]` so the JSON envelope tag stays `"type":"bg_task_update"`. Old payloads that lack `is_background` deserialize as `true` via the same `default_is_background_true` helper introduced in PR-A0.

The existing JSON round-trip test in `child_agent.rs` was extended to assert:
- The historical wire tag is preserved
- `is_background` round-trips
- Legacy payloads (no field) deserialize with `is_background == true`

## API breakage (internal-only — no external consumers)

Three callsite signatures changed:

```rust
// reserve(): added is_background
ChildAgentRegistry::reserve(parent_cancel, spawner, is_background)

// attach(): added is_background between spawner and parent_tool_call_id
ChildAgentRegistry::attach(id, name, prompt, rx, cancel, status_rx,
                            spawner, is_background, parent_tool_call_id, handle)

// ChildStatusEmitter::new(): added is_background between spawner and status_tx
ChildStatusEmitter::new(task_id, spawner, is_background, status_tx, registry)
```

Only **one production callsite each** (`sub_agent_dispatch.rs`); rest are test fixtures. All updated to pass `true` (legacy bg behavior).

## Test additions

- **`ChildTaskSnapshot::for_testing_fg`** — mirror of `for_testing` with `is_background=false`. PR-A's fg-overlay tests will use this without resurrecting brace-init bypass that `#[non_exhaustive]` forbids.
- **JSON round-trip assertion** for `is_background`.
- **`extract` test helper** in `child_agent.rs` returns 4-tuple including `is_background` so downstream pattern matches stay exhaustive (no `..` cheating).

## Verification

- ✅ `cargo build --workspace --tests`: clean
- ✅ `cargo test --workspace --lib`: **2,120 tests, 0 failures**
- ✅ `cargo test -p koda-core --test persisting_sink_test`: 10 passed
- ✅ `cargo test -p koda-core --test golden_test`: 2 passed (wire-format)
- ✅ `cargo clippy --workspace --lib --tests -- -D warnings`: clean
- ✅ `cargo fmt --all`: clean

## Diff stats

`27 files changed, +407/-292` (~115 LoC net delta).

Mostly mechanical sed renames; the substantive additions are the `is_background` field and its three constructor parameter sites.

## Out of scope (lands in PR-A)

- Routing fg sub-agent activity through the registry + overlay
- Adding fg-registration to `tool_dispatch.rs`'s `execute_sub_agent` call
- Tightening `InvokeAgent.background` to required (#1232 §2)
- Filtering `/agents` to `is_background == true` (only matters once fg entries exist)

## Sequencing

This PR depends on **#1233 (PR-A0)** which is merged. Branch is based on current `main`.

PR-A0.5 of #1232 §1 — paves the runway for PR-A to register fg sub-agents and route their activity through the existing overlay.
