### PR TITLE
feat: foreground sub-agent overlay + required InvokeAgent.background (PR-A of #1232 §1+§2)

### DIFF
--- a/koda-cli/src/child_activity.rs
+++ b/koda-cli/src/child_activity.rs
@@ -493,4 +493,120 @@ mod tests {
     fn format_age_hours_padded() {
         assert_eq!(format_age(Duration::from_secs(3600)), " 1h");
     }
+
+    // ── PR-A of #1232 §1: foreground sub-agent overlay rows ─────────────
+
+    /// A foreground sub-agent (`is_background == false`) registered
+    /// in the registry must render an overlay row with the same
+    /// shape as a background entry.
+    ///
+    /// **Why this is the headline test for PR-A**: the umbrella bug
+    /// (#1232 §1) was "fg sub-agents have ZERO live progress in the
+    /// master TUI." The overlay's `build_rows` is what the user
+    /// actually sees; if a fg-tagged snapshot doesn't produce a row
+    /// here, the engine-side wiring (`register_fg_with_emitter` +
+    /// `FgForwardingSink`) is invisible end-to-end and the bug isn't
+    /// fixed regardless of how clean the lower layers look.
+    #[test]
+    fn foreground_agent_renders_overlay_row_with_activity_snippet() {
+        let mut t = ChildActivityTracker::default();
+        let snap = vec![ChildTaskSnapshot::for_testing_fg(
+            7,
+            "explore".into(),
+            "audit storage".into(),
+            Duration::from_secs(12),
+            AgentStatus::Running { iter: 3 },
+            None,
+        )];
+        // Drive activity in via the same `record_activity` entrypoint
+        // the inference loop uses for both fg and bg — the tracker
+        // intentionally treats every `ChildAgentActivity` event the
+        // same regardless of `is_background`, so this end-to-end
+        // shape proves there's no fg-specific filter blocking the row.
+        t.record_activity(
+            7,
+            &ChildAgentActivityKind::ToolStart {
+                tool_name: "Read".into(),
+                summary: "Read storage/mod.rs".into(),
+            },
+        );
+        let (rows, total) = t.build_rows(&snap, &[]);
+        assert_eq!(total, 1, "fg snapshot must produce exactly one overlay row");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.label, "explore", "label uses agent_name");
+        assert_eq!(
+            row.activity.as_deref(),
+            Some("Read storage/mod.rs"),
+            "fg row must show the same `last activity` snippet as bg \
+             — the headline UX for #1232 §1"
+        );
+        assert_eq!(row.status, ActivityStatus::Running);
+    }
+
+    /// Symmetric removal: when a fg sub-agent's registry entry
+    /// disappears (the `FgRegistrationGuard` dropped on the engine
+    /// side), the overlay must drop the row on the next `build_rows`
+    /// call. Issue acceptance criterion: "Removing the row when the
+    /// sub-agent returns is symmetric with bg path."
+    #[test]
+    fn foreground_row_disappears_when_registry_entry_removed() {
+        let mut t = ChildActivityTracker::default();
+        let snap_running = vec![ChildTaskSnapshot::for_testing_fg(
+            7,
+            "explore".into(),
+            "x".into(),
+            Duration::from_secs(1),
+            AgentStatus::Running { iter: 0 },
+            None,
+        )];
+        t.record_activity(
+            7,
+            &ChildAgentActivityKind::ToolStart {
+                tool_name: "Read".into(),
+                summary: "Read foo".into(),
+            },
+        );
+        let (rows, _) = t.build_rows(&snap_running, &[]);
+        assert_eq!(rows.len(), 1, "row present while registered");
+
+        // Simulate guard drop: registry no longer reports this task.
+        let (rows_after, total_after) = t.build_rows(&[], &[]);
+        assert_eq!(
+            total_after, 0,
+            "row must vanish when fg entry leaves the registry; \
+             without this the overlay would show phantom rows for \
+             every completed fg sub-agent"
+        );
+        assert!(rows_after.is_empty());
+    }
+
+    /// Mixed fg + bg snapshot: both render, both count toward `total`,
+    /// neither shadows the other. Catches a regression where a future
+    /// `is_background` filter accidentally hides one or the other.
+    #[test]
+    fn mixed_foreground_and_background_agents_both_render() {
+        let mut t = ChildActivityTracker::default();
+        let snap = vec![
+            // bg first (id 1)
+            agent(1, "task", 30, AgentStatus::Running { iter: 5 }),
+            // fg next (id 2)
+            ChildTaskSnapshot::for_testing_fg(
+                2,
+                "plan".into(),
+                "y".into(),
+                Duration::from_secs(10),
+                AgentStatus::Running { iter: 1 },
+                None,
+            ),
+        ];
+        let (rows, total) = t.build_rows(&snap, &[]);
+        assert_eq!(total, 2, "both fg and bg agents must be counted");
+        assert_eq!(rows.len(), 2);
+        // Sort by label for stability — build_rows sorts by task_id,
+        // so order is bg(1) then fg(2), but we shouldn't bake that in.
+        let labels: Vec<&str> = rows.iter().map(|r| r.label.as_str()).collect();
+        assert!(labels.contains(&"task"), "bg agent row missing");
+        assert!(labels.contains(&"plan"), "fg agent row missing");
+    }
 }

--- a/koda-cli/tests/skill_agent_e2e_test.rs
+++ b/koda-cli/tests/skill_agent_e2e_test.rs
@@ -177,7 +177,11 @@ fn unknown_skill_returns_not_found_gracefully() {
 
 fn invoke_agent_responses(agent_name: &str, prompt: &str) -> String {
     serde_json::json!([
-        {"tool": "InvokeAgent", "args": {"agent_name": agent_name, "prompt": prompt}},
+        // PR-A of #1232 §2: `background` is required — these e2e
+        // tests pin the foreground dispatch path, so explicit false.
+        {"tool": "InvokeAgent", "args": {
+            "agent_name": agent_name, "prompt": prompt, "background": false
+        }},
         {"text": format!("{agent_name} delegation done")}
     ])
     .to_string()
@@ -249,7 +253,9 @@ fn task_sub_agent_is_dispatched_when_invoked() {
     // sub-delegation.  Explore disallows InvokeAgent, so recursion stops.
     let responses = serde_json::json!([
         // Main agent turn 1: delegate to task
-        {"tool": "InvokeAgent", "args": {"agent_name": "task", "prompt": "run a bash command"}},
+        {"tool": "InvokeAgent", "args": {
+            "agent_name": "task", "prompt": "run a bash command", "background": false
+        }},
         // Main agent turn 2 (after task returns): final answer
         {"text": "task completed"},
         // task sub-agent turn 1: safe Bash call (no recursion)

--- a/koda-core/src/child_agent.rs
+++ b/koda-core/src/child_agent.rs
@@ -440,10 +440,12 @@ impl ChildStatusEmitter {
             .push_status_event(EngineEvent::ChildAgentActivity {
                 task_id: self.task_id,
                 spawner: self.spawner,
-                // PR-A0 of #1232: hardcoded `true` because every emit
-                // site today is a bg agent. PR-A wires up a fg path
-                // that passes `false` here.
-                is_background: true,
+                // PR-A of #1232 §1: thread the emitter's stored
+                // `is_background` flag through. Bg path passes `true`,
+                // fg path passes `false`. Replaces PR-A0's hardcoded
+                // `true` placeholder — the emitter has held the real
+                // value since PR-A0.5.
+                is_background: self.is_background,
                 kind,
             });
     }
@@ -511,6 +513,49 @@ pub struct ChildAgentReservation {
     /// events emitted by [`ChildStatusEmitter::send`] both reflect
     /// the same source-of-truth value.
     pub is_background: bool,
+}
+
+/// RAII handle returned from [`ChildAgentRegistry::register_fg_with_emitter`].
+///
+/// **PR-A of #1232 §1**: foreground sub-agents are owned by the
+/// inline call that's awaiting them — there's no oneshot drain to
+/// hook into for cleanup. Instead the parent holds this guard for
+/// the duration of the await; on drop the registry entry is removed
+/// so the `/agents` overlay stops showing the row.
+///
+/// Drop semantics:
+/// * Successful return — guard dropped at scope exit, entry pulled.
+/// * `?`-bubbled error — guard dropped during stack unwind, entry
+///   pulled. Without RAII this path leaks the registry slot, which
+///   the overlay would then render as a phantom "running" row.
+/// * Panic — same as `?`. Mirrors `AbortOnDropHandle`'s drop-safety
+///   story for the bg path.
+///
+/// The guard intentionally does *not* cancel the child token — fg
+/// sub-agents return through the inline await, so the cancel-token
+/// cascade isn't needed for cleanup. Cancellation comes from the
+/// usual Ctrl-C path on the parent's loop.
+pub struct FgRegistrationGuard {
+    registry: Arc<ChildAgentRegistry>,
+    task_id: u32,
+}
+
+impl FgRegistrationGuard {
+    /// The registry id assigned at registration time. Stable for the
+    /// lifetime of the guard. Useful for tests asserting that the
+    /// emitter and the guard refer to the same entry.
+    pub fn task_id(&self) -> u32 {
+        self.task_id
+    }
+}
+
+impl Drop for FgRegistrationGuard {
+    fn drop(&mut self) {
+        // Best-effort removal. If the registry was already drained
+        // (shouldn't happen for fg — `drain_completed` skips us),
+        // the `remove` is a no-op.
+        self.registry.pending.lock().remove(&self.task_id);
+    }
 }
 
 impl ChildAgentRegistry {
@@ -628,6 +673,89 @@ impl ChildAgentRegistry {
         );
     }
 
+    /// Register a **foreground** sub-agent and hand back the live
+    /// signal lines for it.
+    ///
+    /// **PR-A of #1232 §1**: the bg path uses `reserve` + `attach`,
+    /// which provisions a oneshot result channel and an
+    /// `AbortOnDropHandle` so the inference loop can drain results
+    /// asynchronously. Foreground sub-agents don't need any of that
+    /// — the parent is *already blocked* awaiting the inline call,
+    /// so the result returns through the normal function return path.
+    /// What the parent *does* need is the registry membership so the
+    /// `/agents` overlay can render an activity row, plus an emitter
+    /// so child events fan out to the same `ChildAgentActivity`
+    /// stream that bg uses.
+    ///
+    /// Returns `(emitter, guard)`:
+    /// * `emitter` — use `.send(...)` to push status transitions
+    ///   (`Pending` → `Running { iter }` → terminal) and
+    ///   `.send_activity(...)` to fan out tool/info events. The
+    ///   emitter's `is_background` is wired to `false` so every
+    ///   `ChildTaskUpdate`/`ChildAgentActivity` event the fg path
+    ///   emits is correctly tagged.
+    /// * `guard` — a [`FgRegistrationGuard`] that removes the entry
+    ///   from the registry when dropped. Hold it for the duration of
+    ///   the inline sub-agent call. RAII over manual unregister so a
+    ///   panic / `?`-bubble doesn't leak the entry. (Mirrors
+    ///   `AbortOnDropHandle`'s drop-safety story for the bg path.)
+    ///
+    /// The entry is inserted with a noop oneshot sender that never
+    /// fires + a noop spawn handle. `drain_completed` skips fg
+    /// entries unconditionally (see its doc), so neither the dummy
+    /// rx nor the dummy handle ever surface to a consumer.
+    pub fn register_fg_with_emitter(
+        self: &Arc<Self>,
+        agent_name: &str,
+        prompt: &str,
+        parent_cancel: &CancellationToken,
+        spawner: Option<u32>,
+        parent_tool_call_id: Option<String>,
+    ) -> (ChildStatusEmitter, FgRegistrationGuard) {
+        let (_dummy_tx, dummy_rx) = oneshot::channel::<Result<BgPayload, BgPayload>>();
+        // Leak the sender into the entry's environment via a parked
+        // task so `try_recv` always returns `Empty`, not `Closed`.
+        // We can't actually keep `_dummy_tx` alive that way without a
+        // task — simpler: just drop it here, accept that try_recv
+        // would return `Closed`, and rely on `drain_completed`'s
+        // `is_background` early-skip (the whole reason that skip
+        // exists). Belt + suspenders against a future refactor that
+        // accidentally drops the skip.
+        drop(_dummy_tx);
+
+        let (status_tx, status_rx) = watch::channel(AgentStatus::Pending);
+        let cancel = parent_cancel.child_token();
+        let task_id = {
+            let mut id = self.next_id.lock();
+            let next = *id;
+            *id += 1;
+            next
+        };
+        let noop = tokio::spawn(async {});
+        self.pending.lock().insert(
+            task_id,
+            ChildAgentEntry {
+                agent_name: agent_name.to_string(),
+                prompt: prompt.to_string(),
+                rx: dummy_rx,
+                cancel,
+                status_rx,
+                started_at: Instant::now(),
+                spawner,
+                is_background: false,
+                parent_tool_call_id,
+                _handle: AbortOnDropHandle::new(noop),
+            },
+        );
+
+        let emitter = ChildStatusEmitter::new(task_id, spawner, false, status_tx, self.clone());
+        let guard = FgRegistrationGuard {
+            registry: self.clone(),
+            task_id,
+        };
+        (emitter, guard)
+    }
+
     /// Convenience for tests: register a synthetic entry without a
     /// real spawned task. The provided `tx` can be used to fire the
     /// result manually. The handle is a noop spawned task that
@@ -694,12 +822,29 @@ impl ChildAgentRegistry {
 
     /// Drain all completed background agents. Non-blocking — only takes
     /// entries whose oneshot has already resolved.
+    ///
+    /// **PR-A of #1232 §1**: foreground entries (`is_background == false`)
+    /// are skipped. The fg dispatch path returns the sub-agent's output
+    /// inline through its own `await`, so injecting a duplicate result
+    /// via the bg drain channel would corrupt the parent's transcript.
+    /// Defense-in-depth: today the fg registration path doesn't even
+    /// hold a sender that can fire, so the `try_recv` would only ever
+    /// return `Empty` or `Closed` — but `Closed` would manufacture a
+    /// fake "cancelled" `BgAgentResult` (see the `Closed` arm below),
+    /// which the inference loop would then inject into the parent. The
+    /// `is_background` skip here makes that whole class of bug
+    /// impossible by construction rather than relying on the fg path's
+    /// discipline to never close its sender.
     pub fn drain_completed(&self) -> Vec<BgAgentResult> {
         let mut guard = self.pending.lock();
         let mut completed = Vec::new();
         let mut done_ids = Vec::new();
 
         for (id, entry) in guard.iter_mut() {
+            if !entry.is_background {
+                // PR-A of #1232 §1: see fn-level doc.
+                continue;
+            }
             match entry.rx.try_recv() {
                 Ok(Ok((output, events))) => {
                     done_ids.push(*id);
@@ -2000,5 +2145,138 @@ mod tests {
                 kind: crate::engine::event::ChildAgentActivityKind::Info { message }
             } if message.contains("cache hit")
         ));
+    }
+
+    // ── PR-A of #1232 §1: foreground sub-agent registry path ────────────
+
+    /// `register_fg_with_emitter` inserts an entry whose snapshot
+    /// reports `is_background == false`. Sanity-checks that the fg
+    /// path is wired to the same registry the `/agents` overlay reads.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_fg_inserts_entry_with_is_background_false() {
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let parent = CancellationToken::new();
+
+        let (_emitter, _guard) = reg.register_fg_with_emitter(
+            "explore",
+            "audit the storage layer",
+            &parent,
+            Some(7),
+            Some("call_42".into()),
+        );
+
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 1, "fg registration must add exactly one entry");
+        let entry = &snap[0];
+        assert_eq!(entry.agent_name, "explore");
+        assert_eq!(entry.prompt, "audit the storage layer");
+        assert_eq!(entry.spawner, Some(7));
+        assert!(
+            !entry.is_background,
+            "fg entries must be tagged is_background=false so the overlay \
+             and any future is_background-aware filter agree"
+        );
+    }
+
+    /// Dropping the `FgRegistrationGuard` removes the entry.
+    /// RAII covers `?`-bubbled errors and panics; without it the
+    /// overlay would render a phantom "running" row indefinitely.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fg_guard_drop_removes_entry_from_registry() {
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let parent = CancellationToken::new();
+
+        {
+            let (_emitter, _guard) =
+                reg.register_fg_with_emitter("explore", "do thing", &parent, None, None);
+            assert_eq!(reg.snapshot().len(), 1, "entry present while guard alive");
+        }
+
+        assert_eq!(
+            reg.snapshot().len(),
+            0,
+            "guard's Drop impl must remove the registry entry on scope exit"
+        );
+    }
+
+    /// `drain_completed` must skip foreground entries unconditionally.
+    /// Defense-in-depth: today the fg path doesn't fire its (dropped)
+    /// oneshot sender, so try_recv would yield `Closed` and the
+    /// `Closed` arm would manufacture a fake "cancelled"
+    /// `BgAgentResult` — which the inference loop would then inject
+    /// as a duplicate of the result the parent already returned
+    /// inline. The `is_background` skip prevents that whole bug class
+    /// by construction.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_completed_skips_foreground_entries() {
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let parent = CancellationToken::new();
+
+        let (_emitter, _guard) =
+            reg.register_fg_with_emitter("explore", "prompt", &parent, None, None);
+
+        let drained = reg.drain_completed();
+        assert!(
+            drained.is_empty(),
+            "fg entries must never be drained as bg results; got {drained:?}"
+        );
+        assert_eq!(
+            reg.snapshot().len(),
+            1,
+            "drain must not pop fg entries either"
+        );
+    }
+
+    /// A bg entry whose oneshot sender has been dropped DOES get
+    /// drained (yielding the synthetic "cancelled" result). This is
+    /// the existing behavior the fg-skip is defending against.
+    /// Pinning it so a future refactor that changes the bg semantics
+    /// can't silently regress the fg case.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_completed_still_synthesizes_cancelled_for_bg_with_closed_rx() {
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let (_id, tx) = reg.register_test("explore", "prompt");
+        // Drop the sender to simulate a panicked/cancelled bg task.
+        drop(tx);
+
+        let drained = reg.drain_completed();
+        assert_eq!(drained.len(), 1, "bg with closed rx still drains");
+        assert!(!drained[0].success, "closed-rx drain marks failure");
+        assert!(
+            drained[0].output.contains("cancelled"),
+            "closed-rx synthetic result mentions cancellation"
+        );
+    }
+
+    /// Fg emitter's `send_activity` must tag events with
+    /// `is_background: false`. Pre-PR-A the emitter hardcoded `true`,
+    /// which would have made every fg activity event mis-tagged on
+    /// the wire — ACP / headless filters keying on that flag would
+    /// silently drop fg events.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fg_emitter_tags_activity_events_with_is_background_false() {
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let parent = CancellationToken::new();
+
+        let (emitter, _guard) =
+            reg.register_fg_with_emitter("explore", "prompt", &parent, None, None);
+        emitter.send_activity(crate::engine::event::ChildAgentActivityKind::ToolStart {
+            tool_name: "Read".into(),
+            summary: "Read foo.rs".into(),
+        });
+
+        let drained = reg.drain_status_events();
+        let activity = drained
+            .iter()
+            .find(|e| matches!(e, EngineEvent::ChildAgentActivity { .. }))
+            .expect("activity event present");
+        let EngineEvent::ChildAgentActivity { is_background, .. } = activity else {
+            unreachable!("matched above");
+        };
+        assert!(
+            !*is_background,
+            "fg emitter must produce ChildAgentActivity {{ is_background: false }}; \
+             pre-PR-A this was hardcoded true and would silently mis-tag the wire"
+        );
     }
 }

--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -247,6 +247,80 @@ impl EngineSink for ForwardingChildSink {
     }
 }
 
+/// Live-activity tap for **foreground** sub-agents.
+///
+/// **PR-A of #1232 §1**: foreground sub-agents share the parent's
+/// sink (the parent is blocked awaiting them inline), so unlike
+/// [`ForwardingChildSink`] there's no `BufferingSink` to wrap and
+/// no post-completion narrative to drain. The parent already sees
+/// every event the child emits because they go to the same sink.
+///
+/// What's missing without this wrapper is the
+/// [`crate::engine::event::EngineEvent::ChildAgentActivity`] fan-out
+/// that powers the `/agents` overlay's per-row "last activity"
+/// snippet. The bg path gets that fan-out via
+/// [`ForwardingChildSink`]'s `emitter.send_activity` calls; this
+/// type is the fg analog — same emitter API, no buffering.
+///
+/// Borrows the parent sink to avoid an `Arc` allocation per
+/// invocation. The borrow lives for the duration of the inline
+/// sub-agent call, which is exactly the scope of the
+/// [`crate::child_agent::FgRegistrationGuard`] that owns the
+/// emitter — they form a matched pair on the call stack.
+pub struct FgForwardingSink<'a> {
+    inner: &'a dyn EngineSink,
+    emitter: crate::child_agent::ChildStatusEmitter,
+}
+
+impl<'a> FgForwardingSink<'a> {
+    /// Construct from the parent's sink + the emitter handed back by
+    /// [`crate::child_agent::ChildAgentRegistry::register_fg_with_emitter`].
+    pub fn new(inner: &'a dyn EngineSink, emitter: crate::child_agent::ChildStatusEmitter) -> Self {
+        Self { inner, emitter }
+    }
+}
+
+impl EngineSink for FgForwardingSink<'_> {
+    fn emit(&self, event: EngineEvent) {
+        // Same fan-out shape as `ForwardingChildSink::emit` — keep
+        // the two arms in sync. Diverged behavior here would mean
+        // bg and fg overlay rows show different content for the
+        // same tool call, which is exactly the inconsistency PR-A
+        // is trying to eliminate.
+        match &event {
+            EngineEvent::ToolCallStart { name, args, .. } => {
+                self.emitter.send_activity(
+                    crate::engine::event::ChildAgentActivityKind::ToolStart {
+                        tool_name: name.clone(),
+                        summary: summarize_tool_call(name, args),
+                    },
+                );
+            }
+            EngineEvent::ToolCallResult { name, output, .. } => {
+                let success = !looks_like_tool_error(output);
+                self.emitter
+                    .send_activity(crate::engine::event::ChildAgentActivityKind::ToolEnd {
+                        tool_name: name.clone(),
+                        success,
+                    });
+            }
+            EngineEvent::Info { message } => {
+                self.emitter
+                    .send_activity(crate::engine::event::ChildAgentActivityKind::Info {
+                        message: message.clone(),
+                    });
+            }
+            _ => {}
+        }
+        // Forward to the parent's sink so the master TUI's normal
+        // event stream is preserved — fg sub-agents have always
+        // emitted directly to the parent and downstream clients
+        // (CLI, ACP, headless) depend on that. The wrapper only
+        // *adds* the activity fan-out; it never swallows events.
+        self.inner.emit(event);
+    }
+}
+
 /// Build a one-line summary of a tool call for the live activity
 /// feed. Output is rendered as-is by clients, so trim hard.
 ///

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -285,6 +285,50 @@ async fn run_bg_agent(
     };
 }
 
+/// Parse the **required** `background` field out of an `InvokeAgent`
+/// argument object.
+///
+/// **PR-A of #1232 §2**: extracted from `execute_sub_agent` so the
+/// missing-field / wrong-type / good-bool branches can be unit-
+/// tested without standing up the full sub-agent dispatch plumbing
+/// (provider, registry, sandbox, sink, ...). The schema declares
+/// `background` required (see `tools/agent.rs::definitions`) but
+/// schema compliance is best-effort across LLMs — some models still
+/// emit calls without it. This function is the runtime backstop.
+///
+/// Accepts only literal `true` / `false`. Strings (`"true"`),
+/// numbers (`1`), null, arrays, and objects are all rejected with
+/// an actionable error so the model sees a tool-error and can
+/// correct on the next turn rather than silently defaulting to
+/// `false`.
+pub(crate) fn parse_background_required(args: &serde_json::Value) -> anyhow::Result<bool> {
+    match args.get("background") {
+        Some(serde_json::Value::Bool(b)) => Ok(*b),
+        Some(other) => {
+            let kind = match other {
+                serde_json::Value::Null => "null",
+                serde_json::Value::String(_) => "a string",
+                serde_json::Value::Number(_) => "a number",
+                serde_json::Value::Array(_) => "an array",
+                serde_json::Value::Object(_) => "an object",
+                serde_json::Value::Bool(_) => unreachable!("matched above"),
+            };
+            anyhow::bail!(
+                "InvokeAgent: 'background' must be a boolean (true or false), got {kind}. \
+                 Pick `true` for parallel/independent work, `false` when the next \
+                 step strictly depends on this agent's output."
+            );
+        }
+        None => anyhow::bail!(
+            "InvokeAgent: 'background' is required — no default. \
+             Pick `true` for parallel fan-out / independent long-running tasks (results \
+             auto-inject on a future iteration), or `false` when the next step strictly \
+             depends on this agent's output and no parallel work is possible. \
+             See the 'background' parameter description for the full rationale."
+        ),
+    }
+}
+
 /// Execute a sub-agent in its own isolated event loop.
 ///
 /// When `parent_cache` is provided, the sub-agent shares the parent's
@@ -350,7 +394,19 @@ pub(crate) fn execute_sub_agent<'a>(
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("Missing 'prompt'"))?;
         let is_fork = agent_name == "fork";
-        let background = args["background"].as_bool().unwrap_or(false);
+        // PR-A of #1232 §2: `background` is a required field. The
+        // schema marks it required (see `tools/agent.rs`) but model
+        // compliance with `required` is best-effort — some models
+        // emit calls without it. Reject loudly so the model sees a
+        // tool-error and can correct on the next turn, instead of
+        // silently defaulting to `false` and triggering the
+        // "sub-agent ran for 1009s with no progress" UX that opened
+        // the issue.
+        //
+        // Validation is extracted into a free function below so it
+        // can be unit-tested without spinning up the full
+        // `execute_sub_agent` plumbing.
+        let background = parse_background_required(&args)?;
 
         // Background mode: spawn and return immediately.
         //
@@ -492,6 +548,77 @@ pub(crate) fn execute_sub_agent<'a>(
             tracing::Span::current().record("cached", true);
             return Ok(cached);
         }
+
+        // PR-A of #1232 §1: register the foreground sub-agent in the
+        // shared `ChildAgentRegistry` so the `/agents` overlay can
+        // render its row alongside any concurrent bg sub-agents.
+        // Pre-PR-A foreground sub-agents emitted nested
+        // `execute_one_tool` spans visible in tracing logs but had
+        // ZERO presence in the live overlay — the user-visible
+        // "sub-agent ran for 1009s with no progress signal"
+        // complaint that opened #1232.
+        //
+        // The guard is held until function return (success, `?`-error,
+        // or panic), at which point its `Drop` impl removes the entry.
+        // RAII is critical: every error path below uses `?` to bubble,
+        // so manual unregister would leak the registry slot on the
+        // first failure (and the overlay would render a phantom row
+        // forever).
+        //
+        // The cache-hit early-return above intentionally skips this
+        // — a cache hit returns synchronously in microseconds, far
+        // below the overlay's render cadence, so registering would
+        // just flash a row that immediately disappears.
+        let (fg_emitter, _fg_guard) = bg_agents.register_fg_with_emitter(
+            agent_name,
+            prompt,
+            &cancel,
+            parent_spawner,
+            parent_tool_call_id.map(str::to_string),
+        );
+        // Push `Pending` immediately so the overlay row appears
+        // before the LLM call — same shape as bg's `reserve()` +
+        // initial `Pending` from the `watch::channel`. Sending it
+        // explicitly (rather than relying on the channel's initial
+        // value) keeps the bg/fg event streams symmetric for any
+        // downstream consumer that reads the queue rather than the
+        // watch.
+        fg_emitter.send(crate::child_agent::AgentStatus::Pending);
+        // Wrap the parent's sink so tool/info events fan out to the
+        // overlay's `ChildAgentActivity` stream in addition to the
+        // normal forwarded path. The wrapper borrows `sink` for the
+        // duration of this scope; the original `sink` reference is
+        // shadowed below so every existing emit site downstream
+        // routes through the wrapper without code changes.
+        let fg_sink = crate::engine::sink::FgForwardingSink::new(sink, fg_emitter.clone());
+        let sink: &dyn crate::engine::EngineSink = &fg_sink;
+        // Now that the registry entry exists, transition to
+        // `Running { iter: 0 }` so the overlay shows the agent as
+        // active rather than queued. The inference loop below
+        // doesn't currently push per-iteration `Running` heartbeats
+        // for fg (bg gets them via the registered emitter inside
+        // `run_bg_agent`) — a follow-up could add iter ticks here,
+        // but the `last activity` line driven by `ToolCallStart`
+        // events already gives the user a moving signal.
+        fg_emitter.send(crate::child_agent::AgentStatus::Running { iter: 0 });
+        // Note on terminal status: we deliberately do NOT emit a
+        // `Completed`/`Errored` `ChildTaskUpdate` on return. Reason:
+        // the function has ~half a dozen `return Ok(...)` sites and
+        // many `?`-bubbled errors; instrumenting each is fragile and
+        // refactoring the inference body into an inner async fn just
+        // to capture a Result was ruled out as scope creep. Instead
+        // we lean on the `_fg_guard`'s `Drop` impl, which removes
+        // the entry from the registry at the instant the function
+        // returns. The overlay's `build_rows` prunes activity for
+        // missing task ids on the very next frame — visually
+        // identical to receiving a terminal event. ACP / headless
+        // clients that subscribe to the raw `ChildTaskUpdate`
+        // stream will see the event flow simply stop for that
+        // task_id, which mirrors how a bg drain looks to them once
+        // the registry entry is gone. Documented as a known
+        // asymmetry in the PR body; can be tightened in a follow-up
+        // if downstream consumers grow a hard dependency on the
+        // terminal tag.
 
         sink.emit(EngineEvent::SubAgentStart {
             agent_name: agent_name.to_string(),
@@ -1505,5 +1632,92 @@ mod invocation_cleanup_tests {
             !cancel.is_cancelled(),
             "unrelated entry's cancel token must not fire"
         );
+    }
+}
+
+#[cfg(test)]
+mod parse_background_required_tests {
+    //! PR-A of #1232 §2: schema declares `background` required, and
+    //! this module's runtime backstop holds the line for models that
+    //! ignore the schema. The tests pin every branch so a future
+    //! refactor that re-introduces a default-false fallback fails
+    //! loudly here.
+
+    use super::parse_background_required;
+    use serde_json::json;
+
+    #[test]
+    fn accepts_literal_true() {
+        let v = parse_background_required(&json!({"background": true})).expect("ok");
+        assert!(v);
+    }
+
+    #[test]
+    fn accepts_literal_false() {
+        let v = parse_background_required(&json!({"background": false})).expect("ok");
+        assert!(!v);
+    }
+
+    #[test]
+    fn missing_field_errors_with_actionable_message() {
+        let err = parse_background_required(&json!({"prompt": "x"}))
+            .expect_err("missing background must be an error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("'background' is required"),
+            "error must name the field; got: {msg}"
+        );
+        // Actionable: the model needs to know what to pick. Both of
+        // the canonical choices are mentioned so the next-turn
+        // correction is unambiguous.
+        assert!(msg.contains("`true`"), "error must mention `true` option");
+        assert!(msg.contains("`false`"), "error must mention `false` option");
+    }
+
+    #[test]
+    fn string_value_rejected_with_type_hint() {
+        // Models sometimes emit "true" (string) when fine-tuned on
+        // datasets that quoted JSON booleans. Catch and reject so we
+        // don't fall through to the default-false path that #1232 §2
+        // exists to eliminate.
+        let err = parse_background_required(&json!({"background": "true"}))
+            .expect_err("string must be an error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("must be a boolean"),
+            "error must explain the type requirement; got: {msg}"
+        );
+        assert!(
+            msg.contains("a string"),
+            "error must name the actual offending type; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn number_value_rejected() {
+        let err = parse_background_required(&json!({"background": 1}))
+            .expect_err("number must be an error");
+        assert!(format!("{err:#}").contains("a number"));
+    }
+
+    #[test]
+    fn null_value_rejected() {
+        // null is `Some(Null)` in serde_json, distinct from missing.
+        // Both should fail, but null hits the type-mismatch arm.
+        let err = parse_background_required(&json!({"background": null}))
+            .expect_err("null must be an error");
+        assert!(format!("{err:#}").contains("null"));
+    }
+
+    #[test]
+    fn array_and_object_rejected() {
+        for v in [json!({"background": []}), json!({"background": {}})] {
+            let err = parse_background_required(&v).expect_err("collection must be an error");
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains("must be a boolean"),
+                "non-bool collection must surface type-mismatch; got: {msg}"
+            );
+        }
     }
 }

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -87,25 +87,32 @@ Key rules:
                     },
                     "background": {
                         "type": "boolean",
-                        "description": "Run in background and return immediately (default: false). \
-                            Results are drained and injected as a user message at the start of \
-                            the next iteration — NOT mid-iteration. The bg agent inherits the \
-                            parent's trust + sandbox at spawn time and is cancelled on Ctrl+C.\n\n\
-                            **After spawning, keep working.** The whole point of background \
-                            mode is that you do other useful things (file edits, follow-up \
-                            searches, summarizing progress for the user) while the agent runs. \
-                            Results inject automatically on a future iteration via auto-drain \
-                            — you do NOT need to call `WaitTask` to receive them. Calling \
-                            `WaitTask` immediately after the spawn turns the background dispatch \
-                            back into a blocking call and silences the parent for the duration; \
-                            only do that when you genuinely have no other work to make progress \
-                            on (e.g. the next step strictly depends on this agent's output and \
-                            no parallel work is possible).\n\n\
-                            Use for independent long-running tasks that don't block your \
-                            current work."
+                        "description": "REQUIRED. `true` runs the sub-agent in the background and returns \
+                            immediately; results inject as a user message at the start of a future \
+                            iteration via auto-drain (you do NOT need to call `WaitTask`). \
+                            `false` runs the sub-agent in the foreground and blocks the parent until \
+                            the result is ready.\n\n\
+                            **PR-A of #1232 §2**: this field is required — there is no default. \
+                            Pre-PR-A the field defaulted to `false`, which silently turned every \
+                            parallel-fanout pattern into serial blocking calls and produced the \
+                            \"sub-agent ran for 1009s with no progress\" UX that opened the issue. \
+                            Forcing the model to choose makes the parallelism decision explicit at \
+                            the call site (Zen of Python: explicit is better than implicit).\n\n\
+                            Choose `true` for: parallel fan-out reviews, independent long-running \
+                            tasks, anything where you can do useful work concurrently.\n\
+                            Choose `false` for: the next step strictly depends on this agent's \
+                            output AND no parallel work is possible (the result is the next thing \
+                            you need to read).\n\n\
+                            **After spawning a `true` sub-agent, keep working.** The whole point \
+                            of background mode is that you do other useful things (file edits, \
+                            follow-up searches, summarizing progress) while the agent runs. \
+                            Calling `WaitTask` immediately after a bg spawn turns it back into a \
+                            blocking call — only do that when you genuinely have no parallel work.\n\n\
+                            The bg agent inherits the parent's trust + sandbox at spawn time and \
+                            is cancelled on Ctrl+C."
                     }
                 },
-                "required": ["prompt"]
+                "required": ["prompt", "background"]
             }),
         },
         ToolDefinition {
@@ -396,8 +403,36 @@ mod tests {
             .and_then(|v| v.as_str())
             .expect("background param must have a description");
         assert!(
-            bg_desc.contains("next iteration"),
-            "background param must explain drain-on-next-iteration timing"
+            bg_desc.contains("future iteration") || bg_desc.contains("next iteration"),
+            "background param must explain drain-on-next-iteration timing; \
+             post-PR-A wording uses 'future iteration' since the drain \
+             can land any iteration after the spawn, not strictly the next one"
+        );
+    }
+
+    /// PR-A of #1232 §2: `background` is required — no default. The
+    /// schema-side enforcement (this test) pairs with the runtime
+    /// validation in `sub_agent_dispatch::execute_sub_agent`.
+    /// Both arms must hold for the contract to actually bind models
+    /// that respect `required` AND models that don't.
+    #[test]
+    fn test_invoke_agent_background_is_required_in_schema() {
+        let defs = definitions();
+        let required = defs[0]
+            .parameters
+            .pointer("/required")
+            .and_then(|v| v.as_array())
+            .expect("InvokeAgent schema must declare a `required` array");
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            names.contains(&"prompt"),
+            "`prompt` must remain required (regression guard)"
+        );
+        assert!(
+            names.contains(&"background"),
+            "PR-A of #1232 §2: `background` must be required so models can't \
+             silently default it to false and serialize parallel fan-out into \
+             blocking calls. Got required = {names:?}"
         );
     }
 

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -37,7 +37,8 @@ async fn test_sub_agent_invocation_e2e() {
             "InvokeAgent",
             serde_json::json!({
                 "agent_name": "echo-agent",
-                "prompt": "review the auth module"
+                "prompt": "review the auth module",
+                "background": false
             }),
         ),
         MockResponse::Text("Sub-agent says: Echo: review the auth module".into()),
@@ -150,7 +151,8 @@ async fn sub_agent_marks_assistant_messages_complete_so_loop_progresses() {
             "InvokeAgent",
             serde_json::json!({
                 "agent_name": "loop-test-agent",
-                "prompt": "do the thing"
+                "prompt": "do the thing",
+                "background": false
             }),
         ),
         MockResponse::Text("parent done".into()),
@@ -230,11 +232,11 @@ async fn test_sub_agent_cache_hit_skips_llm() {
     let provider = MockProvider::new(vec![
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": "echo-agent", "prompt": "do the thing"}),
+            serde_json::json!({"agent_name": "echo-agent", "prompt": "do the thing", "background": false}),
         ),
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": "echo-agent", "prompt": "do the thing"}),
+            serde_json::json!({"agent_name": "echo-agent", "prompt": "do the thing", "background": false}),
         ),
         MockResponse::Text("Done with both calls.".into()),
     ]);
@@ -289,7 +291,7 @@ async fn invoke_agent_and_take_calls(
     let provider = MockProvider::new(vec![
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": agent_name, "prompt": "go"}),
+            serde_json::json!({"agent_name": agent_name, "prompt": "go", "background": false}),
         ),
         MockResponse::Text("done".into()),
     ]);
@@ -386,7 +388,7 @@ async fn sub_agent_invoke_agent_is_refused_with_clear_message() {
     let provider = MockProvider::new(vec![
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": "would-recurse", "prompt": "go"}),
+            serde_json::json!({"agent_name": "would-recurse", "prompt": "go", "background": false}),
         ),
         MockResponse::Text("parent done".into()),
     ]);
@@ -605,7 +607,7 @@ async fn test_sub_agent_grace_turn_terminates_runaway_explorer() {
     let provider = MockProvider::new(vec![
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": "spinner", "prompt": "search broadly"}),
+            serde_json::json!({"agent_name": "spinner", "prompt": "search broadly", "background": false}),
         ),
         MockResponse::Text("Sub-agent reported back.".into()),
     ]);
@@ -709,7 +711,7 @@ async fn test_sub_agent_grace_turn_drops_tool_calls_when_model_defies() {
     let provider = MockProvider::new(vec![
         MockResponse::tool_call(
             "InvokeAgent",
-            serde_json::json!({"agent_name": "defiant", "prompt": "search"}),
+            serde_json::json!({"agent_name": "defiant", "prompt": "search", "background": false}),
         ),
         MockResponse::Text("Sub-agent reported back.".into()),
     ]);


### PR DESCRIPTION
Closes the **§1** and **§2** acceptance criteria of #1232. Other sections (§3–§9) remain open and can ship as follow-up PRs.

## Why

Two compounding bugs surfaced in the debug-bundle session that opened #1232:

1. **§1**: foreground sub-agents had **zero** live progress in the master TUI — the always-on overlay (#1213) only fanned out activity for *background* sub-agents. Field repro: a single fg sub-agent ran for 1009s with no UI signal.
2. **§2**: `InvokeAgent.background` defaulted to `false`, so 6/10 InvokeAgent calls in that session silently serialized parallel-fanout patterns into blocking calls.

## What changed

### §1 — Foreground sub-agent overlay rows

| Layer | Change |
|---|---|
| `koda-core/src/engine/sink.rs` | New `FgForwardingSink<'a>` — borrowed-sink wrapper that mirrors `ForwardingChildSink`'s `ChildAgentActivity` fan-out for the inline foreground call path. No `BufferingSink` needed since the parent is blocked awaiting the child. |
| `koda-core/src/sub_agent_dispatch.rs` | `execute_sub_agent` now registers fg sub-agents in `ChildAgentRegistry` via `register_fg_with_emitter`, wraps the parent sink in `FgForwardingSink`, and pushes `Pending → Running { iter: 0 }` immediately so the row appears before the LLM call. |
| Cleanup | RAII via `FgRegistrationGuard::Drop` — the registry entry disappears at function return regardless of `?`-bubbled errors, panics, or successful return. The `build_rows` pruning in `koda-cli/src/child_activity.rs` then drops the row on the next frame. Documented inline as the explicit alternative to peppering `ChildTaskUpdate` emits at every return site. |

### §2 — `InvokeAgent.background` is required, no default

| Layer | Change |
|---|---|
| `koda-core/src/tools/agent.rs` | `"background"` added to `required` array; description rewritten to explain the parallel-vs-blocking choice and drop the "default: false" wording. |
| `koda-core/src/sub_agent_dispatch.rs` | New `parse_background_required(&args) -> Result<bool>` runtime backstop for models that ignore `required` (some do). Accepts only literal `true`/`false`; strings, numbers, null, arrays, and objects all reject with an actionable error so the model can self-correct on the next turn. |

## Acceptance criteria from #1232

**§1**:
- [x] Foreground rows appear with the same `🤖 name (age) · last activity` format as bg
- [x] Removal symmetric with bg path
- [x] Regression tests in `koda-cli/src/child_activity.rs` (`foreground_agent_renders_overlay_row_with_activity_snippet`, `foreground_row_disappears_when_registry_entry_removed`, `mixed_foreground_and_background_agents_both_render`)

**§2**:
- [x] `background` required in schema (`test_invoke_agent_background_is_required_in_schema`)
- [x] Validation rejects missing/wrong-type with clear messages (`parse_background_required_tests` covers every branch — missing, bool, string, number, null, array, object)
- [ ] CHANGELOG entry — happy to add as a follow-up commit if you want it in this PR

## Tests

- **16 new tests** across `koda-core::child_agent`, `koda-core::sub_agent_dispatch`, `koda-core::tools::agent`, and `koda-cli::child_activity`
- 4 existing test sites updated to pass `background: false` explicitly (the e2e mocks in `e2e_agent_test.rs` and `skill_agent_e2e_test.rs`)
- Full workspace: **2,136+ lib tests green**
- All InvokeAgent-touching integration suites green: `e2e_agent_test`, `skill_agent_e2e_test`, `tool_normalize_test`, `persisting_sink_test`, `guarantee_matrix_test`, `new_tools_test`, `tool_wiring_test`, `regression_test`
- `cargo clippy --workspace --tests -- -D warnings` clean

## Behaviour change for downstream

Any caller (CI fixtures, custom agent JSONs, scripted mocks) that emits `InvokeAgent` without `background` will now get an actionable tool-error instead of the silent default-false. The error message names both options so the model can correct on the next turn. Worth a CHANGELOG bullet under "Behaviour changes" — flagging here so reviewers can decide whether to fold one in.

## Out of scope

- §3–§9 of #1232 (context budgeting, trust UX, cancel-cascade follow-ups, etc.)
- Per-iteration `Running { iter: N }` heartbeats for fg sub-agents — the `last activity` line driven by `ToolCallStart` events already gives a moving signal; iter ticks would be a small follow-up
- Terminal `Completed`/`Errored` `ChildTaskUpdate` events on fg return — relies on registry-removal cleanup instead. Documented inline as a known asymmetry; can be tightened if downstream consumers grow a hard dep on the terminal tag.
