### PR TITLE
fix(tools/wait_for_mail): reinforce anti-pattern + bg-agent guidance (#1338 issue 2)

### DIFF
--- a/koda-core/src/tools/wait_for_mail.rs
+++ b/koda-core/src/tools/wait_for_mail.rs
@@ -73,7 +73,25 @@ pub fn definitions() -> Vec<ToolDefinition> {
              \n\nDefault timeout: {}ms ({}s). Max: {}ms ({}s). Min: {}ms.\
              \n\nThe mail itself surfaces as user-role messages at the top of your \
              NEXT turn — this tool only signals arrival so you can end your current \
-             turn cleanly. Use it after `SendMessage` if you expect a peer to reply.",
+             turn cleanly.\
+             \n\nWHEN TO USE\
+             \n- After `SendMessage` if you expect a peer to reply.\
+             \n- After `InvokeAgent` / `SpawnAgent` ONLY if (1) you have genuinely run \
+             out of useful concurrent work AND (2) the next step strictly depends on \
+             the sub-agent's output. Every bg-agent exit sends a completion mail \
+             via the `notify_parent_mailbox` bridge, so this tool will unblock the \
+             instant the first sub-agent finishes.\
+             \n\nWHEN NOT TO USE (anti-pattern)\
+             \n- Immediately after spawning a sub-agent with no other work queued. This \
+             defeats the purpose of background execution — you serialize what was \
+             supposed to run in parallel and burn real wall-clock waiting on a \
+             timeout when you could have been doing follow-up reads, searches, or \
+             edits. See `InvokeAgent`'s description for the full guidance.\
+             \n- As a general 'pause and think' mechanism. There is no mail-less wakeup \
+             — if no mail arrives this tool blocks for the full `timeout_ms`.\
+             \n\nResults still inject automatically on a future iteration via auto-drain; \
+             you do NOT need to call `WaitForMail` to receive them. Use it only when \
+             you cannot make forward progress without the reply.",
             DEFAULT_WAIT_TIMEOUT_MS,
             DEFAULT_WAIT_TIMEOUT_MS / 1000,
             MAX_WAIT_TIMEOUT_MS,
@@ -624,5 +642,61 @@ mod tests {
         assert!(desc.contains(&DEFAULT_WAIT_TIMEOUT_MS.to_string()));
         assert!(desc.contains(&MAX_WAIT_TIMEOUT_MS.to_string()));
         assert!(desc.contains(&MIN_WAIT_TIMEOUT_MS.to_string()));
+    }
+
+    #[test]
+    fn definition_reinforces_anti_pattern_and_use_cases() {
+        // #1338 Issue #2: defense-in-depth. `InvokeAgent`'s description
+        // already warns against spawn-then-immediately-wait. The
+        // contract has two endpoints though, and the model may be
+        // looking at `WaitForMail`'s description (not `InvokeAgent`'s)
+        // when it decides to call this tool. So `WaitForMail` must
+        // *also* surface:
+        //
+        //   1. The bg-agent-completion mail use case (post-Phase 5b
+        //      this is one of the two main reasons to call this tool).
+        //   2. A pointer to the `notify_parent_mailbox` bridge so
+        //      the model knows mail will arrive on bg-agent exit.
+        //   3. The spawn-then-immediately-wait anti-pattern (mirroring
+        //      `InvokeAgent`'s own warning).
+        //   4. The original `SendMessage`-reply use case (must NOT
+        //      regress — the previous description's only stated use
+        //      case must still be present).
+        let def = &definitions()[0];
+        let desc = &def.description;
+
+        // (1) bg-agent completion mail surfaced.
+        assert!(
+            desc.contains("InvokeAgent") || desc.contains("SpawnAgent"),
+            "description must mention the spawn tool(s) so the model knows \
+             bg-agent completion is a wait trigger; got:\n{desc}"
+        );
+        assert!(
+            desc.contains("sub-agent") || desc.contains("bg-agent"),
+            "description must reference sub-agents as a mail source; got:\n{desc}"
+        );
+
+        // (2) bridge pointer.
+        assert!(
+            desc.contains("notify_parent_mailbox") || desc.contains("completion mail"),
+            "description must reference the bridge or completion-mail mechanism so \
+             the model knows bg-agent exit unblocks this tool; got:\n{desc}"
+        );
+
+        // (3) anti-pattern explicit.
+        assert!(
+            desc.to_lowercase().contains("anti-pattern") || desc.contains("defeats the purpose"),
+            "description must explicitly call out the spawn-then-immediately-wait \
+             anti-pattern; got:\n{desc}"
+        );
+
+        // (4) inverted regression: original `SendMessage` use case
+        //     must NOT be lost in the rewrite.
+        assert!(
+            desc.contains("SendMessage"),
+            "description must still reference SendMessage — the original \
+             peer-reply use case predates the bg-agent guidance and remains \
+             valid. Do not regress it; got:\n{desc}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Addresses **issue #2 of 4** in #1338 — `WaitForMail`'s description doesn't reinforce the anti-pattern warning from its own side of the contract.

## Background

PR #1337 added explicit guidance to `InvokeAgent`'s description:

> Calling `WaitForMail` immediately after spawning defeats the purpose.
> Use `WaitForMail` ONLY when:
>   1. You have genuinely run out of useful concurrent work, AND
>   2. The next step strictly depends on the sub-agent's output.

But the contract has **two endpoints**, and the model may be looking at `WaitForMail`'s description (not `InvokeAgent`'s) when it decides to call this tool. Pre-fix, `WaitForMail` only said:

> Use it after `SendMessage` if you expect a peer to reply.

No mention of bg-agent completion mail (post-Phase 5b one of the two main reasons to call this tool), no pointer to the `notify_parent_mailbox` bridge, no echo of `InvokeAgent`'s anti-pattern warning. Defense-in-depth gap.

## Change

Rewrites `WaitForMail`'s description with four explicit sections:

1. **Header** — unchanged behavior contract (block until mail or timeout, default/max/min, mail surfaces in next turn).
2. **WHEN TO USE** — both legitimate use cases:
   * After `SendMessage` if you expect a peer to reply (preserved verbatim).
   * After `InvokeAgent` / `SpawnAgent` ONLY when the two-condition test from `InvokeAgent` is met. Calls out the `notify_parent_mailbox` bridge so the model knows bg-agent exit unblocks the wait.
3. **WHEN NOT TO USE (anti-pattern)** — explicit `anti-pattern` label, mirrors `InvokeAgent`'s "defeats the purpose" phrasing, plus the "general pause-and-think" misuse.
4. **Closer** — reminder that auto-drain still injects results without needing this tool.

## Tests

Adds **`definition_reinforces_anti_pattern_and_use_cases`** which pins all four contract surfaces, including the **inverted assertion** the issue specifically requested:

```rust
// (4) inverted regression: original `SendMessage` use case
//     must NOT be lost in the rewrite.
assert!(
    desc.contains("SendMessage"),
    "description must still reference SendMessage \u2014 the original \
     peer-reply use case predates the bg-agent guidance and remains \
     valid. Do not regress it; got:\n{desc}"
);
```

All 10 tests in `tools::wait_for_mail::tests` pass. Existing `definition_documents_default_max_min_in_description` test is left untouched (it pins the bounds).

## Diff size

`koda-core/src/tools/wait_for_mail.rs` only — **+75 / -1**. (Issue estimated ~20 LOC for description + 1 inverted test; the tighter assertion structure pushed it slightly higher but it's all in one file.)

## Acceptance criteria

- [x] Description mentions bg-agent completion as a wait trigger.
- [x] Description references the `notify_parent_mailbox` bridge.
- [x] Description echoes `InvokeAgent`'s spawn-then-wait anti-pattern.
- [x] Original `SendMessage` reference preserved (inverted regression test).
- [x] All existing `tools::wait_for_mail::tests::*` still pass.
- [x] `cargo fmt` + `cargo clippy` clean.

## Refs

- Parent issue: #1338
- Predecessor: #1337 (added the same warning to `InvokeAgent`)
- Spotted in debug bundle: `koda-debug-20260507-231223-session.zip` (gemini-flash-latest)