### PR TITLE
feat: #1325 Phase 4 — per-agent paths + mailbox registry

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -391,6 +391,11 @@ async fn collect_stream(
     tools: &ToolRegistry,
     mode: TrustMode,
     project_root: &Path,
+    // #1325 Phase 4: stamped onto eager-dispatch tool calls so peer
+    // tools (`SendMessage`) attribute mail to the right author.
+    // Eager dispatch only runs read-only tools today (none of which
+    // are peer tools), so this is purely for forward-compat.
+    caller_agent_path: &crate::agent::AgentPath,
 ) -> StreamResult {
     let mut full_text = String::new();
     let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -499,7 +504,13 @@ async fn collect_stream(
                     // above). Bash is never read-only, so `caller_spawner=None`
                     // is correct here — there is no Bash path to mis-tag.
                     let r = tools
-                        .execute(&tc.function_name, &tc.arguments, None, None)
+                        .execute(
+                            &tc.function_name,
+                            &tc.arguments,
+                            None,
+                            None,
+                            caller_agent_path,
+                        )
                         .await;
                     eager_results.push((tc.id.clone(), r.output, r.success, r.full_output));
                 }
@@ -610,6 +621,12 @@ pub struct InferenceContext<'a> {
     /// Generation-based invalidation on mutating tool calls is
     /// honored uniformly via `crate::tool_dispatch::execute_one_tool`.
     pub sub_agent_cache: &'a crate::sub_agent_cache::SubAgentCache,
+
+    /// Caller's identity in the agent spawn tree (#1325 Phase 4).
+    /// `/root` for the user-facing session; `/root/<name>` for
+    /// spawned children. Threaded into `TurnContext.agent_path`
+    /// and on to every tool's `caller_agent_path`.
+    pub agent_path: &'a crate::agent::AgentPath,
 }
 
 /// Run the inference loop: send messages, stream responses, dispatch tool calls.
@@ -655,6 +672,7 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
         file_tracker,
         bg_agents,
         sub_agent_cache,
+        agent_path,
     } = ctx;
 
     // #1108 P1b: wrap the user-facing sink with `PersistingSink` so
@@ -685,6 +703,7 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
         bg_agents,
         mode,
         tools,
+        agent_path,
     );
     // Phase E of #996: top-level inference has no spawner identity —
     // bg-task tools see the global scope. Sub-agents construct their
@@ -1052,7 +1071,16 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
         };
 
         // Collect the streamed response
-        let stream_result = collect_stream(&mut rx, sink, &cancel, tools, mode, project_root).await;
+        let stream_result = collect_stream(
+            &mut rx,
+            sink,
+            &cancel,
+            tools,
+            mode,
+            project_root,
+            agent_path,
+        )
+        .await;
 
         if stream_result.interrupted {
             // Kill the background HTTP reader immediately so the TCP
@@ -1446,7 +1474,16 @@ mod tests {
             // tx drops here → stream ends
         });
 
-        collect_stream(&mut rx, &sink, &cancel, &tools, TrustMode::Auto, tmp.path()).await
+        collect_stream(
+            &mut rx,
+            &sink,
+            &cancel,
+            &tools,
+            TrustMode::Auto,
+            tmp.path(),
+            &crate::agent::AgentPath::root(),
+        )
+        .await
     }
 
     // ── Text streaming ───────────────────────────────────────────
@@ -1571,7 +1608,16 @@ mod tests {
         });
 
         let result =
-            collect_stream(&mut rx, &sink, &cancel, &tools, TrustMode::Auto, tmp.path()).await;
+            collect_stream(
+                &mut rx,
+                &sink,
+                &cancel,
+                &tools,
+                TrustMode::Auto,
+                tmp.path(),
+                &crate::agent::AgentPath::root(),
+            )
+            .await;
 
         assert_eq!(result.tool_calls.len(), 1, "tool call should be recorded");
         assert_eq!(result.eager_results.len(), 1, "should have 1 eager result");
@@ -1661,6 +1707,7 @@ mod tests {
             &tools,
             TrustMode::Auto,
             tmp.path(),
+            &crate::agent::AgentPath::root(),
         )
         .await;
 

--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -1607,17 +1607,16 @@ mod tests {
             let _ = tx.send(StreamChunk::Done(TokenUsage::default())).await;
         });
 
-        let result =
-            collect_stream(
-                &mut rx,
-                &sink,
-                &cancel,
-                &tools,
-                TrustMode::Auto,
-                tmp.path(),
-                &crate::agent::AgentPath::root(),
-            )
-            .await;
+        let result = collect_stream(
+            &mut rx,
+            &sink,
+            &cancel,
+            &tools,
+            TrustMode::Auto,
+            tmp.path(),
+            &crate::agent::AgentPath::root(),
+        )
+        .await;
 
         assert_eq!(result.tool_calls.len(), 1, "tool call should be recorded");
         assert_eq!(result.eager_results.len(), 1, "should have 1 eager result");

--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -333,6 +333,21 @@ pub struct KodaSession {
     /// `Arc` to `agent.tools.set_mailbox_registry(...)` after
     /// construction.
     pub mailbox_registry: Arc<MailboxRegistry>,
+
+    /// This session's identity in the agent spawn tree. The root
+    /// user-facing session is always `/root`; spawned children
+    /// (Phase 4 of #1325) inherit a `/root/<name>` path computed
+    /// at spawn time.
+    ///
+    /// Threaded through the inference loop to `TurnContext` and
+    /// `ToolExecCtx::caller_agent_path`, so peer tools
+    /// (`SendMessage`, `WaitForMail`, the upcoming `SpawnAgent`)
+    /// can stamp the right `author` on outgoing mail and look up
+    /// the right inbox for blocking reads. Without this field,
+    /// every spawned agent would falsely claim `author = /root`
+    /// and corrupt the spawn-tree topology that mail attribution
+    /// relies on.
+    pub agent_path: AgentPath,
 }
 
 impl KodaSession {
@@ -473,6 +488,12 @@ impl KodaSession {
             mailbox_rx: Arc::new(AsyncMutex::new(mailbox_rx)),
             idle_pending_input: Arc::new(AsyncMutex::new(Vec::new())),
             mailbox_registry,
+            // The user-facing root session is always `/root`. Phase 4's
+            // spawn_agent will construct child sessions with
+            // `/root/<name>` paths via a separate constructor (or this
+            // one with an extra arg) — defer that change until the
+            // spawn machinery lands.
+            agent_path: AgentPath::root(),
         }
     }
 
@@ -719,6 +740,12 @@ impl KodaSession {
             file_tracker: &mut self.file_tracker,
             bg_agents: &self.bg_agents,
             sub_agent_cache: &self.sub_agent_cache,
+            // #1325 Phase 4: this session's identity in the spawn
+            // tree (always `/root` for the user-facing session;
+            // future spawned sessions will carry their assigned
+            // child path). Threaded into TurnContext → ToolExecCtx
+            // so peer tools can stamp the right `author` on mail.
+            agent_path: &self.agent_path,
         })
         .await;
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -75,6 +75,76 @@ pub(crate) fn next_invocation_id() -> u32 {
     NEXT_INVOCATION_ID.fetch_add(1, Ordering::Relaxed)
 }
 
+/// Build a unique child [`AgentPath`] under `parent` for a sub-agent
+/// invocation (#1325 Phase 4 — commit 2 of 3).
+///
+/// **Why a helper:** the same composition (sanitize the user-supplied
+/// `agent_name`, append a unique id) is needed at both spawn sites
+/// (the `tokio::spawn(run_bg_agent(...))` block, and the inline
+/// path inside `execute_sub_agent`). Keeping the rule in one place
+/// means the bg/inline paths can never drift on uniqueness or
+/// validation semantics — and it stays unit-testable as a pure fn.
+///
+/// **Sanitization rules** match [`crate::agent::path::AgentPath`]'s
+/// `[a-z0-9_]+` segment grammar:
+///
+/// 1. Lowercase every ASCII letter.
+/// 2. Replace any other char (uppercase letters that didn't ASCII-
+///    lowercase, digits-non-ASCII, punctuation, whitespace, unicode)
+///    with `_`.
+/// 3. Collapse runs of `_` and trim leading/trailing `_`.
+/// 4. If the result is empty (e.g. `agent_name = "!!!"` — pathological
+///    but `parse_agent_name_required` would have accepted it), fall
+///    back to `agent`.
+/// 5. Append `_<unique_id>` so concurrent invocations of the same
+///    agent don't collide (`/root/explore_42`, `/root/explore_43`).
+///
+/// **Why include `unique_id` even when callers pass distinct names:**
+/// Phase 4e of #1325 introduces multi-element `InvokeAgent([...])`
+/// where the same agent name is fanned out in parallel. The id
+/// suffix is the only thing that keeps their mailbox identities
+/// distinct, and adding it unconditionally is cheaper than branching
+/// on "is this the parallel case."
+///
+/// **Future-proofing:** `parent` is taken as a borrow rather than
+/// hard-coded to [`AgentPath::root`] so when nested spawn lands
+/// (Phase 6+) the same helper builds `/root/explore_4/researcher_7`
+/// without a touch — caller passes `parent_tx.turn.agent_path`
+/// today (always `/root`) and the future nested call passes the
+/// in-flight sub-agent's path (also already plumbed by 4a).
+pub(crate) fn child_agent_path(
+    parent: &crate::agent::AgentPath,
+    agent_name: &str,
+    unique_id: u32,
+) -> anyhow::Result<crate::agent::AgentPath> {
+    let mut sanitized = String::with_capacity(agent_name.len());
+    let mut prev_underscore = false;
+    for ch in agent_name.chars() {
+        let mapped = if ch.is_ascii_lowercase() || ch.is_ascii_digit() {
+            ch
+        } else if ch.is_ascii_uppercase() {
+            ch.to_ascii_lowercase()
+        } else {
+            '_'
+        };
+        if mapped == '_' {
+            if prev_underscore {
+                continue;
+            }
+            prev_underscore = true;
+        } else {
+            prev_underscore = false;
+        }
+        sanitized.push(mapped);
+    }
+    let trimmed = sanitized.trim_matches('_');
+    let base = if trimmed.is_empty() { "agent" } else { trimmed };
+    let segment = format!("{base}_{unique_id}");
+    parent
+        .join(&segment)
+        .map_err(|e| anyhow::anyhow!("failed to build child AgentPath from {agent_name:?}: {e}"))
+}
+
 /// RAII cleanup hook for #996 Phase E.
 ///
 /// On drop, cancels every bg-agent registry entry tagged with this
@@ -162,6 +232,14 @@ async fn run_bg_agent(
     // entry was reaped, in which case the queued `ChildTaskUpdate` is
     // harmless extra signal that clients can ignore.
     emitter: crate::child_agent::ChildStatusEmitter,
+    // #1325 Phase 4 (commit 2): the bg agent's identity in the spawn
+    // tree (e.g. `/root/explore_42`). Constructed by the spawn site
+    // BEFORE `tokio::spawn` so we get a path-construction error in
+    // the parent's dispatch flow rather than as a panic inside the
+    // detached task. Threaded into the bg agent's `TurnContext` so
+    // `SendMessage` from inside the bg agent stamps the right
+    // `author`, and 4c+ peer-tools route by it.
+    bg_agent_path: crate::agent::AgentPath,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
@@ -217,13 +295,11 @@ async fn run_bg_agent(
     // `sub_config.allowed_tools`).
     let placeholder_tools =
         crate::tools::ToolRegistry::new(project_root.clone(), parent_config.max_context_tokens);
-    // #1325 Phase 4 (commit 1 — plumbing): bg agents "are" the root
-    // for now because the spawn machinery (`SpawnAgent`, child path
-    // assignment, child mailbox registration) lands in commit 2. As
-    // soon as commit 2 ships this becomes the actual child path so
-    // `SendMessage`/`WaitForMail` from inside the child see the
-    // right inbox / `author`.
-    let bg_agent_path = crate::agent::AgentPath::root();
+    // #1325 Phase 4 (commit 2): the spawn site built our path AND
+    // moved it in via the function parameter. We can't construct it
+    // here — we'd need the parent's path AND the registry-allocated
+    // `task_id`, neither of which lives in `run_bg_agent`'s
+    // owned-data world.
     let bg_turn = crate::turn_context::TurnContext::new(
         &project_root,
         &parent_config,
@@ -636,6 +712,17 @@ pub(crate) fn execute_sub_agent<'a>(
             let bg_policy = parent_sandbox_policy.clone();
             let bg_trust = mode;
 
+            // #1325 Phase 4 (commit 2): build the child's `AgentPath`
+            // BEFORE spawning so it can be moved into the bg task.
+            // Same `parent` as inline (`parent_tx.turn.agent_path`)
+            // so when nested spawn lands the path nesting falls out
+            // for free. Failures here are programmer errors against
+            // `child_agent_path`'s `"agent"` fallback — surface them
+            // as the dispatch error rather than panicking inside the
+            // spawned task.
+            let bg_agent_path =
+                child_agent_path(parent_tx.turn.agent_path, agent_name, task_id)?;
+
             sink.emit(EngineEvent::Info {
                 message: format!(
                     "  \u{1f680} {agent_name} launched in background (task {task_id})"
@@ -654,6 +741,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_trust,
                 bg_policy,
                 emitter,
+                bg_agent_path,
             ));
 
             bg_agents.attach(
@@ -1115,11 +1203,15 @@ pub(crate) fn execute_sub_agent<'a>(
         // inline twice with identical args. Hoisted here because
         // `sub_config`, `sub_session`, and `tools` are all bound by
         // this point and don't change across iterations.
-        // #1325 Phase 4 (commit 1): inline-only sub-agent path
-        // (background=false). Same placeholder reasoning as the
-        // bg-agent path above — commit 2 swaps `/root` for the
-        // child's actual `/root/<name>` path.
-        let sub_agent_path = crate::agent::AgentPath::root();
+        // #1325 Phase 4 (commit 2): build this invocation's path
+        // BEFORE constructing the sub-agent's `TurnContext`.
+        // `my_invocation_id` (allocated near the top of
+        // `execute_sub_agent`) is the unique-per-invocation handle
+        // — perfect for path uniquification when multiple inline
+        // `InvokeAgent`s of the same agent name run concurrently
+        // (Phase 4e's multi-element form).
+        let sub_agent_path =
+            child_agent_path(parent_tx.turn.agent_path, agent_name, my_invocation_id)?;
         let sub_turn = crate::turn_context::TurnContext::new(
             project_root,
             &sub_config,
@@ -1631,6 +1723,99 @@ fn workspace_provision_failure_marker(agent_name: &str, reason: &str) -> String 
          resolve the workspace setup issue, retry without write tools, or attempt the work \
          directly without delegating.]"
     )
+}
+
+#[cfg(test)]
+mod child_agent_path_tests {
+    //! **#1325 Phase 4 (commit 2)** regression tests for
+    //! [`super::child_agent_path`].
+    //!
+    //! Helper is reachable via two spawn sites buried in 1100+ lines
+    //! of `execute_sub_agent`; we'd rather pin its contract here than
+    //! through a giant integration test of either site.
+
+    use super::child_agent_path;
+    use crate::agent::AgentPath;
+
+    #[test]
+    fn passthrough_for_already_valid_lowercase_name() {
+        let p = child_agent_path(&AgentPath::root(), "explore", 42).unwrap();
+        assert_eq!(p.as_str(), "/root/explore_42");
+    }
+
+    #[test]
+    fn keeps_underscores_inside_name() {
+        let p = child_agent_path(&AgentPath::root(), "code_reviewer", 7).unwrap();
+        assert_eq!(p.as_str(), "/root/code_reviewer_7");
+    }
+
+    #[test]
+    fn lowercases_uppercase_letters() {
+        let p = child_agent_path(&AgentPath::root(), "CodeReviewer", 1).unwrap();
+        assert_eq!(p.as_str(), "/root/codereviewer_1");
+    }
+
+    #[test]
+    fn replaces_punctuation_with_underscore_and_collapses_runs() {
+        let p = child_agent_path(&AgentPath::root(), "a.b/c-d", 9).unwrap();
+        assert_eq!(p.as_str(), "/root/a_b_c_d_9");
+    }
+
+    #[test]
+    fn collapses_doubled_underscores_inside_name() {
+        // "a..b" -> two punctuation chars become two underscores; we
+        // collapse to one so the segment stays readable.
+        let p = child_agent_path(&AgentPath::root(), "a..b", 3).unwrap();
+        assert_eq!(p.as_str(), "/root/a_b_3");
+    }
+
+    #[test]
+    fn trims_leading_and_trailing_underscores_from_sanitized_name() {
+        let p = child_agent_path(&AgentPath::root(), "-explore-", 5).unwrap();
+        assert_eq!(p.as_str(), "/root/explore_5");
+    }
+
+    #[test]
+    fn falls_back_to_agent_when_name_sanitizes_to_empty() {
+        // All-punctuation name. `parse_agent_name_required` only
+        // checks non-empty, so this is reachable from a real call.
+        let p = child_agent_path(&AgentPath::root(), "!!!", 12).unwrap();
+        assert_eq!(p.as_str(), "/root/agent_12");
+    }
+
+    #[test]
+    fn unicode_replaced_with_underscore() {
+        let p = child_agent_path(&AgentPath::root(), "\u{1F436}explore", 4).unwrap();
+        assert_eq!(p.as_str(), "/root/explore_4");
+    }
+
+    #[test]
+    fn nests_under_non_root_parent() {
+        // Future-proofing: when nested spawn lands, the same helper
+        // builds `/root/explore_4/researcher_7` from a parent path
+        // of `/root/explore_4`. Pinning today so the property
+        // doesn't silently regress.
+        let parent = AgentPath::root().join("explore_4").unwrap();
+        let p = child_agent_path(&parent, "researcher", 7).unwrap();
+        assert_eq!(p.as_str(), "/root/explore_4/researcher_7");
+    }
+
+    #[test]
+    fn distinct_unique_ids_produce_distinct_paths() {
+        // Phase 4e fan-out invariant: two parallel `InvokeAgent`s of
+        // the same agent name must end up with different paths so
+        // their mailbox identities don't alias.
+        let a = child_agent_path(&AgentPath::root(), "explore", 1).unwrap();
+        let b = child_agent_path(&AgentPath::root(), "explore", 2).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn digits_in_agent_name_are_preserved() {
+        // Numeric suffixes are valid `[a-z0-9_]` chars — keep them.
+        let p = child_agent_path(&AgentPath::root(), "agent42", 99).unwrap();
+        assert_eq!(p.as_str(), "/root/agent42_99");
+    }
 }
 
 #[cfg(test)]

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -839,8 +839,7 @@ pub(crate) fn execute_sub_agent<'a>(
             // `child_agent_path`'s `"agent"` fallback — surface them
             // as the dispatch error rather than panicking inside the
             // spawned task.
-            let bg_agent_path =
-                child_agent_path(parent_tx.turn.agent_path, agent_name, task_id)?;
+            let bg_agent_path = child_agent_path(parent_tx.turn.agent_path, agent_name, task_id)?;
 
             // #1325 Phase 4 (commit 3): hand the parent's registry
             // (Arc) into the bg task so its inner `execute_sub_agent`

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -76,7 +76,7 @@ pub(crate) fn next_invocation_id() -> u32 {
 }
 
 /// Build a unique child [`AgentPath`] under `parent` for a sub-agent
-/// invocation (#1325 Phase 4 — commit 2 of 3).
+/// invocation (#1325 Phase 4 — used by commits 2 and 3).
 ///
 /// **Why a helper:** the same composition (sanitize the user-supplied
 /// `agent_name`, append a unique id) is needed at both spawn sites
@@ -143,6 +143,109 @@ pub(crate) fn child_agent_path(
     parent
         .join(&segment)
         .map_err(|e| anyhow::anyhow!("failed to build child AgentPath from {agent_name:?}: {e}"))
+}
+
+/// RAII unregister-on-drop guard for a sub-agent's mailbox entry
+/// (#1325 Phase 4 — commit 3 of 3).
+///
+/// Holds an [`Arc`](std::sync::Arc) clone of the registry plus the
+/// path it registered itself at. On drop, calls `unregister` so the
+/// path slot becomes available for re-use (Phase 4e fan-out is the
+/// motivating case: one `explore` agent finishes and its slot opens
+/// up for the next).
+///
+/// **Why RAII rather than an explicit unregister at the bottom of
+/// `execute_sub_agent`:** every `?` inside the body would leak a
+/// dangling registry entry without it. The same reasoning drives
+/// the existing [`InvocationCleanup`] guard in this module.
+///
+/// **Idempotent:** if `unregister` returns `false` (entry already
+/// gone), drop logs at trace level and continues. Lets future code
+/// paths explicitly unregister (e.g. for hot-replace) without this
+/// guard double-warning.
+struct MailboxRegistration {
+    registry: std::sync::Arc<crate::agent::MailboxRegistry>,
+    path: crate::agent::AgentPath,
+}
+
+impl Drop for MailboxRegistration {
+    fn drop(&mut self) {
+        if !self.registry.unregister(&self.path) {
+            tracing::trace!(
+                path = %self.path,
+                "MailboxRegistration::drop: entry already gone (idempotent)"
+            );
+        }
+    }
+}
+
+/// Register a fresh mailbox at `path` in `registry` (#1325 Phase 4 —
+/// commit 3 of 3).
+///
+/// Returns the [`MailboxReceiver`] (the sub-agent drains this into
+/// its own DB session at the top of each iter) plus an RAII guard
+/// that unregisters on drop. The sender side stays in the registry
+/// so peers calling `SendMessage{target: <path>}` find a live inbox.
+///
+/// Returns `None` if the path is already registered. Because
+/// [`child_agent_path`] appends a unique `_<id>` suffix per
+/// invocation, this collision should not happen in practice; if it
+/// does, the caller is supposed to fall back to the pre-Phase-4
+/// "everything routes through `/root`" behaviour rather than
+/// silently shadowing another sub-agent's mailbox.
+fn register_sub_agent_mailbox(
+    registry: &std::sync::Arc<crate::agent::MailboxRegistry>,
+    path: &crate::agent::AgentPath,
+) -> Option<(crate::agent::MailboxReceiver, MailboxRegistration)> {
+    let (mailbox, receiver) = crate::agent::Mailbox::new();
+    let mailbox = std::sync::Arc::new(mailbox);
+    match registry.register(path.clone(), mailbox) {
+        crate::agent::RegisterOutcome::Inserted => Some((
+            receiver,
+            MailboxRegistration {
+                registry: std::sync::Arc::clone(registry),
+                path: path.clone(),
+            },
+        )),
+        crate::agent::RegisterOutcome::AlreadyRegistered => {
+            // `child_agent_path` includes a unique id, so this should
+            // never fire. Treat as a programmer error — don't shadow.
+            tracing::error!(
+                path = %path,
+                "sub-agent mailbox path collision \u{2014} registry already has an entry. \
+                 child_agent_path uniquification must be broken."
+            );
+            None
+        }
+    }
+}
+
+/// Drain a sub-agent's mailbox into its DB session as `Role::User`
+/// rows (#1325 Phase 4 — commit 3 of 3).
+///
+/// Mirrors [`crate::session::KodaSession::drain_mail_to_db`] but
+/// scoped to the per-sub-agent receiver and `session_id`. Called at
+/// the top of each iter inside the sub-agent's inline inference loop
+/// so any mail that arrived since the last iter shows up in the
+/// next LLM call's history.
+///
+/// Empty mailbox is a no-op (returns `Ok(())` without writing
+/// anything) — cheaper than guarding at every call site.
+async fn drain_sub_mailbox_into_session(
+    rx: &mut crate::agent::MailboxReceiver,
+    db: &crate::db::Database,
+    session_id: &str,
+) -> anyhow::Result<()> {
+    let items = rx.drain();
+    if items.is_empty() {
+        return Ok(());
+    }
+    for mail in items {
+        let (role, content) = crate::agent::mail_to_user_message(&mail);
+        db.insert_message(session_id, &role, Some(&content), None, None, None)
+            .await?;
+    }
+    Ok(())
 }
 
 /// RAII cleanup hook for #996 Phase E.
@@ -240,6 +343,14 @@ async fn run_bg_agent(
     // `SendMessage` from inside the bg agent stamps the right
     // `author`, and 4c+ peer-tools route by it.
     bg_agent_path: crate::agent::AgentPath,
+    // #1325 Phase 4 (commit 3): the shared mailbox registry. Cloned
+    // by the spawn site from the parent's `tools.mailbox_registry()`
+    // and threaded down so the bg agent's inner `execute_sub_agent`
+    // call sees it on `placeholder_tools.mailbox_registry()` and
+    // takes the registration branch (rather than falling back to
+    // "no per-child mailbox"). `None` propagates the
+    // no-session-context fallback unchanged.
+    bg_mailbox_registry: Option<std::sync::Arc<crate::agent::MailboxRegistry>>,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
@@ -291,10 +402,18 @@ async fn run_bg_agent(
     // `tokio::spawn`), so we have to construct the parent's dispatch
     // context locally from owned borrows. The `tools` field is a
     // throwaway empty registry — `execute_sub_agent` ignores the
-    // parent's tools (sub-agents always build their own from
-    // `sub_config.allowed_tools`).
+    // parent's tools for tool *execution* (sub-agents build their
+    // own from `sub_config.allowed_tools`) but it DOES read
+    // `placeholder_tools.mailbox_registry()` to find the registry
+    // it should install on the sub-agent's tools — see commit 3 of
+    // #1325 Phase 4. Install the threaded-in registry here so that
+    // lookup succeeds (otherwise the bg path silently regresses to
+    // "no per-child mailbox").
     let placeholder_tools =
         crate::tools::ToolRegistry::new(project_root.clone(), parent_config.max_context_tokens);
+    if let Some(reg) = bg_mailbox_registry.as_ref() {
+        placeholder_tools.set_mailbox_registry(std::sync::Arc::clone(reg));
+    }
     // #1325 Phase 4 (commit 2): the spawn site built our path AND
     // moved it in via the function parameter. We can't construct it
     // here — we'd need the parent's path AND the registry-allocated
@@ -723,6 +842,15 @@ pub(crate) fn execute_sub_agent<'a>(
             let bg_agent_path =
                 child_agent_path(parent_tx.turn.agent_path, agent_name, task_id)?;
 
+            // #1325 Phase 4 (commit 3): hand the parent's registry
+            // (Arc) into the bg task so its inner `execute_sub_agent`
+            // recursion can register the bg agent's own mailbox
+            // exactly like the inline path does. `None` means the
+            // parent is itself running without a session-attached
+            // registry (test fixture); pass it through so the bg
+            // path matches the inline fallback semantics.
+            let bg_mailbox_registry = parent_tx.turn.tools.mailbox_registry();
+
             sink.emit(EngineEvent::Info {
                 message: format!(
                     "  \u{1f680} {agent_name} launched in background (task {task_id})"
@@ -742,6 +870,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_policy,
                 emitter,
                 bg_agent_path,
+                bg_mailbox_registry,
             ));
 
             bg_agents.attach(
@@ -1212,6 +1341,40 @@ pub(crate) fn execute_sub_agent<'a>(
         // (Phase 4e's multi-element form).
         let sub_agent_path =
             child_agent_path(parent_tx.turn.agent_path, agent_name, my_invocation_id)?;
+
+        // #1325 Phase 4 (commit 3): give the sub-agent its own
+        // mailbox in the shared registry, install the registry on
+        // its tools, and keep the receiver around so we can drain
+        // it at the top of each iter.
+        //
+        // `parent_registry == None` means this dispatch path is
+        // running without a session (test fixture / no-session
+        // context). Fall back to pre-Phase-4 behaviour: no per-
+        // child mailbox, no peer-tool wiring inside the child. The
+        // child still functions; it just can't `SendMessage` /
+        // `WaitForMail` (which is the same as Phase 1-2).
+        //
+        // The guard MUST live until the end of the `async move` so
+        // the registry entry survives every iter. Binding it as
+        // `_sub_mailbox_guard` (with a leading underscore) silences
+        // the unused-variable warning while still extending the
+        // lifetime to the enclosing scope. `let _ = ...;` would
+        // drop it immediately; `let _x = ...;` keeps it alive.
+        let parent_registry = parent_tx.turn.tools.mailbox_registry();
+        let (mut sub_mailbox_rx, _sub_mailbox_guard) = match parent_registry.as_ref() {
+            Some(reg) => match register_sub_agent_mailbox(reg, &sub_agent_path) {
+                Some((rx, guard)) => (Some(rx), Some(guard)),
+                None => (None, None),
+            },
+            None => (None, None),
+        };
+        if let Some(reg) = parent_registry.as_ref() {
+            // Install the SHARED registry on the sub-agent's tools.
+            // `set_mailbox_registry` takes `&self` (interior
+            // mutability) so the immutable `tools` binding is fine.
+            tools.set_mailbox_registry(std::sync::Arc::clone(reg));
+        }
+
         let sub_turn = crate::turn_context::TurnContext::new(
             project_root,
             &sub_config,
@@ -1291,6 +1454,21 @@ pub(crate) fn execute_sub_agent<'a>(
         }
 
         for iter in 1u32.. {
+            // #1325 Phase 4 (commit 3): drain any peer-agent mail
+            // that arrived since the last iter into the sub-agent's
+            // DB session BEFORE `db.load_context` reads the
+            // conversation. Mirrors `KodaSession::drain_mail_to_db`
+            // for the root session. No-op when no mailbox is wired
+            // (`sub_mailbox_rx` is `None`) or no mail has arrived.
+            //
+            // Drain failure is fatal for the iter — a partial drain
+            // would silently lose mail, and the alternative
+            // (dropping mail on error) is worse than bailing the
+            // sub-agent.
+            if let Some(rx) = sub_mailbox_rx.as_mut() {
+                drain_sub_mailbox_into_session(rx, db, &sub_session).await?;
+            }
+
             // #1110: sub-agents have no hardcoded iteration cap. Termination
             // is driven by the model (clean stop, no tool calls), `LoopDetector`
             // (consecutive identical calls -> feedback -> hard stop), parent
@@ -1815,6 +1993,213 @@ mod child_agent_path_tests {
         // Numeric suffixes are valid `[a-z0-9_]` chars — keep them.
         let p = child_agent_path(&AgentPath::root(), "agent42", 99).unwrap();
         assert_eq!(p.as_str(), "/root/agent42_99");
+    }
+}
+
+#[cfg(test)]
+mod sub_agent_mailbox_tests {
+    //! **#1325 Phase 4 (commit 3)** regression tests for the per-
+    //! sub-agent mailbox lifecycle helpers ([`super::register_sub_agent_mailbox`],
+    //! [`super::MailboxRegistration`], [`super::drain_sub_mailbox_into_session`]).
+    //!
+    //! Helpers are wired into `execute_sub_agent`, which is
+    //! a 1100+ line `async move` deep behind workspace provisioning,
+    //! provider mocking, and sandbox composition. Pure-fn /
+    //! pure-RAII tests here pin the contract that the wiring
+    //! depends on; the wiring itself is exercised by the existing
+    //! sub-agent integration tests.
+
+    use super::{MailboxRegistration, drain_sub_mailbox_into_session, register_sub_agent_mailbox};
+    use crate::agent::{AgentPath, InterAgentCommunication, MailboxRegistry};
+    use crate::db::{Database, Role};
+    use crate::persistence::Persistence;
+    use std::sync::Arc;
+
+    fn sample_mail(content: &str) -> InterAgentCommunication {
+        InterAgentCommunication {
+            author: AgentPath::root(),
+            recipient: AgentPath::root().join("explore_42").unwrap(),
+            other_recipients: Vec::new(),
+            content: content.to_string(),
+            trigger_turn: true,
+        }
+    }
+
+    #[test]
+    fn register_returns_some_for_fresh_path() {
+        // Pin: a path that's never been registered yields a
+        // receiver + guard. Without this, the sub-agent silently
+        // falls back to root — the regression we're fixing.
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let result = register_sub_agent_mailbox(&reg, &path);
+        assert!(result.is_some(), "fresh path must register");
+        assert_eq!(reg.len(), 1, "registry must contain the new entry");
+    }
+
+    #[test]
+    fn register_returns_none_on_collision() {
+        // Pin: collision means uniquification is broken. The helper
+        // refuses to shadow rather than silently masking another
+        // sub-agent's mailbox — documented contract on
+        // RegisterOutcome.
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let _first = register_sub_agent_mailbox(&reg, &path).expect("first register");
+        let second = register_sub_agent_mailbox(&reg, &path);
+        assert!(
+            second.is_none(),
+            "colliding register must return None, not shadow"
+        );
+        assert_eq!(reg.len(), 1, "registry must not grow on collision");
+    }
+
+    #[test]
+    fn drop_unregisters_entry() {
+        // Pin the load-bearing RAII contract: every `?` inside
+        // `execute_sub_agent` would leak a registry entry without it.
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (_rx, guard) = register_sub_agent_mailbox(&reg, &path).expect("register");
+        assert_eq!(reg.len(), 1);
+        drop(guard);
+        assert_eq!(reg.len(), 0, "drop must unregister");
+    }
+
+    #[test]
+    fn drop_is_idempotent_when_entry_already_gone() {
+        // Pin: explicit unregister followed by drop must not panic.
+        // Future code paths may explicitly unregister (e.g. for
+        // hot-replace); this test pins that the RAII guard tolerates it.
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (_rx, guard) = register_sub_agent_mailbox(&reg, &path).expect("register");
+        assert!(reg.unregister(&path), "explicit unregister succeeds");
+        // Now drop the guard — entry is already gone. Must not panic.
+        drop(guard);
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn manual_construction_drops_correctly() {
+        // Pin: MailboxRegistration is constructed by
+        // `register_sub_agent_mailbox` today, but the Drop impl
+        // shouldn't depend on construction path. Verify by hand-
+        // constructing one and dropping it.
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (mb, _rx) = crate::agent::Mailbox::new();
+        reg.register(path.clone(), Arc::new(mb));
+        let guard = MailboxRegistration {
+            registry: Arc::clone(&reg),
+            path: path.clone(),
+        };
+        drop(guard);
+        assert!(
+            reg.get(&path).is_none(),
+            "manually-built guard's Drop must still unregister"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_empty_mailbox_writes_nothing() {
+        // Pin: empty drain is a no-op (no rows inserted, no error).
+        // Called every iter — must be cheap and side-effect-free
+        // when there's no mail.
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("drain_empty.db"))
+            .await
+            .unwrap();
+        let session_id = db.create_session("test", dir.path()).await.unwrap();
+
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (mut rx, _guard) = register_sub_agent_mailbox(&reg, &path).expect("register");
+
+        drain_sub_mailbox_into_session(&mut rx, &db, &session_id)
+            .await
+            .unwrap();
+
+        let history = db.load_context(&session_id).await.unwrap();
+        assert!(history.is_empty(), "empty drain must not insert any rows");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_writes_one_user_row_per_mail_item() {
+        // Pin: each mail item becomes one Role::User row — the same
+        // shape `KodaSession::drain_mail_to_db` produces for the
+        // root session, so the LLM sees the same prompt structure
+        // whether mail lands in the root or in a sub-agent.
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("drain_full.db"))
+            .await
+            .unwrap();
+        let session_id = db.create_session("test", dir.path()).await.unwrap();
+
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (mut rx, _guard) = register_sub_agent_mailbox(&reg, &path).expect("register");
+
+        // Send via the registry handle so we exercise the same path
+        // peer tools use.
+        let mb = reg.get(&path).expect("registered mailbox");
+        mb.send(sample_mail("hello from peer"));
+        mb.send(sample_mail("second message"));
+
+        drain_sub_mailbox_into_session(&mut rx, &db, &session_id)
+            .await
+            .unwrap();
+
+        let history = db.load_context(&session_id).await.unwrap();
+        assert_eq!(history.len(), 2, "two mails -> two rows");
+        for msg in &history {
+            assert_eq!(
+                msg.role,
+                Role::User,
+                "mail must land as user-role to mirror KodaSession::drain_mail_to_db"
+            );
+        }
+        let bodies: Vec<&str> = history
+            .iter()
+            .filter_map(|m| m.content.as_deref())
+            .collect();
+        assert!(
+            bodies.iter().any(|b| b.contains("hello from peer")),
+            "first mail body must be persisted; got: {bodies:?}"
+        );
+        assert!(
+            bodies.iter().any(|b| b.contains("second message")),
+            "second mail body must be persisted; got: {bodies:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_after_unregister_still_drains_buffered_mail() {
+        // Pin: dropping the registry entry doesn't drop the receiver.
+        // A peer's send + our unregister can race; we must not lose
+        // the mail that already landed in the channel.
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::open(&dir.path().join("drain_after_unreg.db"))
+            .await
+            .unwrap();
+        let session_id = db.create_session("test", dir.path()).await.unwrap();
+
+        let reg = Arc::new(MailboxRegistry::new());
+        let path = AgentPath::root().join("explore_42").unwrap();
+        let (mut rx, guard) = register_sub_agent_mailbox(&reg, &path).expect("register");
+        let mb = reg.get(&path).expect("registered mailbox");
+
+        // Send, then drop the guard (unregistering the path) BEFORE
+        // draining. The mail is already in the unbounded channel.
+        mb.send(sample_mail("survives unregister"));
+        drop(guard);
+        drop(mb);
+
+        drain_sub_mailbox_into_session(&mut rx, &db, &session_id)
+            .await
+            .unwrap();
+        let history = db.load_context(&session_id).await.unwrap();
+        assert_eq!(history.len(), 1, "buffered mail must drain post-unregister");
     }
 }
 

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -217,6 +217,13 @@ async fn run_bg_agent(
     // `sub_config.allowed_tools`).
     let placeholder_tools =
         crate::tools::ToolRegistry::new(project_root.clone(), parent_config.max_context_tokens);
+    // #1325 Phase 4 (commit 1 — plumbing): bg agents "are" the root
+    // for now because the spawn machinery (`SpawnAgent`, child path
+    // assignment, child mailbox registration) lands in commit 2. As
+    // soon as commit 2 ships this becomes the actual child path so
+    // `SendMessage`/`WaitForMail` from inside the child see the
+    // right inbox / `author`.
+    let bg_agent_path = crate::agent::AgentPath::root();
     let bg_turn = crate::turn_context::TurnContext::new(
         &project_root,
         &parent_config,
@@ -228,6 +235,7 @@ async fn run_bg_agent(
         &nested_bg,
         parent_trust,
         &placeholder_tools,
+        &bg_agent_path,
     );
     // Phase E of #996: the bg agent has no in-process parent in
     // the spawner sense — its `nested_bg` registry is fresh, and
@@ -1107,6 +1115,11 @@ pub(crate) fn execute_sub_agent<'a>(
         // inline twice with identical args. Hoisted here because
         // `sub_config`, `sub_session`, and `tools` are all bound by
         // this point and don't change across iterations.
+        // #1325 Phase 4 (commit 1): inline-only sub-agent path
+        // (background=false). Same placeholder reasoning as the
+        // bg-agent path above — commit 2 swaps `/root` for the
+        // child's actual `/root/<name>` path.
+        let sub_agent_path = crate::agent::AgentPath::root();
         let sub_turn = crate::turn_context::TurnContext::new(
             project_root,
             &sub_config,
@@ -1118,6 +1131,7 @@ pub(crate) fn execute_sub_agent<'a>(
             bg_agents,
             mode,
             &tools,
+            &sub_agent_path,
         );
         let sub_tx =
             crate::turn_context::ToolExecutionContext::new(&sub_turn, Some(my_invocation_id));

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -257,6 +257,7 @@ pub(crate) async fn execute_one_tool(
         ..
     } = *tx.turn;
     let caller_spawner = tx.caller_spawner;
+    let caller_agent_path = tx.turn.agent_path;
     let _session_id = session_id; // mirror the existing `_session_id` arg name
     let (result, success, full_output) = if matches!(
         tc.function_name.as_str(),
@@ -367,7 +368,13 @@ pub(crate) async fn execute_one_tool(
             None
         };
         let r = tools
-            .execute(&tc.function_name, &tc.arguments, streaming, caller_spawner)
+            .execute(
+                &tc.function_name,
+                &tc.arguments,
+                streaming,
+                caller_spawner,
+                caller_agent_path,
+            )
             .await;
         (r.output, r.success, r.full_output)
     };

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -469,6 +469,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -478,6 +479,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let r = t.execute(&ctx, &serde_json::json!({})).await;
         assert!(!r.success);

--- a/koda-core/src/tools/file_tools.rs
+++ b/koda-core/src/tools/file_tools.rs
@@ -1668,6 +1668,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1677,6 +1678,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let tool: Box<dyn Tool> = Box::new(ReadTool);
         let result = tool
@@ -1699,6 +1701,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1708,6 +1711,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let tool: Box<dyn Tool> = Box::new(WriteTool);
         let result = tool
@@ -1732,6 +1736,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -1741,6 +1746,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let tool: Box<dyn Tool> = Box::new(ReadTool);
         let result = tool

--- a/koda-core/src/tools/glob_tool.rs
+++ b/koda-core/src/tools/glob_tool.rs
@@ -254,6 +254,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -263,6 +264,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let tool: Box<dyn Tool> = Box::new(GlobTool);
         let result = tool

--- a/koda-core/src/tools/grep.rs
+++ b/koda-core/src/tools/grep.rs
@@ -389,6 +389,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -398,6 +399,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let tool: Box<dyn Tool> = Box::new(GrepTool);
         let result = tool

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -1259,7 +1259,13 @@ mod tests {
         // First write: should emit.
         let sink1 = crate::engine::sink::TestSink::new();
         registry
-            .execute("TodoWrite", payload, Some((&sink1, "c1")), None, &crate::agent::AgentPath::root())
+            .execute(
+                "TodoWrite",
+                payload,
+                Some((&sink1, "c1")),
+                None,
+                &crate::agent::AgentPath::root(),
+            )
             .await;
         assert_eq!(sink1.len(), 1);
 
@@ -1267,7 +1273,13 @@ mod tests {
         // message goes back to the model, but clients see nothing.
         let sink2 = crate::engine::sink::TestSink::new();
         let result2 = registry
-            .execute("TodoWrite", payload, Some((&sink2, "c2")), None, &crate::agent::AgentPath::root())
+            .execute(
+                "TodoWrite",
+                payload,
+                Some((&sink2, "c2")),
+                None,
+                &crate::agent::AgentPath::root(),
+            )
             .await;
         assert!(result2.success);
         assert!(

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -585,6 +585,11 @@ impl ToolRegistry {
         // entries are tagged with the calling agent's invocation id.
         // Every other tool ignores this. Top-level callers pass `None`.
         caller_spawner: Option<u32>,
+        // #1325 Phase 4: caller's identity in the agent spawn tree.
+        // Stamped into `ToolExecCtx::caller_agent_path` so peer
+        // tools can `author=`/look up `me` reliably. Top-level
+        // (root) callers pass `&AgentPath::root()`.
+        caller_agent_path: &crate::agent::AgentPath,
     ) -> ToolResult {
         let raw = arguments.trim();
         let raw = if raw.is_empty() { "{}" } else { raw };
@@ -677,6 +682,7 @@ impl ToolRegistry {
                 session,
                 skill_registry: &self.skill_registry,
                 mailbox_registry: mb_reg_arc.as_ref(),
+                caller_agent_path,
             };
             let result = tool.execute(&ctx, &args).await;
             // Post-execution registry-level recording. Lives here
@@ -1228,6 +1234,7 @@ mod tests {
                 r#"{"todos":[{"content":"Add tests","status":"pending","priority":"high"}]}"#,
                 Some((&sink, "call-1")),
                 None,
+                &crate::agent::AgentPath::root(),
             )
             .await;
         assert!(result.success, "first write must succeed: {result:?}");
@@ -1252,7 +1259,7 @@ mod tests {
         // First write: should emit.
         let sink1 = crate::engine::sink::TestSink::new();
         registry
-            .execute("TodoWrite", payload, Some((&sink1, "c1")), None)
+            .execute("TodoWrite", payload, Some((&sink1, "c1")), None, &crate::agent::AgentPath::root())
             .await;
         assert_eq!(sink1.len(), 1);
 
@@ -1260,7 +1267,7 @@ mod tests {
         // message goes back to the model, but clients see nothing.
         let sink2 = crate::engine::sink::TestSink::new();
         let result2 = registry
-            .execute("TodoWrite", payload, Some((&sink2, "c2")), None)
+            .execute("TodoWrite", payload, Some((&sink2, "c2")), None, &crate::agent::AgentPath::root())
             .await;
         assert!(result2.success);
         assert!(
@@ -1287,6 +1294,7 @@ mod tests {
                 r#"{"todos":[{"content":"X","status":"pending","priority":"low"}]}"#,
                 None,
                 None,
+                &crate::agent::AgentPath::root(),
             )
             .await;
         assert!(result.success);
@@ -1309,6 +1317,7 @@ mod tests {
                 ]}"#,
                 Some((&sink, "c1")),
                 None,
+                &crate::agent::AgentPath::root(),
             )
             .await;
         assert!(

--- a/koda-core/src/tools/recall.rs
+++ b/koda-core/src/tools/recall.rs
@@ -210,6 +210,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -219,6 +220,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let r = t.execute(&ctx, &json!({})).await;
         assert!(r.success);

--- a/koda-core/src/tools/send_message.rs
+++ b/koda-core/src/tools/send_message.rs
@@ -328,7 +328,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool
@@ -394,7 +403,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool
@@ -425,7 +443,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool
@@ -445,7 +472,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool
@@ -503,7 +539,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool
@@ -519,7 +564,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = SendMessageTool

--- a/koda-core/src/tools/send_message.rs
+++ b/koda-core/src/tools/send_message.rs
@@ -217,12 +217,16 @@ impl Tool for SendMessageTool {
             }
         };
 
-        // Phase 3 has no per-spawner caller identity yet, so author
-        // is always `/root`. Phase 4 will plumb the real spawner's
-        // path here (mirrors codex's
-        // `turn.session_source.get_agent_path()` lookup).
+        // #1325 Phase 4: stamp the real caller's identity as `author`.
+        // Pre-Phase-4 this was hardcoded to `/root` because every
+        // session pretended to be the root. Now `caller_agent_path`
+        // carries the spawn-tree position threaded down from
+        // `KodaSession::agent_path` → `TurnContext.agent_path`
+        // → `ToolExecCtx.caller_agent_path`, so spawned children
+        // produce attributable mail without colliding with root's
+        // identity (the bug Phase 4 of #1325 exists to close).
         let comm = InterAgentCommunication {
-            author: AgentPath::root(),
+            author: ctx.caller_agent_path.clone(),
             recipient: target_path.clone(),
             other_recipients: Vec::new(),
             content: content.to_string(),
@@ -273,6 +277,7 @@ mod tests {
         policy: &'a koda_sandbox::SandboxPolicy,
         skills: &'a crate::skills::SkillRegistry,
         registry: &'a Arc<MailboxRegistry>,
+        agent_path: &'a AgentPath,
     ) -> ToolExecCtx<'a> {
         ToolExecCtx {
             project_root: root,
@@ -289,6 +294,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: Some(registry),
+            caller_agent_path: agent_path,
         }
     }
 
@@ -320,8 +326,9 @@ mod tests {
         // assigns a sequence number we can observe.
         let (reg, _mb, mut rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool
@@ -345,14 +352,49 @@ mod tests {
         );
     }
 
+    /// #1325 Phase 4: when a child agent (non-root caller) sends mail,
+    /// the delivered envelope's `author` field MUST equal the child's
+    /// path, not a hard-coded `/root`. Regression guard for the bug
+    /// the whole phase exists to fix — without this, peer agents
+    /// can't tell who's talking and the spawn-tree degenerates back
+    /// into a flat namespace.
+    #[tokio::test]
+    async fn child_agent_send_stamps_author_with_child_path() {
+        let (reg, _mb, mut rx) = fresh_registry_with_root();
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        // Simulate dispatch from a child agent: `/root/researcher`.
+        let child = "/root/researcher".parse::<AgentPath>().unwrap();
+        let ctx = ctx_with_registry(
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &child,
+        );
+
+        let result = SendMessageTool
+            .execute(
+                &ctx,
+                &json!({"target": "/root", "content": "status update"}),
+            )
+            .await;
+
+        assert!(result.success, "expected success, got: {}", result.output);
+        let drained = rx.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(
+            drained[0].author.as_str(),
+            "/root/researcher",
+            "author must reflect the caller's spawn-tree path, not /root"
+        );
+        assert_eq!(drained[0].recipient.as_str(), "/root");
+    }
+
     #[tokio::test]
     async fn missing_target_path_returns_helpful_error() {
         // Pin: model-visible error includes the list of available
         // paths so the LLM can self-correct without re-trying blind.
         let (reg, _mb, _rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool
@@ -381,8 +423,9 @@ mod tests {
         // grep-and-find working for anyone debugging from upstream.
         let (reg, _mb, _rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool
@@ -400,8 +443,9 @@ mod tests {
     async fn invalid_path_string_returns_parse_error() {
         let (reg, _mb, _rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool
@@ -422,6 +466,7 @@ mod tests {
         // (standalone-ToolRegistry tests, or future contexts where
         // peer-messaging is not configured).
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ToolExecCtx {
             project_root: &root,
             read_cache: &cache,
@@ -437,6 +482,7 @@ mod tests {
             session: None,
             skill_registry: &skills,
             mailbox_registry: None,
+            caller_agent_path: &agent_path,
         };
 
         let result = SendMessageTool
@@ -455,8 +501,9 @@ mod tests {
     async fn missing_target_field_returns_validation_error() {
         let (reg, _mb, _rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool
@@ -470,8 +517,9 @@ mod tests {
     async fn missing_content_field_returns_validation_error() {
         let (reg, _mb, _rx) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = SendMessageTool

--- a/koda-core/src/tools/todo.rs
+++ b/koda-core/src/tools/todo.rs
@@ -507,6 +507,7 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = crate::tools::ToolExecCtx::for_test(
             tmp.path(),
             &cache,
@@ -516,6 +517,7 @@ mod tests {
             &trust,
             &policy,
             &skills,
+            &agent_path,
         );
         let r = t.execute(&ctx, &json!({"todos": []})).await;
         assert!(r.success);

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -641,7 +641,17 @@ mod tests {
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
         let agent_path = crate::agent::AgentPath::root();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
+        let ctx = make_ctx(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &agent_path,
+        );
 
         let args = json!({"hello": "world"});
         let result = tool.execute(&ctx, &args).await;
@@ -732,7 +742,17 @@ mod tests {
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
         let agent_path = crate::agent::AgentPath::root();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
+        let ctx = make_ctx(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &agent_path,
+        );
 
         let r1 = tools[0].execute(&ctx, &json!({})).await;
         assert!(r1.success);
@@ -756,7 +776,17 @@ mod tests {
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
         let agent_path = crate::agent::AgentPath::root();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
+        let ctx = make_ctx(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &agent_path,
+        );
 
         assert_eq!(ctx.project_root(), root.as_path());
         // Cache is a single shared handle — pointer-equality check.

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -240,6 +240,25 @@ pub struct ToolExecCtx<'a> {
     /// registry across `.await` should clone the `Arc` themselves
     /// at the use site — explicit beats hidden cost.
     pub mailbox_registry: Option<&'a Arc<crate::agent::mailbox_registry::MailboxRegistry>>,
+
+    /// Caller's identity in the agent spawn tree (#1325 Phase 4).
+    /// Source of truth: `TurnContext::agent_path`. Defaults to
+    /// `&AgentPath::root()` for the user-facing session and for
+    /// any standalone-`ToolRegistry` test that doesn't construct
+    /// the field.
+    ///
+    /// Read by the peer tools to:
+    /// - stamp `author` on outgoing `SendMessage` mail (replaces
+    ///   the Phase-3 hardcoded `/root`),
+    /// - look up the caller's own inbox in `WaitForMail`,
+    /// - join child agent names onto the parent path in the
+    ///   forthcoming `SpawnAgent` tool.
+    ///
+    /// Borrowed (not owned) for the same zero-cost reason every
+    /// other ambient field is borrowed: per-tool dispatch happens
+    /// in a hot loop and we don't want a per-call `clone()` on a
+    /// validated path.
+    pub caller_agent_path: &'a crate::agent::AgentPath,
 }
 
 /// A self-contained built-in tool.
@@ -444,6 +463,12 @@ impl<'a> ToolExecCtx<'a> {
         trust: &'a crate::trust::TrustMode,
         sandbox_policy: &'a koda_sandbox::SandboxPolicy,
         skill_registry: &'a crate::skills::SkillRegistry,
+        // #1325 Phase 4: every test caller is conceptually `/root`
+        // unless it explicitly wants to simulate a child agent.
+        // Required (not defaulted via static) so test authors stay
+        // aware of the field — same "safe but visible" discipline
+        // the rest of `for_test` follows.
+        agent_path: &'a crate::agent::AgentPath,
     ) -> Self {
         Self {
             project_root,
@@ -463,6 +488,7 @@ impl<'a> ToolExecCtx<'a> {
             // exercise send_message / wait_for_mail must construct
             // their context manually with a real registry.
             mailbox_registry: None,
+            caller_agent_path: agent_path,
         }
     }
 }
@@ -582,6 +608,7 @@ mod tests {
         trust: &'a crate::trust::TrustMode,
         policy: &'a koda_sandbox::SandboxPolicy,
         skills: &'a SkillRegistry,
+        agent_path: &'a crate::agent::AgentPath,
     ) -> ToolExecCtx<'a> {
         ToolExecCtx {
             project_root: root,
@@ -598,6 +625,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: None,
+            caller_agent_path: agent_path,
         }
     }
 
@@ -612,7 +640,8 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
+        let agent_path = crate::agent::AgentPath::root();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
 
         let args = json!({"hello": "world"});
         let result = tool.execute(&ctx, &args).await;
@@ -702,7 +731,8 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
+        let agent_path = crate::agent::AgentPath::root();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
 
         let r1 = tools[0].execute(&ctx, &json!({})).await;
         assert!(r1.success);
@@ -725,7 +755,8 @@ mod tests {
         let trust = crate::trust::TrustMode::Safe;
         let policy = koda_sandbox::SandboxPolicy::default();
         let skills = crate::skills::SkillRegistry::default();
-        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills);
+        let agent_path = crate::agent::AgentPath::root();
+        let ctx = make_ctx(&root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &agent_path);
 
         assert_eq!(ctx.project_root(), root.as_path());
         // Cache is a single shared handle — pointer-equality check.

--- a/koda-core/src/tools/wait_for_mail.rs
+++ b/koda-core/src/tools/wait_for_mail.rs
@@ -303,7 +303,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         // Spawn a sender that waits 50ms then delivers.
@@ -342,7 +351,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let started = Instant::now();
@@ -376,7 +394,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         // Send before the wait starts. The wait still needs to
@@ -412,7 +439,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         // Pre-existing mail.
@@ -440,7 +476,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let result = WaitForMailTool
@@ -469,7 +514,16 @@ mod tests {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
         let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
         );
 
         let mb_for_send = Arc::clone(&mb);

--- a/koda-core/src/tools/wait_for_mail.rs
+++ b/koda-core/src/tools/wait_for_mail.rs
@@ -40,7 +40,6 @@
 //! will add a `caller_path` field and child agents will wait on
 //! their own mailbox via the same lookup.
 
-use crate::agent::AgentPath;
 use crate::providers::ToolDefinition;
 use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
 use async_trait::async_trait;
@@ -136,19 +135,25 @@ impl Tool for WaitForMailTool {
             }
         };
 
-        // Phase 3: caller is always /root. Phase 4 reads ctx.caller_path
-        // (or equivalent) to support child agents.
-        let own_mailbox = match registry.get(&AgentPath::root()) {
+        // #1325 Phase 4: look up the *caller's* mailbox, not always
+        // root. `caller_agent_path` is threaded down from
+        // `KodaSession::agent_path` so a spawned child blocks on
+        // its own inbox (the only one it can ever read from).
+        let own_path = ctx.caller_agent_path;
+        let own_mailbox = match registry.get(own_path) {
             Some(mb) => mb,
             None => {
                 // Substrate invariant violation — KodaSession::new
-                // pre-registers /root unconditionally. If we hit this,
-                // either the registry was rebuilt without /root or the
-                // session-construction invariant is broken.
+                // pre-registers `/root` unconditionally, and Phase 4's
+                // SpawnAgent registers child paths before yielding
+                // control. If we hit this, either the registry was
+                // rebuilt without the caller's entry or the session-
+                // construction invariant is broken.
                 return ToolResult {
-                    output: "WaitForMail: own mailbox (/root) is not registered. \
-                             This is a session-construction invariant violation."
-                        .to_string(),
+                    output: format!(
+                        "WaitForMail: own mailbox (`{own_path}`) is not registered. \
+                         This is a session-construction invariant violation."
+                    ),
                     success: false,
                     full_output: None,
                 };
@@ -214,7 +219,7 @@ impl Tool for WaitForMailTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{InterAgentCommunication, Mailbox, MailboxRegistry};
+    use crate::agent::{AgentPath, InterAgentCommunication, Mailbox, MailboxRegistry};
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -259,6 +264,7 @@ mod tests {
         policy: &'a koda_sandbox::SandboxPolicy,
         skills: &'a crate::skills::SkillRegistry,
         registry: &'a Arc<MailboxRegistry>,
+        agent_path: &'a AgentPath,
     ) -> ToolExecCtx<'a> {
         ToolExecCtx {
             project_root: root,
@@ -275,6 +281,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: Some(registry),
+            caller_agent_path: agent_path,
         }
     }
 
@@ -294,8 +301,9 @@ mod tests {
         // blocked must wake the wait promptly.
         let (reg, mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         // Spawn a sender that waits 50ms then delivers.
@@ -332,8 +340,9 @@ mod tests {
         // (approximately) the requested duration.
         let (reg, _mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let started = Instant::now();
@@ -365,8 +374,9 @@ mod tests {
         // mail immediately — the tool should still return promptly.
         let (reg, mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         // Send before the wait starts. The wait still needs to
@@ -400,8 +410,9 @@ mod tests {
         // its own past send as a "new" arrival, defeating the point.
         let (reg, mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         // Pre-existing mail.
@@ -427,8 +438,9 @@ mod tests {
     async fn timeout_zero_or_negative_returns_codex_error() {
         let (reg, _mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let result = WaitForMailTool
@@ -455,8 +467,9 @@ mod tests {
         // and observing the wait completes promptly when mail arrives.
         let (reg, mb) = fresh_registry_with_root();
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ctx_with_registry(
-            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg,
+            &root, &cache, &fs, &caps, &bg, &trust, &policy, &skills, &reg, &agent_path,
         );
 
         let mb_for_send = Arc::clone(&mb);
@@ -480,6 +493,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn missing_registry_returns_session_required_error() {
         let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
         let ctx = ToolExecCtx {
             project_root: &root,
             read_cache: &cache,
@@ -495,6 +509,7 @@ mod tests {
             session: None,
             skill_registry: &skills,
             mailbox_registry: None,
+            caller_agent_path: &agent_path,
         };
 
         let result = WaitForMailTool.execute(&ctx, &json!({})).await;

--- a/koda-core/src/turn_context.rs
+++ b/koda-core/src/turn_context.rs
@@ -108,6 +108,14 @@ pub struct TurnContext<'a> {
     /// Tool registry (built-in + MCP). Per-session; constant within
     /// a single turn.
     pub tools: &'a ToolRegistry,
+
+    /// This agent's identity in the spawn tree (#1325 Phase 4).
+    /// `/root` for the user-facing session, `/root/<name>` for any
+    /// spawned child sub-agent. Read by peer tools (`SendMessage`
+    /// stamps it as `author`; `WaitForMail` looks up its own
+    /// inbox by it; `SpawnAgent` joins child names onto it).
+    /// Threaded down into `ToolExecCtx::caller_agent_path`.
+    pub agent_path: &'a crate::agent::AgentPath,
 }
 
 impl<'a> TurnContext<'a> {
@@ -127,6 +135,7 @@ impl<'a> TurnContext<'a> {
         bg_agents: &'a Arc<ChildAgentRegistry>,
         mode: TrustMode,
         tools: &'a ToolRegistry,
+        agent_path: &'a crate::agent::AgentPath,
     ) -> Self {
         Self {
             project_root,
@@ -139,6 +148,7 @@ impl<'a> TurnContext<'a> {
             bg_agents,
             mode,
             tools,
+            agent_path,
         }
     }
 }
@@ -234,6 +244,7 @@ mod tests {
         let sink = NullSink;
 
         // Act: build the context.
+        let agent_path = crate::agent::AgentPath::root();
         let ctx = TurnContext::new(
             &root,
             &config,
@@ -245,6 +256,7 @@ mod tests {
             &bg_agents,
             TrustMode::Safe,
             &tools,
+            &agent_path,
         );
 
         // Assert: every field is reachable + carries the value we passed.
@@ -268,6 +280,7 @@ mod tests {
         let tools = ToolRegistry::new(root.clone(), 8_000);
         let sink = NullSink;
 
+        let agent_path = crate::agent::AgentPath::root();
         let turn = TurnContext::new(
             &root,
             &config,
@@ -279,6 +292,7 @@ mod tests {
             &bg_agents,
             TrustMode::Auto,
             &tools,
+            &agent_path,
         );
 
         // Top-level invocation: no parent spawner.

--- a/koda-core/tests/agent_mailbox_e2e_test.rs
+++ b/koda-core/tests/agent_mailbox_e2e_test.rs
@@ -95,6 +95,7 @@ async fn make_session_with_recorder(
         mailbox_rx: Arc::new(AsyncMutex::new(mailbox_rx)),
         idle_pending_input: Arc::new(AsyncMutex::new(Vec::new())),
         mailbox_registry,
+        agent_path: koda_core::agent::AgentPath::root(),
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/builtin_proxy_e2e_test.rs
+++ b/koda-core/tests/builtin_proxy_e2e_test.rs
@@ -115,7 +115,13 @@ async fn bash_sees_proxy_env_pointing_at_session_proxy() {
     let result = session
         .agent
         .tools
-        .execute("Bash", r#"{"command":"echo \"$HTTPS_PROXY\""}"#, None, None)
+        .execute(
+            "Bash",
+            r#"{"command":"echo \"$HTTPS_PROXY\""}"#,
+            None,
+            None,
+            &koda_core::agent::AgentPath::root(),
+        )
         .await;
 
     assert!(
@@ -271,7 +277,7 @@ async fn macos_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -305,7 +311,7 @@ async fn macos_kernel_allows_tcp_to_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{proxy_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -373,7 +379,7 @@ async fn linux_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"bash -c 'if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None).await;
+    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -425,7 +431,7 @@ async fn linux_kernel_allows_tcp_to_proxy_port() {
     // verify /dev/tcp can reach it. Bash explicitly because
     // Ubuntu's /bin/sh is dash (no /dev/tcp, no `${var##*:}`).
     let cmd = r#"{"command":"bash -c 'port=\"${HTTPS_PROXY##*:}\"; if exec 3<>/dev/tcp/127.0.0.1/$port 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}"#;
-    let result = session.agent.tools.execute("Bash", cmd, None, None).await;
+    let result = session.agent.tools.execute("Bash", cmd, None, None, &koda_core::agent::AgentPath::root()).await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -474,6 +480,7 @@ async fn curl_to_blocked_host_returns_403_via_proxy() {
             r#"{"command":"curl --max-time 5 -sS -o /dev/null -w '%{http_code}\\n' https://blocked.test/ 2>&1; echo exit=$?"}"#,
             None,
             None,
+            &koda_core::agent::AgentPath::root(),
         )
         .await;
 

--- a/koda-core/tests/builtin_proxy_e2e_test.rs
+++ b/koda-core/tests/builtin_proxy_e2e_test.rs
@@ -277,7 +277,17 @@ async fn macos_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
+    let result = session
+        .agent
+        .tools
+        .execute(
+            "Bash",
+            &cmd,
+            None,
+            None,
+            &koda_core::agent::AgentPath::root(),
+        )
+        .await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -311,7 +321,17 @@ async fn macos_kernel_allows_tcp_to_proxy_port() {
     let cmd = format!(
         r#"{{"command":"if exec 3<>/dev/tcp/127.0.0.1/{proxy_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
+    let result = session
+        .agent
+        .tools
+        .execute(
+            "Bash",
+            &cmd,
+            None,
+            None,
+            &koda_core::agent::AgentPath::root(),
+        )
+        .await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -379,7 +399,17 @@ async fn linux_kernel_blocks_direct_tcp_to_non_proxy_port() {
     let cmd = format!(
         r#"{{"command":"bash -c 'if exec 3<>/dev/tcp/127.0.0.1/{target_port} 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}}"#,
     );
-    let result = session.agent.tools.execute("Bash", &cmd, None, None, &koda_core::agent::AgentPath::root()).await;
+    let result = session
+        .agent
+        .tools
+        .execute(
+            "Bash",
+            &cmd,
+            None,
+            None,
+            &koda_core::agent::AgentPath::root(),
+        )
+        .await;
     let combined = format!(
         "{}\n{}",
         result.output,
@@ -431,7 +461,17 @@ async fn linux_kernel_allows_tcp_to_proxy_port() {
     // verify /dev/tcp can reach it. Bash explicitly because
     // Ubuntu's /bin/sh is dash (no /dev/tcp, no `${var##*:}`).
     let cmd = r#"{"command":"bash -c 'port=\"${HTTPS_PROXY##*:}\"; if exec 3<>/dev/tcp/127.0.0.1/$port 2>/dev/null; then echo connected; exec 3<&-; else echo blocked; fi'"}"#;
-    let result = session.agent.tools.execute("Bash", cmd, None, None, &koda_core::agent::AgentPath::root()).await;
+    let result = session
+        .agent
+        .tools
+        .execute(
+            "Bash",
+            cmd,
+            None,
+            None,
+            &koda_core::agent::AgentPath::root(),
+        )
+        .await;
     let combined = format!(
         "{}\n{}",
         result.output,

--- a/koda-core/tests/cancel_test.rs
+++ b/koda-core/tests/cancel_test.rs
@@ -130,6 +130,7 @@ async fn test_cancel_during_chat_stream_returns_immediately() {
         file_tracker: &mut file_tracker,
         bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
+        agent_path: &koda_core::agent::AgentPath::root(),
     })
     .await;
 

--- a/koda-core/tests/e2e_test.rs
+++ b/koda-core/tests/e2e_test.rs
@@ -174,6 +174,7 @@ async fn test_provider_error_emits_error_event() {
         file_tracker: &mut file_tracker,
         bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
+        agent_path: &koda_core::agent::AgentPath::root(),
     })
     .await;
 
@@ -298,6 +299,7 @@ async fn test_cancel_during_streaming() {
         file_tracker: &mut file_tracker,
         bg_agents: &koda_core::child_agent::new_shared(),
         sub_agent_cache: &koda_core::sub_agent_cache::SubAgentCache::new(),
+        agent_path: &koda_core::agent::AgentPath::root(),
     })
     .await;
 

--- a/koda-core/tests/mcp_instructions_bootstrap_test.rs
+++ b/koda-core/tests/mcp_instructions_bootstrap_test.rs
@@ -123,6 +123,7 @@ async fn make_session_with_mcp(
         mailbox_rx: Arc::new(tokio::sync::Mutex::new(mailbox_rx)),
         idle_pending_input: Arc::new(tokio::sync::Mutex::new(Vec::new())),
         mailbox_registry,
+        agent_path: koda_core::agent::AgentPath::root(),
     };
     (session, cancel, recorded)
 }

--- a/koda-core/tests/session_test.rs
+++ b/koda-core/tests/session_test.rs
@@ -88,6 +88,7 @@ async fn make_session(env: &Env, provider: Box<dyn LlmProvider>) -> (KodaSession
         mailbox_rx: std::sync::Arc::new(tokio::sync::Mutex::new(mailbox_rx)),
         idle_pending_input: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
         mailbox_registry,
+        agent_path: koda_core::agent::AgentPath::root(),
     };
     (session, cancel)
 }

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -38,7 +38,15 @@ async fn normalized_lowercase_names_are_routable() {
             registry.has_tool(&canonical),
             "Normalized '{raw_name}' -> '{canonical}' is not in the registry"
         );
-        let result = registry.execute(&canonical, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
+        let result = registry
+            .execute(
+                &canonical,
+                "{}",
+                None,
+                None,
+                &koda_core::agent::AgentPath::root(),
+            )
+            .await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw_name}' normalized to '{canonical}' but dispatcher rejected it: {}",
@@ -74,7 +82,15 @@ async fn normalized_snake_case_names_are_routable() {
             canonical, expected,
             "'{raw}' should normalize to '{expected}', got '{canonical}'"
         );
-        let result = registry.execute(&canonical, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
+        let result = registry
+            .execute(
+                &canonical,
+                "{}",
+                None,
+                None,
+                &koda_core::agent::AgentPath::root(),
+            )
+            .await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw}' -> '{canonical}' rejected by dispatcher: {}",

--- a/koda-core/tests/tool_normalize_test.rs
+++ b/koda-core/tests/tool_normalize_test.rs
@@ -38,7 +38,7 @@ async fn normalized_lowercase_names_are_routable() {
             registry.has_tool(&canonical),
             "Normalized '{raw_name}' -> '{canonical}' is not in the registry"
         );
-        let result = registry.execute(&canonical, "{}", None, None).await;
+        let result = registry.execute(&canonical, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw_name}' normalized to '{canonical}' but dispatcher rejected it: {}",
@@ -74,7 +74,7 @@ async fn normalized_snake_case_names_are_routable() {
             canonical, expected,
             "'{raw}' should normalize to '{expected}', got '{canonical}'"
         );
-        let result = registry.execute(&canonical, "{}", None, None).await;
+        let result = registry.execute(&canonical, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "'{raw}' -> '{canonical}' rejected by dispatcher: {}",

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -34,7 +34,15 @@ async fn test_all_tools_routable_in_dispatcher() {
         if HIGHER_LAYER_DISPATCH.contains(&name.as_str()) {
             continue;
         }
-        let result = registry.execute(&name, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
+        let result = registry
+            .execute(
+                &name,
+                "{}",
+                None,
+                None,
+                &koda_core::agent::AgentPath::root(),
+            )
+            .await;
         assert!(
             !result.output.contains("Unknown tool"),
             "Tool '{name}' is not routed in the dispatcher (tools/mod.rs execute()). \
@@ -50,7 +58,15 @@ async fn test_all_tools_routable_in_dispatcher() {
 async fn test_empty_args_default_to_empty_object() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for input in ["", "  ", "\n", "\t "] {
-        let result = registry.execute("List", input, None, None, &koda_core::agent::AgentPath::root()).await;
+        let result = registry
+            .execute(
+                "List",
+                input,
+                None,
+                None,
+                &koda_core::agent::AgentPath::root(),
+            )
+            .await;
         assert!(
             !result.output.contains("Invalid JSON"),
             "Empty args '{input:?}' should not produce a JSON parse error. Got: {}",

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -34,7 +34,7 @@ async fn test_all_tools_routable_in_dispatcher() {
         if HIGHER_LAYER_DISPATCH.contains(&name.as_str()) {
             continue;
         }
-        let result = registry.execute(&name, "{}", None, None).await;
+        let result = registry.execute(&name, "{}", None, None, &koda_core::agent::AgentPath::root()).await;
         assert!(
             !result.output.contains("Unknown tool"),
             "Tool '{name}' is not routed in the dispatcher (tools/mod.rs execute()). \
@@ -50,7 +50,7 @@ async fn test_all_tools_routable_in_dispatcher() {
 async fn test_empty_args_default_to_empty_object() {
     let registry = koda_core::tools::ToolRegistry::new(PathBuf::from("/tmp/test"), 100_000);
     for input in ["", "  ", "\n", "\t "] {
-        let result = registry.execute("List", input, None, None).await;
+        let result = registry.execute("List", input, None, None, &koda_core::agent::AgentPath::root()).await;
         assert!(
             !result.output.contains("Invalid JSON"),
             "Empty args '{input:?}' should not produce a JSON parse error. Got: {}",

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -290,6 +290,11 @@ impl Env {
             file_tracker: &mut file_tracker,
             bg_agents: &bg_agents,
             sub_agent_cache: &sub_agent_cache,
+            // #1325 Phase 4: test envs are always the user-facing
+            // root agent. SpawnAgent-driven children get their own
+            // path injected by the spawn machinery and don't reach
+            // here.
+            agent_path: &koda_core::agent::AgentPath::root(),
         })
         .await;
 


### PR DESCRIPTION
## Summary

- **Commit 1**: Plumb `caller_agent_path` through `ToolExecCtx` so every tool execution carries its owning agent's path — prerequisite for per-child path construction
- **Commit 2**: Build real `/root/<name>_<id>` paths for spawned children, replacing the placeholder `AgentPath::root()` all sub-agents previously shared
- **Commit 3**: Per-sub-agent mailboxes in shared registry — sub-agents now register their own mailbox at their unique `AgentPath`, drain it at each iter, and unregister via RAII on exit. Fixes `SendMessage` returning "no recipient at that path" and `WaitForMail` returning "registry not installed" from inside sub-agents
- **fmt fixup**: `cargo fmt --all` caught by pre-push hook

Peer-tool round-trips (`SendMessage` + `WaitForMail`) now work end-to-end between root and any sub-agent, in both inline and bg dispatch paths.

## Test plan

- [x] 8 new unit tests in `sub_agent_dispatch::sub_agent_mailbox_tests` (register, collision, RAII drop, drain variants)
- [x] Full `koda-core` suite: 1403 tests pass, 0 failures (4 pre-existing env failures in `sandbox`/`web_fetch` unrelated to this branch)
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --all` clean

Closes #1325 Phase 4.

🌀 Magic applied with [Wibey CLI](https://wibey.walmart.com/cli) 🪄
