### PR TITLE
test: replace remaining "wait for side-effect" sleeps with deterministic readiness (#1312)

### DIFF
--- a/koda-core/src/child_agent.rs
+++ b/koda-core/src/child_agent.rs
@@ -1441,7 +1441,36 @@ mod tests {
         // we wait long enough for a non-aborted task to finish.
         let ran_to_completion = Arc::new(AtomicBool::new(false));
         let flag = ran_to_completion.clone();
+
+        // Deterministic abort signal (#1312): a drop guard inside
+        // the spawned task fires `aborted_tx` whenever the task
+        // unwinds — cooperative completion, parent cancel, or hard
+        // abort. The receiver lets the test wait for *the actual
+        // abort* instead of guessing a settle time.
+        //
+        // Why a drop guard (and not just a `tx.send()` after the
+        // `select!`): `JoinHandle::abort()` does **not** run the
+        // task's normal continuation — it polls the future, sees
+        // it cancelled, and drops it. Code after the await never
+        // runs. The drop guard fires from within the task's
+        // destructor, which DOES run on abort. This is the only
+        // shape that detects abort vs. completion.
+        struct AbortSignal(Option<oneshot::Sender<()>>);
+        impl Drop for AbortSignal {
+            fn drop(&mut self) {
+                if let Some(tx) = self.0.take() {
+                    let _ = tx.send(());
+                }
+            }
+        }
+        let (aborted_tx, aborted_rx) = oneshot::channel::<()>();
+        let abort_signal = AbortSignal(Some(aborted_tx));
+
         let handle = tokio::spawn(async move {
+            // Move the guard into the task so its Drop fires when
+            // the task unwinds (whether via normal completion,
+            // cooperative cancel, or JoinHandle::abort()).
+            let _abort_signal = abort_signal;
             // Either the cancel token fires (parent cascade) or we
             // get aborted (drop cascade). The slow sleep just gives
             // the test time to drop the registry before we'd
@@ -1467,16 +1496,32 @@ mod tests {
             handle,
         );
 
-        // Give the task a tick to start.
-        tokio::time::sleep(Duration::from_millis(20)).await;
+        // No "give the task a tick to start" sleep needed: `attach`
+        // calls `self.pending.lock().insert(...)` synchronously, so
+        // `pending_count` is incremented by the time `attach` returns.
+        // (Pre-#1312 this was a 20ms blind sleep based on the (false)
+        // assumption that the spawned task had to start before the
+        // count moved.)
         assert_eq!(reg.pending_count(), 1);
 
         // Drop the registry — this must abort the spawned task.
         drop(reg);
 
-        // Yield long enough for the abort to land; well under the
-        // 60 s sleep the task would have completed otherwise.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Deterministic readiness (#1312 was: blind `sleep(100ms)`).
+        // Wait for the AbortSignal drop guard to fire. If abort
+        // landed, the guard runs from the task's destructor and
+        // resolves `aborted_rx` immediately. If abort did NOT land,
+        // the receiver hangs (because the task is still running its
+        // 60s sleep and the guard hasn't dropped) and the timeout
+        // bails with a loud message — a real regression signal, not
+        // a flake.
+        tokio::time::timeout(Duration::from_secs(2), aborted_rx)
+            .await
+            .expect(
+                "AbortOnDropHandle did not abort the spawned task within 2s of \
+                 dropping the registry — task destructor never ran",
+            )
+            .expect("AbortSignal sender dropped without sending; task body panicked?");
         assert!(
             !ran_to_completion.load(Ordering::SeqCst),
             "task slept to completion — AbortOnDropHandle did not abort it"

--- a/koda-sandbox/src/pool/tests.rs
+++ b/koda-sandbox/src/pool/tests.rs
@@ -19,20 +19,28 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::TempDir;
+use tokio::sync::Notify;
 
 use crate::ipc::Request;
 use crate::policy::SandboxPolicy;
 use crate::workspace::{CwdProvider, WorkspaceProvider};
 
-// ── Mock provider ─────────────────────────────────────────────────────────
+// ── Mock provider ────────────────────────────────────────────────
 
 /// Counts provision/release calls so tests can assert lifecycle
 /// behavior without a real filesystem provider in the loop.
+///
+/// `release_notify` fires inside `release()` *after* the counter is
+/// incremented, so tests that need to know "the spawned release task
+/// actually ran" can `notify.notified().await` with a deadline
+/// instead of guessing a settle time. See #1312 for the rationale
+/// ("test the decision, not the side effect").
 #[derive(Debug, Default)]
 struct CountingProvider {
     project_root: PathBuf,
     provisioned: AtomicUsize,
     released: AtomicUsize,
+    release_notify: Notify,
 }
 
 impl CountingProvider {
@@ -41,6 +49,7 @@ impl CountingProvider {
             project_root,
             provisioned: AtomicUsize::new(0),
             released: AtomicUsize::new(0),
+            release_notify: Notify::new(),
         })
     }
 }
@@ -53,6 +62,15 @@ impl WorkspaceProvider for CountingProvider {
     }
     async fn release(&self, _slot_id: &str, _path: &Path) -> Result<Option<String>> {
         self.released.fetch_add(1, Ordering::SeqCst);
+        // Notify *after* the counter is bumped so any awaiter that
+        // wakes immediately sees the post-increment value. `notify_one`
+        // is buffered — even if no awaiter is parked yet, the next
+        // `notified()` call returns immediately. (See `Notify` docs:
+        // "if no permits are available, this method awaits the next call
+        // to notify_one". The flip side: `notify_one` issued before any
+        // `notified()` is recorded as a permit and consumed by the next
+        // call.)
+        self.release_notify.notify_one();
         Ok(None)
     }
 }
@@ -431,13 +449,31 @@ async fn slot_outliving_pool_still_drops_cleanly() {
     // Pool gone before slot.
     drop(pool);
 
+    // Park a `notified()` listener BEFORE we drop the slot. `Notify`
+    // is buffered (`notify_one` issued without a parked awaiter is
+    // recorded as one permit), so even if the spawned release task
+    // races ahead and signals before we await, the await returns
+    // immediately by consuming the permit. Listener-first ordering
+    // closes the (theoretical) window between `drop(slot)` and the
+    // listener registration.
+    let release_signal = provider.release_notify.notified();
+    tokio::pin!(release_signal);
+
     // This drop must NOT panic — the slot uses Weak<Pool> precisely
     // so the worker can be killed (not returned) when the pool is
     // already dead.
     drop(slot);
 
-    // Give the async release task a tick to run.
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    // Deterministic readiness (#1312 was: blind `sleep(50ms)`).
+    // The release task signals via `release_notify` after
+    // incrementing `released`, so by the time `notified()` resolves
+    // we know the spawned task has run — not just "50ms have passed."
+    tokio::time::timeout(std::time::Duration::from_secs(2), release_signal)
+        .await
+        .expect(
+            "spawned release task did not run within 2s of dropping the orphaned slot \
+             — SandboxSlot::Drop's `Handle::try_current() + spawn(release)` regressed",
+        );
     assert!(
         provider.released.load(Ordering::SeqCst) >= 1,
         "release should have been spawned even with pool gone"

--- a/koda-sandbox/src/proxy/builtin_socks5.rs
+++ b/koda-sandbox/src/proxy/builtin_socks5.rs
@@ -130,20 +130,44 @@ mod tests {
 
         drop(h);
 
-        // tokio::task::abort is async — give the runtime a tick. Same
-        // pattern as the HTTP proxy test.
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        match TcpStream::connect(("127.0.0.1", port)).await {
-            Err(_) => {} // ECONNREFUSED — listener gone.
-            Ok(mut sock) => {
-                let mut buf = [0u8; 16];
-                let n = tokio::time::timeout(Duration::from_millis(200), sock.read(&mut buf))
-                    .await
-                    .expect("read must not hang post-drop")
-                    .expect("read must not error");
-                assert_eq!(n, 0, "post-drop socket must EOF immediately");
+        // Deterministic readiness (#1312 was: blind `sleep(50ms)`).
+        // `tokio::task::abort` is async — the listener socket isn't
+        // unbound until the spawned accept task is dropped, which
+        // happens after the runtime polls the cancelled future. Poll
+        // with backoff inside a 2s deadline, breaking out on either
+        // `Err(_)` (ECONNREFUSED, listener fully gone) or `Ok(sock)`
+        // that EOFs immediately (kernel still has the bind but the
+        // accept loop has been torn down). Mirrors the HTTP proxy
+        // test's pattern in `koda-core/tests/builtin_proxy_e2e_test.rs`.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match TcpStream::connect(("127.0.0.1", port)).await {
+                Err(_) => break, // ECONNREFUSED — listener gone.
+                Ok(mut sock) => {
+                    let mut buf = [0u8; 16];
+                    let n = tokio::time::timeout(Duration::from_millis(200), sock.read(&mut buf))
+                        .await
+                        .expect("read must not hang post-drop")
+                        .expect("read must not error");
+                    if n == 0 {
+                        // Post-drop socket EOFed immediately — accept
+                        // loop is gone even if the bind hasn't been
+                        // released yet. Acceptable terminal state.
+                        break;
+                    }
+                    // Got real bytes back — listener is still serving
+                    // traffic. The deadline check below will trip if
+                    // this state persists.
+                }
             }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "after 2s post-drop, listener still accepting and serving traffic \
+                 (proxy abort task did not unbind the socket)"
+            );
+            // Small backoff so we don't spin the CPU. 5ms cadence is
+            // ~400 attempts inside the 2s budget — plenty of granularity.
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
     }
 }


### PR DESCRIPTION
test: replace remaining "wait for side-effect" sleeps with deterministic readiness (#1312)

Closes the sweep started in #1306, #1308, #1311. Three sites converted from
blind `tokio::time::sleep + assert` to deterministic event signaling.

## Sites fixed

### 1. `koda-sandbox/src/pool/tests.rs::slot_outliving_pool_still_drops_cleanly`

Was: `drop(slot); sleep(50ms); assert!(provider.released >= 1)` — guessing
how long the spawned release task takes to run.

Now: `CountingProvider::release()` calls `release_notify.notify_one()` after
incrementing the counter. Test parks a `notified()` listener BEFORE dropping
the slot (Notify is buffered, so the ordering is robust either way) and
awaits with a 2s timeout. Resolves the moment the spawned task actually runs.

### 2. `koda-core/src/child_agent.rs::registry_drop_aborts_pending_tasks`

Was: two blind sleeps —
- `sleep(20ms)` after `attach()` to "give the task a tick to start"
- `sleep(100ms)` after `drop(reg)` to "yield long enough for the abort to land"

Now:
- The first sleep is **deleted entirely**. `attach()` does
  `self.pending.lock().insert(...)` synchronously, so `pending_count` is
  incremented by the time `attach` returns. The 20ms sleep was based on a
  false assumption about the spawned task needing to start first.
- The second sleep is replaced by an `AbortSignal` drop guard moved into
  the spawned task. The guard fires `aborted_tx` from its `Drop` impl,
  which runs whether the task completes cooperatively, gets cancelled, or
  is aborted by `JoinHandle::abort()`. Test awaits `aborted_rx` with a 2s
  timeout. This is the only shape that detects abort — `JoinHandle::abort()`
  drops the future without running its continuation, so a `tx.send()` after
  the `select!` would never fire.

Test runtime: ~120ms → 0.02s.

### 3. `koda-sandbox/src/proxy/builtin_socks5.rs::dropping_handle_stops_accepting`

Bonus finding from the AC #3 sweep grep — not in #1312's named scope but
structurally identical to the pool fix. Was: `drop(h); sleep(50ms); match
TcpStream::connect(...)` — guessing how long the proxy abort task takes
to unbind the socket.

Now: poll-with-backoff loop with 2s deadline, breaking on either
`Err(_)` (ECONNREFUSED) or `Ok(sock)` that EOFs immediately. Mirrors the
HTTP proxy test's pattern at `koda-core/tests/builtin_proxy_e2e_test.rs:225`.

## Acceptance criteria from #1312

- [x] `pool::tests::slot_outliving_pool_still_drops_cleanly` uses `Notify`
- [x] `AbortOnDropHandle` test uses oneshot signaling (drop-guard variant)
- [x] Sweep grep re-run; one extra candidate found and fixed in this PR
- [x] No new `sleep + assert` patterns introduced (this PR removes 3, adds 0)

## Sweep status after this PR

| Round | PR | Sites |
|-------|----|----|
| 1 | #1306 | 13 (`approval_flow`) |
| 2 | #1308 | 3 (`PersistingSink`) |
| 3 | #1311 | 2 (`WorkerClient::Drop`, NO_PROXY) |
| 4 | this | 3 (pool, child_agent, socks5) |
| **Total** | | **21 racy sleeps eliminated** |

Remaining `sleep + assert` hits in the codebase per `rg` sweep:

- `koda-core/tests/builtin_proxy_e2e_test.rs:227` — backoff inside `Err(_) => retry`
  arm of a polling loop. Legitimate, not the antipattern.
- `koda-core/src/child_agent.rs:1677` — `snapshot_age_is_monotonic` test.
  The sleep IS the SUT (testing that a clock-derived `age` field advances
  across an elapsed time window). Legitimate.

The sweep is complete. If a future PR introduces a new `sleep + assert`
pattern, escalate to the custom clippy lint mentioned in #1312's non-goals.

## Quality gates

- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets --features koda-core/test-support -- -D warnings` ✅
- `cargo test -p koda-sandbox --lib` ✅ 346 passed
- `cargo test -p koda-core --features test-support --lib child_agent::` ✅ 39 passed

🐕 `code-puppy-7b4d98`
