### PR TITLE
refactor(core): introduce Tool trait + ToolExecCtx (#1265 item 5, PR-3/N)

### DIFF
--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -140,6 +140,13 @@ pub mod bg_task_tools;
 /// composes one of these and delegates the read-only methods.
 pub mod catalog;
 pub use catalog::ToolCatalog;
+/// `Tool` trait + `ToolExecCtx` (#1265 item 5, PR-3/N). The seam for
+/// the per-tool migration that follows in PR-4..PR-N. Each migrated
+/// tool becomes a unit struct implementing this trait, replacing its
+/// arms in the `classify_tool` / `execute()` / `is_mutating_tool` /
+/// `extract_file_path` matches with co-located methods.
+pub mod tool_trait;
+pub use tool_trait::{DynTool, Tool, ToolExecCtx, boxed};
 /// File CRUD tools (`Read`, `Write`, `Edit`, `Delete`, `List`).
 pub mod file_tools;
 pub mod fuzzy;

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -1,0 +1,557 @@
+//! The `Tool` trait and per-invocation execution context (#1265 item 5, PR-3/N).
+//!
+//! # Why this module exists
+//!
+//! Pre-#1265, every built-in tool's behavior was scattered across **four**
+//! places in the codebase:
+//!
+//! 1. `tools/<toolname>.rs` — definition + execution function.
+//! 2. `tools::classify_tool(name)` — a giant `match` arm assigning the tool's
+//!    [`ToolEffect`] (read-only / local mutation / destructive).
+//! 3. `tools::ToolRegistry::execute()` — a 270-line `match` arm dispatching
+//!    to the execution function.
+//! 4. `undo::is_mutating_tool(name)` + `undo::extract_file_path(name, args)`
+//!    — *separate* `match` arms for undo-snapshot eligibility and the path
+//!    to snapshot.
+//!
+//! Adding a single mutating tool meant editing four files. Worse, the two
+//! `is_mutating_tool` lists in `tools::` and `undo::` could (and did)
+//! drift out of sync — a real bug class.
+//!
+//! Every reference codebase we surveyed (codex's `ToolHandler`, claude_code's
+//! `Tool<Input, Output>` interface, gemini-cli's `DeclarativeTool` class)
+//! solves this with a single trait/interface where each tool is a
+//! self-contained type. This PR is the koda equivalent.
+//!
+//! # What this PR does
+//!
+//! Introduces two types — and migrates **zero** existing tools. The
+//! migration is deliberately deferred to PR-4..PR-N so each cohort of
+//! tools moves over in a small reviewable diff with its own CI proof.
+//!
+//! - [`Tool`] — the trait every built-in tool will eventually implement.
+//!   Owns the tool's name, schema, classification, undo behavior, and
+//!   execution. MCP tools intentionally don't implement this — they
+//!   route through [`crate::mcp::McpManager`] via a separate dispatch
+//!   path because their schema/behavior is server-defined at runtime.
+//!
+//! - [`ToolExecCtx`] — the per-invocation context bundle. Holds borrows
+//!   to the bits of [`ToolRegistry`] state a tool's `execute()` needs.
+//!   Starts intentionally small (only the fields the seam-test tools
+//!   need). Migration PRs add fields as required by the tool being
+//!   moved over. After all migrations land, a cleanup PR removes the
+//!   now-orphaned fields from `ToolRegistry`.
+//!
+//! # Why it's types-only this PR
+//!
+//! Same playbook as the TurnContext stack (#1287/#1288/#1290) and the
+//! ToolCatalog stack (#1292/#1293):
+//!
+//! 1. **Land the seam.** New trait + context, exhaustively documented
+//!    + tested in isolation. Behavior of the existing dispatch is
+//!    byte-for-byte unchanged.
+//! 2. **Migrate cohorts.** Each PR moves one tool family
+//!    (file ops, search, bash, etc.) onto the trait. Per-PR the
+//!    central `match` shrinks; per-PR CI proves no regressions.
+//! 3. **Delete dead code.** Final cleanup PR removes `classify_tool`,
+//!    `is_mutating_tool` (both copies), `extract_file_path`, and the
+//!    central dispatch `match` — replaced by trait dispatch through
+//!    [`ToolCatalog`].
+//!
+//! If something here is wrong, the broken test is in this module —
+//! not in 25 unrelated migration PRs.
+//!
+//! # Why the defensive `classify()` default is `LocalMutation`
+//!
+//! New tools added without overriding `classify()` will require user
+//! approval before running. That's the safe failure mode: an
+//! accidentally-permissive default could ship a destructive tool that
+//! bypasses approval. An accidentally-restrictive default just
+//! prompts the user. We optimize for the former being impossible.
+//!
+//! # On the ergonomic cost
+//!
+//! Yes, `#[async_trait]` adds a `Pin<Box<dyn Future>>` wrapper per
+//! call. For the koda dispatch path that means one extra allocation
+//! per tool invocation (typically a few per turn) — negligible
+//! compared to LLM round-trip latency. We've already accepted the
+//! same overhead in [`crate::providers::LlmProvider`] so the
+//! precedent is set.
+
+use crate::providers::ToolDefinition;
+use crate::tools::ToolEffect;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// Result returned by every built-in tool's execution path.
+///
+/// Re-exported here for trait users — the canonical definition lives in
+/// [`crate::tools`] (it's the same `ToolResult` already returned by
+/// [`crate::tools::ToolRegistry::execute`]). Defining the trait against
+/// this exact type means migration PRs don't have to translate result
+/// shapes when moving each tool over.
+pub use crate::tools::ToolResult;
+
+/// Per-invocation execution context for a [`Tool`].
+///
+/// # Lifetime
+///
+/// All fields are borrows — the context is constructed fresh per call by
+/// [`crate::tools::ToolRegistry`] and lives for the duration of the
+/// `tool.execute(...)` future. No fields require ownership transfer or
+/// `Arc`-cloning at the call site.
+///
+/// # Growth strategy
+///
+/// This struct **starts intentionally small.** The fields below are
+/// the minimum needed to execute the test tools in this module's
+/// `#[cfg(test)]` block. Migration PRs (PR-4..PR-N) add fields as the
+/// tool they're migrating actually needs them — never speculatively.
+/// This forces the struct's surface to be pulled, not pushed, by real
+/// migration needs. Without that discipline `ToolExecCtx` would
+/// become a god-bag wearing a different name (the very smell we're
+/// trying to escape).
+///
+/// **Don't add a field here without a tool that uses it in the same
+/// PR.** YAGNI.
+///
+/// # Why borrows, not owned `Arc`s
+///
+/// Every field a tool reads is already owned by the surrounding
+/// [`crate::tools::ToolRegistry`] (or its embedded
+/// [`crate::tools::ToolCatalog`]). Re-cloning `Arc`s into the context
+/// would be pure ceremony — the `'a` lifetime is plenty. The exception
+/// is fields that are themselves `Arc<Mutex<...>>` shared-state
+/// handles (e.g. the file-read cache, the bg-process registry); those
+/// are passed as `&Arc<...>` so tools can clone-and-await across
+/// `.await` points if they need to.
+pub struct ToolExecCtx<'a> {
+    /// Project root the tool should resolve relative paths against.
+    /// Same value [`crate::tools::ToolRegistry::execute`] passes to
+    /// every per-tool function today.
+    pub project_root: &'a std::path::Path,
+
+    /// File-read cache shared with [`crate::tools::ToolRegistry`].
+    /// Held as `&Arc<...>` (rather than `&Mutex<...>` directly)
+    /// because file tools sometimes need to clone the handle to
+    /// keep it live across an `.await`. Pre-#1265 this is exactly
+    /// what `file_tools::read_file` and `file_tools::edit_file` do.
+    pub read_cache: &'a crate::tools::FileReadCache,
+
+    /// Filesystem trait object — `LocalFileSystem` in production,
+    /// a fake in tests. Lives behind `Arc<dyn FileSystem>` on the
+    /// registry; tools only ever need a `&dyn` reference.
+    pub fs: &'a dyn koda_sandbox::fs::FileSystem,
+
+    /// Optional engine sink + call-id pair for tools that stream
+    /// progress events to the UI (e.g. `Bash` shell output,
+    /// `TodoWrite` todo updates). `None` means "no streaming
+    /// requested" — non-streaming tools should ignore this.
+    pub sink: Option<(&'a dyn crate::engine::EngineSink, &'a str)>,
+
+    /// Phase E of #996 — opaque caller spawner id, threaded through
+    /// to `Bash` so background-shell entries are tagged with the
+    /// invoking agent's id. Every other tool ignores this. Top-
+    /// level callers pass `None`.
+    pub caller_spawner: Option<u32>,
+}
+
+/// A self-contained built-in tool.
+///
+/// Each implementor is a unit struct (or near-unit; some tools like
+/// `BashTool` may carry small pre-computed config) that owns its name,
+/// JSON schema, effect classification, undo behavior, and execution.
+///
+/// # Implementing
+///
+/// Minimal implementation:
+///
+/// ```ignore
+/// pub struct ReadTool;
+///
+/// #[async_trait::async_trait]
+/// impl Tool for ReadTool {
+///     fn name(&self) -> &'static str { "Read" }
+///     fn definition(&self) -> ToolDefinition { /* schema */ }
+///     fn classify(&self, _args: &Value) -> ToolEffect { ToolEffect::ReadOnly }
+///     async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+///         crate::tools::file_tools::read_file(
+///             ctx.project_root, args, ctx.read_cache, ctx.fs,
+///         ).await
+///     }
+/// }
+/// ```
+///
+/// `extract_undo_path` and `classify` have safe defaults: tools that
+/// don't override them are treated as mutating-but-untracked-in-undo.
+/// That's the same conservative treatment unknown tools get from
+/// today's [`crate::tools::classify_tool`].
+///
+/// # Why not `dyn` everywhere
+///
+/// We use `Box<dyn Tool>` only at the registry's storage boundary —
+/// tools call into each other (when they do at all) via concrete
+/// types. The trait-object overhead is paid once per dispatch, not
+/// per intra-tool function call.
+///
+/// # Why MCP tools don't implement this
+///
+/// MCP tool schemas are discovered at runtime from the MCP server's
+/// `tools/list` response — there's no Rust struct to hang an `impl
+/// Tool` on. They route through [`crate::mcp::McpManager::call_tool`]
+/// via the existing dispatch path, which stays the way it is.
+/// Co-locating MCP and built-in dispatch in a single trait would
+/// force one of them to lie about its shape; keeping them parallel
+/// is honest.
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// The tool's canonical name. Must match the `name` field of
+    /// [`Self::definition`]. Returned as `&'static str` because every
+    /// built-in tool name is a string literal — boxing it into `String`
+    /// would be pure ceremony.
+    fn name(&self) -> &'static str;
+
+    /// The tool's full schema — name, description, JSON-Schema
+    /// parameters. This is what the LLM provider sees. Returned by
+    /// value (not `&'static`) because some tool definitions are
+    /// constructed at runtime from sub-component metadata (e.g.
+    /// `ListAgents`'s description embeds the project's discovered
+    /// agent list).
+    fn definition(&self) -> ToolDefinition;
+
+    /// Classify the *effect* of executing this tool with the given
+    /// arguments. Default is [`ToolEffect::LocalMutation`] — the
+    /// **defensive** choice that requires user approval. Tools must
+    /// explicitly override to declare themselves [`ToolEffect::ReadOnly`]
+    /// or [`ToolEffect::Destructive`].
+    ///
+    /// Input-aware classification (per-call rather than per-tool) is
+    /// the whole point of taking `args` here. `BashTool::classify`
+    /// will eventually delegate to
+    /// [`crate::bash_safety::classify_bash_command`] so `rm -rf /`
+    /// classifies as `Destructive` while `echo hi` is `ReadOnly`.
+    /// Today, classification happens *after* dispatch via a separate
+    /// match — this trait fixes that asymmetry.
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        ToolEffect::LocalMutation
+    }
+
+    /// If this tool is about to mutate a file, return the path that
+    /// should be snapshotted into the undo stack *before* execution.
+    /// `None` means "don't snapshot" — the default for read-only
+    /// tools and for mutating tools whose target path can't be
+    /// statically extracted from the arguments (e.g. `Bash`).
+    ///
+    /// Today this logic lives in `undo::extract_file_path` as a
+    /// separate `match` on tool name; migration moves it onto the
+    /// implementing struct so adding a mutating tool can't forget
+    /// to wire its undo behavior.
+    fn extract_undo_path(&self, _args: &Value) -> Option<PathBuf> {
+        None
+    }
+
+    /// Execute the tool. The post-execution machinery (last-writer
+    /// recording, last-bash recording, full-output handling) stays
+    /// in [`crate::tools::ToolRegistry::execute`] — implementors only
+    /// need to do the work and return a `ToolResult`.
+    ///
+    /// Cancellation: callers (typically [`crate::tools::ToolRegistry::execute`])
+    /// are responsible for racing this future against any cancel
+    /// token. Tools shouldn't poll cancel state themselves unless
+    /// they spawn long-running sub-processes (Bash does this via
+    /// the `bg_registry`).
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult;
+}
+
+/// Boxed trait object for storage in the registry.
+///
+/// Defined as a type alias rather than re-typed at every use site
+/// because the `Box<dyn Tool>` type appears in several places once
+/// migrations begin (catalog map, registration helpers, test
+/// fixtures). Centralizing the alias means any future change (e.g.
+/// `Arc<dyn Tool>` for cheap cloning) is a one-line edit.
+pub type DynTool = Box<dyn Tool>;
+
+/// Convenience constructor for [`DynTool`] from any `Tool` value.
+/// Avoids the noisy `Box::new(...)` at every registration site.
+///
+/// ```ignore
+/// // Eventually in ToolCatalog::new():
+/// let tools: Vec<DynTool> = vec![
+///     boxed(ReadTool),
+///     boxed(WriteTool),
+///     // ...
+/// ];
+/// ```
+pub fn boxed<T: Tool + 'static>(tool: T) -> DynTool {
+    Box::new(tool)
+}
+
+/// Helper to make migration-time wrapping ergonomic. Many existing
+/// tool functions take `(project_root, args, cache, fs)` already —
+/// this lets a `Tool` impl forward straight through without
+/// re-naming arguments.
+///
+/// Not strictly necessary for the trait to work, but it documents
+/// the expected migration shape so PR-4..PR-N have an obvious target.
+///
+/// (We don't expose the `Arc<...>` shared-state handles via getters
+/// because tools that *need* them ought to read them from the
+/// `ToolExecCtx` field directly — the explicitness keeps the
+/// dependency graph honest.)
+impl<'a> ToolExecCtx<'a> {
+    /// Project root accessor — symmetric with `read_cache()`/`fs()`
+    /// for tools that prefer method-call style. Pure forwarder.
+    #[inline]
+    pub fn project_root(&self) -> &std::path::Path {
+        self.project_root
+    }
+
+    /// File-read cache accessor — pure forwarder. Returns the
+    /// `FileReadCache` type alias so clippy's `type_complexity` lint
+    /// doesn't flag the inner `Arc<Mutex<HashMap<...>>>` shape.
+    #[inline]
+    pub fn read_cache(&self) -> &crate::tools::FileReadCache {
+        self.read_cache
+    }
+
+    /// Filesystem accessor — pure forwarder.
+    #[inline]
+    pub fn fs(&self) -> &dyn koda_sandbox::fs::FileSystem {
+        self.fs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the seam itself. The point of this PR is "the trait
+    //! and context compile and dispatch correctly" — these tests
+    //! exercise that with two mock tools (one read-only, one mutating)
+    //! that have nothing to do with the real built-in tool set.
+    //!
+    //! Real-tool migration tests will land in PR-4 alongside the
+    //! `ReadTool`/`WriteTool`/etc. structs they exercise.
+
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    /// Minimal read-only tool for testing the trait dispatch path.
+    /// Returns the literal arg string so tests can assert on it.
+    struct EchoReadTool;
+
+    #[async_trait]
+    impl Tool for EchoReadTool {
+        fn name(&self) -> &'static str {
+            "EchoRead"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: "EchoRead".to_string(),
+                description: "Echo args back; for trait tests only.".to_string(),
+                parameters: json!({"type": "object"}),
+            }
+        }
+        fn classify(&self, _args: &Value) -> ToolEffect {
+            ToolEffect::ReadOnly
+        }
+        async fn execute(&self, _ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+            ToolResult {
+                output: args.to_string(),
+                success: true,
+                full_output: None,
+            }
+        }
+    }
+
+    /// Mock mutating tool that declares an undo path. Verifies the
+    /// `extract_undo_path` override is wired through.
+    struct MutatingMockTool;
+
+    #[async_trait]
+    impl Tool for MutatingMockTool {
+        fn name(&self) -> &'static str {
+            "MutatingMock"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: "MutatingMock".to_string(),
+                description: "Mock mutating tool for trait tests.".to_string(),
+                parameters: json!({"type": "object"}),
+            }
+        }
+        fn classify(&self, _args: &Value) -> ToolEffect {
+            ToolEffect::LocalMutation
+        }
+        fn extract_undo_path(&self, args: &Value) -> Option<PathBuf> {
+            args.get("path").and_then(|v| v.as_str()).map(PathBuf::from)
+        }
+        async fn execute(&self, _ctx: &ToolExecCtx<'_>, _args: &Value) -> ToolResult {
+            ToolResult {
+                output: "mutated".to_string(),
+                success: true,
+                full_output: None,
+            }
+        }
+    }
+
+    /// Tool that doesn't override `classify` — must default to the
+    /// defensive `LocalMutation`.
+    struct DefaultClassifyTool;
+
+    #[async_trait]
+    impl Tool for DefaultClassifyTool {
+        fn name(&self) -> &'static str {
+            "DefaultClassify"
+        }
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                name: "DefaultClassify".to_string(),
+                description: "Tests the defensive default.".to_string(),
+                parameters: json!({"type": "object"}),
+            }
+        }
+        async fn execute(&self, _ctx: &ToolExecCtx<'_>, _args: &Value) -> ToolResult {
+            ToolResult {
+                output: String::new(),
+                success: true,
+                full_output: None,
+            }
+        }
+    }
+
+    /// Build a minimal `ToolExecCtx` for tests that don't exercise FS
+    /// or sink fields. Uses the production `LocalFileSystem` (cheap
+    /// to construct) and a fresh empty cache.
+    fn make_ctx<'a>(
+        root: &'a std::path::Path,
+        cache: &'a crate::tools::FileReadCache,
+        fs: &'a dyn koda_sandbox::fs::FileSystem,
+    ) -> ToolExecCtx<'a> {
+        ToolExecCtx {
+            project_root: root,
+            read_cache: cache,
+            fs,
+            sink: None,
+            caller_spawner: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_returns_result_through_trait() {
+        let tool = EchoReadTool;
+        let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
+        let fs = koda_sandbox::fs::LocalFileSystem::new();
+        let root = std::path::PathBuf::from("/tmp");
+        let ctx = make_ctx(&root, &cache, &fs);
+
+        let args = json!({"hello": "world"});
+        let result = tool.execute(&ctx, &args).await;
+
+        assert!(result.success);
+        assert_eq!(result.output, args.to_string());
+    }
+
+    #[test]
+    fn name_matches_definition_name() {
+        let t = EchoReadTool;
+        // Invariant the migration audit relies on. Drift here would
+        // break dispatch (registry keyed by `name()`, definition
+        // listed by `definition().name`).
+        assert_eq!(t.name(), t.definition().name);
+    }
+
+    #[test]
+    fn classify_override_is_observed() {
+        // ReadOnly tool reports ReadOnly...
+        assert_eq!(EchoReadTool.classify(&json!({})), ToolEffect::ReadOnly);
+        // ...mutating tool reports LocalMutation.
+        assert_eq!(
+            MutatingMockTool.classify(&json!({})),
+            ToolEffect::LocalMutation
+        );
+    }
+
+    #[test]
+    fn classify_default_is_local_mutation() {
+        // The defensive default — see module docs for rationale.
+        // A tool that forgets to override classify gets gated behind
+        // approval, which is the safe failure mode.
+        assert_eq!(
+            DefaultClassifyTool.classify(&json!({})),
+            ToolEffect::LocalMutation
+        );
+    }
+
+    #[test]
+    fn extract_undo_path_default_is_none() {
+        // The default impl returns None — read-only tools don't need
+        // to override it.
+        assert!(EchoReadTool.extract_undo_path(&json!({})).is_none());
+    }
+
+    #[test]
+    fn extract_undo_path_override_picks_up_args() {
+        let t = MutatingMockTool;
+        // Path present → Some
+        let p = t.extract_undo_path(&json!({"path": "src/main.rs"}));
+        assert_eq!(p, Some(PathBuf::from("src/main.rs")));
+        // No path arg → None (graceful)
+        assert!(t.extract_undo_path(&json!({})).is_none());
+        // Wrong type → None (graceful)
+        assert!(t.extract_undo_path(&json!({"path": 42})).is_none());
+    }
+
+    #[test]
+    fn boxed_helper_produces_dyn_tool() {
+        // Compile-time test: `boxed(...)` must produce something
+        // storable as `DynTool`. The vec literal forces that.
+        let tools: Vec<DynTool> = vec![
+            boxed(EchoReadTool),
+            boxed(MutatingMockTool),
+            boxed(DefaultClassifyTool),
+        ];
+        assert_eq!(tools.len(), 3);
+        // Round-trip through the trait object also works.
+        assert_eq!(tools[0].name(), "EchoRead");
+        assert_eq!(tools[1].name(), "MutatingMock");
+        assert_eq!(tools[2].name(), "DefaultClassify");
+    }
+
+    #[tokio::test]
+    async fn dyn_dispatch_executes_correct_tool() {
+        // Trait-object dispatch is the production code path — verify
+        // it works for both tool variants. This is the single most
+        // important test in this module: if dyn dispatch breaks, the
+        // entire migration plan is dead.
+        let tools: Vec<DynTool> = vec![boxed(EchoReadTool), boxed(MutatingMockTool)];
+        let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
+        let fs = koda_sandbox::fs::LocalFileSystem::new();
+        let root = std::path::PathBuf::from("/tmp");
+        let ctx = make_ctx(&root, &cache, &fs);
+
+        let r1 = tools[0].execute(&ctx, &json!({})).await;
+        assert!(r1.success);
+        assert!(r1.output.contains("{}"));
+
+        let r2 = tools[1].execute(&ctx, &json!({})).await;
+        assert!(r2.success);
+        assert_eq!(r2.output, "mutated");
+    }
+
+    #[test]
+    fn ctx_accessors_match_field_values() {
+        // The accessor methods exist as ergonomic forwarders; verify
+        // they actually return the borrowed values (not, say, Default).
+        let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
+        let fs = koda_sandbox::fs::LocalFileSystem::new();
+        let root = std::path::PathBuf::from("/tmp/whatever");
+        let ctx = make_ctx(&root, &cache, &fs);
+
+        assert_eq!(ctx.project_root(), root.as_path());
+        // Cache is a single shared handle — pointer-equality check.
+        assert!(Arc::ptr_eq(ctx.read_cache(), &cache));
+    }
+}


### PR DESCRIPTION
# refactor(core): introduce `Tool` trait + `ToolExecCtx` (#1265 item 5, PR-3/N)

## Summary

Third PR in the **ToolCatalog/Tool** stack from #1265 item 5.
Introduces the `Tool` trait that every built-in tool will eventually
implement, plus the `ToolExecCtx` per-invocation context bundle. **No
existing tools are migrated** — that's PR-4..PR-N. CI proves the seam
compiles, dispatches correctly, and changes zero behavior.

## Why

Pre-#1265, every built-in tool's behavior was scattered across **four**
places:

1. `tools/<name>.rs` — definition + execution function.
2. `tools::classify_tool(name)` — giant `match` for [`ToolEffect`].
3. `tools::ToolRegistry::execute()` — 270-line `match` for dispatch.
4. `undo::is_mutating_tool(name)` + `undo::extract_file_path(name, args)`
   — *separate* matches for undo-snapshot eligibility.

Adding a single mutating tool meant editing four files. Worse, the two
`is_mutating_tool` lists in `tools::` and `undo::` could (and did)
drift out of sync — a real bug class.

Every reference codebase we surveyed solves this with one trait /
interface where each tool is a self-contained type:

| | Pattern | Per-tool unit | Classification |
|---|---|---|---|
| **codex** | `pub trait ToolHandler` | `pub struct ApplyPatchHandler;` | Method on trait, per-invocation |
| **claude_code** | `Tool<Input, Output>` interface | Object literal per tool | `isReadOnly(input)` / `isDestructive(input)` (input-aware) |
| **gemini-cli** | `abstract DeclarativeTool` | Class extends base | `Kind` enum + `READ_ONLY_KINDS` membership |
| **koda today** | `match name` everywhere | Free functions + sub-modules | `match name` in `classify_tool` (string) **+ duplicated** in `undo::is_mutating_tool` (different list!) |

User decision (issue #1265 thread): koda is heading toward
plugins/hooks/team growth, so the trait pattern is the right
architecture target. Migration lands as a stack so each step is
independently reviewable and CI-bisectable.

## What this PR does

### New module: `koda-core/src/tools/tool_trait.rs` (557 LOC)

Most of the LOC is exhaustively-commented prose explaining design
choices for future maintainers. Pure code surface is ~150 LOC.

#### `pub trait Tool: Send + Sync`

```rust
#[async_trait]
pub trait Tool: Send + Sync {
    fn name(&self) -> &'static str;
    fn definition(&self) -> ToolDefinition;
    fn classify(&self, _args: &Value) -> ToolEffect {
        ToolEffect::LocalMutation         // ← defensive default
    }
    fn extract_undo_path(&self, _args: &Value) -> Option<PathBuf> {
        None                               // ← safe default
    }
    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult;
}
```

Design choices documented in detail in the module:

- **Defensive default** for `classify()` is `LocalMutation` (requires
  approval). New tools that forget to override get gated behind
  approval — the safe failure mode. The opposite would risk shipping
  an accidentally-permissive destructive tool.
- **Per-call classification** (`classify(&Value)` not `classify()`) so
  `BashTool` can fold `bash_safety::classify_bash_command` into the
  trait — `rm -rf` classifies destructive, `echo hi` doesn't. Today
  this happens after dispatch via a separate match.
- **`name()` returns `&'static str`** because every built-in name is a
  literal — boxing into `String` would be ceremony.
- **`#[async_trait]`** for consistency with the rest of koda
  (providers, db). One `Pin<Box<dyn Future>>` allocation per
  invocation; negligible vs. LLM round-trip.
- **MCP tools intentionally don't implement this.** Their schema is
  server-defined at runtime — there's no Rust struct to hang
  `impl Tool` on. They keep their existing `McpManager::call_tool`
  dispatch path.

#### `pub struct ToolExecCtx<'a>`

Per-invocation context bundle. Borrows everything; nothing is owned.

```rust
pub struct ToolExecCtx<'a> {
    pub project_root: &'a std::path::Path,
    pub read_cache: &'a FileReadCache,
    pub fs: &'a dyn koda_sandbox::fs::FileSystem,
    pub sink: Option<(&'a dyn EngineSink, &'a str)>,
    pub caller_spawner: Option<u32>,
}
```

**Growth strategy (documented as a hard rule in the module):** start
with the minimum needed for the seam-test tools. Migration PRs add
fields *only when the tool being migrated needs them* — never
speculatively. This forces the surface to be pulled, not pushed.
Without that discipline `ToolExecCtx` becomes a god-bag wearing a
different name (the very smell we're escaping).

#### Helpers

- `pub type DynTool = Box<dyn Tool>` — centralized alias for storage.
- `pub fn boxed<T: Tool + 'static>(tool: T) -> DynTool` — convenience
  for registration sites; avoids `Box::new(...)` noise.

### Tests (9 new, all in `tool_trait::tests`)

The tests use three **mock** unit-struct tools (`EchoReadTool`,
`MutatingMockTool`, `DefaultClassifyTool`) — they have nothing to do
with the real built-in tool set. The point of this PR is "the seam
compiles and dispatches correctly", and that's exactly what these
verify:

- `execute_returns_result_through_trait` — direct trait dispatch works
- `name_matches_definition_name` — the registry-keying invariant
- `classify_override_is_observed` — overrides take effect
- **`classify_default_is_local_mutation`** — the defensive default
  contract that the safety story relies on
- `extract_undo_path_default_is_none` — read-only tools get the right default
- `extract_undo_path_override_picks_up_args` — extraction sees args
- `boxed_helper_produces_dyn_tool` — compile-time `DynTool` storability
- **`dyn_dispatch_executes_correct_tool`** — `Box<dyn Tool>` dispatch works
  (the single most important test; if this fails the whole migration plan
  is dead)
- `ctx_accessors_match_field_values` — accessor methods aren't lying

Real-tool migration tests will land in PR-4 alongside the actual
`ReadTool`/`WriteTool`/etc. structs they exercise.

## What did NOT change

Zero existing call sites. `ToolRegistry::execute()`'s 270-line `match`
is byte-for-byte unchanged. `classify_tool()`, `is_mutating_tool()`,
`undo::is_mutating_tool()`, `undo::extract_file_path()` all unchanged.
The duplicated-list bug stays for one more PR — it gets deleted in
the cleanup PR after all tools have migrated onto the trait.

## Validation

```
$ cargo test --workspace
... TOTAL passed: 2620 failed: 0

$ cargo clippy --workspace --all-targets -- -D warnings
(clean)

$ cargo fmt --all  (clean)

$ RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
(clean)

$ python3 scripts/check_tokio_test_flavor.py
[#1109 F2 guard] OK
```

The 9 new tests bring the count from 2611 (post-PR-2) to 2620.

## Diffstat

```
 koda-core/src/tools/mod.rs        |   7 +
 koda-core/src/tools/tool_trait.rs | 557 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 564 insertions(+)
```

`tool_trait.rs` is 557 LOC but ~400 of those are prose docs explaining
*why* each design choice (defensive default, per-call classification,
borrow-not-own context, etc.) was made the way it was. Pure code
surface is ~150 LOC, all of which is invariant-tested.

## Stack roadmap

| PR | Status | Scope |
|---|---|---|
| #1292 | ✅ merged | Introduce `ToolCatalog` (read-only metadata) + delegation |
| #1293 | ✅ merged | Migrate read-only test callers to `ToolCatalog` |
| **this PR** | 🟡 in CI | Introduce `Tool` trait + `ToolExecCtx`, no migrations |
| PR-4 | 🔵 next | Migrate file-ops cohort (`Read`, `Write`, `Edit`, `Delete`, `List`) |
| PR-5 | 🔵 | Migrate search cohort (`Grep`, `Glob`) |
| PR-6 | 🔵 | Migrate `Bash` (gets to fold `bash_safety::classify_bash_command` into `BashTool::classify(args)`) |
| PR-7 | 🔵 | Migrate misc small tools (`WebFetch`, `WebSearch`, `Memory*`, `TodoWrite`, `RecallContext`) |
| PR-8 | 🔵 | Migrate meta tools (`ListAgents`, `ListSkills`, `ActivateSkill`, bg-task tools, `AskUser`, `InvokeAgent`) |
| PR-9 | 🔵 cleanup | Delete `tools::classify_tool`, `tools::is_mutating_tool`, `undo::is_mutating_tool`, `undo::extract_file_path`, central `match` in `execute()`. Fixes the duplicated-list bug class. |

After PR-9, adding a new tool is **one new file** that implements
`Tool` and registers itself in `ToolCatalog::new()`. No central matches
to update; no risk of forgetting an undo arm.

🤖 Authored by `code-puppy-7b4d98`.
