### PR TITLE
refactor(core): introduce ToolCatalog (read-only metadata) (#1265 item 5, PR-1/N)

### DIFF
--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -1,0 +1,455 @@
+//! Read-only tool metadata catalog (#1265 item 5, PR-1/N).
+//!
+//! # Why this module exists
+//!
+//! Pre-#1265, [`crate::tools::ToolRegistry`] was a 1662-LOC god-object
+//! that owned everything tool-related: built-in definitions, the
+//! filesystem trait object, the undo stack, the file-read cache, the
+//! database/session handles, the skill registry, output caps, the
+//! background-process registry, trust mode, sandbox policy, the MCP
+//! manager handle, and per-session proxy ports — *plus* every tool's
+//! execution body in a single 400-line `match`.
+//!
+//! That mass smelled bad in three concrete ways:
+//!
+//! 1. **Read-vs-write coupling.** Pure read-only callers (tests that
+//!    just want a definition list, the engine's prompt-builder asking
+//!    "what tools exist?") had to construct a full registry with FS,
+//!    proxy, MCP, and undo state they'd never touch.
+//! 2. **Over-broad lock surface.** Several `RwLock<...>` slots
+//!    (`mcp_manager`, `proxy_port`, `socks5_port`, `db`, `session_id`)
+//!    coexisted on the same struct so a contention bug in one field's
+//!    consumer was impossible to scope to that consumer.
+//! 3. **Test fixtures had to mock everything.** Wiring tests for "is
+//!    every built-in tool registered?" pulled in skill discovery, FS
+//!    initialization, and undo-stack construction.
+//!
+//! # What this PR does
+//!
+//! Introduces [`ToolCatalog`] — a focused type that owns *only* the
+//! read-only metadata side of the registry:
+//!
+//! - The map of built-in [`ToolDefinition`]s, populated once at
+//!   construction by aggregating each tool sub-module's
+//!   `definitions()` function.
+//! - The MCP manager handle (a hot-pluggable slot, populated after
+//!   MCP servers connect).
+//! - Methods that read those two things: name lookup, allowlist /
+//!   denylist filtering, MCP-aware effect classification.
+//!
+//! [`ToolRegistry`] now *composes* one of these via a `catalog` field
+//! and delegates the corresponding methods. The public API of
+//! `ToolRegistry` is byte-for-byte unchanged in this PR; behavior is
+//! preserved exactly. Subsequent PRs in the stack will migrate
+//! callers that don't need a full registry to use `ToolCatalog`
+//! directly, shrinking `ToolRegistry`'s blast radius incrementally.
+//!
+//! # Why this PR is types-only
+//!
+//! Same playbook as the TurnContext stack (#1287 → #1288 → #1290):
+//! introducing the type with full delegation in PR-1 means CI proves
+//! "no behavior changed" before any caller migration starts. If
+//! something here is wrong, the broken test is in the catalog
+//! module, not in 30 unrelated call sites.
+//!
+//! [`ToolRegistry`]: crate::tools::ToolRegistry
+//! [`ToolDefinition`]: crate::types::ToolDefinition
+
+use crate::providers::ToolDefinition;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use super::{
+    ToolEffect, agent, ask_user, bg_task_tools, classify_tool, file_tools, glob_tool, grep, memory,
+    recall, shell, skill_tools, todo, web_fetch, web_search,
+};
+
+/// The read-only metadata side of [`crate::tools::ToolRegistry`].
+///
+/// Owns the built-in tool definition map and the MCP manager slot.
+/// Does **not** own filesystem state, caches, undo, session/DB
+/// handles, or proxy ports — those stay on `ToolRegistry` because
+/// they're either mutable per-turn or only meaningful during
+/// execution.
+///
+/// ## Threading model
+///
+/// `definitions` is immutable after `new()` so requires no
+/// synchronization. `mcp_manager` is a `std::sync::RwLock` slot so
+/// late attachment (after MCP servers connect) doesn't require
+/// `&mut self`. Read-side contention is negligible because writers
+/// only fire at MCP-server-lifecycle boundaries (connect / refresh /
+/// disconnect), not on every tool invocation.
+///
+/// ## Construction cost
+///
+/// `new()` walks every per-tool `definitions()` function and inserts
+/// the results into a `HashMap`. That's O(builtin_tool_count) and
+/// happens once per registry creation. Cheap enough that we don't
+/// bother lazy-initializing.
+pub struct ToolCatalog {
+    /// All built-in tool definitions, keyed by tool name. Populated
+    /// at construction time by [`Self::new`]; never mutated.
+    definitions: HashMap<String, ToolDefinition>,
+
+    /// Hot-pluggable MCP manager handle. `None` until
+    /// [`Self::set_mcp_manager`] is called by `KodaSession::new`
+    /// after MCP servers have connected. The outer `RwLock` allows
+    /// late attachment without `&mut self`; the inner
+    /// `tokio::sync::RwLock` is the manager's own concurrency
+    /// primitive (it serves async readers from tool dispatch).
+    mcp_manager: RwLock<Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>>,
+}
+
+impl ToolCatalog {
+    /// Build a fresh catalog containing every built-in tool's
+    /// definitions. The MCP slot starts empty and is filled later via
+    /// [`Self::set_mcp_manager`].
+    ///
+    /// Definition aggregation pattern: each tool sub-module exposes a
+    /// `definitions() -> Vec<ToolDefinition>` (or `definition() ->
+    /// ToolDefinition` for single-def modules like `recall`) — this
+    /// method walks them all and inserts into the map. Adding a new
+    /// built-in tool means: define the function in your sub-module,
+    /// then add one `for def in mymod::definitions() { ... }` block
+    /// here. The audit's acceptance criterion ("adding a simple
+    /// built-in tool requires one module plus one registration line")
+    /// is partially met by the existing per-module `definitions()`
+    /// pattern; this PR doesn't change that surface.
+    pub fn new() -> Self {
+        let mut definitions = HashMap::new();
+
+        // Register all built-in tools. Order doesn't matter — we
+        // insert into a HashMap and the LLM never sees the map's
+        // iteration order (callers that need stability sort the
+        // result, e.g. `all_builtin_tool_names`).
+        for def in file_tools::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in grep::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in shell::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in agent::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in bg_task_tools::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in ask_user::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in glob_tool::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in web_fetch::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in web_search::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in todo::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in memory::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        for def in skill_tools::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
+        // RecallContext is a singleton (not a `Vec`) — it has a
+        // single canonical definition and the sub-module reflects
+        // that with `definition()` instead of `definitions()`.
+        let recall_def = recall::definition();
+        definitions.insert(recall_def.name.clone(), recall_def);
+
+        Self {
+            definitions,
+            mcp_manager: RwLock::new(None),
+        }
+    }
+
+    /// Attach an MCP connection manager. Called once per session,
+    /// after MCP servers have connected and discovered their tools.
+    ///
+    /// Lock-poisoning policy: if the inner `RwLock` is poisoned we
+    /// silently keep the previous value. Matches the precedent set
+    /// by the pre-#1265 `set_mcp_manager` on `ToolRegistry` — a
+    /// poisoned lock means another thread already panicked, and
+    /// piling on with our own panic just makes the ultimate
+    /// diagnosis harder.
+    pub fn set_mcp_manager(&self, manager: Arc<tokio::sync::RwLock<crate::mcp::McpManager>>) {
+        if let Ok(mut guard) = self.mcp_manager.write() {
+            *guard = Some(manager);
+        }
+    }
+
+    /// Read the currently-attached MCP manager, if any. Returns a
+    /// cloned `Arc` so callers can hold it across `.await` points
+    /// without keeping the catalog's `RwLock` read guard live.
+    pub fn mcp_manager(&self) -> Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>> {
+        self.mcp_manager.read().ok().and_then(|g| g.clone())
+    }
+
+    /// Classify a tool into its [`ToolEffect`], using MCP annotations
+    /// when available.
+    ///
+    /// - **Built-in tools** delegate to the free function
+    ///   [`classify_tool`].
+    /// - **MCP tools** look up cached annotations on the manager.
+    /// - If we *think* a name is an MCP tool but the manager isn't
+    ///   attached or its lock is contended, we fall back to
+    ///   [`ToolEffect::RemoteAction`] — a defensible "side effects
+    ///   somewhere remote" guess that errs toward asking for approval.
+    pub fn classify_tool_with_mcp(&self, name: &str) -> ToolEffect {
+        if crate::mcp::is_mcp_tool_name(name) {
+            if let Some(mgr) = self.mcp_manager()
+                && let Ok(mgr) = mgr.try_read()
+            {
+                return mgr.classify_tool(name);
+            }
+            // Fallback: no manager or lock contention.
+            return ToolEffect::RemoteAction;
+        }
+        classify_tool(name)
+    }
+
+    /// Sorted list of every registered built-in tool name. Used by
+    /// wiring tests to verify every tool sub-module is plumbed in.
+    /// Sort is stable+lexicographic so test snapshots don't churn.
+    pub fn all_builtin_tool_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.definitions.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// Whether a name maps to a known built-in tool. Does **not**
+    /// consult MCP — call sites that want MCP awareness should also
+    /// check `mcp_manager().map(|m| m.try_read().has_tool(name))` or
+    /// rely on [`Self::get_definitions`] which merges both sources.
+    pub fn has_tool(&self, name: &str) -> bool {
+        self.definitions.contains_key(name)
+    }
+
+    /// Filtered view of all tool definitions (built-ins + MCP).
+    ///
+    /// Filter semantics — preserved verbatim from the pre-#1265
+    /// `ToolRegistry::get_definitions` so the model's tool-listing
+    /// behavior is byte-identical:
+    ///
+    /// - `allowed` non-empty → only those tools (allowlist mode).
+    /// - `denied` non-empty → all tools except those (denylist mode).
+    /// - Both empty → all tools.
+    /// - If both are specified, allowlist wins (deny ignored).
+    ///
+    /// MCP tools are appended after built-ins. Within each group,
+    /// iteration order is `HashMap` order (unspecified) — deliberate:
+    /// callers that need a sorted list must sort, and most LLM
+    /// providers don't care about order.
+    pub fn get_definitions(&self, allowed: &[String], denied: &[String]) -> Vec<ToolDefinition> {
+        let mut defs: Vec<ToolDefinition> = if !allowed.is_empty() {
+            allowed
+                .iter()
+                .filter_map(|name| self.definitions.get(name).cloned())
+                .collect()
+        } else if !denied.is_empty() {
+            self.definitions
+                .values()
+                .filter(|d| !denied.contains(&d.name))
+                .cloned()
+                .collect()
+        } else {
+            self.definitions.values().cloned().collect()
+        };
+
+        // Append MCP tool definitions, applying the same filter
+        // semantics. `try_read` (not `read`) is intentional: if a
+        // writer is mid-update we'd rather return the built-ins
+        // immediately than block the LLM's prompt-build path.
+        if let Some(mgr) = self.mcp_manager()
+            && let Ok(mgr) = mgr.try_read()
+        {
+            let mcp_defs = mgr.all_tool_definitions();
+            if !allowed.is_empty() {
+                for def in mcp_defs {
+                    if allowed.contains(&def.name) {
+                        defs.push(def);
+                    }
+                }
+            } else if !denied.is_empty() {
+                for def in mcp_defs {
+                    if !denied.contains(&def.name) {
+                        defs.push(def);
+                    }
+                }
+            } else {
+                defs.extend(mcp_defs);
+            }
+        }
+
+        defs
+    }
+}
+
+impl Default for ToolCatalog {
+    /// `Default` is a one-liner over `new()` — exists only because
+    /// clippy::new_without_default would otherwise nag. Construction
+    /// is non-trivial (per-tool definitions walk) but observably
+    /// stateless, so a `Default` impl is honest.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Catalog-only tests. Construct a `ToolCatalog` in isolation
+    //! (no FS, no project root, no undo stack, no caps) — the whole
+    //! point of this PR is that you *can*. Pre-#1265 these tests
+    //! had to build a full `ToolRegistry`.
+    //!
+    //! These tests exercise the *invariants* of the catalog (every
+    //! built-in registers, filter modes work, MCP slot is a valid
+    //! lifecycle). Wiring tests that prove "every tool actually
+    //! routes through dispatch" stay in their existing locations
+    //! (`koda-core/tests/tool_wiring_test.rs`,
+    //! `tool_normalize_test.rs`) because those touch ToolRegistry.
+
+    use super::*;
+
+    #[test]
+    fn new_registers_every_builtin_tool() {
+        let catalog = ToolCatalog::new();
+        let names = catalog.all_builtin_tool_names();
+        // Spot-check a representative sample from each sub-module.
+        // The exhaustive list lives in `tool_wiring_test.rs`; here
+        // we just want to prove the aggregation walked every module.
+        for expected in [
+            "Read",
+            "Write",
+            "Edit",
+            "Delete",
+            "List",
+            "Grep",
+            "Glob",
+            "Bash",
+            "InvokeAgent",
+            "ListBackgroundTasks",
+            "CancelTask",
+            "WaitTask",
+            "AskUser",
+            "WebFetch",
+            "WebSearch",
+            "TodoWrite",
+            "MemoryRead",
+            "MemoryWrite",
+            "ListSkills",
+            "ActivateSkill",
+            "RecallContext",
+        ] {
+            assert!(
+                names.contains(&expected.to_string()),
+                "missing built-in tool {expected:?} (got {names:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn all_builtin_tool_names_returns_sorted() {
+        let names = ToolCatalog::new().all_builtin_tool_names();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(
+            names, sorted,
+            "names must be sorted for stable test snapshots"
+        );
+    }
+
+    #[test]
+    fn has_tool_matches_builtin_set() {
+        let catalog = ToolCatalog::new();
+        assert!(catalog.has_tool("Read"), "Read must be registered");
+        assert!(catalog.has_tool("Bash"), "Bash must be registered");
+        assert!(!catalog.has_tool("definitely_not_a_real_tool"));
+    }
+
+    #[test]
+    fn get_definitions_no_filter_returns_all() {
+        let catalog = ToolCatalog::new();
+        let defs = catalog.get_definitions(&[], &[]);
+        let names: std::collections::HashSet<_> = defs.iter().map(|d| d.name.clone()).collect();
+        // Every name in the all-list must appear in the no-filter
+        // get_definitions result. (The reverse holds by definition.)
+        for name in catalog.all_builtin_tool_names() {
+            assert!(names.contains(&name), "missing {name} in no-filter result");
+        }
+    }
+
+    #[test]
+    fn get_definitions_allowlist_only_returns_allowed() {
+        let catalog = ToolCatalog::new();
+        let defs = catalog.get_definitions(&["Read".to_string(), "Write".to_string()], &[]);
+        let names: Vec<_> = defs.iter().map(|d| d.name.clone()).collect();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"Read".to_string()));
+        assert!(names.contains(&"Write".to_string()));
+    }
+
+    #[test]
+    fn get_definitions_denylist_excludes_denied() {
+        let catalog = ToolCatalog::new();
+        let defs = catalog.get_definitions(&[], &["Bash".to_string()]);
+        let names: std::collections::HashSet<_> = defs.iter().map(|d| d.name.clone()).collect();
+        assert!(!names.contains("Bash"), "Bash should be filtered out");
+        assert!(names.contains("Read"), "Read should still be present");
+    }
+
+    #[test]
+    fn get_definitions_allowlist_wins_over_denylist() {
+        // Verbatim behavior preservation — pre-#1265 the same precedence
+        // applied in `ToolRegistry::get_definitions`. Documenting it as
+        // a test means a future drift will fail loudly.
+        let catalog = ToolCatalog::new();
+        let defs = catalog.get_definitions(
+            &["Read".to_string()], // allowlist: just Read
+            &["Read".to_string()], // denylist: also says no Read
+        );
+        let names: Vec<_> = defs.iter().map(|d| d.name.clone()).collect();
+        assert_eq!(names, vec!["Read".to_string()], "allowlist must win");
+    }
+
+    #[test]
+    fn classify_tool_with_mcp_falls_back_for_builtins() {
+        let catalog = ToolCatalog::new();
+        // Built-ins go through the free `classify_tool` function.
+        // We just verify the wrapper preserves that behavior for a
+        // representative sample.
+        assert_eq!(catalog.classify_tool_with_mcp("Read"), ToolEffect::ReadOnly);
+        assert_eq!(
+            catalog.classify_tool_with_mcp("Write"),
+            ToolEffect::LocalMutation
+        );
+        assert_eq!(
+            catalog.classify_tool_with_mcp("Delete"),
+            ToolEffect::Destructive
+        );
+    }
+
+    #[test]
+    fn classify_tool_with_mcp_unknown_mcp_returns_remote_action() {
+        // No MCP manager attached → MCP-named tool falls back to
+        // RemoteAction (defensible "asks approval" default).
+        let catalog = ToolCatalog::new();
+        // `__` is the MCP qualifier separator; see `mcp::is_mcp_tool_name`.
+        let effect = catalog.classify_tool_with_mcp("someserver__sometool");
+        assert_eq!(effect, ToolEffect::RemoteAction);
+    }
+
+    #[test]
+    fn mcp_manager_starts_empty() {
+        let catalog = ToolCatalog::new();
+        assert!(catalog.mcp_manager().is_none());
+    }
+}

--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -53,7 +53,7 @@
 //! module, not in 30 unrelated call sites.
 //!
 //! [`ToolRegistry`]: crate::tools::ToolRegistry
-//! [`ToolDefinition`]: crate::types::ToolDefinition
+//! [`ToolDefinition`]: crate::providers::ToolDefinition
 
 use crate::providers::ToolDefinition;
 use std::collections::HashMap;

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -135,6 +135,11 @@ pub mod bg_process;
 /// Background-task management tools — `ListBackgroundTasks`,
 /// `CancelTask`, `WaitTask` (Layer 2 of #996).
 pub mod bg_task_tools;
+/// Read-only tool metadata catalog (#1265 item 5, PR-1/N).
+/// Owns built-in definitions + the MCP manager slot. `ToolRegistry`
+/// composes one of these and delegates the read-only methods.
+pub mod catalog;
+pub use catalog::ToolCatalog;
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
 pub mod fuzzy;
@@ -236,7 +241,14 @@ pub struct ToolResult {
 /// The tool registry: maps tool names to their definitions and handlers.
 pub struct ToolRegistry {
     project_root: PathBuf,
-    definitions: HashMap<String, ToolDefinition>,
+    /// Read-only tool metadata — built-in definitions and the MCP
+    /// manager slot. Extracted into [`ToolCatalog`] in #1265 item 5
+    /// PR-1; `ToolRegistry` delegates `get_definitions`,
+    /// `all_builtin_tool_names`, `has_tool`, `classify_tool_with_mcp`,
+    /// `set_mcp_manager`, and `mcp_manager` to it. Pre-#1265 these
+    /// were two separate fields (`definitions: HashMap<...>` and
+    /// `mcp_manager: RwLock<Option<...>>`) on this struct.
+    catalog: ToolCatalog,
     read_cache: FileReadCache,
     /// Filesystem abstraction — `LocalFileSystem` by default; swap to
     /// `SandboxedFileSystem` when a sandbox slot is active (Phase 2d, #934).
@@ -270,9 +282,6 @@ pub struct ToolRegistry {
     /// so behavior is byte-for-byte unchanged — PR-3 starts populating it
     /// with non-default values via [`crate::sandbox::policy_for_agent`].
     sandbox_policy: koda_sandbox::SandboxPolicy,
-    /// MCP connection manager — owns all MCP server connections (#662).
-    /// `None` until attached via `set_mcp_manager()`.
-    mcp_manager: std::sync::RwLock<Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>>>,
     /// Loopback port of the per-session HTTP CONNECT proxy (Phase 3b of
     /// #934). When `Some`, [`crate::sandbox::build`] attaches the
     /// canonical `HTTPS_PROXY`/`NO_PROXY`/etc. env-var bouquet to every
@@ -307,54 +316,16 @@ impl ToolRegistry {
         max_context_tokens: usize,
         trust: crate::trust::TrustMode,
     ) -> Self {
-        let mut definitions = HashMap::new();
-
-        // Register all built-in tools
-        for def in file_tools::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-
-        for def in grep::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in shell::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in agent::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in bg_task_tools::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in ask_user::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in glob_tool::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in web_fetch::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in web_search::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in todo::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in memory::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        for def in skill_tools::definitions() {
-            definitions.insert(def.name.clone(), def);
-        }
-        // RecallContext — on-demand history retrieval
-        let recall_def = recall::definition();
-        definitions.insert(recall_def.name.clone(), recall_def);
+        // Built-in tool definitions and the MCP manager slot moved
+        // into [`ToolCatalog`] in #1265 item 5 PR-1. Construction is
+        // a single call now — the per-tool `definitions()` walk
+        // lives inside `ToolCatalog::new()`.
+        let catalog = ToolCatalog::new();
         let skill_registry = crate::skills::SkillRegistry::discover(&project_root);
 
         Self {
             project_root,
-            definitions,
+            catalog,
             read_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             fs: Arc::new(LocalFileSystem::new()),
             last_writer: Arc::new(std::sync::Mutex::new(HashMap::new())),
@@ -370,7 +341,6 @@ impl ToolRegistry {
             // can override via [`Self::with_sandbox_policy`] (sub-agent
             // dispatch does this; the main agent inherits the default).
             sandbox_policy: koda_sandbox::SandboxPolicy::strict_default(),
-            mcp_manager: std::sync::RwLock::new(None),
             proxy_port: std::sync::RwLock::new(None),
             socks5_port: std::sync::RwLock::new(None),
         }
@@ -442,15 +412,16 @@ impl ToolRegistry {
     ///
     /// Called after MCP servers have connected and discovered their tools.
     /// Tool definitions are merged into the registry so the LLM can see them.
+    ///
+    /// Delegates to [`ToolCatalog::set_mcp_manager`] (#1265 item 5 PR-1).
     pub fn set_mcp_manager(&self, manager: Arc<tokio::sync::RwLock<crate::mcp::McpManager>>) {
-        if let Ok(mut guard) = self.mcp_manager.write() {
-            *guard = Some(manager);
-        }
+        self.catalog.set_mcp_manager(manager);
     }
 
-    /// Get the MCP manager (if attached).
+    /// Get the MCP manager (if attached). Delegates to
+    /// [`ToolCatalog::mcp_manager`] (#1265 item 5 PR-1).
     pub fn mcp_manager(&self) -> Option<Arc<tokio::sync::RwLock<crate::mcp::McpManager>>> {
-        self.mcp_manager.read().ok().and_then(|guard| guard.clone())
+        self.catalog.mcp_manager()
     }
 
     /// Attach (or detach) the per-session HTTP CONNECT proxy port.
@@ -495,30 +466,25 @@ impl ToolRegistry {
     ///
     /// For built-in tools, delegates to `classify_tool()`.
     /// For MCP tools, looks up cached annotations in the manager.
+    ///
+    /// Delegates to [`ToolCatalog::classify_tool_with_mcp`] (#1265 item 5 PR-1).
     pub fn classify_tool_with_mcp(&self, name: &str) -> ToolEffect {
-        if crate::mcp::is_mcp_tool_name(name) {
-            if let Some(mgr) = self.mcp_manager()
-                && let Ok(mgr) = mgr.try_read()
-            {
-                return mgr.classify_tool(name);
-            }
-            // Fallback: no manager or lock contention.
-            return ToolEffect::RemoteAction;
-        }
-        classify_tool(name)
+        self.catalog.classify_tool_with_mcp(name)
     }
 
     /// Get all built-in tool names.
     /// Used by wiring tests to verify every tool is properly integrated.
+    ///
+    /// Delegates to [`ToolCatalog::all_builtin_tool_names`] (#1265 item 5 PR-1).
     pub fn all_builtin_tool_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = self.definitions.keys().cloned().collect();
-        names.sort();
-        names
+        self.catalog.all_builtin_tool_names()
     }
 
     /// Check whether a tool name is known.
+    ///
+    /// Delegates to [`ToolCatalog::has_tool`] (#1265 item 5 PR-1).
     pub fn has_tool(&self, name: &str) -> bool {
-        self.definitions.contains_key(name)
+        self.catalog.has_tool(name)
     }
 
     /// List all available skills as `(name, description, source)` tuples.
@@ -561,48 +527,10 @@ impl ToolRegistry {
     /// - `denied` non-empty → all tools except those (denylist).
     /// - Both empty → all tools.
     /// - If both are specified, allowlist wins (deny is ignored).
+    ///
+    /// Delegates to [`ToolCatalog::get_definitions`] (#1265 item 5 PR-1).
     pub fn get_definitions(&self, allowed: &[String], denied: &[String]) -> Vec<ToolDefinition> {
-        let mut defs: Vec<ToolDefinition> = if !allowed.is_empty() {
-            allowed
-                .iter()
-                .filter_map(|name| self.definitions.get(name).cloned())
-                .collect()
-        } else if !denied.is_empty() {
-            self.definitions
-                .values()
-                .filter(|d| !denied.contains(&d.name))
-                .cloned()
-                .collect()
-        } else {
-            self.definitions.values().cloned().collect()
-        };
-
-        // Append MCP tool definitions.
-        if let Some(mgr) = self.mcp_manager()
-            && let Ok(mgr) = mgr.try_read()
-        {
-            let mcp_defs = mgr.all_tool_definitions();
-            if !allowed.is_empty() {
-                // Allowlist mode: only include MCP tools in the allowlist.
-                for def in mcp_defs {
-                    if allowed.contains(&def.name) {
-                        defs.push(def);
-                    }
-                }
-            } else if !denied.is_empty() {
-                // Denylist mode: include MCP tools not in the denylist.
-                for def in mcp_defs {
-                    if !denied.contains(&def.name) {
-                        defs.push(def);
-                    }
-                }
-            } else {
-                // No filter: include all MCP tools.
-                defs.extend(mcp_defs);
-            }
-        }
-
-        defs
+        self.catalog.get_definitions(allowed, denied)
     }
 
     /// Execute a tool by name with the given JSON arguments.


### PR DESCRIPTION
# refactor(core): introduce `ToolCatalog` (read-only metadata) (#1265 item 5, PR-1/N)

## Summary

First PR in the **ToolCatalog extraction** stack from #1265 item 5.
Introduces a focused `ToolCatalog` type that owns the **read-only
metadata side** of the kitchen-sink `ToolRegistry`, with full
delegation. **No behavior change** — `ToolRegistry`'s public API is
byte-for-byte identical.

Same playbook as the TurnContext stack (#1287 → #1288 → #1290): land
the type with delegation in PR-1, prove via CI that nothing changed,
then migrate callers in subsequent PRs.

## Why

Per the audit (#1265, item 5), `koda-core/src/tools/mod.rs` is a
1662-LOC god-object owning:

> registry, definitions, caches, FS, undo, skill registry, DB/session
> handles, caps, background registry, trust, sandbox policy, MCP,
> proxy ports, dispatch, path helpers, descriptions, and tests.

That mass smelled bad in three concrete ways:

1. **Read-vs-write coupling.** Pure read-only callers (tests asking
   "what tools exist?", the engine's prompt-builder) had to construct
   a full registry with FS, proxy, MCP, and undo state they'd never
   touch.
2. **Over-broad lock surface.** Several `RwLock<...>` slots
   (`mcp_manager`, `proxy_port`, `socks5_port`, `db`, `session_id`)
   coexisted on the same struct so a contention bug in one consumer
   was impossible to scope.
3. **Test fixtures had to mock everything.** Wiring tests for "is
   every built-in tool registered?" pulled in skill discovery, FS
   initialization, and undo-stack construction.

## What changed

### New module: `koda-core/src/tools/catalog.rs`

`ToolCatalog` owns:

- `definitions: HashMap<String, ToolDefinition>` — built-in tool defs,
  populated once at construction by aggregating each tool sub-module's
  `definitions()` function.
- `mcp_manager: RwLock<Option<Arc<RwLock<McpManager>>>>` —
  hot-pluggable MCP manager handle.

`ToolCatalog` exposes:

| Method | Behavior |
|---|---|
| `new()` / `default()` | Build catalog with all built-in defs registered |
| `set_mcp_manager(m)` | Attach MCP manager (late binding from `KodaSession::new`) |
| `mcp_manager()` | Read MCP manager handle (cloned `Arc`) |
| `classify_tool_with_mcp(name)` | MCP-aware effect classification |
| `all_builtin_tool_names()` | Sorted list (for wiring tests) |
| `has_tool(name)` | Built-in name lookup |
| `get_definitions(allowed, denied)` | Filtered list (built-ins + MCP) |

### Wired into `ToolRegistry` via composition

- Two old fields (`definitions: HashMap<...>` and
  `mcp_manager: RwLock<Option<...>>`) replaced by **one** field:
  `catalog: ToolCatalog`.
- 6 methods (`set_mcp_manager`, `mcp_manager`, `classify_tool_with_mcp`,
  `all_builtin_tool_names`, `has_tool`, `get_definitions`) now
  oneine delegates to `self.catalog.<method>(...)`.
- `ToolRegistry::with_trust` constructor: 50+ lines of definition-map
  building collapsed to one `ToolCatalog::new()` call.

### Public API: byte-for-byte unchanged

Every old `ToolRegistry::xyz()` signature is preserved. Tests, the
engine, the CLI, and the MCP wiring path don't have to change.
That's the whole point of PR-1.

## Tests

10 new unit tests in `tools::catalog::tests`, exercising the catalog
in isolation (no FS, no project root, no caps — pre-#1265 these tests
had to build a full `ToolRegistry`):

- `new_registers_every_builtin_tool` — sample-checks every sub-module
  is plumbed in
- `all_builtin_tool_names_returns_sorted` — stable test snapshots
- `has_tool_matches_builtin_set`
- `definitions_no_filter_returns_all`
- `get_definitions_allowlist_only_returns_allowed`
- `get_definitions_denylist_excludes_denied`
- `get_definitions_allowlist_wins_over_denylist` — explicit precedence
- `classify_tool_with_mcp_falls_back_for_builtins`
- `classify_tool_with_mcp_unknown_mcp_returns_remote_action` — fallback
- `mcp_manager_starts_empty` — lifecycle invariant

## Validation

```
$ cargo test -p koda-core
test result: ... 1557 passed; 0 failed; 1 ignored

$ cargo test -p koda-cli -p koda-sandbox -p koda-test-utils
test result: ... 1054 passed; 0 failed

$ cargo clippy --workspace --all-targets -- -D warnings
(clean)

$ cargo fmt --all  (clean)

$ python3 scripts/check_tokio_test_flavor.py
[#1109 F2 guard] OK
```

Total: **2611/0** across the workspace.

## Diffstat

```
 koda-core/src/tools/catalog.rs | 455 ++++++++++  (new file; ~150 lines code, ~305 docs+tests)
 koda-core/src/tools/mod.rs     | 146 +-           (-109 lines net: 80 method bodies + 50 def-building - 21 delegates)
 2 files changed, 492 insertions(+), 109 deletions(-)
```

`mod.rs` shrank by 109 lines of behavioral code while gaining a
clean composition seam. `catalog.rs` is 455 lines but most are
prose docs (the *why*) and tests; new behavioral code is ~150
lines, all of which moved verbatim from `mod.rs`.

## Stack roadmap

This is **PR-1/N** of the ToolCatalog extraction. Subsequent PRs in
the stack:

- **PR-2:** Migrate read-only callers (tests, engine prompt-builder)
  to use `ToolCatalog` directly instead of constructing a full
  `ToolRegistry`. Concrete win: wiring tests like
  `tool_normalize_test.rs` and `tool_wiring_test.rs` stop pulling in
  FS / undo / caps.
- **PR-3 (maybe):** Extract `BuiltinToolExecutor` from
  `ToolRegistry::execute()` (the 400-line dispatch match), per the
  audit's recommendation. Would let per-tool execution code live
  closer to its definition + classification — getting closer to the
  audit's `ToolSpec` concept.

## Audit progress

Item 5 of #1265 in motion (PR-1 of N). Remaining:
- Item 8 (test determinism) — independent quality work

🤖 Authored by `code-puppy-7b4d98`.
