### PR TITLE
fix(tui): revert Auto badge inversion — black-on-green unreadable on some color schemes

### DIFF
--- a/docs/src/approval.md
+++ b/docs/src/approval.md
@@ -22,12 +22,15 @@ confirmation prompt before each mutation. There are no separate
 |------|-------|---------------|
 | **Plan** | 📋 PLAN (cyan) | "Investigation only — no side effects." Read tools auto-approve; mutating and destructive tools are **blocked** (not just confirmed). Use for code review, exploration, and dry runs. |
 | **Safe** | 🔒 SAFE (yellow) | "Confirm every side effect." Read tools auto-approve; everything that mutates state asks first. The conservative default. |
-| **Auto** | ⚡ **AUTO** (inverted black-on-green) | "Trust the sandbox." Read and mutating ops auto-approve within the sandbox; destructive ops (`rm -rf`, `git reset --hard`, `git push --force`, `Delete`) still ask. Outside-project writes still ask. |
+| **Auto** | ⚡ **AUTO** (bold green) | "Trust the sandbox." Read and mutating ops auto-approve within the sandbox; destructive ops (`rm -rf`, `git reset --hard`, `git push --force`, `Delete`) still ask. Outside-project writes still ask. |
 
-The `Auto` badge is **inverted black-on-green** specifically because
-Auto is the most-permissive mode and the user must never be unsure
-they're in it. Plan and Safe stay as bold colored text — visible but
-not as visually loud. (#1232 §8a)
+All three badges share the same icon + UPPERCASE + bold styling so
+the trust mode is unmissable in the status bar regardless of which
+mode you're in. Auto originally rendered as inverted black-on-green
+for extra loudness, but the hardcoded background clashed with
+terminal color schemes that already use bright green palettes;
+reverted to bold green text for guaranteed readability on every
+scheme. (#1232 §8a, originally #1243; reverted post-merge.)
 
 ## Trust mode × tool effect matrix (top-level / master agent)
 

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -118,23 +118,27 @@ impl Widget for StatusBar<'_> {
         // both. Bug-review session that opened #1232: "User wasn't
         // sure whether they were in Safe or Auto."
         //
-        // The new badge is icon + UPPERCASE + bold for every mode,
-        // with **inverted black-on-color** for Auto specifically
-        // (since Auto is the "be careful" mode that should be
-        // unmissable, especially before/when #1241 flips the default).
-        // Plan and Safe stay as bold colored text — visible but not
-        // as visually loud, matching the relative caution-level.
+        // The new badge is icon + UPPERCASE + bold for every mode.
+        // Auto used to render as a black-on-green inverted badge for
+        // extra loudness, but a hardcoded `bg: Green` clashes badly
+        // with terminal color schemes that already use a bright or
+        // light green palette — the black foreground washes out and
+        // "AUTO" becomes unreadable. Bold green text on the user's
+        // own background works on every scheme. (#1243 → reverted in
+        // this commit's PR; if #1241 needs more loudness post-flip,
+        // use `Modifier::REVERSED` which inverts using the user's own
+        // terminal colors instead of imposing fixed colors.)
         //
         // Color/icon choices match the prompt indicator in
         // `tui_viewport.rs` so users see the SAME color for the SAME
-        // mode across both surfaces (pre-fix Safe was Cyan in the
+        // mode across both surfaces (pre-#1243 Safe was Cyan in the
         // prompt and Yellow in the bar — confusing inconsistency).
         // Drive-by: the dead `"strict"` arm is gone (TrustMode never
         // emits that label; only `plan`/`safe`/`auto`).
         let (mode_icon, mode_fg, mode_bg) = match self.mode_label {
             "plan" => ("\u{1f4cb}", Color::Cyan, None),
             "safe" => ("\u{1f512}", Color::Yellow, None),
-            "auto" => ("\u{26a1}", Color::Black, Some(Color::Green)),
+            "auto" => ("\u{26a1}", Color::Green, None),
             // Defensive default for any future mode label that gets added
             // to `TrustMode` without updating this match. Renders as a
             // visible-but-bland "?" badge so it's obvious something is
@@ -441,8 +445,12 @@ mod tests {
     // The bug-review session that opened #1232 reported that the user
     // couldn't tell whether they were in Safe or Auto. The fix makes
     // the trust-mode segment unmissable: icon + UPPERCASE + bold for
-    // every mode, with **inverted black-on-color** specifically for
-    // Auto so the most-permissive mode reads as a colored badge.
+    // every mode. (#1243 originally rendered Auto as an inverted
+    // black-on-green badge for extra loudness, but the hardcoded
+    // green bg clashed with terminal color schemes that use bright
+    // green and made "AUTO" unreadable; reverted to bold green text
+    // matching Plan/Safe styling. The icon + uppercase + bold trio
+    // still makes Auto distinguishable at a glance.)
     //
     // Tests below pin the contract so a future "let's use a single
     // muted color for all status segments" refactor fails loudly.
@@ -470,17 +478,24 @@ mod tests {
     }
 
     #[test]
-    fn auto_badge_is_inverted_black_on_green_and_bold() {
-        // Auto is the loudest mode — inverted black-on-green badge.
-        // This is the configuration that's most likely to surprise a
-        // user (they're in YOLO-ish territory) so it MUST be visually
-        // distinct from regular colored text. Pin all three style
-        // attributes so the badge can't silently regress to plain
-        // colored text.
+    fn auto_badge_is_bold_green_text_no_background() {
+        // Auto used to render as inverted black-on-green for extra
+        // loudness, but a hardcoded Green background clashed with
+        // terminal color schemes that already use bright/light green
+        // — the black fg washed out and "AUTO" became unreadable.
+        // Now matches Plan/Safe styling: bold colored text on the
+        // user's own background, which works on every scheme. The
+        // ICON (⚡), the UPPERCASE label, and the bold modifier still
+        // make Auto distinguishable from Plan/Safe at a glance.
+        //
+        // If #1241 (flip default to Auto) needs more loudness, use
+        // `Modifier::REVERSED` here — it inverts using the user's
+        // own terminal colors instead of imposing fixed colors,
+        // guaranteed-readable on any scheme.
         let bar = StatusBar::new("gpt-4", "auto", 50);
         let (fg, bg, modifier) = cell_style_at(bar, "AUTO", 200);
-        assert_eq!(fg, Color::Black, "Auto badge fg must be black");
-        assert_eq!(bg, Color::Green, "Auto badge bg must be green (inverted)");
+        assert_eq!(fg, Color::Green, "Auto badge fg must be green");
+        assert_eq!(bg, Color::Reset, "Auto badge must have NO background fill");
         assert!(
             modifier.contains(Modifier::BOLD),
             "Auto badge must be bold; got modifier: {modifier:?}"
@@ -490,7 +505,8 @@ mod tests {
     #[test]
     fn safe_badge_is_bold_yellow_text_no_background() {
         // Safe is conservative-default — visible (bold yellow) but
-        // not as loud as Auto's inverted badge. No background fill.
+        // matches Plan/Auto styling: bold colored text on the user's
+        // own background, no fill.
         // Yellow matches the prompt indicator in `tui_viewport.rs`
         // (post-fix); pre-fix Safe was Cyan in the prompt, Yellow in
         // the bar — confusing inconsistency this test pins gone.


### PR DESCRIPTION
## Summary

#1243 introduced an inverted black-on-green badge for the Auto trust mode in the status bar. The intent was good (Auto is the most-permissive mode, so it should be the most visually loud), but the implementation hardcoded `bg: Color::Green` which **clashes badly with terminal color schemes that already use a bright or light green palette** — the black foreground washes out against the bright green and "AUTO" becomes literally unreadable.

This is a real user-reported regression: *"looks terrible for my color scheme … I can't read the text 'auto' at all"*.

## What changes

| Mode | Icon | Label | Style | Status |
|---|---|---|---|---|
| Plan | 📋 | PLAN | bold cyan, no bg | unchanged |
| Safe | 🔒 | SAFE | bold yellow, no bg | unchanged |
| **Auto** | ⚡ | **AUTO** | **bold green, no bg** | **fixed (was: black on green)** |

The icon (⚡) + UPPERCASE label + bold modifier still make Auto distinguishable from Plan/Safe at a glance. We're losing the inversion gimmick, not the visual distinction.

### Files touched

**`koda-cli/src/widgets/status_bar.rs`**
- One match-arm change: `("auto", Color::Green, None)` instead of `(Color::Black, Some(Color::Green))`
- Inline doc comments updated to explain the revert + point future tweaks toward `Modifier::REVERSED` (see "Considered alternatives" below)

**`koda-cli/src/widgets/status_bar.rs` tests**
- `auto_badge_is_inverted_black_on_green_and_bold` → `auto_badge_is_bold_green_text_no_background`
- The contract pin **flipped**: the test now ENFORCES bold-green-no-bg and would fail if a future commit reintroduces the hardcoded green bg
- Surrounding test-module comment + Safe test's stale "not as loud as Auto's inverted badge" comparison updated

**`docs/src/approval.md`**
- Three modes table: Auto badge preview changed from "(inverted black-on-green)" to "(bold green)"
- Follow-up paragraph that justified the inversion replaced with a note explaining the revert

## What does NOT change

- The icon + UPPERCASE + bold treatment for all three modes — the substantive #1243 readability win stays
- Prompt indicator colors in `tui_viewport.rs` — already used `Color::Green` (foreground) for Auto, no inversion. Good.
- The match arm for unknown mode labels (`?` placeholder) — still there as a defensive default
- Trust mode behavior — pure visual change. **Zero behavior delta.**

## Considered alternatives

- **`Modifier::REVERSED`** instead of fixed black-on-green: would swap fg/bg using the user's terminal scheme, guaranteed-readable on any scheme. Rejected for now because plain bold green matches Plan/Safe styling more cleanly. **If #1241 (flip default to Auto) needs more loudness, REVERSED is the right tool** — documented in the inline comment so the next person doesn't reach for a hardcoded color again.
- **Combine with #1241** (flip default Safe→Auto): rejected. #1241 has an outstanding "sandbox-availability telemetry" prereq that this fix doesn't share, and combining a 50-line readability fix with a multi-file default flip creates avoidable review surface.

## Verification

- `cargo test -p koda-cli --lib` → **618 passing** (renamed test green; pinned `bg=Color::Reset`, `fg=Color::Green`, `BOLD` modifier)
- `cargo clippy -p koda-cli --all-targets -D warnings` → **clean**
- `mdbook build docs/` → **clean** (one pre-existing `<name>` warning in `mcp.md`, unrelated)

## Diff stats

```
 docs/src/approval.md               | 13 +++++----
 koda-cli/src/widgets/status_bar.rs | 56 ++++++++++++++++++++++++--------------
 2 files changed, 44 insertions(+), 25 deletions(-)
```

## Refs

- Reverts the `bg: Some(Color::Green)` portion of #1243 (#1232 §8a)
- The rest of #1243 (icon, uppercase, bold, prompt-color alignment, dead `"strict"` arm removal, defensive `_` arm) is **preserved**
- Unblocks #1241 (badge styling now consistent across modes; if more loudness needed post-flip, use `Modifier::REVERSED`)
