### PR TITLE
feat: pre-flight context-budget check for sub-agent dispatch (#1232 §3a)

### DIFF
--- a/koda-core/src/inference_helpers.rs
+++ b/koda-core/src/inference_helpers.rs
@@ -65,6 +65,103 @@ pub fn estimate_tokens(messages: &[ChatMessage]) -> usize {
         .sum()
 }
 
+/// Pre-flight context-budget breakdown for a single sub-agent invocation.
+///
+/// **#1232 §3a**: prior to this check, sub-agent dispatch could fire an
+/// LLM call that the model rejected with a raw `400 "Context size has been
+/// exceeded"` from upstream — leaving the user with no actionable hint.
+/// This pre-flight estimate runs *before* the first provider call and lets
+/// the dispatcher bail with a useful breakdown instead.
+///
+/// Token counts are heuristic estimates using the same `chars / 3.5 + overhead`
+/// model the live token gauge uses (see [`estimate_tokens`]); calibrated to
+/// over-estimate slightly, which is the safe direction for a pre-flight gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreflightTokenBudget {
+    /// Estimated tokens for the rendered system prompt.
+    pub system_prompt_tokens: usize,
+    /// Estimated tokens for the serialized tool definitions array.
+    pub tool_defs_tokens: usize,
+    /// Estimated tokens for the user-supplied prompt (the body of the
+    /// `InvokeAgent` call).
+    pub user_prompt_tokens: usize,
+    /// `system + tools + user`. Rough lower bound on what the first turn
+    /// will send to the provider.
+    pub total_tokens: usize,
+    /// `max_context_tokens` from the sub-agent's resolved config.
+    pub limit_tokens: usize,
+}
+
+impl PreflightTokenBudget {
+    /// Whether the estimated total exceeds the configured budget.
+    pub fn is_over_budget(&self) -> bool {
+        self.total_tokens > self.limit_tokens
+    }
+
+    /// Render the breakdown as a single-line, human-readable summary
+    /// suitable for both error messages and debug logging. Numbers are
+    /// rounded to 0.1k for readability — the underlying estimates are
+    /// heuristic, so additional precision would be false confidence.
+    pub fn summary(&self) -> String {
+        format!(
+            "system={}k + tools={}k + prompt={}k = {}k / limit {}k",
+            (self.system_prompt_tokens as f64 / 1000.0).round() as usize,
+            (self.tool_defs_tokens as f64 / 1000.0).round() as usize,
+            (self.user_prompt_tokens as f64 / 1000.0).round() as usize,
+            (self.total_tokens as f64 / 1000.0).round() as usize,
+            (self.limit_tokens as f64 / 1000.0).round() as usize,
+        )
+    }
+}
+
+/// Estimate the first-turn token cost of dispatching a sub-agent before
+/// the LLM call is made.
+///
+/// Inputs mirror what `sub_agent_dispatch::execute_sub_agent` already has
+/// in scope:
+///   * `system_prompt` — the result of `build_system_prompt(...)`.
+///   * `tool_defs` — the filtered tool list from `tools.get_definitions(...)`.
+///   * `user_prompt` — the `prompt` argument from the `InvokeAgent` call.
+///   * `limit_tokens` — `sub_config.max_context_tokens`.
+///
+/// The breakdown intentionally does NOT account for the (empty) initial
+/// transcript, persisted history (sub-agents start fresh), or the response
+/// budget. The goal is a fast, conservative pre-flight signal — not a
+/// perfect simulation of the wire payload.
+pub fn estimate_subagent_preflight(
+    system_prompt: &str,
+    tool_defs: &[crate::providers::ToolDefinition],
+    user_prompt: &str,
+    limit_tokens: usize,
+) -> PreflightTokenBudget {
+    let system_prompt_tokens = (system_prompt.len() as f64 / CHARS_PER_TOKEN) as usize
+        + PER_MESSAGE_OVERHEAD
+        + SYSTEM_PROMPT_OVERHEAD;
+
+    // Tool defs travel as JSON; the serialized form is the wire-cost proxy.
+    // serde_json::to_string failures are vanishingly unlikely for our owned
+    // types, but treat any failure as zero rather than panicking — a
+    // pre-flight that crashes is strictly worse than a pre-flight that
+    // under-estimates by a few k tokens.
+    let tool_defs_chars = serde_json::to_string(tool_defs)
+        .map(|s| s.len())
+        .unwrap_or(0);
+    let tool_defs_tokens = (tool_defs_chars as f64 / CHARS_PER_TOKEN) as usize;
+
+    let user_prompt_tokens =
+        (user_prompt.len() as f64 / CHARS_PER_TOKEN) as usize + PER_MESSAGE_OVERHEAD;
+
+    let total_tokens = system_prompt_tokens + tool_defs_tokens + user_prompt_tokens;
+
+    PreflightTokenBudget {
+        system_prompt_tokens,
+        tool_defs_tokens,
+        user_prompt_tokens,
+        total_tokens,
+        limit_tokens,
+    }
+}
+
 /// Synthetic assistant message injected between consecutive user-side messages.
 ///
 /// Inserted in-memory by [`assemble_messages`] — never written to the DB.
@@ -549,7 +646,116 @@ mod tests {
         assert!(tokens > 20 && tokens < 40, "tokens={tokens}");
     }
 
-    // ── is_server_error ──────────────────────────────────────────────
+    // ── estimate_subagent_preflight (#1232 §3a) ─────────────────────
+
+    fn fake_tool_def(name: &str, desc: &str) -> crate::providers::ToolDefinition {
+        crate::providers::ToolDefinition {
+            name: name.to_string(),
+            description: desc.to_string(),
+            parameters: serde_json::json!({"type": "object", "properties": {}}),
+        }
+    }
+
+    /// Tiny payloads must always fit in any reasonable budget. Sanity
+    /// floor: if a 50-char system prompt + 1 trivial tool + 10-char
+    /// user prompt blows the gate, the heuristic itself is broken.
+    #[test]
+    fn preflight_under_budget_for_tiny_payloads() {
+        let pf = estimate_subagent_preflight(
+            "You are helpful.",
+            &[fake_tool_def("Read", "Read a file")],
+            "do the thing",
+            100_000,
+        );
+        assert!(
+            !pf.is_over_budget(),
+            "tiny payload must fit in 100k budget; got {}",
+            pf.summary()
+        );
+        assert!(pf.total_tokens > 0, "some tokens should be counted");
+    }
+
+    /// Pathological case: a giant system prompt blows the gate. Pre-PR
+    /// the dispatcher would have plowed ahead and let upstream return a
+    /// raw 400.
+    #[test]
+    fn preflight_over_budget_when_system_prompt_dwarfs_window() {
+        let huge_prompt = "x".repeat(500_000); // ~143k tokens
+        let pf = estimate_subagent_preflight(&huge_prompt, &[], "hi", 100_000);
+        assert!(
+            pf.is_over_budget(),
+            "500k-char system prompt must exceed 100k budget; got {}",
+            pf.summary()
+        );
+    }
+
+    /// Tool definitions count toward the budget. The bug-review session
+    /// in #1232 specifically called out "~30 tools" as a non-trivial
+    /// share of the baseline — if tools were free, we'd be lying about
+    /// the cost.
+    #[test]
+    fn preflight_tool_defs_contribute_to_total() {
+        let no_tools = estimate_subagent_preflight("sys", &[], "prompt", 100_000);
+        let many_tools: Vec<_> = (0..30)
+            .map(|i| fake_tool_def(&format!("Tool{i}"), &"description ".repeat(50)))
+            .collect();
+        let with_tools = estimate_subagent_preflight("sys", &many_tools, "prompt", 100_000);
+        assert!(
+            with_tools.total_tokens > no_tools.total_tokens,
+            "30 tool defs must add to the total: {} vs {}",
+            with_tools.summary(),
+            no_tools.summary()
+        );
+        assert!(
+            with_tools.tool_defs_tokens > 0,
+            "tool_defs_tokens must be non-zero when tools are passed"
+        );
+    }
+
+    /// Summary string is human-readable and surfaces every component so
+    /// the caller's error message is actionable. Pin the format — the
+    /// dispatcher quotes it directly into the bubbled-up error.
+    #[test]
+    fn preflight_summary_includes_all_components() {
+        let pf = PreflightTokenBudget {
+            system_prompt_tokens: 12_345,
+            tool_defs_tokens: 6_789,
+            user_prompt_tokens: 1_000,
+            total_tokens: 20_134,
+            limit_tokens: 100_000,
+        };
+        let s = pf.summary();
+        assert!(
+            s.contains("system="),
+            "summary must name the system arm: {s}"
+        );
+        assert!(s.contains("tools="), "summary must name the tools arm: {s}");
+        assert!(
+            s.contains("prompt="),
+            "summary must name the prompt arm: {s}"
+        );
+        assert!(s.contains("limit "), "summary must show the limit: {s}");
+    }
+
+    /// Boundary case: total exactly at the limit is NOT over budget
+    /// (strict `>` keeps the gate tight; the heuristic is already
+    /// conservative enough that we don't need extra slack).
+    #[test]
+    fn preflight_at_exact_limit_is_under_budget() {
+        let pf = PreflightTokenBudget {
+            system_prompt_tokens: 0,
+            tool_defs_tokens: 0,
+            user_prompt_tokens: 0,
+            total_tokens: 100,
+            limit_tokens: 100,
+        };
+        assert!(
+            !pf.is_over_budget(),
+            "exactly-at-limit must not trip the gate — over-budget should be strict >"
+        );
+    }
+
+    // ── is_server_error ───────────────────────────────────────────────────
 
     #[test]
     fn test_is_server_error_http_codes() {

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -962,6 +962,54 @@ pub(crate) fn execute_sub_agent<'a>(
         // `local-executor.ts:436`.
         let mut grace_turn_done = false;
 
+        // #1232 §3a: pre-flight context-budget check.
+        //
+        // Estimate `system_prompt + tool_defs + user_prompt` size against
+        // the resolved `max_context_tokens` for this sub-agent. Bail with
+        // an actionable breakdown when over budget instead of letting the
+        // user see a raw `400 "Context size has been exceeded"` from
+        // upstream (the actual UX in the bug-review session that opened
+        // #1232: 4/10 sub-agents failed this way with no usable hint).
+        //
+        // The estimate is heuristic and conservative — it doesn't account
+        // for the response budget or any future tool-call traffic, but it
+        // catches the common "baseline already exceeds the window"
+        // failure mode that drove the issue. Subsequent in-loop estimates
+        // (`estimate_tokens(&messages)` further down) handle the
+        // grow-during-the-conversation case.
+        let preflight = crate::inference_helpers::estimate_subagent_preflight(
+            &system_prompt,
+            &tool_defs,
+            prompt,
+            sub_config.max_context_tokens,
+        );
+        tracing::debug!(
+            agent = agent_name,
+            preflight = %preflight.summary(),
+            "sub-agent context pre-flight"
+        );
+        if preflight.is_over_budget() {
+            // Surface to the inference loop's normal narrative so the
+            // master TUI / ACP / headless clients all see the same
+            // structured signal alongside the bubbled error.
+            sink.emit(EngineEvent::Info {
+                message: format!(
+                    "  \u{1f6d1} {agent_name}: context pre-flight failed ({})",
+                    preflight.summary()
+                ),
+            });
+            // Best-effort cleanup mirrors the cancel path below — release
+            // any provisioned workspace before bubbling so we don't leak
+            // a tempdir on every over-budget sub-agent invocation.
+            let _ = workspace.release(&sub_session, &effective_root).await;
+            anyhow::bail!(
+                "Sub-agent '{agent_name}' context exceeds model window: {summary}. \
+                 Reduce the prompt, drop tools (set `disallowed_tools` on the agent), \
+                 or pick a model with a larger context window.",
+                summary = preflight.summary(),
+            );
+        }
+
         for iter in 1u32.. {
             // #1110: sub-agents have no hardcoded iteration cap. Termination
             // is driven by the model (clean stop, no tool calls), `LoopDetector`

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -753,3 +753,176 @@ async fn test_sub_agent_grace_turn_drops_tool_calls_when_model_defies() {
          must be dropped, not executed. got: {events:?}"
     );
 }
+
+// ── #1232 §3a: pre-flight context-budget check ──────────────────────────────
+
+/// When the resolved sub-agent context (system + tools + prompt) exceeds the
+/// model's `max_context_tokens`, dispatch must bail BEFORE any LLM call with
+/// an actionable breakdown — not let the user see a raw upstream 400.
+///
+/// We trigger the gate by setting `max_context_tokens: 50` in the agent
+/// JSON. The system prompt + 1 inherited tool + the user prompt easily
+/// blow past 50 tokens, so the pre-flight tripwire fires on the first
+/// iteration. (`max_context_tokens` is per-agent, not parent-inherited
+/// — it comes from `ModelSettings::defaults_for(model)` unless the agent
+/// JSON overrides it.)
+///
+/// Asserts:
+///   * the sub-agent's `InvokeAgent` tool result mentions the over-budget
+///     condition (the actionable error the model sees on its next turn);
+///   * a `ChildAgentActivity` activity message tagged with the pre-flight
+///     summary is emitted so the overlay (#1232 §1) shows the failure
+///     reason instead of just a silent "agent finished" row;
+///   * NO mock provider call was ever made — the gate fires before
+///     `provider.chat(...)`. Pre-PR, the dispatch would have plowed ahead
+///     and the user would have seen the upstream 400.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sub_agent_preflight_bails_when_context_exceeds_window() {
+    let _lock = ENV_MUTEX.lock().await;
+    // Sub-agent's `max_context_tokens` does NOT inherit from the parent
+    // (config.rs builds it from `ModelSettings::defaults_for(model)`).
+    // Set the budget directly in the agent JSON so the gate has a knob
+    // to trip on.
+    let env = Env::new().await;
+
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("over-budget-agent.json"),
+        serde_json::json!({
+            "name": "over-budget-agent",
+            "system_prompt": "You are a moderately verbose agent. \
+                              Take your time, think step by step, and \
+                              explain your reasoning carefully before \
+                              answering. This system prompt alone is \
+                              already large enough to blow a tiny \
+                              context window many times over.",
+            "allowed_tools": [],
+            "provider": "mock",
+            "base_url": "http://localhost:0",
+            // 50-token budget is small enough that the system prompt
+            // alone busts it. Pre-flight tripwire fires first iteration.
+            "max_context_tokens": 50
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    // If the gate fails to fire, this MockProvider would be hit and the
+    // test would still pass for the wrong reason. Set a sentinel response
+    // that, if observed in the final transcript, proves the bypass.
+    runtime_env::set(
+        "KODA_MOCK_RESPONSES",
+        r#"[{"text": "BYPASSED_PREFLIGHT_GATE"}]"#,
+    );
+    env.insert_user_message("delegate to the over-budget agent")
+        .await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({
+                "agent_name": "over-budget-agent",
+                "prompt": "do the thing",
+                "background": false
+            }),
+        ),
+        MockResponse::Text("done".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+    runtime_env::remove("KODA_MOCK_RESPONSES");
+
+    // 1. The pre-flight Info event must surface so the overlay shows
+    //    the failure reason. Pin substrings the dispatcher emits.
+    let preflight_signal = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Info { message } if message.contains("context pre-flight failed")
+        )
+    });
+    assert!(
+        preflight_signal,
+        "expected pre-flight failed Info event; got: {events:?}"
+    );
+
+    // 2. The sub-agent's InvokeAgent tool result must contain the
+    //    actionable error so the model can self-correct on the next
+    //    turn (drop tools, switch model, shorten prompt).
+    let invoke_result = events.iter().find_map(|e| match e {
+        EngineEvent::ToolCallResult { name, output, .. } if name == "InvokeAgent" => {
+            Some(output.clone())
+        }
+        _ => None,
+    });
+    let invoke_result = invoke_result.expect("InvokeAgent tool result must be present");
+    assert!(
+        invoke_result.contains("context exceeds model window")
+            || invoke_result.contains("pre-flight"),
+        "InvokeAgent result must surface the pre-flight bail; got: {invoke_result}"
+    );
+
+    // 3. The sub-agent's MockProvider must NOT have been hit. If our
+    //    sentinel ever appears in the assistant transcript, the gate
+    //    was bypassed.
+    let last = env
+        .db
+        .last_assistant_message(&env.session_id)
+        .await
+        .unwrap_or_default();
+    assert!(
+        !last.contains("BYPASSED_PREFLIGHT_GATE"),
+        "sub-agent's mock provider was reached \u{2014} pre-flight gate bypassed! transcript: {last}"
+    );
+}
+
+/// Negative case: a generously-budgeted sub-agent must NOT be tripped by
+/// the pre-flight gate. Catches a regression where the heuristic over-counts
+/// and starts blocking legitimately-sized invocations.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sub_agent_preflight_passes_under_normal_budget() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::builder().max_context_tokens(200_000).build().await;
+
+    let agents_dir = env.root.join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    std::fs::write(
+        agents_dir.join("normal-agent.json"),
+        serde_json::json!({
+            "name": "normal-agent",
+            "system_prompt": "You are helpful.",
+            "allowed_tools": [],
+            "provider": "mock",
+            "base_url": "http://localhost:0"
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    runtime_env::set("KODA_MOCK_RESPONSES", r#"[{"text": "ok"}]"#);
+    env.insert_user_message("delegate to normal-agent").await;
+
+    let provider = MockProvider::new(vec![
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({
+                "agent_name": "normal-agent",
+                "prompt": "hi",
+                "background": false
+            }),
+        ),
+        MockResponse::Text("done".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+    runtime_env::remove("KODA_MOCK_RESPONSES");
+
+    let preflight_failed = events.iter().any(|e| {
+        matches!(
+            e,
+            EngineEvent::Info { message } if message.contains("context pre-flight failed")
+        )
+    });
+    assert!(
+        !preflight_failed,
+        "200k budget must not trip the gate \u{2014} regression! got events: {events:?}"
+    );
+}


### PR DESCRIPTION
Closes the **§3a pre-flight context-budget check** sub-task of #1232. ~110 LoC of impl + ~190 LoC of tests.

## Why

In the bug-review session that opened #1232, **4/10 sub-agents** failed with a raw `400: "Context size has been exceeded"` from upstream. Zero actionable signal — no breakdown of which component blew the budget, no guidance on which knob to turn (drop a tool? shorten the prompt? switch model?). The user was left guessing.

## What changed

### New helper: `inference_helpers::estimate_subagent_preflight()`

Returns `PreflightTokenBudget` with a per-component breakdown:

| Field | What it counts |
|---|---|
| `system_prompt_tokens` | rendered prompt + `SYSTEM_PROMPT_OVERHEAD` |
| `tool_defs_tokens` | `serde_json::to_string` of the tool array (the wire format) |
| `user_prompt_tokens` | the `InvokeAgent` `prompt` arg |
| `total_tokens` | sum of the three above |
| `limit_tokens` | `sub_config.max_context_tokens` |

Plus `is_over_budget()` and `summary()` for one-line human-readable output like:

```
system=18k + tools=12k + prompt=2k = 32k / limit 25k
```

### Wired into sub-agent dispatch

`sub_agent_dispatch::execute_sub_agent` now calls the helper **before** the inference loop starts. If `is_over_budget()`:

1. Emits `EngineEvent::Info` with the breakdown — surfaces in the overlay (#1232 §1) so the failure reason isn't silent.
2. Best-effort releases the workspace (mirrors the cancel path; no tempdir leak).
3. Bails with an actionable error:
   > Sub-agent 'X' context exceeds model window: `<breakdown>`. Reduce the prompt, drop tools (set `disallowed_tools` on the agent), or pick a model with a larger context window.

The estimate is heuristic and conservative — same `chars / 3.5 + overhead` model the live token gauge uses (calibrated to over-estimate slightly; safe direction for a pre-flight gate). It does NOT account for response budget, future tool-call traffic, or dynamic memory growth — that's what the existing in-loop `estimate_tokens(&messages)` covers. **The goal here is to catch the common "baseline already exceeds the window" failure mode that drove the issue**, not to perfectly simulate the wire payload.

## Acceptance criteria from #1232 §3a

- [x] Sub-agent dispatch performs a token-count pre-flight; fails fast with actionable message when over budget
- [x] Test covers both the pre-flight failure path and the under-budget pass-through path

> ℹ️ §3b (de-dup `CLAUDE.md` reload across parallel sub-agents) is intentionally **not** in this PR — it's a separate sub-bug that comes later in the suggested order.

## Tests

**5 unit tests** in `inference_helpers.rs`:
- `preflight_under_budget_for_tiny_payloads` — sanity floor
- `preflight_over_budget_when_system_prompt_dwarfs_window` — pathological positive
- `preflight_tool_defs_contribute_to_total` — pins the bug-review session's "~30 tools is non-trivial" claim
- `preflight_summary_includes_all_components` — pins the human-readable format the dispatcher quotes verbatim
- `preflight_at_exact_limit_is_under_budget` — strict `>` boundary semantics

**2 integration tests** in `e2e_agent_test.rs`:
- `sub_agent_preflight_bails_when_context_exceeds_window` — end-to-end bail. **Critically asserts the sub-agent's `MockProvider` was NEVER hit** via a sentinel response (`"BYPASSED_PREFLIGHT_GATE"`). If that string ever appears in the transcript the gate was bypassed and the test fails loudly.
- `sub_agent_preflight_passes_under_normal_budget` — negative regression guard against the heuristic over-counting and starting to block legitimate invocations.

## Test status

- `cargo test -p koda-core --lib` → **1,198 passing** (5 new), 1 ignored, 0 failed
- `cargo test -p koda-core --test e2e_agent_test` → **11 passing** (2 new), 0 failed
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --tests -- -D warnings` → clean
- `python3 scripts/check_tokio_test_flavor.py` → OK (both new e2e tests use `multi_thread`)

## Implementation note worth flagging

`max_context_tokens` for sub-agents is **not** parent-inherited — it comes from `ModelSettings::defaults_for(model)` in `config.rs`, optionally overridden by the agent's own JSON. I tripped over this writing the integration test (set the budget on the parent `Env`, watched the gate not fire). If you want this to also pick up a parent-side override, that'd be a separate config change — out of scope here, but happy to follow up.

## Out of scope

- §3b (de-dup `CLAUDE.md` per-session reload) — same root issue, separate fix
- Adjusting the heuristic constants (`CHARS_PER_TOKEN`, `PER_MESSAGE_OVERHEAD`) — they're shared with the live token gauge; tuning belongs in its own PR with calibration data
- Inheriting `max_context_tokens` from parent → sub-agent — separate config change
