### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-05
+
+### Fixed
+
+- **Persisted/resumed `Auto` sessions now obey the same sandbox gate as startup** (#1241 release audit). Fresh CLI/env/default startup already rejected Auto when the kernel sandbox was unavailable, but session restore paths trusted the DB mode directly. A session persisted as `auto` on a sandboxed machine could therefore be resumed on an unsandboxed host and bypass the headline invariant. TUI startup and `/sessions resume` now route persisted modes through the same top-level resolver: parse → Plan-to-Safe coercion → `require_sandbox_for_auto`. Invalid persisted Auto fails loudly with the same setup hint instead of silently entering Auto.
+
 ### Changed (BREAKING for first-run UX)
 
 - **Default trust mode flipped from `Safe` → `Auto`** (#1241). Running `koda` with no `--mode` flag and no `KODA_MODE` env var now starts in Auto mode (auto-approve mutations within the kernel sandbox; destructive ops and outside-project writes still confirm). The previous Safe-by-default — which prompted on **every** mutation — was the dominant source of "why is this thing nagging me?" friction and effectively encouraged users to flip to Auto on first use, making the safety value of Safe-by-default mostly theatrical.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,7 +401,7 @@ For capabilities that ship in the koda workspace (same release cycle):
 7. Add `--version` flag to `main.rs` (standalone server wrapper)
 8. Write integration tests in `tests/mcp_integration_test.rs`
 9. Update `release.yml`: version verify, build, package, publish, Homebrew
-10. Sync version with workspace (currently 0.3.0)
+10. Sync version with workspace (currently 0.3.1)
 11. Update this file (CLAUDE.md)
 
 ## CI Workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "koda-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agent-client-protocol-schema",
  "ansi-to-tui",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "koda-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "koda-sandbox"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -979,8 +979,9 @@ user-facing mental-model doc).
 **Accepted risks**:
 1. Shell command parsing is heuristic — complex pipelines can bypass classification
 2. Network is unrestricted in all modes (required for `cargo fetch`, `npm install`)
-3. If the sandbox backend is unavailable (e.g. no bwrap on Linux), Koda falls
-   back to unsandboxed execution with a warning rather than hard-erroring
+3. If the sandbox backend is unavailable (e.g. no bwrap on Linux), `Auto`
+   refuses to start or resume; `Safe`/`Plan` may still run with warnings and
+   human approval floors
 
 ### File Lifecycle Tracking (P2)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,11 @@ within 7 days of a confirmed vulnerability.
 ## Sandbox Security Model
 
 Koda enforces filesystem-write and exec policy via a kernel-backed
-sandbox (Seatbelt on macOS, Landlock on Linux; not supported on
+sandbox (Seatbelt on macOS, bubblewrap on Linux; not supported on
 Windows). The sandbox protects credential files and koda's own
-configuration even in `--yolo` trust mode.
+configuration even in `--mode auto` trust mode. Auto requires the
+kernel sandbox; if the backend is unavailable, koda refuses Auto with
+an actionable setup hint and users can opt into `--mode safe`.
 
 For the full model — file-tool read policy, write restrictions,
 credential protection, agent-file protection, sub-agent inheritance,

--- a/docs/src/approval.md
+++ b/docs/src/approval.md
@@ -143,16 +143,18 @@ where `write_access` only spoke to the second half.
 
 ## Headless mode
 
-In headless mode there is no human to prompt. The trust mode is
-effectively "Auto with the destructive backstop": read and mutating
-tools approve, destructive Bash commands and `Delete` are rejected,
-and the sandbox enforces the perimeter. See [Headless mode](./headless.md).
+In headless mode there is no human to prompt. Koda applies the
+headless policy documented in [Headless mode](./headless.md): read
+and safe in-project mutating tools approve, destructive Bash commands
+and `Delete` are rejected, and the sandbox enforces the perimeter.
+Auto still requires the kernel sandbox before headless execution can
+start.
 
 ## Reference
 
 - Master matrix: `koda_core::trust::check_tool`
 - Sub-agent matrix: `koda_core::trust::check_tool_for_sub_agent`
-- Sandbox-unavailable fallback: `koda_core::trust::is_outside_project`
-  + #860 downgrade in `trust.rs`
+- Sandbox-unavailable Auto refusal: `koda_core::trust::require_sandbox_for_auto`
+  + setup hints from `koda_core::sandbox::setup_hint`
 - Per-agent loader & deprecation warning: `koda_core::config::KodaConfig::load`
 - Status-bar badge rendering: `koda_cli::widgets::status_bar`

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance AI coding agent for macOS and Linux"
@@ -18,7 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Core engine
-koda-core = { path = "../koda-core", version = "0.3.0" }
+koda-core = { path = "../koda-core", version = "0.3.1" }
 
 # CLI
 clap = { version = "4", features = ["derive", "env"] }

--- a/koda-cli/README.md
+++ b/koda-cli/README.md
@@ -14,6 +14,12 @@ cargo install koda-cli
 
 On first run, an onboarding wizard guides you through provider and API key setup.
 
+Linux note: the default trust mode is Auto, which requires bubblewrap
+(`bwrap`) so the kernel sandbox can contain auto-approved mutations.
+Install it with your package manager (`apt install bubblewrap`,
+`dnf install bubblewrap`, `pacman -S bubblewrap`) or start with
+`koda --mode safe` to keep the human in every approval loop.
+
 ## Quick start
 
 ```bash
@@ -29,18 +35,18 @@ Cycle with `Shift+Tab`:
 
 | Mode | Behavior |
 |------|----------|
-| **Safe** (default) | Confirm every side effect. Read-only tools auto-approved. |
-| **Auto** | Auto-approve all actions within the project sandbox. |
+| **Auto** (default) | Auto-approve safe in-project mutations within the kernel sandbox. Destructive ops and outside-project writes still ask. Requires sandbox availability. |
+| **Safe** | Confirm every mutation. Read-only tools auto-approved. Use this for CI or locked-down machines. |
 
 A third mode, **Plan**, is available for agent definitions that need
 investigation-only access — all writes are denied.
 
 ```bash
-# Start in Auto mode
-koda --mode auto
+# Keep the old prompt-every-mutation behavior
+koda --mode safe
 
 # Via environment variable
-export KODA_MODE=auto
+export KODA_MODE=safe
 ```
 
 ## Sandbox

--- a/koda-cli/src/tui_commands.rs
+++ b/koda-cli/src/tui_commands.rs
@@ -461,6 +461,35 @@ async fn handle_resume_session(
                     0 => tui_output::err_msg(buffer, format!("No session found matching '{id}'.")),
                     1 => {
                         let target = &matches[0];
+                        let mode_to_apply = match session
+                            .db
+                            .get_session_mode(&target.id)
+                            .await
+                            .ok()
+                            .flatten()
+                        {
+                            Some(mode_str) => match trust::TrustMode::parse(&mode_str) {
+                                Some(parsed) => {
+                                    let (m, warning) = trust::coerce_for_top_level(parsed);
+                                    let report = koda_core::sandbox::dependency_report();
+                                    match trust::require_sandbox_for_auto(m, report.available) {
+                                        Ok(validated) => Some((validated, warning)),
+                                        Err(msg) => {
+                                            tui_output::err_msg(
+                                                buffer,
+                                                format!(
+                                                    "Cannot resume session in Auto mode: {msg}\n\nSetup:\n{}",
+                                                    koda_core::sandbox::setup_hint(report.backend)
+                                                ),
+                                            );
+                                            return;
+                                        }
+                                    }
+                                }
+                                None => None,
+                            },
+                            None => None,
+                        };
                         session.id = target.id.clone();
                         session.title_set = true;
                         let short_id = target.id[..8].to_string();
@@ -487,16 +516,14 @@ async fn handle_resume_session(
                         // `coerce_for_top_level` so a session that
                         // somehow got persisted with `plan` (older
                         // koda version, manual DB edit, race) is
-                        // coerced to Safe with a visible banner
-                        // instead of silently resurrecting a confused
-                        // "read-only main session" state. Sub-agents
-                        // never persist their own session-level mode
-                        // here — only the top-level session does —
-                        // so this coercion is the right scope.
-                        if let Ok(Some(mode_str)) = session.db.get_session_mode(&session.id).await
-                            && let Some(parsed) = trust::TrustMode::parse(&mode_str)
-                        {
-                            let (m, warning) = trust::coerce_for_top_level(parsed);
+                        // coerced to Safe with a visible banner.
+                        //
+                        // **#1241 release audit**: validate Auto with
+                        // `require_sandbox_for_auto` BEFORE switching
+                        // `session.id`; otherwise a persisted Auto
+                        // session could bypass the startup sandbox
+                        // refusal when resumed on an unsandboxed host.
+                        if let Some((m, warning)) = mode_to_apply {
                             if let Some(w) = warning {
                                 tui_output::warn_msg(buffer, w.to_string());
                             }

--- a/koda-cli/src/tui_context/mod.rs
+++ b/koda-cli/src/tui_context/mod.rs
@@ -158,11 +158,21 @@ pub(crate) enum CommandOutcome {
 /// back to the user's current `config.trust` — **never** to a hardcoded
 /// constant. Hardcoding `Auto` here was the original bug: it silently
 /// overrode `--mode safe`, defeating the whole point of the flag.
+///
+/// Top-level safety semantics (#1241 release audit): persisted modes must obey
+/// the same top-level rules as CLI/env startup. Plan coerces to Safe, and Auto
+/// is rejected when the kernel sandbox is unavailable. Without this, a session
+/// persisted as `auto` on a sandboxed host could be resumed on an unsandboxed
+/// host and bypass the startup Auto refusal. Sneaky little gremlin.
 pub(crate) fn resolve_initial_trust_mode(
     persisted: Option<&str>,
     fallback: TrustMode,
-) -> TrustMode {
-    persisted.and_then(TrustMode::parse).unwrap_or(fallback)
+    sandbox_available: bool,
+) -> Result<(TrustMode, Option<&'static str>), String> {
+    let parsed = persisted.and_then(TrustMode::parse).unwrap_or(fallback);
+    let (mode, warning) = koda_core::trust::coerce_for_top_level(parsed);
+    let mode = koda_core::trust::require_sandbox_for_auto(mode, sandbox_available)?;
+    Ok((mode, warning))
 }
 
 impl TuiContext {
@@ -250,7 +260,7 @@ impl TuiContext {
         // Fallback to the user's current CLI/config trust mode (not a hardcoded
         // constant) so `--mode safe` is honored on first run when there's no
         // persisted mode yet. Fixes #982.
-        let initial_mode = {
+        let (initial_mode, initial_mode_warning) = {
             use koda_core::persistence::Persistence;
             let persisted = session
                 .db
@@ -258,8 +268,21 @@ impl TuiContext {
                 .await
                 .ok()
                 .flatten();
-            resolve_initial_trust_mode(persisted.as_deref(), config.trust)
+            let report = koda_core::sandbox::dependency_report();
+            resolve_initial_trust_mode(persisted.as_deref(), config.trust, report.available)
+                .map_err(|msg| {
+                    anyhow::anyhow!(
+                        "{msg}\n\nSetup:\n{}",
+                        koda_core::sandbox::setup_hint(report.backend)
+                    )
+                })?
         };
+        if let Some(warning) = initial_mode_warning {
+            startup_lines.push(Line::from(vec![
+                Span::styled("  \u{26a0} ", Style::new().fg(Color::Yellow)),
+                Span::styled(warning.to_string(), Style::new().fg(Color::Yellow)),
+            ]));
+        }
         let shared_mode = trust::new_shared_trust(initial_mode);
 
         // Terminal + textarea
@@ -799,32 +822,44 @@ mod tests {
         // The exact bug: fresh session, no persisted mode, user passed `--mode safe`.
         // Pre-fix this returned hardcoded `Auto`, ignoring the user's choice.
         assert_eq!(
-            resolve_initial_trust_mode(None, TrustMode::Safe),
+            resolve_initial_trust_mode(None, TrustMode::Safe, true)
+                .unwrap()
+                .0,
             TrustMode::Safe,
         );
+        // Plan is sub-agent-only; top-level fallback still goes through
+        // coerce_for_top_level, so it resolves to Safe with a warning.
+        let (mode, warning) = resolve_initial_trust_mode(None, TrustMode::Plan, true).unwrap();
+        assert_eq!(mode, TrustMode::Safe);
+        assert!(warning.is_some());
         assert_eq!(
-            resolve_initial_trust_mode(None, TrustMode::Plan),
-            TrustMode::Plan,
-        );
-        assert_eq!(
-            resolve_initial_trust_mode(None, TrustMode::Auto),
+            resolve_initial_trust_mode(None, TrustMode::Auto, true)
+                .unwrap()
+                .0,
             TrustMode::Auto,
         );
     }
 
     #[test]
-    fn persisted_mode_wins_over_config_trust_on_resume() {
-        // Resume semantics from #590: a stored mode beats the CLI fallback.
+    fn persisted_mode_wins_over_config_trust_on_resume_after_top_level_coercion() {
+        // Resume semantics from #590: a stored mode beats the CLI fallback,
+        // then the top-level safety rules are applied.
         assert_eq!(
-            resolve_initial_trust_mode(Some("plan"), TrustMode::Auto),
-            TrustMode::Plan,
-        );
-        assert_eq!(
-            resolve_initial_trust_mode(Some("safe"), TrustMode::Auto),
+            resolve_initial_trust_mode(Some("plan"), TrustMode::Auto, true)
+                .unwrap()
+                .0,
             TrustMode::Safe,
         );
         assert_eq!(
-            resolve_initial_trust_mode(Some("auto"), TrustMode::Safe),
+            resolve_initial_trust_mode(Some("safe"), TrustMode::Auto, true)
+                .unwrap()
+                .0,
+            TrustMode::Safe,
+        );
+        assert_eq!(
+            resolve_initial_trust_mode(Some("auto"), TrustMode::Safe, true)
+                .unwrap()
+                .0,
             TrustMode::Auto,
         );
     }
@@ -834,12 +869,39 @@ mod tests {
         // The other half of the bug: corrupt/unknown persisted strings used
         // to fall through to a hardcoded `Auto`. Now they honor config.trust.
         assert_eq!(
-            resolve_initial_trust_mode(Some("bogus"), TrustMode::Safe),
+            resolve_initial_trust_mode(Some("bogus"), TrustMode::Safe, true)
+                .unwrap()
+                .0,
             TrustMode::Safe,
         );
         assert_eq!(
-            resolve_initial_trust_mode(Some(""), TrustMode::Plan),
-            TrustMode::Plan,
+            resolve_initial_trust_mode(Some(""), TrustMode::Plan, true)
+                .unwrap()
+                .0,
+            TrustMode::Safe,
+        );
+    }
+
+    #[test]
+    fn persisted_auto_requires_sandbox_on_resume() {
+        let err = resolve_initial_trust_mode(Some("auto"), TrustMode::Safe, false).unwrap_err();
+        assert!(err.contains("Auto mode requires"));
+        assert!(err.contains("--mode safe"));
+    }
+
+    #[test]
+    fn fallback_auto_requires_sandbox_on_fresh_session() {
+        let err = resolve_initial_trust_mode(None, TrustMode::Auto, false).unwrap_err();
+        assert!(err.contains("Auto mode requires"));
+    }
+
+    #[test]
+    fn persisted_safe_still_allowed_without_sandbox() {
+        assert_eq!(
+            resolve_initial_trust_mode(Some("safe"), TrustMode::Auto, false)
+                .unwrap()
+                .0,
+            TrustMode::Safe,
         );
     }
 
@@ -848,16 +910,22 @@ mod tests {
         // `TrustMode::parse` accepts aliases like "yolo", "strict", etc.
         // Make sure resume of older sessions stored under those names still works.
         assert_eq!(
-            resolve_initial_trust_mode(Some("yolo"), TrustMode::Safe),
+            resolve_initial_trust_mode(Some("yolo"), TrustMode::Safe, true)
+                .unwrap()
+                .0,
             TrustMode::Auto,
         );
         assert_eq!(
-            resolve_initial_trust_mode(Some("strict"), TrustMode::Auto),
+            resolve_initial_trust_mode(Some("strict"), TrustMode::Auto, true)
+                .unwrap()
+                .0,
             TrustMode::Safe,
         );
         assert_eq!(
-            resolve_initial_trust_mode(Some("readonly"), TrustMode::Auto),
-            TrustMode::Plan,
+            resolve_initial_trust_mode(Some("readonly"), TrustMode::Auto, true)
+                .unwrap()
+                .0,
+            TrustMode::Safe,
         );
     }
 }

--- a/koda-cli/tests/smoke_test.rs
+++ b/koda-cli/tests/smoke_test.rs
@@ -100,14 +100,14 @@ fn mock_destructive_bash_rejected_in_auto_mode_in_headless() {
 }
 
 #[test]
-fn mock_destructive_bash_rejected_in_safe_mode_in_headless() {
-    // End-to-end regression test for #982. Pre-fix, headless hardcoded
+fn mock_destructive_bash_rejected_in_safe_and_default_modes_in_headless() {
+    // End-to-end regression test for #982 + #1241. Pre-fix, headless hardcoded
     // `TrustMode::Auto`, so `--mode safe` was silently ignored and destructive
-    // actions ran without confirmation. Post-fix, `--mode safe` is honored
-    // and the same destructive Bash invocation is rejected by the trust layer.
+    // actions ran without confirmation. Post-fix, `--mode safe` is honored.
     //
-    // We test BOTH: explicit `--mode safe` AND default (no flag, since CLI
-    // default_value = "safe"). Both must reject.
+    // We test BOTH explicit `--mode safe` and the current default (`Auto` since
+    // #1241). Both must reject destructive Bash; the user gave consent for
+    // ordinary work, not for rm -rf. Tiny detail, huge difference, no bananas.
     let responses = r#"[
         {"tool":"Bash","args":{"command":"rm -rf /tmp/nonexistent_test_dir"}},
         {"text":"Done."}
@@ -118,8 +118,8 @@ fn mock_destructive_bash_rejected_in_safe_mode_in_headless() {
         let (_stdout, stderr, _success) = run_mock_with_mode("delete everything", responses, mode);
         assert!(
             stderr.contains("Rejected destructive action"),
-            "[mode={label}] Safe mode (or default) MUST reject destructive Bash. \
-             If this fails, #982 has regressed.\nstderr: {stderr}"
+            "[mode={label}] Safe and default Auto MUST reject destructive Bash. \
+             If this fails, #982/#1241 has regressed.\nstderr: {stderr}"
         );
     }
 }

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-core"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Core engine for the Koda AI coding agent (macOS and Linux only)"
@@ -88,7 +88,7 @@ http = "1"
 # First-party workspace libraries (direct calls)
 
 # Sandbox runtime — kernel-level FS/net/exec policies (#934)
-koda-sandbox = { path = "../koda-sandbox", version = "0.3.0" }
+koda-sandbox = { path = "../koda-sandbox", version = "0.3.1" }
 
 # Async trait support
 async-trait = { workspace = true }

--- a/koda-core/src/sandbox.rs
+++ b/koda-core/src/sandbox.rs
@@ -8,18 +8,19 @@
 //! ## Public API
 //!
 //! - [`build`](crate::sandbox::build) — main entry point used by `tools/shell.rs`
-//! - [`is_available`](crate::sandbox::is_available) — used by `trust.rs` to gate Auto → Safe downgrade
+//! - [`is_available`](crate::sandbox::is_available) — used by `trust.rs` to reject Auto when the sandbox is unavailable
 //! - [`is_fully_denied`](crate::sandbox::is_fully_denied) — used by `tools/mod.rs` for in-process Read/Edit
 //!   parity with the kernel sandbox (#882, #898)
 //!
 //! ## Behavior
 //!
-//! All trust modes get the same kernel-enforced "strict" baseline today
+//! All trust modes use the same kernel-enforced baseline today
 //! (project sandbox + credential write-protection + full deny on
-//! `~/.config/koda/db`). When the platform sandbox backend is missing
-//! (e.g. `bwrap` not installed on Linux, unsupported OS), commands run
-//! unsandboxed with a one-time warning — the sandbox is best-effort and
-//! never blocks the user.
+//! `~/.config/koda/db`) when a platform backend exists. When the
+//! backend is missing (e.g. `bwrap` not installed on Linux, unsupported
+//! OS), `Auto` refuses to start/resume because it auto-approves
+//! mutations and relies on the sandbox perimeter. `Safe`/`Plan` may
+//! still run with warning + human approval floors.
 //!
 //! Phase 1+ will let trust modes diverge by passing a richer
 //! [`koda_sandbox::SandboxPolicy`] through the shim.
@@ -43,9 +44,8 @@ use tokio::process::Command;
 
 /// Returns `true` if the platform sandbox backend is available.
 ///
-/// Used by the trust layer to downgrade Auto → Safe when the sandbox
-/// is unavailable, ensuring destructive ops still get a confirmation
-/// prompt (#860). Cached after first probe.
+/// Used by the trust layer to reject Auto when the sandbox is
+/// unavailable (#860/#1259). Cached after first probe.
 pub fn is_available() -> bool {
     ks_is_available()
 }

--- a/koda-core/src/trust.rs
+++ b/koda-core/src/trust.rs
@@ -346,22 +346,12 @@ pub fn require_sandbox_for_auto(
 /// Compute the **default** trust mode for a session given sandbox
 /// availability. Auto when the sandbox is present, Safe when not.
 ///
-/// This is the helper that #1241 (default `Safe → Auto` flip) uses
-/// when neither `--mode` nor `KODA_MODE` are set. Today the clap
-/// layer hardcodes `default_value = "auto"` (we picked the loud
-/// option: Auto everywhere, fail-fast on unsandboxed platforms via
-/// [`require_sandbox_for_auto`] with inline install hints from
-/// [`crate::sandbox::setup_hint`]). The helper remains exported
-/// for downstream embedders who want sandbox-aware defaulting
-/// without the hard-refusal UX.
-///
-/// The asymmetry is deliberate:
-/// - **Implicit default** picks the strongest mode the platform
-///   can support — better UX on the supported case, no foot-gun
-///   on the unsupported case.
-/// - **Explicit request** is honored or rejected, never silently
-///   coerced — follows the Zen of Python rule that errors should
-///   never pass silently.
+/// The CLI's top-level default is now the louder `Auto` everywhere
+/// choice (#1241): it hardcodes `default_value = "auto"` and then
+/// fails fast on unsandboxed platforms via [`require_sandbox_for_auto`]
+/// with inline install hints from [`crate::sandbox::setup_hint`]. This
+/// helper remains exported for downstream embedders who prefer
+/// sandbox-aware defaulting without the hard-refusal UX.
 ///
 /// # Examples
 ///

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koda-sandbox"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Capability-aware sandbox layer for Koda — kernel-enforced FS/net/exec policies (refs #934)"


### PR DESCRIPTION
## Summary

- prepare v0.3.1 release metadata across `koda-cli`, `koda-core`, `koda-sandbox`, and `Cargo.lock`
- promote the changelog and refresh stale Auto/Safe/sandbox docs
- fix a release-audit blocker: persisted/resumed Auto modes now go through the same `require_sandbox_for_auto` gate as fresh startup
- validate `/sessions resume` before switching `session.id`, so an unsandboxed host cannot revive a DB-persisted Auto session

## Note on #1212

Issue #1212 is already closed and was fixed by merged PR #1218 (`a834e9f`, `fix(trust): classify TodoWrite as ReadOnly (#1212)`). I did not create a duplicate TodoWrite PR because duplicate fixes are how gremlins reproduce.

## Test plan

- `cargo fmt --all`
- `cargo test --workspace --all-targets`
- `cargo test -q -p koda-cli tui_context::tests --lib`
- `cargo test -q -p koda-core trust::tests --lib`
- `cargo test -q -p koda-cli --test smoke_test mock_destructive_bash_rejected_in_safe_and_default_modes_in_headless`
- `cargo doc --no-deps --workspace`
- `cargo audit --deny unsound --deny yanked --no-fetch --stale`
- push hook: `fmt` + `clippy`

## Packaging notes

- `cargo package -p koda-sandbox --allow-dirty --no-verify --offline` succeeds.
- Packaging `koda-core` / `koda-cli` offline cannot resolve the just-bumped unpublished internal crates from crates.io; online packaging also hit local DNS failure for `index.crates.io` during the earlier audit. Not a code issue, just the network wearing clown shoes.
