### PR TITLE
refactor(core): migrate file-ops cohort onto Tool trait (#1265 item 5, PR-4/N)

### DIFF
--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -60,8 +60,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use super::{
-    ToolEffect, agent, ask_user, bg_task_tools, classify_tool, file_tools, glob_tool, grep, memory,
-    recall, shell, skill_tools, todo, web_fetch, web_search,
+    DynTool, Tool, ToolEffect, agent, ask_user, bg_task_tools, boxed, classify_tool, file_tools,
+    glob_tool, grep, memory, recall, shell, skill_tools, todo, web_fetch, web_search,
 };
 
 /// The read-only metadata side of [`crate::tools::ToolRegistry`].
@@ -91,6 +91,25 @@ pub struct ToolCatalog {
     /// All built-in tool definitions, keyed by tool name. Populated
     /// at construction time by [`Self::new`]; never mutated.
     definitions: HashMap<String, ToolDefinition>,
+
+    /// Migrated built-in tools (#1265 item 5, PR-4..PR-N), keyed by
+    /// name. Each entry implements [`Tool`] and is the authoritative
+    /// source for that tool's classification, undo behavior, and
+    /// execution.
+    ///
+    /// Coexists with [`Self::definitions`] during the migration
+    /// window: callers that need a definition look it up there
+    /// (where every tool's def lives, migrated or not), and callers
+    /// that dispatch execution check this map first — a hit means
+    /// "call `Tool::execute`", a miss means "fall through to the
+    /// legacy match arm in `ToolRegistry::execute`". After all
+    /// tools migrate, the legacy match disappears and the
+    /// `definitions` map will be derived from `tools` (cleanup PR).
+    ///
+    /// Stored as `HashMap<&'static str, DynTool>` because every tool
+    /// name is a string literal returned by `Tool::name()`. Avoids
+    /// allocating a `String` key per registration.
+    tools: HashMap<&'static str, DynTool>,
 
     /// Hot-pluggable MCP manager handle. `None` until
     /// [`Self::set_mcp_manager`] is called by `KodaSession::new`
@@ -165,8 +184,29 @@ impl ToolCatalog {
         let recall_def = recall::definition();
         definitions.insert(recall_def.name.clone(), recall_def);
 
+        // Tools migrated onto the `Tool` trait. PR-4 introduces the
+        // file-ops cohort. Subsequent PRs (5..8) register the search,
+        // bash, misc, and meta cohorts here; the cleanup PR drops
+        // the legacy match arms in `ToolRegistry::execute` and the
+        // duplicated `is_mutating_tool` / `extract_file_path` lists
+        // in `crate::undo`.
+        //
+        // Each `boxed(...)` cost is a single allocation at construction
+        // time — negligible compared to the rest of session start-up.
+        let mut tools: HashMap<&'static str, DynTool> = HashMap::new();
+        for tool in [
+            boxed(file_tools::ReadTool),
+            boxed(file_tools::WriteTool),
+            boxed(file_tools::EditTool),
+            boxed(file_tools::DeleteTool),
+            boxed(file_tools::ListTool),
+        ] {
+            tools.insert(tool.name(), tool);
+        }
+
         Self {
             definitions,
+            tools,
             mcp_manager: RwLock::new(None),
         }
     }
@@ -231,6 +271,22 @@ impl ToolCatalog {
     /// rely on [`Self::get_definitions`] which merges both sources.
     pub fn has_tool(&self, name: &str) -> bool {
         self.definitions.contains_key(name)
+    }
+
+    /// Look up a migrated [`Tool`] by name.
+    ///
+    /// Returns `Some(&dyn Tool)` for tools that have been migrated
+    /// onto the trait (#1265 item 5, PR-4..PR-N) and `None` for
+    /// tools still dispatched via the legacy `match` arm in
+    /// [`crate::tools::ToolRegistry::execute`]. The caller is expected
+    /// to fall through to the legacy path on `None`.
+    ///
+    /// **Not** the same as [`Self::has_tool`] — a tool can be
+    /// known to the catalog (definition registered) without yet
+    /// being trait-migrated. The two checks converge after the
+    /// cleanup PR removes the legacy dispatch.
+    pub fn get_tool(&self, name: &str) -> Option<&dyn Tool> {
+        self.tools.get(name).map(|boxed| &**boxed as &dyn Tool)
     }
 
     /// Filtered view of all tool definitions (built-ins + MCP).

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -708,6 +708,176 @@ pub async fn list_files(project_root: &Path, args: &Value, max_entries: usize) -
     }
 }
 
+// =============================================================
+// Tool trait implementations (#1265 item 5, PR-4/N).
+//
+// Each struct delegates to the corresponding free function above
+// — the functions stay public because tests in `tests/file_tools_test.rs`
+// call them directly. The structs are the canonical entry point
+// for production dispatch (via `ToolCatalog::get_tool` → `Tool::execute`).
+//
+// Why structs *and* free functions, instead of moving the bodies
+// into the trait impl?
+//
+//   1. Test stability. `tests/file_tools_test.rs` exercises
+//      `file_tools::edit_file` directly with custom fixtures. Moving
+//      the body into a trait method would force test churn for no
+//      win — the existing tests already cover the bodies and
+//      changing them is out of scope for this PR.
+//   2. Optionality. Other code paths (e.g. future scripted
+//      pre/post hooks) may want to call the file-op functions
+//      without going through the trait. Keeping them public costs
+//      nothing.
+//   3. Reviewability. This PR's diff stays focused on "add the
+//      trait seam"; the trait impls are mechanical 4-line forwarders
+//      that any reviewer can read top-to-bottom.
+//
+// `definition()` for each struct re-derives its definition from the
+// existing `definitions()` aggregator — single source of truth, no
+// risk of drift. We `expect()` because the names are compile-time
+// literals that `definitions()` is *required* to contain (an unwrap
+// here would crash on registry construction, which is exactly when
+// you want to find out).
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// Helper for the trait impls below — looks up a definition by
+/// name from the centralized `definitions()` aggregator. Panics if
+/// the name isn't registered, which can only happen if `definitions()`
+/// drifted out of sync with the structs below — a bug worth crashing
+/// the registry's construction over.
+fn def(name: &str) -> ToolDefinition {
+    definitions()
+        .into_iter()
+        .find(|d| d.name == name)
+        .unwrap_or_else(|| panic!("file_tools::definitions() is missing {name:?}"))
+}
+
+/// `Read` — read a file's contents.
+pub struct ReadTool;
+
+#[async_trait]
+impl Tool for ReadTool {
+    fn name(&self) -> &'static str {
+        "Read"
+    }
+    fn definition(&self) -> ToolDefinition {
+        def("Read")
+    }
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+        let r = read_file(ctx.project_root, args, ctx.read_cache, ctx.fs).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// `Write` — create or overwrite a file.
+pub struct WriteTool;
+
+#[async_trait]
+impl Tool for WriteTool {
+    fn name(&self) -> &'static str {
+        "Write"
+    }
+    fn definition(&self) -> ToolDefinition {
+        def("Write")
+    }
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        ToolEffect::LocalMutation
+    }
+    fn extract_undo_path(&self, args: &Value) -> Option<std::path::PathBuf> {
+        extract_file_path_arg(args)
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+        let r = write_file(ctx.project_root, args, ctx.fs).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// `Edit` — in-place find/replace edit on an existing file.
+pub struct EditTool;
+
+#[async_trait]
+impl Tool for EditTool {
+    fn name(&self) -> &'static str {
+        "Edit"
+    }
+    fn definition(&self) -> ToolDefinition {
+        def("Edit")
+    }
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        ToolEffect::LocalMutation
+    }
+    fn extract_undo_path(&self, args: &Value) -> Option<std::path::PathBuf> {
+        extract_file_path_arg(args)
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+        let r = edit_file(ctx.project_root, args, ctx.read_cache, ctx.fs).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// `Delete` — remove a file.
+pub struct DeleteTool;
+
+#[async_trait]
+impl Tool for DeleteTool {
+    fn name(&self) -> &'static str {
+        "Delete"
+    }
+    fn definition(&self) -> ToolDefinition {
+        def("Delete")
+    }
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        // Matches the pre-#1265 `tools::classify_tool` arm — Delete
+        // is irreversible-without-undo, the strictest gating tier.
+        ToolEffect::Destructive
+    }
+    fn extract_undo_path(&self, args: &Value) -> Option<std::path::PathBuf> {
+        extract_file_path_arg(args)
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+        let r = delete_file(ctx.project_root, args).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// `List` — directory listing.
+pub struct ListTool;
+
+#[async_trait]
+impl Tool for ListTool {
+    fn name(&self) -> &'static str {
+        "List"
+    }
+    fn definition(&self) -> ToolDefinition {
+        def("List")
+    }
+    fn classify(&self, _args: &Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &Value) -> ToolResult {
+        let r = list_files(ctx.project_root, args, ctx.caps.list_entries).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// Pull `file_path` (or its `path` alias) out of an args object.
+/// Used by `Write`/`Edit`/`Delete`'s `extract_undo_path` — same
+/// extraction logic that lives in `undo::extract_file_path` today.
+/// In the cleanup PR, `undo::extract_file_path` will delegate here
+/// (or be deleted entirely once all mutating tools have migrated).
+fn extract_file_path_arg(args: &Value) -> Option<std::path::PathBuf> {
+    args.get("file_path")
+        .or_else(|| args.get("path"))
+        .and_then(|v| v.as_str())
+        .map(std::path::PathBuf::from)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1352,5 +1522,217 @@ mod tests {
             .await
             .expect("in-project symlink write must succeed");
         assert_eq!(std::fs::read(&real_file).unwrap(), b"new");
+    }
+
+    // =========================================================
+    // Tool trait invariants (#1265 item 5, PR-4/N).
+    //
+    // These tests live alongside the structs they exercise so any
+    // future contributor adding a file-op tool sees the contract
+    // they need to maintain. They cover four classes of bug the
+    // trait migration is *supposed* to make impossible:
+    //
+    //   1. `name()` and `definition().name` drift apart — breaks
+    //      registry lookup.
+    //   2. `classify()` returns the wrong tier — breaks approval
+    //      gating (this is what the duplicated `is_mutating_tool`
+    //      lists allowed pre-PR).
+    //   3. `extract_undo_path()` returns `None` for a mutating tool
+    //      — breaks `/undo`.
+    //   4. `extract_undo_path()` returns `Some` for a read-only
+    //      tool — wastes snapshot work and pollutes the undo stack.
+    // =========================================================
+
+    /// All five file-op trait impls plus their expected metadata.
+    /// Centralized so the assertions below stay table-driven.
+    fn cohort() -> Vec<(
+        &'static str,
+        Box<dyn crate::tools::Tool>,
+        ToolEffect,
+        bool, // expects an undo path when args carry `file_path`
+    )> {
+        vec![
+            ("Read", Box::new(ReadTool), ToolEffect::ReadOnly, false),
+            (
+                "Write",
+                Box::new(WriteTool),
+                ToolEffect::LocalMutation,
+                true,
+            ),
+            ("Edit", Box::new(EditTool), ToolEffect::LocalMutation, true),
+            (
+                "Delete",
+                Box::new(DeleteTool),
+                ToolEffect::Destructive,
+                true,
+            ),
+            ("List", Box::new(ListTool), ToolEffect::ReadOnly, false),
+        ]
+    }
+
+    #[test]
+    fn name_matches_definition_for_every_file_op() {
+        // Registry lookup is keyed by `name()` and the LLM sees
+        // `definition().name`. Drift = silent dispatch failure.
+        for (expected, tool, _, _) in cohort() {
+            assert_eq!(tool.name(), expected);
+            assert_eq!(tool.definition().name, expected);
+        }
+    }
+
+    #[test]
+    fn classify_matches_pre_migration_tiers() {
+        // Locks the classification each tool was assigned by the
+        // pre-#1265 `tools::classify_tool` arms. Any change here
+        // is a behavior change — must be intentional.
+        for (name, tool, expected, _) in cohort() {
+            assert_eq!(
+                tool.classify(&serde_json::json!({})),
+                expected,
+                "{name} classified incorrectly",
+            );
+        }
+    }
+
+    #[test]
+    fn extract_undo_path_only_for_mutating_tools() {
+        // Mutating cohort returns Some(path); read-only cohort returns
+        // None even when `file_path` is present. Prevents pollution
+        // of the undo stack with read-only operations.
+        let args = serde_json::json!({"file_path": "src/main.rs"});
+        for (name, tool, _, expects_path) in cohort() {
+            let actual = tool.extract_undo_path(&args);
+            assert_eq!(
+                actual.is_some(),
+                expects_path,
+                "{name} undo-path extraction wrong",
+            );
+            if expects_path {
+                assert_eq!(actual, Some(std::path::PathBuf::from("src/main.rs")));
+            }
+        }
+    }
+
+    #[test]
+    fn extract_undo_path_accepts_path_alias() {
+        // The legacy `undo::extract_file_path` accepts both
+        // `file_path` and `path`. Migrated tools must too — some
+        // older test fixtures and a few prompt examples use `path`.
+        let args = serde_json::json!({"path": "lib.rs"});
+        assert_eq!(
+            WriteTool.extract_undo_path(&args),
+            Some(std::path::PathBuf::from("lib.rs")),
+        );
+        assert_eq!(
+            EditTool.extract_undo_path(&args),
+            Some(std::path::PathBuf::from("lib.rs")),
+        );
+        assert_eq!(
+            DeleteTool.extract_undo_path(&args),
+            Some(std::path::PathBuf::from("lib.rs")),
+        );
+    }
+
+    #[test]
+    fn extract_undo_path_handles_missing_args_gracefully() {
+        // No path at all — must return None, not panic. (A common
+        // failure mode of "unwrap because args _should_ have it".)
+        for tool in [
+            Box::new(WriteTool) as Box<dyn Tool>,
+            Box::new(EditTool),
+            Box::new(DeleteTool),
+        ] {
+            assert!(tool.extract_undo_path(&serde_json::json!({})).is_none());
+            // Wrong-typed value — also graceful.
+            assert!(
+                tool.extract_undo_path(&serde_json::json!({"file_path": 42}))
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_dispatch_executes_read() {
+        // End-to-end proof that a migrated tool's full code path
+        // (definition + classification + execution) works through
+        // the trait. Mirrors `dyn_dispatch_executes_correct_tool`
+        // from PR-3's seam tests but on a *real* tool.
+        let tmp = tempfile::tempdir().unwrap();
+        let f = tmp.path().join("x.txt");
+        std::fs::write(&f, "hi").unwrap();
+
+        let cache = cache();
+        let fs = fs();
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = crate::tools::ToolExecCtx {
+            project_root: tmp.path(),
+            read_cache: &cache,
+            fs: &fs,
+            caps: &caps,
+            sink: None,
+            caller_spawner: None,
+        };
+        let tool: Box<dyn Tool> = Box::new(ReadTool);
+        let result = tool
+            .execute(&ctx, &serde_json::json!({"file_path": "x.txt"}))
+            .await;
+        assert!(result.success, "trait dispatch failed: {}", result.output);
+        assert!(result.output.contains("hi"));
+    }
+
+    #[tokio::test]
+    async fn trait_dispatch_executes_write_and_writes_file() {
+        // Verifies `WriteTool::execute` actually mutates the FS —
+        // not just "returns success". The bug class this catches is
+        // a trait impl that delegates to the wrong free function.
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache();
+        let fs = fs();
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = crate::tools::ToolExecCtx {
+            project_root: tmp.path(),
+            read_cache: &cache,
+            fs: &fs,
+            caps: &caps,
+            sink: None,
+            caller_spawner: None,
+        };
+        let tool: Box<dyn Tool> = Box::new(WriteTool);
+        let result = tool
+            .execute(
+                &ctx,
+                &serde_json::json!({"file_path": "new.txt", "content": "abc"}),
+            )
+            .await;
+        assert!(result.success, "{}", result.output);
+        assert_eq!(std::fs::read(tmp.path().join("new.txt")).unwrap(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn trait_dispatch_error_path_returns_failure_result() {
+        // Errors from the underlying free function must land as
+        // `success: false` (the contract `wrap_result` enforces).
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = cache();
+        let fs = fs();
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = crate::tools::ToolExecCtx {
+            project_root: tmp.path(),
+            read_cache: &cache,
+            fs: &fs,
+            caps: &caps,
+            sink: None,
+            caller_spawner: None,
+        };
+        let tool: Box<dyn Tool> = Box::new(ReadTool);
+        let result = tool
+            .execute(&ctx, &serde_json::json!({"file_path": "does-not-exist"}))
+            .await;
+        assert!(!result.success);
+        assert!(
+            result.output.starts_with("Error:"),
+            "error output should be prefixed: {}",
+            result.output
+        );
     }
 }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -245,6 +245,34 @@ pub struct ToolResult {
     pub full_output: Option<String>,
 }
 
+/// Convert a `Result<String>` (the legacy free-function return shape)
+/// into a `ToolResult` with consistent error formatting.
+///
+/// Used by `Tool` trait implementations that delegate to existing free
+/// functions returning `Result<String>` (PR-4..PR-N migrations of
+/// #1265 item 5). The error formatting (`{:#}` walks the anyhow
+/// context chain per #1232 §4) matches the centralized post-match
+/// converter in `ToolRegistry::execute` byte-for-byte — no behavior
+/// drift between migrated and not-yet-migrated tools.
+///
+/// `full_output` is always `None` here; tools that produce truncated
+/// output (currently only `Bash`) populate it themselves by
+/// constructing `ToolResult` directly.
+pub fn wrap_result(r: anyhow::Result<String>) -> ToolResult {
+    match r {
+        Ok(output) => ToolResult {
+            output,
+            success: true,
+            full_output: None,
+        },
+        Err(e) => ToolResult {
+            output: format!("Error: {e:#}"),
+            success: false,
+            full_output: None,
+        },
+    }
+}
+
 /// The tool registry: maps tool names to their definitions and handlers.
 pub struct ToolRegistry {
     project_root: PathBuf,
@@ -577,30 +605,74 @@ impl ToolRegistry {
             arguments.len()
         );
 
-        // Snapshot file before mutation (for /undo)
-        if let Some(file_path) = crate::undo::is_mutating_tool(name)
-            .then(|| crate::undo::extract_file_path(name, &args))
-            .flatten()
-        {
+        // Snapshot file before mutation (for /undo).
+        //
+        // Source-of-truth precedence:
+        //  1. Migrated tools (#1265 item 5, PR-4..PR-N) own their
+        //     undo behavior via `Tool::extract_undo_path` — the
+        //     trait's `None` default means "don't snapshot".
+        //  2. Non-migrated tools fall back to the legacy
+        //     `crate::undo::is_mutating_tool` + `extract_file_path`
+        //     pair. That fallback list is gradually shrinking; the
+        //     cleanup PR after PR-8 removes it entirely.
+        //
+        // Why the trait wins for migrated tools: the legacy list
+        // contains `"Overwrite"` (a tool that doesn't exist) and
+        // would silently miss any new mutating tool that forgot to
+        // update both lists. Routing migrated tools through the
+        // trait fixes that drift class as each cohort migrates.
+        let undo_path = if let Some(tool) = self.catalog.get_tool(name) {
+            tool.extract_undo_path(&args)
+        } else if crate::undo::is_mutating_tool(name) {
+            crate::undo::extract_file_path(name, &args).map(std::path::PathBuf::from)
+        } else {
+            None
+        };
+        if let Some(file_path) = undo_path {
             let resolved = self.project_root.join(&file_path);
             if let Ok(mut undo) = self.undo.lock() {
                 undo.snapshot(&resolved);
             }
         }
 
+        // Trait dispatch for migrated tools (#1265 item 5, PR-4..PR-N).
+        //
+        // Hits this fast path for any tool registered in
+        // `ToolCatalog::tools`; misses fall through to the legacy
+        // `match` below. The branch is taken in `O(1)` (HashMap
+        // lookup) so the cost on the miss path is negligible.
+        //
+        // Post-execution `Write`/`Edit` recording for the
+        // file-tracker stays here — it's a registry-level concern
+        // (it touches `self.last_writer`) and doesn't belong on the
+        // per-tool struct. Same logic the legacy `match result`
+        // block below applies; centralized here so it fires for
+        // both migrated and not-yet-migrated tools.
+        if let Some(tool) = self.catalog.get_tool(name) {
+            let ctx = tool_trait::ToolExecCtx {
+                project_root: &self.project_root,
+                read_cache: &self.read_cache,
+                fs: &*self.fs,
+                caps: &self.caps,
+                sink: None,
+                caller_spawner: None,
+            };
+            let result = tool.execute(&ctx, &args).await;
+            if result.success
+                && matches!(name, "Write" | "Edit")
+                && let Some(path) =
+                    crate::file_tracker::resolve_file_path_from_args(&args, &self.project_root)
+                && let Ok(mut guard) = self.last_writer.lock()
+            {
+                guard.insert(path, (name.to_string(), std::time::Instant::now()));
+            }
+            return result;
+        }
+
         let result = match name {
-            // File tools
-            "Read" => {
-                file_tools::read_file(&self.project_root, &args, &self.read_cache, &*self.fs).await
-            }
-            "Write" => file_tools::write_file(&self.project_root, &args, &*self.fs).await,
-            "Edit" => {
-                file_tools::edit_file(&self.project_root, &args, &self.read_cache, &*self.fs).await
-            }
-            "Delete" => file_tools::delete_file(&self.project_root, &args).await,
-            "List" => {
-                file_tools::list_files(&self.project_root, &args, self.caps.list_entries).await
-            }
+            // File tools — migrated to `Tool` trait in PR-4 of #1265
+            // item 5; dispatched above. The arms below stay only
+            // for tools that haven't migrated yet.
 
             // Search tools
             "Grep" => {

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -144,6 +144,14 @@ pub struct ToolExecCtx<'a> {
     /// registry; tools only ever need a `&dyn` reference.
     pub fs: &'a dyn koda_sandbox::fs::FileSystem,
 
+    /// Output caps — token-budget-derived limits for tool output
+    /// (e.g. `caps.list_entries` for `List`, `caps.grep_matches` for
+    /// `Grep`). Added in PR-4 of #1265 item 5 because `ListTool`
+    /// needs `caps.list_entries`. Future migrations (Grep, Glob,
+    /// Bash, WebFetch) will read other fields off this same handle
+    /// — no need to add separate accessors per tool.
+    pub caps: &'a crate::output_caps::OutputCaps,
+
     /// Optional engine sink + call-id pair for tools that stream
     /// progress events to the UI (e.g. `Bash` shell output,
     /// `TodoWrite` todo updates). `None` means "no streaming
@@ -321,6 +329,14 @@ impl<'a> ToolExecCtx<'a> {
     pub fn fs(&self) -> &dyn koda_sandbox::fs::FileSystem {
         self.fs
     }
+
+    /// Output caps accessor — pure forwarder. Tools that need a
+    /// specific limit (e.g. `caps.list_entries`) read it directly
+    /// off this handle rather than us exposing a getter per limit.
+    #[inline]
+    pub fn caps(&self) -> &crate::output_caps::OutputCaps {
+        self.caps
+    }
 }
 
 #[cfg(test)]
@@ -424,16 +440,20 @@ mod tests {
 
     /// Build a minimal `ToolExecCtx` for tests that don't exercise FS
     /// or sink fields. Uses the production `LocalFileSystem` (cheap
-    /// to construct) and a fresh empty cache.
+    /// to construct) and a fresh empty cache. Caps come from the
+    /// `for_context` helper with a generous budget so List-style
+    /// tools don't accidentally truncate test fixtures.
     fn make_ctx<'a>(
         root: &'a std::path::Path,
         cache: &'a crate::tools::FileReadCache,
         fs: &'a dyn koda_sandbox::fs::FileSystem,
+        caps: &'a crate::output_caps::OutputCaps,
     ) -> ToolExecCtx<'a> {
         ToolExecCtx {
             project_root: root,
             read_cache: cache,
             fs,
+            caps,
             sink: None,
             caller_spawner: None,
         }
@@ -445,7 +465,8 @@ mod tests {
         let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
         let fs = koda_sandbox::fs::LocalFileSystem::new();
         let root = std::path::PathBuf::from("/tmp");
-        let ctx = make_ctx(&root, &cache, &fs);
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = make_ctx(&root, &cache, &fs, &caps);
 
         let args = json!({"hello": "world"});
         let result = tool.execute(&ctx, &args).await;
@@ -530,7 +551,8 @@ mod tests {
         let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
         let fs = koda_sandbox::fs::LocalFileSystem::new();
         let root = std::path::PathBuf::from("/tmp");
-        let ctx = make_ctx(&root, &cache, &fs);
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = make_ctx(&root, &cache, &fs, &caps);
 
         let r1 = tools[0].execute(&ctx, &json!({})).await;
         assert!(r1.success);
@@ -548,7 +570,8 @@ mod tests {
         let cache: crate::tools::FileReadCache = Arc::new(Mutex::new(HashMap::new()));
         let fs = koda_sandbox::fs::LocalFileSystem::new();
         let root = std::path::PathBuf::from("/tmp/whatever");
-        let ctx = make_ctx(&root, &cache, &fs);
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let ctx = make_ctx(&root, &cache, &fs, &caps);
 
         assert_eq!(ctx.project_root(), root.as_path());
         // Cache is a single shared handle — pointer-equality check.


### PR DESCRIPTION
# refactor(core): migrate file-ops cohort onto `Tool` trait (#1265 item 5, PR-4/N)

## Summary

Fourth PR in the **ToolCatalog/Tool** stack from #1265 item 5.
First **real-tool migration**: `Read`, `Write`, `Edit`, `Delete`,
`List` move onto the [`Tool`] trait introduced in PR-3 (#1294).

Their dispatch arms in `ToolRegistry::execute`'s 270-line `match` are
deleted in favor of trait dispatch through `ToolCatalog::get_tool`.
Their undo-snapshot extraction now flows through `Tool::extract_undo_path`
instead of the legacy `crate::undo::is_mutating_tool` /
`extract_file_path` pair (which famously contains a `"Overwrite"` arm
for a tool that doesn't exist — exhibit A for the duplicated-list
bug class this whole stack is unwinding).

## What changed

### `koda-core/src/tools/file_tools.rs` (+382)

Five unit-struct trait impls — `ReadTool`, `WriteTool`, `EditTool`,
`DeleteTool`, `ListTool`. Each delegates to the existing free
function (`read_file`, `write_file`, etc.) which stays public for
the `tests/file_tools_test.rs` integration suite.

Per-tool overrides:

| Tool | `classify` | `extract_undo_path` |
|---|---|---|
| `Read` | `ReadOnly` | (default `None`) |
| `Write` | `LocalMutation` | `file_path`/`path` arg → `PathBuf` |
| `Edit` | `LocalMutation` | `file_path`/`path` arg → `PathBuf` |
| `Delete` | **`Destructive`** ← matches pre-#1265 `classify_tool` | `file_path`/`path` arg → `PathBuf` |
| `List` | `ReadOnly` | (default `None`) |

Each `definition()` reuses `definitions()` via a small `def(name)`
helper — single source of truth, panics on construction if drift is
introduced (the right time to find out).

Plus 9 new tests in a focused `tests` sub-section:

- `name_matches_definition_for_every_file_op` — registry-keying invariant
- `classify_matches_pre_migration_tiers` — locks pre-#1265 behavior
- `extract_undo_path_only_for_mutating_tools` — table-driven
- `extract_undo_path_accepts_path_alias` — `path` works alongside `file_path`
- `extract_undo_path_handles_missing_args_gracefully` — no panics
- `trait_dispatch_executes_read` — end-to-end through `dyn Tool`
- `trait_dispatch_executes_write_and_writes_file` — proves FS mutation
- `trait_dispatch_error_path_returns_failure_result` — `wrap_result` contract

### `koda-core/src/tools/catalog.rs` (+60 / -2)

Adds `tools: HashMap<&'static str, DynTool>` and `get_tool(name) ->
Option<&dyn Tool>`. `new()` registers the 5 file-op tools. The map
is keyed by `&'static str` (every tool name is a string literal
returned from `Tool::name()`) so registration costs zero `String`
allocations.

### `koda-core/src/tools/mod.rs` (+106 / -23)

Two changes to `ToolRegistry::execute`:

1. **Undo-snapshot precedence.** Migrated tools now go through
   `tool.extract_undo_path(&args)`; non-migrated tools fall through
   to the legacy `crate::undo::is_mutating_tool` + `extract_file_path`
   pair. The legacy fallback shrinks PR-by-PR and disappears in the
   cleanup PR. The trait's `None` default for read-only tools means
   no spurious snapshots.

2. **Trait dispatch fast path.** Inserted *above* the legacy `match`:
   `if let Some(tool) = self.catalog.get_tool(name)`, build a
   `ToolExecCtx`, call `tool.execute(&ctx, &args).await`, return
   the result. The existing post-execution `Write`/`Edit`
   `last_writer` recording lives here too (it touches registry
   state, not per-tool state).

Plus a public `wrap_result(Result<String>) -> ToolResult` helper that
mirrors the post-`match` converter byte-for-byte (`{:#}` for anyhow
context chains per #1232 §4) so migrated and non-migrated tools
produce identical error envelopes.

The 5 file-op match arms are now gone. Net `match` shrinkage: ~10 lines.

### `koda-core/src/tools/tool_trait.rs` (+31 / -2)

Adds `pub caps: &'a OutputCaps` to `ToolExecCtx` (needed by
`ListTool::execute` for `caps.list_entries`). `caps()` accessor +
test-fixture builder updated. Three internal test call sites updated
to construct `caps` from `OutputCaps::for_context(100_000)` — a
generous budget so test assertions don't accidentally hit truncation.

This is the first concrete demonstration of the **growth-by-pull**
discipline documented in PR-3: `caps` was added because `ListTool`
needed it, not speculatively.

## Validation

```
$ cargo test --workspace
... TOTAL passed: 2628 failed: 0    (+8 vs PR-3 baseline of 2620)

$ cargo clippy --workspace --all-targets -- -D warnings   (clean)
$ cargo fmt --all                                          (clean)
$ RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps  (clean)
$ python3 scripts/check_tokio_test_flavor.py               (OK)
```

Behavior preservation evidence:

- All 30 pre-existing `tools::file_tools::tests::*` tests still pass
  (they exercise the free functions the trait impls delegate to).
- All `tests/file_tools_test.rs` integration tests still pass.
- The `last_writer` recording for `Write`/`Edit` lives in the
  dispatch path, not the trait, so file-tracker semantics are
  byte-identical pre/post.

## What's still legacy (intentional)

- `tools::classify_tool` still has arms for `Read`/`Write`/`Edit`/
  `Delete`/`List`. Removed in the cleanup PR after all tools migrate.
- `crate::undo::is_mutating_tool` still has its (buggy!) list with
  the phantom `"Overwrite"` arm. Removed in the cleanup PR.
- The legacy `match` in `ToolRegistry::execute` still has arms for
  `Grep`, `Glob`, `Bash`, `WebFetch`, `WebSearch`, `Memory*`,
  `TodoWrite`, `RecallContext`, `ListAgents`, `ListSkills`,
  `ActivateSkill`, `AskUser`, `InvokeAgent`, bg-task tools, MCP
  fallback. Migrated cohort-by-cohort in PR-5..PR-8.

## Diffstat

```
 koda-core/src/tools/catalog.rs    |  60 +++++-
 koda-core/src/tools/file_tools.rs | 382 ++++++++++++++++++++++++++++++++++++++
 koda-core/src/tools/mod.rs        | 106 +++++++++--
 koda-core/src/tools/tool_trait.rs |  31 +++-
 4 files changed, 556 insertions(+), 23 deletions(-)
```

## Stack roadmap

| PR | Status | Scope |
|---|---|---|
| #1292 | ✅ | `ToolCatalog` (read-only metadata) |
| #1293 | ✅ | Migrate read-only test callers |
| #1294 | ✅ | `Tool` trait + `ToolExecCtx` seam |
| **this PR** | 🟡 in CI | **File-ops cohort** (`Read`/`Write`/`Edit`/`Delete`/`List`) |
| PR-5 | 🔵 next | Search cohort (`Grep`, `Glob`) |
| PR-6 | 🔵 | `Bash` (folds `bash_safety::classify_bash_command` into `BashTool::classify(args)`) |
| PR-7 | 🔵 | Misc (`WebFetch`, `WebSearch`, `Memory*`, `TodoWrite`, `RecallContext`) |
| PR-8 | 🔵 | Meta (`ListAgents`, `ListSkills`, `ActivateSkill`, bg-task tools, `AskUser`, `InvokeAgent`) |
| PR-9 | 🔵 cleanup | Delete `tools::classify_tool`, `tools::is_mutating_tool`, `undo::is_mutating_tool` (+ phantom `Overwrite`!), `undo::extract_file_path`, the legacy `match` |

🤖 Authored by `code-puppy-7b4d98`.
