### PR TITLE
fix: name EngineCommand variant in WARN log instead of `Discriminant(N)` (#1232 §6)

### DIFF
--- a/koda-core/src/engine/event.rs
+++ b/koda-core/src/engine/event.rs
@@ -509,6 +509,31 @@ pub enum EngineCommand {
     },
 }
 
+impl EngineCommand {
+    /// Stable, payload-free name of this variant.
+    ///
+    /// **#1232 §6**: pre-fix, `inference.rs` logged unexpected commands
+    /// as `Discriminant(2)`, forcing devs to grep the source to map the
+    /// integer back to a variant. Naive `{:?}` on `Self` would surface
+    /// the variant name but also dump payload fields like
+    /// `AskUserResponse.answer` and `QueueNext.text` — user-typed
+    /// content that has no business in a structured log line. This
+    /// accessor returns just the variant name so logs stay readable
+    /// AND payload-safe.
+    ///
+    /// Returned strings are stable identifiers — treat them as a
+    /// public API for downstream metric/log filters.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Interrupt => "Interrupt",
+            Self::AskUserResponse { .. } => "AskUserResponse",
+            Self::ApprovalResponse { .. } => "ApprovalResponse",
+            Self::LoopDecision { .. } => "LoopDecision",
+            Self::QueueNext { .. } => "QueueNext",
+        }
+    }
+}
+
 /// The user's decision on an approval request.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "decision", rename_all = "snake_case")]
@@ -915,5 +940,71 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // ── EngineCommand::kind (#1232 §6) ──────────────────────────
+
+    /// Pin every variant → stable name. If a future PR adds a new
+    /// `EngineCommand` variant the `match` in `kind()` becomes
+    /// non-exhaustive and the build breaks — but if someone *renames*
+    /// an existing variant without updating `kind()`, only this test
+    /// catches it. Treat the names as a stable API.
+    #[test]
+    fn engine_command_kind_names_every_variant() {
+        let cases: &[(EngineCommand, &str)] = &[
+            (EngineCommand::Interrupt, "Interrupt"),
+            (
+                EngineCommand::AskUserResponse {
+                    id: "x".into(),
+                    answer: "y".into(),
+                },
+                "AskUserResponse",
+            ),
+            (
+                EngineCommand::ApprovalResponse {
+                    id: "x".into(),
+                    decision: ApprovalDecision::Approve,
+                },
+                "ApprovalResponse",
+            ),
+            (
+                EngineCommand::LoopDecision {
+                    action: crate::loop_guard::LoopContinuation::Stop,
+                },
+                "LoopDecision",
+            ),
+            (EngineCommand::QueueNext { text: "hi".into() }, "QueueNext"),
+        ];
+        for (cmd, expected) in cases {
+            assert_eq!(
+                cmd.kind(),
+                *expected,
+                "variant name mismatch — update kind() AND log/metric consumers if renaming"
+            );
+        }
+    }
+
+    /// Payload-safety guard: `kind()` must NOT leak user-typed text
+    /// into the returned static string. The whole point of using
+    /// `kind()` instead of `{:?}` in the WARN log is to keep
+    /// `AskUserResponse.answer` and `QueueNext.text` out of logs.
+    #[test]
+    fn engine_command_kind_does_not_leak_payload() {
+        let secret = "P@SSW0RD-leaked-via-logs";
+        let answer_cmd = EngineCommand::AskUserResponse {
+            id: "x".into(),
+            answer: secret.into(),
+        };
+        let queue_cmd = EngineCommand::QueueNext {
+            text: secret.into(),
+        };
+        assert!(
+            !answer_cmd.kind().contains(secret),
+            "AskUserResponse.kind() leaked the answer payload"
+        );
+        assert!(
+            !queue_cmd.kind().contains(secret),
+            "QueueNext.kind() leaked the text payload"
+        );
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -807,9 +807,17 @@ pub async fn inference_loop(ctx: InferenceContext<'_>) -> Result<()> {
                 match cmd {
                     EngineCommand::QueueNext { text } => next_texts.push(text),
                     other => {
+                        // #1232 §6: name the variant instead of
+                        // dumping `Discriminant(N)` (which forces
+                        // devs to grep the source to figure out
+                        // which `EngineCommand` integer N maps to)
+                        // — and use `.kind()` rather than `{:?}` so
+                        // potentially-sensitive payload fields
+                        // (e.g. `AskUserResponse.answer`,
+                        // `QueueNext.text`) stay out of logs.
                         tracing::warn!(
-                            "inference_loop: unexpected command at iteration start (discarded): {:?}",
-                            std::mem::discriminant(&other)
+                            "inference_loop: unexpected command at iteration start (discarded): {}",
+                            other.kind()
                         );
                     }
                 }


### PR DESCRIPTION
Closes the **§6 `Discriminant(N)` log** sub-task of #1232. Tiny drive-by — ~30 LoC of impl + ~60 LoC of tests.

## Why

Pre-fix, `inference_loop` logged unexpected commands as `Discriminant(2)`, forcing devs to grep the source to map the integer back to a variant. From the bug-review session that opened #1232: a 2-LoC drive-by, free debuggability win.

## What changed

New `EngineCommand::kind() -> &'static str` returns the variant name. `inference.rs` now logs `other.kind()` instead of `std::mem::discriminant(&other)`.

**Why `kind()` and not naive `{:?}`:** `EngineCommand` already derives `Debug`, but several variants carry user-typed payloads (`AskUserResponse.answer`, `QueueNext.text`) that have no business in structured logs. `kind()` returns just the variant name — payload-safe by construction. The returned strings are stable identifiers; treat them as a public API surface for downstream metric/log filters.

**Before:**
```
WARN inference_loop: unexpected command at iteration start (discarded): Discriminant(2)
```

**After:**
```
WARN inference_loop: unexpected command at iteration start (discarded): ApprovalResponse
```

## Acceptance criteria from #1232 §6

- [x] WARN message names the variant
- [x] `EngineCommand`'s `Debug` carries user-typed payload, so a payload-free `kind()` accessor is the right knob (per the issue's hint)

## Tests

- `engine_command_kind_names_every_variant` — pins the variant→name map for all 5 variants. The `match` in `kind()` is exhaustive so the compiler catches *added* variants, but **renames** are only caught by this test.
- `engine_command_kind_does_not_leak_payload` — guards the payload-safety property: a sentinel secret stuffed into `answer` / `text` must not appear in `kind()`'s output. If a future PR carelessly switches `kind()` to format the payload, this fails loudly.

## Test status

- `cargo test -p koda-core --lib engine::event::` → **18 passing** (2 new), 0 failed
- `cargo test -p koda-core --lib` → **1,200 passing**, 1 ignored, 0 failed
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --tests -- -D warnings` → clean
