### PR TITLE
refactor(core): migrate meta cohort + collapse legacy dispatcher (#1265 item 5, PR-8/N)

### DIFF
--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -342,9 +342,148 @@ fn capitalize_first(s: &str) -> String {
     }
 }
 
+// =============================================================
+// Tool trait implementations (#1265 item 5, PR-8/N).
+//
+// `ListAgents` is read-only (it scans the agents directory).
+//
+// `InvokeAgent` is **special** — it's intercepted by
+// `tool_dispatch.rs` before reaching the registry, because it needs
+// to spawn a sub-agent (which the registry can't do). The trait
+// impl below preserves the pre-#1265 "this branch should not be
+// reached in normal flow" failure path: the dispatch fast path
+// will only ever invoke this if something has gone seriously
+// wrong upstream.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `ListAgents` — enumerate sub-agents from project + user dirs.
+pub struct ListAgentsTool;
+
+#[async_trait]
+impl Tool for ListAgentsTool {
+    fn name(&self) -> &'static str {
+        "ListAgents"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "ListAgents")
+            .expect("agent::definitions() must contain ListAgents")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        let detail = args["detail"].as_bool().unwrap_or(false);
+        let output = if detail {
+            list_agents_detail(ctx.project_root)
+        } else {
+            let agents = list_agents(ctx.project_root);
+            if agents.is_empty() {
+                "No sub-agents configured.".to_string()
+            } else {
+                agents
+                    .iter()
+                    .map(|(name, desc, source)| {
+                        if source == "built-in" {
+                            format!("  {name} \u{2014} {desc}")
+                        } else {
+                            format!("  {name} \u{2014} {desc} [{source}]")
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        };
+        ToolResult {
+            output,
+            success: true,
+            full_output: None,
+        }
+    }
+}
+
+/// `InvokeAgent` — intercepted by `tool_dispatch.rs`. This trait
+/// impl exists only to make the catalog complete; it preserves the
+/// pre-#1265 "this branch should not be reached in normal flow"
+/// behavior (success=false with a self-explanatory message).
+pub struct InvokeAgentTool;
+
+#[async_trait]
+impl Tool for InvokeAgentTool {
+    fn name(&self) -> &'static str {
+        "InvokeAgent"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "InvokeAgent")
+            .expect("agent::definitions() must contain InvokeAgent")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        // Sub-agents inherit the parent's approval mode; classification
+        // here is a placeholder — dispatch never asks.
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, _ctx: &ToolExecCtx<'_>, _args: &serde_json::Value) -> ToolResult {
+        ToolResult {
+            output: "InvokeAgent is handled by the inference loop.".to_string(),
+            success: false,
+            full_output: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Trait invariants (#1265 PR-8) ─────────────────────────
+
+    #[test]
+    fn list_agents_tool_metadata() {
+        let t = ListAgentsTool;
+        assert_eq!(t.name(), "ListAgents");
+        assert_eq!(t.definition().name, "ListAgents");
+        assert_eq!(
+            t.classify(&serde_json::json!({})),
+            crate::tools::ToolEffect::ReadOnly,
+        );
+    }
+
+    /// `InvokeAgent` is intercepted upstream of the registry.
+    /// If dispatch ever falls through to the trait impl, it must
+    /// preserve the pre-#1265 "should not be reached" failure path:
+    /// success=false with the same message verbatim.
+    #[tokio::test]
+    async fn invoke_agent_unreached_path_returns_failure() {
+        let t = InvokeAgentTool;
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = crate::tools::FileReadCache::default();
+        let fs = koda_sandbox::fs::LocalFileSystem;
+        let caps = crate::output_caps::OutputCaps::for_context(100_000);
+        let bg = crate::tools::bg_process::BgRegistry::new();
+        let trust = crate::trust::TrustMode::Safe;
+        let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
+        let ctx = crate::tools::ToolExecCtx::for_test(
+            tmp.path(),
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+        );
+        let r = t.execute(&ctx, &serde_json::json!({})).await;
+        assert!(!r.success);
+        assert_eq!(r.output, "InvokeAgent is handled by the inference loop.");
+    }
+
     use tempfile::TempDir;
 
     #[test]

--- a/koda-core/src/tools/ask_user.rs
+++ b/koda-core/src/tools/ask_user.rs
@@ -52,6 +52,46 @@ pub fn definitions() -> Vec<ToolDefinition> {
     }]
 }
 
+// =============================================================
+// Tool trait implementation (#1265 item 5, PR-8/N).
+//
+// `AskUser` is **special** — it's intercepted by
+// `execute_tools_sequential` (which has the sink + cmd_rx needed
+// to wait on user input). The trait impl below preserves the
+// pre-#1265 "this branch should not be reached in normal flow"
+// failure path: the dispatch fast path will only ever invoke this
+// if something has gone wrong upstream. Same shape as `InvokeAgent`.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `AskUser` — prompt the user for input mid-conversation.
+pub struct AskUserTool;
+
+#[async_trait]
+impl Tool for AskUserTool {
+    fn name(&self) -> &'static str {
+        "AskUser"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "AskUser")
+            .expect("ask_user::definitions() must contain AskUser")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, _ctx: &ToolExecCtx<'_>, _args: &serde_json::Value) -> ToolResult {
+        ToolResult {
+            output: "AskUser is handled by the inference loop.".to_string(),
+            success: false,
+            full_output: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -212,6 +212,15 @@ impl ToolCatalog {
             boxed(memory::MemoryWriteTool),
             boxed(todo::TodoWriteTool),
             boxed(recall::RecallContextTool),
+            // PR-8: meta cohort. `InvokeAgent` and `AskUser` are
+            // intercepted upstream of the registry; their trait
+            // impls preserve the pre-#1265 "should not be reached"
+            // failure path so the catalog stays complete.
+            boxed(agent::ListAgentsTool),
+            boxed(agent::InvokeAgentTool),
+            boxed(skill_tools::ListSkillsTool),
+            boxed(skill_tools::ActivateSkillTool),
+            boxed(ask_user::AskUserTool),
         ] {
             tools.insert(tool.name(), tool);
         }

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -1667,6 +1667,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1675,6 +1676,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let tool: Box<dyn Tool> = Box::new(ReadTool);
         let result = tool
@@ -1696,6 +1698,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1704,6 +1707,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let tool: Box<dyn Tool> = Box::new(WriteTool);
         let result = tool
@@ -1727,6 +1731,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1735,6 +1740,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let tool: Box<dyn Tool> = Box::new(ReadTool);
         let result = tool

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -253,6 +253,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -261,6 +262,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let tool: Box<dyn Tool> = Box::new(GlobTool);
         let result = tool

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -388,6 +388,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -396,6 +397,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let tool: Box<dyn Tool> = Box::new(GrepTool);
         let result = tool

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -680,6 +680,7 @@ impl ToolRegistry {
                 proxy_port,
                 socks5_port,
                 session,
+                skill_registry: &self.skill_registry,
             };
             let result = tool.execute(&ctx, &args).await;
             // Post-execution registry-level recording. Lives here
@@ -715,146 +716,72 @@ impl ToolRegistry {
             return result;
         }
 
-        let result = match name {
-            // File tools — migrated to `Tool` trait in PR-4 of #1265
-            // item 5; dispatched above. The arms below stay only
-            // for tools that haven't migrated yet.
+        // ----------------------------------------------------------
+        // Fall-through: every built-in tool is now on the `Tool`
+        // trait (PR-4 through PR-8 of #1265 item 5). The only paths
+        // that reach here are MCP tool dispatch (`server__tool`
+        // names) and the unknown-tool error reporter.
+        //
+        // Pre-#1265 the `match name { ... }` had ~16 arms ending in
+        // a giant post-processing `match result { Ok|Err => ... }`
+        // block that recorded Write/Edit timestamps and wrapped
+        // results. All of that is now dead code (the trait fast
+        // path above handles Write/Edit/Bash recording, and the
+        // legacy fall-through never produces a path-tagged Ok
+        // anymore). PR-9 cleanup deleted it.
+        // ----------------------------------------------------------
 
-            // Search tools — migrated in PR-5.
-
-            // Shell — migrated in PR-6 (and gets per-call classification
-            // via `bash_safety::classify_bash_command`).
-
-            // Web — migrated in PR-7.
-            // TodoWrite — migrated in PR-7 (owns its own TodoUpdate emit).
-            // Memory — migrated in PR-7.
-            // RecallContext — migrated in PR-7.
-
-            // Agent tools
-            "ListAgents" => {
-                let detail = args["detail"].as_bool().unwrap_or(false);
-                if detail {
-                    Ok(agent::list_agents_detail(&self.project_root))
-                } else {
-                    let agents = agent::list_agents(&self.project_root);
-                    if agents.is_empty() {
-                        Ok("No sub-agents configured.".to_string())
-                    } else {
-                        let lines: Vec<String> = agents
-                            .iter()
-                            .map(|(name, desc, source)| {
-                                if source == "built-in" {
-                                    format!("  {name} — {desc}")
-                                } else {
-                                    format!("  {name} — {desc} [{source}]")
-                                }
-                            })
-                            .collect();
-                        Ok(lines.join("\n"))
-                    }
-                }
-            }
-            // Skill tools
-            "ListSkills" => Ok(skill_tools::list_skills(&self.skill_registry, &args)),
-            "ActivateSkill" => Ok(skill_tools::activate_skill(&self.skill_registry, &args)),
-
-            "InvokeAgent" => {
-                // Handled by tool_dispatch.rs before reaching here.
-                // This branch should not be reached in normal flow.
-                return ToolResult {
-                    output: "InvokeAgent is handled by the inference loop.".to_string(),
-                    success: false,
-                    full_output: None,
+        // MCP tool dispatch (#662): route `server__tool` calls to
+        // the appropriate MCP server.
+        if crate::mcp::is_mcp_tool_name(name) {
+            if let Some(mgr) = self.mcp_manager() {
+                let result = {
+                    let mgr = mgr.read().await;
+                    mgr.call_tool(name, args.clone()).await
                 };
-            }
-
-            "AskUser" => {
-                // Handled by execute_tools_sequential (needs sink + cmd_rx).
-                // This branch should not be reached in normal flow.
-                return ToolResult {
-                    output: "AskUser is handled by the inference loop.".to_string(),
-                    success: false,
-                    full_output: None,
-                };
-            }
-
-            other => {
-                // MCP tool dispatch (#662): route `server__tool` calls
-                // to the appropriate MCP server.
-                if crate::mcp::is_mcp_tool_name(other) {
-                    if let Some(mgr) = self.mcp_manager() {
-                        let result = {
-                            let mgr = mgr.read().await;
-                            mgr.call_tool(other, args.clone()).await
-                        };
-                        return match result {
-                            Ok(output) => ToolResult {
-                                output,
-                                success: true,
-                                full_output: None,
-                            },
-                            Err(e) => ToolResult {
-                                // #1232 §4: `{:#}` walks the anyhow context chain so the
-                                // model sees the full cause, not just the topmost label.
-                                output: format!("Error: {e:#}"),
-                                success: false,
-                                full_output: None,
-                            },
-                        };
-                    }
-                    return ToolResult {
-                        output: format!(
-                            "MCP tool '{other}' not available — \
-                             no MCP servers connected."
-                        ),
+                return match result {
+                    Ok(output) => ToolResult {
+                        output,
+                        success: true,
+                        full_output: None,
+                    },
+                    Err(e) => ToolResult {
+                        // #1232 §4: `{:#}` walks the anyhow context
+                        // chain so the model sees the full cause.
+                        output: format!("Error: {e:#}"),
                         success: false,
                         full_output: None,
-                    };
-                }
-
-                // Detect garbled tool names (JSON blobs, very long strings)
-                // — a sign the model can't do structured tool calling.
-                let warning = if other.contains('{') || other.len() > 64 {
-                    format!(
-                        "Unknown tool: {other}. \
-                         This model appears to struggle with tool calling. \
-                         Consider switching to a model with native function-call support."
-                    )
-                } else {
-                    format!("Unknown tool: {other}")
+                    },
                 };
-                Err(anyhow::anyhow!(warning))
             }
-        };
-
-        match result {
-            Ok(output) => {
-                // Record successful Write/Edit so the validation layer can
-                // name the responsible tool in staleness error messages.
-                if matches!(name, "Write" | "Edit")
-                    && let Some(path) =
-                        crate::file_tracker::resolve_file_path_from_args(&args, &self.project_root)
-                    && let Ok(mut guard) = self.last_writer.lock()
-                {
-                    guard.insert(path, (name.to_string(), std::time::Instant::now()));
-                }
-                ToolResult {
-                    output,
-                    success: true,
-                    full_output: None,
-                }
-            }
-            Err(e) => ToolResult {
-                // #1232 §4: `{:#}` walks the anyhow context chain so the
-                // model sees the full cause, not just the topmost label.
-                output: format!("Error: {e:#}"),
+            return ToolResult {
+                output: format!(
+                    "MCP tool '{name}' not available \u{2014} \
+                     no MCP servers connected."
+                ),
                 success: false,
                 full_output: None,
-            },
+            };
+        }
+
+        // Detect garbled tool names (JSON blobs, very long strings)
+        // — a sign the model can't do structured tool calling.
+        let warning = if name.contains('{') || name.len() > 64 {
+            format!(
+                "Unknown tool: {name}. \
+                 This model appears to struggle with tool calling. \
+                 Consider switching to a model with native function-call support."
+            )
+        } else {
+            format!("Unknown tool: {name}")
+        };
+        ToolResult {
+            output: format!("Error: {warning}"),
+            success: false,
+            full_output: None,
         }
     }
 }
-
 /// Validate and resolve a path, preventing directory traversal.
 ///
 /// Works for both existing and non-existing files (no `canonicalize!`).

--- a/koda-core/src/tools/recall.rs
+++ b/koda-core/src/tools/recall.rs
@@ -209,6 +209,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -217,6 +218,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let r = t.execute(&ctx, &json!({})).await;
         assert!(r.success);

--- a/koda-core/src/tools/skill_tools.rs
+++ b/koda-core/src/tools/skill_tools.rs
@@ -145,6 +145,69 @@ pub fn activate_skill(registry: &SkillRegistry, args: &serde_json::Value) -> Str
     }
 }
 
+// =============================================================
+// Tool trait implementations (#1265 item 5, PR-8/N).
+//
+// Both tools are read-only; both read the `SkillRegistry` off the
+// context (added in PR-8). Pre-#1265 they were thin wrappers in
+// the dispatch match arm; now they're a proper pair of structs.
+// =============================================================
+
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+
+/// `ListSkills` — enumerate available skills (built-in + user + project).
+pub struct ListSkillsTool;
+
+#[async_trait]
+impl Tool for ListSkillsTool {
+    fn name(&self) -> &'static str {
+        "ListSkills"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "ListSkills")
+            .expect("skill_tools::definitions() must contain ListSkills")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        ToolResult {
+            output: list_skills(ctx.skill_registry, args),
+            success: true,
+            full_output: None,
+        }
+    }
+}
+
+/// `ActivateSkill` — load a skill's full SKILL.md content.
+pub struct ActivateSkillTool;
+
+#[async_trait]
+impl Tool for ActivateSkillTool {
+    fn name(&self) -> &'static str {
+        "ActivateSkill"
+    }
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .find(|d| d.name == "ActivateSkill")
+            .expect("skill_tools::definitions() must contain ActivateSkill")
+    }
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        ToolEffect::ReadOnly
+    }
+    async fn execute(&self, ctx: &ToolExecCtx<'_>, args: &serde_json::Value) -> ToolResult {
+        ToolResult {
+            output: activate_skill(ctx.skill_registry, args),
+            success: true,
+            full_output: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -506,6 +506,7 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
+        let skills = crate::skills::SkillRegistry::default();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -514,6 +515,7 @@ mod tests {
             &bg,
             &trust,
             &policy,
+            &skills,
         );
         let r = t.execute(&ctx, &json!({"todos": []})).await;
         assert!(r.success);

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -217,6 +217,10 @@ pub struct ToolExecCtx<'a> {
     /// does the same snapshot once and threads borrows through
     /// the context.
     pub session: Option<(&'a crate::db::Database, &'a str)>,
+
+    /// Skill registry for `ListSkills` / `ActivateSkill`. Other
+    /// tools ignore this. Added in PR-8 of #1265 item 5.
+    pub skill_registry: &'a crate::skills::SkillRegistry,
 }
 
 /// A self-contained built-in tool.
@@ -409,6 +413,7 @@ impl<'a> ToolExecCtx<'a> {
     /// safely defaulted, this constructor stops compiling and the
     /// test author has to think about the field. Good failure mode.
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)] // test fixture, all args are borrows
     pub(crate) fn for_test(
         project_root: &'a std::path::Path,
         read_cache: &'a crate::tools::FileReadCache,
@@ -417,6 +422,7 @@ impl<'a> ToolExecCtx<'a> {
         bg_registry: &'a crate::tools::bg_process::BgRegistry,
         trust: &'a crate::trust::TrustMode,
         sandbox_policy: &'a koda_sandbox::SandboxPolicy,
+        skill_registry: &'a crate::skills::SkillRegistry,
     ) -> Self {
         Self {
             project_root,
@@ -431,6 +437,7 @@ impl<'a> ToolExecCtx<'a> {
             proxy_port: None,
             socks5_port: None,
             session: None,
+            skill_registry,
         }
     }
 }
@@ -446,6 +453,7 @@ mod tests {
     //! `ReadTool`/`WriteTool`/etc. structs they exercise.
 
     use super::*;
+    use crate::skills::SkillRegistry;
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -539,6 +547,7 @@ mod tests {
     /// to construct) and a fresh empty cache. Caps come from the
     /// `for_context` helper with a generous budget so List-style
     /// tools don't accidentally truncate test fixtures.
+    #[allow(clippy::too_many_arguments)] // test helper, all args are borrows
     fn make_ctx<'a>(
         root: &'a std::path::Path,
         cache: &'a crate::tools::FileReadCache,
@@ -547,6 +556,7 @@ mod tests {
         bg: &'a crate::tools::bg_process::BgRegistry,
         trust: &'a crate::trust::TrustMode,
         policy: &'a koda_sandbox::SandboxPolicy,
+        skills: &'a SkillRegistry,
     ) -> ToolExecCtx<'a> {
         ToolExecCtx {
             project_root: root,
@@ -561,6 +571,7 @@ mod tests {
             proxy_port: None,
             socks5_port: None,
             session: None,
+            skill_registry: skills,
         }
     }
 
@@ -574,7 +585,8 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy);
+        let skills = crate::skills::SkillRegistry::default();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
 
         let args = json!({"hello": "world"});
         let result = tool.execute(&ctx, &args).await;
@@ -663,7 +675,8 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy);
+        let skills = crate::skills::SkillRegistry::default();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
 
         let r1 = tools[0].execute(&ctx, &json!({})).await;
         assert!(r1.success);
@@ -685,7 +698,8 @@ mod tests {
         let bg = crate::tools::bg_process::BgRegistry::new();
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy);
+        let skills = crate::skills::SkillRegistry::default();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
 
         assert_eq!(ctx.project_root(), root.as_path());
         // Cache is a single shared handle — pointer-equality check.


### PR DESCRIPTION
# refactor(core): migrate meta cohort + collapse legacy dispatcher (#1265 item 5, PR-8/N)

## Summary

**Final** PR in the **ToolCatalog/Tool** stack. Migrates the meta
cohort (5 tools): `ListAgents`, `InvokeAgent`, `ListSkills`,
`ActivateSkill`, `AskUser`. Collapses the now-dead legacy `match
name { ... }` dispatcher into a clean MCP+unknown fall-through.

After this PR, **18 of 18 built-in tools are on the `Tool` trait**.

## What changed

### `koda-core/src/tools/agent.rs` (+139)

- `ListAgentsTool` — `ReadOnly`, reads `ctx.project_root`. Real
  delegating impl.
- `InvokeAgentTool` — **placeholder** trait impl that preserves
  the pre-#1265 "should not be reached in normal flow" failure
  path: `success=false` with the exact same message verbatim
  (`"InvokeAgent is handled by the inference loop."`). The real
  invocation happens in `tool_dispatch.rs` upstream of the registry.
  This preserves dispatch completeness — if anything ever falls
  through, the user gets the same unambiguous error as before.

2 new trait tests:
- `list_agents_tool_metadata`
- `invoke_agent_unreached_path_returns_failure` — proves the
  failure path is byte-identical to pre-#1265.

### `koda-core/src/tools/skill_tools.rs` (+63)

- `ListSkillsTool` — `ReadOnly`, reads `ctx.skill_registry`.
- `ActivateSkillTool` — `ReadOnly`, reads `ctx.skill_registry`.

Both delegate to the existing pure functions (`list_skills`,
`activate_skill`).

### `koda-core/src/tools/ask_user.rs` (+40)

- `AskUserTool` — placeholder trait impl, same shape as
  `InvokeAgentTool`. Real handling lives in
  `execute_tools_sequential` (which has the sink + `cmd_rx`).

### `koda-core/src/tools/tool_trait.rs` (+15 / -3)

One new field on `ToolExecCtx`:

```rust
pub skill_registry: &'a SkillRegistry,
```

Pulled in by `ListSkills` + `ActivateSkill`. Also extended the
test-only `for_test(...)` constructor to take a `&SkillRegistry`,
and `#[allow(clippy::too_many_arguments)]` on it (test fixture,
all args are borrows; bundling them would just push the noise
elsewhere).

### `koda-core/src/tools/mod.rs` (+57 / -127)

**Headline cleanup.** The legacy `match name { ... }` collapsed
from 5 arms (post-PR-7) to **zero arms** — only the `other =>`
fall-through remained, so the entire `match` was a `let` in
disguise (clippy caught it).

Replaced the whole `let result = match name { ... }; match result
{ Ok|Err => ... }` block with a flat MCP+unknown handler:

- MCP tool dispatch (`server__tool` names) — unchanged behavior.
- Unknown-tool reporter — unchanged behavior, now builds
  `ToolResult` directly instead of round-tripping through `Err`.

Also deleted dead post-processing code: the `if matches!(name,
"Write" | "Edit") { ...record last_writer... }` block in the
post-`match` was unreachable because Write/Edit's recording
already happens in the trait fast path (PR-4). Same deal for the
`format!("Error: {e:#}")` wrapper — moved inline into the MCP
handler.

**Net change in `mod.rs`: +57 / -127 (-70 LOC).** The dispatcher
body is now ~60 lines of straight-line code plus one trait
fast-path block; pre-#1265 it was 200+ lines of nested `match`.

### `koda-core/src/tools/catalog.rs` (+9)

Five `boxed(...)` registrations.

### Test fixture updates (file_tools, grep, glob, recall, todo) (+14)

Each `for_test(...)` call site gets a `let skills =
SkillRegistry::default();` and `&skills` arg. Centralized via the
test-only constructor introduced in PR-6.

## Validation

```
$ cargo test --workspace --no-fail-fast
... TOTAL passed: 2641 failed: 0   (+2 vs PR-7 baseline of 2639)

$ cargo clippy --workspace --all-targets -- -D warnings   (clean)
$ cargo fmt --all                                          (clean)
$ RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps  (clean)
```

## Stack progress

**18 of 18 built-in tools on the trait.** ✅

The full migration set: Read, Write, Edit, Delete, List, Grep,
Glob, Bash, WebFetch, WebSearch, MemoryRead, MemoryWrite,
TodoWrite, RecallContext, **ListAgents, InvokeAgent, ListSkills,
ActivateSkill, AskUser**.

Bg-task tools (`ListBackgroundTasks`, `CancelTask`, `WaitTask`)
are intentionally **not** on the trait — they bypass the registry
entirely via `tool_dispatch.rs` because they need
`Arc<ChildAgentRegistry>` (which the registry doesn't hold).
Adding them would require a separate ctx type or threading more
state through; the PR-9 cleanup will document this explicitly.

## Remaining for PR-9 (cleanup)

- Delete `tools::classify_tool` (now redundant — every effect-class
  decision goes through `Tool::classify(args)`).
- Delete `tools::is_mutating_tool` (now redundant — every undo
  decision goes through `Tool::extract_undo_path(args)`).
- Delete `undo::is_mutating_tool` (with its phantom `"Overwrite"`
  list entry — never existed as a tool name).
- Delete `undo::extract_file_path` (now `extract_undo_path` lives
  on each tool struct).
- Audit remaining call sites of the removed APIs and migrate them
  to `ToolCatalog`/`Tool` accessors.

## Diffstat

```
 koda-core/src/tools/agent.rs       | 139 +++++++++++++++++++++++++++
 koda-core/src/tools/ask_user.rs    |  40 ++++++++
 koda-core/src/tools/catalog.rs     |   9 ++
 koda-core/src/tools/file_tools.rs  |   6 ++
 koda-core/src/tools/glob_tool.rs   |   2 +
 koda-core/src/tools/grep.rs        |   2 +
 koda-core/src/tools/mod.rs         | 185 +++++++++++--------------------------
 koda-core/src/tools/recall.rs      |   2 +
 koda-core/src/tools/skill_tools.rs |  63 +++++++++++++
 koda-core/src/tools/todo.rs        |   2 +
 koda-core/src/tools/tool_trait.rs  |  20 +++-
 11 files changed, 338 insertions(+), 132 deletions(-)
```

> **Note:** based on PR #1298 (PR-7/misc). Will rebase to `main`
> automatically once PR-7 lands.

🤖 Authored by `code-puppy-7b4d98`.
