### PR TITLE
feat: require `agent_name` on InvokeAgent + honor built-in description (#1232 §5)

### DIFF
--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -301,6 +301,96 @@ async fn run_bg_agent(
 /// an actionable error so the model sees a tool-error and can
 /// correct on the next turn rather than silently defaulting to
 /// `false`.
+/// Parse the **required** `agent_name` field out of an `InvokeAgent`
+/// argument object.
+///
+/// **#1232 §5**: extracted from `execute_sub_agent` so the missing-
+/// field / wrong-type / empty-string / unknown-agent branches can be
+/// unit-tested without spinning up the full sub-agent dispatch
+/// plumbing. The schema declares `agent_name` required (see
+/// `tools/agent.rs::definitions`) but schema compliance is best-
+/// effort across LLMs. Pre-fix the field silently defaulted to
+/// `"task"` (`unwrap_or("task")`) so every InvokeAgent call routed
+/// to the generic worker even when the model's prompt was written
+/// for a specialist ("Rust code architect", "security specialist",
+/// etc. — see the bug-review session that opened the issue: 10/10
+/// calls omitted the field).
+///
+/// On any failure the error message lists the available agents
+/// (discovered via `tools::agent::discover_all_agents`) so the model
+/// can self-correct on the next turn. Discovery is project-aware
+/// (built-in → user → project precedence), so a project that adds
+/// custom agents under `<root>/agents/` sees them in the hint too.
+///
+/// Accepts only non-empty strings. Missing, null, empty, wrong-type,
+/// and unknown-agent cases all bail with actionable text.
+pub(crate) fn parse_agent_name_required(
+    args: &serde_json::Value,
+    project_root: &std::path::Path,
+) -> anyhow::Result<String> {
+    let raw = match args.get("agent_name") {
+        Some(serde_json::Value::String(s)) => s,
+        Some(serde_json::Value::Null) | None => {
+            anyhow::bail!(
+                "InvokeAgent: 'agent_name' is required \u{2014} no default. {hint}",
+                hint = available_agents_hint(project_root),
+            );
+        }
+        Some(other) => {
+            let kind = match other {
+                serde_json::Value::Null => "null",
+                serde_json::Value::Bool(_) => "a boolean",
+                serde_json::Value::Number(_) => "a number",
+                serde_json::Value::Array(_) => "an array",
+                serde_json::Value::Object(_) => "an object",
+                serde_json::Value::String(_) => unreachable!("matched above"),
+            };
+            anyhow::bail!(
+                "InvokeAgent: 'agent_name' must be a string, got {kind}. {hint}",
+                hint = available_agents_hint(project_root),
+            );
+        }
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!(
+            "InvokeAgent: 'agent_name' must be a non-empty string. {hint}",
+            hint = available_agents_hint(project_root),
+        );
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Build the "Available agents: ..." suffix used by
+/// `parse_agent_name_required`'s error messages.
+///
+/// Lists every discovered agent's name plus `fork` (the special
+/// context-inheriting pseudo-agent that doesn't appear in discovery
+/// because it isn't a real agent file). Sorted, comma-separated, so
+/// the model gets a stable hint string it can copy-paste from.
+fn available_agents_hint(project_root: &std::path::Path) -> String {
+    let mut names: Vec<String> = crate::tools::agent::discover_all_agents(project_root)
+        .into_iter()
+        .map(|a| a.name)
+        .collect();
+    // `fork` is dispatched specially in `execute_sub_agent` and is
+    // never a real agent on disk — surface it here so the model knows
+    // it's a valid choice for context-inheriting work.
+    names.push("fork".to_string());
+    names.sort();
+    names.dedup();
+    if names.len() == 1 {
+        // Should be unreachable in practice (built-ins always present)
+        // but be defensive.
+        format!("Available agent: {}.", names[0])
+    } else {
+        format!(
+            "Available agents (call ListAgents for descriptions): {}.",
+            names.join(", "),
+        )
+    }
+}
+
 pub(crate) fn parse_background_required(args: &serde_json::Value) -> anyhow::Result<bool> {
     match args.get("background") {
         Some(serde_json::Value::Bool(b)) => Ok(*b),
@@ -388,7 +478,21 @@ pub(crate) fn execute_sub_agent<'a>(
         // hook below uses to reap any orphaned bg work.
         let my_invocation_id = next_invocation_id();
         let args: serde_json::Value = serde_json::from_str(arguments)?;
-        let agent_name = args["agent_name"].as_str().unwrap_or("task");
+        // **#1232 §5**: `agent_name` is a required field. Pre-fix the
+        // dispatcher used `args["agent_name"].as_str().unwrap_or("task")`,
+        // which silently routed every missing-field call to the
+        // generic worker even when the model's prompt was written for
+        // a specialist ("Rust code architect", "security specialist",
+        // ...). The bug-review session that opened the issue showed
+        // 10/10 InvokeAgent calls hit this path.
+        //
+        // Validation is extracted into a free function so the
+        // missing / wrong-type / empty / bad-name branches can be
+        // unit-tested without spinning up the full dispatch
+        // plumbing. The error message lists available agents so the
+        // model can self-correct on the next turn.
+        let agent_name_owned = parse_agent_name_required(&args, project_root)?;
+        let agent_name = agent_name_owned.as_str();
         tracing::Span::current().record("agent_name", agent_name);
         let prompt = args["prompt"]
             .as_str()
@@ -1767,5 +1871,119 @@ mod parse_background_required_tests {
                 "non-bool collection must surface type-mismatch; got: {msg}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod parse_agent_name_required_tests {
+    //! #1232 §5: schema declares `agent_name` required, and this
+    //! module's runtime backstop holds the line for models that
+    //! ignore the schema. The tests pin every branch so a future
+    //! refactor that re-introduces an `unwrap_or("task")` fallback
+    //! fails loudly here.
+
+    use super::{available_agents_hint, parse_agent_name_required};
+    use serde_json::json;
+    use std::path::Path;
+
+    /// Tests use `Path::new(".")` for the project root. Discovery
+    /// will return only built-in agents (`explore`, `plan`, `task`,
+    /// `verify`) plus any in `<cwd>/agents/` if it exists. The
+    /// hint-suffix assertions only check for built-in names that
+    /// must always be present.
+    fn root() -> &'static Path {
+        Path::new(".")
+    }
+
+    #[test]
+    fn accepts_well_formed_string() {
+        let name = parse_agent_name_required(&json!({"agent_name": "explore"}), root())
+            .expect("explore must parse");
+        assert_eq!(name, "explore");
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        // Models occasionally emit `"  explore  "` from sloppy
+        // template interpolation. Accept it rather than reject.
+        let name = parse_agent_name_required(&json!({"agent_name": "  explore  "}), root())
+            .expect("trimmed string must parse");
+        assert_eq!(name, "explore");
+    }
+
+    #[test]
+    fn rejects_missing_field_with_actionable_hint() {
+        let err = parse_agent_name_required(&json!({"prompt": "x"}), root())
+            .expect_err("missing agent_name must fail")
+            .to_string();
+        assert!(
+            err.contains("'agent_name' is required"),
+            "missing-field error must name the field: {err}"
+        );
+        assert!(
+            err.contains("Available agent"),
+            "error must list available agents: {err}"
+        );
+        // Built-ins must be discoverable from any project root.
+        assert!(err.contains("task"), "hint must list `task`: {err}");
+    }
+
+    #[test]
+    fn rejects_explicit_null() {
+        let err = parse_agent_name_required(&json!({"agent_name": null}), root())
+            .expect_err("null agent_name must fail")
+            .to_string();
+        // null falls into the same arm as missing — same error message.
+        assert!(err.contains("'agent_name' is required"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_string() {
+        // Empty / whitespace-only strings are useless and silently-
+        // routing them anywhere would resurrect the original bug.
+        for empty in ["", "   ", "\t\n"] {
+            let err = parse_agent_name_required(&json!({"agent_name": empty}), root())
+                .expect_err("empty agent_name must fail")
+                .to_string();
+            assert!(
+                err.contains("non-empty"),
+                "empty {empty:?} must produce 'non-empty' error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_types() {
+        for (value, expected_kind) in [
+            (json!({"agent_name": true}), "a boolean"),
+            (json!({"agent_name": 42}), "a number"),
+            (json!({"agent_name": ["explore"]}), "an array"),
+            (json!({"agent_name": {"name": "explore"}}), "an object"),
+        ] {
+            let err = parse_agent_name_required(&value, root())
+                .expect_err("wrong-type agent_name must fail")
+                .to_string();
+            assert!(
+                err.contains(expected_kind),
+                "got: {err} — expected to mention {expected_kind:?}"
+            );
+            assert!(
+                err.contains("Available"),
+                "wrong-type error must also surface the available list: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn hint_lists_builtins_and_fork() {
+        let hint = available_agents_hint(root());
+        // The four built-in agents must always be present.
+        for name in ["explore", "plan", "task", "verify", "fork"] {
+            assert!(hint.contains(name), "hint must list `{name}`: {hint}");
+        }
+        // Names are sorted + deduplicated; `fork` should appear exactly once
+        // even though it's pushed in addition to discovery.
+        let fork_count = hint.matches("fork").count();
+        assert_eq!(fork_count, 1, "`fork` must not be duplicated: {hint}");
     }
 }

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -6,13 +6,16 @@
 //!
 //! ## Usage patterns
 //!
-//! - **Delegate a task**: `InvokeAgent { prompt: "write tests for auth.rs" }`
-//!   (uses the `task` agent by default)
-//! - **Use a specialist**: `InvokeAgent { agent_name: "explore", prompt: "find all error handling" }`
-//! - **Fork context**: `InvokeAgent { agent_name: "fork", prompt: "..." }`
+//! - **Delegate a task**: `InvokeAgent { agent_name: "task", prompt: "write tests for auth.rs", background: false }`
+//! - **Use a specialist**: `InvokeAgent { agent_name: "explore", prompt: "find all error handling", background: false }`
+//! - **Fork context**: `InvokeAgent { agent_name: "fork", prompt: "...", background: false }`
 //!   (inherits parent's full conversation)
-//! - **Background work**: `InvokeAgent { prompt: "...", background: true }`
+//! - **Background work**: `InvokeAgent { agent_name: "task", prompt: "...", background: true }`
 //!   (returns immediately, results injected when complete)
+//!
+//! `agent_name` and `background` are both **required** — see #1232 §2 + §5
+//! for the rationale (silently-defaulted fields hid routing intent and
+//! turned every parallel pattern into serial blocking calls).
 //!
 //! ## When to use sub-agents
 //!
@@ -72,14 +75,25 @@ Key rules:
 - A result starting with '[ERROR: sub-agent ...]' is a structural failure (e.g. workspace setup, isolation issue), not a model answer. Re-strategize rather than treat as content.
 - Always write a clear, self-contained prompt — the sub-agent hasn't seen your conversation
 - Include specific file paths, function names, and success criteria in your prompt
-- Omit agent_name to use the 'task' worker (full write access)"
+- agent_name is REQUIRED. Pick a specific specialist from the 'Available Sub-Agents' list in your system prompt (typically: explore, plan, task, verify). Use 'fork' to inherit the full parent context."
                 .to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
                     "agent_name": {
                         "type": "string",
-                        "description": "Name of the sub-agent (from ListAgents). Omit for 'task', use 'fork' to inherit parent context."
+                        "description": "REQUIRED. Name of the sub-agent to dispatch to. \
+                            Pick a specialist from the 'Available Sub-Agents' list in your system \
+                            prompt \u{2014} commonly `explore` (read-only search/analysis), `plan` \
+                            (architecture / step-by-step design), `task` (general-purpose worker, \
+                            full write access), `verify` (adversarial review). Use `fork` to \
+                            inherit the full parent conversation context.\n\n\
+                            **#1232 \u{00a7}5**: this field is required \u{2014} there is no default. \
+                            Pre-fix the field silently defaulted to `task`, so every InvokeAgent \
+                            call routed to the generic worker even when the model's prompt was \
+                            written for a specialist (\"Rust code architect\", \"security \
+                            specialist\", etc.). Forcing the choice surfaces routing intent at \
+                            the call site (Zen of Python: explicit is better than implicit)."
                     },
                     "prompt": {
                         "type": "string",
@@ -112,7 +126,7 @@ Key rules:
                             is cancelled on Ctrl+C."
                     }
                 },
-                "required": ["prompt", "background"]
+                "required": ["agent_name", "prompt", "background"]
             }),
         },
         ToolDefinition {
@@ -151,15 +165,31 @@ pub fn discover_all_agents(project_root: &Path) -> Vec<AgentInfo> {
     // 1. Built-in agents (lowest priority)
     for (name, config) in crate::config::KodaConfig::builtin_agents() {
         // Skip `default` — it's the main agent, not a sub-agent.
-        // Map omitted agent_name to `task` instead (see InvokeAgent schema).
+        // (Pre-#1232 §5 there was also no "omitted agent_name" path
+        // routing here — dispatch now requires the field.)
         if name == "default" {
             continue;
         }
+        // **#1232 §5 (drive-by)**: prefer the explicit `description`
+        // field over the heuristic `extract_description(system_prompt)`.
+        // The four built-in JSONs (`explore`, `plan`, `task`, `verify`)
+        // all carry rich, model-facing one-liners in their
+        // `description` fields, but pre-fix this branch ignored them
+        // and showed the heuristic's first-sentence guess instead
+        // (often "You are a ..."). The disk-load branch in
+        // `load_agents_from_dir` already does this fallback dance
+        // — this aligns the built-in branch to match.
+        let description = config
+            .description
+            .as_deref()
+            .filter(|d| !d.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| extract_description(&config.system_prompt));
         agents.insert(
             name.clone(),
             AgentInfo {
                 name,
-                description: extract_description(&config.system_prompt),
+                description,
                 source: "built-in",
                 system_prompt: config.system_prompt,
             },

--- a/koda-core/tests/e2e_agent_test.rs
+++ b/koda-core/tests/e2e_agent_test.rs
@@ -926,3 +926,60 @@ async fn sub_agent_preflight_passes_under_normal_budget() {
         "200k budget must not trip the gate \u{2014} regression! got events: {events:?}"
     );
 }
+
+// ── #1232 §5: required `agent_name` ─────────────────────────────────────────
+
+/// When the model emits `InvokeAgent` without `agent_name`, dispatch must
+/// surface an actionable validation error (with the available-agent list)
+/// instead of silently routing to `task` — the bug-review session showed
+/// 10/10 calls hit the silent-default path, so every "Rust code architect"
+/// / "security specialist" prompt was actually answered by the generic
+/// worker.
+///
+/// Asserts:
+///   * the InvokeAgent tool result is an error string mentioning
+///     `'agent_name' is required` (the runtime backstop bailed);
+///   * the error string lists at least one built-in agent name
+///     (so the model can self-correct on the next turn).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invoke_agent_without_agent_name_is_rejected_with_actionable_error() {
+    let _lock = ENV_MUTEX.lock().await;
+    let env = Env::new().await;
+
+    env.insert_user_message("call without agent_name").await;
+
+    let provider = MockProvider::new(vec![
+        // No `agent_name` field — the silently-defaulted path pre-#1232 §5.
+        MockResponse::tool_call(
+            "InvokeAgent",
+            serde_json::json!({
+                "prompt": "do something",
+                "background": false,
+            }),
+        ),
+        MockResponse::Text("acknowledged".into()),
+    ]);
+    let events = env.run_inference(&provider).await;
+
+    let invoke_result = events
+        .iter()
+        .find_map(|e| match e {
+            EngineEvent::ToolCallResult { name, output, .. } if name == "InvokeAgent" => {
+                Some(output.clone())
+            }
+            _ => None,
+        })
+        .expect("InvokeAgent tool result must be present");
+
+    assert!(
+        invoke_result.contains("'agent_name' is required"),
+        "result must surface the required-field error; got: {invoke_result}"
+    );
+    // The hint must list available agents so the model can self-correct.
+    // Don't pin a specific name beyond `task` (always present as a built-in)
+    // — discovery output is environment-sensitive.
+    assert!(
+        invoke_result.contains("task"),
+        "error must list `task` in the available agents hint; got: {invoke_result}"
+    );
+}


### PR DESCRIPTION
Closes the **§5 required `agent_name`** sub-task of #1232. ~120 LoC of impl + ~150 LoC of tests.

## Why

In the bug-review session that opened #1232, **all 10 InvokeAgent calls omitted `agent_name`** and were dispatched to the generic `task` agent — even though the model's prompts said "Rust code architect", "security specialist", "performance engineer", "testing quality engineer". Routing intent was hidden from the user and the specialist personas were silently ignored.

## What changed

### 1. Schema: `agent_name` is now required

`tools/agent.rs::definitions` adds `agent_name` to the `required` array. Description leads with **REQUIRED** and lists canonical built-ins so the model has a stable picking guide. Stale "Omit agent_name to use the 'task' worker" guidance and matching module-doc examples are gone.

### 2. Runtime backstop: `parse_agent_name_required`

New free function in `sub_agent_dispatch.rs` mirrors the `parse_background_required` pattern from #1232 §2. Replaces `args["agent_name"].as_str().unwrap_or("task")` with strict validation:

| Input | Result |
|---|---|
| `"explore"` | `Ok("explore")` |
| `"  explore  "` | `Ok("explore")` (trimmed; models occasionally emit padded strings) |
| missing / `null` | `Err("'agent_name' is required …")` + agent list |
| `42`, `true`, `[…]`, `{…}` | `Err("must be a string, got <kind> …")` + agent list |
| `""` / `"   "` | `Err("must be a non-empty string …")` + agent list |

The hint is built by `available_agents_hint(project_root)` which uses the existing `discover_all_agents` (built-in → user → project precedence) and adds `fork` (the special context-inheriting pseudo-agent that has no on-disk file).

### 3. Drive-by: built-in branch honors `description`

`discover_all_agents`'s built-in branch was using `extract_description(&config.system_prompt)` — the heuristic — even though the four built-in JSONs (`explore`, `plan`, `task`, `verify`) all carry rich `description` fields written specifically for model-facing routing hints. The disk-load branch already preferred the explicit field; this PR aligns the built-in branch to match.

This directly serves #5's "system prompt mentions explore / plan / verify / task with one-line role hints" criterion — the prompt builder already lists agents, this fix just gives those listings useful descriptions.

## Acceptance criteria from #1232 §5

- [x] `agent_name` is required at the schema level — missing → validation error with a list of available agents
- [x] System prompt mentions `explore` / `plan` / `verify` / `task` with one-line role hints (now using their explicit descriptions, not the heuristic)
- [x] Test for the validation failure mode (7 unit + 1 integration)

## Tests

**7 unit tests** in `parse_agent_name_required_tests`:
- `accepts_well_formed_string`, `trims_surrounding_whitespace`
- `rejects_missing_field_with_actionable_hint` — pins both error text and presence of agent list
- `rejects_explicit_null` — same arm as missing; same error
- `rejects_empty_string` — `""`, `"   "`, `"\t\n"` all rejected
- `rejects_wrong_types` — `bool`, `number`, `array`, `object` each get type-specific messages
- `hint_lists_builtins_and_fork` — pins format: every built-in present, `fork` deduped to single occurrence

**1 integration test** `invoke_agent_without_agent_name_is_rejected_with_actionable_error`:
End-to-end repro of the bug-review pattern. Mock model emits InvokeAgent without `agent_name` → tool result must contain `'agent_name' is required` and list `task` (built-ins always discoverable). Pre-PR this would have silently routed to `task` and the test would have failed.

## Test status

- `cargo test -p koda-core --lib` → **1,207 passing** (7 new), 1 ignored, 0 failed
- `cargo test -p koda-core --test e2e_agent_test` → **12 passing** (1 new), 0 failed
- All other InvokeAgent-touching test files still pass (already supplied `agent_name`):
  - `guarantee_matrix_test`: 14 ✓
  - `tool_normalize_test`: 3 ✓
  - `persisting_sink_test`: 10 ✓
  - `tool_wiring_test`: 5 ✓
  - `new_tools_test`: 14 ✓
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --tests -- -D warnings` → clean
- `python3 scripts/check_tokio_test_flavor.py` → OK (the new e2e test uses `multi_thread`)

## Compatibility

Schema is a **tightening**. Well-behaved models (compliant with `required`) are unaffected. Non-compliant models that previously silently routed to `task` now get an actionable error and can self-correct on the next turn — the whole point of the fix.

## Out of scope

- Surfacing routing decisions in the overlay (#1232 §1 work) — separate concern
- Changing how the `fork` pseudo-agent is dispatched — only added to the hint list, behavior unchanged
