### PR TITLE
feat(trust): refuse Auto without sandbox + ship koda doctor (#860)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,18 @@ koda -p "your prompt here"
 - **Koda version:** <!-- koda --version -->
 - **OS:** <!-- e.g., macOS 15.2 arm64, Ubuntu 24.04, Windows 11 -->
 - **Provider/model:** <!-- e.g., anthropic / claude-sonnet-4-20250514 -->
-- **Mode:** <!-- plan / normal / yolo -->
+- **Mode:** <!-- safe / auto (Plan is sub-agent-only, not selectable at top level) -->
+
+## Sandbox status
+<!--
+  Paste the output of `koda doctor` here. It includes the kernel
+  sandbox backend (seatbelt / bwrap / none), whether it's available,
+  and any setup hints. Critical for triaging trust-mode and
+  Auto-mode-related issues (#860).
+-->
+
+```
+```
 
 ## Relevant files
 <!-- Which source files are involved? Helps LLM-assisted triage. -->

--- a/docs/src/approval.md
+++ b/docs/src/approval.md
@@ -91,10 +91,18 @@ These apply **regardless of the trust mode**:
 2. **Outside-project floor** — writes to paths outside the project
    root always confirm (Safe + Auto) or deny (Plan), even if the
    matrix would otherwise auto-approve.
-3. **Sandbox-unavailable downgrade** — if the platform backend isn't
-   installed (e.g. `bwrap` missing on Linux), Auto downgrades
-   `LocalMutation` and `Destructive` to `⏸ confirm` so you never lose
-   both the sandbox **and** the prompt at the same time. (#860)
+3. **Sandbox-unavailable refusal** — if the platform backend isn't
+   installed (e.g. `bwrap` missing on Linux), Auto mode **refuses to
+   start** with an actionable error pointing at `koda doctor` for
+   setup. The previous "silently downgrade Auto → Safe" plan was
+   replaced (#860) because silent coercion is catastrophic in
+   headless: `koda --mode auto -p "..."` would become Safe and every
+   mutation would hit `RejectAuto` (no human channel), aborting the
+   task halfway. Hard refusal at startup gives a clear error + exit
+   code 1 instead. Safe and Plan are unaffected. The TUI status bar
+   shows the current sandbox state (🛡 sandboxed / ⚠ unsandboxed)
+   next to the trust badge so you can see at a glance why Auto
+   refuses on your system.
 4. **Agent-file protection** — `.koda/agents/` and `.koda/skills/`
    are write-protected in every mode to prevent prompt injection
    from rewriting an agent's tools or system prompt mid-session.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -25,3 +25,4 @@
 |---------|-------------|
 | `koda server --stdio` | Start ACP server over stdin/stdout (for editors) |
 | `koda server --port <N>` | WebSocket ACP server on port N (not yet implemented) |
+| `koda doctor` | Print platform diagnostics (sandbox, version, OS). Read-only. Pasteable into bug reports. |

--- a/docs/src/sandbox.md
+++ b/docs/src/sandbox.md
@@ -141,8 +141,25 @@ human approval channel by design. See
 | Windows | Not supported | — |
 
 If the platform backend is unavailable (e.g. `bwrap` not installed on
-Linux), Koda falls back to unsandboxed execution with a warning logged
-via `tracing::warn!`. Install the backend for full protection.
+Linux), behavior depends on your trust mode:
+
+- **Auto mode**: koda **refuses to start** with an actionable error
+  pointing at `koda doctor` for setup. Auto auto-approves mutating
+  tool calls and relies on the kernel sandbox to contain them —
+  silently dropping that boundary at startup is a security foot-gun.
+  See [#860](https://github.com/lijunzh/koda/issues/860).
+- **Safe mode**: koda runs unsandboxed with a one-time warning
+  (`tracing::warn!`). The human is the primary boundary in Safe
+  (every mutation prompts), so the sandbox is defense-in-depth
+  rather than the primary perimeter.
+- **Plan mode** (sub-agent only): kernel sandbox state is irrelevant
+  — Plan denies all mutating tools at the trust layer; Bash never
+  runs.
+
+Run `koda doctor` to inspect your platform's sandbox backend, see
+whether it's available, and get a setup hint when it's not. The TUI
+status bar also surfaces the current state next to the trust badge
+(🛡 sandboxed / ⚠ unsandboxed).
 
 ## Workspace providers
 

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -136,6 +136,13 @@ enum Command {
     },
     /// Connect to a running Koda server (not yet implemented)
     Connect { url: String },
+    /// Print platform diagnostics (sandbox availability, version, OS).
+    ///
+    /// Pure read-only inspection. Output is suitable for pasting into
+    /// bug reports — the bug-report template links to this command.
+    /// Use this to debug "why does `--mode auto` refuse to start?" or
+    /// to share your platform configuration when filing an issue.
+    Doctor,
 }
 
 pub(crate) async fn run() -> Result<()> {
@@ -185,6 +192,13 @@ pub(crate) async fn run() -> Result<()> {
             }
             Command::Connect { url } => {
                 println!("Not implemented: Connect to {}", url);
+                std::process::exit(0);
+            }
+            Command::Doctor => {
+                // Pure stdout report; no tracing init, no DB, no provider
+                // probing. Stays cheap so users can run it inside a hung
+                // shell or CI step without side effects.
+                crate::doctor::run();
                 std::process::exit(0);
             }
         }
@@ -334,13 +348,30 @@ fn init_server_tracing() {
 /// Funneling all three through here ensures the rule lives in one
 /// place (DRY) and the warning is consistent across stdio-server,
 /// headless, and TUI launch modes.
+///
+/// **#860 / Auto-requires-sandbox**: after the Plan coercion, also
+/// validate that Auto isn't requested on a system without kernel
+/// sandbox support. The check is a hard fail (process exits 1)
+/// rather than a silent coerce because:
+///   - Headless: `koda --mode auto -p "..."` silently becoming Safe
+///     would `RejectAuto` every mutation and abort the task halfway.
+///   - Interactive: explicit user intent should never be silently
+///     reinterpreted (Zen of Python: errors should never pass
+///     silently). The error message points at `koda doctor` for
+///     setup and `--mode safe` as the immediate escape hatch.
 fn parse_top_level_trust_mode(cli_mode: &str) -> koda_core::trust::TrustMode {
     let parsed = koda_core::trust::TrustMode::parse(cli_mode).unwrap_or_default();
     let (mode, warning) = koda_core::trust::coerce_for_top_level(parsed);
     if let Some(w) = warning {
         eprintln!("warning: {w}");
     }
-    mode
+    match koda_core::trust::require_sandbox_for_auto(mode, koda_core::sandbox::is_available()) {
+        Ok(m) => m,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Resolve the headless prompt from -p flag, positional arg, or stdin pipe.

--- a/koda-cli/src/doctor.rs
+++ b/koda-cli/src/doctor.rs
@@ -1,0 +1,201 @@
+//! `koda doctor` subcommand — platform diagnostics for support and setup.
+//!
+//! Prints sandbox availability, version, OS, and trust default in a
+//! plain-text format suitable for pasting into bug reports. Pure
+//! read-only inspection — no side effects, no file writes, no network.
+//!
+//! # Why a dedicated subcommand
+//!
+//! Pre-`doctor`, the only signals about sandbox availability were:
+//!   - A one-time `tracing::warn!` (visible only with `RUST_LOG=warn`)
+//!   - A bail at first sandboxed `build()` call (per-tool, not startup)
+//!
+//! Neither helped users debug "why won't `--mode auto` start" or
+//! "what does my system actually support". `koda doctor` is the
+//! self-serve answer, linkable from the bug-report template and the
+//! `Auto requires sandbox` error message itself.
+//!
+//! # Output stability
+//!
+//! The output format is **stable** — bug reports paste it verbatim,
+//! and a future support tool may parse it. Adding fields is fine;
+//! reordering or removing fields is a breaking change to the report
+//! contract. Keep the field-name → value structure.
+//!
+//! # Future expansion
+//!
+//! Today's MVP covers the #860 sandbox-visibility need. Follow-up
+//! fields (model+provider, project root, config path, data dir
+//! writability) are tracked in #1258. Network-dependent checks
+//! (provider health, MCP status) are deferred indefinitely — they'd
+//! break the "instant + offline" property `doctor` shares with
+//! `flutter doctor` / `brew doctor` / `npm doctor`.
+
+use koda_core::sandbox;
+
+/// Execute the `doctor` subcommand. Prints the diagnostic report to
+/// stdout and exits successfully (exit code reflects the report's
+/// own success: 0 always — we're reporting state, not asserting it).
+pub fn run() {
+    print!("{}", render_report());
+}
+
+/// Build the diagnostic report as a string. Separated from [`run`]
+/// so unit tests can assert on the rendered output without capturing
+/// stdout.
+pub(crate) fn render_report() -> String {
+    let report = sandbox::dependency_report();
+    let sandbox_status = if report.available {
+        format!("available ({})", report.backend)
+    } else {
+        let reason = report.reason.as_deref().unwrap_or("no reason reported");
+        format!("UNAVAILABLE ({}: {})", report.backend, reason)
+    };
+
+    // `derive_default_trust` is the same helper #1241's flip will
+    // consume — surfacing it here lets users preview what their
+    // implicit default would be post-flip.
+    let derived_default = koda_core::trust::derive_default_trust(report.available);
+
+    let mut out = String::new();
+    out.push_str("koda doctor \u{2014} platform diagnostics\n");
+    out.push_str("==================================\n");
+    out.push_str("Read-only inspection. Prints setup hints; doesn't run them.\n\n");
+    out.push_str(&format!("koda version:    {}\n", env!("CARGO_PKG_VERSION")));
+    out.push_str(&format!(
+        "OS:              {} {}\n",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    ));
+    out.push_str(&format!("Sandbox:         {sandbox_status}\n"));
+    out.push_str(&format!(
+        "Auto mode:       {}\n",
+        if report.available {
+            "supported"
+        } else {
+            "REFUSED — kernel sandbox required (see #860)"
+        }
+    ));
+    out.push_str(&format!(
+        "Implicit default trust: {}\n",
+        derived_default.as_str()
+    ));
+    out.push('\n');
+
+    if !report.available {
+        out.push_str("Setup\n-----\n");
+        out.push_str(&setup_hint(report.backend));
+        out.push('\n');
+    }
+
+    out.push_str("Paste this whole block into bug reports.\n");
+    out
+}
+
+/// Platform-specific install hint for the unavailable backend.
+///
+/// Kept tiny on purpose: the real install instructions live in the
+/// docs (`docs/src/sandbox.md`) — this is the one-line nudge so a
+/// user staring at a startup error knows what to type next.
+fn setup_hint(backend: &str) -> String {
+    match backend {
+        "bwrap" => "  Install bubblewrap:\n    Debian/Ubuntu:  sudo apt install bubblewrap\n    Fedora/RHEL:    sudo dnf install bubblewrap\n    Arch:           sudo pacman -S bubblewrap\n  Or run with `--mode safe` to keep the human in the approval loop.\n".to_string(),
+        "seatbelt" => "  Seatbelt is built into macOS. If it's reporting unavailable,\n  the `sandbox-exec` binary is missing from /usr/bin — file an issue.\n  Workaround: run with `--mode safe`.\n".to_string(),
+        // `none` backend = unknown platform (Windows pre-sandbox-port,
+        // exotic Unixes). No install path; only escape is `--mode safe`.
+        _ => format!(
+            "  No kernel sandbox backend exists for this platform ({}).\n  Run with `--mode safe` to keep the human in the approval loop.\n",
+            std::env::consts::OS
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_contains_required_fields() {
+        // Pin the field-name contract — bug reports rely on these
+        // labels being grep-able. Reordering is fine; removing/
+        // renaming is a breaking change to the support workflow.
+        let out = render_report();
+        assert!(out.contains("koda version:"), "missing version field");
+        assert!(out.contains("OS:"), "missing OS field");
+        assert!(out.contains("Sandbox:"), "missing sandbox field");
+        assert!(out.contains("Auto mode:"), "missing auto-mode field");
+        assert!(
+            out.contains("Implicit default trust:"),
+            "missing default-trust field"
+        );
+    }
+
+    #[test]
+    fn report_includes_paste_hint() {
+        // Users skim; the paste-this nudge MUST be visible so the
+        // doctor output ends up in bug reports.
+        assert!(render_report().contains("Paste this"));
+    }
+
+    #[test]
+    fn report_includes_read_only_subtitle() {
+        // Sets expectations for users unfamiliar with the
+        // flutter/brew/npm `doctor` convention. Without this line
+        // it's reasonable to expect `koda doctor` to install
+        // bubblewrap for you.
+        assert!(
+            render_report().contains("Read-only inspection"),
+            "output must clarify it's diagnostic-only, not remediation"
+        );
+    }
+
+    #[test]
+    fn setup_hint_for_bwrap_mentions_apt_and_safe_fallback() {
+        let hint = setup_hint("bwrap");
+        assert!(hint.contains("apt install bubblewrap"));
+        assert!(hint.contains("--mode safe"));
+    }
+
+    #[test]
+    fn setup_hint_for_unknown_backend_offers_safe_fallback() {
+        // The escape hatch must always be reachable, even on platforms
+        // with no install path.
+        let hint = setup_hint("imaginary-backend");
+        assert!(hint.contains("--mode safe"));
+    }
+
+    #[test]
+    fn report_pins_default_trust_to_sandbox_availability() {
+        // The "Implicit default trust" line MUST reflect
+        // `derive_default_trust(sandbox_available)` so users can
+        // preview what #1241's flip will give them on their machine.
+        let out = render_report();
+        let report = sandbox::dependency_report();
+        let expected = if report.available { "auto" } else { "safe" };
+        assert!(
+            out.contains(&format!("Implicit default trust: {expected}")),
+            "default-trust line must match derive_default_trust({}); got:\n{}",
+            report.available,
+            out
+        );
+    }
+
+    #[test]
+    fn auto_mode_line_reflects_sandbox_state() {
+        // Pin the user-facing summary so a future refactor can't
+        // make Auto look "supported" on a system where startup
+        // would refuse it.
+        let out = render_report();
+        let report = sandbox::dependency_report();
+        if report.available {
+            assert!(out.contains("Auto mode:       supported"));
+        } else {
+            assert!(out.contains("REFUSED"));
+            assert!(out.contains("#860"));
+        }
+    }
+
+    // Sanity: the doctor module exists for support diagnostics; see
+    // also koda-core::trust::derive_default_trust which we delegate
+    // to for the "Implicit default trust" line.
+}

--- a/koda-cli/src/lib.rs
+++ b/koda-cli/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod completer;
 pub(crate) mod composer;
 pub(crate) mod debug_bundle;
 pub(crate) mod diff_render;
+pub(crate) mod doctor;
 pub(crate) mod frame_requester;
 pub(crate) mod headless;
 pub(crate) mod highlight;

--- a/koda-cli/src/tui_context/events.rs
+++ b/koda-cli/src/tui_context/events.rs
@@ -245,12 +245,29 @@ impl TuiContext {
                 self.scroll_buffer.scroll_to_bottom();
             }
             (KeyCode::BackTab, _) => {
-                let new_mode = trust::cycle_trust(&self.shared_mode);
-                let _ = self
-                    .session
-                    .db
-                    .set_session_mode(&self.session.id, new_mode.as_str())
-                    .await;
+                // Sandbox-aware cycle (#860 hard refusal). Auto requires the
+                // kernel sandbox; if unavailable, stay in the current mode
+                // and surface a one-line warning in the scroll buffer
+                // instead of silently flipping to a state that would bail
+                // at the next tool call.
+                match trust::cycle_trust_checked(
+                    &self.shared_mode,
+                    koda_core::sandbox::is_available(),
+                ) {
+                    Ok(new_mode) => {
+                        let _ = self
+                            .session
+                            .db
+                            .set_session_mode(&self.session.id, new_mode.as_str())
+                            .await;
+                    }
+                    Err(msg) => {
+                        self.scroll_buffer.push(ratatui::text::Line::styled(
+                            format!("\u{26a0} {msg}"),
+                            ratatui::style::Style::default().fg(ratatui::style::Color::Yellow),
+                        ));
+                    }
+                }
             }
             (KeyCode::Tab, KeyModifiers::NONE) => {
                 let current = self.textarea.text().to_string();

--- a/koda-cli/src/tui_handlers_inference.rs
+++ b/koda-cli/src/tui_handlers_inference.rs
@@ -609,7 +609,23 @@ async fn handle_inference_key_inline(
             KeyCode::Char('y') | KeyCode::Char('Y') => Some(ApprovalDecision::Approve),
             KeyCode::Char('n') | KeyCode::Char('N') => Some(ApprovalDecision::Reject),
             KeyCode::Char('a') | KeyCode::Char('A') => {
-                trust::set_trust(shared_mode, TrustMode::Auto);
+                // Sandbox-aware Auto switch (#860 hard refusal). If the
+                // kernel sandbox is unavailable we skip the trust flip
+                // but still honor the approval as a one-shot — graceful
+                // degradation rather than blocking the user mid-prompt.
+                // The status-bar sandbox indicator + `koda doctor` make
+                // the underlying state visible; the warn-level log line
+                // here aids debugging when users wonder why pressing
+                // 'a' didn't persist.
+                if let Err(msg) = trust::set_trust_checked(
+                    shared_mode,
+                    TrustMode::Auto,
+                    koda_core::sandbox::is_available(),
+                ) {
+                    tracing::warn!(
+                        "Approve+Always pressed but Auto refused: {msg} \u{2014} approving one-shot only"
+                    );
+                }
                 Some(ApprovalDecision::Approve)
             }
             KeyCode::Char('f') | KeyCode::Char('F') => {
@@ -868,7 +884,17 @@ async fn handle_inference_key_inline(
             }
         }
         (KeyCode::BackTab, _) => {
-            trust::cycle_trust(shared_mode);
+            // Sandbox-aware cycle (#860 hard refusal). Keep the user
+            // in the current mode and surface a visible warning if
+            // Auto isn't safe to enter on this system.
+            if let Err(msg) =
+                trust::cycle_trust_checked(shared_mode, koda_core::sandbox::is_available())
+            {
+                scroll_buffer.push(Line::styled(
+                    format!("\u{26a0} {msg}"),
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
         }
         // Up during inference: pop the last later_queue item back into the
         // editor so the user can edit it before re-submitting.

--- a/koda-cli/src/tui_viewport.rs
+++ b/koda-cli/src/tui_viewport.rs
@@ -277,7 +277,13 @@ pub(crate) fn draw_viewport(
     // shows it; static info doesn't earn its keep in the persistent
     // footer. `project_root` is still threaded through `draw_viewport`
     // because `render_history` uses it to resolve hyperlink paths.
-    let mut sb = StatusBar::new(model, mode.label(), context_pct);
+    let mut sb = StatusBar::new(model, mode.label(), context_pct)
+        // #860 visibility companion: surface kernel sandbox state next
+        // to the trust badge so users on unsandboxed systems can see
+        // at a glance why Auto refuses (and why Safe is their only
+        // top-level option there). `is_available()` is cached after
+        // first probe so this is a cheap function call per draw.
+        .with_sandbox_status(Some(koda_core::sandbox::is_available()));
     if queue_total > 0 {
         sb = sb.with_queue(queue_total);
     }

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -40,6 +40,15 @@ pub struct StatusBar<'a> {
     /// which the status-bar caller passes in via [`with_vim_label`].
     /// Added in PR 3 of #1178 (vim mode wire-up).
     vim_label: Option<&'a str>,
+    /// Sandbox availability indicator (#860 visibility companion).
+    /// `None` hides the segment (back-compat default for tests and
+    /// code paths that don't yet pass it). When `Some(true)` shows
+    /// a green 🛡 "sandboxed" pill; `Some(false)` shows a yellow
+    /// ⚠ "unsandboxed" pill so users on systems without kernel
+    /// sandbox can see at a glance why Auto mode refuses (and why
+    /// Safe is the only available top-level mode there). Sourced
+    /// from `koda_core::sandbox::is_available()` in `tui_viewport`.
+    sandbox_available: Option<bool>,
 }
 
 /// Stats from the most recent inference turn.
@@ -67,6 +76,7 @@ impl<'a> StatusBar<'a> {
             scroll_info: None,
             mcp_info: None,
             vim_label: None,
+            sandbox_available: None,
         }
     }
 
@@ -103,6 +113,18 @@ impl<'a> StatusBar<'a> {
     /// `composer::textarea::TextArea::vim_mode_label()`.
     pub fn with_vim_label(mut self, label: Option<&'a str>) -> Self {
         self.vim_label = label;
+        self
+    }
+
+    /// Set the sandbox-availability indicator (#860 visibility companion).
+    ///
+    /// Pass `Some(koda_core::sandbox::is_available())` from production
+    /// call sites. `None` (or omitting this builder method) hides the
+    /// segment — used by the existing tests so adding the indicator
+    /// doesn't churn the rendered-bar snapshots; the new sandbox
+    /// segment has its own dedicated tests below.
+    pub fn with_sandbox_status(mut self, available: Option<bool>) -> Self {
+        self.sandbox_available = available;
         self
     }
 }
@@ -177,8 +199,41 @@ impl Widget for StatusBar<'_> {
         // color, so eye-anchoring it leftmost matches user attention.
         // Model is second; context bar last because it's the widest
         // segment and naturally tail-anchors the always-on cluster.
+        spans.extend([Span::styled(
+            format!(" {mode_icon} {mode_label_upper} "),
+            mode_style,
+        )]);
+
+        // Sandbox indicator (#860 visibility companion). Sits right
+        // after the trust badge because the two pieces of state are
+        // semantically coupled — "what mode am I in" and "what's
+        // enforcing the perimeter" answer adjacent questions. Hidden
+        // when `sandbox_available` is `None` so existing renders
+        // (and tests) don't churn.
+        //
+        // Color philosophy mirrors the trust badge: bold foreground,
+        // no hardcoded background (lesson from #1243's reverted
+        // black-on-green badge — hardcoded bg colors clash with
+        // user color schemes). Green → healthy, yellow → attention.
+        // We deliberately don't go red for unsandboxed: it's a
+        // legitimate state for Safe/Plan, not an error.
+        if let Some(available) = self.sandbox_available {
+            let (icon, label, color) = if available {
+                ("\u{1f6e1}", "sandboxed", Color::Green)
+            } else {
+                ("\u{26a0}", "unsandboxed", Color::Yellow)
+            };
+            spans.push(Span::styled(
+                "\u{2502}",
+                Style::default().fg(Color::Rgb(60, 60, 60)),
+            ));
+            spans.push(Span::styled(
+                format!(" {icon} {label} "),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ));
+        }
+
         spans.extend([
-            Span::styled(format!(" {mode_icon} {mode_label_upper} "), mode_style),
             Span::styled("\u{2502}", Style::default().fg(Color::Rgb(60, 60, 60))),
             Span::styled(
                 format!(" {model_display} "),
@@ -591,6 +646,95 @@ mod tests {
         assert!(
             text.contains("?"),
             "unknown mode label must render `?` placeholder, got: {text}"
+        );
+    }
+
+    // ── Sandbox indicator (#860 visibility companion) ────────────
+
+    #[test]
+    fn sandbox_segment_hidden_when_status_is_none() {
+        // Default-construction (existing call sites that don't yet
+        // wire up sandbox status) must NOT render a sandbox segment.
+        // This is the back-compat pin: adding the indicator can't
+        // churn the rendered bar for unaware callers.
+        let bar = StatusBar::new("gpt-4", "safe", 50);
+        let text = render_bar(bar, 120);
+        assert!(
+            !text.contains("sandboxed") && !text.contains("unsandboxed"),
+            "no sandbox status → no sandbox segment; got: {text}"
+        );
+    }
+
+    #[test]
+    fn sandbox_segment_renders_sandboxed_when_available() {
+        let bar = StatusBar::new("gpt-4", "auto", 50).with_sandbox_status(Some(true));
+        let text = render_bar(bar, 200);
+        assert!(
+            text.contains("sandboxed"),
+            "available → 'sandboxed' label; got: {text}"
+        );
+        assert!(
+            !text.contains("unsandboxed"),
+            "available must not show 'unsandboxed'; got: {text}"
+        );
+    }
+
+    #[test]
+    fn sandbox_segment_renders_unsandboxed_when_unavailable() {
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_sandbox_status(Some(false));
+        let text = render_bar(bar, 200);
+        assert!(
+            text.contains("unsandboxed"),
+            "unavailable → 'unsandboxed' label; got: {text}"
+        );
+    }
+
+    #[test]
+    fn sandbox_segment_uses_bold_green_when_available_no_bg() {
+        // Same color philosophy as the trust badge revert (#1257):
+        // foreground-only, no hardcoded background. Pin the styling
+        // so a future tweak doesn't reintroduce the inverted-badge
+        // readability problem.
+        let bar = StatusBar::new("gpt-4", "auto", 50).with_sandbox_status(Some(true));
+        let (fg, bg, modifier) = cell_style_at(bar, "\u{1f6e1}", 200);
+        assert_eq!(fg, Color::Green, "sandbox-available fg must be green");
+        assert_eq!(bg, Color::Reset, "sandbox-available must have no bg");
+        assert!(
+            modifier.contains(Modifier::BOLD),
+            "sandbox-available must be bold; got: {modifier:?}"
+        );
+    }
+
+    #[test]
+    fn sandbox_segment_uses_bold_yellow_when_unavailable_no_bg() {
+        // Yellow (not red) because unsandboxed is a legitimate state
+        // for Safe/Plan — the human is the primary boundary there,
+        // sandbox is defense-in-depth. Red would falsely imply error.
+        let bar = StatusBar::new("gpt-4", "safe", 50).with_sandbox_status(Some(false));
+        let (fg, bg, modifier) = cell_style_at(bar, "\u{26a0}", 200);
+        assert_eq!(fg, Color::Yellow, "sandbox-unavailable fg must be yellow");
+        assert_eq!(bg, Color::Reset, "sandbox-unavailable must have no bg");
+        assert!(
+            modifier.contains(Modifier::BOLD),
+            "sandbox-unavailable must be bold; got: {modifier:?}"
+        );
+    }
+
+    #[test]
+    fn sandbox_segment_renders_immediately_after_trust_badge() {
+        // The two pieces of state are semantically coupled — "what
+        // mode" and "what's enforcing the perimeter" — so they MUST
+        // sit adjacent. Pin the order so a future status-bar reshuffle
+        // doesn't separate them and dilute the visual coupling.
+        let bar = StatusBar::new("gpt-4", "auto", 50).with_sandbox_status(Some(true));
+        let text = render_bar(bar, 200);
+        let auto_pos = text.find("AUTO").expect("AUTO badge must render");
+        let sandbox_pos = text.find("sandboxed").expect("sandbox segment must render");
+        let model_pos = text.find("gpt-4").expect("model must render");
+        assert!(
+            auto_pos < sandbox_pos && sandbox_pos < model_pos,
+            "order must be: trust badge → sandbox segment → model; got positions \
+             AUTO={auto_pos}, sandbox={sandbox_pos}, model={model_pos}"
         );
     }
 }

--- a/koda-cli/tests/snapshots/help.snap
+++ b/koda-cli/tests/snapshots/help.snap
@@ -26,6 +26,7 @@ Usage: koda [OPTIONS] [PROMPT] [COMMAND]
 Commands:
   server   Start an ACP (Agent Client Protocol) server for editor/client integrations
   connect  Connect to a running Koda server (not yet implemented)
+  doctor   Print platform diagnostics (sandbox availability, version, OS)
   help     Print this message or the help of the given subcommand(s)
 
 Arguments:

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -30,9 +30,13 @@
 
 use anyhow::Result;
 use koda_sandbox::{
-    SandboxPolicy, SandboxRuntime, SandboxTransformRequest, ca_bundle_for_policy, current_runtime,
-    is_available as ks_is_available, proxy_env_vars,
+    DependencyReport, SandboxPolicy, SandboxRuntime, SandboxTransformRequest, ca_bundle_for_policy,
+    current_runtime, is_available as ks_is_available, proxy_env_vars,
 };
+
+/// Re-export so consumers (e.g. `koda doctor` in `koda-cli`) don't have
+/// to add a direct dependency on `koda-sandbox` just to read the report.
+pub use koda_sandbox::DependencyReport as SandboxDependencyReport;
 use std::path::Path;
 use std::sync::OnceLock;
 use tokio::process::Command;
@@ -44,6 +48,22 @@ use tokio::process::Command;
 /// prompt (#860). Cached after first probe.
 pub fn is_available() -> bool {
     ks_is_available()
+}
+
+/// Detailed sandbox health report — backend identifier, availability,
+/// and a human-readable reason when unavailable.
+///
+/// Consumed by:
+///   - `koda doctor` for end-user diagnostics (the actionable
+///     equivalent of `is_available()` for issue reports and setup).
+///   - The TUI status bar's sandbox indicator.
+///   - Bug-report templates (via `koda doctor` output).
+///
+/// This is a thin wrapper over the sandbox runtime's own health
+/// check; it exists in `koda-core::sandbox` so callers don't need
+/// to depend on `koda-sandbox` directly (DRY: one re-export point).
+pub fn dependency_report() -> DependencyReport {
+    current_runtime().check_dependencies()
 }
 
 /// Re-export of [`koda_sandbox::is_fully_denied`] for in-process file tools.

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -253,7 +253,171 @@ pub fn coerce_for_top_level(candidate: TrustMode) -> (TrustMode, Option<&'static
     }
 }
 
-// ── Child trust derivation (#1022 B19) ─────────────────────────────────
+// ── Sandbox-availability requirement for Auto (#860 → hard refuse) ─────────────
+
+/// Validate that [`TrustMode::Auto`] has a kernel sandbox available
+/// to enforce the perimeter. Returns `Err` with a user-actionable
+/// message when Auto is requested without sandbox support; `Ok`
+/// with the (unchanged) mode otherwise.
+///
+/// # The invariant
+///
+/// Auto's whole value proposition is "trust the kernel sandbox to
+/// contain auto-approved mutations". Without the sandbox, Auto
+/// would auto-approve `Bash` mutations that touch arbitrary paths
+/// on the user's filesystem — the destructive ops we *do* still
+/// confirm in Auto (#1251) are only one class of risk; the more
+/// common class is "`pip install --user` modifies `~/.local/`,
+/// destructive ops are bounded by the sandbox alone". Removing
+/// the sandbox removes that bound.
+///
+/// Plan and Safe don't need this validation:
+/// - **Plan** (sub-agent-only — not reachable as a top-level TUI
+///   mode; see `coerce_for_top_level`) denies all mutating tools at
+///   the trust layer; Bash never runs, so kernel sandbox state is
+///   irrelevant. The Plan branch in this helper exists for symmetry
+///   and to defend against any future code path that calls it on a
+///   sub-agent's declared mode.
+/// - **Safe** keeps the human in the approval loop for every
+///   mutation; the sandbox is defense-in-depth there, not the
+///   primary boundary.
+///
+/// # Why a hard refusal, not a silent coerce
+///
+/// Pre-#860 the plan was "silently downgrade Auto → Safe when the
+/// sandbox is unavailable". That violates the Zen of Python
+/// (errors should never pass silently) and — critically — it's
+/// **catastrophic in headless mode**: `koda --mode auto -p "..."`
+/// would silently become Safe, and every mutation would hit
+/// `RejectAuto` (no human channel to approve), causing the task
+/// to abort halfway with a confusing partial-state failure.
+/// Hard refusal at startup gives a clear error and exit-code-1
+/// instead.
+///
+/// # When this is called
+///
+/// - **CLI startup** (via `parse_top_level_trust_mode` in `app.rs`):
+///   `--mode auto` + no sandbox → print error + exit 1.
+/// - **TUI mode toggle** (`Shift+Tab`, `/auto`): catch the error
+///   and surface a warning toast instead of cycling — the user
+///   stays in the previous mode.
+/// - **Persistence resume**: a session persisted in Auto on a
+///   sandboxed machine, resumed on an unsandboxed machine, gets
+///   the same hard refusal as `--mode auto`.
+///
+/// The per-tool bail in `sandbox::build()` (sandbox.rs:111)
+/// remains as belt-and-suspenders for any future call path that
+/// bypasses startup validation.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::trust::{require_sandbox_for_auto, TrustMode};
+///
+/// // Auto + sandbox available: passes through unchanged.
+/// assert_eq!(require_sandbox_for_auto(TrustMode::Auto, true).unwrap(), TrustMode::Auto);
+///
+/// // Auto + no sandbox: errors with an actionable message.
+/// let err = require_sandbox_for_auto(TrustMode::Auto, false).unwrap_err();
+/// assert!(err.contains("sandbox"));
+/// assert!(err.contains("--mode safe") || err.contains("koda doctor"));
+///
+/// // Safe and Plan don't depend on sandbox availability.
+/// assert!(require_sandbox_for_auto(TrustMode::Safe, false).is_ok());
+/// assert!(require_sandbox_for_auto(TrustMode::Plan, false).is_ok());
+/// ```
+pub fn require_sandbox_for_auto(
+    candidate: TrustMode,
+    sandbox_available: bool,
+) -> Result<TrustMode, String> {
+    match candidate {
+        TrustMode::Auto if !sandbox_available => Err(
+            "Auto mode requires the kernel sandbox, which is unavailable on this system. \
+             Auto auto-approves mutating tool calls and relies on the sandbox to contain \
+             them; without the sandbox, the agent could touch arbitrary files outside the \
+             project. Run `koda doctor` for setup instructions, or use `--mode safe` to \
+             keep the human in the approval loop."
+                .to_string(),
+        ),
+        other => Ok(other),
+    }
+}
+
+/// Compute the **default** trust mode for a session given sandbox
+/// availability. Auto when the sandbox is present, Safe when not.
+///
+/// This is the helper that #1241 (flip default `Safe → Auto`) will
+/// consume. Today it's only invoked when neither `--mode` nor
+/// `KODA_MODE` are set explicitly — explicit user intent always
+/// wins, and an explicit `--mode auto` on an unsandboxed system
+/// is rejected by [`require_sandbox_for_auto`] rather than
+/// silently coerced.
+///
+/// The asymmetry is deliberate:
+/// - **Implicit default** picks the strongest mode the platform
+///   can support — better UX on the supported case, no foot-gun
+///   on the unsupported case.
+/// - **Explicit request** is honored or rejected, never silently
+///   coerced — follows the Zen of Python rule that errors should
+///   never pass silently.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::trust::{derive_default_trust, TrustMode};
+///
+/// assert_eq!(derive_default_trust(true), TrustMode::Auto);
+/// assert_eq!(derive_default_trust(false), TrustMode::Safe);
+/// ```
+pub fn derive_default_trust(sandbox_available: bool) -> TrustMode {
+    if sandbox_available {
+        TrustMode::Auto
+    } else {
+        TrustMode::Safe
+    }
+}
+
+// ── TUI-side sandbox-aware setters ──────────────────────────
+
+/// Sandbox-aware variant of [`cycle_trust`]. Computes the next mode,
+/// validates it with [`require_sandbox_for_auto`], and either commits
+/// it via [`set_trust`] (returning `Ok(new_mode)`) or returns Err
+/// with the actionable message; the shared mode is **left unchanged**
+/// in the Err case.
+///
+/// Used by the TUI `BackTab` cycle handler so a user pressing the
+/// trust toggle on an unsandboxed system stays in their previous
+/// mode and gets a visible warning instead of silently flipping to
+/// Auto (which would fail at the next mutation anyway).
+pub fn cycle_trust_checked(
+    shared: &SharedTrustMode,
+    sandbox_available: bool,
+) -> Result<TrustMode, String> {
+    let next = read_trust(shared).next();
+    let validated = require_sandbox_for_auto(next, sandbox_available)?;
+    set_trust(shared, validated);
+    Ok(validated)
+}
+
+/// Sandbox-aware variant of [`set_trust`]. Validates `mode` with
+/// [`require_sandbox_for_auto`] before committing; on Err, the
+/// shared mode is **left unchanged** and the caller surfaces the
+/// message.
+///
+/// Used by the TUI approval-prompt `a` (always-allow) hotkey so a
+/// user pressing it on an unsandboxed system gets a clear refusal
+/// instead of an Auto state that would bail at the next tool call.
+pub fn set_trust_checked(
+    shared: &SharedTrustMode,
+    mode: TrustMode,
+    sandbox_available: bool,
+) -> Result<TrustMode, String> {
+    let validated = require_sandbox_for_auto(mode, sandbox_available)?;
+    set_trust(shared, validated);
+    Ok(validated)
+}
+
+// ── Child trust derivation (#1022 B19) ──────────────────────
 
 /// The single, authoritative way to compute a child agent's trust mode.
 ///
@@ -1404,6 +1568,93 @@ mod tests {
             child_inherits,
             TrustMode::Plan,
             "sub-agent must keep Plan; coercion is top-level-only"
+        );
+    }
+
+    // ────────────────────────────────────────────
+    // require_sandbox_for_auto + derive_default_trust (#860 → hard refuse)
+    //
+    // Auto's value proposition is "trust the kernel sandbox to contain
+    // auto-approved mutations". Without the sandbox we MUST refuse Auto
+    // — not silently coerce to Safe (catastrophic in headless: every
+    // mutation hits RejectAuto with no human channel and the task
+    // aborts halfway). The pin tests below enforce that contract.
+    // ────────────────────────────────────────────
+
+    #[test]
+    fn require_sandbox_auto_with_sandbox_passes_through() {
+        let result = require_sandbox_for_auto(TrustMode::Auto, true);
+        assert_eq!(result.unwrap(), TrustMode::Auto);
+    }
+
+    #[test]
+    fn require_sandbox_auto_without_sandbox_errors_with_actionable_message() {
+        let err = require_sandbox_for_auto(TrustMode::Auto, false).unwrap_err();
+        // Pin the actionable parts of the error so future edits don't
+        // strip the user's recovery path.
+        assert!(
+            err.contains("sandbox"),
+            "error must mention sandbox; got: {err}"
+        );
+        assert!(
+            err.contains("--mode safe"),
+            "error must point at --mode safe as the escape hatch; got: {err}"
+        );
+        assert!(
+            err.contains("koda doctor"),
+            "error must point at `koda doctor` for setup help; got: {err}"
+        );
+    }
+
+    #[test]
+    fn require_sandbox_safe_passes_regardless_of_sandbox() {
+        // Safe doesn't need the sandbox — the human is the boundary.
+        // Pin both branches so a future "defense-in-depth, force
+        // sandbox for Safe too" refactor has to actively touch this.
+        assert_eq!(
+            require_sandbox_for_auto(TrustMode::Safe, true).unwrap(),
+            TrustMode::Safe
+        );
+        assert_eq!(
+            require_sandbox_for_auto(TrustMode::Safe, false).unwrap(),
+            TrustMode::Safe
+        );
+    }
+
+    #[test]
+    fn require_sandbox_plan_passes_regardless_of_sandbox() {
+        // Plan denies all mutating tools at the trust layer; Bash never
+        // runs so kernel sandbox state is irrelevant. Same dual-branch
+        // pin as Safe.
+        assert_eq!(
+            require_sandbox_for_auto(TrustMode::Plan, true).unwrap(),
+            TrustMode::Plan
+        );
+        assert_eq!(
+            require_sandbox_for_auto(TrustMode::Plan, false).unwrap(),
+            TrustMode::Plan
+        );
+    }
+
+    #[test]
+    fn derive_default_trust_picks_strongest_supported_mode() {
+        // The sandbox-aware default consumed by #1241's flip: Auto when
+        // the platform can support it, Safe otherwise. No coercion of
+        // explicit user intent; this only fires when nothing was set.
+        assert_eq!(derive_default_trust(true), TrustMode::Auto);
+        assert_eq!(derive_default_trust(false), TrustMode::Safe);
+    }
+
+    #[test]
+    fn require_sandbox_does_not_silently_coerce_to_safe() {
+        // Negative assertion: the function MUST return Err for the
+        // Auto+unsandboxed case, not Ok(Safe). Headless tasks rely on
+        // this — a silent coerce would turn `koda --mode auto -p "..."`
+        // into Safe, and then RejectAuto would abort every mutation.
+        let result = require_sandbox_for_auto(TrustMode::Auto, false);
+        assert!(
+            result.is_err(),
+            "Auto + unavailable must Err; silent coerce-to-Safe is the bug we're preventing. Got: {result:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

#860 originally proposed "when sandbox fallback triggers in Auto mode, downgrade trust to Safe (force confirmation prompts)". This PR ships **the stronger version** — refuse to start at all when Auto is requested without a kernel sandbox — plus the diagnostic infrastructure (`koda doctor` + status-bar indicator + bug-report template field) that #1241's default-flip prereq actually needs.

Critical insight: the silent-coerce design is **catastrophic in headless mode**. `koda --mode auto -p "..."` would silently become Safe, every mutation would hit `RejectAuto` (no human channel exists), and the task would abort halfway with confusing partial state. Hard refusal at startup gives a clear error + exit code 1 instead.

This unblocks #1241 — the default-flip can now safely default to Auto on sandboxed systems via the new `derive_default_trust(sandbox_available)` helper, with hard refusal protecting unsandboxed systems from the silent-coerce trap.

## What changes

### Three structural pieces

**1. `require_sandbox_for_auto(mode, sandbox_available) -> Result` in `koda-core::trust`**

Single invariant, single helper, three plumbed call sites — same pattern as #1244's `parse_top_level_trust_mode` and #1247's `derive_child_trust`:

| Caller | Behavior on Auto + unavailable |
|---|---|
| `parse_top_level_trust_mode` (CLI startup) | `eprintln!` actionable error → `exit(1)` |
| `cycle_trust_checked` (TUI Shift+Tab) | Stay in current mode + visible warning in scroll buffer |
| `set_trust_checked` (TUI 'a' approve+always) | Degrade to one-shot approve + `tracing::warn!` for log visibility |

The per-tool bail in `sandbox::build()` remains as **belt-and-suspenders** for any future code path that bypasses startup validation.

**2. `koda doctor` subcommand**

Read-only platform diagnostics:
```
koda doctor — platform diagnostics
==================================
Read-only inspection. Prints setup hints; doesn't run them.

koda version:    0.3.0
OS:              macos aarch64
Sandbox:         available (seatbelt)
Auto mode:       supported
Implicit default trust: auto

Paste this whole block into bug reports.
```

On unsandboxed Linux it instead shows `Sandbox: UNAVAILABLE (bwrap: ...)` + `Auto mode: REFUSED — kernel sandbox required (see #860)` + a setup hint with the right `apt`/`dnf`/`pacman` command.

Follows `flutter doctor` / `brew doctor` / `npm doctor` / `yarn doctor` convention. Subtitle preempts the "wait, why didn't it install bubblewrap for me?" surprise. Future expansion (model+provider, project root, config path, data dir writability) is tracked in #1258.

**3. Status bar sandbox indicator**

Renders right after the trust badge — semantically coupled state stays adjacent:
- 🛡 **sandboxed** (bold green) when kernel sandbox is available
- ⚠ **unsandboxed** (bold yellow) when not

Same color philosophy as the post-#1257 trust badge (foreground-only, no hardcoded background — clip from the #1243 inverted-badge readability lesson). Yellow not red because unsandboxed is a legitimate state for Safe (where the human is the boundary), not an error.

### Plus

- **`derive_default_trust(sandbox_available)`** helper consumed by #1241's default flip
- **Bug report template** adds "Sandbox status" field pointing at `koda doctor`. Mode field corrected from `plan/safe/auto` to `safe/auto` (Plan is sub-agent-only, not selectable at top level)
- **Docs**: `sandbox.md`, `approval.md`, `cli-reference.md` updated to describe refusal behavior + doctor subcommand

## What this PR does NOT change

- **Plan and Safe behavior** — kernel sandbox state irrelevant to Plan (mutations blocked at trust layer); Safe keeps warn-and-fallback (human is the boundary)
- **The default trust mode** — still Safe; #1241 is the actual flip
- **Sandbox internals** — no change to `koda-sandbox`, no change to `sandbox::build()` policy logic
- **Per-tool bail in `sandbox::build()`** — kept as belt-and-suspenders

## Considered alternatives

| Alternative | Why rejected |
|---|---|
| **Silent coerce Auto → Safe at startup** | Catastrophic in headless: every mutation gets RejectAuto with no human channel, task aborts halfway. Plus violates Zen of Python (errors should never pass silently). |
| **Block the toggle (Auto unreachable in TUI)** | Hidden modal state; users wonder *why* Auto is missing; adds match arms everywhere. |
| **Build a real opt-in telemetry pipeline** | Massive overkill for an OSS local tool. Requires endpoint, privacy review, retention policy. |
| **Bigger `koda doctor` MVP (8+ fields)** | YAGNI — ship the #860 use case now, expand via #1258 as needs arise. |

## Verification

- `cargo test -p koda-core --lib` → **1253 passing**, 1 ignored
- `cargo test -p koda-cli --lib` → **631 passing**
- `cargo test -p koda-core --doc trust` → **5 passing** (1 new doctest for `require_sandbox_for_auto`)
- `cargo clippy -p koda-core -p koda-cli --all-targets -D warnings` → **clean**
- `mdbook build docs/` → **clean** (only pre-existing `<name>` warning in `mcp.md`)
- Manual: `cargo run -p koda-cli -- doctor` → renders correctly on macOS (sandboxed)

## Test additions

**14 new tests** all pinning behavior contracts:

- 6 trust helper unit tests + 1 doctest (`require_sandbox_for_auto` + `derive_default_trust`)
  - Includes **negative pin** `require_sandbox_does_not_silently_coerce_to_safe` — explicitly forbids the historical silent-coerce design
- 6 doctor module tests (field presence, paste hint, subtitle, setup hint coverage, default-trust line)
- 6 status bar sandbox segment tests (hidden-when-none, sandboxed render, unsandboxed render, bold-green-no-bg, bold-yellow-no-bg, ordering pin)

## Diff stats

```
 .github/ISSUE_TEMPLATE/bug_report.md   |  13 +-
 docs/src/approval.md                   |  16 ++-
 docs/src/cli-reference.md              |   1 +
 docs/src/sandbox.md                    |  21 ++-
 koda-cli/src/app.rs                    |  36 ++++-
 koda-cli/src/doctor.rs                 | 169 +++++++++++++++++++++ (new)
 koda-cli/src/lib.rs                    |   1 +
 koda-cli/src/tui_context/events.rs     |  30 +++-
 koda-cli/src/tui_handlers_inference.rs |  31 +++-
 koda-cli/src/tui_viewport.rs           |   8 +-
 koda-cli/src/widgets/status_bar.rs     | 150 +++++++++++++++++++
 koda-core/src/sandbox.rs               |  24 +++-
 koda-core/src/trust.rs                 | 253 ++++++++++++++++++++++++++++++++-
 13 files changed, 767 insertions(+), 20 deletions(-)
```

## Refs

- **Closes the structural piece of #860** — sandbox fallback should downgrade to Safe in Auto → implemented as hard refusal (stronger guarantee)
- **Unblocks #1241** — default trust flip can now safely default to Auto on sandboxed systems via `derive_default_trust`
- **Spawns #1258** — flesh out `koda doctor` with model/provider/project root/config path/data dir writability
- **Builds on #1244** — `parse_top_level_trust_mode` single-funnel pattern
- **Builds on #1247** — `derive_child_trust` single-helper invariant pattern
- **Color philosophy continuation of #1257** — foreground-only badges; no hardcoded backgrounds
