### PR TITLE
refactor(core): migrate execute_sub_agent + run_bg_agent to TurnContext (#1265 item 4, PR-3/3)

### DIFF
--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -18,13 +18,13 @@ use crate::sub_agent_cache::SubAgentCache;
 use crate::tool_dispatch::execute_one_tool;
 use crate::tools::{self, ToolRegistry};
 use crate::trust::{self, ToolApproval, TrustMode, derive_child_trust};
+use crate::turn_context::ToolExecutionContext;
 
 use anyhow::{Context, Result};
 use koda_sandbox::{CwdProvider, GitWorktreeProvider, WorkspaceProvider};
 
 #[cfg(target_os = "macos")]
 use koda_sandbox::ClonefileProvider;
-use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -208,26 +208,39 @@ async fn run_bg_agent(
     // not "Errored". Clone before the move.
     let cancel_for_status = cancel.clone();
 
-    let result = execute_sub_agent(
+    // #1265 item 4 PR-3: bg agents own their args (`'static` for
+    // `tokio::spawn`), so we have to construct the parent's dispatch
+    // context locally from owned borrows. The `tools` field is a
+    // throwaway empty registry — `execute_sub_agent` ignores the
+    // parent's tools (sub-agents always build their own from
+    // `sub_config.allowed_tools`).
+    let placeholder_tools =
+        crate::tools::ToolRegistry::new(project_root.clone(), parent_config.max_context_tokens);
+    let bg_turn = crate::turn_context::TurnContext::new(
         &project_root,
         &parent_config,
         &db,
-        &sync_arguments,
-        parent_trust,
+        &parent_session,
         &buffering_sink,
         cancel,
+        &sub_agent_cache,
+        &nested_bg,
+        parent_trust,
+        &placeholder_tools,
+    );
+    // Phase E of #996: the bg agent has no in-process parent in
+    // the spawner sense — its `nested_bg` registry is fresh, and
+    // any bg work it spawns gets tagged with the bg agent's *own*
+    // invocation id (allocated inside the recursive call). The
+    // parent's cascade-cancel covers cross-registry teardown.
+    let bg_tx = crate::turn_context::ToolExecutionContext::new(&bg_turn, None);
+
+    let result = execute_sub_agent(
+        bg_tx,
+        &sync_arguments,
         &mut cmd_rx,
         None,
-        &sub_agent_cache,
-        &parent_session,
-        &nested_bg,
         &parent_sandbox_policy,
-        // Phase E of #996: the bg agent has no in-process parent in
-        // the spawner sense — its `nested_bg` registry is fresh, and
-        // any bg work it spawns gets tagged with the bg agent's *own*
-        // invocation id (allocated inside the recursive call). The
-        // parent's cascade-cancel covers cross-registry teardown.
-        None,
         // Layer 4 of #996 + #1076: forward the status emitter so the
         // loop can push live `Running { iter }` updates that fan out
         // to BOTH the watch channel (for `/agents` snapshots) and
@@ -432,34 +445,23 @@ pub(crate) fn parse_background_required(args: &serde_json::Value) -> anyhow::Res
 ///
 /// Results are cached in `sub_agent_cache` keyed by `(agent_name, prompt_hash)`.
 /// On cache hit, returns immediately without any LLM calls.
+///
+/// **#1265 item 4 PR-3**: takes the parent's [`ToolExecutionContext`]
+/// instead of 11 individual ambient args. The parent's `tools` field
+/// is intentionally unused — sub-agents construct their own
+/// `sub_tools` registry from `sub_config.allowed_tools`.
 #[tracing::instrument(skip_all, fields(agent_name, cached = false))]
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_sub_agent<'a>(
-    project_root: &'a Path,
-    parent_config: &'a KodaConfig,
-    db: &'a Database,
+    parent_tx: ToolExecutionContext<'a>,
     arguments: &'a str,
-    mode: TrustMode,
-    sink: &'a dyn crate::engine::EngineSink,
-    cancel: CancellationToken,
     cmd_rx: &'a mut mpsc::Receiver<EngineCommand>,
     parent_cache: Option<crate::tools::FileReadCache>,
-    sub_agent_cache: &'a SubAgentCache,
-    parent_session_id: &'a str,
-    bg_agents: &'a std::sync::Arc<crate::child_agent::ChildAgentRegistry>,
     // Phase 5 PR-4 of #934: parent's effective sandbox policy. The
     // child policy is composed onto this so the child can only narrow,
     // never widen — see [`koda_sandbox::SandboxPolicy::compose`] for
     // the per-field rules. Pass `&SandboxPolicy::strict_default()`
     // when there is no meaningful parent (top-level invocation).
     parent_sandbox_policy: &'a koda_sandbox::SandboxPolicy,
-    // Phase E of #996: the **caller's** invocation id. Used as the
-    // `spawner` tag on bg-sub-agent reservations so the parent (not
-    // the child) owns the right to wait/cancel its bg children. Pass
-    // `None` when called from top-level inference. Distinct from the
-    // child's own `my_invocation_id`, which is allocated below and
-    // tags any bg work the child itself spawns.
-    parent_spawner: Option<u32>,
     // Layer 4 of #996 + #1076: live iteration heartbeat.  Pass the
     // bg-agent's `ChildStatusEmitter` so each loop iteration can push
     // `Running { iter }` to BOTH the registry's per-task watch
@@ -478,6 +480,25 @@ pub(crate) fn execute_sub_agent<'a>(
     parent_tool_call_id: Option<&'a str>,
 ) -> impl std::future::Future<Output = Result<String>> + Send + 'a {
     async move {
+        // #1265 item 4 PR-3: rebind context fields to the same names
+        // the body has used since pre-refactor, so the rest of this
+        // 700-line function reads exactly as before. The parent's
+        // `tools` registry is intentionally NOT bound — sub-agents
+        // build their own from `sub_config.allowed_tools`.
+        let crate::turn_context::TurnContext {
+            project_root,
+            config: parent_config,
+            db,
+            session_id: parent_session_id,
+            sink,
+            sub_agent_cache,
+            bg_agents,
+            mode,
+            ..
+        } = *parent_tx.turn;
+        let cancel = parent_tx.turn.cancel.clone();
+        let parent_spawner = parent_tx.caller_spawner;
+
         // Phase E of #996: allocate this invocation's id up-front. It
         // becomes the `caller_spawner` for every tool call inside
         // this sub-agent's loop, AND the `spawner` tag the cleanup
@@ -1080,6 +1101,27 @@ pub(crate) fn execute_sub_agent<'a>(
             &tools.skill_registry,
         );
 
+        // #1265 item 4 PR-3: build the sub-agent's own dispatch
+        // context once. Used by both `execute_one_tool` callsites in
+        // the per-iteration loop below — PR-2 had to construct this
+        // inline twice with identical args. Hoisted here because
+        // `sub_config`, `sub_session`, and `tools` are all bound by
+        // this point and don't change across iterations.
+        let sub_turn = crate::turn_context::TurnContext::new(
+            project_root,
+            &sub_config,
+            db,
+            &sub_session,
+            sink,
+            cancel.clone(),
+            sub_agent_cache,
+            bg_agents,
+            mode,
+            &tools,
+        );
+        let sub_tx =
+            crate::turn_context::ToolExecutionContext::new(&sub_turn, Some(my_invocation_id));
+
         // #1135: gemini-pattern grace turn. When `iter > max_turns` we
         // append a system reminder to the message list ("you have one
         // final chance — give your best answer NOW, no more tools")
@@ -1395,25 +1437,7 @@ pub(crate) fn execute_sub_agent<'a>(
                             //     loop." with success=false.
                             //   - Bash output streams through the parent
                             //     sink (free visibility win).
-                            let (_id, result, _success, _full) = {
-                                let sub_turn = crate::turn_context::TurnContext::new(
-                                    project_root,
-                                    &sub_config,
-                                    db,
-                                    &sub_session,
-                                    sink,
-                                    cancel.clone(),
-                                    sub_agent_cache,
-                                    bg_agents,
-                                    mode,
-                                    &tools,
-                                );
-                                let sub_tx = crate::turn_context::ToolExecutionContext::new(
-                                    &sub_turn,
-                                    Some(my_invocation_id),
-                                );
-                                execute_one_tool(tc, sub_tx).await
-                            };
+                            let (_id, result, _success, _full) = execute_one_tool(tc, sub_tx).await;
                             result
                         }
                         ToolApproval::Blocked => {
@@ -1456,25 +1480,8 @@ pub(crate) fn execute_sub_agent<'a>(
                             .await
                             {
                                 Some(ApprovalDecision::Approve) => {
-                                    let (_id, result, _success, _full) = {
-                                        let sub_turn = crate::turn_context::TurnContext::new(
-                                            project_root,
-                                            &sub_config,
-                                            db,
-                                            &sub_session,
-                                            sink,
-                                            cancel.clone(),
-                                            sub_agent_cache,
-                                            bg_agents,
-                                            mode,
-                                            &tools,
-                                        );
-                                        let sub_tx = crate::turn_context::ToolExecutionContext::new(
-                                            &sub_turn,
-                                            Some(my_invocation_id),
-                                        );
-                                        execute_one_tool(tc, sub_tx).await
-                                    };
+                                    let (_id, result, _success, _full) =
+                                        execute_one_tool(tc, sub_tx).await;
                                     result
                                 }
                                 Some(ApprovalDecision::Reject) => "[rejected by user]".to_string(),

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -242,12 +242,8 @@ pub(crate) async fn execute_one_tool(
     tx: ToolExecutionContext<'_>,
 ) -> (String, String, bool, Option<String>) {
     let TurnContext {
-        project_root,
-        config,
-        db,
         session_id,
         tools,
-        mode,
         sink,
         sub_agent_cache,
         bg_agents,
@@ -307,28 +303,14 @@ pub(crate) async fn execute_one_tool(
         let policy = tools.sandbox_policy().clone();
         let read_cache = tools.file_read_cache();
         let fut = sub_agent_dispatch::execute_sub_agent(
-            project_root,
-            config,
-            db,
+            tx,
             &tc.arguments,
-            mode,
-            sink,
-            cancel.clone(),
             // Sub-agents get a fresh command channel (they auto-approve in all modes)
             &mut dummy_rx,
             Some(read_cache),
-            sub_agent_cache,
-            _session_id,
-            bg_agents,
             // Phase 5 PR-4 of #934: hand the parent's effective policy
             // to the child so `compose()` can stack restrictions.
             &policy,
-            // Phase E of #996: parent's spawner identity. The new
-            // sub-agent uses this to tag any bg-sub-agent reservation
-            // it makes (so the parent owns/can-cancel its bg children),
-            // and allocates a fresh `my_invocation_id` internally for
-            // its own bg-task scoping.
-            caller_spawner,
             // Layer 4 of #996 + #1076: foreground sub-agents are not
             // tracked in the bg-agent registry, so there is no
             // `ChildStatusEmitter` to fan out per-iteration heartbeats
@@ -336,7 +318,7 @@ pub(crate) async fn execute_one_tool(
             None,
             // #1108 P2a: pass the InvokeAgent tool_call_id so any
             // bg-sub-agent reservation can record it. The drain
-            // handler in `inference_loop` then persists the bg
+            // hook in the inference loop will persist the bg sub-
             // agent's narrative trace to `session_events` keyed by
             // this id, so the transcript renderer can fold it under
             // the parent's `InvokeAgent` tool result.


### PR DESCRIPTION
## What & why

Refs #1265 — **PR-3 (final) of the audit's item-4 stack**. Migrates `execute_sub_agent` (16 args → 7) and folds the verbose inline `TurnContext::new` calls PR-2 had to add at the sub-agent dispatch sites.

**Stacked on top of #1288** — base it once #1287 + #1288 land.

## Function signature deltas

### `execute_sub_agent`: 16 → 7 args ✂️

The 9 fields removed (`project_root`, `parent_config`, `db`, `mode`, `sink`, `cancel`, `sub_agent_cache`, `parent_session_id`, `bg_agents`, `parent_spawner`) all live on the parent's `ToolExecutionContext`. The remaining 6 are genuinely per-call:

| arg | why it stays explicit |
|-----|-----------------------|
| `arguments` | per-call JSON |
| `cmd_rx` | `&mut`, can't bundle |
| `parent_cache` | optional, per-call |
| `parent_sandbox_policy` | parent-specific, not ambient |
| `emitter` | bg-agent only |
| `parent_tool_call_id` | bg-agent only |

Body destructures `parent_tx.turn` into the same local names the old args used (`config: parent_config`, `session_id: parent_session_id`) so the 700-line body reads exactly as before. The parent's `tools` field is intentionally **not** bound — sub-agents build their own from `sub_config.allowed_tools`.

### `tool_dispatch.rs::execute_one_tool`

The InvokeAgent branch now passes `tx` straight through (it already *is* the parent's `ToolExecutionContext`). After this, the destructure at the top of `execute_one_tool` no longer needs `project_root`, `config`, `db`, or `mode` — those were used only to build the old explicit `execute_sub_agent` arg list. Tightened accordingly.

### `sub_agent_dispatch.rs::run_bg_agent` — internal recursive call

The bg-agent path is `tokio::spawn`'d, so it owns its inputs (no parent borrow available). It now constructs a local `TurnContext` / `ToolExecutionContext` from those owned values to pass to the recursive `execute_sub_agent` call.

The `tools: &ToolRegistry` slot is filled with a freshly-built empty `ToolRegistry` — `execute_sub_agent` ignores the parent's tools field (sub-agents build their own), so any value satisfies the type. The cost is one zero-tool registry alloc per bg-agent dispatch (negligible vs the spawn + LLM round-trip we already pay for).

## Inline TurnContext construction collapse

PR-2 added two inline `TurnContext::new(...)` blocks at the two `execute_one_tool` callsites inside `execute_sub_agent`'s loop body (the AutoApprove path and the post-approval Approve arm). Both used identical args. PR-3 hoists the construction once, after `sub_config` / `sub_session` / `tools` are bound:

```rust
let sub_turn = TurnContext::new(
    project_root, &sub_config, db, &sub_session, sink,
    cancel.clone(), sub_agent_cache, bg_agents, mode, &tools,
);
let sub_tx = ToolExecutionContext::new(&sub_turn, Some(my_invocation_id));
```

Each call site collapses to:
```rust
let (_id, result, _success, _full) = execute_one_tool(tc, sub_tx).await;
```

`sub_tx` is `Copy` (its fields are all references / `Copy` types) so reusing it across iterations and across both call sites is free.

## Final `#[allow(clippy::too_many_arguments)]` scoreboard

| file                         | pre-PR-1 baseline | after PR-3 (this) | Δ |
|------------------------------|-------------------|-------------------|---|
| `inference.rs`               | 0                 | 0                 | 0 |
| `tool_dispatch.rs`           | 6                 | 0                 | **−6** |
| `sub_agent_dispatch.rs`      | 2                 | 1                 | **−1** |
| `child_agent.rs`             | 2                 | 2                 | 0 (out of scope) |
| **consumer sites total**     | **10**            | **3**             | **−7** |
| `turn_context.rs` (lib overhead) | 0             | 2                 | +2 (constructors) |

The remaining `sub_agent_dispatch.rs` allow is on `run_bg_agent` — deferred per PR-1's design discussion (10 owned-args needed for `tokio::spawn`'s `'static + Send` requirement; bundling into an owned struct would just rename the warning).

The two `child_agent.rs` allows are on `ChildAgentRegistry::reserve` and `attach`, also deferred — they're builder-shaped, not ambient context.

**−7 at consumer sites — exactly hits the audit's realistic ceiling** (`Realistic 11 → 7 (Tier 1 only)` from #1265 item 4). 🎯

## Behavior change

**None.** Every line of executable logic is preserved. The only diff in semantics is the bookkeeping trail: the `tracing::instrument` span on `execute_sub_agent` no longer pre-fields `agent_name = ...` until later in the body (it always was set inside the body via `tracing::Span::current().record(...)`, but we lost the up-front attribute pre-record). The recorded value is identical.

**Bug fix during refactor**: my first edit pass accidentally dropped the `Some(ApprovalDecision::Reject) => "[rejected by user]".to_string()` arm when collapsing the inline TurnContext block at the second callsite. Caught by the borrow checker (E0004 non-exhaustive match) before tests ran. Restored. *Don't fight Rust — let it catch your dumb edits.*

## Validation

```text
cargo fmt --all -- --check                              ✓
cargo clippy --workspace --all-targets -- -D warnings   ✓
RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps ✓
cargo test --workspace                                  ✓ 2597 passed, 0 failed
```

Same total as PR-1 / PR-2 baselines.

## Stack

- #1287 — PR-1, types only
- #1288 — PR-2, migrate `tool_dispatch.rs`
- **#1289 (this) — PR-3, migrate `execute_sub_agent` + collapse inline construction**

Stack closes out item 4 of the audit. Next big targets in the audit (per #1265):
- Item 6 (textarea decision) — needs design call
- Item 7 (provider HTTP helpers) — independent refactor
- Item 8 (test determinism) — independent quality fix
