### PR TITLE
feat(trust): flip default trust mode `Safe` → `Auto` (closes #1241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed (BREAKING for first-run UX)
+
+- **Default trust mode flipped from `Safe` → `Auto`** (#1241). Running `koda` with no `--mode` flag and no `KODA_MODE` env var now starts in Auto mode (auto-approve mutations within the kernel sandbox; destructive ops and outside-project writes still confirm). The previous Safe-by-default — which prompted on **every** mutation — was the dominant source of "why is this thing nagging me?" friction and effectively encouraged users to flip to Auto on first use, making the safety value of Safe-by-default mostly theatrical.
+  - **Why this is safe to flip now**: the kernel sandbox (#1259), outside-project floor (`is_outside_project`), destructive backstop (#1251 — `Auto × Destructive` confirms, doesn't auto-approve), scratch-zone allowlist (#1236), and pre-flight context-budget check (#1237) are all in place. The trust badge is also legible (#1257) and accompanied by a sandbox indicator (#1259) so the active mode is unmissable.
+  - **What happens on unsandboxed platforms (Linux without bwrap, Windows)**: Auto refuses to start with an actionable error that includes platform-specific install instructions (#1259 + #1260). Users either install the sandbox backend (one command) or pass `--mode safe` to opt into the previous behavior. We picked **loud-fail-fast** over silent coercion for the same reason #1259 did: silent coercion in headless (`koda --mode auto -p "..."` becoming Safe and aborting every mutation) is catastrophic.
+  - **Migration for users who want the old behavior**: pass `--mode safe`, set `KODA_MODE=safe` in your shell, or per-session toggle with `Shift+Tab` in the TUI.
+  - **Migration for CI users**: explicitly pass `--mode safe` in your CI command. CI shouldn't rely on default behavior anyway.
+  - **No silent change for sub-agents**: per-agent `trust:` declarations in agent JSON are unaffected. Built-in agents continue to ship with their explicit `trust: "safe"` / `trust: "plan"` declarations. Only the **top-level session default** changes.
+
 ### Documentation
 
 - **Trust-mode mental model documented end-to-end across all surfaces** (#1250 doc follow-up). Updated the user-facing book in `docs/src/`, the architecture overview in `DESIGN.md`, and the contributor primer in `CLAUDE.md` to reflect the post-#1251/#1252 state:

--- a/docs/src/approval.md
+++ b/docs/src/approval.md
@@ -21,8 +21,8 @@ confirmation prompt before each mutation. There are no separate
 | Mode | Badge | Mental model |
 |------|-------|---------------|
 | **Plan** | 📋 PLAN (cyan) | "Investigation only — no side effects." Read tools auto-approve; mutating and destructive tools are **blocked** (not just confirmed). Use for code review, exploration, and dry runs. |
-| **Safe** | 🔒 SAFE (yellow) | "Confirm every side effect." Read tools auto-approve; everything that mutates state asks first. The conservative default. |
-| **Auto** | ⚡ **AUTO** (bold green) | "Trust the sandbox." Read and mutating ops auto-approve within the sandbox; destructive ops (`rm -rf`, `git reset --hard`, `git push --force`, `Delete`) still ask. Outside-project writes still ask. |
+| **Safe** | 🔒 SAFE (yellow) | "Confirm every side effect." Read tools auto-approve; everything that mutates state asks first. Use this in CI, locked-down workstations, or any context where you want a human in every approval loop. |
+| **Auto** | ⚡ **AUTO** (bold green) | "Trust the sandbox." Read and mutating ops auto-approve within the sandbox; destructive ops (`rm -rf`, `git reset --hard`, `git push --force`, `Delete`) still ask. Outside-project writes still ask. **Default since #1241** — the kernel sandbox + outside-project floor + destructive backstop combined provide a solid baseline without nag-by-default friction. Auto requires the kernel sandbox; on unsandboxed platforms koda refuses to start (#860 / #1259). |
 
 All three badges share the same icon + UPPERCASE + bold styling so
 the trust mode is unmissable in the status bar regardless of which

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -15,7 +15,7 @@
 | `--temperature <F>` | | Sampling temperature (0.0–2.0) |
 | `--thinking-budget <N>` | | Anthropic extended thinking budget (tokens) |
 | `--reasoning-effort <L>` | | OpenAI reasoning effort (`low`, `medium`, `high`) |
-| `--mode <MODE>` | `KODA_MODE` | Trust mode: `safe` (default) or `auto`. Safe confirms every side effect; Auto auto-approves all actions within the project sandbox. Kernel sandbox with credential protection is always active |
+| `--mode <MODE>` | `KODA_MODE` | Trust mode: `auto` (default, #1241) or `safe`. Auto auto-approves mutating actions; the kernel sandbox contains them — destructive ops (`rm -rf`, `git reset --hard`, `git push --force`, `Delete`) and outside-project writes still confirm. Auto requires the kernel sandbox; on unsandboxed platforms koda refuses to start (use `--mode safe` or install the platform sandbox backend). Safe confirms every mutation. Kernel sandbox with credential protection is always active when available. |
 | `--output-format <FMT>` | | Headless output format: `text` (default) or `json` |
 | `--project-root <DIR>` | | Project root (defaults to cwd) |
 

--- a/koda-cli/src/app.rs
+++ b/koda-cli/src/app.rs
@@ -111,11 +111,18 @@ struct Cli {
     #[arg(long)]
     reasoning_effort: Option<String>,
 
-    /// Trust mode: safe (default) or auto.
-    /// "safe" confirms every side effect before executing.
-    /// "auto" auto-approves all actions within the project sandbox.
+    /// Trust mode: auto (default) or safe.
+    /// "auto" auto-approves mutating actions; the kernel sandbox
+    /// contains them. Destructive ops (rm -rf, git reset --hard,
+    /// git push --force, Delete) and outside-project writes still
+    /// confirm. Auto requires the kernel sandbox; on unsandboxed
+    /// platforms koda refuses to start with an actionable error
+    /// (use --mode safe or install the platform sandbox backend).
+    /// "safe" confirms every mutation before executing — use this
+    /// in CI, locked-down workstations, or any context where you
+    /// want a human in every approval loop.
     /// Sandbox with credential protection is always active.
-    #[arg(long, env = "KODA_MODE", default_value = "safe",
+    #[arg(long, env = "KODA_MODE", default_value = "auto",
           value_parser = ["safe", "auto"])]
     mode: String,
 }

--- a/koda-cli/src/widgets/status_bar.rs
+++ b/koda-cli/src/widgets/status_bar.rs
@@ -559,9 +559,10 @@ mod tests {
 
     #[test]
     fn safe_badge_is_bold_yellow_text_no_background() {
-        // Safe is conservative-default — visible (bold yellow) but
-        // matches Plan/Auto styling: bold colored text on the user's
-        // own background, no fill.
+        // Safe is the opt-in conservative mode (post-#1241 Auto is
+        // the default) — visible (bold yellow) but matches Plan/Auto
+        // styling: bold colored text on the user's own background,
+        // no fill.
         // Yellow matches the prompt indicator in `tui_viewport.rs`
         // (post-fix); pre-fix Safe was Cyan in the prompt, Yellow in
         // the bar — confusing inconsistency this test pins gone.

--- a/koda-cli/tests/snapshots/help.snap
+++ b/koda-cli/tests/snapshots/help.snap
@@ -81,10 +81,10 @@ Options:
           OpenAI reasoning effort (low, medium, high)
 
       --mode <MODE>
-          Trust mode: safe (default) or auto. "safe" confirms every side effect before executing. "auto" auto-approves all actions within the project sandbox. Sandbox with credential protection is always active
+          Trust mode: auto (default) or safe. "auto" auto-approves mutating actions; the kernel sandbox contains them. Destructive ops (rm -rf, git reset --hard, git push --force, Delete) and outside-project writes still confirm. Auto requires the kernel sandbox; on unsandboxed platforms koda refuses to start with an actionable error (use --mode safe or install the platform sandbox backend). "safe" confirms every mutation before executing — use this in CI, locked-down workstations, or any context where you want a human in every approval loop. Sandbox with credential protection is always active
           
           [env: KODA_MODE=]
-          [default: safe]
+          [default: auto]
           [possible values: safe, auto]
 
   -h, --help

--- a/koda-core/src/config.rs
+++ b/koda-core/src/config.rs
@@ -200,7 +200,7 @@ pub struct KodaConfig {
     /// Skip injecting project/global memory into the system prompt.
     /// Set by `skip_memory: true` in agent JSON. Default: `false`.
     pub skip_memory: bool,
-    /// Trust mode for this session. Default: `TrustMode::Safe`.
+    /// Trust mode for this session. Default: `TrustMode::Auto` (#1241).
     pub trust: crate::trust::TrustMode,
 }
 
@@ -553,7 +553,7 @@ impl KodaConfig {
             model_settings,
             max_iterations: crate::loop_guard::MAX_ITERATIONS_DEFAULT,
             skip_memory: false,
-            trust: crate::trust::TrustMode::Safe,
+            trust: crate::trust::TrustMode::Auto,
         }
     }
 

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -14,7 +14,7 @@
 //! | Mode | Sandbox | Approval | Use case |
 //! |------|---------|----------|----------|
 //! | **Plan** | project, read-only | deny all non-read | Sub-agent investigation only — see [`coerce_for_top_level()`](crate::trust::coerce_for_top_level) |
-//! | **Safe** | project, read+write | confirm side effects | User default |
+//! | **Safe** | project, read+write | confirm side effects | Opt-in via `--mode safe` (CI, locked-down workstations) |
 //! | **Auto** | project, read+write | auto-approve mutations; destructive still confirms | Autonomous coding |
 //!
 //! Plan is **sub-agent-only** for the top-level session (#1244): the
@@ -346,12 +346,14 @@ pub fn require_sandbox_for_auto(
 /// Compute the **default** trust mode for a session given sandbox
 /// availability. Auto when the sandbox is present, Safe when not.
 ///
-/// This is the helper that #1241 (flip default `Safe → Auto`) will
-/// consume. Today it's only invoked when neither `--mode` nor
-/// `KODA_MODE` are set explicitly — explicit user intent always
-/// wins, and an explicit `--mode auto` on an unsandboxed system
-/// is rejected by [`require_sandbox_for_auto`] rather than
-/// silently coerced.
+/// This is the helper that #1241 (default `Safe → Auto` flip) uses
+/// when neither `--mode` nor `KODA_MODE` are set. Today the clap
+/// layer hardcodes `default_value = "auto"` (we picked the loud
+/// option: Auto everywhere, fail-fast on unsandboxed platforms via
+/// [`require_sandbox_for_auto`] with inline install hints from
+/// [`crate::sandbox::setup_hint`]). The helper remains exported
+/// for downstream embedders who want sandbox-aware defaulting
+/// without the hard-refusal UX.
 ///
 /// The asymmetry is deliberate:
 /// - **Implicit default** picks the strongest mode the platform


### PR DESCRIPTION
## Summary

Flips the default trust mode from `Safe` → `Auto`. Running `koda` with no `--mode` flag and no `KODA_MODE` env var now starts in **Auto** mode.

**The actual code change is two lines** (clap default + test fixture). The rest of the diff is doc updates, a comment in a test, the help-snapshot refresh, and the CHANGELOG entry.

```diff
-    #[arg(long, env = "KODA_MODE", default_value = "safe",
+    #[arg(long, env = "KODA_MODE", default_value = "auto",
```

```diff
-            trust: crate::trust::TrustMode::Safe,
+            trust: crate::trust::TrustMode::Auto,
```

## Why now

The previous Safe-by-default prompted on **every** mutation — Write, Edit, Delete, every mutating Bash. This was the dominant source of "why is this thing nagging me?" friction and effectively encouraged users to flip to Auto on first use anyway. The safety value of Safe-by-default was mostly theatrical: the people who needed it (CI, locked-down workstations) explicitly pass `--mode safe` already; the people who got it by accident just ratchet to Auto and never look back.

The #1232 / #1241 prerequisite checklist is now substantively complete:

| Backstop | Source | Effect |
|---|---|---|
| **Kernel sandbox refusal** | #1259 | Auto cannot start without a working sandbox — silent coercion impossible |
| **Self-fixing inline install hints** | #1260 | Auto-refusal error includes platform-specific install instructions; no second command to remember |
| **Outside-project floor** | pre-existing (`is_outside_project`) | Writes outside the project root still confirm in Auto |
| **Destructive backstop** | #1251 | `Auto × Destructive` confirms (was auto-approve pre-#1251); covers `rm -rf`, `git reset --hard`, `git push --force`, `Delete` |
| **Scratch-zone allowlist** | #1236 | `/tmp`, `$TMPDIR`, `~/.cache/koda/` skip the outside-project gate — kills 80% of "Auto is too quiet about my scratch dirs" friction |
| **Pre-flight context-budget check** | #1237 | Sub-agent dispatch fails fast on over-budget invocations — bounds Auto's worst-case "runaway sub-agent burns context" surprise |
| **Trust badge legibility** | #1257 | Bold colored text, no inverted backgrounds; readable on every color scheme |
| **Sandbox state indicator** | #1259 | 🛡 / ⚠ next to trust badge — sandbox-down case is unmissable |

So Auto-by-default is **not** "YOLO mode" — it's "trust the sandbox + outside-project floor + destructive backstop, prompt only when those backstops fail."

## Behavior on unsandboxed platforms

This is the only place the change has any teeth, and it was an explicit design decision (see comment thread on #1241):

| Platform | First-run with new default |
|---|---|
| macOS (Seatbelt always available) | ✅ Default = Auto, works |
| Linux + bwrap installed | ✅ Default = Auto, works |
| **Linux without bwrap** | ❌ Auto refuses to start with the #1259 + #1260 error: *"Auto requires sandbox. Install bubblewrap (apt/dnf/pacman) or use `--mode safe`."* |
| **Windows** | ❌ Same error; user opts into `--mode safe` or installs the platform sandbox backend |

We picked **loud-fail-fast over silent coercion** for the same reason #1259 did:

> Headless `koda --mode auto -p "..."` silently coerced to Safe = catastrophic. Every mutation aborts. Loud refusal at startup is strictly better UX — the user knows immediately what's wrong AND how to fix it.

The error from #1260 is now *self-fixing*:

```
error: Auto mode requires the kernel sandbox, ... Use `--mode safe` to keep
the human in the approval loop, or install the platform sandbox backend.

Setup:
  Install bubblewrap:
     Debian/Ubuntu:  sudo apt install bubblewrap
     Fedora/RHEL:    sudo dnf install bubblewrap
     Arch:           sudo pacman -S bubblewrap
  Or run with `--mode safe` to keep the human in the approval loop.
```

So the unsandboxed first-run user gets a clear, fixable error in two paths: install bwrap (one command) or pass `--mode safe`. Neither requires reading docs.

## Migration

| User type | Action |
|---|---|
| **Want the old Safe-by-default behavior** | Pass `--mode safe`, set `KODA_MODE=safe`, or per-session toggle with `Shift+Tab` in the TUI |
| **CI users** | Explicitly pass `--mode safe` in your CI command. CI shouldn't rely on default behavior anyway. |
| **Sub-agents** | Per-agent `trust:` declarations in agent JSON are unaffected. Built-in agents continue to ship with their explicit `trust: "safe"` / `trust: "plan"` declarations. **Only the top-level session default changes.** |

## Considered alternatives (and why this is the simpler call)

| Alternative | Why rejected |
|---|---|
| `derive_default_trust(sandbox::is_available())` — Auto on sandboxed, Safe on unsandboxed | Hides the sandbox-availability question. Unsandboxed users silently keep the old Safe behavior forever; never realize they could install bwrap and get Auto. The flip then provides no value to them. |
| Add a `--no-prompt` flag that opts into Auto explicitly | Users would still default to Safe. Same nag-on-every-write problem. Doesn't solve the real friction. |
| Default Auto + first-run-after-upgrade notice | Notice requires version-tracking in the state DB. Out of scope per agreed-tight scope; release notes cover the upgrade communication. |
| Wait on §4 (error-message detail) and sandbox telemetry | §4 is independent of trust default. Telemetry is nice-to-have for measuring fallout but not a gate. Don't block the user-impact change on observability work. |

## What's NOT in this PR (deliberately)

- **First-run-after-upgrade banner** — release notes only, per agreed scope. If upgrade complaints come in, we add it as a follow-up.
- **§4 error-message detail propagation** — separate concern, not a flip prerequisite.
- **§7 CLAUDE.md `gh --body-file` nudge** — trivial doc change, separate PR.
- **Sandbox availability telemetry** — would let us measure how often the #1259 fallback fires in the wild. Worth doing but doesn't gate the flip.
- **Removing Safe mode** — Safe stays. Some users (CI, locked-down workstations) genuinely want it. The flip is about defaults, not capabilities.

## Files

| File | Change |
|---|---|
| `koda-cli/src/app.rs` | `--mode` clap default `"safe"` → `"auto"`. Docstring expanded with destructive-op + sandbox-requirement detail (matches new behavior). |
| `koda-core/src/config.rs` | `KodaConfig.trust` doc updated to "Default: `TrustMode::Auto` (#1241)". `default_for_testing` fixture flipped to `Auto` for consistency with the user-facing default. |
| `koda-core/src/trust.rs` | Module-level table: `Safe` row's "User default" → "Opt-in via `--mode safe`". `derive_default_trust` doc-comment updated to reflect the flip is now LIVE (was "will consume" pending). |
| `docs/src/cli-reference.md` | `--mode` row prose updated. Notes Auto requires sandbox; on unsandboxed platforms koda refuses to start. |
| `docs/src/approval.md` | Badge table updated: Safe is now "use this in CI / locked-down workstations"; Auto noted as "Default since #1241". |
| `koda-cli/src/widgets/status_bar.rs` | One comment in `safe_badge_is_bold_yellow_text_no_background` test updated to note Safe is now the opt-in conservative mode. |
| `koda-cli/tests/snapshots/help.snap` | Regenerated to match new `--help` output (`[default: auto]`). |
| `CHANGELOG.md` | New `Changed (BREAKING for first-run UX)` entry with rationale + migration paths. |

## Verification

- `cargo test --workspace --features koda-core/test-support` → **2544 passing, 0 failed**
- `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` → **clean**
- `cargo fmt --all --check` → **clean**
- `mdbook build docs` → **clean** (only the pre-existing `<name>` warning in `mcp.md`)
- Manual smoke: `koda --help` shows `[default: auto]` ✅
- Manual smoke: `koda --version` → `koda 0.3.0 (sandbox: available [seatbelt])` ✅

## Diff stats

```
 CHANGELOG.md                       |  9 +++++++++
 docs/src/approval.md               |  4 ++--
 docs/src/cli-reference.md          |  2 +-
 koda-cli/src/app.rs                | 15 +++++++++++----
 koda-cli/src/widgets/status_bar.rs |  7 ++++---
 koda-cli/tests/snapshots/help.snap |  4 ++--
 koda-core/src/config.rs            |  4 ++--
 koda-core/src/trust.rs             | 16 +++++++++-------
 8 files changed, 40 insertions(+), 21 deletions(-)
```

## Refs

- **Closes #1241**
- Builds on #1259 (sandbox refusal) and #1260 (self-fixing error hint) — without these two, this flip would have been irresponsible.
- Builds on #1251 (`Auto × Destructive` confirms), #1236 (scratch-zone allowlist), #1237 (pre-flight context check), #1257 (badge legibility) — the prerequisite stack from the #1232 umbrella.
