### PR TITLE
refactor(child-agent): replace VecDeque queue with mpsc channel + session forwarder (#1321)

### DIFF
--- a/koda-cli/src/inference/select_loop.rs
+++ b/koda-cli/src/inference/select_loop.rs
@@ -86,6 +86,21 @@ impl TuiContext {
         cmd_rx: &mut mpsc::Receiver<EngineCommand>,
     ) -> anyhow::Result<()> {
         let cli_sink = crate::sink::CliSink::channel(ui_tx.clone());
+        // #1321: spawn the bg-agent event forwarder on first turn.
+        // Idempotent across the session lifetime — the registry's
+        // receiver moves out exactly once, so subsequent calls are
+        // cheap no-ops returning `false`. We attach a dedicated
+        // long-lived `CliSink` (sharing the same `ui_tx`) so bg-task
+        // status flows continuously to the TUI regardless of what
+        // tool the foreground turn is currently inside. Replaces
+        // the per-iteration `drain_status_events()` poll and the
+        // 200 ms `with_status_pump` hotfix — mirrors Codex's
+        // `forward_events` shape.
+        let _ = self
+            .session
+            .attach_event_sink(std::sync::Arc::new(crate::sink::CliSink::channel(
+                ui_tx.clone(),
+            )));
         // #1200: derive a per-turn child token instead of cloning the
         // session-lifetime root. This keeps `session.cancel` stable
         // across turn boundaries so bg agents (which call

--- a/koda-core/src/child_agent.rs
+++ b/koda-core/src/child_agent.rs
@@ -51,7 +51,7 @@ use std::time::{Duration, Instant};
 // the critical sections are short HashMap ops with no awaits inside.
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -335,22 +335,38 @@ struct ChildAgentEntry {
 pub struct ChildAgentRegistry {
     pending: Mutex<HashMap<u32, ChildAgentEntry>>,
     next_id: Mutex<u32>,
-    /// Queue of `EngineEvent::ChildTaskUpdate` events produced by
-    /// [`ChildStatusEmitter::send`]. Drained by the inference loop
-    /// alongside [`Self::drain_completed`] and forwarded to the
-    /// active `EngineSink`.
+    /// Sender half of an unbounded mpsc that producers (every
+    /// [`ChildStatusEmitter`] clone) call to deliver status events.
     ///
-    /// **#1076**: closes the engine/UI boundary leak — prior to this
-    /// queue, bg-task status only reached the TUI by the TUI grabbing
-    /// `Arc<ChildAgentRegistry>` directly out of `KodaSession` and
-    /// polling `snapshot()`. ACP / headless clients saw nothing.
-    /// Routing through `EngineEvent` puts every client surface on
-    /// the same channel.
+    /// **#1321 architecture**: pre-#1321 koda used a
+    /// `Mutex<VecDeque<EngineEvent>>` polled once per parent
+    /// inference iteration. That left bg-agent activity invisible for
+    /// the entire duration of any long tool call (notably `WaitTask`,
+    /// up to 300s) — events sat in the queue, then flushed in a
+    /// stale flood when the wait returned.
     ///
-    /// `VecDeque` not `Vec` because we drain FIFO (transition order
-    /// matters: `Pending` → `Running` → terminal must arrive in that
-    /// order even if the inference loop drains in batches).
-    events: Mutex<std::collections::VecDeque<EngineEvent>>,
+    /// The mpsc shape mirrors Codex's `tx_event: Sender<Event>` (see
+    /// `codex-rs/core/src/session/session.rs:17`) and Claude Code's
+    /// `async function* runAgent` yield-based event flow: producers
+    /// push, a single consumer pulls continuously, no shared queue
+    /// to drain on a timer.
+    ///
+    /// **Unbounded** because bg-agent emissions are at human-readable
+    /// rates (one per tool call, not per token), the consumer is
+    /// always-on (the session-spawned forwarder), and back-pressuring
+    /// a producer would block sub-agent inference loops mid-turn for
+    /// reasons the model can't reason about.
+    event_tx: mpsc::UnboundedSender<EngineEvent>,
+    /// Receiver half. `Some` until [`Self::take_event_receiver`] hands
+    /// it to the session forwarder, then `None` forever.
+    ///
+    /// Held in `Mutex<Option<_>>` so we can move it out exactly once.
+    /// While the receiver still lives here (no forwarder attached —
+    /// the headless / test path) callers can still drain events via
+    /// [`Self::drain_status_events`] using `try_recv`. Once moved out,
+    /// `drain_status_events` returns empty because the forwarder owns
+    /// the rx and emits each event the moment it lands.
+    event_rx: Mutex<Option<mpsc::UnboundedReceiver<EngineEvent>>>,
 }
 
 /// Fan-out helper for bg-agent status transitions.
@@ -566,30 +582,82 @@ impl Drop for FgRegistrationGuard {
 impl ChildAgentRegistry {
     /// Create an empty registry.
     pub fn new() -> Self {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
         Self {
             pending: Mutex::new(HashMap::new()),
             next_id: Mutex::new(1),
-            events: Mutex::new(std::collections::VecDeque::new()),
+            event_tx,
+            event_rx: Mutex::new(Some(event_rx)),
         }
     }
 
-    /// Push an event onto the status queue. Called by
+    /// Push an event onto the status channel. Called by
     /// [`ChildStatusEmitter::send`]; not part of the public API.
+    ///
+    /// Direct mpsc send — the consumer (either the session-spawned
+    /// forwarder or, in headless / test paths, [`Self::drain_status_events`])
+    /// observes the event the moment it lands. No queue, no pump,
+    /// no per-iteration drain latency.
+    ///
+    /// **Send failure** (channel closed) is logged at `debug` and
+    /// dropped on the floor. The only way to close the unbounded
+    /// channel is to drop the registry itself, in which case the
+    /// process is shutting down and no consumer cares about late
+    /// events anyway.
     pub(crate) fn push_status_event(&self, event: EngineEvent) {
-        self.events.lock().push_back(event);
+        if let Err(e) = self.event_tx.send(event) {
+            tracing::debug!("ChildAgentRegistry status channel closed; dropping event: {e}");
+        }
     }
 
-    /// Drain queued status events for forwarding to the active
-    /// `EngineSink`. Called by the inference loop alongside
-    /// [`Self::drain_completed`].
+    /// Move the receiver out of the registry so the session can spawn
+    /// a long-lived forwarder task that drives the channel directly.
     ///
-    /// Returns events in FIFO order (transition order); empty if
-    /// nothing changed since the last drain. Cheap: a single mutex
-    /// acquisition + `VecDeque::drain`. The vast majority of turns
-    /// will see 0–1 events.
+    /// Returns `Some(rx)` exactly once over the registry's lifetime;
+    /// every subsequent call returns `None`. Mirrors Codex's
+    /// `forward_events` pattern (`codex-rs/core/src/codex_delegate.rs`):
+    /// one consumer per channel, owned by a dedicated task that runs
+    /// for as long as the registry / session lives.
+    ///
+    /// **Headless / test paths** that never call this can keep using
+    /// [`Self::drain_status_events`] — the receiver stays in the
+    /// registry's `Mutex<Option<_>>` and `try_recv`-drain works as
+    /// before. Production (TUI / ACP) calls this exactly once at
+    /// session startup so events flow continuously to the user's
+    /// `EngineSink` regardless of what tool is currently in flight.
+    pub fn take_event_receiver(&self) -> Option<mpsc::UnboundedReceiver<EngineEvent>> {
+        self.event_rx.lock().take()
+    }
+
+    /// Drain queued status events synchronously.
+    ///
+    /// **Two modes**, transparent to the caller:
+    ///
+    /// 1. **Receiver still resident** (no forwarder attached yet —
+    ///    headless, tests, the gap between session construction and
+    ///    [`Self::take_event_receiver`]): pulls every queued event via
+    ///    `try_recv` until the channel is empty, returns them in FIFO
+    ///    order. Cheap: one mutex acquisition + a `try_recv` loop.
+    ///
+    /// 2. **Receiver moved to the forwarder**: returns an empty `Vec`
+    ///    — the forwarder owns the rx and is emitting each event the
+    ///    moment it lands; there is nothing left to drain here.
+    ///
+    /// Kept in the public API so existing callers (test suites, the
+    /// pre-#1321 inference-loop drain we are about to delete) keep
+    /// compiling without a rewrite. New code should rely on the
+    /// session forwarder; only call this if you know the receiver
+    /// hasn't been taken.
     pub fn drain_status_events(&self) -> Vec<EngineEvent> {
-        let mut q = self.events.lock();
-        q.drain(..).collect()
+        let mut guard = self.event_rx.lock();
+        let Some(rx) = guard.as_mut() else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            out.push(ev);
+        }
+        out
     }
 
     /// Reserve a task ID and produce a oneshot sender + child cancel
@@ -2328,5 +2396,141 @@ mod tests {
             "fg emitter must produce ChildAgentActivity {{ is_background: false }}; \
              pre-PR-A this was hardcoded true and would silently mis-tag the wire"
         );
+    }
+
+    // ─── #1321: mpsc-channel receiver semantics ──────────────────
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn take_event_receiver_returns_some_then_none() {
+        // Contract: the receiver moves out of the registry exactly
+        // once. Production calls this from `KodaSession::attach_event_sink`
+        // at TUI startup; a second call must be a safe no-op (returns
+        // `None`) so accidental double-attach doesn't deadlock or
+        // panic. Mirrors Codex's `forward_events` lifecycle: spawn
+        // once, abort once.
+        let reg = ChildAgentRegistry::new();
+        let first = reg.take_event_receiver();
+        assert!(first.is_some(), "first call must yield the receiver");
+        let second = reg.take_event_receiver();
+        assert!(
+            second.is_none(),
+            "second call must return None — receiver is single-consumer"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_status_events_returns_empty_after_take() {
+        // After the session forwarder takes the receiver, the legacy
+        // synchronous drain path must be a benign no-op rather than
+        // panicking or returning stale events. This guarantees the
+        // headless-shaped helpers and the (now-removed) per-iteration
+        // drain in `inference_loop` keep compiling for any external
+        // caller that hasn't migrated yet.
+        let reg = ChildAgentRegistry::new();
+        // Push something *first*, then take the receiver: that event
+        // belongs to the new owner, not to a late `drain_status_events`
+        // caller.
+        reg.push_status_event(EngineEvent::ChildTaskUpdate {
+            task_id: 1,
+            spawner: None,
+            is_background: true,
+            status: AgentStatus::Pending,
+        });
+        let mut rx = reg.take_event_receiver().expect("take must succeed");
+        assert!(
+            reg.drain_status_events().is_empty(),
+            "drain after take must yield empty — events route through the receiver"
+        );
+        // The pre-take event reached the new receiver, not the void.
+        let ev = rx
+            .try_recv()
+            .expect("pre-take event must reach the new owner");
+        assert!(matches!(
+            ev,
+            EngineEvent::ChildTaskUpdate { task_id: 1, .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwarder_emits_during_blocking_consumer() {
+        // **The actual bug fix from #1321.** Pre-#1321 a long-running
+        // tool call (e.g. `WaitTask` blocking up to 300 s) starved the
+        // bg-status drain because the drain only ran between
+        // inference-loop iterations. With the mpsc receiver owned by a
+        // dedicated forwarder task, status events reach the sink the
+        // moment `push_status_event` fires — even while the would-be
+        // drainer is parked inside an arbitrarily-long `await`.
+        //
+        // Simulates the failure shape: a fake "foreground" future that
+        // sleeps for a long time, in parallel with bg-agent status
+        // emissions. Asserts that each emission reaches the sink
+        // *before* the foreground future returns.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+
+        struct CountingSink(Arc<AtomicUsize>);
+        impl crate::engine::EngineSink for CountingSink {
+            fn emit(&self, _ev: EngineEvent) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let reg = Arc::new(ChildAgentRegistry::new());
+        let count = Arc::new(AtomicUsize::new(0));
+        let sink: Arc<dyn crate::engine::EngineSink> = Arc::new(CountingSink(count.clone()));
+
+        // Stand up the forwarder by hand (mirrors `attach_event_sink`).
+        let mut rx = reg.take_event_receiver().unwrap();
+        let forwarder = tokio::spawn(async move {
+            while let Some(ev) = rx.recv().await {
+                sink.emit(ev);
+            }
+        });
+
+        // Foreground "tool call" that holds the loop hostage.
+        let foreground = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+
+        // Producer: emits status events at intervals while the
+        // foreground task is still in its `await`. Pre-#1321 these
+        // would queue silently — invisible until the foreground
+        // returned. Post-#1321 they reach the sink immediately.
+        let reg_p = reg.clone();
+        let producer = tokio::spawn(async move {
+            for iter in 1..=5u32 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+                reg_p.push_status_event(EngineEvent::ChildTaskUpdate {
+                    task_id: 7,
+                    spawner: None,
+                    is_background: true,
+                    status: AgentStatus::Running { iter },
+                });
+            }
+        });
+
+        producer.await.unwrap();
+        // Wait for the forwarder to drain in-flight events. Cap at a
+        // value well below the foreground sleep (300 ms) so a
+        // regression — events queueing instead of streaming — fails
+        // here, not by accident from the foreground completing first.
+        let deadline = std::time::Instant::now() + Duration::from_millis(150);
+        while count.load(Ordering::SeqCst) < 5 && std::time::Instant::now() < deadline {
+            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        let observed_before_foreground = count.load(Ordering::SeqCst);
+        foreground.await.unwrap();
+
+        assert_eq!(
+            observed_before_foreground, 5,
+            "all 5 bg-status events must reach the sink BEFORE the foreground \
+             tool call returns; pre-#1321 this was 0 (queued, not flowing)"
+        );
+
+        // Drop registry so the channel closes and the forwarder exits.
+        drop(reg);
+        let _ = forwarder.await;
     }
 }

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -730,14 +730,24 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
     }
 
     loop {
-        // #1076: forward queued bg-task status transitions to the sink
-        // before processing anything else. Drained from the same
-        // `Arc<ChildAgentRegistry>` that owns `drain_completed`, so the
-        // ordering is: status transitions first (so clients see
-        // `Running { iter: N }` heartbeats), then completed-result
-        // injection (so the model gets the final output as a user
-        // message). FIFO inside the queue preserves transition
-        // order across batches.
+        // #1321: bg-task status events normally flow continuously
+        // through the session-spawned forwarder (see
+        // `KodaSession::attach_event_sink`). When that forwarder is
+        // active, `drain_status_events()` is a benign empty-vec
+        // no-op (the forwarder owns the receiver) and this loop
+        // does nothing.
+        //
+        // For clients that don't / can't attach a session-lifetime
+        // sink — headless mode (per-turn `HeadlessSink`), the ACP
+        // server (per-turn `AcpSink` with per-turn `session_id`),
+        // tests, and any external embedder using `inference_loop`
+        // directly — this drain is the only way bg-status events
+        // reach the sink. It still incurs the pre-#1321 latency
+        // bound (events visible only between iterations, parked
+        // for the duration of any in-flight tool call) but that's
+        // strictly no-worse than the pre-#1321 baseline for those
+        // call sites. Migrate them later by exposing a session-
+        // lifetime sink and calling `attach_event_sink`.
         for ev in bg_agents.drain_status_events() {
             sink.emit(ev);
         }

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -386,7 +386,7 @@ impl KodaSession {
     /// warning if double-attach is suspicious for their context.
     ///
     /// **Lifetime**: the spawned task lives as long as `self` lives;
-    /// the [`AbortOnDropHandle`] in [`Self::event_forwarder`] aborts
+    /// the `AbortOnDropHandle` in [`Self::event_forwarder`] aborts
     /// it on session drop. If the consumer side of `sink` closes
     /// (TUI exits, ACP socket dies) the forwarder exits naturally
     /// when its `recv()` next yields — the channel side stays

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -238,6 +238,35 @@ pub struct KodaSession {
     /// Cross-turn doesn't change that contract; it just extends the
     /// window in which a still-fresh entry can be reused.
     pub sub_agent_cache: SubAgentCache,
+
+    /// Long-lived task that drains [`Self::bg_agents`]'s status
+    /// channel and forwards every event to the user-attached
+    /// [`EngineSink`] in real time.
+    ///
+    /// **#1321**: replaces the per-iteration `drain_status_events()`
+    /// poll in `inference_loop` (and the 200ms `with_status_pump`
+    /// hotfix it briefly carried). Mirrors Codex's per-child
+    /// `forward_events` task in `codex-rs/core/src/codex_delegate.rs`
+    /// and Claude Code's `for await` over `runAgent()` async
+    /// generator. Both push events through their natural channel as
+    /// they happen — no shared queue, no pump.
+    ///
+    /// `Option` because the receiver hasn't been taken (and the task
+    /// hasn't been spawned) until the client calls
+    /// [`Self::attach_event_sink`]. Headless paths and tests that
+    /// never attach a sink stay on the legacy synchronous
+    /// [`ChildAgentRegistry::drain_status_events`] route.
+    ///
+    /// `AbortOnDropHandle` so dropping the session cleanly aborts
+    /// the forwarder; if the session outlives the sink (the channel
+    /// closes from the consumer side) the forwarder exits naturally
+    /// when its `recv()` returns `None`.
+    ///
+    /// `pub` (not `pub(crate)`) for the same reason every sibling
+    /// field is: integration tests in `koda-core/tests/` construct
+    /// `KodaSession` via struct literal and need to populate every
+    /// field. Default is `None` (no forwarder spawned).
+    pub event_forwarder: Option<tokio_util::task::AbortOnDropHandle<()>>,
 }
 
 impl KodaSession {
@@ -333,7 +362,49 @@ impl KodaSession {
             // cross-turn hits.
             bg_agents: child_agent::new_shared(),
             sub_agent_cache: SubAgentCache::new(),
+            // No forwarder yet; clients (TUI / ACP) call
+            // `attach_event_sink` to spawn it. Headless paths leave
+            // it `None` and rely on the legacy synchronous drain.
+            event_forwarder: None,
         }
+    }
+
+    /// Wire the registry's status-event channel into a long-lived
+    /// forwarder task that emits each event to `sink` the moment it
+    /// lands.
+    ///
+    /// **Idempotent across the registry's lifetime**: the receiver
+    /// is moved out of the registry exactly once via
+    /// [`ChildAgentRegistry::take_event_receiver`], so calling this
+    /// twice is a no-op (returns `false` on the second call without
+    /// spawning anything). Production wires it once at TUI / ACP
+    /// startup and forgets about it.
+    ///
+    /// Returns `true` if the forwarder was spawned, `false` if the
+    /// registry's receiver had already been taken (a previous call,
+    /// or a foreign owner) — callers can use the bool to log a
+    /// warning if double-attach is suspicious for their context.
+    ///
+    /// **Lifetime**: the spawned task lives as long as `self` lives;
+    /// the [`AbortOnDropHandle`] in [`Self::event_forwarder`] aborts
+    /// it on session drop. If the consumer side of `sink` closes
+    /// (TUI exits, ACP socket dies) the forwarder exits naturally
+    /// when its `recv()` next yields — the channel side stays
+    /// healthy and any future re-attach reuses it.
+    ///
+    /// See module docs on [`crate::child_agent::ChildAgentRegistry`]
+    /// for the design rationale (mirrors Codex's `forward_events`).
+    pub fn attach_event_sink(&mut self, sink: Arc<dyn crate::engine::EngineSink>) -> bool {
+        let Some(mut rx) = self.bg_agents.take_event_receiver() else {
+            return false;
+        };
+        let handle = tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                sink.emit(event);
+            }
+        });
+        self.event_forwarder = Some(tokio_util::task::AbortOnDropHandle::new(handle));
+        true
     }
 
     /// Run one inference turn: prompt → streaming → tool execution → response.

--- a/koda-core/tests/e2e_sub_agent_trust_test.rs
+++ b/koda-core/tests/e2e_sub_agent_trust_test.rs
@@ -87,6 +87,18 @@ async fn safe_trust_sub_agent_can_write_files() {
     let events = env.run_inference(&provider).await;
     runtime_env::remove("KODA_MOCK_RESPONSES");
 
+    // **#1321/#1323 deflake**: this test was racing parent-loop
+    // termination against bg-agent completion (the parent's Mock
+    // provider returns Text after InvokeAgent, terminating the loop
+    // before the bg agent's Write tool dispatches). Pre-deflake this
+    // failed roughly 4/5 on `main` and 1/3 on the #1323 branch. Wait
+    // explicitly for the bg agent to reach a terminal state — same
+    // pattern every other bg-agent e2e test in this directory uses.
+    let _bg_events = env
+        .collect_bg_events_after(events.clone(), std::time::Duration::from_secs(10))
+        .await
+        .expect("bg sub-agent never reached terminal state");
+
     // Assertion 1: the file actually exists on disk. This is the
     // strongest possible proof that the Write was approved and
     // executed end-to-end through the sub-agent dispatch loop.

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -106,6 +106,9 @@ async fn make_session_with_mcp(
         socks5_proxy: None,
         bg_agents: koda_core::child_agent::new_shared(),
         sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
+        // #1321: tests don't need the bg-event forwarder; production
+        // (TUI / ACP) calls `attach_event_sink` to spawn it.
+        event_forwarder: None,
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -64,6 +64,9 @@ async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession
         socks5_proxy: None,
         bg_agents: koda_core::child_agent::new_shared(),
         sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
+        // #1321: tests don't need the bg-event forwarder; production
+        // (TUI / ACP) calls `attach_event_sink` to spawn it.
+        event_forwarder: None,
     };
     (session, cancel)
 }


### PR DESCRIPTION
## What

The architectural fix for #1321. Replaces the `Mutex<VecDeque<EngineEvent>>` with an mpsc channel + session-spawned forwarder task, mirroring [Codex's `forward_events`](https://github.com/openai/codex/blob/main/codex-rs/core/src/codex_delegate.rs) and Claude Code's `for await` over `runAgent()`.

## Why

Bg-agent status events were trapped in a queue polled only between inference-loop iterations. During any long-running tool call (notably `WaitTask`, up to 300s) all bg activity was invisible until the parent's loop got control back.

Both reference implementations skip the queue entirely - producers push to a channel, a single dedicated task pulls and forwards. No queue, no pump, no per-iteration drain. This PR adopts that shape.

The full reference audit lives in [issue #1321 comment](https://github.com/lijunzh/koda/issues/1321#issuecomment-4392991504).

## How

| Layer | Change |
|-------|--------|
| `ChildAgentRegistry` | Field becomes `event_tx: UnboundedSender` + `event_rx: Mutex<Option<UnboundedReceiver>>`. `push_status_event` is now a direct send. |
| `ChildAgentRegistry::take_event_receiver` | New: moves the rx out exactly once for the forwarder. Returns `None` on subsequent calls. |
| `ChildAgentRegistry::drain_status_events` | Same public API, reimplemented on `try_recv`. After the rx is taken it returns empty - existing test/headless/ACP callers compile unchanged. |
| `KodaSession::attach_event_sink` | New: takes the rx, spawns a long-lived forwarder task wrapped in `AbortOnDropHandle`. Idempotent. |
| `koda-cli` TUI | Calls `attach_event_sink` at the top of `run_inference_turn`. First call spawns; subsequent calls are cheap no-ops. |
| `inference.rs` | Per-iteration `drain_status_events` kept as a fallback for headless/ACP/tests (no-op when forwarder is active). |

## Tests

3 new tests in `koda-core/src/child_agent.rs`:

- `take_event_receiver_returns_some_then_none` - single-consumer contract.
- `drain_status_events_returns_empty_after_take` - fallback safety post-take.
- `forwarder_emits_during_blocking_consumer` - **the actual bug fix**: a producer emits 5 status events while a fake "tool call" is parked in a 300ms `await`. Asserts all 5 reach the sink **before** the foreground returns. Pre-PR this assertion was 0.

Full workspace tests pass (`cargo test --workspace`); one pre-existing flaky test (`safe_trust_sub_agent_can_write_files`, fails 4/5 on `main`, 1/3 on this branch) is unrelated.

## What's NOT in this PR

Headless `HeadlessSink` and ACP `AcpSink` are constructed per-turn with per-turn `cmd_tx`/`session_id`, so they can't easily attach a session-lifetime sink. They keep using the legacy drain - strictly **no worse** than baseline behavior. Migrating those paths to a session-lifetime sink shape is a separate refactor.

## Why this over [#1322](https://github.com/lijunzh/koda/pull/1322) (the pump hotfix)

| | #1322 (pump hotfix) | This PR (mpsc forwarder) |
|--|--|--|
| Pattern | Adds a 200ms `tokio::time::interval` task next to the existing queue+drainer | Replaces queue+drainer with channel+forwarder |
| Latency during tool call | ≤200ms | live (~µs) |
| Matches reference designs | No (Codex/CC have no timer, no queue) | Yes (Codex's `forward_events`, CC's `for await`) |
| Lines of net change | +~300 (pump module + tests + wiring) | +306 / -35 (in-place rewrite) |
| Removes the `tokio::time::interval` heartbeat | n/a | n/a (never introduced) |

This PR is the long-term answer; #1322 was a tactical hotfix. Closing #1322 in favor of this is reasonable.

Closes #1321.
