### PR TITLE
refactor: extract pure persistence classifier to kill racy negative-assertion sleeps (#1265 item 8a, PR-2)

### DIFF
--- a/koda-core/src/engine/sink.rs
+++ b/koda-core/src/engine/sink.rs
@@ -454,55 +454,76 @@ impl<'a> PersistingSink<'a> {
     }
 }
 
+/// Pure classification of an [`EngineEvent`] into a persistence
+/// decision. `None` means "skip — do not write a row"; `Some((kind,
+/// payload))` is exactly the row [`PersistingSink::persist`] would
+/// spawn.
+///
+/// Pulled out of [`PersistingSink::emit`] so the routing contract
+/// ("which events persist on which path?") is testable as a pure
+/// function. Without this, the only way to assert "event X must NOT
+/// persist" was to send X, sleep an arbitrary wall-clock duration
+/// hoping any erroneous spawn would land, then check the DB was
+/// still empty — a fundamentally racy negative-assertion shape.
+///
+/// Branches on `parent_tool_call_id`:
+/// - `None` (top-level) — persist `Info` and `ChildTaskUpdate` only.
+///   Other events are already in `messages.*`.
+/// - `Some(_)` (sub-agent) — persist a richer set matching what
+///   [`BufferingSink::emit`] renders, so the parent transcript can
+///   reconstruct the sub-agent trace.
+pub(crate) fn classify_for_persist(
+    event: &EngineEvent,
+    parent_tool_call_id: Option<&str>,
+) -> Option<(&'static str, String)> {
+    use crate::persistence::session_event_kind as sek;
+    if parent_tool_call_id.is_some() {
+        match event {
+            EngineEvent::Info { message } => Some((sek::SUB_AGENT_EVENT, message.clone())),
+            EngineEvent::ToolCallStart { name, .. } => {
+                Some((sek::SUB_AGENT_EVENT, format!("  \u{1f527} {name}")))
+            }
+            EngineEvent::ApprovalRequest { tool_name, .. } => Some((
+                sek::SUB_AGENT_EVENT,
+                format!("  \u{2398} approval auto-rejected for {tool_name} (no user channel)"),
+            )),
+            EngineEvent::AskUserRequest { question, .. } => {
+                let truncated: String = question.chars().take(80).collect();
+                Some((
+                    sek::SUB_AGENT_EVENT,
+                    format!("  \u{2398} ask-user auto-skipped: {truncated}"),
+                ))
+            }
+            _ => None,
+        }
+    } else {
+        match event {
+            EngineEvent::Info { message } => Some((sek::INFO, message.clone())),
+            EngineEvent::ChildTaskUpdate { .. } => {
+                // serde_json::to_string on EngineEvent is infallible in
+                // practice (every variant is `Serialize`-clean), but
+                // we preserve the original silent-skip-on-error
+                // behaviour rather than panic. A future test could
+                // construct an event that fails serialization — we'd
+                // log and skip, not crash a session.
+                serde_json::to_string(event)
+                    .ok()
+                    .map(|json| (sek::BG_TASK_UPDATE, json))
+            }
+            _ => None,
+        }
+    }
+}
+
 impl EngineSink for PersistingSink<'_> {
     fn emit(&self, event: EngineEvent) {
-        use crate::persistence::session_event_kind as sek;
-        // Branch on whether this is a sub-agent context. Sub-agents
-        // need a richer event set persisted (the inner trace) so the
-        // parent transcript can show what they did. Top-level only
-        // needs Info / ChildTaskUpdate — tool calls there are already
-        // in `messages.tool_calls`.
-        if self.parent_tool_call_id.is_some() {
-            // Sub-agent: persist the same set BufferingSink renders
-            // (see [`BufferingSink::emit`]). Use the rendered string
-            // form so the transcript matches the live trace.
-            match &event {
-                EngineEvent::Info { message } => {
-                    self.persist(sek::SUB_AGENT_EVENT, message.clone());
-                }
-                EngineEvent::ToolCallStart { name, .. } => {
-                    self.persist(sek::SUB_AGENT_EVENT, format!("  \u{1f527} {name}"));
-                }
-                EngineEvent::ApprovalRequest { tool_name, .. } => {
-                    self.persist(
-                        sek::SUB_AGENT_EVENT,
-                        format!(
-                            "  \u{2398} approval auto-rejected for {tool_name} (no user channel)"
-                        ),
-                    );
-                }
-                EngineEvent::AskUserRequest { question, .. } => {
-                    let truncated: String = question.chars().take(80).collect();
-                    self.persist(
-                        sek::SUB_AGENT_EVENT,
-                        format!("  \u{2398} ask-user auto-skipped: {truncated}"),
-                    );
-                }
-                _ => {}
-            }
-        } else {
-            // Top-level: only sink-only events not already in messages.
-            match &event {
-                EngineEvent::Info { message } => {
-                    self.persist(sek::INFO, message.clone());
-                }
-                EngineEvent::ChildTaskUpdate { .. } => {
-                    if let Ok(json) = serde_json::to_string(&event) {
-                        self.persist(sek::BG_TASK_UPDATE, json);
-                    }
-                }
-                _ => {}
-            }
+        // The routing decision is a pure function (see
+        // [`classify_for_persist`]); `emit` only wires it to the
+        // fire-and-forget spawner and forwards unconditionally.
+        if let Some((kind, payload)) =
+            classify_for_persist(&event, self.parent_tool_call_id.as_deref())
+        {
+            self.persist(kind, payload);
         }
         self.inner.emit(event);
     }
@@ -1165,5 +1186,171 @@ mod tests {
             })
             .await;
         assert!(result.is_err());
+    }
+
+    // ── classify_for_persist (8a PR-2) ──────────────────────────────
+    //
+    // The pre-#1265-8a-PR-2 negative-assertion tests for PersistingSink
+    // (in `tests/persisting_sink_test.rs`) sent a non-allowlisted event,
+    // slept 50ms hoping any erroneous fire-and-forget DB insert would
+    // land, then asserted the table was empty. That's a fundamentally
+    // racy negative assertion: "absence after a guess."
+    //
+    // The classifier extraction makes the routing decision a pure
+    // function. We can now assert exactly the right thing — the
+    // *decision*, not the side effect — with no async, no DB, no sleep.
+
+    use crate::child_agent::AgentStatus;
+    use crate::persistence::session_event_kind as sek;
+
+    fn child_task_update_event() -> EngineEvent {
+        EngineEvent::ChildTaskUpdate {
+            task_id: 42,
+            spawner: Some(7),
+            is_background: true,
+            status: AgentStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn classify_top_level_persists_info_with_message_payload() {
+        let event = EngineEvent::Info {
+            message: "hello".into(),
+        };
+        let decision = classify_for_persist(&event, None);
+        assert_eq!(decision, Some((sek::INFO, "hello".to_string())));
+    }
+
+    #[test]
+    fn classify_top_level_persists_child_task_update_with_json_payload() {
+        let event = child_task_update_event();
+        let (kind, payload) =
+            classify_for_persist(&event, None).expect("ChildTaskUpdate must persist top-level");
+        assert_eq!(kind, sek::BG_TASK_UPDATE);
+        // Payload is a JSON-serialized EngineEvent; sanity-check a
+        // couple of fields rather than pinning the full schema.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("payload must parse as JSON");
+        assert_eq!(parsed["task_id"], 42);
+        assert_eq!(parsed["is_background"], true);
+    }
+
+    #[test]
+    fn classify_top_level_skips_non_allowlisted_events() {
+        // Anything not Info / ChildTaskUpdate must skip on the
+        // top-level path — these events are already in `messages.*`.
+        // Replaces the racy `top_level_passes_through_non_persistable_
+        // events_without_db_writes` integration sleep test.
+        let cases = [
+            EngineEvent::ResponseStart,
+            EngineEvent::TextDelta { text: "a".into() },
+            EngineEvent::TextDone,
+            EngineEvent::ToolCallStart {
+                id: "call-1".into(),
+                name: "Read".into(),
+                args: serde_json::json!({"path": "f.txt"}),
+                is_sub_agent: false,
+            },
+        ];
+        for event in cases {
+            assert_eq!(
+                classify_for_persist(&event, None),
+                None,
+                "top-level must skip {event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_sub_agent_persists_info_with_sub_agent_kind() {
+        let event = EngineEvent::Info {
+            message: "sub said hi".into(),
+        };
+        let decision = classify_for_persist(&event, Some("parent-call"));
+        assert_eq!(
+            decision,
+            Some((sek::SUB_AGENT_EVENT, "sub said hi".to_string()))
+        );
+    }
+
+    #[test]
+    fn classify_sub_agent_persists_tool_call_start_as_rendered_line() {
+        let event = EngineEvent::ToolCallStart {
+            id: "c-1".into(),
+            name: "Read".into(),
+            args: serde_json::json!({}),
+            is_sub_agent: false,
+        };
+        let (kind, payload) = classify_for_persist(&event, Some("parent-call"))
+            .expect("ToolCallStart must persist on sub-agent path");
+        assert_eq!(kind, sek::SUB_AGENT_EVENT);
+        assert_eq!(payload, "  \u{1f527} Read");
+    }
+
+    #[test]
+    fn classify_sub_agent_persists_approval_request_as_auto_reject_line() {
+        let event = EngineEvent::ApprovalRequest {
+            id: "a-1".into(),
+            tool_name: "WriteFile".into(),
+            detail: "write 1 file".into(),
+            preview: None,
+            effect: crate::tools::ToolEffect::LocalMutation,
+        };
+        let (kind, payload) = classify_for_persist(&event, Some("parent-call"))
+            .expect("ApprovalRequest must persist on sub-agent path");
+        assert_eq!(kind, sek::SUB_AGENT_EVENT);
+        assert!(
+            payload.contains("approval auto-rejected for WriteFile"),
+            "payload should explain the auto-rejection: {payload:?}"
+        );
+    }
+
+    #[test]
+    fn classify_sub_agent_truncates_ask_user_question_to_80_chars() {
+        let long_question = "q".repeat(200);
+        let event = EngineEvent::AskUserRequest {
+            id: "q-1".into(),
+            question: long_question,
+            options: Vec::new(),
+        };
+        let (kind, payload) = classify_for_persist(&event, Some("parent-call"))
+            .expect("AskUserRequest must persist on sub-agent path");
+        assert_eq!(kind, sek::SUB_AGENT_EVENT);
+        // Prefix is fixed; the question slice must be exactly 80 chars
+        // (truncation contract). 8 chars of prefix + 80 of question = 88.
+        let prefix = "  \u{2398} ask-user auto-skipped: ";
+        let question_part = payload.strip_prefix(prefix).expect("prefix should match");
+        assert_eq!(
+            question_part.chars().count(),
+            80,
+            "question must truncate to 80 chars, got {} in {payload:?}",
+            question_part.chars().count()
+        );
+    }
+
+    #[test]
+    fn classify_sub_agent_skips_child_task_update() {
+        // ChildTaskUpdate is a top-level-only signal (parent transcript
+        // shows sub-agent activity through InvokeAgent's tool result).
+        // Replaces the racy `sub_agent_does_not_persist_bg_task_update`
+        // integration sleep test.
+        let event = child_task_update_event();
+        assert_eq!(classify_for_persist(&event, Some("parent-call")), None);
+    }
+
+    #[test]
+    fn classify_sub_agent_skips_other_non_allowlisted_events() {
+        let cases = [
+            EngineEvent::ResponseStart,
+            EngineEvent::TextDelta { text: "a".into() },
+            EngineEvent::TextDone,
+        ];
+        for event in cases {
+            assert_eq!(
+                classify_for_persist(&event, Some("parent-call")),
+                None,
+                "sub-agent must skip {event:?}"
+            );
+        }
     }
 }

--- a/koda-core/tests/persisting_sink_test.rs
+++ b/koda-core/tests/persisting_sink_test.rs
@@ -181,12 +181,16 @@ async fn top_level_bg_task_update_persists_as_json_with_null_parent() {
     assert_eq!(parsed["status"]["iter"], 7, "full payload: {parsed}");
 }
 
-/// Sanity: events that aren't on the `Info` / `ChildTaskUpdate` allowlist
-/// do NOT create rows in the top-level routing path. If `TextDelta`
-/// started persisting we'd flood the table on every streaming token —
-/// regression guard for that explicit bug shape.
+/// Forwarding contract: events that aren't on the `Info` /
+/// `ChildTaskUpdate` allowlist must still reach the inner sink
+/// untouched. The persistence-side guarantee ("these events do not
+/// write rows") is covered as a pure-function test in
+/// [`koda_core::engine::sink::tests::classify_top_level_skips_non_allowlisted_events`]
+/// — see #1265 item 8a, PR-2 for why the negative DB assertion
+/// previously here was deleted in favour of testing the *decision*
+/// instead of waiting for the *side effect*.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn top_level_passes_through_non_persistable_events_without_db_writes() {
+async fn top_level_forwards_non_persistable_events_unconditionally() {
     let (_tmp, db, session_id) = fresh_db().await;
     let inner = TestSink::new();
     let sink = PersistingSink::new(&inner, db.clone(), session_id.clone(), None);
@@ -202,17 +206,6 @@ async fn top_level_passes_through_non_persistable_events_without_db_writes() {
         args: serde_json::json!({"path": "f.txt"}),
         is_sub_agent: false,
     });
-
-    // Give any (incorrectly) spawned inserts a beat to land before
-    // asserting the table is empty. Without the small wait a buggy
-    // implementation that DID spawn writes could race past us.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let events = db.load_session_events(&session_id).await.unwrap();
-    assert!(
-        events.is_empty(),
-        "top-level routing must only persist Info/ChildTaskUpdate; \
-         got rows for non-allowlisted events: {events:?}"
-    );
 
     // Forwarding still works for every event, persisted or not.
     assert_eq!(inner.len(), 4);
@@ -360,10 +353,14 @@ async fn sub_agent_ask_user_request_persists_truncated() {
     );
 }
 
-/// Sub-agent routing must NOT persist `ChildTaskUpdate` (that's a
-/// top-level concept). Tests the negative side of the asymmetry.
+/// Forwarding contract on the sub-agent path: `ChildTaskUpdate`
+/// must reach the inner sink even though it's not on the sub-agent
+/// persist allowlist. The persistence-side guarantee is covered as
+/// a pure-function test in
+/// [`koda_core::engine::sink::tests::classify_sub_agent_skips_child_task_update`]
+/// — see #1265 item 8a, PR-2.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn sub_agent_does_not_persist_bg_task_update() {
+async fn sub_agent_forwards_child_task_update_unconditionally() {
     use koda_core::child_agent::AgentStatus;
 
     let (_tmp, db, session_id) = fresh_db().await;
@@ -381,16 +378,6 @@ async fn sub_agent_does_not_persist_bg_task_update() {
         is_background: true,
         status: AgentStatus::Pending,
     });
-
-    // Wait long enough for an erroneously-spawned insert to land,
-    // then assert nothing did. (The forwarding contract still fires —
-    // checked separately on the inner sink below.)
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let events = db.load_session_events(&session_id).await.unwrap();
-    assert!(
-        events.is_empty(),
-        "ChildTaskUpdate must not persist on the sub-agent path; got: {events:?}"
-    );
 
     // Inner sink still saw the event — forwarding is unconditional.
     assert_eq!(inner.len(), 1);
@@ -465,6 +452,12 @@ async fn sub_agent_multi_event_sequence_preserves_order_and_parent_id() {
 /// to the inner sink. Locks in the "decorator transparency" contract
 /// — a buggy implementation that early-returned after the routing
 /// branches would silently drop these events.
+///
+/// The persistence-side guarantee for these events ("do not write
+/// rows") is covered as a pure-function test in
+/// [`koda_core::engine::sink::tests::classify_sub_agent_skips_other_non_allowlisted_events`]
+/// — see #1265 item 8a, PR-2 for why the negative DB assertion
+/// previously here was deleted.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn forwarding_is_unconditional_for_non_persisted_events() {
     let (_tmp, db, session_id) = fresh_db().await;
@@ -474,15 +467,7 @@ async fn forwarding_is_unconditional_for_non_persisted_events() {
     sink.emit(EngineEvent::ResponseStart);
     sink.emit(EngineEvent::TextDone);
 
-    // Neither event is on either persistence allowlist.
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    let events = db.load_session_events(&session_id).await.unwrap();
-    assert!(
-        events.is_empty(),
-        "non-allowlisted events must not write rows; got: {events:?}"
-    );
-
-    // But the inner sink saw both — forwarding is unconditional.
+    // Inner sink saw both — forwarding is unconditional.
     assert_eq!(inner.len(), 2);
     assert!(matches!(&inner.events()[0], EngineEvent::ResponseStart));
     assert!(matches!(&inner.events()[1], EngineEvent::TextDone));


### PR DESCRIPTION
# refactor: extract pure persistence classifier to kill racy negative-assertion sleeps (#1265 item 8a, PR-2)

## Why this PR exists

When I closed 8a after PR-1 (#1306) with the comment "koda is at parity with codex on negative-assertion sleeps," @lijunzh pushed back: *"guess a time and sleep on it still doesn't sound right."*

He was correct. **"Codex does it too" is argument from authority, not Zen of Python.** There IS a deterministic answer.

## The actual problem

Three tests in `koda-core/tests/persisting_sink_test.rs` had this shape:

```rust
sink.emit(non_persistable_event);
tokio::time::sleep(Duration::from_millis(50)).await;  // ⚠️
let events = db.load_session_events(...).await.unwrap();
assert!(events.is_empty(), "must not persist");
```

These tests asserted the **side effect** (no DB row). The 50ms was a guess for how long an erroneously-spawned write would take to land. On a slow CI runner the guess is wrong; the assertion races past a real bug.

## The actual answer

`PersistingSink::emit` makes a **synchronous** persist-or-skip decision in a `match` block, then either spawns or returns. Test the decision directly. Don't wait for the absent side effect.

This PR extracts the decision into a pure function:

```rust
pub(crate) fn classify_for_persist(
    event: &EngineEvent,
    parent_tool_call_id: Option<&str>,
) -> Option<(&'static str, String)>
```

`emit` becomes a tiny dispatcher:

```rust
fn emit(&self, event: EngineEvent) {
    if let Some((kind, payload)) =
        classify_for_persist(&event, self.parent_tool_call_id.as_deref())
    {
        self.persist(kind, payload);
    }
    self.inner.emit(event);
}
```

Pure function = pure tests. No DB, no async runtime, no sleep.

## What's deleted

Three `tokio::time::sleep(Duration::from_millis(50))` calls in negative-assertion tests:

| Old test | Action | Notes |
|---|---|---|
| `top_level_passes_through_non_persistable_events_without_db_writes` | Renamed → `top_level_forwards_non_persistable_events_unconditionally` | Retains synchronous `assert_eq!(inner.len(), 4)` forwarding check |
| `sub_agent_does_not_persist_bg_task_update` | Renamed → `sub_agent_forwards_child_task_update_unconditionally` | Retains `assert_eq!(inner.len(), 1)` |
| `forwarding_is_unconditional_for_non_persisted_events` | Same name | Drops only the redundant DB-empty assertion |

**The `sleep(5ms)` inside `wait_for_events` STAYS** — that's a polling cadence inside a 2s deadline, which is the correct codex-equivalent pattern (matches `wait_for_pid_file` in `codex/codex-rs/core/tests/common/process.rs`).

## What's added

Nine pure unit tests for `classify_for_persist` covering the classification contract from both directions:

- `classify_top_level_persists_info_with_message_payload`
- `classify_top_level_persists_child_task_update_with_json_payload`
- `classify_top_level_skips_non_allowlisted_events` *(replaces old test 1)*
- `classify_sub_agent_persists_info_with_sub_agent_kind`
- `classify_sub_agent_persists_tool_call_start_as_rendered_line`
- `classify_sub_agent_persists_approval_request_as_auto_reject_line`
- `classify_sub_agent_truncates_ask_user_question_to_80_chars`
- `classify_sub_agent_skips_child_task_update` *(replaces old test 2)*
- `classify_sub_agent_skips_other_non_allowlisted_events` *(replaces old test 3)*

These run synchronously in **0.00s total**.

## Why this beats "sleep is fine because codex does it"

| Property | Sleep-then-assert | Pure classifier test |
|---|---|---|
| Tests the contract | ❌ tests the side effect | ✅ tests the decision |
| Race-prone on slow CI | 🔴 yes (50ms guess) | ✅ no (sync) |
| Catches "classifier returns wrong kind" | ❌ | ✅ |
| Catches "classifier returns wrong payload" | ❌ | ✅ |
| Runtime per test | ≥50ms | <0.1ms |
| Needs DB setup | yes | no |

**The classifier extraction also IMPROVED coverage.** Previously we couldn't test that the rendered `ToolCallStart` line is exactly `  🔧 <name>` or that `AskUserRequest.question` truncates to exactly 80 chars — those payload-format details lived inline inside `emit` where they were impossible to assert separately. Now they're contract-tested.

## Validation

```text
cargo test --workspace --features koda-core/test-support --no-fail-fast:
  TOTAL passed: 2653, failed: 0  (was 2644; +9 new classifier tests)
cargo clippy --workspace --all-targets -D warnings: clean
cargo fmt --all: clean
```

The integration test file went from **4 sleeps → 1 sleep** (the polling cadence in `wait_for_events`, which is correct).

## Lesson for future PRs

When you see `sleep(N).await; assert!(empty)`, it's almost always **testing the wrong layer**. Refactor production code to expose the synchronous decision, then test that. The Zen of Python: *"There should be one-- and preferably only one --obvious way to do it."* The obvious way to test "does X persist?" is to call the function that decides "should X persist?"

## Diffstat

```
 koda-core/src/engine/sink.rs            | 281 ++++++++++++++++++++++++++------
 koda-core/tests/persisting_sink_test.rs |  61 +++----
 2 files changed, 257 insertions(+), 85 deletions(-)
```

🤖 Authored by `code-puppy-7b4d98`. Thanks to @lijunzh for the right pushback at the right time. 🐕
