### PR TITLE
refactor(core): introduce TurnContext + ToolExecutionContext (#1265 item 4, PR-1/3)

### DIFF
--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -131,6 +131,9 @@ pub mod tools;
 pub mod truncate;
 /// Unified trust mode — single permission knob replacing ApprovalMode × SandboxMode.
 pub mod trust;
+/// Per-turn ambient context (`TurnContext`, `ToolExecutionContext`)
+/// — see #1265 item 4.
+pub mod turn_context;
 /// Undo stack for file mutations.
 pub mod undo;
 /// Version string and update-check helpers.

--- a/koda-core/src/turn_context.rs
+++ b/koda-core/src/turn_context.rs
@@ -1,0 +1,305 @@
+//! `TurnContext` and `ToolExecutionContext` — typed bundles for the
+//! ambient state passed through the inference / tool-dispatch / sub-agent
+//! call graph.
+//!
+//! ## Why
+//!
+//! Pre-PR-1-of-#1265-item-4, six functions in [`crate::tool_dispatch`]
+//! and one in `crate::sub_agent_dispatch` (private module) each took 11–13
+//! explicit parameters. Each one carried `#[allow(clippy::too_many_arguments)]`
+//! and called the same `(project_root, config, db, session_id, sink,
+//! cancel, sub_agent_cache, bg_agents, …)` quartet through every
+//! layer. Adding a new ambient field (e.g. a tracing span, a per-turn
+//! quota, a feature flag) meant editing every signature.
+//!
+//! `TurnContext` collects the per-turn ambient context once at the
+//! inference-loop entry and threads a single reference through dispatch.
+//! `ToolExecutionContext` adds the few fields that are scoped to a
+//! single batch of tool calls (`caller_spawner`).
+//!
+//! ## What stays OUT of TurnContext
+//!
+//! - **`file_tracker: &mut FileTracker`** — the only mutable piece of
+//!   ambient state. Pulling it into `TurnContext` would force a `&mut
+//!   TurnContext` everywhere, which conflicts with the parallel-execution
+//!   path (the mutation only happens in the post-join `record_tool_result`
+//!   loop, not inside the parallel futures themselves). Passing it as a
+//!   separate `&mut FileTracker` argument keeps `TurnContext` cheap to
+//!   share across borrow boundaries.
+//! - **`cmd_rx: &mut mpsc::Receiver<EngineCommand>`** — also `&mut`,
+//!   and only relevant to dispatch paths that may issue interactive
+//!   approvals (sequential / split-batch). Lives outside the context
+//!   for the same reason as `file_tracker`.
+//! - **Per-call data** like `tc: &ToolCall`, `result: &str`,
+//!   `tool_calls: &[ToolCall]` — these are inputs, not context.
+//!
+//! ## Lifetimes
+//!
+//! `TurnContext<'a>` borrows everything by `&'a` reference except
+//! `cancel: CancellationToken`, which is internally `Arc`-backed and
+//! Clone, so storing by value avoids a third lifetime parameter.
+//! `ToolExecutionContext<'a>` borrows the `TurnContext<'a>` and adds
+//! per-batch fields with their own (shorter or equal) lifetime.
+//!
+//! ## Migration policy
+//!
+//! - **PR-1 of #1265 item 4 (this PR)**: introduce the types only.
+//!   Zero callsite migration. Smoke-test via unit tests that construct
+//!   one and read its fields.
+//! - **PR-2**: migrate `tool_dispatch.rs` (6 functions, 6 allows).
+//! - **PR-3**: migrate `sub_agent_dispatch::execute_sub_agent`
+//!   (1 function, 1 allow). The owned-args `run_bg_agent` stays
+//!   explicit because tokio-spawn requires `'static`.
+//! - **Out of scope**: `ChildAgentRegistry::attach` — author has
+//!   explicitly opted out (per-call data, not context).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::child_agent::ChildAgentRegistry;
+use crate::config::KodaConfig;
+use crate::db::Database;
+use crate::engine::EngineSink;
+use crate::sub_agent_cache::SubAgentCache;
+use crate::tools::ToolRegistry;
+use crate::trust::TrustMode;
+
+/// Per-turn ambient context shared across the inference loop, tool
+/// dispatch, and sub-agent invocation.
+///
+/// Constructed once per turn at the inference-loop entry; threaded
+/// by `&` reference through dispatch. All fields are immutable
+/// borrows or `Clone`-by-value handles — see module docs for why
+/// `file_tracker` and `cmd_rx` stay outside.
+pub struct TurnContext<'a> {
+    /// Project root — used for path safety + workspace scoping.
+    pub project_root: &'a Path,
+
+    /// Per-session config (model, caps, model_settings, …).
+    pub config: &'a KodaConfig,
+
+    /// SQLite-backed message + tool-result store.
+    pub db: &'a Database,
+
+    /// Active session id for `db` writes.
+    pub session_id: &'a str,
+
+    /// Engine event sink (TUI / headless / ACP).
+    pub sink: &'a dyn EngineSink,
+
+    /// Per-turn child cancel token. Stored by value because
+    /// `CancellationToken` is `Arc`-backed and `Clone`. Cloning is
+    /// cheap; nested calls clone freely.
+    pub cancel: CancellationToken,
+
+    /// Cache of compiled sub-agent specs (#1086 invocation cache).
+    pub sub_agent_cache: &'a SubAgentCache,
+
+    /// Background-agent registry — used for `ListBackgroundTasks`,
+    /// `CancelTask`, `WaitTask`, and bg-sub-agent reservations.
+    pub bg_agents: &'a Arc<ChildAgentRegistry>,
+
+    /// Per-turn trust snapshot. Read once at turn entry; the user
+    /// can cycle trust between turns but not mid-turn.
+    pub mode: TrustMode,
+
+    /// Tool registry (built-in + MCP). Per-session; constant within
+    /// a single turn.
+    pub tools: &'a ToolRegistry,
+}
+
+impl<'a> TurnContext<'a> {
+    /// Construct a per-turn context. All borrows must outlive `'a`;
+    /// the typical caller is the inference loop in
+    /// [`crate::inference`], which holds these in named locals.
+    #[allow(clippy::too_many_arguments)] // 10 args is the WHOLE POINT — this is the
+    // bundling site, exactly one allow at the constructor instead of one per consumer.
+    pub fn new(
+        project_root: &'a Path,
+        config: &'a KodaConfig,
+        db: &'a Database,
+        session_id: &'a str,
+        sink: &'a dyn EngineSink,
+        cancel: CancellationToken,
+        sub_agent_cache: &'a SubAgentCache,
+        bg_agents: &'a Arc<ChildAgentRegistry>,
+        mode: TrustMode,
+        tools: &'a ToolRegistry,
+    ) -> Self {
+        Self {
+            project_root,
+            config,
+            db,
+            session_id,
+            sink,
+            cancel,
+            sub_agent_cache,
+            bg_agents,
+            mode,
+            tools,
+        }
+    }
+}
+
+/// Per-tool-batch execution context.
+///
+/// Adds fields scoped narrower than a turn — currently just
+/// `caller_spawner`, but a likely home for future per-batch state
+/// (tracing span, batch id, retry counter, …).
+///
+/// Constructed by the dispatch-entry function (`execute_tools_*`) and
+/// passed by reference to inner helpers (`execute_one_tool`,
+/// `validate_then_execute_one_tool`).
+#[derive(Clone, Copy)]
+pub struct ToolExecutionContext<'a> {
+    /// Borrowed turn context. The narrower lifetime annotation lets
+    /// the batch context outlive specific tool-call iterations
+    /// without forcing the turn context to.
+    pub turn: &'a TurnContext<'a>,
+
+    /// Spawner identity for cleanup routing (Phase E of #996). `None`
+    /// at top-level inference (no parent invocation). `Some(id)` when
+    /// invoked from inside a sub-agent — bg-task tools tag their
+    /// reservations with `spawner = caller_spawner` so the parent
+    /// owns the right to cancel/wait its bg children.
+    pub caller_spawner: Option<u32>,
+}
+
+impl<'a> ToolExecutionContext<'a> {
+    /// Construct a per-batch execution context.
+    pub fn new(turn: &'a TurnContext<'a>, caller_spawner: Option<u32>) -> Self {
+        Self {
+            turn,
+            caller_spawner,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Smoke tests: construct each context with stub-y values and read
+    //! every field. The point isn't to test behavior (there is none —
+    //! these are dumb data bundles); it's to pin the public shape so a
+    //! future PR can't accidentally widen / narrow / reshape the type
+    //! without updating callers.
+    //!
+    //! Real call-graph migration arrives in PR-2 (tool_dispatch) and
+    //! PR-3 (sub_agent_dispatch); those will exercise the contexts
+    //! through the existing 2594-test workspace battery.
+    //!
+    //! Note: we use `MemDb::new()` and an inline `EngineSink` impl to
+    //! avoid pulling in heavy fixtures for what is genuinely a
+    //! shape-only test.
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use crate::config::ProviderType;
+    use crate::engine::EngineEvent;
+    use crate::trust::TrustMode;
+
+    struct NullSink;
+    impl EngineSink for NullSink {
+        fn emit(&self, _event: EngineEvent) {}
+    }
+
+    /// Build the heaviest fixtures (db + tools) once per test. Kept
+    /// inline rather than promoted to `koda-test-utils` because
+    /// turn_context's tests are intentionally minimal — the call
+    /// graph migration in PR-2/PR-3 will exercise these types
+    /// through the real workspace battery.
+    async fn fixtures() -> (TempDir, crate::config::KodaConfig, crate::db::Database) {
+        let dir = TempDir::new().expect("tempdir");
+        let config = crate::config::KodaConfig::default_for_testing(ProviderType::Mock);
+        let db = crate::db::Database::open(&dir.path().join("turn_ctx.db"))
+            .await
+            .expect("open db");
+        (dir, config, db)
+    }
+
+    #[tokio::test]
+    async fn turn_context_holds_all_fields() {
+        // Arrange: minimum-viable stand-ins for every TurnContext field.
+        let (dir, config, db) = fixtures().await;
+        let root: PathBuf = dir.path().to_path_buf();
+        let cancel = CancellationToken::new();
+        let cache = SubAgentCache::new();
+        let bg_agents = Arc::new(ChildAgentRegistry::new());
+        let tools = ToolRegistry::new(root.clone(), 8_000);
+        let sink = NullSink;
+
+        // Act: build the context.
+        let ctx = TurnContext::new(
+            &root,
+            &config,
+            &db,
+            "session-smoke",
+            &sink,
+            cancel.clone(),
+            &cache,
+            &bg_agents,
+            TrustMode::Safe,
+            &tools,
+        );
+
+        // Assert: every field is reachable + carries the value we passed.
+        assert_eq!(ctx.project_root, root.as_path());
+        assert_eq!(ctx.session_id, "session-smoke");
+        assert!(matches!(ctx.mode, TrustMode::Safe));
+        assert!(!ctx.cancel.is_cancelled());
+        // sub_agent_cache + bg_agents + db + config + tools + sink are
+        // pointer-equal to the inputs — checked transitively by
+        // construction (no copy / move happens for &-borrowed fields).
+        // Pointer equality on the heap-allocated Arc:
+        assert!(Arc::ptr_eq(ctx.bg_agents, &bg_agents));
+    }
+
+    #[tokio::test]
+    async fn tool_execution_context_borrows_turn() {
+        let (dir, config, db) = fixtures().await;
+        let root: PathBuf = dir.path().to_path_buf();
+        let cache = SubAgentCache::new();
+        let bg_agents = Arc::new(ChildAgentRegistry::new());
+        let tools = ToolRegistry::new(root.clone(), 8_000);
+        let sink = NullSink;
+
+        let turn = TurnContext::new(
+            &root,
+            &config,
+            &db,
+            "session-tx",
+            &sink,
+            CancellationToken::new(),
+            &cache,
+            &bg_agents,
+            TrustMode::Auto,
+            &tools,
+        );
+
+        // Top-level invocation: no parent spawner.
+        let tx = ToolExecutionContext::new(&turn, None);
+        assert!(tx.caller_spawner.is_none());
+        assert_eq!(tx.turn.session_id, "session-tx");
+        assert!(matches!(tx.turn.mode, TrustMode::Auto));
+
+        // Nested invocation (e.g. inside a sub-agent): explicit spawner.
+        let nested = ToolExecutionContext::new(&turn, Some(42));
+        assert_eq!(nested.caller_spawner, Some(42));
+        // Same turn context underneath — sanity check the borrow.
+        assert_eq!(nested.turn.session_id, "session-tx");
+    }
+
+    #[test]
+    fn tool_execution_context_is_copy() {
+        // Cheap to pass by value through inner dispatch helpers; this
+        // pins the trait so a future field addition doesn't silently
+        // remove `Copy` and force callers to clone.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<ToolExecutionContext<'_>>();
+    }
+}

--- a/koda-core/src/turn_context.rs
+++ b/koda-core/src/turn_context.rs
@@ -222,7 +222,7 @@ mod tests {
         (dir, config, db)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn turn_context_holds_all_fields() {
         // Arrange: minimum-viable stand-ins for every TurnContext field.
         let (dir, config, db) = fixtures().await;
@@ -259,7 +259,7 @@ mod tests {
         assert!(Arc::ptr_eq(ctx.bg_agents, &bg_agents));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tool_execution_context_borrows_turn() {
         let (dir, config, db) = fixtures().await;
         let root: PathBuf = dir.path().to_path_buf();


### PR DESCRIPTION
## What & why

Refs #1265 — PR-1 of 3 from the audit's P1 architectural batch (item 4: typed context objects).

The audit said:

> Several functions need `#[allow(clippy::too_many_arguments)]`. `tool_dispatch` and `sub_agent_dispatch` pass the same universe of session/tool/sink/cancel/file-tracker values around.

A grep across the four largest core modules found **10 functions** flagged with `#[allow(clippy::too_many_arguments)]`:

- `tool_dispatch.rs`: 6
- `sub_agent_dispatch.rs`: 2 (`run_bg_agent`, `execute_sub_agent`)
- `child_agent.rs`: 2 (`attach`, plus 1 inline comment justifying the allow)

Triaging the parameter lists by frequency revealed a textbook recurring set across the 6 `tool_dispatch` functions:

| field                                     | callsites |
|-------------------------------------------|-----------|
| `project_root: &Path`                     | 6/6 |
| `db: &Database`                           | 6/6 |
| `sink: &dyn EngineSink`                   | 6/6 |
| `session_id: &str`                        | 5/6 |
| `tools: &ToolRegistry`                    | 5/6 |
| `sub_agent_cache: &SubAgentCache`         | 5/6 |
| `mode: TrustMode`                         | 5/6 |
| `config: &KodaConfig`                     | 5/6 |
| `cancel: CancellationToken`               | 5/6 |
| `bg_agents: &Arc<ChildAgentRegistry>`     | 5/6 |
| `file_tracker: &mut FileTracker`          | 4/6 |
| `caller_spawner: Option<u32>`             | 3/6 |

That **is** the per-turn ambient context the audit asked us to bundle.

## What's in this PR

New file `koda-core/src/turn_context.rs` with two types + 3 unit tests pinning the public shape:

```rust
pub struct TurnContext<'a> {
    pub project_root: &'a Path,
    pub config: &'a KodaConfig,
    pub db: &'a Database,
    pub session_id: &'a str,
    pub sink: &'a dyn EngineSink,
    pub cancel: CancellationToken,           // Arc-backed, store by value
    pub sub_agent_cache: &'a SubAgentCache,
    pub bg_agents: &'a Arc<ChildAgentRegistry>,
    pub mode: TrustMode,
    pub tools: &'a ToolRegistry,
}

#[derive(Clone, Copy)]
pub struct ToolExecutionContext<'a> {
    pub turn: &'a TurnContext<'a>,
    pub caller_spawner: Option<u32>,
}
```

**Zero callsite migration in this PR.** PR-2 will migrate the 6 `tool_dispatch.rs` functions; PR-3 will migrate `execute_sub_agent`.

## Design choices that diverge from the audit's proposed shape

### `file_tracker` stays OUTSIDE the context

The audit's proposed shape included `file_tracker: &'a mut FileTracker` in `TurnContext`. After tracing the actual mutation pattern in `execute_tools_parallel` (mutation only happens in the post-join `record_tool_result` loop, NOT inside the parallel futures), I deliberately left it out:

- Pulling `&mut FileTracker` into `TurnContext` forces `&mut TurnContext` everywhere, infecting the parallel futures with a `&mut` borrow they don't need.
- Passing `file_tracker` as a separate `&mut FileTracker` arg to the 4 functions that touch it preserves the parallel-execution borrow pattern unchanged.
- The audit's shape was a spec; this is the implementation that survives contact with the existing concurrency story.

`cmd_rx: &mut mpsc::Receiver<EngineCommand>` stays out for the same reason.

### `caller_spawner` lives in `ToolExecutionContext`, not `TurnContext`

3/6 of the dispatch functions need it (the ones invoking bg-task tools or sub-agents); the other 3 don't (`record_tool_result`, the parallel join's record loop). Splitting it out keeps `TurnContext` focused on per-turn concerns and `ToolExecutionContext` focused on per-batch concerns.

`ToolExecutionContext` is `Copy` so inner helpers can take it by value without ceremony — pinned by a `static_assert`-style unit test (`tool_execution_context_is_copy`).

## Out of scope (deliberately)

- **`run_bg_agent` (sub_agent_dispatch.rs)** — `tokio::spawn`'d, takes owned values for `'static`. Doesn't fit the borrowed shape. Would need a separate `OwnedTurnContext` variant; not worth the complexity for one callsite.
- **`ChildAgentRegistry::attach`** — author has explicitly opted out in a code comment: *"Bundling into a struct just to satisfy a heuristic would add a one-use type for no readability win — 'practicality beats purity'"*. Respect the call.

So the realistic acceptance criterion across PR-1+2+3 is **7 of 10 allows removed**, not 10/10. We do **gain one new allow** at the constructor (10-arg `TurnContext::new`) — but that's the WHOLE POINT: one allow at the bundling site replaces N allows at the consumer sites.

## Validation

```text
cargo fmt --all -- --check                              ✓
cargo clippy --workspace --all-targets -- -D warnings   ✓
RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps ✓
cargo test --workspace                                  ✓ 2597 passed (was 2594, +3 new), 0 failed
cargo test -p koda-core --lib turn_context::            ✓ 3/3
```

## Diff size

2 files, +308/−0. New module + one `pub mod` line in `lib.rs`. Easy to review on its own; PR-2 will reference this PR's shape directly.

## Stack

This is the bottom of a 3-PR stack:
- **PR-1 (this)** — types only, zero migration
- PR-2 — migrate `tool_dispatch.rs` (6 functions)
- PR-3 — migrate `execute_sub_agent` (1 function)

Each PR will be independently reviewable.
