### PR TITLE
fix: gate TrustMode::Plan to sub-agents only at top-level entry points (#1244)

### DIFF
--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -175,9 +175,7 @@ pub(crate) async fn run() -> Result<()> {
                             cli.thinking_budget,
                             cli.reasoning_effort.clone(),
                         )
-                        .with_trust(
-                            koda_core::trust::TrustMode::parse(&cli.mode).unwrap_or_default(),
-                        );
+                        .with_trust(parse_top_level_trust_mode(&cli.mode));
                     server::run_stdio_server(project_root, config).await?;
                 } else {
                     eprintln!("WebSocket server (--port {port}) not yet implemented. Use --stdio.");
@@ -251,7 +249,7 @@ pub(crate) async fn run() -> Result<()> {
                 cli.thinking_budget,
                 cli.reasoning_effort,
             )
-            .with_trust(koda_core::trust::TrustMode::parse(&cli.mode).unwrap_or_default());
+            .with_trust(parse_top_level_trust_mode(&cli.mode));
         let session_id = match cli.session {
             Some(id) => id,
             None => db.create_session(&config.agent_name, &project_root).await?,
@@ -284,7 +282,7 @@ pub(crate) async fn run() -> Result<()> {
             cli.thinking_budget,
             cli.reasoning_effort,
         )
-        .with_trust(koda_core::trust::TrustMode::parse(&cli.mode).unwrap_or_default());
+        .with_trust(parse_top_level_trust_mode(&cli.mode));
 
     // Initialize database is already done above
 
@@ -323,6 +321,26 @@ fn init_server_tracing() {
         .with_target(true)
         .try_init();
     tracing::info!("koda server --stdio: tracing initialized");
+}
+
+/// Parse the `--mode` CLI flag and coerce to a top-level-valid trust
+/// mode, emitting a warning to stderr if Plan was requested.
+///
+/// **#1244**: this is the single CLI-side coercion point. Three
+/// `with_trust(...)` call sites in this file used to call
+/// `TrustMode::parse(&cli.mode).unwrap_or_default()` directly, which
+/// silently let `--mode plan` through to the top-level session —
+/// where Plan is sub-agent-only and just makes every write tool fail.
+/// Funneling all three through here ensures the rule lives in one
+/// place (DRY) and the warning is consistent across stdio-server,
+/// headless, and TUI launch modes.
+fn parse_top_level_trust_mode(cli_mode: &str) -> koda_core::trust::TrustMode {
+    let parsed = koda_core::trust::TrustMode::parse(cli_mode).unwrap_or_default();
+    let (mode, warning) = koda_core::trust::coerce_for_top_level(parsed);
+    if let Some(w) = warning {
+        eprintln!("warning: {w}");
+    }
+    mode
 }
 
 /// Resolve the headless prompt from -p flag, positional arg, or stdin pipe.

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -482,10 +482,24 @@ async fn handle_resume_session(
                                 Span::styled(detail, DIM),
                             ]),
                         );
-                        // Restore persisted approval mode (#590)
+                        // Restore persisted approval mode (#590).
+                        // **#1244**: route the parsed mode through
+                        // `coerce_for_top_level` so a session that
+                        // somehow got persisted with `plan` (older
+                        // koda version, manual DB edit, race) is
+                        // coerced to Safe with a visible banner
+                        // instead of silently resurrecting a confused
+                        // "read-only main session" state. Sub-agents
+                        // never persist their own session-level mode
+                        // here — only the top-level session does —
+                        // so this coercion is the right scope.
                         if let Ok(Some(mode_str)) = session.db.get_session_mode(&session.id).await
-                            && let Some(m) = trust::TrustMode::parse(&mode_str)
+                            && let Some(parsed) = trust::TrustMode::parse(&mode_str)
                         {
+                            let (m, warning) = trust::coerce_for_top_level(parsed);
+                            if let Some(w) = warning {
+                                tui_output::warn_msg(buffer, w.to_string());
+                            }
                             trust::set_trust(shared_mode, m);
                         }
                         // Read idle time BEFORE load_context updates last_accessed_at.

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -71,10 +71,17 @@ pub enum TrustMode {
 impl TrustMode {
     /// Cycle between user-facing modes: Safe ↔ Auto.
     ///
-    /// Plan is agent-only and never toggled by the user.
+    /// Plan is **sub-agent-only** (#1244) and never reachable for the
+    /// top-level session via any path — not the keyboard toggle, not
+    /// the `--mode plan` CLI flag, not `/resume` of a Plan-persisted
+    /// session. All non-toggle entry paths funnel through
+    /// [`coerce_for_top_level`] which coerces Plan → Safe + warns.
+    /// The toggle simply loops Plan → Plan as a defensive no-op for
+    /// the (impossible-by-construction) case where a sub-agent's
+    /// runtime mode somehow gets cycled.
     pub fn next(self) -> Self {
         match self {
-            Self::Plan => Self::Plan, // agent-only, no toggle
+            Self::Plan => Self::Plan, // sub-agent-only; #1244
             Self::Safe => Self::Auto,
             Self::Auto => Self::Safe,
         }
@@ -119,6 +126,53 @@ impl TrustMode {
     /// this is simply `std::cmp::min(parent, child)`.
     pub fn clamp(parent: TrustMode, child: TrustMode) -> TrustMode {
         std::cmp::min(parent, child)
+    }
+}
+
+/// Coerce a candidate trust mode to one valid for the **top-level**
+/// session, returning `(coerced, warning)`.
+///
+/// **#1244**: `Plan` is sub-agent-only. Pre-fix, the main session
+/// could enter Plan via `--mode plan`, `/resume` of a Plan-persisted
+/// session, or any other call that fed `TrustMode::parse(..)` output
+/// directly into `KodaConfig::with_trust(..)` / `set_trust(..)`. None
+/// of those paths offered a coherent UX — the user would land in a
+/// "read-only main session" where every write tool the model called
+/// would be silently denied, leading to confused
+/// retry-loop-then-give-up behavior.
+///
+/// This helper is the **single coercion point**: every call site that
+/// turns a parsed/persisted/CLI-flag mode into a top-level session
+/// trust value must route through here. Sub-agent dispatch uses
+/// [`derive_child_trust`] instead and is unaffected — sub-agents can
+/// (and should) still be Plan.
+///
+/// Returns the warning as `Option<&'static str>` (not `String`) because
+/// the message is wholly static — callers can `eprintln!`/`warn_msg`
+/// without an intermediate allocation.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::trust::{TrustMode, coerce_for_top_level};
+/// // Plan → Safe with a warning
+/// let (m, w) = coerce_for_top_level(TrustMode::Plan);
+/// assert_eq!(m, TrustMode::Safe);
+/// assert!(w.is_some());
+/// // Safe / Auto pass through unchanged with no warning
+/// assert_eq!(coerce_for_top_level(TrustMode::Safe), (TrustMode::Safe, None));
+/// assert_eq!(coerce_for_top_level(TrustMode::Auto), (TrustMode::Auto, None));
+/// ```
+pub fn coerce_for_top_level(candidate: TrustMode) -> (TrustMode, Option<&'static str>) {
+    match candidate {
+        TrustMode::Plan => (
+            TrustMode::Safe,
+            Some(
+                "Plan mode is sub-agent-only (read-only mode for spawned agents). \
+                 Falling back to Safe for the main session.",
+            ),
+        ),
+        other => (other, None),
     }
 }
 
@@ -1016,6 +1070,105 @@ mod tests {
             check_tool_with_tracker("Delete", &args, TrustMode::Safe, Some(root), None),
             ToolApproval::NeedsConfirmation,
             "Without tracker, Delete should need confirmation in Safe"
+        );
+    }
+
+    // ── #1244: Plan is sub-agent-only for the top-level session ────────────────
+    //
+    // The bug-review session that opened #1232 surfaced that a user
+    // can land in `TrustMode::Plan` for the **main session** via:
+    //   * `koda --mode plan` CLI flag
+    //   * `/resume` of a session that was previously persisted in Plan
+    // …which makes no sense — Plan denies all write tools, so the
+    // top-level user gets a model that can read but never act.
+    // `coerce_for_top_level` is the single funnel every non-sub-agent
+    // entry point goes through; sub-agent dispatch (`derive_child_trust`)
+    // is unaffected and continues to produce Plan freely.
+
+    #[test]
+    fn coerce_top_level_plan_falls_back_to_safe_with_warning() {
+        // The whole point of the fix: Plan must NOT survive as a
+        // top-level mode. Pin the coercion target (Safe — the most
+        // conservative writable mode) and the presence of a warning
+        // (callers depend on the `Some(_)` to know they should emit
+        // a banner / eprintln).
+        let (coerced, warning) = coerce_for_top_level(TrustMode::Plan);
+        assert_eq!(coerced, TrustMode::Safe, "Plan must coerce to Safe");
+        assert!(
+            warning.is_some(),
+            "Plan coercion must yield a warning so the user sees what happened"
+        );
+        // Sniff for the keywords callers will look for in the message;
+        // a wholesale rephrasing is fine but it must still self-explain.
+        let msg = warning.unwrap();
+        assert!(
+            msg.contains("Plan") && msg.contains("Safe"),
+            "warning must mention both Plan and Safe so the user knows what changed; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn coerce_top_level_safe_passes_through_unchanged_no_warning() {
+        // Negative regression: only Plan should ever produce a
+        // warning. Safe — the existing default — must round-trip
+        // exactly so users who explicitly `--mode safe` don't get
+        // a spurious banner.
+        let (coerced, warning) = coerce_for_top_level(TrustMode::Safe);
+        assert_eq!(coerced, TrustMode::Safe);
+        assert!(
+            warning.is_none(),
+            "Safe must not warn (it's the coerce target, not the source)"
+        );
+    }
+
+    #[test]
+    fn coerce_top_level_auto_passes_through_unchanged_no_warning() {
+        // Same negative regression for Auto. After #1241 flips the
+        // default to Auto, this test is the load-bearing assertion
+        // that the new default doesn't get caught by some future
+        // "coerce dangerous modes" change — only Plan ever coerces.
+        let (coerced, warning) = coerce_for_top_level(TrustMode::Auto);
+        assert_eq!(coerced, TrustMode::Auto);
+        assert!(
+            warning.is_none(),
+            "Auto is a valid top-level mode; no warning"
+        );
+    }
+
+    #[test]
+    fn coerce_top_level_is_idempotent() {
+        // Coercing the output of `coerce_for_top_level` again must
+        // never produce a warning — the result of a coerce IS valid
+        // by construction. Defends against a future change that
+        // accidentally widens what coerces (e.g. "also coerce Auto").
+        for mode in [TrustMode::Plan, TrustMode::Safe, TrustMode::Auto] {
+            let (first, _) = coerce_for_top_level(mode);
+            let (second, second_warn) = coerce_for_top_level(first);
+            assert_eq!(
+                first, second,
+                "coerce must be idempotent for input {mode:?}"
+            );
+            assert!(
+                second_warn.is_none(),
+                "coerce of an already-coerced value must not warn (input {mode:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn coerce_top_level_does_not_affect_derive_child_trust() {
+        // Sanity: the sub-agent dispatch path (`derive_child_trust`)
+        // is the LEGITIMATE source of Plan and must remain untouched
+        // by the top-level coercion. If a parent in Plan spawns a
+        // child, the child stays in Plan — coercion never enters
+        // the picture. This test pins that separation so a future
+        // "unify all trust-routing" refactor can't accidentally
+        // funnel sub-agents through `coerce_for_top_level`.
+        let child_inherits = derive_child_trust(TrustMode::Plan, TrustMode::Auto);
+        assert_eq!(
+            child_inherits,
+            TrustMode::Plan,
+            "sub-agent must keep Plan; coercion is top-level-only"
         );
     }
 }


### PR DESCRIPTION
Closes #1244. ~50 LoC of impl across 3 files + ~110 LoC of regression tests + 1 doctest.

## Why

`TrustMode::Plan` was *designed* as sub-agent-only — the keyboard toggle (Shift+Tab) loops Plan → Plan, and the `next()` doc-comment literally says *"agent-only, no toggle"*. But three other entry paths into the **top-level session** bypassed that intent:

| Path | Code | What happened pre-fix |
|---|---|---|
| `koda --mode plan` CLI flag | `app.rs:179, 254, 287` (3 sites) — `TrustMode::parse(&cli.mode)` accepts `plan` / `readonly` / `read-only`, fed straight into `with_trust(...)` | Top-level session lands in Plan; model's write tools silently denied → confused retry-loop-then-give-up |
| `/resume` of a Plan-persisted session | `tui_commands.rs:487` — `set_trust(shared_mode, parsed)` no-questions-asked | Resurrects the same confused state |
| Sub-agent dispatch via `derive_child_trust` | `trust.rs:176` | ✅ **Legitimate** — untouched by this PR |

Discovered during PR #1243 review when @lijunzh asked: *"I didn't know that we have a plan mode. I thought plan mode is only for sub agent."* They were right that Plan **should** be sub-agent-only; the code just didn't enforce that everywhere.

## What changed

### Single coercion point: `coerce_for_top_level` in `koda-core/src/trust.rs`

```rust
pub fn coerce_for_top_level(candidate: TrustMode) -> (TrustMode, Option<&'static str>) {
    match candidate {
        TrustMode::Plan => (TrustMode::Safe, Some("Plan mode is sub-agent-only …")),
        other => (other, None),
    }
}
```

Returns `&'static str` not `String` because the message is wholly static — callers `eprintln!` / `warn_msg` without an extra allocation.

### Three CLI sites in `koda-cli/src/app.rs`

All three sites now funnel through a new private helper:

```rust
fn parse_top_level_trust_mode(cli_mode: &str) -> koda_core::trust::TrustMode {
    let parsed = koda_core::trust::TrustMode::parse(cli_mode).unwrap_or_default();
    let (mode, warning) = koda_core::trust::coerce_for_top_level(parsed);
    if let Some(w) = warning { eprintln!("warning: {w}"); }
    mode
}
```

Call sites stay one-liners: `with_trust(parse_top_level_trust_mode(&cli.mode))`. DRY: the rule "Plan is sub-agent-only" lives in `coerce_for_top_level`, the "how do CLI flags pick up that rule" lives in this helper, and call sites stay tiny.

### One TUI site in `koda-cli/src/tui_commands.rs`

The `/resume` path calls `coerce_for_top_level` directly and emits the warning via the existing `tui_output::warn_msg(buffer, …)` so the user sees a banner in the chat history (not just stderr — which they can't see in the TUI).

### Drive-by docs fix

The misleading `Plan => Plan, // agent-only, no toggle` comment in `trust.rs:75-87` now reads `// sub-agent-only; #1244` and the `next()` doc-comment explains the new architecture so the next reader doesn't have to reverse-engineer it.

## What did NOT change

- `derive_child_trust` is **untouched**. Sub-agents inherit Plan freely — that's the whole point of the mode.
- `TrustMode::parse("plan")` still returns `Some(Plan)`. The parse layer is shared with the sub-agent dispatch path and shouldn't lie about which strings are recognized.
- The status-bar / prompt-indicator Plan rendering from #1243 stays as **defensive code**. Post-fix it'll never fire for the main session, but if a future regression somehow lands the top-level in Plan, the UI displays it correctly instead of silently misrendering.

## Tests

5 new unit tests in `koda_core::trust::tests`:

| Test | Pins |
|---|---|
| `coerce_top_level_plan_falls_back_to_safe_with_warning` | Both the coercion target (Safe) AND the presence of a warning string. Sniffs the warning for keywords "Plan" and "Safe" so a wholesale rephrasing is fine but the user-facing meaning has to survive. |
| `coerce_top_level_safe_passes_through_unchanged_no_warning` | Negative regression: only Plan ever produces a warning. Safe must round-trip exactly so users who explicitly `--mode safe` don't get a spurious banner. |
| `coerce_top_level_auto_passes_through_unchanged_no_warning` | Same negative regression for Auto. After #1241 flips the default to Auto, this test is the load-bearing assertion that the new default doesn't get caught by some future "coerce dangerous modes" change — only Plan ever coerces. |
| `coerce_top_level_is_idempotent` | Coercing the output of `coerce_for_top_level` again must never produce a warning (the result of a coerce IS valid by construction). Defends against a future change that accidentally widens what coerces. |
| `coerce_top_level_does_not_affect_derive_child_trust` | Sanity: the sub-agent path (`derive_child_trust`) is untouched. If a future "unify all trust-routing" refactor accidentally funnels sub-agents through `coerce_for_top_level`, this fails loudly. |

Plus the **doctest on `coerce_for_top_level`** exercises all three modes inline so the API contract is part of the rendered docs.

## Test status

- `cargo test -p koda-core --lib trust::` → **45 passing** (+5)
- `cargo test -p koda-core --doc trust` → **3 passing** (+1 doctest)
- `cargo test -p koda-core --lib` → **1,221 passing** (+5), 1 ignored, 0 failed
- `cargo test -p koda-cli --lib` → 618 passing (no koda-cli test changes)
- `cargo fmt --all --check` → clean
- `cargo clippy --workspace --tests -- -D warnings` → clean

## Compatibility

**Behavior change** for users who pass `--mode plan` or resume Plan-persisted sessions:
- They now land in **Safe** (the coerce target) with a one-line warning explaining what happened.
- Pre-fix they landed in Plan and every write tool the model called was silently denied — a worse UX even though it was technically what was requested.

**No public-API change** beyond adding `coerce_for_top_level`. `TrustMode::parse` is unchanged. `derive_child_trust` is unchanged. `Display`/`as_str`/`label` all unchanged.

## Out of scope

- Removing `TrustMode::Plan` entirely — sub-agents legitimately use it.
- Adding a `/mode <plan|safe|auto>` slash command — separate UX question; the loud badge in #1243 + Shift+Tab already cover Safe ↔ Auto cycling.
- Changing the alias map (`yolo`, `strict`, `readonly`, `read-only` → ...) — those still parse fine; only the **routing** of `Plan` to the main session changes.

## Refs

- Closes #1244 (the issue this PR implements)
- Refs #1232 (parent bug-review issue that surfaced the broader UX confusion)
- Refs #1243 (loud trust-mode badge — added Plan rendering, which prompted the discovery)
- Refs #1241 (flip default Safe → Auto — independent but the new "only Plan coerces" contract is the load-bearing invariant for that flip's safety)
