### PR TITLE
refactor(core): migrate tool_dispatch.rs to TurnContext (#1265 item 4, PR-2/3)

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -669,6 +669,29 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
     );
     let sink: &dyn EngineSink = &_persisting_sink;
 
+    // #1265 item 4 PR-2: collect the per-turn ambient state into a
+    // single `TurnContext` so the dispatch helpers don't each take
+    // 11–13 explicit args. Reconstructed each turn (`mode` can change
+    // between turns), but borrows the same long-lived locals from the
+    // destructure above.
+    let turn_ctx = crate::turn_context::TurnContext::new(
+        project_root,
+        config,
+        db,
+        session_id,
+        sink,
+        cancel.clone(),
+        sub_agent_cache,
+        bg_agents,
+        mode,
+        tools,
+    );
+    // Phase E of #996: top-level inference has no spawner identity —
+    // bg-task tools see the global scope. Sub-agents construct their
+    // own `ToolExecutionContext` with `Some(parent_spawner)` inside
+    // `sub_agent_dispatch`.
+    let tool_ctx = crate::turn_context::ToolExecutionContext::new(&turn_ctx, None);
+
     // Hard cap is configurable per-agent; user can extend it interactively.
     let mut hard_cap = config.max_iterations;
     let mut iteration = 0u32;
@@ -1237,12 +1260,8 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
                         result,
                         *success,
                         full_output.as_deref(),
-                        db,
-                        session_id,
-                        tools.caps.tool_result_chars,
-                        project_root,
+                        &turn_ctx,
                         file_tracker,
-                        sink,
                     )
                     .await?;
                 }
@@ -1275,12 +1294,8 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
                         &err_msg,
                         false,
                         None,
-                        db,
-                        session_id,
-                        tools.caps.tool_result_chars,
-                        project_root,
+                        &turn_ctx,
                         file_tracker,
-                        sink,
                     )
                     .await?;
                 } else {
@@ -1300,60 +1315,11 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
         if remaining_tools.len() > 1
             && can_parallelize(&remaining_tools, mode, project_root, Some(file_tracker))
         {
-            execute_tools_parallel(
-                &remaining_tools,
-                project_root,
-                config,
-                db,
-                session_id,
-                tools,
-                mode,
-                sink,
-                cancel.clone(),
-                sub_agent_cache,
-                file_tracker,
-                bg_agents,
-                // Phase E of #996: top-level inference has no spawner
-                // identity — bg-task tools see the global scope.
-                None,
-            )
-            .await?;
+            execute_tools_parallel(&remaining_tools, tool_ctx, file_tracker).await?;
         } else if remaining_tools.len() > 1 {
-            execute_tools_split_batch(
-                &remaining_tools,
-                project_root,
-                config,
-                db,
-                session_id,
-                tools,
-                mode,
-                sink,
-                cancel.clone(),
-                cmd_rx,
-                sub_agent_cache,
-                file_tracker,
-                bg_agents,
-                None,
-            )
-            .await?;
+            execute_tools_split_batch(&remaining_tools, tool_ctx, cmd_rx, file_tracker).await?;
         } else if !remaining_tools.is_empty() {
-            execute_tools_sequential(
-                &remaining_tools,
-                project_root,
-                config,
-                db,
-                session_id,
-                tools,
-                mode,
-                sink,
-                cancel.clone(),
-                cmd_rx,
-                sub_agent_cache,
-                file_tracker,
-                bg_agents,
-                None,
-            )
-            .await?;
+            execute_tools_sequential(&remaining_tools, tool_ctx, cmd_rx, file_tracker).await?;
         }
 
         // Update skill scope: if any ActivateSkill call was made, check whether

--- a/koda-core/src/lib.rs
+++ b/koda-core/src/lib.rs
@@ -131,6 +131,9 @@ pub mod tools;
 pub mod truncate;
 /// Unified trust mode — single permission knob replacing ApprovalMode × SandboxMode.
 pub mod trust;
+/// Per-turn ambient context (`TurnContext`, `ToolExecutionContext`)
+/// — see #1265 item 4.
+pub mod turn_context;
 /// Undo stack for file mutations.
 pub mod undo;
 /// Version string and update-check helpers.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -1395,21 +1395,25 @@ pub(crate) fn execute_sub_agent<'a>(
                             //     loop." with success=false.
                             //   - Bash output streams through the parent
                             //     sink (free visibility win).
-                            let (_id, result, _success, _full) = execute_one_tool(
-                                tc,
-                                project_root,
-                                &sub_config,
-                                db,
-                                &sub_session,
-                                &tools,
-                                mode,
-                                sink,
-                                cancel.clone(),
-                                sub_agent_cache,
-                                bg_agents,
-                                Some(my_invocation_id),
-                            )
-                            .await;
+                            let (_id, result, _success, _full) = {
+                                let sub_turn = crate::turn_context::TurnContext::new(
+                                    project_root,
+                                    &sub_config,
+                                    db,
+                                    &sub_session,
+                                    sink,
+                                    cancel.clone(),
+                                    sub_agent_cache,
+                                    bg_agents,
+                                    mode,
+                                    &tools,
+                                );
+                                let sub_tx = crate::turn_context::ToolExecutionContext::new(
+                                    &sub_turn,
+                                    Some(my_invocation_id),
+                                );
+                                execute_one_tool(tc, sub_tx).await
+                            };
                             result
                         }
                         ToolApproval::Blocked => {
@@ -1452,21 +1456,25 @@ pub(crate) fn execute_sub_agent<'a>(
                             .await
                             {
                                 Some(ApprovalDecision::Approve) => {
-                                    let (_id, result, _success, _full) = execute_one_tool(
-                                        tc,
-                                        project_root,
-                                        &sub_config,
-                                        db,
-                                        &sub_session,
-                                        &tools,
-                                        mode,
-                                        sink,
-                                        cancel.clone(),
-                                        sub_agent_cache,
-                                        bg_agents,
-                                        Some(my_invocation_id),
-                                    )
-                                    .await;
+                                    let (_id, result, _success, _full) = {
+                                        let sub_turn = crate::turn_context::TurnContext::new(
+                                            project_root,
+                                            &sub_config,
+                                            db,
+                                            &sub_session,
+                                            sink,
+                                            cancel.clone(),
+                                            sub_agent_cache,
+                                            bg_agents,
+                                            mode,
+                                            &tools,
+                                        );
+                                        let sub_tx = crate::turn_context::ToolExecutionContext::new(
+                                            &sub_turn,
+                                            Some(my_invocation_id),
+                                        );
+                                        execute_one_tool(tc, sub_tx).await
+                                    };
                                     result
                                 }
                                 Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -28,39 +28,46 @@
 //!   Rust's exhaustive matching catches missing handlers at compile time.
 
 use crate::approval_flow::{handle_ask_user, request_approval};
-use crate::config::KodaConfig;
-use crate::db::{Database, Role};
+use crate::db::Role;
 use crate::engine::{ApprovalDecision, EngineCommand, EngineEvent};
 use crate::file_tracker::FileTracker;
 use crate::persistence::Persistence;
 use crate::preview;
 use crate::providers::ToolCall;
-use crate::sub_agent_cache::SubAgentCache;
 use crate::sub_agent_dispatch;
 use crate::tools;
 use crate::trust::{self, ToolApproval, TrustMode};
+use crate::turn_context::{ToolExecutionContext, TurnContext};
 
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 
 /// Post-execution recording: emit result event, persist to DB, track progress
 /// and file lifecycle. Called after every successful tool execution regardless
 /// of execution strategy (parallel, split-batch, or sequential).
-#[allow(clippy::too_many_arguments)]
+///
+/// Takes `&TurnContext` (not `ToolExecutionContext`) because spawner
+/// identity is irrelevant to recording — only the per-turn ambient
+/// fields are read. `file_tracker` stays as a separate `&mut` arg per
+/// the design rationale in `crate::turn_context` module docs.
 pub(crate) async fn record_tool_result(
     tc: &ToolCall,
     result: &str,
     success: bool,
     full_output: Option<&str>,
-    db: &Database,
-    session_id: &str,
-    max_result_chars: usize,
-    project_root: &Path,
+    ctx: &TurnContext<'_>,
     file_tracker: &mut FileTracker,
-    sink: &dyn crate::engine::EngineSink,
 ) -> Result<()> {
+    let TurnContext {
+        db,
+        session_id,
+        project_root,
+        sink,
+        tools,
+        ..
+    } = *ctx;
+    let max_result_chars = tools.caps.tool_result_chars;
     sink.emit(EngineEvent::ToolCallResult {
         id: tc.id.clone(),
         name: tc.function_name.clone(),
@@ -230,21 +237,25 @@ pub(crate) fn can_parallelize(
 
 /// Execute a single tool call, returning (tool_call_id, result_output, success).
 #[tracing::instrument(skip_all, fields(tool = %tc.function_name))]
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_one_tool(
     tc: &ToolCall,
-    project_root: &Path,
-    config: &KodaConfig,
-    db: &Database,
-    _session_id: &str,
-    tools: &crate::tools::ToolRegistry,
-    mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
-    sub_agent_cache: &SubAgentCache,
-    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
-    caller_spawner: Option<u32>,
+    tx: ToolExecutionContext<'_>,
 ) -> (String, String, bool, Option<String>) {
+    let TurnContext {
+        project_root,
+        config,
+        db,
+        session_id,
+        tools,
+        mode,
+        sink,
+        sub_agent_cache,
+        bg_agents,
+        ref cancel,
+        ..
+    } = *tx.turn;
+    let caller_spawner = tx.caller_spawner;
+    let _session_id = session_id; // mirror the existing `_session_id` arg name
     let (result, success, full_output) = if matches!(
         tc.function_name.as_str(),
         "ListBackgroundTasks" | "CancelTask" | "WaitTask"
@@ -261,7 +272,7 @@ pub(crate) async fn execute_one_tool(
             bg_agents,
             &tools.bg_registry,
             caller_spawner,
-            &cancel,
+            cancel,
         )
         .await;
         (r.output, r.success, r.full_output)
@@ -374,21 +385,15 @@ pub(crate) async fn execute_one_tool(
 /// confirmation that's guaranteed to fail. Parallel/split-batch only
 /// reach this point when every tool was already classified `AutoApprove`,
 /// so validate-then-execute is the right order.
-#[allow(clippy::too_many_arguments)]
 async fn validate_then_execute_one_tool(
     tc: &ToolCall,
-    project_root: &Path,
-    config: &KodaConfig,
-    db: &Database,
-    session_id: &str,
-    tools: &crate::tools::ToolRegistry,
-    mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
-    sub_agent_cache: &SubAgentCache,
-    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
-    caller_spawner: Option<u32>,
+    tx: ToolExecutionContext<'_>,
 ) -> (String, String, bool, Option<String>) {
+    let TurnContext {
+        project_root,
+        tools,
+        ..
+    } = *tx.turn;
     let parsed_args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
 
     let validation_error = tools::validate::validate_with_registry(
@@ -408,42 +413,18 @@ async fn validate_then_execute_one_tool(
         );
     }
 
-    execute_one_tool(
-        tc,
-        project_root,
-        config,
-        db,
-        session_id,
-        tools,
-        mode,
-        sink,
-        cancel,
-        sub_agent_cache,
-        bg_agents,
-        caller_spawner,
-    )
-    .await
+    execute_one_tool(tc, tx).await
 }
 
 /// Run multiple tool calls concurrently and store results.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_tools_parallel(
     tool_calls: &[ToolCall],
-    project_root: &Path,
-    config: &KodaConfig,
-    db: &Database,
-    session_id: &str,
-    tools: &crate::tools::ToolRegistry,
-    mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
-    sub_agent_cache: &SubAgentCache,
+    tx: ToolExecutionContext<'_>,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
-    caller_spawner: Option<u32>,
 ) -> Result<()> {
+    let ctx = tx.turn;
     let count = tool_calls.len();
-    sink.emit(EngineEvent::Info {
+    ctx.sink.emit(EngineEvent::Info {
         message: format!("Running {count} tools in parallel..."),
     });
 
@@ -455,27 +436,14 @@ pub(crate) async fn execute_tools_parallel(
             // does this *before* approval; here every tool is already
             // AutoApproved (see `can_parallelize`) so validate-then-execute
             // is the right order.
-            validate_then_execute_one_tool(
-                tc,
-                project_root,
-                config,
-                db,
-                session_id,
-                tools,
-                mode,
-                sink,
-                cancel.clone(),
-                sub_agent_cache,
-                bg_agents,
-                caller_spawner,
-            )
+            validate_then_execute_one_tool(tc, tx)
         })
         .collect();
     let results = futures_util::future::join_all(futures).await;
 
     // Emit banner + result together so each tool's output is visually grouped
     for (i, (tc_id, result, success, full_output)) in results.into_iter().enumerate() {
-        sink.emit(EngineEvent::ToolCallStart {
+        ctx.sink.emit(EngineEvent::ToolCallStart {
             id: tc_id.clone(),
             name: tool_calls[i].function_name.clone(),
             args: serde_json::from_str(&tool_calls[i].arguments).unwrap_or_default(),
@@ -486,12 +454,8 @@ pub(crate) async fn execute_tools_parallel(
             &result,
             success,
             full_output.as_deref(),
-            db,
-            session_id,
-            tools.caps.tool_result_chars,
-            project_root,
+            ctx,
             file_tracker,
-            sink,
         )
         .await?;
     }
@@ -504,35 +468,25 @@ pub(crate) async fn execute_tools_parallel(
 /// This is the key optimization for mixed batches like
 /// `[InvokeAgent, InvokeAgent, Write]` — the two sub-agents run in
 /// parallel while the Write waits for confirmation.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_tools_split_batch(
     tool_calls: &[ToolCall],
-    project_root: &Path,
-    config: &KodaConfig,
-    db: &Database,
-    session_id: &str,
-    tools: &crate::tools::ToolRegistry,
-    mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
+    tx: ToolExecutionContext<'_>,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
-    caller_spawner: Option<u32>,
 ) -> Result<()> {
+    let ctx = tx.turn;
     // Partition into parallelizable vs sequential
     let (parallel, sequential): (Vec<_>, Vec<_>) = tool_calls.iter().partition(|tc| {
         let args: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
         matches!(
-            trust::check_tool(&tc.function_name, &args, mode, Some(project_root),),
+            trust::check_tool(&tc.function_name, &args, ctx.mode, Some(ctx.project_root),),
             ToolApproval::AutoApprove
         )
     });
 
     // Run parallelizable tools concurrently (if more than one)
     if parallel.len() > 1 {
-        sink.emit(EngineEvent::Info {
+        ctx.sink.emit(EngineEvent::Info {
             message: format!("Running {} tools in parallel...", parallel.len()),
         });
 
@@ -542,26 +496,13 @@ pub(crate) async fn execute_tools_split_batch(
                 // #1022 B14: validate before executing. Same reasoning
                 // as `execute_tools_parallel` — every tool here is
                 // already AutoApproved.
-                validate_then_execute_one_tool(
-                    tc,
-                    project_root,
-                    config,
-                    db,
-                    session_id,
-                    tools,
-                    mode,
-                    sink,
-                    cancel.clone(),
-                    sub_agent_cache,
-                    bg_agents,
-                    caller_spawner,
-                )
+                validate_then_execute_one_tool(tc, tx)
             })
             .collect();
         let results = futures_util::future::join_all(futures).await;
 
         for (j, (tc_id, result, success, full_output)) in results.into_iter().enumerate() {
-            sink.emit(EngineEvent::ToolCallStart {
+            ctx.sink.emit(EngineEvent::ToolCallStart {
                 id: tc_id.clone(),
                 name: parallel[j].function_name.clone(),
                 args: serde_json::from_str(&parallel[j].arguments).unwrap_or_default(),
@@ -572,12 +513,8 @@ pub(crate) async fn execute_tools_split_batch(
                 &result,
                 success,
                 full_output.as_deref(),
-                db,
-                session_id,
-                tools.caps.tool_result_chars,
-                project_root,
+                ctx,
                 file_tracker,
-                sink,
             )
             .await?;
         }
@@ -585,69 +522,37 @@ pub(crate) async fn execute_tools_split_batch(
         // 0–1 parallelizable tools — just run sequentially
         for tc in &parallel {
             let calls = std::slice::from_ref(*tc);
-            execute_tools_sequential(
-                calls,
-                project_root,
-                config,
-                db,
-                session_id,
-                tools,
-                mode,
-                sink,
-                cancel.clone(),
-                cmd_rx,
-                sub_agent_cache,
-                file_tracker,
-                bg_agents,
-                caller_spawner,
-            )
-            .await?;
+            execute_tools_sequential(calls, tx, cmd_rx, file_tracker).await?;
         }
     }
 
     // Run non-parallelizable tools sequentially
     if !sequential.is_empty() {
         let seq_calls: Vec<ToolCall> = sequential.into_iter().cloned().collect();
-        execute_tools_sequential(
-            &seq_calls,
-            project_root,
-            config,
-            db,
-            session_id,
-            tools,
-            mode,
-            sink,
-            cancel.clone(),
-            cmd_rx,
-            sub_agent_cache,
-            file_tracker,
-            bg_agents,
-            caller_spawner,
-        )
-        .await?;
+        execute_tools_sequential(&seq_calls, tx, cmd_rx, file_tracker).await?;
     }
 
     Ok(())
 }
 
 /// Run tool calls one at a time (when confirmation is needed, or single call).
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_tools_sequential(
     tool_calls: &[ToolCall],
-    project_root: &Path,
-    config: &KodaConfig,
-    db: &Database,
-    session_id: &str,
-    tools: &crate::tools::ToolRegistry,
-    mode: TrustMode,
-    sink: &dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
+    tx: ToolExecutionContext<'_>,
     cmd_rx: &mut mpsc::Receiver<EngineCommand>,
-    sub_agent_cache: &SubAgentCache,
     file_tracker: &mut FileTracker,
-    bg_agents: &std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
-    caller_spawner: Option<u32>,
 ) -> Result<()> {
+    let ctx = tx.turn;
+    let TurnContext {
+        project_root,
+        db,
+        session_id,
+        tools,
+        mode,
+        sink,
+        ref cancel,
+        ..
+    } = *ctx;
     for tc in tool_calls {
         // Check for interrupt before each tool
         if cancel.is_cancelled() {
@@ -670,25 +575,13 @@ pub(crate) async fn execute_tools_sequential(
         // AskUser: pause inference, show question in TUI, wait for typed answer.
         // Handled here (not in execute_one_tool) because it needs sink + cmd_rx.
         if tc.function_name == "AskUser" {
-            let answer = handle_ask_user(sink, cmd_rx, &cancel, &parsed_args).await;
+            let answer = handle_ask_user(sink, cmd_rx, cancel, &parsed_args).await;
             let result = match answer {
                 Some(text) if !text.trim().is_empty() => text,
                 Some(_) => "User did not provide an answer.".into(),
                 None => return Ok(()), // cancelled
             };
-            record_tool_result(
-                tc,
-                &result,
-                true,
-                None, // AskUser has no full_output
-                db,
-                session_id,
-                tools.caps.tool_result_chars,
-                project_root,
-                file_tracker,
-                sink,
-            )
-            .await?;
+            record_tool_result(tc, &result, true, None, ctx, file_tracker).await?;
             continue;
         }
 
@@ -707,12 +600,8 @@ pub(crate) async fn execute_tools_sequential(
                 &format!("Validation error: {error}"),
                 false,
                 None,
-                db,
-                session_id,
-                tools.caps.tool_result_chars,
-                project_root,
+                ctx,
                 file_tracker,
-                sink,
             )
             .await?;
             continue;
@@ -765,7 +654,7 @@ pub(crate) async fn execute_tools_sequential(
                 match request_approval(
                     sink,
                     cmd_rx,
-                    &cancel,
+                    cancel,
                     &tc.function_name,
                     &detail,
                     diff_preview,
@@ -824,32 +713,14 @@ pub(crate) async fn execute_tools_sequential(
             }
         }
 
-        let (_, result, success, full_output) = execute_one_tool(
-            tc,
-            project_root,
-            config,
-            db,
-            session_id,
-            tools,
-            mode,
-            sink,
-            cancel.clone(),
-            sub_agent_cache,
-            bg_agents,
-            caller_spawner,
-        )
-        .await;
+        let (_, result, success, full_output) = execute_one_tool(tc, tx).await;
         record_tool_result(
             tc,
             &result,
             success,
             full_output.as_deref(),
-            db,
-            session_id,
-            tools.caps.tool_result_chars,
-            project_root,
+            ctx,
             file_tracker,
-            sink,
         )
         .await?;
     }

--- a/koda-core/src/turn_context.rs
+++ b/koda-core/src/turn_context.rs
@@ -1,0 +1,305 @@
+//! `TurnContext` and `ToolExecutionContext` — typed bundles for the
+//! ambient state passed through the inference / tool-dispatch / sub-agent
+//! call graph.
+//!
+//! ## Why
+//!
+//! Pre-PR-1-of-#1265-item-4, six functions in [`crate::tool_dispatch`]
+//! and one in `crate::sub_agent_dispatch` (private module) each took 11–13
+//! explicit parameters. Each one carried `#[allow(clippy::too_many_arguments)]`
+//! and called the same `(project_root, config, db, session_id, sink,
+//! cancel, sub_agent_cache, bg_agents, …)` quartet through every
+//! layer. Adding a new ambient field (e.g. a tracing span, a per-turn
+//! quota, a feature flag) meant editing every signature.
+//!
+//! `TurnContext` collects the per-turn ambient context once at the
+//! inference-loop entry and threads a single reference through dispatch.
+//! `ToolExecutionContext` adds the few fields that are scoped to a
+//! single batch of tool calls (`caller_spawner`).
+//!
+//! ## What stays OUT of TurnContext
+//!
+//! - **`file_tracker: &mut FileTracker`** — the only mutable piece of
+//!   ambient state. Pulling it into `TurnContext` would force a `&mut
+//!   TurnContext` everywhere, which conflicts with the parallel-execution
+//!   path (the mutation only happens in the post-join `record_tool_result`
+//!   loop, not inside the parallel futures themselves). Passing it as a
+//!   separate `&mut FileTracker` argument keeps `TurnContext` cheap to
+//!   share across borrow boundaries.
+//! - **`cmd_rx: &mut mpsc::Receiver<EngineCommand>`** — also `&mut`,
+//!   and only relevant to dispatch paths that may issue interactive
+//!   approvals (sequential / split-batch). Lives outside the context
+//!   for the same reason as `file_tracker`.
+//! - **Per-call data** like `tc: &ToolCall`, `result: &str`,
+//!   `tool_calls: &[ToolCall]` — these are inputs, not context.
+//!
+//! ## Lifetimes
+//!
+//! `TurnContext<'a>` borrows everything by `&'a` reference except
+//! `cancel: CancellationToken`, which is internally `Arc`-backed and
+//! Clone, so storing by value avoids a third lifetime parameter.
+//! `ToolExecutionContext<'a>` borrows the `TurnContext<'a>` and adds
+//! per-batch fields with their own (shorter or equal) lifetime.
+//!
+//! ## Migration policy
+//!
+//! - **PR-1 of #1265 item 4 (this PR)**: introduce the types only.
+//!   Zero callsite migration. Smoke-test via unit tests that construct
+//!   one and read its fields.
+//! - **PR-2**: migrate `tool_dispatch.rs` (6 functions, 6 allows).
+//! - **PR-3**: migrate `sub_agent_dispatch::execute_sub_agent`
+//!   (1 function, 1 allow). The owned-args `run_bg_agent` stays
+//!   explicit because tokio-spawn requires `'static`.
+//! - **Out of scope**: `ChildAgentRegistry::attach` — author has
+//!   explicitly opted out (per-call data, not context).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::child_agent::ChildAgentRegistry;
+use crate::config::KodaConfig;
+use crate::db::Database;
+use crate::engine::EngineSink;
+use crate::sub_agent_cache::SubAgentCache;
+use crate::tools::ToolRegistry;
+use crate::trust::TrustMode;
+
+/// Per-turn ambient context shared across the inference loop, tool
+/// dispatch, and sub-agent invocation.
+///
+/// Constructed once per turn at the inference-loop entry; threaded
+/// by `&` reference through dispatch. All fields are immutable
+/// borrows or `Clone`-by-value handles — see module docs for why
+/// `file_tracker` and `cmd_rx` stay outside.
+pub struct TurnContext<'a> {
+    /// Project root — used for path safety + workspace scoping.
+    pub project_root: &'a Path,
+
+    /// Per-session config (model, caps, model_settings, …).
+    pub config: &'a KodaConfig,
+
+    /// SQLite-backed message + tool-result store.
+    pub db: &'a Database,
+
+    /// Active session id for `db` writes.
+    pub session_id: &'a str,
+
+    /// Engine event sink (TUI / headless / ACP).
+    pub sink: &'a dyn EngineSink,
+
+    /// Per-turn child cancel token. Stored by value because
+    /// `CancellationToken` is `Arc`-backed and `Clone`. Cloning is
+    /// cheap; nested calls clone freely.
+    pub cancel: CancellationToken,
+
+    /// Cache of compiled sub-agent specs (#1086 invocation cache).
+    pub sub_agent_cache: &'a SubAgentCache,
+
+    /// Background-agent registry — used for `ListBackgroundTasks`,
+    /// `CancelTask`, `WaitTask`, and bg-sub-agent reservations.
+    pub bg_agents: &'a Arc<ChildAgentRegistry>,
+
+    /// Per-turn trust snapshot. Read once at turn entry; the user
+    /// can cycle trust between turns but not mid-turn.
+    pub mode: TrustMode,
+
+    /// Tool registry (built-in + MCP). Per-session; constant within
+    /// a single turn.
+    pub tools: &'a ToolRegistry,
+}
+
+impl<'a> TurnContext<'a> {
+    /// Construct a per-turn context. All borrows must outlive `'a`;
+    /// the typical caller is the inference loop in
+    /// [`crate::inference`], which holds these in named locals.
+    #[allow(clippy::too_many_arguments)] // 10 args is the WHOLE POINT — this is the
+    // bundling site, exactly one allow at the constructor instead of one per consumer.
+    pub fn new(
+        project_root: &'a Path,
+        config: &'a KodaConfig,
+        db: &'a Database,
+        session_id: &'a str,
+        sink: &'a dyn EngineSink,
+        cancel: CancellationToken,
+        sub_agent_cache: &'a SubAgentCache,
+        bg_agents: &'a Arc<ChildAgentRegistry>,
+        mode: TrustMode,
+        tools: &'a ToolRegistry,
+    ) -> Self {
+        Self {
+            project_root,
+            config,
+            db,
+            session_id,
+            sink,
+            cancel,
+            sub_agent_cache,
+            bg_agents,
+            mode,
+            tools,
+        }
+    }
+}
+
+/// Per-tool-batch execution context.
+///
+/// Adds fields scoped narrower than a turn — currently just
+/// `caller_spawner`, but a likely home for future per-batch state
+/// (tracing span, batch id, retry counter, …).
+///
+/// Constructed by the dispatch-entry function (`execute_tools_*`) and
+/// passed by reference to inner helpers (`execute_one_tool`,
+/// `validate_then_execute_one_tool`).
+#[derive(Clone, Copy)]
+pub struct ToolExecutionContext<'a> {
+    /// Borrowed turn context. The narrower lifetime annotation lets
+    /// the batch context outlive specific tool-call iterations
+    /// without forcing the turn context to.
+    pub turn: &'a TurnContext<'a>,
+
+    /// Spawner identity for cleanup routing (Phase E of #996). `None`
+    /// at top-level inference (no parent invocation). `Some(id)` when
+    /// invoked from inside a sub-agent — bg-task tools tag their
+    /// reservations with `spawner = caller_spawner` so the parent
+    /// owns the right to cancel/wait its bg children.
+    pub caller_spawner: Option<u32>,
+}
+
+impl<'a> ToolExecutionContext<'a> {
+    /// Construct a per-batch execution context.
+    pub fn new(turn: &'a TurnContext<'a>, caller_spawner: Option<u32>) -> Self {
+        Self {
+            turn,
+            caller_spawner,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Smoke tests: construct each context with stub-y values and read
+    //! every field. The point isn't to test behavior (there is none —
+    //! these are dumb data bundles); it's to pin the public shape so a
+    //! future PR can't accidentally widen / narrow / reshape the type
+    //! without updating callers.
+    //!
+    //! Real call-graph migration arrives in PR-2 (tool_dispatch) and
+    //! PR-3 (sub_agent_dispatch); those will exercise the contexts
+    //! through the existing 2594-test workspace battery.
+    //!
+    //! Note: we use `MemDb::new()` and an inline `EngineSink` impl to
+    //! avoid pulling in heavy fixtures for what is genuinely a
+    //! shape-only test.
+    use super::*;
+
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use crate::config::ProviderType;
+    use crate::engine::EngineEvent;
+    use crate::trust::TrustMode;
+
+    struct NullSink;
+    impl EngineSink for NullSink {
+        fn emit(&self, _event: EngineEvent) {}
+    }
+
+    /// Build the heaviest fixtures (db + tools) once per test. Kept
+    /// inline rather than promoted to `koda-test-utils` because
+    /// turn_context's tests are intentionally minimal — the call
+    /// graph migration in PR-2/PR-3 will exercise these types
+    /// through the real workspace battery.
+    async fn fixtures() -> (TempDir, crate::config::KodaConfig, crate::db::Database) {
+        let dir = TempDir::new().expect("tempdir");
+        let config = crate::config::KodaConfig::default_for_testing(ProviderType::Mock);
+        let db = crate::db::Database::open(&dir.path().join("turn_ctx.db"))
+            .await
+            .expect("open db");
+        (dir, config, db)
+    }
+
+    #[tokio::test]
+    async fn turn_context_holds_all_fields() {
+        // Arrange: minimum-viable stand-ins for every TurnContext field.
+        let (dir, config, db) = fixtures().await;
+        let root: PathBuf = dir.path().to_path_buf();
+        let cancel = CancellationToken::new();
+        let cache = SubAgentCache::new();
+        let bg_agents = Arc::new(ChildAgentRegistry::new());
+        let tools = ToolRegistry::new(root.clone(), 8_000);
+        let sink = NullSink;
+
+        // Act: build the context.
+        let ctx = TurnContext::new(
+            &root,
+            &config,
+            &db,
+            "session-smoke",
+            &sink,
+            cancel.clone(),
+            &cache,
+            &bg_agents,
+            TrustMode::Safe,
+            &tools,
+        );
+
+        // Assert: every field is reachable + carries the value we passed.
+        assert_eq!(ctx.project_root, root.as_path());
+        assert_eq!(ctx.session_id, "session-smoke");
+        assert!(matches!(ctx.mode, TrustMode::Safe));
+        assert!(!ctx.cancel.is_cancelled());
+        // sub_agent_cache + bg_agents + db + config + tools + sink are
+        // pointer-equal to the inputs — checked transitively by
+        // construction (no copy / move happens for &-borrowed fields).
+        // Pointer equality on the heap-allocated Arc:
+        assert!(Arc::ptr_eq(ctx.bg_agents, &bg_agents));
+    }
+
+    #[tokio::test]
+    async fn tool_execution_context_borrows_turn() {
+        let (dir, config, db) = fixtures().await;
+        let root: PathBuf = dir.path().to_path_buf();
+        let cache = SubAgentCache::new();
+        let bg_agents = Arc::new(ChildAgentRegistry::new());
+        let tools = ToolRegistry::new(root.clone(), 8_000);
+        let sink = NullSink;
+
+        let turn = TurnContext::new(
+            &root,
+            &config,
+            &db,
+            "session-tx",
+            &sink,
+            CancellationToken::new(),
+            &cache,
+            &bg_agents,
+            TrustMode::Auto,
+            &tools,
+        );
+
+        // Top-level invocation: no parent spawner.
+        let tx = ToolExecutionContext::new(&turn, None);
+        assert!(tx.caller_spawner.is_none());
+        assert_eq!(tx.turn.session_id, "session-tx");
+        assert!(matches!(tx.turn.mode, TrustMode::Auto));
+
+        // Nested invocation (e.g. inside a sub-agent): explicit spawner.
+        let nested = ToolExecutionContext::new(&turn, Some(42));
+        assert_eq!(nested.caller_spawner, Some(42));
+        // Same turn context underneath — sanity check the borrow.
+        assert_eq!(nested.turn.session_id, "session-tx");
+    }
+
+    #[test]
+    fn tool_execution_context_is_copy() {
+        // Cheap to pass by value through inner dispatch helpers; this
+        // pins the trait so a future field addition doesn't silently
+        // remove `Copy` and force callers to clone.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<ToolExecutionContext<'_>>();
+    }
+}

--- a/koda-core/src/turn_context.rs
+++ b/koda-core/src/turn_context.rs
@@ -222,7 +222,7 @@ mod tests {
         (dir, config, db)
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn turn_context_holds_all_fields() {
         // Arrange: minimum-viable stand-ins for every TurnContext field.
         let (dir, config, db) = fixtures().await;
@@ -259,7 +259,7 @@ mod tests {
         assert!(Arc::ptr_eq(ctx.bg_agents, &bg_agents));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tool_execution_context_borrows_turn() {
         let (dir, config, db) = fixtures().await;
         let root: PathBuf = dir.path().to_path_buf();


### PR DESCRIPTION
## What & why

Refs #1265 — PR-2 of 3 from the audit's P1 architectural batch (item 4: typed context objects).

Migrates the 6 functions in `tool_dispatch.rs` from explicit 11–13-arg signatures to `TurnContext` + `ToolExecutionContext` (introduced in PR-1, #1287).

**Stacked on top of #1287** — base it once #1287 lands.

## Function signature deltas

All 6 functions in `tool_dispatch.rs`:

| function                          | before  | after | shape |
|-----------------------------------|---------|-------|-------|
| `record_tool_result`              | 10 args | 6     | `&TurnContext` (no spawner needed) |
| `execute_one_tool`                | 12 args | 2     | `ToolExecutionContext` |
| `validate_then_execute_one_tool`  | 12 args | 2     | `ToolExecutionContext` |
| `execute_tools_parallel`          | 13 args | 3     | + `&mut FileTracker` |
| `execute_tools_split_batch`       | 14 args | 4     | + `&mut cmd_rx` |
| `execute_tools_sequential`        | 14 args | 4     | + `&mut cmd_rx` |

Bodies are nearly identical — each function destructures the `TurnContext` at the top to bind the same local names the old args used (so the rest of the function reads exactly like before — `git diff --color-moved=zebra` should make this obvious).

## `#[allow(clippy::too_many_arguments)]` count

| file                         | before PR-1 | after PR-1 | after PR-2 (this) |
|------------------------------|-------------|------------|-------------------|
| `inference.rs`               | 0           | 0          | 0 |
| `tool_dispatch.rs`           | 6           | 6          | **0** ← all 6 removed |
| `sub_agent_dispatch.rs`      | 2           | 2          | 2 (PR-3 will remove 1) |
| `child_agent.rs`             | 2           | 2          | 2 (out of scope per #1287) |
| `turn_context.rs` (new)      | —           | 1          | 1 (the bundling site — `TurnContext::new`, by design) |
| **TOTAL (consumer sites)**   | **10**      | **10**     | **5** |

Net **−5 allows at consumer sites**. PR-3 takes it to **−6**, hitting the audit's realistic 7/10 ceiling.

## Callsite updates

### `koda-core/src/inference.rs` (`inference_loop_inner`)

- Constructs `TurnContext` once after the `_persisting_sink` block.
- Constructs `ToolExecutionContext::new(&turn_ctx, None)` once (top-level inference has no spawner identity).
- All 5 callsites (`record_tool_result` ×2 + `execute_tools_*` ×3) now pass the contexts.
- **Net: −62 lines of arg-passing.**

### `koda-core/src/sub_agent_dispatch.rs` (inside `execute_sub_agent` body)

- 2 inline `execute_one_tool` calls now construct a per-call `TurnContext` (because the sub-agent uses different `sub_config`, `sub_session`, `tools` than the parent) plus a `ToolExecutionContext::new(&sub_turn, Some(my_invocation_id))`.
- The construction is verbose at the callsite but only happens at the two sites where a sub-agent dispatches a *non-InvokeAgent* tool.
- **PR-3 will fold this into `execute_sub_agent`'s own context** so it can be constructed once and reused.

### Imports cleanup

`tool_dispatch.rs` no longer needs `KodaConfig`, `Database`, `SubAgentCache`, `CancellationToken` at the top level — the destructure in each function body brings the field bindings into scope without requiring the type names. Removed.

## Behavior change

**None.** Every line of executable logic was preserved verbatim; only the parameter-passing layer changed.

## Validation

```text
cargo fmt --all -- --check                              ✓
cargo clippy --workspace --all-targets -- -D warnings   ✓
RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps ✓
cargo test --workspace                                  ✓ 2597 passed, 0 failed (same as PR-1 baseline)
```

## Diff size

5 files, +448/−295. Most of the deletion is the 12 `\n        arg,\n        arg,\n        ...` blocks that disappear from each callsite + signature.

## Reviewer hints

- The `git diff --color-moved=zebra` view should highlight that every function body is essentially `let TurnContext { ... } = *ctx;` followed by the unchanged old body.
- The two inline `TurnContext::new` calls in `sub_agent_dispatch.rs` look bulky — yes, they are, intentionally — PR-3 will collapse them when the outer `execute_sub_agent` function gets its own `TurnContext`.
- I removed `&cancel` → `cancel` in one bg-task callsite (`tool_dispatch.rs` line 275) because after the destructure `cancel: &CancellationToken` already, and clippy's `needless_borrow` flagged the double-ref.

## Stack

- #1287 — PR-1, types only
- **#1288 (this) — PR-2, migrate `tool_dispatch.rs`**
- PR-3 (next) — migrate `execute_sub_agent`
