### PR TITLE
fix(ci): correct upstream paths and trace renames in vendor-sync workflow

### DIFF
--- a/.github/workflows/vendor-sync-reminder.yml
+++ b/.github/workflows/vendor-sync-reminder.yml
@@ -56,12 +56,20 @@ jobs:
 
           # Mapping: local koda path → upstream codex path.
           # Update this list when adding/removing vendored files.
+          #
+          # Path note: upstream paths reflect codex's CURRENT layout, not
+          # the layout at our pinned SHA. We pass `--follow` to `git log`
+          # below so renames between pin and HEAD are traced correctly
+          # (e.g. `keymap.rs` was at `bottom_pane/` at our original pin
+          # and lives at `tui/src/` today; `--follow` connects the two).
+          # If you re-pin to a SHA that predates a rename, leave the
+          # mapping pointing at the file's CURRENT location.
           declare -A FILES=(
             ["koda-cli/src/composer/textarea.rs"]="codex-rs/tui/src/bottom_pane/textarea.rs"
-            ["koda-cli/src/composer/keymap.rs"]="codex-rs/tui/src/bottom_pane/keymap.rs"
+            ["koda-cli/src/composer/keymap.rs"]="codex-rs/tui/src/keymap.rs"
             ["koda-cli/src/composer/key_hint.rs"]="codex-rs/tui/src/key_hint.rs"
             ["koda-cli/src/composer/paste_burst.rs"]="codex-rs/tui/src/bottom_pane/paste_burst.rs"
-            ["koda-cli/src/composer/text_element.rs"]="codex-rs/tui/src/bottom_pane/text_element.rs"
+            ["koda-cli/src/composer/text_element.rs"]="codex-rs/protocol/src/user_input.rs"
             ["koda-cli/src/composer/wrapping.rs"]="codex-rs/tui/src/wrapping.rs"
           )
 
@@ -93,7 +101,14 @@ jobs:
             # Count commits that touched the upstream file since the pin.
             # `git log` returns a clean exit even if the path no longer
             # exists upstream — check that case explicitly.
-            count=$(git -C ../codex log --oneline "${sha}..HEAD" -- "$upstream_path" 2>/dev/null | wc -l | tr -d ' ')
+            #
+            # `--follow` is critical: without it, a rename between pin and
+            # HEAD silently hides all drift (we'd see 0 commits because
+            # the path didn't exist under its new name pre-rename).
+            # Discovered the hard way on 2026-05-05 — `keymap.rs` was
+            # moved upstream from `bottom_pane/` to `tui/src/` and the
+            # initial workflow reported 0 drift instead of 2 commits.
+            count=$(git -C ../codex log --oneline --follow "${sha}..HEAD" -- "$upstream_path" 2>/dev/null | wc -l | tr -d ' ')
 
             if [[ "$count" -eq 0 ]]; then
               # File exists upstream and is unchanged since pin.
@@ -107,7 +122,8 @@ jobs:
             fi
 
             # Pull a short summary of upstream changes for the issue body.
-            short_log=$(git -C ../codex log --oneline "${sha}..HEAD" -- "$upstream_path" | head -5)
+            # `--follow` for the same reason as the count above.
+            short_log=$(git -C ../codex log --oneline --follow "${sha}..HEAD" -- "$upstream_path" | head -5)
             report+="| \`${local_path}\` | **${count} commit(s) behind** | <details><summary>show</summary>"$'\n\n'"\`\`\`"$'\n'"${short_log}"$'\n'"\`\`\`"$'\n'"</details> |"$'\n'
             total_drift=$((total_drift + count))
           done


### PR DESCRIPTION
## TL;DR

The first run of the vendor-sync workflow (#1276) surfaced two real bugs in its own path mapping plus one latent bug for future renames. Fixes all three. With these in, real drift is **7 commits across 4 files** (not 5/3 as the first run reported).

## Bugs fixed

### 1. `keymap.rs` upstream path was stale
Upstream moved it from `bottom_pane/keymap.rs` → `tui/src/keymap.rs` after our pin SHA. The hardcoded mapping pointed at the old location, producing a "renamed?" warning instead of a drift count.

### 2. `text_element.rs` upstream path was wrong from day one
Our local file is a port of `codex_protocol::user_input::{ByteRange, TextElement}` per its provenance comment. That's a Rust *module* path, not a file path. The actual upstream lives in the `codex-protocol` crate at `codex-rs/protocol/src/user_input.rs`, **not** in the `tui` crate. The original mapping guessed at `tui/src/bottom_pane/text_element.rs` (a path that has never existed in codex history).

### 3. `git log` without `--follow` silently hides drift across renames
Even with the keymap.rs path corrected to its current location, plain `git log <pin>..HEAD -- <new_path>` would report 0 commits because the file didn't exist under that name pre-rename. We'd silently drift forever. Adding `--follow` to both `git log` invocations (count + short_log) traces a single path through renames within the requested commit range.

## Real drift (corrected)

| File | Status |
|------|--------|
| `textarea.rs` | 2 commits behind |
| `keymap.rs` | **2 commits behind** (was hidden by the rename) |
| `key_hint.rs` | 2 commits behind |
| `paste_burst.rs` | 1 commit behind |
| `text_element.rs` | up to date (was a false warning) |
| `wrapping.rs` | up to date |

## Plan after merge

1. Close issue #1276 with a comment pointing here
2. Re-trigger the workflow via `workflow_dispatch` on main
3. Verify the new issue shows 7 commits / 4 files / 0 warnings

## Why this validates the original design

The audit thread's debate was 4-layer manifest framework vs. single weekly nudge. We picked the nudge. **Two days in, the nudge surfaced real upstream churn that none of us were tracking** (keymap.rs moved, key_hint.rs got 2 unrelated commits, paste_burst.rs got a Windows fix). A manifest-driven framework would have given the same answer at much higher build-and-maintain cost.

The fact that the first run also caught its OWN path-mapping bugs — via the warnings channel that travels with drift in the same issue — means we fix both in one pass rather than discovering the path bug months later on some unrelated upstream change.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/vendor-sync-reminder.yml` | +20/-4: 2 path corrections, `--follow` on both `git log` calls, comment updates explaining why |

No production code touched.
