### PR TITLE
feat(agent): wire mailbox into KodaSession + drain at turn start (#1325 Phase 2)

### DIFF
--- a/koda-core/src/agent/mail_message.rs
+++ b/koda-core/src/agent/mail_message.rs
@@ -1,0 +1,215 @@
+//! Convert `InterAgentCommunication` mailbox items into the form
+//! koda's inference loop consumes — `(Role, String)` ready for
+//! [`crate::persistence::Persistence::insert_message`].
+//!
+//! # Why this exists (vs. codex's `to_response_input_item`)
+//!
+//! Codex serializes the full `InterAgentCommunication` as JSON inside
+//! a `ResponseInputItem::Message { role: "assistant", phase:
+//! Some(MessagePhase::Commentary) }`. The `Commentary` phase tag tells
+//! the model "this is side-channel mail, not your own prior output" —
+//! that's what makes role-assistant safe.
+//!
+//! Koda has no `MessagePhase` field on its [`crate::persistence::Message`]
+//! type, and adding one is a DB-schema migration that touches every
+//! provider adapter + every persistence call site. That migration is
+//! its own PR (deferred until a real consumer needs it). For now we
+//! use [`crate::persistence::Role::User`] with a clear, structured
+//! prefix that preserves every wire field (author, recipient,
+//! trigger_turn, content) so:
+//!
+//! - The model sees mail as user-side input it should react to —
+//!   semantically correct given we have no commentary-phase signal.
+//! - All wire fields are preserved verbatim, so a future phase-column
+//!   migration can re-derive structured form from the prefix without
+//!   information loss.
+//! - The format is human-readable in the transcript export — useful
+//!   for debugging multi-agent traces.
+//!
+//! # Format
+//!
+//! ```text
+//! [mail from /root/agent_a → /root/agent_b (trigger_turn=true)]
+//! <content>
+//! ```
+//!
+//! When `other_recipients` is non-empty, the header gains a `cc`
+//! clause matching email convention:
+//!
+//! ```text
+//! [mail from /root/a → /root/b cc: /root/c, /root/d (trigger_turn=true)]
+//! <content>
+//! ```
+//!
+//! The arrow + parenthetical header is one line; the content body
+//! follows on subsequent lines verbatim. Authorship is unambiguous;
+//! the parser is trivial (split on first `\n`).
+//!
+//! # Phase 3+ migration note
+//!
+//! When `MessagePhase` (or equivalent) is added to koda's
+//! [`crate::persistence::Message`], replace this converter with one
+//! that emits `Role::Assistant + Phase::Commentary` with a
+//! JSON-serialized body matching codex's wire shape. At that point
+//! pin the change to the upstream `to_response_input_item` SHA and
+//! delete the deferral note in `inter_agent.rs`'s `Vendor-sync skips`
+//! section.
+
+use crate::agent::inter_agent::InterAgentCommunication;
+use crate::persistence::Role;
+
+/// Format a mailbox item as `(Role::User, content_string)` suitable
+/// for [`crate::persistence::Persistence::insert_message`].
+///
+/// See module docs for format rationale.
+///
+/// # Examples
+///
+/// ```
+/// use koda_core::agent::{AgentPath, InterAgentCommunication};
+/// use koda_core::agent::mail_message::mail_to_user_message;
+/// use koda_core::persistence::Role;
+///
+/// let mail = InterAgentCommunication {
+///     author: AgentPath::root(),
+///     recipient: "/root/researcher".parse().unwrap(),
+///     other_recipients: Vec::new(),
+///     content: "please summarize the design doc".to_string(),
+///     trigger_turn: true,
+/// };
+/// let (role, body) = mail_to_user_message(&mail);
+/// assert_eq!(role, Role::User);
+/// assert_eq!(
+///     body,
+///     "[mail from /root → /root/researcher (trigger_turn=true)]\n\
+///      please summarize the design doc"
+/// );
+/// ```
+pub fn mail_to_user_message(mail: &InterAgentCommunication) -> (Role, String) {
+    let cc_clause = if mail.other_recipients.is_empty() {
+        String::new()
+    } else {
+        let cc_list = mail
+            .other_recipients
+            .iter()
+            .map(|p| p.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(" cc: {cc_list}")
+    };
+    let body = format!(
+        "[mail from {} → {}{} (trigger_turn={})]\n{}",
+        mail.author, mail.recipient, cc_clause, mail.trigger_turn, mail.content,
+    );
+    (Role::User, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::AgentPath;
+
+    fn sample_mail() -> InterAgentCommunication {
+        InterAgentCommunication {
+            author: AgentPath::root(),
+            recipient: "/root/worker".parse().unwrap(),
+            other_recipients: Vec::new(),
+            content: "do the thing".to_string(),
+            trigger_turn: true,
+        }
+    }
+
+    #[test]
+    fn role_is_always_user() {
+        // Pin: until koda gains a MessagePhase column, mail must land
+        // as Role::User. Role::Assistant would confuse the LLM into
+        // thinking it produced the mail itself.
+        let (role, _) = mail_to_user_message(&sample_mail());
+        assert_eq!(role, Role::User);
+    }
+
+    #[test]
+    fn header_includes_author_recipient_and_trigger_turn() {
+        // Pin the wire-field preservation contract: any future
+        // refactor that drops a field would break the
+        // information-equivalence guarantee documented in module docs.
+        let (_, body) = mail_to_user_message(&sample_mail());
+        assert!(body.contains("/root"), "header missing author");
+        assert!(body.contains("/root/worker"), "header missing recipient");
+        assert!(body.contains("trigger_turn=true"), "header missing trigger_turn");
+    }
+
+    #[test]
+    fn body_separates_header_and_content_with_single_newline() {
+        // The parser contract is "split on first \n". If a future
+        // refactor uses \n\n or some other delimiter, that contract
+        // breaks silently for any consumer relying on it.
+        let (_, body) = mail_to_user_message(&sample_mail());
+        let (header, content) = body.split_once('\n').expect("must split on \\n");
+        assert!(header.starts_with('['));
+        assert_eq!(content, "do the thing");
+    }
+
+    #[test]
+    fn content_is_preserved_verbatim_including_newlines() {
+        // Mail content can be multi-line markdown / code / whatever.
+        // The format must not mangle it — a future refactor that
+        // escapes newlines or trims whitespace would silently corrupt
+        // peer-agent communications.
+        let mail = InterAgentCommunication {
+            author: AgentPath::root(),
+            recipient: "/root/worker".parse().unwrap(),
+            other_recipients: Vec::new(),
+            content: "line one\nline two\n  indented".to_string(),
+            trigger_turn: false,
+        };
+        let (_, body) = mail_to_user_message(&mail);
+        let (_, content) = body.split_once('\n').unwrap();
+        assert_eq!(content, "line one\nline two\n  indented");
+    }
+
+    #[test]
+    fn trigger_turn_false_is_distinguishable_from_true() {
+        // Pin: trigger_turn must round-trip into the rendered header.
+        // Phase 3's wait_agent tool will read this back to decide
+        // whether mail "wakes" the recipient or "FYI's" them.
+        let mut mail = sample_mail();
+        mail.trigger_turn = false;
+        let (_, body) = mail_to_user_message(&mail);
+        assert!(body.contains("trigger_turn=false"));
+        assert!(!body.contains("trigger_turn=true"));
+    }
+
+    #[test]
+    fn cc_clause_omitted_when_other_recipients_empty() {
+        // Pin: zero-cost when no cc — don't pollute the header with
+        // an empty `cc:` clause. Codex's JSON-blob format always
+        // includes the field; our human-readable format suppresses it
+        // when there's no information to convey.
+        let (_, body) = mail_to_user_message(&sample_mail());
+        assert!(!body.contains("cc"), "empty cc must not render: {body}");
+    }
+
+    #[test]
+    fn cc_clause_lists_all_other_recipients_in_order() {
+        // Pin the cc preservation contract — mirrors the
+        // wire-field-equivalence guarantee for primary recipient.
+        // Order matters: Phase 3 may build replies that mirror the
+        // recipient set, and stable order makes that deterministic.
+        let mail = InterAgentCommunication {
+            author: AgentPath::root(),
+            recipient: "/root/a".parse().unwrap(),
+            other_recipients: vec![
+                "/root/b".parse().unwrap(),
+                "/root/c".parse().unwrap(),
+            ],
+            content: "hi all".to_string(),
+            trigger_turn: false,
+        };
+        let (_, body) = mail_to_user_message(&mail);
+        assert!(
+            body.contains("cc: /root/b, /root/c"),
+            "cc clause must list both recipients in order: {body}"
+        );
+    }
+}

--- a/koda-core/src/agent/mail_message.rs
+++ b/koda-core/src/agent/mail_message.rs
@@ -136,7 +136,10 @@ mod tests {
         let (_, body) = mail_to_user_message(&sample_mail());
         assert!(body.contains("/root"), "header missing author");
         assert!(body.contains("/root/worker"), "header missing recipient");
-        assert!(body.contains("trigger_turn=true"), "header missing trigger_turn");
+        assert!(
+            body.contains("trigger_turn=true"),
+            "header missing trigger_turn"
+        );
     }
 
     #[test]
@@ -199,10 +202,7 @@ mod tests {
         let mail = InterAgentCommunication {
             author: AgentPath::root(),
             recipient: "/root/a".parse().unwrap(),
-            other_recipients: vec![
-                "/root/b".parse().unwrap(),
-                "/root/c".parse().unwrap(),
-            ],
+            other_recipients: vec!["/root/b".parse().unwrap(), "/root/c".parse().unwrap()],
             content: "hi all".to_string(),
             trigger_turn: false,
         };

--- a/koda-core/src/agent/mod.rs
+++ b/koda-core/src/agent/mod.rs
@@ -26,10 +26,12 @@
 
 pub mod inter_agent;
 pub mod koda_agent;
+pub mod mail_message;
 pub mod mailbox;
 pub mod path;
 
 pub use inter_agent::InterAgentCommunication;
 pub use koda_agent::KodaAgent;
+pub use mail_message::mail_to_user_message;
 pub use mailbox::{Mailbox, MailboxReceiver};
 pub use path::AgentPath;

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -561,7 +561,7 @@ impl KodaSession {
             return Ok(());
         }
 
-        for mail in idle.into_iter().chain(mailbox_items.into_iter()) {
+        for mail in idle.into_iter().chain(mailbox_items) {
             let (role, content) = mail_to_user_message(&mail);
             self.db
                 .insert_message(&self.id, &role, Some(&content), None, None, None)

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -23,12 +23,16 @@
 //! (e.g., main REPL + background sub-agents) without shared mutable state.
 
 use crate::agent::KodaAgent;
+use crate::agent::inter_agent::InterAgentCommunication;
+use crate::agent::mail_message::mail_to_user_message;
+use crate::agent::mailbox::{Mailbox, MailboxReceiver};
 use crate::child_agent::{self, ChildAgentRegistry};
 use crate::config::KodaConfig;
 use crate::db::Database;
 use crate::engine::{EngineCommand, EngineSink};
 use crate::file_tracker::FileTracker;
 use crate::inference::InferenceContext;
+use crate::persistence::Persistence;
 use crate::providers::{self, ImageData, LlmProvider};
 use crate::sub_agent_cache::SubAgentCache;
 use crate::trust::TrustMode;
@@ -37,6 +41,7 @@ use anyhow::Result;
 use koda_sandbox::{BuiltInProxy, BuiltInSocks5Proxy, DEFAULT_DEV_ALLOWLIST, Filter, ProxyHandle};
 use parking_lot::RwLock;
 use std::sync::{Arc, OnceLock};
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -267,6 +272,46 @@ pub struct KodaSession {
     /// `KodaSession` via struct literal and need to populate every
     /// field. Default is `None` (no forwarder spawned).
     pub event_forwarder: Option<tokio_util::task::AbortOnDropHandle<()>>,
+
+    // ── Phase 1 of #1325: peer-agent message-passing substrate. ──────────
+    //
+    // Each session owns a mailbox; mail sent here lands in the next
+    // turn's user input via `drain_mail_to_db` (called from
+    // `run_turn`). Phase 2 wires the substrate; Phase 3 exposes the
+    // peer tools (`spawn_agent`/`send_message`/`wait_agent`) that
+    // exercise it from the LLM side.
+    /// Cloneable sender handle for this session's mailbox. Hand out
+    /// clones to peer agents that need to send mail to this session.
+    pub mailbox: Mailbox,
+
+    /// Drain side of the mailbox. `tokio::sync::Mutex` because
+    /// `drain_mail_to_db` is `async` (does DB writes) and codex's
+    /// reference implementation uses the async mutex too — keeps the
+    /// concurrency contract identical. Single-consumer by
+    /// construction (`MailboxReceiver` is not `Clone`).
+    ///
+    /// Drained at the top of every `run_turn` before the inference
+    /// loop reads the conversation. **Phase 2 deferral**: codex has a
+    /// `MailboxDeliveryPhase` enum that lets late-arriving mail go to
+    /// either the current turn or the next one depending on whether
+    /// final-answer text has streamed yet. Koda always treats it as
+    /// CurrentTurn (drain at start, no mid-turn worry). When koda
+    /// adopts streaming-aware semantics, port the phase enum then.
+    pub mailbox_rx: Arc<AsyncMutex<MailboxReceiver>>,
+
+    /// Mail enqueued for the next turn while no turn is active.
+    ///
+    /// **Why a separate queue from `mailbox` itself**: the mailbox
+    /// `mpsc` lets producers fire whenever; this queue is the
+    /// drain-and-stash buffer that survives between turns so a single
+    /// drain at `run_turn` start picks up everything (including mail
+    /// that arrived between turns). Mirrors codex's
+    /// `idle_pending_input` field with identical semantics.
+    ///
+    /// Phase 2 keeps it as the raw wire format (`InterAgentCommunication`)
+    /// rather than pre-formatted strings so a future `MessagePhase`
+    /// migration can re-serialize from source without information loss.
+    pub idle_pending_input: Arc<AsyncMutex<Vec<InterAgentCommunication>>>,
 }
 
 impl KodaSession {
@@ -346,6 +391,12 @@ impl KodaSession {
             }
         };
 
+        // #1325 Phase 2: per-session mailbox pair. Producer (`Mailbox`)
+        // is cloneable; consumer (`MailboxReceiver`) is not — enforced
+        // by `mpsc` semantics. Constructed unconditionally because the
+        // substrate has zero runtime cost when no mail is sent.
+        let (mailbox, mailbox_rx) = Mailbox::new();
+
         Self {
             id,
             agent,
@@ -366,6 +417,15 @@ impl KodaSession {
             // `attach_event_sink` to spawn it. Headless paths leave
             // it `None` and rely on the legacy synchronous drain.
             event_forwarder: None,
+            // #1325 Phase 2: per-session mailbox. The substrate is
+            // wired but no LLM-facing tool produces mail yet — Phase
+            // 3 lands `spawn_agent`/`send_message`/`wait_agent`.
+            // Constructing here means the substrate is uniformly
+            // available to test code and future tools without a
+            // capability-detection branch elsewhere.
+            mailbox,
+            mailbox_rx: Arc::new(AsyncMutex::new(mailbox_rx)),
+            idle_pending_input: Arc::new(AsyncMutex::new(Vec::new())),
         }
     }
 
@@ -451,6 +511,65 @@ impl KodaSession {
         self.cancel.interrupt();
     }
 
+    // ── #1325 Phase 2: peer-agent mailbox plumbing. ────────────────────
+
+    /// Borrow the cloneable [`Mailbox`] sender. Hand `clone()`s out
+    /// to peer agents that need to mail this session.
+    ///
+    /// Phase 2 keeps this as a bare accessor; Phase 3's
+    /// `send_message` tool will wrap it with caller-spawner scoping
+    /// (Model E from #996) so an agent can only mail siblings/children
+    /// it spawned, not arbitrary peers.
+    pub fn mailbox(&self) -> &Mailbox {
+        &self.mailbox
+    }
+
+    /// Queue mail for the next turn while no turn is active.
+    ///
+    /// Mirrors codex's `queue_response_items_for_next_turn` but takes
+    /// the raw [`InterAgentCommunication`] (preserving wire fields)
+    /// rather than a pre-formatted message. Drained alongside the
+    /// mailbox itself by [`Self::drain_mail_to_db`].
+    pub async fn enqueue_for_next_turn(&self, communication: InterAgentCommunication) {
+        self.idle_pending_input.lock().await.push(communication);
+    }
+
+    /// Drain mailbox + idle queue into the session's persisted message
+    /// history as user-role messages. Called from [`Self::run_turn`]
+    /// before the inference loop reads the conversation, so any mail
+    /// in flight at turn-start lands in the next LLM call.
+    ///
+    /// Order: idle queue first (FIFO across the gap between turns),
+    /// then mailbox (FIFO within this turn-start drain). Matches
+    /// codex's `take_queued_response_items_for_next_turn` + mailbox
+    /// drain order so cross-codebase reasoning stays portable.
+    ///
+    /// **Phase 2 deferral**: codex's `MailboxDeliveryPhase` lets
+    /// late-arriving mail go to either the current turn or the next
+    /// one depending on whether final-answer text has streamed yet.
+    /// We always treat it as CurrentTurn (drain at start, no mid-turn
+    /// worry). When koda adopts streaming-aware semantics, port the
+    /// phase enum then.
+    pub async fn drain_mail_to_db(&self) -> Result<()> {
+        // Drain idle-queue first so any cross-turn FYI mail lands
+        // ahead of mid-turn deliveries that might reference it.
+        let idle: Vec<InterAgentCommunication> =
+            std::mem::take(&mut *self.idle_pending_input.lock().await);
+        let mailbox_items: Vec<InterAgentCommunication> = self.mailbox_rx.lock().await.drain();
+
+        if idle.is_empty() && mailbox_items.is_empty() {
+            return Ok(());
+        }
+
+        for mail in idle.into_iter().chain(mailbox_items.into_iter()) {
+            let (role, content) = mail_to_user_message(&mail);
+            self.db
+                .insert_message(&self.id, &role, Some(&content), None, None, None)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// # Per-turn cancellation (#1208)
     ///
     /// `turn_cancel` lets callers (notably the TUI) wire Ctrl+C / Esc to a
@@ -472,6 +591,29 @@ impl KodaSession {
         sink.emit(crate::engine::EngineEvent::TurnStart {
             turn_id: turn_id.clone(),
         });
+
+        // #1325 Phase 2: drain any peer-agent mail (mailbox + idle
+        // queue) into persisted user messages BEFORE the inference
+        // loop reads the conversation. This is the codex-equivalent
+        // of `take_queued_response_items_for_next_turn` +
+        // `get_pending_input` (which fold mail into `pending_input`).
+        // Koda persists the conversation, so mail-as-user-message
+        // achieves the same "LLM sees mail at turn start" semantics
+        // without an in-memory pending-input vector.
+        //
+        // No tool produces mail yet (Phase 3 lands the peer tools);
+        // the drain is a no-op until then. Failure here is fatal for
+        // the turn — a partially-drained mailbox would silently lose
+        // mail, which is worse than a visible error.
+        if let Err(e) = self.drain_mail_to_db().await {
+            sink.emit(crate::engine::EngineEvent::TurnEnd {
+                turn_id,
+                reason: crate::engine::event::TurnEndReason::Error {
+                    message: format!("failed to drain mailbox: {e}"),
+                },
+            });
+            return Err(e);
+        }
 
         // Compose the per-turn system prompt: static `agent.system_prompt`
         // plus a dynamically-rendered MCP server-instructions section. We

--- a/koda-core/tests/agent_mailbox_e2e_test.rs
+++ b/koda-core/tests/agent_mailbox_e2e_test.rs
@@ -1,0 +1,263 @@
+//! End-to-end test for #1325 Phase 2: peer-agent mailbox integration.
+//!
+//! Phase 2 wired [`koda_core::session::KodaSession`]'s mailbox into
+//! the turn lifecycle. This test pins the **observable contract** of
+//! that wiring from outside the session module:
+//!
+//! 1. Mail sent via [`KodaSession::mailbox()`] before a turn lands as
+//!    a `Role::User` row in the persisted conversation, and shows up
+//!    in the messages sent to the LLM provider on the next turn.
+//! 2. Mail enqueued via [`KodaSession::enqueue_for_next_turn`]
+//!    behaves identically to (1) — it's the "while idle" sibling of
+//!    the live mailbox drain.
+//! 3. With no mail, `run_turn` is a no-op for the mailbox path
+//!    (regression guard against accidentally inserting empty
+//!    user-role rows on every turn).
+//!
+//! Why a separate test file (vs. extending `session_test.rs`): this
+//! exercises the integration *boundary* between the mailbox
+//! substrate (`agent::mailbox` + `agent::mail_message`) and the turn
+//! lifecycle (`session::run_turn`). Keeping it isolated means a
+//! Phase 3 refactor that touches both can update one file's
+//! assertions without contaminating session-lifecycle tests.
+
+use koda_core::{
+    agent::{AgentPath, InterAgentCommunication, KodaAgent, Mailbox},
+    engine::EngineCommand,
+    persistence::{Persistence, Role},
+    session::{KodaSession, SessionCancel},
+    tools::{ToolCatalog, ToolRegistry},
+    trust::TrustMode,
+};
+use koda_test_utils::{Env, MockProvider, MockResponse, TestSink};
+use std::sync::Arc;
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+
+/// Build a `KodaSession` wired to the supplied provider, returning
+/// the session, its cancellation handle, and a clone of the recorded-
+/// calls handle so tests can assert on what the LLM saw.
+///
+/// Mirrors the pattern in `session_test.rs` — duplicated here rather
+/// than imported because cross-test-binary helpers would force a
+/// `koda-test-utils` extension just for this one test file.
+async fn make_session_with_recorder(
+    env: &Env,
+    provider: MockProvider,
+) -> (
+    KodaSession,
+    SessionCancel,
+    Arc<std::sync::Mutex<Vec<Vec<koda_test_utils::ChatMessage>>>>,
+) {
+    let cancel = SessionCancel::new();
+    let recorded = provider.recorded_calls_handle();
+
+    let tools = ToolRegistry::new(env.root.clone(), env.config.max_context_tokens);
+    let agent = Arc::new(KodaAgent {
+        project_root: env.root.clone(),
+        tools,
+        tool_defs: ToolCatalog::new().get_definitions(&[], &[]),
+        system_prompt: "You are a test assistant.".to_string(),
+        semantic_memory: String::new(),
+    });
+    agent
+        .tools
+        .set_session(Arc::new(env.db.clone()), env.session_id.clone());
+
+    let file_tracker =
+        koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
+
+    let (mailbox, mailbox_rx) = Mailbox::new();
+
+    let session = KodaSession {
+        id: env.session_id.clone(),
+        agent,
+        db: env.db.clone(),
+        provider: Box::new(provider),
+        mode: TrustMode::Auto,
+        cancel: cancel.clone(),
+        file_tracker,
+        title_set: false,
+        proxy: None,
+        socks5_proxy: None,
+        bg_agents: koda_core::child_agent::new_shared(),
+        sub_agent_cache: koda_core::sub_agent_cache::SubAgentCache::new(),
+        event_forwarder: None,
+        mailbox,
+        mailbox_rx: Arc::new(AsyncMutex::new(mailbox_rx)),
+        idle_pending_input: Arc::new(AsyncMutex::new(Vec::new())),
+    };
+    (session, cancel, recorded)
+}
+
+fn sample_mail(content: &str) -> InterAgentCommunication {
+    InterAgentCommunication {
+        author: "/root/peer".parse().unwrap(),
+        recipient: AgentPath::root(),
+        other_recipients: Vec::new(),
+        content: content.to_string(),
+        trigger_turn: true,
+    }
+}
+
+/// **Contract**: mail sent before a turn lands as a `Role::User` row
+/// in the DB and appears in the messages handed to the provider.
+///
+/// This is the load-bearing pin for Phase 2 — if a future refactor
+/// drops the drain call, splits the persistence path, or accidentally
+/// converts mail to a non-user role, this test fails loudly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mailbox_send_lands_as_user_message_in_next_turn() {
+    let env = Env::new().await;
+    // No prior user message — the mail itself is the only user input.
+    let provider = MockProvider::new(vec![MockResponse::Text("ack".to_string())]);
+    let (mut session, _cancel, recorded) = make_session_with_recorder(&env, provider).await;
+
+    // Send mail *before* run_turn — simulates a peer agent posting
+    // mail while the recipient session is idle between turns.
+    session.mailbox().send(sample_mail("hello from peer"));
+
+    let sink = TestSink::new();
+    let (_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+    session
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
+        .await
+        .expect("turn should succeed");
+
+    // Assertion 1: mail persisted as Role::User.
+    let messages = env
+        .db
+        .load_all_messages(&env.session_id)
+        .await
+        .expect("load_all_messages");
+    let user_msgs: Vec<_> = messages.iter().filter(|m| m.role == Role::User).collect();
+    assert_eq!(
+        user_msgs.len(),
+        1,
+        "expected exactly one user message (the drained mail), got {}: {:?}",
+        user_msgs.len(),
+        user_msgs.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+    let body = user_msgs[0]
+        .content
+        .as_deref()
+        .expect("user message must have content");
+    assert!(
+        body.contains("hello from peer"),
+        "user message must contain mail body, got: {body}"
+    );
+    assert!(
+        body.contains("[mail from /root/peer"),
+        "user message must contain the mail header, got: {body}"
+    );
+
+    // Assertion 2: the LLM saw the mail in its context.
+    let calls = recorded.lock().unwrap().clone();
+    assert!(!calls.is_empty(), "provider should have been called");
+    let last_call = calls.last().unwrap();
+    let saw_mail = last_call.iter().any(|m| {
+        m.content
+            .as_deref()
+            .is_some_and(|c| c.contains("hello from peer"))
+    });
+    assert!(
+        saw_mail,
+        "LLM context must include the mail body; messages were: {:?}",
+        last_call.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+}
+
+/// **Contract**: `enqueue_for_next_turn` is the "while idle" sibling
+/// of the live mailbox drain — same end-state, different producer.
+///
+/// Pins the FIFO order: idle queue first, then mailbox.  If a Phase 3
+/// refactor reverses the order, downstream peer-agent reasoning that
+/// expects "earlier-queued mail appears earlier in the LLM context"
+/// breaks silently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_queue_drains_before_live_mailbox_in_same_turn() {
+    let env = Env::new().await;
+    let provider = MockProvider::new(vec![MockResponse::Text("ack".to_string())]);
+    let (mut session, _cancel, _recorded) = make_session_with_recorder(&env, provider).await;
+
+    // Idle queue gets one message; mailbox gets another.
+    session
+        .enqueue_for_next_turn(sample_mail("idle-first"))
+        .await;
+    session.mailbox().send(sample_mail("mailbox-second"));
+
+    let sink = TestSink::new();
+    let (_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+    session
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
+        .await
+        .expect("turn should succeed");
+
+    let messages = env
+        .db
+        .load_all_messages(&env.session_id)
+        .await
+        .expect("load_all_messages");
+    let user_bodies: Vec<String> = messages
+        .iter()
+        .filter(|m| m.role == Role::User)
+        .filter_map(|m| m.content.clone())
+        .collect();
+    assert_eq!(
+        user_bodies.len(),
+        2,
+        "expected 2 drained mail rows, got {}: {user_bodies:?}",
+        user_bodies.len()
+    );
+    let idle_idx = user_bodies
+        .iter()
+        .position(|b| b.contains("idle-first"))
+        .expect("idle-first must be present");
+    let mailbox_idx = user_bodies
+        .iter()
+        .position(|b| b.contains("mailbox-second"))
+        .expect("mailbox-second must be present");
+    assert!(
+        idle_idx < mailbox_idx,
+        "idle queue must drain before live mailbox; got idle={idle_idx}, mailbox={mailbox_idx}"
+    );
+}
+
+/// **Regression guard**: with no mail at all, the drain must not
+/// pollute the conversation with empty user-role rows.
+///
+/// Cheap pin against a class of bug where "always insert" creeps in
+/// during refactors.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_mailbox_does_not_create_user_row() {
+    let env = Env::new().await;
+    env.insert_user_message("real user input").await;
+    let provider = MockProvider::new(vec![MockResponse::Text("ack".to_string())]);
+    let (mut session, _cancel, _recorded) = make_session_with_recorder(&env, provider).await;
+
+    let sink = TestSink::new();
+    let (_tx, mut cmd_rx) = mpsc::channel::<EngineCommand>(1);
+    session
+        .run_turn(&env.config, None, &sink, &mut cmd_rx, None)
+        .await
+        .expect("turn should succeed");
+
+    let messages = env
+        .db
+        .load_all_messages(&env.session_id)
+        .await
+        .expect("load_all_messages");
+    let user_msgs: Vec<_> = messages.iter().filter(|m| m.role == Role::User).collect();
+    assert_eq!(
+        user_msgs.len(),
+        1,
+        "only the real user message should exist; drain must not insert empty rows. \
+         Got {} user rows: {:?}",
+        user_msgs.len(),
+        user_msgs.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        user_msgs[0].content.as_deref(),
+        Some("real user input"),
+        "the only user row must be the real one"
+    );
+}

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -93,6 +93,9 @@ async fn make_session_with_mcp(
     let provider = MockProvider::new(responses);
     let recorded = provider.recorded_calls_handle();
 
+    // #1325 Phase 2: per-session mailbox pair (cheap mpsc + watch).
+    let (mailbox, mailbox_rx) = koda_core::agent::Mailbox::new();
+
     let session = KodaSession {
         id: env.session_id.clone(),
         agent,
@@ -109,6 +112,9 @@ async fn make_session_with_mcp(
         // #1321: tests don't need the bg-event forwarder; production
         // (TUI / ACP) calls `attach_event_sink` to spawn it.
         event_forwarder: None,
+        mailbox,
+        mailbox_rx: Arc::new(tokio::sync::Mutex::new(mailbox_rx)),
+        idle_pending_input: Arc::new(tokio::sync::Mutex::new(Vec::new())),
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -51,6 +51,12 @@ async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession
     let file_tracker =
         koda_core::file_tracker::FileTracker::new(&env.session_id, env.db.clone()).await;
 
+    // #1325 Phase 2: per-session mailbox pair. Cheap (`mpsc` +
+    // `watch::Sender<u64>`) and the substrate is uniformly available
+    // everywhere so test sessions get one too — even though no Phase
+    // 2 code path produces mail yet.
+    let (mailbox, mailbox_rx) = koda_core::agent::Mailbox::new();
+
     let session = KodaSession {
         id: env.session_id.clone(),
         agent,
@@ -67,6 +73,9 @@ async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession
         // #1321: tests don't need the bg-event forwarder; production
         // (TUI / ACP) calls `attach_event_sink` to spawn it.
         event_forwarder: None,
+        mailbox,
+        mailbox_rx: std::sync::Arc::new(tokio::sync::Mutex::new(mailbox_rx)),
+        idle_pending_input: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
     };
     (session, cancel)
 }


### PR DESCRIPTION
**Phase 2 of #1325 — wire codex's mailbox substrate into KodaSession.**

Builds on Phase 1 (#1326) which vendored `Mailbox` / `MailboxReceiver` / `InterAgentCommunication` / `AgentPath` from openai/codex. This PR makes the substrate observable end-to-end: every `KodaSession` now owns a mailbox, and `run_turn` drains it into persisted user-role messages before the inference loop reads the conversation. No LLM-facing tool produces mail yet — Phase 3 lands the peer tools (`spawn_agent` / `send_message` / `wait_agent`) that exercise this path from the model side.

## Mapping to codex

| codex | koda |
|---|---|
| `Session.mailbox / mailbox_rx` | `KodaSession.mailbox / mailbox_rx` |
| `Session.idle_pending_input: Mutex<Vec<ResponseInputItem>>` | `KodaSession.idle_pending_input: Mutex<Vec<InterAgentCommunication>>` |
| `take_queued_response_items_for_next_turn` | `drain_mail_to_db` (idle half) |
| `get_pending_input` | `drain_mail_to_db` (mailbox half) |
| `pending_input` vec consumed by turn | `Role::User` rows in DB |
| `InterAgentCommunication::to_response_input_item` | `agent::mail_message::mail_to_user_message` |

Drain order matches codex: idle queue first (FIFO across the gap between turns), then mailbox (FIFO within this turn-start drain). Cross-codebase reasoning stays portable.

## Why `Role::User` instead of `Role::Assistant + MessagePhase::Commentary`

Codex serializes mail as `role: assistant + phase: Commentary` — the phase tag is what makes role-assistant safe (the model knows it's side-channel, not its own prior output). Koda has **no `MessagePhase` field** on its `persistence::Message`, and adding one is a DB-schema migration that touches every provider adapter and persistence call site. That migration is its own PR (deferred until a real consumer needs it).

For now we use `Role::User` with a structured human-readable prefix that preserves every wire field:

```
[mail from /root/peer → /root cc: /root/observer (trigger_turn=true)]
hello from peer
```

Information loss is zero — a future phase-column migration can re-derive structured form from the prefix.

## Other Phase 2 deferrals

- **`MailboxDeliveryPhase` enum** — codex uses CurrentTurn vs NextTurn to decide whether late-arriving mail folds into the in-flight turn or the next one. We always treat as CurrentTurn (drain at start, no mid-turn worry). Port the enum when koda gains streaming-aware final-text signaling.
- **Per-session `AgentPath` tree** — root session uses `AgentPath::root()`. Sub-paths land in Phase 3 when peer tools introduce a real spawner tree.
- **Migration of existing `child_agent` / sub-agent flows** — Phase 4-5.

## Commits (read top-down)

1. `feat(agent): add mail_to_user_message converter` — pure converter + 7 unit tests + 1 doctest. Pins the format contract.
2. `feat(session): wire mailbox into KodaSession + drain at turn start` — the architectural change. New public API: `mailbox()`, `enqueue_for_next_turn`, `drain_mail_to_db`. Drain failure is fatal for the turn (emits `TurnEnd::Error`) — partially-drained mailboxes silently lose mail, which is worse than a visible error.
3. `test(agent): e2e mailbox-to-conversation integration test` — 3 boundary tests pinning the observable contract:
   - **mail-send → user message**: load-bearing pin against any future drop-the-drain refactor.
   - **idle-before-mailbox FIFO order**: matches codex; downstream peer reasoning depends on it.
   - **empty-mailbox is a no-op**: regression guard against "always insert" creep.

## Test coverage

- 7 new unit tests + 1 doctest in `koda-core/src/agent/mail_message.rs`
- 3 new e2e tests in `koda-core/tests/agent_mailbox_e2e_test.rs`
- 8 existing struct-literal session tests updated for the new fields, all still green
- Full koda-core suite: **1359+ tests green**
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all`: clean

## Out of scope (Phase 3+)

- `spawn_agent` / `send_message` / `wait_agent` / `list_agents` peer tools
- `MailboxDeliveryPhase` semantics
- Migration of `InvokeAgent` to a spawn-and-wait convenience over the substrate
- Deletion of `WaitTask` / `ListBackgroundTasks`

Refs: #1325, follows #1326.
