### PR TITLE
feat: #1325 Phase 5a — SpawnAgent tool + bg-completion mailbox bridge

### DIFF
--- a/koda-core/src/skill_scope.rs
+++ b/koda-core/src/skill_scope.rs
@@ -55,12 +55,20 @@ const META_TOOLS: &[&str] = &[
     "ListSkills",
     "ListAgents",
     "InvokeAgent",
+    // #1325 Phase 5a: SpawnAgent is the codex v2 peer-spawn shape;
+    // always available so skill-scoped agents can spawn sub-agents
+    // without listing it in every manifest (same rationale as InvokeAgent).
+    "SpawnAgent",
     "AskUser",
     // #996 Phase G — bg-task management always-available so a
     // skill-scoped agent can still see / wait / cancel its own work.
     "ListBackgroundTasks",
     "CancelTask",
     "WaitTask",
+    // #1325 Phase 3/5a: peer-messaging always-available so skill-scoped
+    // agents can communicate with peers without listing them in manifests.
+    "SendMessage",
+    "WaitForMail",
 ];
 
 /// Tracks the active skill's tool scope during an inference loop.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -1349,7 +1349,8 @@ pub(crate) fn execute_sub_agent<'a>(
             // Filtering at the tool-def level keeps the model from
             // ever seeing the tool. The sub-agent dispatch loop also
             // contains a defense-in-depth refusal in case a rogue or
-            // scripted model emits `InvokeAgent` regardless.
+            // scripted model emits `InvokeAgent` or `SpawnAgent`
+            // regardless.
             if !denied.contains(&"InvokeAgent".to_string()) {
                 denied.push("InvokeAgent".to_string());
             }
@@ -1715,6 +1716,30 @@ pub(crate) fn execute_sub_agent<'a>(
                 // confusing `success=false` boilerplate).
                 if tc.function_name == "InvokeAgent" {
                     let refusal = "InvokeAgent is not available inside a sub-agent. \
+                                   Sub-agents are autonomous workers and cannot spawn \
+                                   further sub-agents. Complete the task directly with \
+                                   the tools you have, or report back what additional \
+                                   dispatch the parent agent should perform.";
+                    db.insert_message(
+                        &sub_session,
+                        &Role::Tool,
+                        Some(refusal),
+                        None,
+                        Some(&tc.id),
+                        None,
+                    )
+                    .await?;
+                    continue;
+                }
+                // #1325 Phase 5a: SpawnAgent re-maps to InvokeAgent at
+                // dispatch time (`tool_dispatch.rs::execute_one_tool`),
+                // so a rogue or scripted model emitting `SpawnAgent`
+                // would otherwise drive the same unbounded recursion
+                // the InvokeAgent block above prevents. Refuse with
+                // the same shape so the deny-list filter at line 1356
+                // and this defense-in-depth refusal stay symmetric.
+                if tc.function_name == "SpawnAgent" {
+                    let refusal = "SpawnAgent is not available inside a sub-agent. \
                                    Sub-agents are autonomous workers and cannot spawn \
                                    further sub-agents. Complete the task directly with \
                                    the tools you have, or report back what additional \

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -292,6 +292,49 @@ impl Drop for InvocationCleanup<'_> {
 
 /// Run a sub-agent in the background. Owns all data (no borrows).
 ///
+/// Send a completion notification to the parent's mailbox.
+///
+/// **#1325 Phase 5a — bridge**: fires *before* the result oneshot in
+/// `run_bg_agent` so the parent's mailbox watch-sequence increments
+/// before the drain-injection path adds the `Role::Tool` row. This
+/// ordering ensures `WaitForMail`'s watch wakeup happens before the
+/// drain loop could race to inject the result — the parent wakes and
+/// reads a populated mailbox.
+///
+/// **Best-effort**: if the registry is `None` or holds no entry for
+/// `parent_path`, we skip silently. The existing `drain_completed`
+/// loop in `inference.rs` still injects the result on the next
+/// iteration, so nothing is lost — the parent just doesn't wake
+/// immediately.
+///
+/// Extracted from `run_bg_agent` so the three core behaviors
+/// (completion mail content, error-path format, silent-skip) can be
+/// pinned by unit tests without standing up the full bg-agent machinery.
+pub(crate) fn notify_parent_mailbox(
+    registry: Option<&crate::agent::MailboxRegistry>,
+    child_path: &crate::agent::AgentPath,
+    parent_path: &crate::agent::AgentPath,
+    result: &Result<String, anyhow::Error>,
+) {
+    let parent_mailbox_opt = registry.and_then(|r| r.get(parent_path));
+    if let Some(parent_mailbox) = parent_mailbox_opt {
+        let summary = match result {
+            Ok(output) => format!("Background agent '{child_path}' completed.\n{output}"),
+            Err(e) => format!("Background agent '{child_path}' failed: {e:#}"),
+        };
+        let mail = crate::agent::inter_agent::InterAgentCommunication::new(
+            child_path.clone(),
+            parent_path.clone(),
+            Vec::new(),
+            summary,
+            // trigger_turn=true: wake an idle parent immediately so
+            // `WaitForMail` unblocks as soon as the child exits.
+            true,
+        );
+        let _seq = parent_mailbox.send(mail);
+    }
+}
+
 /// **Phase 2 of #1022 (B5 complete):** uses the multi-thread runtime
 /// via `tokio::spawn`. This requires `execute_sub_agent`'s future to
 /// be `Send`, which we enforce explicitly via the `+ Send` bound on
@@ -512,41 +555,14 @@ async fn run_bg_agent(
 
     // #1325 Phase 5a: notify the parent via its mailbox so any
     // `WaitForMail` call in the parent session can unblock on child
-    // completion. This fires *before* the oneshot so the watch
-    // sequence increment is visible before the drain-injection
-    // path adds the `Role::Tool` row — ordering that avoids the
-    // race where `WaitForMail` wakes, calls `drain_completed` and
-    // finds nothing yet.
-    //
-    // Send is best-effort: if the registry has no entry for the
-    // parent (e.g. top-level session running without a registry,
-    // or the parent already exited), we silently skip — the
-    // existing drain path (`inference.rs` `drain_completed`) still
-    // injects the result on the next iteration, so nothing is lost.
-    let parent_mailbox_opt = bg_mailbox_registry
-        .as_deref()
-        .and_then(|r| r.get(&parent_agent_path));
-    if let Some(parent_mailbox) = parent_mailbox_opt {
-        let summary = match &result {
-            Ok(output) => format!(
-                "Background agent '{}' completed.\n{}",
-                bg_agent_path, output
-            ),
-            Err(e) => format!("Background agent '{}' failed: {e:#}", bg_agent_path),
-        };
-        let mail = crate::agent::inter_agent::InterAgentCommunication::new(
-            bg_agent_path.clone(),
-            parent_agent_path,
-            Vec::new(),
-            summary,
-            // trigger_turn=true: wake the parent immediately so
-            // `WaitForMail` unblocks as soon as the child exits
-            // rather than waiting for the parent's next natural turn.
-            true,
-        );
-        // `send` returns the sequence number; we don't need it.
-        let _seq = parent_mailbox.send(mail);
-    }
+    // completion. Fires *before* the oneshot — see `notify_parent_mailbox`
+    // for the ordering rationale and test coverage.
+    notify_parent_mailbox(
+        bg_mailbox_registry.as_deref(),
+        &bg_agent_path,
+        &parent_agent_path,
+        &result,
+    );
 
     let _ = match result {
         Ok(output) => tx.send(Ok((output, events))),
@@ -1336,6 +1352,14 @@ pub(crate) fn execute_sub_agent<'a>(
             // scripted model emits `InvokeAgent` regardless.
             if !denied.contains(&"InvokeAgent".to_string()) {
                 denied.push("InvokeAgent".to_string());
+            }
+            // #1325 Phase 5a: SpawnAgent re-maps to InvokeAgent at dispatch
+            // time, so it must be denied here too. Without this a sub-agent
+            // could call SpawnAgent → tool_dispatch re-maps → execute_sub_agent
+            // → unbounded mutual recursion, silently bypassing the flat-design
+            // invariant above. Deny both names so the model never sees either.
+            if !denied.contains(&"SpawnAgent".to_string()) {
+                denied.push("SpawnAgent".to_string());
             }
             // #1022 B8: AskUser requires a live `cmd_rx` connected to the
             // user. Sub-agents have a detached channel (foreground sub-agents
@@ -2665,5 +2689,135 @@ mod error_chain_format_tests {
             "LLM API returned 400 Bad Request: {{\"error\":\"Context size has been exceeded.\"}}"
         );
         assert_eq!(format!("{e}"), format!("{e:#}"));
+    }
+}
+
+/// Tests for the `notify_parent_mailbox` bridge (#1325 Phase 5a).
+///
+/// Pins three behaviors:
+/// 1. Completion mail lands in the parent mailbox (content + `trigger_turn`).
+/// 2. Missing parent registry entry → silent skip, no panic.
+/// 3. Error result is formatted as "failed: …" and still delivered.
+#[cfg(test)]
+mod notify_parent_mailbox_tests {
+    use super::notify_parent_mailbox;
+    use crate::agent::mailbox::Mailbox;
+    use crate::agent::mailbox_registry::RegisterOutcome;
+    use crate::agent::{AgentPath, MailboxRegistry};
+    use std::sync::Arc;
+
+    fn child_path() -> AgentPath {
+        AgentPath::root().join("worker_1").unwrap()
+    }
+    fn parent_path() -> AgentPath {
+        AgentPath::root()
+    }
+
+    /// Register `path` in `reg` and return the `MailboxReceiver` for drain.
+    fn register(reg: &MailboxRegistry, path: AgentPath) -> crate::agent::mailbox::MailboxReceiver {
+        let (mb, rx) = Mailbox::new();
+        let outcome = reg.register(path, Arc::new(mb));
+        assert_eq!(outcome, RegisterOutcome::Inserted);
+        rx
+    }
+
+    // ── 1. Completion mail content + ordering ────────────────────────────
+
+    #[test]
+    fn success_mail_lands_in_parent_mailbox() {
+        // Pin: Ok result → mail lands in parent mailbox with the
+        // expected content prefix and trigger_turn=true.
+        let reg = MailboxRegistry::new();
+        let mut rx = register(&reg, parent_path());
+
+        let result: Result<String, anyhow::Error> = Ok("the answer is 42".to_string());
+        notify_parent_mailbox(Some(&reg), &child_path(), &parent_path(), &result);
+
+        let items = rx.drain();
+        assert_eq!(items.len(), 1, "exactly one mail must be delivered");
+        let mail = &items[0];
+        assert_eq!(mail.author, child_path());
+        assert_eq!(mail.recipient, parent_path());
+        assert!(
+            mail.trigger_turn,
+            "trigger_turn must be true to wake WaitForMail"
+        );
+        assert!(
+            mail.content.contains("completed"),
+            "success mail must say 'completed'; got: {}",
+            mail.content
+        );
+        assert!(
+            mail.content.contains("the answer is 42"),
+            "success mail must include the agent output"
+        );
+    }
+
+    #[test]
+    fn error_mail_formats_as_failed_and_is_delivered() {
+        // Pin: Err result → mail says "failed: …" and is still
+        // delivered (not swallowed).
+        let reg = MailboxRegistry::new();
+        let mut rx = register(&reg, parent_path());
+
+        let err = anyhow::anyhow!("connection refused").context("Failed to call LLM API");
+        let result: Result<String, anyhow::Error> = Err(err);
+        notify_parent_mailbox(Some(&reg), &child_path(), &parent_path(), &result);
+
+        let items = rx.drain();
+        assert_eq!(items.len(), 1);
+        let mail = &items[0];
+        assert!(
+            mail.content.contains("failed"),
+            "error mail must say 'failed'; got: {}",
+            mail.content
+        );
+        // {:#} chains the context — both layers must appear.
+        assert!(
+            mail.content.contains("Failed to call LLM API"),
+            "error mail must include outer context"
+        );
+        assert!(
+            mail.content.contains("connection refused"),
+            "error mail must include root cause via anyhow alternate format"
+        );
+        assert!(mail.trigger_turn, "trigger_turn must be true even on error");
+    }
+
+    // ── 2. Silent skip when registry/parent missing ──────────────────────
+
+    #[test]
+    fn none_registry_skips_silently() {
+        // Pin: None registry → no panic, nothing delivered.
+        // (The oneshot path continues regardless.)
+        let result: Result<String, anyhow::Error> = Ok("done".to_string());
+        // Should not panic.
+        notify_parent_mailbox(None, &child_path(), &parent_path(), &result);
+    }
+
+    #[test]
+    fn missing_parent_entry_skips_silently() {
+        // Pin: registry exists but parent is NOT registered (e.g.
+        // top-level session without its own mailbox slot). No panic,
+        // no delivery.
+        let reg = MailboxRegistry::new();
+        // Do NOT register the parent — it's intentionally absent.
+        let result: Result<String, anyhow::Error> = Ok("done".to_string());
+        notify_parent_mailbox(Some(&reg), &child_path(), &parent_path(), &result);
+        // If we got here without panic, the contract holds.
+    }
+
+    #[test]
+    fn child_not_registered_does_not_affect_delivery() {
+        // Pin: only the *parent* mailbox needs to be registered for
+        // delivery. The child may or may not have a slot — irrelevant.
+        let reg = MailboxRegistry::new();
+        let mut rx = register(&reg, parent_path());
+        // child is NOT registered — that's the common case (the child
+        // finishes and its RAII guard has already unregistered it).
+        let result: Result<String, anyhow::Error> = Ok("work done".to_string());
+        notify_parent_mailbox(Some(&reg), &child_path(), &parent_path(), &result);
+
+        assert_eq!(rx.drain().len(), 1, "mail must still arrive");
     }
 }

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -351,6 +351,13 @@ async fn run_bg_agent(
     // "no per-child mailbox"). `None` propagates the
     // no-session-context fallback unchanged.
     bg_mailbox_registry: Option<std::sync::Arc<crate::agent::MailboxRegistry>>,
+    // #1325 Phase 5a: the parent's `AgentPath`. At task completion we
+    // send the result to the parent's mailbox so `WaitForMail` can
+    // unblock on child completion. `bg_agent_path` is the author;
+    // `parent_agent_path` is the recipient. Separate from
+    // `bg_mailbox_registry` (which serves the child's own mailbox
+    // registration) so the two concerns don't conflate.
+    parent_agent_path: crate::agent::AgentPath,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
@@ -500,6 +507,43 @@ async fn run_bg_agent(
                 }
             };
             emitter.send(status);
+        }
+    }
+
+    // #1325 Phase 5a: notify the parent via its mailbox so any
+    // `WaitForMail` call in the parent session can unblock on child
+    // completion. This fires *before* the oneshot so the watch
+    // sequence increment is visible before the drain-injection
+    // path adds the `Role::Tool` row — ordering that avoids the
+    // race where `WaitForMail` wakes, calls `drain_completed` and
+    // finds nothing yet.
+    //
+    // Send is best-effort: if the registry has no entry for the
+    // parent (e.g. top-level session running without a registry,
+    // or the parent already exited), we silently skip — the
+    // existing drain path (`inference.rs` `drain_completed`) still
+    // injects the result on the next iteration, so nothing is lost.
+    if let Some(registry) = bg_mailbox_registry.as_deref() {
+        if let Some(parent_mailbox) = registry.get(&parent_agent_path) {
+            let summary = match &result {
+                Ok(output) => format!(
+                    "Background agent '{}' completed.\n{}",
+                    bg_agent_path, output
+                ),
+                Err(e) => format!("Background agent '{}' failed: {e:#}", bg_agent_path),
+            };
+            let mail = crate::agent::inter_agent::InterAgentCommunication::new(
+                bg_agent_path.clone(),
+                parent_agent_path,
+                Vec::new(),
+                summary,
+                // trigger_turn=true: wake the parent immediately so
+                // `WaitForMail` unblocks as soon as the child exits
+                // rather than waiting for the parent's next natural turn.
+                true,
+            );
+            // `send` returns the sequence number; we don't need it.
+            let _seq = parent_mailbox.send(mail);
         }
     }
 
@@ -856,6 +900,10 @@ pub(crate) fn execute_sub_agent<'a>(
                 ),
             });
 
+            // #1325 Phase 5a: clone the parent's path so the bg task
+            // can send the completion mail to the parent's mailbox.
+            let parent_path_for_bg = parent_tx.turn.agent_path.clone();
+
             let handle = tokio::spawn(run_bg_agent(
                 project_root_owned,
                 parent_config_owned,
@@ -870,6 +918,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 emitter,
                 bg_agent_path,
                 bg_mailbox_registry,
+                parent_path_for_bg,
             ));
 
             bg_agents.attach(

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -523,28 +523,29 @@ async fn run_bg_agent(
     // or the parent already exited), we silently skip — the
     // existing drain path (`inference.rs` `drain_completed`) still
     // injects the result on the next iteration, so nothing is lost.
-    if let Some(registry) = bg_mailbox_registry.as_deref() {
-        if let Some(parent_mailbox) = registry.get(&parent_agent_path) {
-            let summary = match &result {
-                Ok(output) => format!(
-                    "Background agent '{}' completed.\n{}",
-                    bg_agent_path, output
-                ),
-                Err(e) => format!("Background agent '{}' failed: {e:#}", bg_agent_path),
-            };
-            let mail = crate::agent::inter_agent::InterAgentCommunication::new(
-                bg_agent_path.clone(),
-                parent_agent_path,
-                Vec::new(),
-                summary,
-                // trigger_turn=true: wake the parent immediately so
-                // `WaitForMail` unblocks as soon as the child exits
-                // rather than waiting for the parent's next natural turn.
-                true,
-            );
-            // `send` returns the sequence number; we don't need it.
-            let _seq = parent_mailbox.send(mail);
-        }
+    let parent_mailbox_opt = bg_mailbox_registry
+        .as_deref()
+        .and_then(|r| r.get(&parent_agent_path));
+    if let Some(parent_mailbox) = parent_mailbox_opt {
+        let summary = match &result {
+            Ok(output) => format!(
+                "Background agent '{}' completed.\n{}",
+                bg_agent_path, output
+            ),
+            Err(e) => format!("Background agent '{}' failed: {e:#}", bg_agent_path),
+        };
+        let mail = crate::agent::inter_agent::InterAgentCommunication::new(
+            bg_agent_path.clone(),
+            parent_agent_path,
+            Vec::new(),
+            summary,
+            // trigger_turn=true: wake the parent immediately so
+            // `WaitForMail` unblocks as soon as the child exits
+            // rather than waiting for the parent's next natural turn.
+            true,
+        );
+        // `send` returns the sequence number; we don't need it.
+        let _seq = parent_mailbox.send(mail);
     }
 
     let _ = match result {

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -352,6 +352,51 @@ pub(crate) async fn execute_one_tool(
             // model, ask the user to check the network, ...).
             Err(e) => (format!("Error invoking sub-agent: {e:#}"), false, None),
         }
+    } else if tc.function_name == "SpawnAgent" {
+        // #1325 Phase 5a: SpawnAgent — codex v2 compatible peer-spawn.
+        //
+        // Same dispatch path as `InvokeAgent` but with a different
+        // surface shape: `task_name` + `message` → `agent_name` + `prompt`.
+        // Re-map the arguments before forwarding to `execute_sub_agent`
+        // so the existing dispatch logic is reused without duplication.
+        //
+        // Box::pin is required for the same mutual-recursion reason as
+        // `InvokeAgent` above — see that branch's comment.
+        let remapped = {
+            let mut v: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
+            if let Some(obj) = v.as_object_mut() {
+                if let Some(task_name) = obj.remove("task_name") {
+                    obj.insert("agent_name".to_string(), task_name);
+                }
+                if let Some(message) = obj.remove("message") {
+                    obj.insert("prompt".to_string(), message);
+                }
+            }
+            serde_json::to_string(&v).unwrap_or_else(|_| tc.arguments.clone())
+        };
+        let remapped_tc = crate::providers::ToolCall {
+            function_name: "InvokeAgent".to_string(),
+            arguments: remapped,
+            id: tc.id.clone(),
+            thought_signature: tc.thought_signature.clone(),
+        };
+        let (_, mut dummy_rx) = mpsc::channel(1);
+        let policy = tools.sandbox_policy().clone();
+        let read_cache = tools.file_read_cache();
+        let fut = sub_agent_dispatch::execute_sub_agent(
+            tx,
+            &remapped_tc.arguments,
+            &mut dummy_rx,
+            Some(read_cache),
+            &policy,
+            None,
+            Some(&remapped_tc.id),
+            false,
+        );
+        match Box::pin(fut).await {
+            Ok(output) => (output, true, None),
+            Err(e) => (format!("Error spawning agent: {e:#}"), false, None),
+        }
     } else {
         // Invalidate sub-agent cache on file mutations.
         //

--- a/koda-core/src/tool_dispatch.rs
+++ b/koda-core/src/tool_dispatch.rs
@@ -362,18 +362,28 @@ pub(crate) async fn execute_one_tool(
         //
         // Box::pin is required for the same mutual-recursion reason as
         // `InvokeAgent` above — see that branch's comment.
-        let remapped = {
-            let mut v: serde_json::Value = serde_json::from_str(&tc.arguments).unwrap_or_default();
-            if let Some(obj) = v.as_object_mut() {
-                if let Some(task_name) = obj.remove("task_name") {
-                    obj.insert("agent_name".to_string(), task_name);
-                }
-                if let Some(message) = obj.remove("message") {
-                    obj.insert("prompt".to_string(), message);
-                }
+        // Parse first — explicit error rather than silently becoming Null
+        // and then getting a downstream "agent_name is required" error.
+        let mut parsed: serde_json::Value = match serde_json::from_str(&tc.arguments) {
+            Ok(v) => v,
+            Err(e) => {
+                return (
+                    tc.id.clone(),
+                    format!("SpawnAgent: argument JSON is malformed: {e}"),
+                    false,
+                    None,
+                );
             }
-            serde_json::to_string(&v).unwrap_or_else(|_| tc.arguments.clone())
         };
+        if let Some(obj) = parsed.as_object_mut() {
+            if let Some(task_name) = obj.remove("task_name") {
+                obj.insert("agent_name".to_string(), task_name);
+            }
+            if let Some(message) = obj.remove("message") {
+                obj.insert("prompt".to_string(), message);
+            }
+        }
+        let remapped = serde_json::to_string(&parsed).unwrap_or_else(|_| tc.arguments.clone());
         let remapped_tc = crate::providers::ToolCall {
             function_name: "InvokeAgent".to_string(),
             arguments: remapped,

--- a/koda-core/src/tool_normalize.rs
+++ b/koda-core/src/tool_normalize.rs
@@ -41,6 +41,7 @@ const CANONICAL: &[&str] = &[
     "Read",
     "RecallContext",
     "SendMessage",
+    "SpawnAgent",
     "TodoWrite",
     "WaitForMail",
     "WaitTask",

--- a/koda-core/src/tools/catalog.rs
+++ b/koda-core/src/tools/catalog.rs
@@ -61,7 +61,8 @@ use std::sync::{Arc, RwLock};
 
 use super::{
     DynTool, Tool, ToolEffect, agent, ask_user, bg_task_tools, boxed, file_tools, glob_tool, grep,
-    memory, recall, send_message, shell, skill_tools, todo, wait_for_mail, web_fetch, web_search,
+    memory, recall, send_message, shell, skill_tools, spawn_agent, todo, wait_for_mail, web_fetch,
+    web_search,
 };
 
 /// The read-only metadata side of [`crate::tools::ToolRegistry`].
@@ -188,6 +189,11 @@ impl ToolCatalog {
         for def in wait_for_mail::definitions() {
             definitions.insert(def.name.clone(), def);
         }
+        // #1325 Phase 5a: SpawnAgent — codex v2 compatible peer-spawn.
+        // Intercepted by `tool_dispatch.rs` like `InvokeAgent`.
+        for def in spawn_agent::definitions() {
+            definitions.insert(def.name.clone(), def);
+        }
         // RecallContext is a singleton (not a `Vec`) — it has a
         // single canonical definition and the sub-module reflects
         // that with `definition()` instead of `definitions()`.
@@ -243,6 +249,8 @@ impl ToolCatalog {
             // mailbox registry is read off ToolExecCtx.
             boxed(send_message::SendMessageTool),
             boxed(wait_for_mail::WaitForMailTool),
+            // #1325 Phase 5a: SpawnAgent — intercepted by tool_dispatch.rs.
+            boxed(spawn_agent::SpawnAgentTool),
         ] {
             tools.insert(tool.name(), tool);
         }

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -115,6 +115,8 @@ pub mod send_message;
 pub mod shell;
 /// Skill discovery and activation tools (`ListSkills`, `ActivateSkill`).
 pub mod skill_tools;
+/// Sub-agent spawn tool — codex v2 peer-style (`SpawnAgent`). (#1325 Phase 5a)
+pub mod spawn_agent;
 /// Renderer-agnostic tool-call display payload (the single source of
 /// truth for "what does a tool call show?"). See [`summary`] for the
 /// drift problem this exists to solve.

--- a/koda-core/src/tools/spawn_agent.rs
+++ b/koda-core/src/tools/spawn_agent.rs
@@ -1,0 +1,141 @@
+//! `SpawnAgent` — codex v2 peer-style spawn tool (#1325 Phase 5a).
+//!
+//! Mirrors codex's `spawn_agent` shape: `task_name` + `message` (no
+//! `background` flag, no `fork_turns`) so prompts written against
+//! codex v2 are structurally compatible with koda.
+//!
+//! ## Relationship to `InvokeAgent`
+//!
+//! Both tools dispatch to the same `execute_sub_agent` machinery in
+//! `sub_agent_dispatch.rs`. The difference is surface shape and naming:
+//!
+//! | | `InvokeAgent` | `SpawnAgent` |
+//! |---|---|---|
+//! | `agent_name` field | explicit | `agent` (built-in only for now) |
+//! | task description | `prompt` | `message` |
+//! | style | koda-native | codex v2 / Claude Code compatible |
+//!
+//! `SpawnAgent` is intercepted by `tool_dispatch.rs` exactly like
+//! `InvokeAgent`. The actual dispatch path is reused; this file just
+//! provides the schema and the catalog stub so the LLM can call it.
+//!
+//! ## Phase 5a scope
+//!
+//! Phase 5a adds the tool shape + dispatch wiring. Phase 5b will retire
+//! `WaitTask`/`ListBackgroundTasks`/`CancelTask` once all callers migrate.
+
+use crate::providers::ToolDefinition;
+use crate::tools::{Tool, ToolEffect, ToolExecCtx, ToolResult};
+use async_trait::async_trait;
+use serde_json::json;
+
+/// Return tool definitions for the LLM.
+pub fn definitions() -> Vec<ToolDefinition> {
+    vec![ToolDefinition {
+        name: "SpawnAgent".to_string(),
+        description: "Spawn a named sub-agent to work on a task in the background.\n\
+            \n\
+            Compatible with the codex v2 / Claude Code `spawn_agent` shape.\n\
+            Returns IMMEDIATELY with a task_id. The sub-agent runs concurrently;\n\
+            you keep working in parallel. Results are delivered to your mailbox\n\
+            at task completion — use `WaitForMail` to block until a result arrives.\n\
+            \n\
+            `task_name` identifies the agent configuration to load (same as\n\
+            `InvokeAgent`'s `agent_name`). Use `ListAgents` to see available agents.\n\
+            \n\
+            `message` is the task prompt handed to the sub-agent."
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "task_name": {
+                    "type": "string",
+                    "description": "Agent configuration name (e.g. `explore`, `task`, `fork`). \
+                        Use `ListAgents` to see what is available."
+                },
+                "message": {
+                    "type": "string",
+                    "description": "The task prompt to hand to the sub-agent."
+                }
+            },
+            "required": ["task_name", "message"]
+        }),
+    }]
+}
+
+/// `SpawnAgent` — intercepted by `tool_dispatch.rs`.
+///
+/// The trait impl exists only to register the tool in the catalog and
+/// keep the dispatch table complete. Actual execution is handled by
+/// `tool_dispatch.rs` (which re-maps `task_name`/`message` to the
+/// `agent_name`/`prompt` fields that `execute_sub_agent` expects).
+pub struct SpawnAgentTool;
+
+#[async_trait]
+impl Tool for SpawnAgentTool {
+    fn name(&self) -> &'static str {
+        "SpawnAgent"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        definitions()
+            .into_iter()
+            .next()
+            .expect("spawn_agent::definitions() must be non-empty")
+    }
+
+    fn classify(&self, _args: &serde_json::Value) -> ToolEffect {
+        // Sub-agents inherit the parent's approval mode; classification
+        // here is a placeholder — dispatch never reaches this impl.
+        ToolEffect::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolExecCtx<'_>, _args: &serde_json::Value) -> ToolResult {
+        ToolResult {
+            output: "SpawnAgent is handled by the inference loop.".to_string(),
+            success: false,
+            full_output: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_name_matches_definition() {
+        let t = SpawnAgentTool;
+        assert_eq!(t.name(), "SpawnAgent");
+        assert_eq!(t.definition().name, "SpawnAgent");
+    }
+
+    #[test]
+    fn classify_is_read_only() {
+        let t = SpawnAgentTool;
+        assert_eq!(t.classify(&serde_json::Value::Null), ToolEffect::ReadOnly);
+    }
+
+    #[test]
+    fn definition_requires_task_name_and_message() {
+        let def = SpawnAgentTool.definition();
+        let required = def.parameters["required"]
+            .as_array()
+            .expect("required array");
+        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            required_names.contains(&"task_name"),
+            "task_name must be required"
+        );
+        assert!(
+            required_names.contains(&"message"),
+            "message must be required"
+        );
+    }
+
+    #[test]
+    fn definitions_non_empty() {
+        assert!(!definitions().is_empty());
+        assert_eq!(definitions()[0].name, "SpawnAgent");
+    }
+}

--- a/koda-core/tests/new_tools_test.rs
+++ b/koda-core/tests/new_tools_test.rs
@@ -238,6 +238,7 @@ mod naming_convention {
         "Read",
         "RecallContext",
         "SendMessage",
+        "SpawnAgent",
         "TodoWrite",
         "WaitForMail",
         "WaitTask",
@@ -276,11 +277,12 @@ mod naming_convention {
 
     #[test]
     fn test_expected_tool_count() {
-        // 24 built-in tools.
+        // 25 built-in tools.
         // - #996 Layer 2 added ListBackgroundTasks, CancelTask,
         //   WaitTask (19 → 22).
         // - #1325 Phase 3 added SendMessage, WaitForMail (22 → 24).
-        assert_eq!(BUILTIN_TOOLS.len(), 24);
+        // - #1325 Phase 5a added SpawnAgent (24 → 25).
+        assert_eq!(BUILTIN_TOOLS.len(), 25);
     }
 
     /// Ensure BUILTIN_TOOLS stays in sync with the actual registry.

--- a/koda-core/tests/tool_wiring_test.rs
+++ b/koda-core/tests/tool_wiring_test.rs
@@ -153,6 +153,10 @@ fn test_classify_tool_covers_all_tools_explicitly() {
         // it mutates the recipient's mailbox state. See module
         // docs on each for the full rationale.
         ("WaitForMail", ToolEffect::ReadOnly),
+        // #1325 Phase 5a: SpawnAgent re-maps to InvokeAgent at dispatch
+        // time; ReadOnly for the same reason InvokeAgent is ReadOnly
+        // (sub-agents inherit the parent's approval mode).
+        ("SpawnAgent", ToolEffect::ReadOnly),
         // Local mutations
         ("Write", ToolEffect::LocalMutation),
         ("Edit", ToolEffect::LocalMutation),


### PR DESCRIPTION
## Summary

Phase 5a of #1325 — three tightly coupled changes that complete the `SpawnAgent` + `WaitForMail` pairing:

- **Mailbox bridge** (`sub_agent_dispatch.rs`): `run_bg_agent` now notifies the parent's mailbox at task completion (before the oneshot fires). `WaitForMail` can now unblock the moment a child exits rather than sitting until the next-iteration drain loop runs. Best-effort: silently skips if the parent has no registered mailbox (top-level session, test fixtures).

- **`SpawnAgent` tool** (`tools/spawn_agent.rs`): codex v2 / Claude Code compatible shape — `task_name` + `message`. Intercepted by `tool_dispatch.rs`, which re-maps fields to `agent_name` + `prompt` before forwarding to the existing `execute_sub_agent` path. Zero duplication.

- **META_TOOLS** (`skill_scope.rs`): adds `SpawnAgent`, `SendMessage`, and `WaitForMail` to the always-available set so skill-scoped agents don't need to list peer-messaging tools in every manifest.

## What comes next (Phase 5b — separate PR)

Retire `WaitTask`, `ListBackgroundTasks`, `CancelTask` once callers migrate. Rewrite `InvokeAgent` description to point at `SpawnAgent`. Update DESIGN.md + CHANGELOG.

## Test plan

- [x] `cargo test -p koda-core --features test-support -- --skip web_fetch --skip sandbox::tests::build_omits_proxy_env` — 1381 passed, 2 skipped (both pre-existing env failures)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Pre-push hook passes

🌀 Magic applied with [Wibey CLI](https://wibey.walmart.com/cli) 🪄
