### PR TITLE
fix(security): WebFetch redirect SSRF hardening (#1280, Tier 1 from #1265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Security
+
+- **WebFetch SSRF: re-validate every redirect hop** (#1280, Tier 1 from #1265). Pre-#1280, `web_fetch` validated only the initial URL via `is_safe_url` + DNS check, then handed off to a shared `reqwest::Client` whose default redirect policy follows up to 10 hops with NO re-validation. A public-looking URL could redirect to `127.0.0.1`, `169.254.169.254` (cloud metadata), or any RFC1918 private host, and reqwest would silently follow. WebFetch now uses its own client with `redirect::Policy::none()` and a hand-rolled `safely_follow_redirects` loop that re-runs the full SSRF check (host blocklist + IP-range check + DNS pre-check) on every hop, including relative and scheme-relative `Location` headers. The 15s timeout now bounds the entire chain (initial + all redirects), not just the first request. The shared `build_http_client` is unchanged and still defaults to reqwest's max-10-hops policy — the new `build_http_client_with_redirect_policy` is opt-in. Six new redirect re-validation tests cover: redirect to loopback blocked, redirect to cloud-metadata blocked, max-hop limit enforced, relative `Location` resolves correctly, scheme-relative `Location` re-validated, and a happy-path two-hop chain. Total web_fetch test count: 14 → 20.
+
 ### Added
 
 - **Modified Backspace/Delete defaults in vendored editor keymap** (#1278). Ported upstream codex commit `87d2235b54` (#21058) into `composer/keymap.rs` and `composer/textarea.rs`: the default `EditorKeymap` now binds `Shift+Backspace` and `Shift+Delete` to grapheme-delete (so Windows terminals that distinguish modified delete keys don't drop them on the floor), plus `Ctrl+Backspace`, `Ctrl+Shift+Backspace`, `Ctrl+Delete`, and `Ctrl+Shift+Delete` to word-delete (matching Windows text-input conventions). 4 new regression tests pin the new defaults so future refactors of `RuntimeKeymap::defaults()` can't silently drop them.
@@ -14,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`create_provider` routing tests** (#1264 priority 9). The function `koda_core::providers::create_provider` is the central provider-construction switchboard — it's called from at least 8 sites (`session::update_provider`, `tui_commands` for `/model`, `tui_context::menus` for the provider picker, `headless`, `server`, `sub_agent_dispatch`, `tui_context` session bootstrap, `builtin_proxy` smoke check). Despite that fan-in, it had **zero direct routing tests** — a `match` arm regression here would silently misroute a whole provider family at runtime, surfacing as "my Anthropic key doesn't work" reports that are actually "the request went to OpenAI-compat with the wrong base URL." Added 4 tests pinning every current `ProviderType` variant explicitly: `Anthropic` → `"anthropic"`, `Gemini` → `"gemini"`, `Mock` → `"mock"`, and the OpenAI-compat fallthrough family (`OpenAI`, `Groq`, `DeepSeek`, `Fireworks`) → `"openai-compat"`. The fall-through arm `_ => Box::new(openai_compat::...)` is the specific footgun: any new `ProviderType` variant added to the enum without a matching arm gets silently routed to OpenAI-compat (Rust doesn't warn on `_` arms catching new variants — by design — so we backstop with a test that lists the family explicitly and tells future contributors how to extend it). Closes #1264 priority 9.
 
 ### Fixed
+
+- **Internal `koda-core` dep version drift in `koda-cli/Cargo.toml`** (#1265 Tier 2). Runtime path-dep was pinned to `0.3.1` but the dev-dep (`features = ["test-support"]`) was still on `0.3.0`, which would fail to build the moment `koda-core` ever published as a real registry crate. Bumped both to `0.3.1`. Trivial, folded into the WebFetch SSRF PR for hygiene.
 
 - **System prompt no longer lies about a non-existent git-checkpointing feature** (#1264 priority 2). The system prompt sent to every LLM call contained:
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -99,7 +99,7 @@ harness = false
 
 [dev-dependencies]
 tempfile = { workspace = true }
-koda-core = { path = "../koda-core", version = "0.3.0", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.3.1", features = ["test-support"] }
 serde_json = { workspace = true }
 # tokio's `test-util` feature enables `#[tokio::test(start_paused = true)]` so
 # frame_requester tests can manipulate the clock deterministically without

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -198,7 +198,28 @@ fn is_localhost_url(url: &str) -> bool {
 ///   models (Gemini 3.x Pro, MiniMax 2.x, etc.) that may silent-think
 ///   for several minutes between SSE chunks. See issue #1119.
 pub fn build_http_client(base_url: Option<&str>) -> reqwest::Client {
-    let mut builder = reqwest::Client::builder();
+    // Default redirect policy: reqwest's built-in (max 10 hops, no
+    // re-validation). This matches historical behavior for LLM provider
+    // clients, where redirect chains are between trusted endpoints.
+    //
+    // For untrusted-input URL fetches (e.g. WebFetch tool), use
+    // [`build_http_client_with_redirect_policy`] with `Policy::none()`
+    // and re-validate every hop manually — reqwest's default policy
+    // does NOT re-run our SSRF safety checks across redirects.
+    build_http_client_with_redirect_policy(base_url, reqwest::redirect::Policy::default())
+}
+
+/// Like [`build_http_client`] but with a caller-controlled redirect policy.
+///
+/// Used by callers that need to disable reqwest's automatic redirect
+/// following so they can re-run security checks on each hop themselves.
+/// All other configuration (timeouts, proxy, TLS-bypass-for-local) is
+/// identical to [`build_http_client`].
+pub fn build_http_client_with_redirect_policy(
+    base_url: Option<&str>,
+    redirect_policy: reqwest::redirect::Policy,
+) -> reqwest::Client {
+    let mut builder = reqwest::Client::builder().redirect(redirect_policy);
 
     // ── Timeouts ──────────────────────────────────────────────────────────
     //

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -12,7 +12,7 @@
 //! - HTML pages are converted to clean text (strips tags, scripts, styles)
 //! - JSON and plain text are returned as-is
 //! - Output is truncated to context-scaled caps
-//! - Follows redirects (up to [`MAX_REDIRECTS`] hops), re-validating SSRF
+//! - Follows redirects (up to 10 hops, see `MAX_REDIRECTS`), re-validating SSRF
 //!   safety on every hop (#1280). Redirects to loopback / RFC1918 private
 //!   ranges / link-local cloud-metadata IPs are blocked even if the
 //!   initial URL was public.
@@ -472,7 +472,7 @@ mod tests {
         assert!(!result.contains("   ")); // No triple spaces
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_web_fetch_bad_url() {
         let args = json!({ "url": "not-a-url" });
         let result = web_fetch(&args, 15_000).await;
@@ -544,7 +544,7 @@ mod tests {
         assert!(is_safe_ip(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_web_fetch_blocks_ssrf() {
         let args = json!({ "url": "http://169.254.169.254/latest/meta-data/" });
         let result = web_fetch(&args, 15_000).await;
@@ -552,7 +552,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("blocked"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_web_fetch_missing_url() {
         let args = json!({});
         let result = web_fetch(&args, 15_000).await;
@@ -665,7 +665,7 @@ mod tests {
     /// The headline #1280 bug: a public-looking URL redirects to loopback,
     /// and the production validator must reject the redirect target even
     /// though the initial server URL was "reachable."
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_redirect_to_loopback_is_blocked_by_production_validator() {
         // Server's first response: 302 -> http://127.0.0.1:1/secret.
         // The production validator MUST reject this redirect target.
@@ -693,7 +693,7 @@ mod tests {
     /// Same bug, cloud-metadata variant. The classic GCP/AWS
     /// credential-exfil target. Must be rejected on redirect just like a
     /// direct hit.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_redirect_to_cloud_metadata_is_blocked() {
         let (server_url, ct) = spawn_test_server(vec![Step::Redirect(
             "http://169.254.169.254/latest/meta-data/iam/security-credentials/".to_string(),
@@ -717,7 +717,7 @@ mod tests {
     /// Exceeding the hop limit must be a hard error, not silently truncated.
     /// Uses the permissive validator so we isolate the hop-count enforcement
     /// from the SSRF check.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_max_redirect_hops_enforced() {
         // 11 redirects in a chain — max_hops=3 should bail at hop 3.
         let mut steps: Vec<Step> = (0..11)
@@ -741,7 +741,7 @@ mod tests {
 
     /// Relative `Location` headers must resolve against the current URL
     /// (RFC 3986) and be re-validated like absolute ones.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_relative_redirect_resolves_against_current_url() {
         // Two-hop relative redirect: /a -> /b (relative) -> 200 OK.
         let (server_url, ct) = spawn_test_server(vec![
@@ -770,7 +770,7 @@ mod tests {
 
     /// Scheme-relative `Location: //evil.com/...` resolves against the
     /// current URL's scheme — verify it doesn't sneak past the validator.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_scheme_relative_redirect_revalidated() {
         // `//127.0.0.1:1/x` resolves to `http://127.0.0.1:1/x` against an
         // http base; production validator must still reject.
@@ -794,7 +794,7 @@ mod tests {
     /// Happy path: a normal 302 chain that ends at 200 with permissive
     /// validation works end to end. Sanity check that the loop returns the
     /// right body.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_happy_path_two_hop_redirect_chain() {
         let (server_url, ct) = spawn_test_server(vec![
             Step::Redirect("/step2".to_string()),

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -12,14 +12,28 @@
 //! - HTML pages are converted to clean text (strips tags, scripts, styles)
 //! - JSON and plain text are returned as-is
 //! - Output is truncated to context-scaled caps
-//! - Follows redirects (up to 10 hops)
-//! - Timeout: 15 seconds (see `DEFAULT_TIMEOUT_SECS`)
+//! - Follows redirects (up to [`MAX_REDIRECTS`] hops), re-validating SSRF
+//!   safety on every hop (#1280). Redirects to loopback / RFC1918 private
+//!   ranges / link-local cloud-metadata IPs are blocked even if the
+//!   initial URL was public.
+//! - Timeout: 15 seconds (see `DEFAULT_TIMEOUT_SECS`) for the entire
+//!   fetch including all redirect hops.
 
 use crate::providers::ToolDefinition;
 use anyhow::Result;
 use serde_json::{Value, json};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 15;
+
+/// Maximum number of HTTP redirect hops WebFetch will follow.
+///
+/// Matches reqwest's default of 10. The original web_fetch implementation
+/// inherited this from `reqwest::redirect::Policy::default()` but did NOT
+/// re-validate safety on each hop. Now made explicit because we own the
+/// redirect loop ourselves (#1280).
+pub(crate) const MAX_REDIRECTS: usize = 10;
+
+const USER_AGENT: &str = "Koda/0.1 (AI coding agent)";
 
 /// Return tool definitions for the LLM.
 pub fn definitions() -> Vec<ToolDefinition> {
@@ -47,78 +61,190 @@ pub fn definitions() -> Vec<ToolDefinition> {
     }]
 }
 
-/// Fetch a URL and return its content.
-pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
-    let url = args["url"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Missing 'url' argument"))?;
-    let raw = args["raw"].as_bool().unwrap_or(false);
-
-    if !url.starts_with("http://") && !url.starts_with("https://") {
+/// Validate a URL against koda's SSRF policy.
+///
+/// Combines the synchronous `is_safe_url` host-list / IP-range checks
+/// with a DNS pre-check that resolves domain names and rejects any
+/// resolution that rivate/internal IP. Returns the parsed
+/// [`url::Url`] on success so callers don't re-parse.
+///
+/// This is the **single seam** all WebFetch reachability decisions go
+/// through — both the initial URL check and every redirect hop call this
+/// function. Adding a new SSRF check here is automatically applied to
+/// redirect chains too (#1280).
+async fn validate_url_safety(url_str: &str) -> Result<url::Url> {
+    if !url_str.starts_with("http://") && !url_str.starts_with("https://") {
         anyhow::bail!("URL must start with http:// or https://");
     }
 
-    // SSRF protection: block requests to internal/private networks
-    if !is_safe_url(url) {
+    if !is_safe_url(url_str) {
         anyhow::bail!(
             "URL blocked: requests to internal/private networks are not allowed. \
              This includes localhost, private IPs, and cloud metadata endpoints."
         );
     }
 
-    // DNS rebinding protection: resolve the hostname and verify the IP
-    // is not private/internal before making the request. This prevents
-    // TOCTOU attacks where DNS re-resolves to a different IP.
-    if let Ok(parsed) = url::Url::parse(url)
-        && let Some(host) = parsed.host_str()
-    {
-        // Only resolve domain names (IPs are already checked above)
-        if parsed
+    let parsed = url::Url::parse(url_str)
+        .map_err(|e| anyhow::anyhow!("Failed to parse URL '{url_str}': {e}"))?;
+
+    if let Some(host) = parsed.host_str()
+        && parsed
             .host()
             .is_some_and(|h| matches!(h, url::Host::Domain(_)))
-        {
-            match tokio::net::lookup_host(format!(
-                "{}:{}",
-                host,
-                parsed.port_or_known_default().unwrap_or(80)
-            ))
-            .await
-            {
-                Ok(addrs) => {
-                    for addr in addrs {
-                        if !is_safe_ip(addr.ip()) {
-                            anyhow::bail!(
-                                "URL blocked: domain '{host}' resolves to private/internal IP {}.",
-                                addr.ip()
-                            );
-                        }
+    {
+        let port = parsed.port_or_known_default().unwrap_or(80);
+        match tokio::net::lookup_host(format!("{host}:{port}")).await {
+            Ok(addrs) => {
+                for addr in addrs {
+                    if !is_safe_ip(addr.ip()) {
+                        anyhow::bail!(
+                            "URL blocked: domain '{host}' resolves to private/internal IP {}.",
+                            addr.ip()
+                        );
                     }
                 }
-                Err(e) => {
-                    anyhow::bail!("DNS resolution failed for '{host}': {e}");
-                }
+            }
+            Err(e) => {
+                anyhow::bail!("DNS resolution failed for '{host}': {e}");
             }
         }
     }
 
-    static HTTP_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
-    let client = HTTP_CLIENT
-        .get_or_init(|| crate::providers::build_http_client(None))
-        .clone();
+    Ok(parsed)
+}
+
+/// Follow HTTP redirects manually, re-validating SSRF safety on every hop.
+///
+/// `client` MUST be configured with `redirect::Policy::none()` (which is
+/// what [`web_fetch_client`] does); otherwise reqwest will silently
+/// follow redirects without re-validation, defeating the whole point.
+///
+/// `validator` is the safety check applied to every redirect target.
+/// Production callers pass [`validate_url_safety`]; tests can pass a
+/// permissive validator to exercise the redirect loop itself without
+/// hitting SSRF blocks on a loopback test server.
+///
+/// Headers added to the initial request (User-Agent) are re-applied to
+/// each redirected request. We deliberately do NOT carry forward any
+/// caller-supplied `Authorization`, `Cookie`, or `Proxy-Authorization`
+/// headers across redirects because (a) WebFetch doesn't set any today,
+/// and (b) this guards against future API additions accidentally
+/// leaking secrets to a redirect target.
+///
+/// Method is GET throughout (WebFetch only does GETs); see the function
+/// body for the RFC 7231 method-preservation note we'd need to revisit
+/// if WebFetch ever gains POST.
+pub(crate) async fn safely_follow_redirects<F, Fut>(
+    client: &reqwest::Client,
+    initial_url: url::Url,
+    max_hops: usize,
+    validator: F,
+) -> Result<reqwest::Response>
+where
+    F: Fn(String) -> Fut,
+    Fut: std::future::Future<Output = Result<url::Url>>,
+{
+    let mut current_url = initial_url;
+    // hop 0 is the initial request; redirects 1..=max_hops are the followed ones.
+    for hop in 0..=max_hops {
+        let response = client
+            .get(current_url.clone())
+            .header("User-Agent", USER_AGENT)
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("HTTP request failed: {e}"))?;
+
+        let status = response.status();
+        if !status.is_redirection() {
+            return Ok(response);
+        }
+
+        // Only the standard redirect codes follow a Location header.
+        // 304 Not Modified and other 3xx values are returned to the caller as-is.
+        if !matches!(status.as_u16(), 301 | 302 | 303 | 307 | 308) {
+            return Ok(response);
+        }
+
+        if hop == max_hops {
+            anyhow::bail!(
+                "WebFetch exceeded max redirect hops ({max_hops}); last URL: {current_url}"
+            );
+        }
+
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Redirect status {status} from {current_url} but no Location header"
+                )
+            })?
+            .to_str()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Redirect Location header from {current_url} is not valid UTF-8: {e}"
+                )
+            })?
+            .to_string();
+
+        // `Url::join` handles absolute URLs, scheme-relative URLs (`//foo/bar`),
+        // path-absolute (`/foo`), and relative (`foo`) Location values per RFC 3986.
+        let next_url = current_url.join(&location).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to resolve redirect Location '{location}' against {current_url}: {e}"
+            )
+        })?;
+
+        // Re-validate the redirect target. This is the whole point of #1280:
+        // the initial is_safe_url+DNS check does NOT cover redirect chains, so
+        // a public URL redirecting to 169.254.169.254 would have been silently
+        // followed before. Now every hop is checked.
+        current_url = validator(next_url.to_string()).await.map_err(|e| {
+            anyhow::anyhow!("Redirect from {current_url} to {next_url} blocked by SSRF policy: {e}")
+        })?;
+    }
+
+    // Loop exits via the `is_redirection() == false` early return or the
+    // max_hops bail; this line is unreachable but the compiler can't prove it.
+    unreachable!("safely_follow_redirects loop exited without returning")
+}
+
+/// Get-or-init the WebFetch HTTP client. Configured with redirect policy
+/// **disabled** (`Policy::none()`) so [`safely_follow_redirects`] owns
+/// the redirect loop and can re-validate every hop against SSRF policy.
+fn web_fetch_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        crate::providers::build_http_client_with_redirect_policy(
+            None,
+            reqwest::redirect::Policy::none(),
+        )
+    })
+}
+
+/// Fetch a URL and return its content.
+pub async fn web_fetch(args: &Value, max_body_chars: usize) -> Result<String> {
+    let url_str = args["url"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Missing 'url' argument"))?;
+    let raw = args["raw"].as_bool().unwrap_or(false);
+
+    let initial_url = validate_url_safety(url_str).await?;
+    let client = web_fetch_client();
+
     let response = tokio::time::timeout(
         std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS),
-        client
-            .get(url)
-            .header("User-Agent", "Koda/0.1 (AI coding agent)")
-            .send(),
+        safely_follow_redirects(client, initial_url, MAX_REDIRECTS, |u| async move {
+            validate_url_safety(&u).await
+        }),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("Request timed out after {DEFAULT_TIMEOUT_SECS}s"))?
-    .map_err(|e| anyhow::anyhow!("HTTP request failed: {e}"))?;
+    .map_err(|_| anyhow::anyhow!("Request timed out after {DEFAULT_TIMEOUT_SECS}s"))??;
 
+    let final_url = response.url().clone();
     let status = response.status();
     if !status.is_success() {
-        anyhow::bail!("HTTP {status} for {url}");
+        anyhow::bail!("HTTP {status} for {final_url}");
     }
 
     let body = response
@@ -431,5 +557,261 @@ mod tests {
         let args = json!({});
         let result = web_fetch(&args, 15_000).await;
         assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Redirect re-validation tests (#1280)
+    //
+    // The bug we're guarding against: pre-#1280, web_fetch validated only
+    // the initial URL via is_safe_url + DNS check, then handed off to a
+    // shared reqwest::Client whose default redirect policy follows up to
+    // 10 hops with NO re-validation. A public URL could redirect to
+    // 127.0.0.1, 169.254.169.254, an RFC1918 host, etc., and reqwest
+    // would silently follow.
+    //
+    // Strategy: spin up a real tiny HTTP server on a loopback port, have it
+    // serve a configurable sequence of redirects, and assert that
+    // safely_follow_redirects() either re-validates each hop (when given the
+    // production validator) or honors a hop limit (when given a permissive
+    // validator). Using a real server matters: a mock that bypasses the
+    // reqwest Client wouldn't exercise the actual redirect policy wiring.
+    // ========================================================================
+
+    use axum::{Router, extract::State, http::StatusCode, response::IntoResponse, routing::get};
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tokio_util::sync::CancellationToken;
+
+    /// One step in a scripted server response sequence.
+    #[derive(Clone, Debug)]
+    enum Step {
+        /// Respond 302 with the given Location header value.
+        Redirect(String),
+        /// Respond 200 OK with the given body.
+        Ok(String),
+    }
+
+    #[derive(Clone)]
+    struct ServerState {
+        /// Pop-front queue of scripted responses. After exhaustion, the server
+        /// returns 500 so test failures are loud.
+        steps: Arc<StdMutex<Vec<Step>>>,
+    }
+
+    async fn handler(
+        State(state): State<ServerState>,
+        uri: axum::http::Uri,
+    ) -> axum::response::Response {
+        let step = state.steps.lock().expect("steps mutex poisoned").pop();
+        match step {
+            Some(Step::Redirect(loc)) => (
+                StatusCode::FOUND,
+                [(axum::http::header::LOCATION, loc)],
+                String::new(),
+            )
+                .into_response(),
+            Some(Step::Ok(body)) => (StatusCode::OK, body).into_response(),
+            None => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("unexpected request to {uri} — test script exhausted"),
+            )
+                .into_response(),
+        }
+    }
+
+    /// Spin up an axum server on 127.0.0.1:0 with a scripted response queue.
+    /// Returns the base URL (e.g. `http://127.0.0.1:54321`) and a cancel
+    /// token the test must trigger to shut the server down.
+    async fn spawn_test_server(steps: Vec<Step>) -> (String, CancellationToken) {
+        // Steps are pushed back into a stack-style Vec so handler can `pop()`
+        // in O(1) and the test reads top-down. Reverse here so the first
+        // request gets steps[0].
+        let mut reversed = steps;
+        reversed.reverse();
+        let state = ServerState {
+            steps: Arc::new(StdMutex::new(reversed)),
+        };
+        let app = Router::new()
+            .route("/{*path}", get(handler))
+            .route("/", get(handler))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{addr}");
+        let ct = CancellationToken::new();
+        let ct_server = ct.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move { ct_server.cancelled_owned().await })
+                .await
+                .ok();
+        });
+        (url, ct)
+    }
+
+    /// A validator that allows any URL. Lets us exercise the redirect loop
+    /// itself (loopback test server hitting loopback redirect targets)
+    /// without the production SSRF check rejecting our own test fixtures.
+    async fn permissive_validator(url: String) -> Result<url::Url> {
+        url::Url::parse(&url).map_err(|e| anyhow::anyhow!("parse: {e}"))
+    }
+
+    fn test_client() -> reqwest::Client {
+        crate::providers::build_http_client_with_redirect_policy(
+            None,
+            reqwest::redirect::Policy::none(),
+        )
+    }
+
+    /// The headline #1280 bug: a public-looking URL redirects to loopback,
+    /// and the production validator must reject the redirect target even
+    /// though the initial server URL was "reachable."
+    #[tokio::test]
+    async fn test_redirect_to_loopback_is_blocked_by_production_validator() {
+        // Server's first response: 302 -> http://127.0.0.1:1/secret.
+        // The production validator MUST reject this redirect target.
+        let (server_url, ct) = spawn_test_server(vec![Step::Redirect(
+            "http://127.0.0.1:1/secret".to_string(),
+        )])
+        .await;
+
+        let initial = url::Url::parse(&server_url).unwrap();
+        let client = test_client();
+        let result = safely_follow_redirects(&client, initial, MAX_REDIRECTS, |u| async move {
+            validate_url_safety(&u).await
+        })
+        .await;
+
+        ct.cancel();
+        let err = result.expect_err("redirect to loopback must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("blocked") || msg.contains("SSRF"),
+            "error should mention SSRF/blocked, got: {msg}"
+        );
+    }
+
+    /// Same bug, cloud-metadata variant. The classic GCP/AWS
+    /// credential-exfil target. Must be rejected on redirect just like a
+    /// direct hit.
+    #[tokio::test]
+    async fn test_redirect_to_cloud_metadata_is_blocked() {
+        let (server_url, ct) = spawn_test_server(vec![Step::Redirect(
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/".to_string(),
+        )])
+        .await;
+
+        let initial = url::Url::parse(&server_url).unwrap();
+        let client = test_client();
+        let result = safely_follow_redirects(&client, initial, MAX_REDIRECTS, |u| async move {
+            validate_url_safety(&u).await
+        })
+        .await;
+
+        ct.cancel();
+        assert!(
+            result.is_err(),
+            "redirect to 169.254.169.254 must be rejected"
+        );
+    }
+
+    /// Exceeding the hop limit must be a hard error, not silently truncated.
+    /// Uses the permissive validator so we isolate the hop-count enforcement
+    /// from the SSRF check.
+    #[tokio::test]
+    async fn test_max_redirect_hops_enforced() {
+        // 11 redirects in a chain — max_hops=3 should bail at hop 3.
+        let mut steps: Vec<Step> = (0..11)
+            .map(|i| Step::Redirect(format!("/hop{i}")))
+            .collect();
+        steps.push(Step::Ok("never reached".to_string()));
+        let (server_url, ct) = spawn_test_server(steps).await;
+
+        let initial = url::Url::parse(&server_url).unwrap();
+        let client = test_client();
+        let result = safely_follow_redirects(&client, initial, 3, permissive_validator).await;
+
+        ct.cancel();
+        let err = result.expect_err("hop limit must be enforced");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("max redirect hops"),
+            "error should mention hop cap, got: {msg}"
+        );
+    }
+
+    /// Relative `Location` headers must resolve against the current URL
+    /// (RFC 3986) and be re-validated like absolute ones.
+    #[tokio::test]
+    async fn test_relative_redirect_resolves_against_current_url() {
+        // Two-hop relative redirect: /a -> /b (relative) -> 200 OK.
+        let (server_url, ct) = spawn_test_server(vec![
+            Step::Redirect("/b".to_string()),
+            Step::Ok("final body".to_string()),
+        ])
+        .await;
+
+        let initial = url::Url::parse(&format!("{server_url}/a")).unwrap();
+        let client = test_client();
+        let response =
+            safely_follow_redirects(&client, initial, MAX_REDIRECTS, permissive_validator)
+                .await
+                .expect("relative redirect should succeed");
+
+        let final_url = response.url().clone();
+        let body = response.text().await.unwrap();
+
+        ct.cancel();
+        assert_eq!(body, "final body");
+        assert!(
+            final_url.path().ends_with("/b"),
+            "final URL should be the relative-resolved /b, got: {final_url}"
+        );
+    }
+
+    /// Scheme-relative `Location: //evil.com/...` resolves against the
+    /// current URL's scheme — verify it doesn't sneak past the validator.
+    #[tokio::test]
+    async fn test_scheme_relative_redirect_revalidated() {
+        // `//127.0.0.1:1/x` resolves to `http://127.0.0.1:1/x` against an
+        // http base; production validator must still reject.
+        let (server_url, ct) =
+            spawn_test_server(vec![Step::Redirect("//127.0.0.1:1/x".to_string())]).await;
+
+        let initial = url::Url::parse(&server_url).unwrap();
+        let client = test_client();
+        let result = safely_follow_redirects(&client, initial, MAX_REDIRECTS, |u| async move {
+            validate_url_safety(&u).await
+        })
+        .await;
+
+        ct.cancel();
+        assert!(
+            result.is_err(),
+            "scheme-relative redirect to loopback must be rejected"
+        );
+    }
+
+    /// Happy path: a normal 302 chain that ends at 200 with permissive
+    /// validation works end to end. Sanity check that the loop returns the
+    /// right body.
+    #[tokio::test]
+    async fn test_happy_path_two_hop_redirect_chain() {
+        let (server_url, ct) = spawn_test_server(vec![
+            Step::Redirect("/step2".to_string()),
+            Step::Redirect("/final".to_string()),
+            Step::Ok("hello world".to_string()),
+        ])
+        .await;
+
+        let initial = url::Url::parse(&server_url).unwrap();
+        let client = test_client();
+        let response =
+            safely_follow_redirects(&client, initial, MAX_REDIRECTS, permissive_validator)
+                .await
+                .expect("happy path should succeed");
+        let body = response.text().await.unwrap();
+
+        ct.cancel();
+        assert_eq!(body, "hello world");
     }
 }


### PR DESCRIPTION
## What & why

Closes #1280. Refs #1265 (Tier 1 security item).

### The bug

Pre-this-PR, `web_fetch` validated only the **initial URL** via `is_safe_url` + DNS check, then handed off to a shared `reqwest::Client` whose default redirect policy follows up to 10 hops with **no re-validation**. The doc-comment even said "Follows redirects (up to 10 hops)" without mentioning that hops weren't safety-checked.

A public-looking URL could redirect to:

| Redirect target | Attack |
|---|---|
| `127.0.0.1` / `[::1]` | SSRF to host services (admin panels, debug ports) |
| `169.254.169.254` | Cloud metadata exfil (the classic GCP/AWS credential-exfil) |
| `10/8`, `172.16/12`, `192.168/16` | RFC1918 private network probe |

…and reqwest would silently follow.

### The fix

WebFetch now owns its redirect loop:

1. **New providers helper** `build_http_client_with_redirect_policy(base_url, policy)`. Existing `build_http_client()` delegates to it with the default policy → all 8 existing call sites unchanged.
2. **WebFetch's static client** is initialized with `reqwest::redirect::Policy::none()`.
3. **New `safely_follow_redirects(client, initial_url, max_hops, validator)`** manually loops up to `max_hops`, re-running the full SSRF check (`validator`) on every hop. The validator is parameterized so tests can pass a permissive variant to exercise the loop on a loopback test server, while production passes `validate_url_safety` which re-runs `is_safe_url` + DNS check end-to-end.
4. **Relative and scheme-relative `Location` headers** (per RFC 3986) are resolved against the current URL via `url::Url::join` *before* re-validation.
5. **Only standard redirect codes** (301, 302, 303, 307, 308) trigger the loop. 304 and other 3xx return to the caller as-is.
6. **The 15s timeout now bounds the entire chain**, not just the first request. Stricter than before — intentional, since a malicious chain could otherwise take `10 × per-hop timeout`.
7. **No header forwarding** — WebFetch only sets `User-Agent`. Defensive against future API additions accidentally leaking `Authorization`/`Cookie`/`Proxy-Authorization`.

## Tests

**6 new redirect re-validation tests, all green.** Total `web_fetch` test count: **14 → 20**.

| Test | What it pins |
|---|---|
| `test_redirect_to_loopback_is_blocked_by_production_validator` | The headline #1280 bug: `302 → http://127.0.0.1:1/secret` is rejected. |
| `test_redirect_to_cloud_metadata_is_blocked` | Classic GCP/AWS credential-exfil target `169.254.169.254`. |
| `test_max_redirect_hops_enforced` | 11-redirect chain with `max_hops=3` bails with a clear error. |
| `test_relative_redirect_resolves_against_current_url` | Two-hop `/a → /b → 200 OK` chain works end-to-end. |
| `test_scheme_relative_redirect_revalidated` | `//127.0.0.1:1/x` against an http base resolves to loopback and is rejected. |
| `test_happy_path_two_hop_redirect_chain` | Sanity: a normal 302 chain ending at 200 returns the right body. |

**Test infrastructure**: tiny axum server on `127.0.0.1:0` with a scripted response queue. Reuses koda's existing pattern from `mcp_http_transport_test.rs`. `axum` was already a dev-dep — no new dependencies.

## Out of scope (tracked separately)

- **DNS-pre-check TOCTOU** (validated IP ≠ connected IP) is documented in #1280 as a known limitation. Mitigation needs binding the actual TCP connect to the validated IP — bigger change, separate PR if/when worth doing.
- **File mutation symlink/TOCTOU hardening** — sibling Tier-1 item from #1265, tracked at #1281 (will be PR B).

## Hygiene chore folded in (#1265 Tier 2)

`koda-cli/Cargo.toml` had `koda-core` runtime path-dep at `0.3.1` but dev-dep (`features = ["test-support"]`) at `0.3.0`. Both bumped to `0.3.1`. Folded here because it's a 1-line trivial change and would otherwise need its own PR.

## Validation

```text
cargo fmt --all -- --check                                     ✓
cargo clippy --workspace --all-targets -- -D warnings          ✓
cargo test --workspace --lib                                   ✓
   2240 passed (634 koda-cli + 1267 koda-core + 337 + 2)
   1 ignored (pre-existing)
   0 failed
```

## Diff size

| File | + / − |
|---|---|
| `koda-core/src/tools/web_fetch.rs` | +482 / −52 (rewrite of fetch path + 6 new tests + test infra) |
| `koda-core/src/providers/mod.rs` | +22 / −1 (factor out `build_http_client_with_redirect_policy`) |
| `koda-cli/Cargo.toml` | +1 / −1 (dep version drift fix) |
| `CHANGELOG.md` | +6 / −0 |
