### PR TITLE
fix(prompt): drop phantom git-checkpointing claim from system prompt (#1264 P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **System prompt no longer lies about a non-existent git-checkpointing feature** (#1264 priority 2). The system prompt sent to every LLM call contained:
+
+  > ### Git Checkpointing
+  >
+  > Auto-snapshots working tree before each turn. `/undo` to rollback.
+
+  No such feature exists. `git.rs` is *read-only* — it runs `git rev-parse`, `git diff --stat`, and `git log` to format a context block for the system prompt; it never mutates state. The module's own doc comment even says so under "What this module does NOT do". The actual `/undo` is the in-memory stack in `undo.rs` (which itself was completely broken until #1271 yesterday) and dies with the process. Models receiving the false claim were reassuring users that destructive operations were safe to attempt because "the auto-snapshot will catch it" — they weren't, and it didn't. Replaced with a truthful Undo section that explicitly calls out the durability gap and tells the model to advise users to commit before quitting if they want durable rollback. Also fixed two stale references in `CLAUDE.md` (architecture overview line + module map line) that pointed at the same phantom feature. Added `prompt::tests::prompt_does_not_lie_about_git_checkpointing` regression guard so the marketing copy can't sneak back in via copy-paste from old git history. Closes #1264 priority 2 with a "drop the scaffolding" rationale; if a real git-backed checkpoint subsystem ever lands, delete the regression test and update the prompt with the truth.
+
 ### Added
 
 - **Context-window management — 4 new e2e scenarios** (#1264 priority 4). The existing `inference_context_test.rs` covered display accuracy only (the `ContextUsage`/`Footer` event emission, see #874 / #946). New `koda-core/tests/context_management_e2e_test.rs` covers the *behaviour* gaps the issue called out: pre-flight compaction firing when the heuristic gauge crosses [`AUTO_COMPACT_THRESHOLD`] (85%); pre-flight compaction being skipped under the threshold; provider-rejected context overflow triggering `try_overflow_recovery` → compact → retry → success; and overflow recovery propagating the original error when the session is too short for compaction to help (`CompactSkip::TooShort`). Module doc explains the `MockResponse` ordering required for the compact summary call vs. the streamed chat call. Tests are serialized via a file-scoped `LazyLock<Mutex>` because `compact::CONSECUTIVE_FAILURES` is a process-global atomic — same hazard the existing `compact.rs` test module called out at line 723 when it deleted duplicate breaker tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ No phases, no tiers — the model drives execution directly.
   - Fallback: `model_context.rs` lookup table
 - **Rate limit retry**: exponential backoff (2/4/8/16/32s) for 429 errors
 - **Built-in agents**: default (others via user-created agent configs)
-- **Git checkpointing** (`git.rs`): auto-snapshot before each turn
+- **Undo** (`undo.rs`): in-memory snapshot stack of file mutations. `/undo` rolls back the most recent turn. Does NOT survive process restarts — there is no on-disk or git-backed checkpoint subsystem. `git.rs` only injects branch/diff/recent-commits *context* into the system prompt; it never mutates state.
 
 Approval is per-tool. A single `TrustMode` enum (Plan/Safe/Auto) is the
 **single mechanism** for tool gating — it derives kernel sandbox bounds,
@@ -116,7 +116,7 @@ koda/
 │   │   │   ├── queries.rs  # Persistence trait impl (all SQL queries)
 │   │   │   └── tests.rs    # Database integration tests
 │   │   ├── file_tracker.rs # File lifecycle tracking (create/edit/delete ownership)
-│   │   ├── git.rs          # Git checkpointing + rollback
+│   │   ├── git.rs          # Read-only git context for the system prompt (branch, diff, recent commits)
 │   │   ├── inference.rs    # Streaming inference loop + tool execution
 │   │   ├── inference_helpers.rs # Token estimation, message assembly, overflow detection
 │   │   ├── keystore.rs     # Secure API key storage (~/.config/koda/keys.toml, 0600)

--- a/koda-core/src/prompt.rs
+++ b/koda-core/src/prompt.rs
@@ -95,8 +95,11 @@ pub fn build_system_prompt(
          Hotkeys during tool confirmation: `y` approve, `n` reject, `f` feedback, `a` always.\n",
     );
     prompt.push_str(
-        "\n### Git Checkpointing\n\n\
-         Auto-snapshots working tree before each turn. `/undo` to rollback.\n",
+        "\n### Undo\n\n\
+         `/undo` rolls back file mutations from the most recent turn (Write,\n\
+         Edit, Delete, Overwrite). The undo stack is **in-memory only** — it\n\
+         does not survive process restarts. Tell the user to commit work to\n\
+         git before quitting if they want durable rollback.\n",
     );
 
     // Tool definitions intentionally NOT rendered here — each provider
@@ -793,5 +796,41 @@ mod tests {
         // Sanity: prompt should be non-empty + contain expected sections.
         assert!(total_chars > 1000, "prompt suspiciously short");
         assert!(prompt.contains("## Skills"));
+    }
+
+    /// Regression guard: the system prompt must NOT promise the model
+    /// an auto-git-snapshot/checkpoint feature, because no such feature
+    /// exists. The only undo mechanism is the in-memory stack in
+    /// [`crate::undo`], which dies with the process. Telling the model
+    /// otherwise causes it to reassure users ("don't worry, your changes
+    /// are checkpointed in git") that data loss is impossible — a lie.
+    ///
+    /// If a real git-backed checkpoint subsystem ever lands, delete this
+    /// test and update the prompt section with the truth.
+    #[test]
+    fn prompt_does_not_lie_about_git_checkpointing() {
+        let env = test_env();
+        let registry = SkillRegistry::default();
+        let prompt = build_system_prompt("You are koda.", "", &env, &[], &registry);
+
+        // Phrases from the old (deleted) lie. If any of these come back,
+        // either ship the feature or delete them again — do not just
+        // re-introduce the marketing copy.
+        for forbidden in [
+            "Git Checkpointing",
+            "Auto-snapshots working tree",
+            "auto-snapshot before each turn",
+            "auto-snapshot the working tree",
+        ] {
+            assert!(
+                !prompt.contains(forbidden),
+                "system prompt re-introduced a phantom-feature claim: {forbidden:?}"
+            );
+        }
+
+        // Positive: the truthful Undo section is present and explicitly
+        // calls out the durability gap.
+        assert!(prompt.contains("### Undo"));
+        assert!(prompt.contains("in-memory only"));
     }
 }


### PR DESCRIPTION
## TL;DR

The system prompt sent to every LLM call has been telling the model — for who knows how long — about an "auto-snapshot working tree before each turn" feature **that does not exist**. Models then reassure users that destructive operations are safe ("don't worry, the auto-snapshot will catch it"). Drop the lie, document the real `/undo` durability story, add a regression test so the lie can't sneak back. Closes #1264 priority 2 with a "drop the scaffolding" rationale.

## The smoking gun

`koda-core/src/prompt.rs` (before this PR):

```rust
prompt.push_str(
    "\n### Git Checkpointing\n\n\
     Auto-snapshots working tree before each turn. `/undo` to rollback.\n",
);
```

Reality check on `koda-core/src/git.rs`:

```rust
//! ## What this module does NOT do
//!
//! - **File-level undo** — handled by [`crate::undo`] (in-memory snapshots)
//! - **Git operations** — commits, pushes, etc. are done via the Bash tool
//! - **Worktree management** — handled by [`koda_sandbox::GitWorktreeProvider`]
```

The whole `git.rs` module is 154 lines: `git_context()` (runs `git rev-parse` + `git diff --stat` + `git log` and formats the output), `git_cmd()` (internal shell helper), `truncate_str()` (string trimmer). Zero state mutation, zero `git stash`, zero `git commit`. The author of `git.rs` realised the gap and added the disclaimer to *their* module — but never went upstream to fix the system prompt or the architecture doc that pointed at it.

The actual `/undo` is the in-memory stack in `undo.rs`, which itself was completely broken (turns never committed) until #1271 yesterday. Even now-fixed, it dies with the process. There is no on-disk or git-backed checkpoint subsystem.

## What this PR does

### 1. Replace the lie in the system prompt

```diff
-### Git Checkpointing
-
-Auto-snapshots working tree before each turn. `/undo` to rollback.
+### Undo
+
+`/undo` rolls back file mutations from the most recent turn (Write,
+Edit, Delete, Overwrite). The undo stack is **in-memory only** — it
+does not survive process restarts. Tell the user to commit work to
+git before quitting if they want durable rollback.
```

The new section tells the model the truth so it can give users honest advice instead of false reassurance.

### 2. Fix two stale references in `CLAUDE.md`

`CLAUDE.md:30` — architecture overview:

```diff
-- **Git checkpointing** (`git.rs`): auto-snapshot before each turn
+- **Undo** (`undo.rs`): in-memory snapshot stack of file mutations.
+  `/undo` rolls back the most recent turn. Does NOT survive process
+  restarts — there is no on-disk or git-backed checkpoint subsystem.
+  `git.rs` only injects branch/diff/recent-commits *context* into
+  the system prompt; it never mutates state.
```

`CLAUDE.md:119` — module map:

```diff
-│   │   ├── git.rs          # Git checkpointing + rollback
+│   │   ├── git.rs          # Read-only git context for the system prompt (branch, diff, recent commits)
```

### 3. Regression test

`prompt::tests::prompt_does_not_lie_about_git_checkpointing` asserts the forbidden phrases are absent and the truthful Undo section is present:

```rust
for forbidden in [
    "Git Checkpointing",
    "Auto-snapshots working tree",
    "auto-snapshot before each turn",
    "auto-snapshot the working tree",
] {
    assert!(!prompt.contains(forbidden), ...);
}
assert!(prompt.contains("### Undo"));
assert!(prompt.contains("in-memory only"));
```

So the marketing copy can't quietly come back via copy-paste from old git history. Test docstring explicitly says: *"If a real git-backed checkpoint subsystem ever lands, delete this test and update the prompt section with the truth."*

## Why "drop" instead of "build"

#1264 priority 2 originally framed this as a missing-tests problem ("Git checkpointing has no tests"). My deeper dig found there's no implementation either — only docs and a system-prompt lie pointing at vapor. Two paths existed:

- **Option A (this PR):** Drop the scaffolding. ~10 minute fix. Stops active user-facing harm immediately.
- **Option B (follow-up):** Build a real git-backed checkpoint subsystem (pre-turn `git stash create` → store SHA in DB → `/undo` checks DB first, falls back to in-memory). Half-day of work. Real durability win.

Going with A first because the lie in the system prompt is doing damage *right now*. B can be its own PR if there's appetite — it would be additive (extend the test, replace the prompt section with the new truth).

## Type

- [x] **Bug fix** — user-facing safety lie removed from system prompt
- [ ] New feature
- [x] **Refactor** — docs aligned with reality
- [x] **Docs / tests** — regression test + CLAUDE.md cleanup + CHANGELOG entry
- [ ] Performance
- [x] **Security-adjacent** — false safety claim → user data loss risk

## Files changed

| File | Change |
|------|--------|
| `koda-core/src/prompt.rs` | -3/+7 production: replaced phantom feature claim with truthful Undo section. +35: new regression test. |
| `CLAUDE.md` | -2/+2: architecture overview line + module map line corrected. |
| `CHANGELOG.md` | +1 entry under `[Unreleased] / Fixed`. |

## Verification

- `cargo test -p koda-core --lib --tests` — all unit + every integration suite pass; new regression test passes.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Manual `rg` for any remaining "checkpoint" / "auto-snapshot" references — surviving mentions are legitimate (CONTRIBUTING.md uses "checkpoint" in a generic English sense, and the disclaimer paragraph in `undo.rs` added by #1271 is correct).

## Out of scope (intentional)

- **Building Option B** (real git-backed checkpoint subsystem). Will file as a follow-up issue if/when there's appetite.
- **Auditing other potential prompt lies.** A quick scan didn't surface other obvious phantom-feature claims, but a broader audit pass could be its own task.

Closes #1264 priority 2.
