### PR TITLE
chore(deps): hoist shared crates to workspace.dependencies (#1265 P2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,15 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Shared third-party deps used by 2+ crates. Hoisted here under #1265
+# dep-hygiene so version bumps land in one place and `cargo tree -d`
+# stays clean.
+futures-util = "0.3"
+glob = "0.3"
+ignore = "0.4"
+libc = "0.2"
+regex = "1"
+
 # Dev-only deps shared across crates.
 tempfile = "3"
 

--- a/koda-cli/Cargo.toml
+++ b/koda-cli/Cargo.toml
@@ -56,7 +56,7 @@ unicode-segmentation = "1.13"
 # (via crossterm → signal-hook-mio); declared explicitly here because we use
 # them directly and transitive contracts are fragile.
 signal-hook = "0.3"
-libc = "0.2"
+libc = { workspace = true }
 
 # Clipboard (for Ctrl+Y copy)
 arboard = "3"
@@ -74,7 +74,7 @@ ansi-to-tui = "8"
 
 # Regex — used to highlight Grep match substrings (mirrors koda-core's
 # Grep tool, so the same pattern compiles in both places).
-regex = "1"
+regex = { workspace = true }
 
 # Logging (subscriber for CLI configuration)
 tracing = { workspace = true }
@@ -91,7 +91,7 @@ time = "0.3"
 # Base64 encoding (for image input)
 base64 = "0.22"
 agent-client-protocol-schema = { version = "0.11", features = ["unstable_session_model", "unstable_session_list", "unstable"] }
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 [[bench]]
 name = "render_bench"

--- a/koda-core/Cargo.toml
+++ b/koda-core/Cargo.toml
@@ -33,19 +33,19 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 # File system (respects .gitignore)
-ignore = "0.4"
+ignore = { workspace = true }
 
 # Path normalization
 path-clean = "1"
 
 # Text search
-regex = "1"
+regex = { workspace = true }
 
 # Diff computation
 similar = "3"
 
 # File globbing
-glob = "0.3"
+glob = { workspace = true }
 
 # URL parsing (for SSRF protection)
 url = "2"
@@ -69,7 +69,7 @@ parking_lot = "0.12"
 reqwest = { version = "0.13", features = ["json", "stream"] }
 
 # Streaming support
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 # Error handling
 anyhow = { workspace = true }
@@ -112,8 +112,8 @@ axum = { version = "0.8", default-features = false, features = ["http1", "tokio"
 koda-test-utils = { path = "../koda-test-utils" }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
-regex = "1"
-ignore = "0.4"
+regex = { workspace = true }
+ignore = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 

--- a/koda-sandbox/Cargo.toml
+++ b/koda-sandbox/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["os", "filesystem", "concurrency"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 # File globbing for `LocalFileSystem::glob`. Same version as koda-core.
-glob = "0.3"
+glob = { workspace = true }
 # Recursive walk + .gitignore handling for `LocalFileSystem::grep`.
 # Same version as koda-core.
-ignore = "0.4"
+ignore = { workspace = true }
 # Regex matching for `LocalFileSystem::grep`. Same version as koda-core.
-regex = "1"
+regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["process", "rt", "io-util", "io-std", "net", "macros", "fs", "time", "sync"] }
@@ -32,11 +32,11 @@ tracing-subscriber = { workspace = true }
 # prctl for parent-death, execvp). Tokio's tiny libc dep is not
 # enough — we want the public surface so it's a direct workspace dep.
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 # macOS needs libc for clonefile(2) used by ClonefileProvider (Phase 4d).
 [target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/koda-test-utils/Cargo.toml
+++ b/koda-test-utils/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = { workspace = true }
-koda-core = { path = "../koda-core", features = ["test-support"] }
+koda-core = { path = "../koda-core", version = "0.3.1", features = ["test-support"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-util = { workspace = true }


### PR DESCRIPTION
## What & why

Refs #1265 — third PR from the audit's P2 batch (after #1283 + #1284).

Mechanical dep-hygiene cleanup. Two issues fixed; one deliberately deferred with rationale below.

## Hoisted to `[workspace.dependencies]`

Five third-party deps used by 2+ workspace crates with the SAME version spec. Pre-fix each crate carried its own copy; bumping required N edits. Post-fix one source of truth:

| dep            | callsites before | hoisted version |
|----------------|------------------|-----------------|
| `regex`        | 4 (cli, core ×2, sandbox) | `1` |
| `ignore`       | 3 (core ×2, sandbox)      | `0.4` |
| `glob`         | 2 (core, sandbox)         | `0.3` |
| `libc`         | 3 (cli, sandbox ×2)       | `0.2` |
| `futures-util` | 2 (cli, core)             | `0.3` |

Each callsite is now `name = { workspace = true }`. Same resolved versions in `Cargo.lock`.

## Fixed missing `version =` on internal path dep

`koda-test-utils/Cargo.toml` had:

```toml
koda-core = { path = "../koda-core", features = ["test-support"] }
```

while every other internal `koda-*` path dep specifies `version = "0.3.1"`. The omission was inconsistent — pinning to whatever path resolves at the time is fragile across vendoring/publish workflows. Added it.

## Audit's #1 finding was already gone

The original audit (#1265) called out that `koda-cli`'s runtime `koda-core` path dep was `0.3.1` but the dev-dep was still `0.3.0`. A prior version bump unified both at `0.3.1`, so no action needed — flagged here so reviewers don't grep for it.

## Deliberately deferred: `tokio = features = ["full"]`

The audit also said *"Replace production `tokio/full` with explicit feature lists where reasonable."* Six callsites use `tokio = features = ["full"]`:

- `koda-cli` (runtime + dev)
- `koda-core` (runtime + dev)
- `koda-sandbox` (dev)
- `koda-test-utils` (dev)

Why deferred:

1. `"full"` enables ~15 sub-features (rt, rt-multi-thread, macros, sync, fs, net, time, signal, process, io-util, io-std, parking_lot, tracing, …). Auditing every `tokio::` import to derive minimal feature sets is a 1-2 hour static-analysis dance, and any miss surfaces as a confusing `unresolved import`.
2. `"full"` is explicitly fine for application-level crates per the tokio docs; the optimization mainly helps libraries. We're binaries, not libraries.
3. The mechanical hoist in this PR has zero risk; tokio surgery has real risk for marginal build-time wins.

Tracking as a future follow-up if anyone is chasing build-time wins.

## Validation

```text
cargo check --workspace --all-targets                   ✓
cargo fmt --all -- --check                              ✓
cargo clippy --workspace --all-targets -- -D warnings   ✓
cargo test --workspace                                  ✓ 2594 passed, 0 failed
cargo tree -d                                           ✓ no NEW duplicate-version entries
                                                          (pre-existing transitives untouched)
cargo tree -e normal -p {regex,ignore,glob,libc,futures-util}
                                                        ✓ each resolves to one version
```

## Diff size

5 files, +24/−15. The hoist-to-workspace pattern is explicit and grep-friendly.
