### PR TITLE
docs(claude.md): teach gh --body-file heredoc pattern for multi-line content (#1232 §7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **CLAUDE.md teaches the `gh --body-file` heredoc pattern for multi-line content** (#1232 §7). The Bash tool runs commands through `sh -c "…"`; inlining content with newlines, backticks, `$(…)`, or quotes burns a turn on `sh: -c: line N: syntax error near unexpected token …`. The bug-review session that opened #1232 reproduced this exact failure when the model called `gh issue create --title "…" --body "…"` with a markdown body containing backticks. New "Bash tool: pass multi-line / backtick content via files, not inline" subsection in `CLAUDE.md §Conventions` shows the always-good heredoc-into-temp-file pattern (`<<'EOF'` is single-quoted so nothing inside expands) and lists the canonical sites: `gh pr create --body-file`, `gh issue create --body-file`, `git commit -F`. CLAUDE.md is loaded as project memory on every session, so the nudge reaches both the master agent and every sub-agent. No code changes — docs only.
+
 ### Behaviour change
 
 - **Sub-agent trust matrix is now context-sensitive; `write_access` is deprecated in favor of `trust`** (#1250, #1251 PR A, this PR is PR B). Two changes that close the dead-channel bug from #1249 and consolidate the agent-scoping mechanism:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,6 +278,36 @@ Tools use PascalCase names. `mod.rs` has the registry, dispatcher, and `safe_res
   require cross-file context-switching. Test: if you must read file B
   every time you read file A, they should be the same file.
 
+### Bash tool: pass multi-line / backtick content via files, not inline
+
+The Bash tool runs commands through `sh -c "…"`. Inlining content that
+contains newlines, backticks, `$(…)`, or shell metacharacters in the
+argument string burns a turn on `sh: -c: line N: syntax error near
+unexpected token …` (#1232 §7).
+
+**Always-good pattern for `gh` issue/PR creation, commit messages,
+and any other multi-line payload:**
+
+```bash
+# 1. write the body to a temp file
+cat > /tmp/pr_body.md <<'EOF'
+## Summary
+
+Multi-line content with `backticks`, $(commands), and "quotes" all
+survive because the heredoc is parsed BEFORE sh -c sees the arg.
+EOF
+
+# 2. reference it via --body-file / -F
+gh pr create --title "…" --body-file /tmp/pr_body.md
+gh issue create --title "…" --body-file /tmp/pr_body.md
+git commit -F /tmp/commit_msg.md
+```
+
+The heredoc is single-quoted (`<<'EOF'`) so nothing inside it is
+expanded — you don't have to escape `$`, backticks, or `"`. This is
+strictly safer than `--body "…"` even for content you think is safe;
+the foot-gun is recurring and has zero upside to ignoring.
+
 ## Test Structure
 
 ### Quick reference


### PR DESCRIPTION
## Summary

Closes the **§7** sub-task of #1232 — the last small docs-only item in the bug-review umbrella. With this and the already-merged §1/§2/§3a/§3b/§4/§5/§6/§8a/§8b, the remaining unchecked item on the #1232 umbrella checklist is just sandbox-availability telemetry (a separate, more involved deliverable).

## Background

The Bash tool runs commands through `sh -c "…"`. Inlining content with newlines, backticks, `$(…)`, or shell metacharacters in the argument string burns a turn on `sh: -c: line N: syntax error near unexpected token …`.

The bug-review session that opened #1232 reproduced this exact failure when the model called `gh issue create --title "…" --body "…"` with a multi-line markdown body containing backticks. Per #1232 §7, the agreed mitigation is a CLAUDE.md / system-prompt nudge teaching the heredoc-into-temp-file pattern. The "real fix" (argv-array Bash variant) is much bigger surgery and explicitly out-of-scope for this issue.

## What this PR adds

A new "Bash tool: pass multi-line / backtick content via files, not inline" subsection in `CLAUDE.md §Conventions` showing:

- The always-good pattern: `cat > /tmp/file <<'EOF' … EOF` then reference via `--body-file` / `-F`
- Why the single-quoted heredoc (`<<'EOF'`) is the right primitive: nothing inside expands, no escaping needed for `$`, backticks, or `"`
- Three canonical sites: `gh pr create --body-file`, `gh issue create --body-file`, `git commit -F`

## Why CLAUDE.md (not the system prompt)

CLAUDE.md is loaded as project memory on every session start (and is shared across master agent + every sub-agent thanks to the #1240 memo cache). The default agent's `system_prompt` is intentionally minimal:

> You are an interactive CLI agent for software engineering tasks.

…and delegates project conventions to CLAUDE.md. Adding the nudge here reaches every agent without bloating the per-agent prompt.

## Diff

```
 CHANGELOG.md |  4 ++++
 CLAUDE.md    | 30 ++++++++++++++++++++++++++++++
 2 files changed, 34 insertions(+)
```

No code changes. No tests added (this is a documentation/prompt nudge; testing it would mean asserting the LLM behavior change, which is the domain of the next bug-review bundle).

## Refs

- Closes #1232 §7
- Companion to #1235, #1236, #1237, #1238, #1239, #1240, #1242, #1243 (#1232 sub-task series)
- Brings #1241 (Safe→Auto default flip) one item closer to ready
