### PR TITLE
fix(ci): promote bare #[tokio::test] in agent.rs to multi_thread (#1109 F2)

### DIFF
--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -458,7 +458,7 @@ mod tests {
     /// If dispatch ever falls through to the trait impl, it must
     /// preserve the pre-#1265 "should not be reached" failure path:
     /// success=false with the same message verbatim.
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn invoke_agent_unreached_path_returns_failure() {
         let t = InvokeAgentTool;
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
# fix(ci): promote bare `#[tokio::test]` in `agent.rs` to multi_thread (#1109 F2)

## Why

`main` is red — the `Format` job's #1109 F2 guard
(`scripts/check_tokio_test_flavor.py`) is failing on the test I
added in PR-8 (#1299):

```
[#1109 F2 guard] FAIL — found bare #[tokio::test] in modules that
                 use tokio::spawn / BgAgentRegistry / sub-agent dispatch /
                 watch / broadcast channels. These tests run on the
                 current_thread runtime by default, which silently
                 hides spawned-future bugs (see #1090).

Offenders:
  koda-core/src/tools/agent.rs:461: #[tokio::test]

Fix: add (flavor = "multi_thread", worker_threads = 2) to each.
Or run: python3 scripts/check_tokio_test_flavor.py --fix
```

`koda-core/src/tools/agent.rs` is in the guard's danger set
(sub-agent dispatch lives next door). Even though
`invoke_agent_unreached_path_returns_failure` doesn't itself
spawn anything, the guard is a **structural invariant** — every
`#[tokio::test]` in these modules must use `multi_thread` so the
discipline doesn't get lost when someone adds spawning later.

## Fix

Auto-fixed via the existing repair script:

```bash
python3 scripts/check_tokio_test_flavor.py --fix
```

One-line diff:

```diff
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
```

## Validation

```text
$ python3 scripts/check_tokio_test_flavor.py
[#1109 F2 guard] OK — every #[tokio::test] in danger-pattern modules uses multi_thread.

$ cargo test -p koda-core invoke_agent_unreached_path_returns_failure
test tools::agent::tests::invoke_agent_unreached_path_returns_failure ... ok
test result: ok. 1 passed; 0 failed
```

## Why this slipped through

I ran `cargo test --workspace`, `cargo clippy`, `cargo fmt`, and
`cargo doc` locally before opening PR-8 — all clean. The
tokio-flavor guard is a separate Python script invoked from the
CI's Format job, and I didn't run it locally. Adding it to my
pre-PR checklist for future Tool-trait work.

🤖 Authored by `code-puppy-7b4d98`. Sorry about the red main, fixing it now! 🐕
