### PR TITLE
refactor(providers): extract send_or_bail/send_and_parse_json helpers (#1265 item 7)

### DIFF
--- a/koda-core/src/providers/anthropic.rs
+++ b/koda-core/src/providers/anthropic.rs
@@ -475,27 +475,15 @@ impl LlmProvider for AnthropicProvider {
             tools: api_tools,
         };
 
-        let resp = self
+        let req = self
             .client
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_API_VERSION)
             .header("anthropic-beta", beta_header(extended_ctx))
-            .json(&request)
-            .send()
-            .await
-            .context("Failed to call Anthropic API")?;
+            .json(&request);
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Anthropic API returned {status}: {body}");
-        }
-
-        let msg_resp: MessagesResponse = resp
-            .json()
-            .await
-            .context("Failed to parse Anthropic response")?;
+        let msg_resp: MessagesResponse = super::http::send_and_parse_json(req, "Anthropic").await?;
 
         // Parse response content blocks into our unified format
         let mut content_text = String::new();
@@ -677,22 +665,15 @@ impl LlmProvider for AnthropicProvider {
             body["tools"] = serde_json::to_value(&api_tools)?;
         }
 
-        let resp = self
+        let req = self
             .client
             .post(format!("{}/v1/messages", self.base_url))
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", ANTHROPIC_API_VERSION)
             .header("anthropic-beta", beta_header(extended_ctx))
-            .json(&body)
-            .send()
-            .await
-            .context("Failed to call Anthropic API (stream)")?;
+            .json(&body);
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Anthropic API returned {status}: {body}");
-        }
+        let resp = super::http::send_or_bail(req, "Anthropic").await?;
 
         let collector = super::stream_collector::spawn_sse_collector(
             resp,

--- a/koda-core/src/providers/gemini.rs
+++ b/koda-core/src/providers/gemini.rs
@@ -446,24 +446,12 @@ impl LlmProvider for GeminiProvider {
             cache_name.as_deref(),
         );
 
-        let resp = self
+        let req = self
             .client
             .post(self.api_url(&format!("models/{model}:generateContent")))
-            .json(&body)
-            .send()
-            .await
-            .context("Failed to call Gemini API")?;
+            .json(&body);
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Gemini API returned {status}: {body}");
-        }
-
-        let gen_resp: GenerateResponse = resp
-            .json()
-            .await
-            .context("Failed to parse Gemini response")?;
+        let gen_resp: GenerateResponse = super::http::send_and_parse_json(req, "Gemini").await?;
 
         self.parse_response(gen_resp)
     }
@@ -554,22 +542,15 @@ impl LlmProvider for GeminiProvider {
             Some(settings),
         );
 
-        let resp =
+        let req =
             self.client
                 .post(self.api_url_with_params(
                     &format!("models/{model}:streamGenerateContent"),
                     "alt=sse",
                 ))
-                .json(&body)
-                .send()
-                .await
-                .context("Failed to call Gemini API (stream)")?;
+                .json(&body);
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Gemini API returned {status}: {body}");
-        }
+        let resp = super::http::send_or_bail(req, "Gemini").await?;
 
         let collector =
             super::stream_collector::spawn_sse_collector(resp, Box::new(GeminiChunkParser::new()));

--- a/koda-core/src/providers/http.rs
+++ b/koda-core/src/providers/http.rs
@@ -1,0 +1,234 @@
+//! Provider-neutral HTTP helpers (#1265 item 7).
+//!
+//! Pre-#1265 the three native providers (`anthropic`, `gemini`,
+//! `openai_compat`) each open-coded the same three-line dance for
+//! every request:
+//!
+//! ```ignore
+//! let resp = req.send().await.context("Failed to call X API")?;
+//! let status = resp.status();
+//! if !status.is_success() {
+//!     let body = resp.text().await.unwrap_or_default();
+//!     anyhow::bail!("X API returned {status}: {body}");
+//! }
+//! let parsed: SomeType = resp.json().await.context("Failed to parse X response")?;
+//! ```
+//!
+//! Eight sites copy that block with only the provider name varying.
+//! That's a textbook DRY violation, *and* a change-amplifier — adding
+//! redacted logging, a retry policy, or a richer error type would
+//! require touching every site.
+//!
+//! This module collects the dominant pattern into two helpers:
+//!
+//! - [`send_or_bail`] — send + status check, return the [`Response`]
+//!   for further processing (streaming, custom parsing, etc.).
+//! - [`send_and_parse_json`] — full send + status + JSON parse, the
+//!   common case for non-streaming endpoints.
+//!
+//! ## What is *not* in scope
+//!
+//! Three sites use bespoke status handling and stay inline:
+//!
+//! 1. **Auth-aware error translation** (`anthropic.rs`, `gemini.rs`):
+//!    they translate 401/403 into a user-friendly "Invalid API key"
+//!    message before the generic bail. Pulling that into a helper
+//!    would just multiply parameters and re-encode the same string
+//!    template; YAGNI until a third provider needs it.
+//! 2. **Soft-fail to default** (`gemini.rs` cache creation):
+//!    intentionally swallows errors and returns `None` because the
+//!    cache is best-effort. The pattern is one-off and isn't a
+//!    candidate for sharing.
+//!
+//! ## Provider name parameter
+//!
+//! Every helper takes `provider_name: &str` purely for error message
+//! quality. It's threaded through `with_context` and `bail!` so the
+//! resulting error chain reads e.g. `"Failed to call Anthropic API:
+//! connection refused"`. Pre-#1265 each provider hard-coded its own
+//! name in the `.context(...)` string; this just lifts the literal
+//! up by one stack frame.
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::{RequestBuilder, Response};
+use serde::de::DeserializeOwned;
+
+/// Send a request; if the response status is not 2xx, read the body
+/// and bail with `"<provider> API returned <status>: <body>"`.
+/// Otherwise return the [`Response`] for further processing.
+///
+/// Use this when you want to inspect headers, stream the body, or
+/// otherwise do non-JSON things with the response. For the common
+/// JSON-response case prefer [`send_and_parse_json`].
+///
+/// ## Errors
+///
+/// - The underlying transport (`reqwest::Error`) wrapped in a
+///   `"Failed to call <provider> API"` context.
+/// - HTTP non-2xx status, with the response body included verbatim
+///   so the model has something to act on.
+pub(crate) async fn send_or_bail(request: RequestBuilder, provider_name: &str) -> Result<Response> {
+    let resp = request
+        .send()
+        .await
+        .with_context(|| format!("Failed to call {provider_name} API"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        // `text()` consumes the response, so we read it eagerly here
+        // and surface it inside the bail message. `unwrap_or_default`
+        // mirrors pre-#1265 behavior — a body-read failure shouldn't
+        // mask the underlying status code.
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("{provider_name} API returned {status}: {body}"));
+    }
+    Ok(resp)
+}
+
+/// Send a request, check status, and parse the JSON response into
+/// `T`. The non-streaming common case.
+///
+/// ## Errors
+///
+/// - Anything [`send_or_bail`] can return.
+/// - JSON deserialization failure wrapped in
+///   `"Failed to parse <provider> response"` context.
+pub(crate) async fn send_and_parse_json<T: DeserializeOwned>(
+    request: RequestBuilder,
+    provider_name: &str,
+) -> Result<T> {
+    let resp = send_or_bail(request, provider_name).await?;
+    resp.json()
+        .await
+        .with_context(|| format!("Failed to parse {provider_name} response"))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Behavioral parity with pre-#1265 inline sites. Tests use a
+    //! locally-bound `axum` server on `127.0.0.1:0` to keep the
+    //! assertions transport-real without depending on a live
+    //! provider. This matches the `web_fetch.rs` test pattern
+    //! already used elsewhere in this crate — no new dev-deps.
+    //!
+    //! Threading model: the bare current_thread tokio test runtime is
+    //! **not** safe here because the axum server runs on a
+    //! `tokio::spawn`'d task; current_thread silently hides
+    //! spawn-related bugs. See #1109 F2 /
+    //! `scripts/check_tokio_test_flavor.py`.
+
+    use super::*;
+    use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+    use serde::Deserialize;
+    use tokio_util::sync::CancellationToken;
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Echo {
+        ok: bool,
+        msg: String,
+    }
+
+    /// Spin up an axum server on `127.0.0.1:0` serving `/ok`,
+    /// `/boom`, `/echo`, and `/bad`. Returns the base URL and a
+    /// cancel token the test must trigger before dropping. Same
+    /// shape as `web_fetch.rs::spawn_test_server` so this stays
+    /// idiomatic with the existing crate-local convention.
+    async fn spawn_server() -> (String, CancellationToken) {
+        async fn ok() -> impl IntoResponse {
+            (StatusCode::OK, "hello")
+        }
+        async fn boom() -> impl IntoResponse {
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal kaboom")
+        }
+        async fn echo() -> impl IntoResponse {
+            (
+                StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                r#"{"ok":true,"msg":"hi"}"#,
+            )
+        }
+        async fn bad() -> impl IntoResponse {
+            // 200 OK but non-JSON body — forces parse failure path.
+            (StatusCode::OK, "not json")
+        }
+
+        let app = Router::new()
+            .route("/ok", get(ok))
+            .route("/boom", get(boom))
+            .route("/echo", get(echo))
+            .route("/bad", get(bad));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let ct = CancellationToken::new();
+        let ct_server = ct.clone();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move { ct_server.cancelled_owned().await })
+                .await
+                .ok();
+        });
+        (url, ct)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_or_bail_returns_response_on_2xx() {
+        let (url, ct) = spawn_server().await;
+        let client = reqwest::Client::new();
+        let req = client.get(format!("{url}/ok"));
+        let resp = send_or_bail(req, "TestProvider").await.expect("ok");
+        let body = resp.text().await.expect("body");
+        assert_eq!(body, "hello");
+        ct.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_or_bail_includes_status_and_body_on_error() {
+        let (url, ct) = spawn_server().await;
+        let client = reqwest::Client::new();
+        let req = client.get(format!("{url}/boom"));
+        let err = send_or_bail(req, "TestProvider").await.unwrap_err();
+        let msg = format!("{err}");
+        // Verbatim format: pre-#1265 inline sites used the same
+        // shape, and the model's error-recovery path matches
+        // against it. Don't change without bumping consumers.
+        assert!(msg.contains("TestProvider API returned"), "got: {msg}");
+        assert!(msg.contains("500"), "got: {msg}");
+        assert!(msg.contains("internal kaboom"), "got: {msg}");
+        ct.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_and_parse_json_round_trips_typed_body() {
+        let (url, ct) = spawn_server().await;
+        let client = reqwest::Client::new();
+        let req = client.get(format!("{url}/echo"));
+        let parsed: Echo = send_and_parse_json(req, "TestProvider").await.expect("ok");
+        assert_eq!(
+            parsed,
+            Echo {
+                ok: true,
+                msg: "hi".into()
+            }
+        );
+        ct.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn send_and_parse_json_errors_on_malformed_body() {
+        let (url, ct) = spawn_server().await;
+        let client = reqwest::Client::new();
+        let req = client.get(format!("{url}/bad"));
+        let err = send_and_parse_json::<Echo>(req, "TestProvider")
+            .await
+            .unwrap_err();
+        // The parse-failure context is what pre-#1265 inline sites
+        // surfaced verbatim — keep the model's recovery path stable.
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("Failed to parse TestProvider response"),
+            "got: {chain}"
+        );
+        ct.cancel();
+    }
+}

--- a/koda-core/src/providers/mod.rs
+++ b/koda-core/src/providers/mod.rs
@@ -44,6 +44,10 @@ pub mod stream_collector;
 /// Streaming XML tag filter for think/reasoning tags.
 pub mod stream_tag_filter;
 
+/// Provider-neutral HTTP helpers (#1265 item 7) — send/status/parse
+/// boilerplate that was duplicated 8x across the three providers.
+pub(crate) mod http;
+
 /// Mock provider for deterministic testing.
 #[cfg(any(test, feature = "test-support"))]
 pub mod mock;

--- a/koda-core/src/providers/openai_compat.rs
+++ b/koda-core/src/providers/openai_compat.rs
@@ -399,19 +399,8 @@ impl LlmProvider for OpenAiCompatProvider {
             req = req.bearer_auth(key);
         }
 
-        let resp = req
-            .json(&request)
-            .send()
-            .await
-            .context("Failed to call LLM API")?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("LLM API returned {status}: {body}");
-        }
-
-        let chat_resp: ChatResponse = resp.json().await.context("Failed to parse LLM response")?;
+        let resp_req = req.json(&request);
+        let chat_resp: ChatResponse = super::http::send_and_parse_json(resp_req, "LLM").await?;
 
         let choice = chat_resp
             .choices
@@ -461,17 +450,7 @@ impl LlmProvider for OpenAiCompatProvider {
             req = req.bearer_auth(key);
         }
 
-        let resp = req
-            .json(&request)
-            .send()
-            .await
-            .context("Failed to call LLM API (stream)")?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("LLM API returned {status}: {body}");
-        }
+        let resp = super::http::send_or_bail(req.json(&request), "LLM").await?;
 
         let collector =
             super::stream_collector::spawn_sse_collector(resp, Box::new(OpenAiChunkParser::new()));


### PR DESCRIPTION
# refactor(providers): extract `send_or_bail` / `send_and_parse_json` helpers (#1265 item 7)

## Summary

Migrates **6 of 8 duplicate** provider HTTP boilerplate sites to two
shared helpers in a new `koda-core::providers::http` module. Each
provider now reads as the API call it actually makes, not the
copy-pasted ceremony around it.

## Why

Per the audit (#1265, item 7 in the suggested migration order), the
three native providers — `anthropic.rs`, `gemini.rs`,
`openai_compat.rs` — each open-coded the same three-line dance for
every request:

```rust
let resp = req.send().await.context("Failed to call X API")?;
let status = resp.status();
if !status.is_success() {
    let body = resp.text().await.unwrap_or_default();
    anyhow::bail!("X API returned {status}: {body}");
}
let parsed: T = resp.json().await.context("Failed to parse X response")?;
```

Eight copies across three files, with only the provider name varying.
That's textbook DRY violation, **and** a change-amplifier — adding
redacted logging, a retry policy, or a richer error type would
require touching every site.

## What changed

### New module

- **`koda-core/src/providers/http.rs`** (`pub(crate)`) — two helpers:
  - `send_or_bail(req, "Provider")` — send + status check, returns
    `Response` for further processing (streaming, custom parsing).
  - `send_and_parse_json(req, "Provider")` — full send + status +
    JSON parse for the non-streaming common case.

### Migrated sites (6)

| Provider          | Endpoint                  | Helper                |
|-------------------|---------------------------|------------------------|
| anthropic.rs      | non-streaming chat        | `send_and_parse_json` |
| anthropic.rs      | streaming preflight       | `send_or_bail`        |
| gemini.rs         | non-streaming chat        | `send_and_parse_json` |
| gemini.rs         | streaming preflight       | `send_or_bail`        |
| openai_compat.rs  | non-streaming chat        | `send_and_parse_json` |
| openai_compat.rs  | streaming preflight       | `send_or_bail`        |

### Deliberately NOT migrated (2)

These stay inline because they have *behavioral* differences, not
just message variation — pulling them into a helper would either
multiply parameters or hide intent. YAGNI per the audit.

| File          | Site                | Why kept inline                                   |
|---------------|---------------------|--------------------------------------------------|
| anthropic.rs  | `list_models`       | Auth-aware: 401 → "Invalid API key" before bail  |
| gemini.rs     | `list_models`       | Auth-aware: 400/403 → "Invalid API key" before bail |

(A third site — gemini cache creation — uses soft-fail-to-default
semantics and was already not following the dominant pattern.)

## Behavior parity

- **Error message format unchanged.** The bail!() template
  `"<Provider> API returned <status>: <body>"` is preserved
  verbatim. The model's error-recovery prompts pattern-match against
  it; tests in the new module assert this verbatim format so any
  future drift is caught.
- **`.context()` chain shape preserved.** `"Failed to call X API"`
  on transport errors and `"Failed to parse X response"` on
  deserialization errors — same wording, lifted up one stack frame.
- **One tiny intentional drift.** Streaming-preflight sites used to
  say `"Failed to call X API (stream)"` in the `.context()` chain;
  they now say `"Failed to call X API"`. The user-facing `bail!`
  message never had the `(stream)` suffix, so this only affects
  internal error chain readability. Not worth a parameter on the
  helper — pre-#1265 was already inconsistent.

## Tests

New `providers::http::tests` module — 4 tests using the same axum
local-server pattern already in use in `tools/web_fetch.rs` (no new
dev-deps):

- `send_or_bail_returns_response_on_2xx`
- `send_or_bail_includes_status_and_body_on_error` — verbatim format
- `send_and_parse_json_round_trips_typed_body`
- `send_and_parse_json_errors_on_malformed_body` — verbatim context

All marked `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]`
per the #1109 F2 guard, since axum's `serve` runs on a `tokio::spawn`'d
task and current_thread runtime would silently hide spawn-related bugs.

## Validation

```
$ cargo test -p koda-core --lib
test result: ok. 1279 passed; 0 failed; 1 ignored

$ cargo test -p koda-core --tests
test result: ok. 8 passed; 0 failed; 0 ignored

$ cargo test -p koda-cli
(green)

$ cargo clippy --workspace --all-targets -- -D warnings
(no warnings)

$ cargo fmt --all  (clean)

$ python3 scripts/check_tokio_test_flavor.py
[#1109 F2 guard] OK
```

## Diffstat

```
 anthropic.rs     |  31 +---
 gemini.rs        |  31 +---
 http.rs          | 234 +++++  (110 of which are tests + docs)
 mod.rs           |   4 +
 openai_compat.rs |  27 +---
 5 files changed, 253 insertions(+), 74 deletions(-)
```

Provider files shrank by 89 lines combined; behavioral provider code
shrank by ~55 lines. The `http.rs` line count is dominated by
prose docs (the *why*, not the *what*) and tests — exactly the
trade we want.

## Audit progress

Item 7 of #1265 done. Remaining items:
- Item 5 (ToolCatalog extraction) — needs a daytime session, multi-PR stack
- Item 6 (textarea decision) — needs your call (vendored vs owned)
- Item 8 (test determinism) — independent quality work

Closes the "Provider HTTP/request parsing duplication" checkbox in #1265.

🤖 Authored by `code-puppy-7b4d98`.
