### PR TITLE
ci: gate PRs on per-file security coverage thresholds (#1265 item 8c, PR-2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,11 +2,22 @@ name: Coverage
 
 on:
   push:
-    branches: [main]   # Runs after every merge — informational, not a PR gate
+    branches: [main]   # Post-merge: opens/closes regression issues, badge source.
+  # Pull-request gate (#1265 item 8c, PR-2): block merging when a
+  # security-boundary file regresses below its per-file threshold.
+  # Path filter limits CI cost — PRs that don't touch the gated
+  # crates can't possibly regress their coverage. Workflow + script
+  # changes ARE included so threshold edits get re-validated.
+  pull_request:
+    paths:
+      - 'koda-core/**'
+      - 'koda-sandbox/**'
+      - '.github/workflows/coverage.yml'
+      - 'scripts/check_per_file_coverage.py'
 
 permissions:
   contents: read
-  issues:   write      # Needed to open / comment on regression issues
+  issues:   write      # Needed to open / comment on regression issues (push-to-main only)
 
 env:
   CARGO_TERM_COLOR: always
@@ -355,7 +366,11 @@ jobs:
       # result is 'failure'. Suppress when an infra flake was detected:
       # we can't trust 'failure' to mean "real regression" in that case.
       - name: Report regression
-        if: needs.coverage.result == 'failure' && steps.flake.outputs.detected != 'true'
+        # Push-only: PR failures should NOT open "Coverage regression
+        # on main" issues — the PR's own failed check is the signal.
+        # The PR-time gate is enforced by the final `Fail if any crate
+        # below threshold` step, which still runs on PRs.
+        if: github.event_name == 'push' && needs.coverage.result == 'failure' && steps.flake.outputs.detected != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -395,7 +410,10 @@ jobs:
       # step we never measured coverage, so we mustn't close a legitimate
       # open regression issue.
       - name: Close regression issue if green
-        if: needs.coverage.result == 'success' && steps.flake.outputs.detected != 'true'
+        # Push-only: PRs don't manage main's open-issue state. A PR
+        # passing while a main regression issue is open just means the
+        # PR didn't reproduce the regression — not that main is fixed.
+        if: github.event_name == 'push' && needs.coverage.result == 'success' && steps.flake.outputs.detected != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
# ci: gate PRs on per-file security coverage thresholds (#1265 item 8c, PR-2)

## What changed

`coverage.yml` now runs on `pull_request` in addition to `push: main`. The per-file threshold check from PR-1 (#1309) becomes a **PR-blocking gate**, not just a post-merge alarm.

## Why this matters (vs. PR-1 alone)

PR-1 catches a regression *after* it lands on main → opens an issue → someone has to revert or fix forward. That's recovery, not prevention.

PR-2 catches the *same* regression at PR review time → submitter sees the failed check → adds tests before merge. **Shift-left.**

## Why split from PR-1

PR-1 delivered the threshold *mechanism* (table + checker + workflow wiring). It deliberately stayed push-only so the review could focus on **"does the gate work?"** without entangling the **"when does the gate fire?"** decision. This PR is purely about the trigger surface — 22 added lines, 4 removed.

## Design choices

### 1. Path filter to limit PR CI cost

Coverage takes ~10min on each runner. Without a filter every PR (docs-only, CLI-only, infra-only) would pay that cost.

```yaml
paths:
  - 'koda-core/**'
  - 'koda-sandbox/**'
  - '.github/workflows/coverage.yml'
  - 'scripts/check_per_file_coverage.py'
```

A PR that doesn't touch the gated crates literally cannot regress their coverage. Workflow + script changes ARE in the filter so threshold edits get re-validated end-to-end.

### 2. Issue-management steps gated to push-only

`Report regression` and `Close regression issue if green` now have `if: github.event_name == 'push' && ...`.

Rationale:

- A PR failure is signalled by the PR's own red check. We don't want to open `Coverage regression on main` issues for PR failures — main is fine, the PR is what's broken.
- A PR success while a main regression issue is open means the PR didn't reproduce the regression — not that main is fixed. Closing the issue from a PR run would be a false-clear.

### 3. Final fail-step UNCHANGED

`Fail if any crate below threshold` has no event_name filter, so it runs on both push AND PR. **That's how the PR gets blocked.**

### 4. Self-validation 🎯

This PR touches `.github/workflows/coverage.yml`, which is in the path filter. So the new `pull_request` trigger fires on this PR itself. End-to-end verification with no extra setup.

## Failure-mode matrix

| Scenario | Push to main | Pull request |
|---|---|---|
| Coverage green | close issue if open | ✅ pass check |
| Per-file regression | open/comment issue, fail badge | ❌ fail check, no issue churn |
| Crate-level regression | open/comment issue, fail badge | ❌ fail check, no issue churn |
| Infra flake (CDN down) | ⚠️ warning, no issue change | ⚠️ warning, pass check |

## Closes out #1265 🎉

This is the last item from the original architecture review.

| # | Item | PR(s) |
|---|------|-------|
| 1 | WebFetch SSRF hardening | #1282 |
| 2 | File mutation symlink/TOCTOU hardening | #1283 |
| 3 | Internal path dep version drift | #1278 |
| 4 | `TurnContext` / `ToolExecutionContext` | #1289, #1290 |
| 5 | `ToolCatalog` + `Tool` trait migration | #1292…#1304 (9 PRs) |
| 6 | `textarea.rs` vendored-sync strategy | (already done pre-issue) |
| 7 | Provider HTTP helper extraction | (already done pre-issue) |
| 8a | Sleep → readiness | #1306, #1308 |
| 8b | Fail-closed CI for security-boundary tests | #1307 |
| 8c | Per-file coverage thresholds | #1309, **#1310 (this PR)** |

After this merges, **#1265 can be closed**.

🤖 Authored by `code-puppy-7b4d98`. 🐕 *Going from 0 → reviewed-and-shipped on a 9-month architecture review feels good.*
