### PR TITLE
refactor(core): migrate misc cohort onto Tool trait (#1265 item 5, PR-7/N)

### DIFF
--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -205,6 +205,13 @@ impl ToolCatalog {
             boxed(glob_tool::GlobTool),
             // PR-6: shell.
             boxed(shell::BashTool),
+            // PR-7: misc cohort.
+            boxed(web_fetch::WebFetchTool),
+            boxed(web_search::WebSearchTool),
+            boxed(memory::MemoryReadTool),
+            boxed(memory::MemoryWriteTool),
+            boxed(todo::TodoWriteTool),
+            boxed(recall::RecallContextTool),
         ] {
             tools.insert(tool.name(), tool);
         }

--- a/koda-core/src/tools/memory.rs
+++ b/koda-core/src/tools/memory.rs
@@ -98,6 +98,69 @@ pub async fn memory_write(project_root: &Path, args: &Value) -> Result<String> {
     }
 }
 
+// =============================================================
+// Tool trait implementations (#1265 item 5, PR-7/N).
+//
+// `MemoryRead` is read-only; `MemoryWrite` is `LocalMutation`. The
+// memory file (`.koda/memory.md`) is its own concern — we don't
+// integrate it into the file-undo stack (matches pre-#1265 behavior).
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `MemoryRead` — return the project memory file contents.
+pub struct MemoryReadTool;
+
+#[async_trait]
+impl Tool for MemoryReadTool {
+    fn name(&self) -> &'static str {
+        "MemoryRead"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "MemoryRead")
+            .expect("memory::definitions() must contain MemoryRead")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, _args: &serde_json::Value) -> ToolResult {
+        let r = memory_read(ctx.project_root).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+/// `MemoryWrite` — append a line to the project memory file.
+pub struct MemoryWriteTool;
+
+#[async_trait]
+impl Tool for MemoryWriteTool {
+    fn name(&self) -> &'static str {
+        "MemoryWrite"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "MemoryWrite")
+            .expect("memory::definitions() must contain MemoryWrite")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::LocalMutation
+    }
+    /// `extract_undo_path` returns `None` because the memory file
+    /// is intentionally outside the file-undo stack — same as
+    /// pre-#1265 (`MemoryWrite` was not in `undo::is_mutating_tool`).
+    fn extract_undo_path(&self, _args: &serde_json::Value) -> Option<std::path::PathBuf> {
+        None
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let r = memory_write(ctx.project_root, args).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -658,6 +658,15 @@ impl ToolRegistry {
             let policy = self.sandbox_policy();
             let proxy_port = self.proxy_port();
             let socks5_port = self.socks5_port();
+            // Snapshot the session pair under one lock-acquisition
+            // each, hold the `Arc<Database>` so the borrow into the
+            // ctx stays valid for the duration of `tool.execute`.
+            let db_arc = self.db.read().ok().and_then(|g| g.clone());
+            let sid_str = self.session_id.read().ok().and_then(|g| g.clone());
+            let session = match (db_arc.as_deref(), sid_str.as_deref()) {
+                (Some(db), Some(sid)) => Some((db, sid)),
+                _ => None,
+            };
             let ctx = tool_trait::ToolExecCtx {
                 project_root: &self.project_root,
                 read_cache: &self.read_cache,
@@ -670,6 +679,7 @@ impl ToolRegistry {
                 sandbox_policy: policy,
                 proxy_port,
                 socks5_port,
+                session,
             };
             let result = tool.execute(&ctx, &args).await;
             // Post-execution registry-level recording. Lives here
@@ -715,41 +725,10 @@ impl ToolRegistry {
             // Shell — migrated in PR-6 (and gets per-call classification
             // via `bash_safety::classify_bash_command`).
 
-            // Web
-            "WebFetch" => web_fetch::web_fetch(&args, self.caps.web_body_chars).await,
-            "WebSearch" => web_search::web_search(&args).await,
-            "TodoWrite" => {
-                let db_opt = self.db.read().ok().and_then(|g| g.clone());
-                let sid_opt = self.session_id.read().ok().and_then(|g| g.clone());
-                match (db_opt, sid_opt) {
-                    (Some(db), Some(sid)) => match todo::todo_write(&db, &sid, &args).await {
-                        Ok(outcome) => {
-                            // #1077 Phase A: surface the transition to
-                            // every client (TUI / ACP / headless) via
-                            // EngineEvent::TodoUpdate. The dedup-nudge
-                            // path returns an empty diff so we suppress
-                            // the event there — unchanged-list writes
-                            // are a no-op for clients, only a reminder
-                            // for the model.
-                            if !outcome.diff.is_empty()
-                                && let Some((sink, _call_id)) = sink_for_streaming
-                            {
-                                sink.emit(crate::engine::EngineEvent::TodoUpdate {
-                                    items: outcome.items.clone(),
-                                    diff: outcome.diff.clone(),
-                                });
-                            }
-                            Ok(outcome.message)
-                        }
-                        Err(e) => Err(e),
-                    },
-                    _ => Ok("TodoWrite requires an active session.".to_string()),
-                }
-            }
-
-            // Memory
-            "MemoryRead" => memory::memory_read(&self.project_root).await,
-            "MemoryWrite" => memory::memory_write(&self.project_root, &args).await,
+            // Web — migrated in PR-7.
+            // TodoWrite — migrated in PR-7 (owns its own TodoUpdate emit).
+            // Memory — migrated in PR-7.
+            // RecallContext — migrated in PR-7.
 
             // Agent tools
             "ListAgents" => {
@@ -778,17 +757,6 @@ impl ToolRegistry {
             // Skill tools
             "ListSkills" => Ok(skill_tools::list_skills(&self.skill_registry, &args)),
             "ActivateSkill" => Ok(skill_tools::activate_skill(&self.skill_registry, &args)),
-
-            // Recall context tool
-            "RecallContext" => {
-                let db_opt = self.db.read().ok().and_then(|g| g.clone());
-                let sid_opt = self.session_id.read().ok().and_then(|g| g.clone());
-                if let (Some(db), Some(sid)) = (db_opt, sid_opt) {
-                    Ok(recall::recall_context(&db, &sid, &args).await)
-                } else {
-                    Ok("RecallContext requires an active session.".to_string())
-                }
-            }
 
             "InvokeAgent" => {
                 // Handled by tool_dispatch.rs before reaching here.

--- a/koda-core/src/tools/recall.rs
+++ b/koda-core/src/tools/recall.rs
@@ -146,11 +146,94 @@ fn extract_snippet(text: &str, query: &str, max_len: usize) -> String {
     }
 }
 
+// =============================================================
+// Tool trait implementation (#1265 item 5, PR-7/N).
+//
+// `RecallContext` is read-only — it queries the session DB for
+// previously-seen full-output content.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `RecallContext` — fetch full-output snippets from session history.
+pub struct RecallContextTool;
+
+#[async_trait]
+impl Tool for RecallContextTool {
+    fn name(&self) -> &'static str {
+        "RecallContext"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definition()
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let Some((db, sid)) = ctx.session else {
+            return ToolResult {
+                output: "RecallContext requires an active session.".to_string(),
+                success: true,
+                full_output: None,
+            };
+        };
+        // recall_context returns a `String` (not Result) — always success.
+        ToolResult {
+            output: recall_context(db, sid, args).await,
+            success: true,
+            full_output: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::persistence::{Persistence, Role};
     use serde_json::json;
+
+    // ── Trait invariants (#1265 PR-7) ─────────────────────────
+
+    /// Pre-#1265 the no-session path returned a successful tool
+    /// result with a self-explanatory message (`Ok("...")`). The
+    /// trait must preserve that exactly — same message, same
+    /// success flag.
+    #[tokio::test]
+    async fn recall_no_session_returns_graceful_message() {
+        let t = RecallContextTool;
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = crate::tools::FileReadCache::default();
+        let fs = koda_sandbox::fs::LocalFileSystem;
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let bg = crate::tools::bg_process::BgRegistry::new();
+        let trust = crate::trust::TrustMode::Safe;
+        let policy = koda_sandbox::SandboxPolicy::default();
+        let ctx = crate::tools::ToolExecCtx::for_test(
+            tmp.path(),
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+        );
+        let r = t.execute(&ctx, &json!({})).await;
+        assert!(r.success);
+        assert_eq!(r.output, "RecallContext requires an active session.");
+    }
+
+    #[test]
+    fn recall_tool_metadata() {
+        let t = RecallContextTool;
+        assert_eq!(t.name(), "RecallContext");
+        assert_eq!(t.definition().name, "RecallContext");
+        assert_eq!(
+            t.classify(&serde_json::json!({})),
+            crate::tools::ToolEffect::ReadOnly,
+        );
+        assert!(t.extract_undo_path(&serde_json::json!({})).is_none());
+    }
 
     #[test]
     fn test_definition() {

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -395,6 +395,85 @@ fn format_todo_list(todos: &[TodoItem]) -> String {
     out
 }
 
+// =============================================================
+// Tool trait implementation (#1265 item 5, PR-7/N).
+//
+// `TodoWrite` is `ReadOnly` from a user-impact perspective: it
+// only mutates Koda's own session-state todo list, not the user's
+// files or shell. Gating it behind approval breaks Plan-mode
+// planning entirely (#1212). Same classification as pre-#1265.
+//
+// Special wrinkle: on success, `TodoWrite` emits an
+// `EngineEvent::TodoUpdate` to the streaming sink so all clients
+// (TUI / ACP / headless) see the transition (#1077 Phase A). We
+// fold that emit *into* the trait's `execute`, so the registry's
+// dispatch fast path doesn't need a `name == "TodoWrite"` arm —
+// the trait owns its own side-effect plumbing.
+//
+// Empty-diff writes (the dedup-nudge path) suppress the event by
+// design — unchanged-list writes are a no-op for clients, only a
+// reminder for the model.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `TodoWrite` — update the session-state todo list.
+pub struct TodoWriteTool;
+
+#[async_trait]
+impl Tool for TodoWriteTool {
+    fn name(&self) -> &'static str {
+        "TodoWrite"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "TodoWrite")
+            .expect("todo::definitions() must contain TodoWrite")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        // ReadOnly because it only mutates Koda's own state.
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let Some((db, sid)) = ctx.session else {
+            // Pre-#1265 dispatch returned `Ok("requires an active session.")`
+            // — a successful tool result with a self-explanatory message.
+            // Behavior preserved exactly.
+            return ToolResult {
+                output: "TodoWrite requires an active session.".to_string(),
+                success: true,
+                full_output: None,
+            };
+        };
+        match todo_write(db, sid, args).await {
+            Ok(outcome) => {
+                // #1077 Phase A: surface the transition unless the
+                // diff is empty (dedup-nudge path).
+                if !outcome.diff.is_empty()
+                    && let Some((sink, _call_id)) = ctx.sink
+                {
+                    sink.emit(crate::engine::EngineEvent::TodoUpdate {
+                        items: outcome.items.clone(),
+                        diff: outcome.diff.clone(),
+                    });
+                }
+                ToolResult {
+                    output: outcome.message,
+                    success: true,
+                    full_output: None,
+                }
+            }
+            Err(e) => ToolResult {
+                output: format!("Error: {e:#}"),
+                success: false,
+                full_output: None,
+            },
+        }
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -402,6 +481,44 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::TempDir;
+
+    // ── Trait invariants (#1265 PR-7) ─────────────────────────
+
+    #[test]
+    fn todo_tool_metadata() {
+        let t = TodoWriteTool;
+        assert_eq!(t.name(), "TodoWrite");
+        assert_eq!(t.definition().name, "TodoWrite");
+        // ReadOnly: only mutates Koda's own state (#1212).
+        assert_eq!(t.classify(&json!({})), crate::tools::ToolEffect::ReadOnly,);
+        assert!(t.extract_undo_path(&json!({})).is_none());
+    }
+
+    /// No-session path returns a graceful Ok message (preserves
+    /// pre-#1265 behavior exactly).
+    #[tokio::test]
+    async fn todo_no_session_returns_graceful_message() {
+        let t = TodoWriteTool;
+        let tmp = TempDir::new().unwrap();
+        let cache = crate::tools::FileReadCache::default();
+        let fs = koda_sandbox::fs::LocalFileSystem;
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let bg = crate::tools::bg_process::BgRegistry::new();
+        let trust = crate::trust::TrustMode::Safe;
+        let policy = koda_sandbox::SandboxPolicy::default();
+        let ctx = crate::tools::ToolExecCtx::for_test(
+            tmp.path(),
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+        );
+        let r = t.execute(&ctx, &json!({"todos": []})).await;
+        assert!(r.success);
+        assert_eq!(r.output, "TodoWrite requires an active session.");
+    }
 
     async fn test_db() -> (Database, TempDir, String) {
         let dir = TempDir::new().unwrap();

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -204,6 +204,19 @@ pub struct ToolExecCtx<'a> {
 
     /// SOCKS5 proxy port. Same shape and consumers as `proxy_port`.
     pub socks5_port: Option<u16>,
+
+    /// Optional session handle — (`Database`, `session_id`) pair for
+    /// tools that read/write per-session state. `None` means "no
+    /// active session" — tools that need it should return a
+    /// graceful 'requires an active session' message in that case.
+    ///
+    /// Added in PR-7 of #1265 item 5 because `TodoWrite`,
+    /// `RecallContext` (and the bg-task tools, in PR-8) all need
+    /// the session pair. Pre-#1265 the dispatch arms snapshotted
+    /// these from `RwLock`s on the registry; the fast path now
+    /// does the same snapshot once and threads borrows through
+    /// the context.
+    pub session: Option<(&'a crate::db::Database, &'a str)>,
 }
 
 /// A self-contained built-in tool.
@@ -417,6 +430,7 @@ impl<'a> ToolExecCtx<'a> {
             sandbox_policy,
             proxy_port: None,
             socks5_port: None,
+            session: None,
         }
     }
 }
@@ -546,6 +560,7 @@ mod tests {
             sandbox_policy: policy,
             proxy_port: None,
             socks5_port: None,
+            session: None,
         }
     }
 

--- a/koda-core/src/tools/web_fetch.rs
+++ b/koda-core/src/tools/web_fetch.rs
@@ -443,6 +443,39 @@ fn strip_html(html: &str) -> String {
         .replace("&nbsp;", " ")
 }
 
+// =============================================================
+// Tool trait implementation (#1265 item 5, PR-7/N).
+//
+// `WebFetch` is read-only — GET-only fetch, no undo, no mutation.
+// Reads `caps.web_body_chars` off the context.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `WebFetch` — GET a URL and return body (HTML to plain text).
+pub struct WebFetchTool;
+
+#[async_trait]
+impl Tool for WebFetchTool {
+    fn name(&self) -> &'static str {
+        "WebFetch"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "WebFetch")
+            .expect("web_fetch::definitions() must contain WebFetch")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let r = web_fetch(args, ctx.caps.web_body_chars).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-core/src/tools/web_search.rs
+++ b/koda-core/src/tools/web_search.rs
@@ -258,7 +258,39 @@ fn percent_decode(s: &str) -> String {
     out
 }
 
-// ── Tests ──────────────────────────────────────────────────────────────────
+// =============================================================
+// Tool trait implementation (#1265 item 5, PR-7/N).
+//
+// `WebSearch` is read-only — search results are pure reads.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `WebSearch` — query a search engine and return results.
+pub struct WebSearchTool;
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn name(&self) -> &'static str {
+        "WebSearch"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "WebSearch")
+            .expect("web_search::definitions() must contain WebSearch")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, _ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let r = web_search(args).await;
+        crate::tools::wrap_result(r)
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# refactor(core): migrate misc cohort onto `Tool` trait (#1265 item 5, PR-7/N)

## Summary

Seventh PR in the **ToolCatalog/Tool** stack. Migrates the **misc
cohort** (6 tools): `WebFetch`, `WebSearch`, `MemoryRead`,
`MemoryWrite`, `TodoWrite`, `RecallContext`.

This is the cohort with the most variety — three different effect
classes, two different "session-required" tools, and one tool
(`TodoWrite`) that emits a side event (`EngineEvent::TodoUpdate`)
on success. The PR ends with **only `Agent`/`Skill`/bg-task tools
left** for PR-8.

## What changed

### `koda-core/src/tools/web_fetch.rs` (+33)

`WebFetchTool` — `ReadOnly`, no undo, reads `caps.web_body_chars`
off ctx. Pure forwarder.

### `koda-core/src/tools/web_search.rs` (+34 / -1)

`WebSearchTool` — `ReadOnly`, no undo, no ctx state. Pure forwarder.

### `koda-core/src/tools/memory.rs` (+63)

Two structs:
- `MemoryReadTool` — `ReadOnly`.
- `MemoryWriteTool` — `LocalMutation`. `extract_undo_path` returns
  `None` because `.koda/memory.md` is intentionally outside the
  file-undo stack (matches pre-#1265: `MemoryWrite` was not in
  `undo::is_mutating_tool`).

### `koda-core/src/tools/todo.rs` (+117)

`TodoWriteTool` — `ReadOnly` (only mutates Koda's own session
state; gating it breaks Plan-mode planning per #1212).

**Headline:** the `EngineEvent::TodoUpdate` emit (#1077 Phase A) is
now folded *into* the trait's `execute`, so the registry's dispatch
fast path doesn't need a `name == "TodoWrite"` arm — the trait owns
its own side-effect plumbing. Empty-diff writes (the dedup-nudge
path) still suppress the event by design.

No-session path returns `Ok("TodoWrite requires an active session.")`
— preserves pre-#1265 behavior **byte-for-byte**.

2 trait tests:
- `todo_tool_metadata`
- `todo_no_session_returns_graceful_message`

### `koda-core/src/tools/recall.rs` (+83)

`RecallContextTool` — `ReadOnly`. `recall_context` returns a `String`
(not `Result`), so `execute` builds the `ToolResult` directly. Same
graceful no-session message as `TodoWrite`.

2 trait tests:
- `recall_tool_metadata`
- `recall_no_session_returns_graceful_message`

### `koda-core/src/tools/tool_trait.rs` (+15)

One new field on `ToolExecCtx`:

```rust
pub session: Option<(&'a Database, &'a str)>,
```

Used by `TodoWrite`, `RecallContext` (and the bg-task tools coming
in PR-8). Pre-#1265 the dispatch arms each snapshotted db+sid from
`RwLock`s on the registry; the fast path now does the snapshot
**once** and threads borrows through ctx. Less code, single
acquisition point.

### `koda-core/src/tools/mod.rs` (+13 / -47)

- Fast path snapshots `db` + `session_id` once and constructs
  `session: Option<(&Database, &str)>` for ctx.
- Six match arms deleted (WebFetch, WebSearch, TodoWrite, MemoryRead,
  MemoryWrite, RecallContext).
- Net -34 LOC in the dispatcher.

### `koda-core/src/tools/catalog.rs` (+7)

Six `boxed(...)` registrations.

## Validation

```
$ cargo test --workspace
... TOTAL passed: 2639 failed: 0   (+4 vs PR-6 baseline of 2635)

$ cargo clippy --workspace --all-targets -- -D warnings   (clean)
$ cargo fmt --all                                          (clean)
$ RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps  (clean)
```

## Stack progress

**14 of 18 tools on the trait:** Read, Write, Edit, Delete, List,
Grep, Glob, Bash, **WebFetch, WebSearch, MemoryRead, MemoryWrite,
TodoWrite, RecallContext**.

Remaining for **PR-8 (Meta)**: ListAgents, ListSkills, ActivateSkill,
AskUser, InvokeAgent, bg-task tools (ListBackgroundTasks,
GetBackgroundTaskOutput, CancelBackgroundTask,
WaitForBackgroundTask).

PR-9 cleanup: delete `tools::classify_tool`, `tools::is_mutating_tool`,
the legacy `match`, `undo::is_mutating_tool` (with phantom `"Overwrite"`),
`undo::extract_file_path`.

## Diffstat

```
 koda-core/src/tools/catalog.rs    |   7 +++
 koda-core/src/tools/memory.rs     |  63 ++++++++++++++++++++
 koda-core/src/tools/mod.rs        |  60 +++++--------------
 koda-core/src/tools/recall.rs     |  83 +++++++++++++++++++++++++++
 koda-core/src/tools/todo.rs       | 117 ++++++++++++++++++++++++++++++++++++++
 koda-core/src/tools/tool_trait.rs |  15 +++++
 koda-core/src/tools/web_fetch.rs  |  33 +++++++++++
 koda-core/src/tools/web_search.rs |  34 ++++++++++-
 8 files changed, 365 insertions(+), 47 deletions(-)
```

> **Note:** based on PR #1297 (PR-6/Bash). Will rebase to `main`
> automatically once PR-6 lands.

🤖 Authored by `code-puppy-7b4d98`.
