### PR TITLE
fix(tools/wait_for_mail): rich timeout payload (#1338 issue 3)

### DIFF
--- a/koda-core/src/session.rs
+++ b/koda-core/src/session.rs
@@ -458,6 +458,15 @@ impl KodaSession {
             .tools
             .set_mailbox_registry(Arc::clone(&mailbox_registry));
 
+        // #1338 Issue #3: hand the bg-agent registry to the tool
+        // layer so `WaitForMail`'s timeout payload can list which
+        // sub-agents are still running. Constructed here (instead of
+        // inline in the `Self { bg_agents: ... }` literal below) so we
+        // can `Arc::clone` it into both places without touching the
+        // shape of the struct constructor.
+        let bg_agents = child_agent::new_shared();
+        agent.tools.set_bg_agents(Arc::clone(&bg_agents));
+
         Self {
             id,
             agent,
@@ -472,7 +481,7 @@ impl KodaSession {
             // #1022 B12: registry + cache live on the session so bg
             // agents survive across turns and the cache yields
             // cross-turn hits.
-            bg_agents: child_agent::new_shared(),
+            bg_agents,
             sub_agent_cache: SubAgentCache::new(),
             // No forwarder yet; clients (TUI / ACP) call
             // `attach_event_sink` to spawn it. Headless paths leave

--- a/koda-core/src/tools/mod.rs
+++ b/koda-core/src/tools/mod.rs
@@ -304,6 +304,15 @@ pub struct ToolRegistry {
     /// every other tool ignores it.
     mailbox_registry:
         std::sync::RwLock<Option<Arc<crate::agent::mailbox_registry::MailboxRegistry>>>,
+
+    /// #1338 Issue #3 — per-session bg-agent registry. Set by
+    /// [`crate::session::KodaSession::new`] (and the test-utils
+    /// `Env`) so [`crate::tools::wait_for_mail::WaitForMailTool`]
+    /// can enrich its timeout payload with the caller's in-flight
+    /// bg-agents. `None` in standalone-`ToolRegistry` tests, in
+    /// which case `WaitForMail`'s timeout payload silently falls
+    /// back to the legacy minimal shape (`{message, timed_out}`).
+    bg_agents: std::sync::RwLock<Option<Arc<crate::child_agent::ChildAgentRegistry>>>,
 }
 
 impl ToolRegistry {
@@ -352,6 +361,7 @@ impl ToolRegistry {
             proxy_port: std::sync::RwLock::new(None),
             socks5_port: std::sync::RwLock::new(None),
             mailbox_registry: std::sync::RwLock::new(None),
+            bg_agents: std::sync::RwLock::new(None),
         }
     }
 
@@ -497,6 +507,26 @@ impl ToolRegistry {
     /// boundaries without holding the registry-slot lock.
     pub fn mailbox_registry(&self) -> Option<Arc<crate::agent::mailbox_registry::MailboxRegistry>> {
         self.mailbox_registry.read().ok().and_then(|g| g.clone())
+    }
+
+    /// Attach a bg-agent registry (#1338 Issue #3). Mirrors
+    /// [`Self::set_mailbox_registry`]: same interior-mutability
+    /// rationale, same poison-tolerance (silently keep the prior
+    /// value if the lock is poisoned). Called by
+    /// [`crate::session::KodaSession::new`] after the registry is
+    /// minted; standalone-`ToolRegistry` tests skip this and
+    /// `WaitForMail` falls back to the minimal timeout payload.
+    pub fn set_bg_agents(&self, registry: Arc<crate::child_agent::ChildAgentRegistry>) {
+        if let Ok(mut guard) = self.bg_agents.write() {
+            *guard = Some(registry);
+        }
+    }
+
+    /// Current bg-agent registry, if one has been attached.
+    /// Returns the `Arc` clone so the caller can hold it across
+    /// `.await` boundaries without holding the registry-slot lock.
+    pub fn bg_agents(&self) -> Option<Arc<crate::child_agent::ChildAgentRegistry>> {
+        self.bg_agents.read().ok().and_then(|g| g.clone())
     }
 
     /// Borrow the underlying read-only metadata catalog.
@@ -678,6 +708,10 @@ impl ToolRegistry {
             // local `mb_reg_arc` keeps the `Arc` alive across the
             // `.await`; the borrow handed to the tool is `Option<&'_ Arc<_>>`.
             let mb_reg_arc = self.mailbox_registry.read().ok().and_then(|g| g.clone());
+            // Same snapshot pattern for the bg-agent registry — clone
+            // the `Arc` once per dispatch so the borrow handed to the
+            // tool stays valid through `tool.execute(...).await`.
+            let bg_agents_arc = self.bg_agents.read().ok().and_then(|g| g.clone());
             let ctx = tool_trait::ToolExecCtx {
                 project_root: &self.project_root,
                 read_cache: &self.read_cache,
@@ -693,6 +727,7 @@ impl ToolRegistry {
                 session,
                 skill_registry: &self.skill_registry,
                 mailbox_registry: mb_reg_arc.as_ref(),
+                bg_agents: bg_agents_arc.as_ref(),
                 caller_agent_path,
             };
             let result = tool.execute(&ctx, &args).await;

--- a/koda-core/src/tools/send_message.rs
+++ b/koda-core/src/tools/send_message.rs
@@ -294,6 +294,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: Some(registry),
+            bg_agents: None,
             caller_agent_path: agent_path,
         }
     }
@@ -518,6 +519,7 @@ mod tests {
             session: None,
             skill_registry: &skills,
             mailbox_registry: None,
+            bg_agents: None,
             caller_agent_path: &agent_path,
         };
 

--- a/koda-core/src/tools/tool_trait.rs
+++ b/koda-core/src/tools/tool_trait.rs
@@ -241,6 +241,19 @@ pub struct ToolExecCtx<'a> {
     /// at the use site — explicit beats hidden cost.
     pub mailbox_registry: Option<&'a Arc<crate::agent::mailbox_registry::MailboxRegistry>>,
 
+    /// Per-session bg-agent registry (#1338 Issue #3). `None` when
+    /// running outside a session (standalone-`ToolRegistry` tests).
+    /// Today only [`crate::tools::wait_for_mail::WaitForMailTool`]
+    /// reads it \u2014 specifically on the timeout path, to enrich the
+    /// returned payload with `bg_agents_in_flight` and per-task
+    /// snapshots so the model can decide what to do next without
+    /// guessing whether sub-agents are still working.
+    ///
+    /// Borrowed (`&'a Arc`) for the same zero-clone-per-dispatch
+    /// reason as [`Self::mailbox_registry`]. Peer tools that hold
+    /// the registry across `.await` should `Arc::clone` themselves.
+    pub bg_agents: Option<&'a Arc<crate::child_agent::ChildAgentRegistry>>,
+
     /// Caller's identity in the agent spawn tree (#1325 Phase 4).
     /// Source of truth: `TurnContext::agent_path`. Defaults to
     /// `&AgentPath::root()` for the user-facing session and for
@@ -488,6 +501,7 @@ impl<'a> ToolExecCtx<'a> {
             // exercise send_message / wait_for_mail must construct
             // their context manually with a real registry.
             mailbox_registry: None,
+            bg_agents: None,
             caller_agent_path: agent_path,
         }
     }
@@ -625,6 +639,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: None,
+            bg_agents: None,
             caller_agent_path: agent_path,
         }
     }

--- a/koda-core/src/tools/wait_for_mail.rs
+++ b/koda-core/src/tools/wait_for_mail.rs
@@ -89,6 +89,16 @@ pub fn definitions() -> Vec<ToolDefinition> {
              edits. See `InvokeAgent`'s description for the full guidance.\
              \n- As a general 'pause and think' mechanism. There is no mail-less wakeup \
              — if no mail arrives this tool blocks for the full `timeout_ms`.\
+             \n\nRETURN PAYLOAD\
+             \n- On mail arrival: `{{\"message\": \"Wait completed.\", \"timed_out\": false}}`. \
+             End your turn so the next iteration drains the mailbox.\
+             \n- On timeout: `{{\"message\": \"Wait timed out.\", \"timed_out\": true, \
+             \"bg_agents_in_flight\": <N>, \"bg_agents\": [...], \"hint\": \"...\"}}`. \
+             Use `bg_agents_in_flight` and the per-task `bg_agents` summary \
+             (task_id, agent_name, status, age_secs) to decide what to do next: \
+             if N > 0, sub-agents are still working — do useful concurrent work \
+             and re-check; if N = 0, no work was queued — proceed yourself. The \
+             `hint` string spells out the recommendation.\
              \n\nResults still inject automatically on a future iteration via auto-drain; \
              you do NOT need to call `WaitForMail` to receive them. Use it only when \
              you cannot make forward progress without the reply.",
@@ -245,15 +255,141 @@ impl Tool for WaitForMailTool {
         // human-readable `message` string + a structured `timed_out`
         // bool. Returned as JSON so downstream tooling (and the
         // model) can branch on the bool without parsing prose.
-        let payload = json!({
-            "message": if timed_out { "Wait timed out." } else { "Wait completed." },
-            "timed_out": timed_out,
-        });
+        //
+        // #1338 Issue #3: on the timeout path the bare `{message,
+        // timed_out}` payload told the model nothing about WHY the
+        // wait failed (was a bg-agent still running? was no agent
+        // ever spawned?). Without that signal the model's recovery
+        // was correct-but-slow: "timeout \u2192 do exploration myself \u2192
+        // re-wait \u2192 timeout again". Burning real wall-clock for no
+        // good reason.
+        //
+        // We now enrich the timeout payload with `bg_agents_in_flight`
+        // (count) plus a per-task `bg_agents` summary (task_id,
+        // agent_name, status, age_secs) and a `hint` string nudging
+        // the model toward the right next move. The success payload
+        // stays minimal because there's nothing useful to say beyond
+        // "go drain your mailbox on the next iteration".
+        let payload = if timed_out {
+            build_timed_out_payload(ctx)
+        } else {
+            json!({
+                "message": "Wait completed.",
+                "timed_out": false,
+            })
+        };
         ToolResult {
             output: payload.to_string(),
             success: true,
             full_output: None,
         }
+    }
+}
+
+/// Construct the rich timeout payload (#1338 Issue #3).
+///
+/// Reads the bg-agent registry off `ctx.bg_agents` and scopes the
+/// snapshot to the caller via `ctx.caller_spawner` (so a sub-agent
+/// only sees its own children, not its siblings'). Falls back to
+/// the legacy minimal payload when no registry is attached —
+/// preserves bytewise behavior for standalone-`ToolRegistry` tests
+/// and any future caller that wires `WaitForMail` without the
+/// registry.
+///
+/// Pure function (no async, no I/O beyond cloning snapshots) so it
+/// can be tested in isolation.
+fn build_timed_out_payload(ctx: &ToolExecCtx<'_>) -> Value {
+    let Some(registry) = ctx.bg_agents else {
+        // Legacy minimal payload — standalone-`ToolRegistry` tests
+        // and any caller that hasn't wired `set_bg_agents`.
+        return json!({
+            "message": "Wait timed out.",
+            "timed_out": true,
+        });
+    };
+
+    // Scope to caller. A top-level wait sees its own bg-agents;
+    // a sub-agent waiter sees only its own children. Mirrors the
+    // scoping rules of `ListBackgroundTasks`.
+    let mut snapshots = registry.snapshot_for_caller(ctx.caller_spawner);
+    // Drop terminal entries — once a bg-agent has Completed/Errored/
+    // Cancelled it's no longer "in flight" and reporting it would
+    // mislead the model into waiting for something that's already
+    // done. Keep `Pending` and `Running { .. }` only.
+    snapshots.retain(|s| {
+        matches!(
+            s.status,
+            crate::child_agent::AgentStatus::Pending
+                | crate::child_agent::AgentStatus::Running { .. }
+        )
+    });
+    let in_flight = snapshots.len();
+
+    // Per-task summary. `prompt` is intentionally omitted — it can be
+    // very long and the model already saw it when it spawned the agent.
+    // `age_secs` rounds to whole seconds; sub-second precision would be
+    // noise in a payload aimed at human-scale recovery decisions.
+    let bg_agents_summary: Vec<Value> = snapshots
+        .iter()
+        .map(|s| {
+            json!({
+                "task_id": s.task_id,
+                "agent_name": s.agent_name,
+                "status": agent_status_label(&s.status),
+                "age_secs": s.age.as_secs(),
+            })
+        })
+        .collect();
+
+    // Hint string. Three cases:
+    //   1. No bg-agents in flight → the wait timed out for some
+    //      OTHER reason (a peer that was supposed to reply didn't,
+    //      or the model called WaitForMail speculatively). Tell it
+    //      to make forward progress on its own.
+    //   2. ≥1 bg-agent in flight → they're still working; nudge
+    //      toward useful concurrent work + shorter re-poll.
+    //   3. (Implicit) no registry attached → we already returned
+    //      the legacy minimal payload above.
+    let hint = if in_flight == 0 {
+        "No background sub-agents are in flight. The wait timed out \
+         because no mail arrived; consider whether the work you were \
+         waiting on was actually started, or proceed with the task \
+         yourself."
+            .to_string()
+    } else {
+        format!(
+            "{in_flight} background sub-agent(s) still running. Consider \
+             doing other useful work (reads, searches, edits) and re-checking \
+             with a shorter timeout next turn — or end your turn now and \
+             let auto-drain inject results on a future iteration."
+        )
+    };
+
+    json!({
+        "message": "Wait timed out.",
+        "timed_out": true,
+        "bg_agents_in_flight": in_flight,
+        "bg_agents": bg_agents_summary,
+        "hint": hint,
+    })
+}
+
+/// Stable, lowercase string label for an [`AgentStatus`].
+///
+/// Lives here (rather than as `Display` on `AgentStatus`) because
+/// the canonical `Display` impl on `AgentStatus` doesn't exist and
+/// adding one feels like API-surface bloat for a single payload
+/// consumer. The labels match the JSON serde representation
+/// (`#[serde(tag = "kind", rename_all = "snake_case")]`) so consumers
+/// can correlate with the `ChildTaskUpdate` engine event stream.
+fn agent_status_label(status: &crate::child_agent::AgentStatus) -> &'static str {
+    use crate::child_agent::AgentStatus::*;
+    match status {
+        Pending => "pending",
+        Running { .. } => "running",
+        Cancelled => "cancelled",
+        Completed { .. } => "completed",
+        Errored { .. } => "errored",
     }
 }
 
@@ -322,6 +458,7 @@ mod tests {
             session: None,
             skill_registry: skills,
             mailbox_registry: Some(registry),
+            bg_agents: None,
             caller_agent_path: agent_path,
         }
     }
@@ -612,6 +749,7 @@ mod tests {
             session: None,
             skill_registry: &skills,
             mailbox_registry: None,
+            bg_agents: None,
             caller_agent_path: &agent_path,
         };
 
@@ -698,5 +836,336 @@ mod tests {
              peer-reply use case predates the bg-agent guidance and remains \
              valid. Do not regress it; got:\n{desc}"
         );
+    }
+
+    // ── #1338 Issue #3: rich timeout payload ──────────────────────
+    //
+    // Tests for the bg_agents-aware timeout payload. They use the
+    // same `ctx_with_registry` helper as the existing tests but
+    // attach a real `ChildAgentRegistry` so we can exercise the
+    // snapshot path. Each test pins exactly ONE behavior so failure
+    // messages stay focused.
+
+    /// Build a `ToolExecCtx` with both mailbox and bg-agent
+    /// registries attached. Callers that need to scope to a specific
+    /// caller (sub-agent test) override `caller_spawner` after.
+    #[allow(clippy::too_many_arguments)]
+    fn ctx_with_bg_agents<'a>(
+        root: &'a std::path::Path,
+        cache: &'a crate::tools::FileReadCache,
+        fs: &'a dyn koda_sandbox::fs::FileSystem,
+        caps: &'a crate::output_caps::OutputCaps,
+        bg: &'a crate::tools::bg_process::BgRegistry,
+        trust: &'a crate::trust::TrustMode,
+        policy: &'a koda_sandbox::SandboxPolicy,
+        skills: &'a crate::skills::SkillRegistry,
+        registry: &'a Arc<MailboxRegistry>,
+        bg_agents: &'a Arc<crate::child_agent::ChildAgentRegistry>,
+        agent_path: &'a AgentPath,
+    ) -> ToolExecCtx<'a> {
+        ToolExecCtx {
+            project_root: root,
+            read_cache: cache,
+            fs,
+            caps,
+            sink: None,
+            caller_spawner: None,
+            bg_registry: bg,
+            trust,
+            sandbox_policy: policy,
+            proxy_port: None,
+            socks5_port: None,
+            session: None,
+            skill_registry: skills,
+            mailbox_registry: Some(registry),
+            bg_agents: Some(bg_agents),
+            caller_agent_path: agent_path,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_payload_includes_bg_agents_in_flight() {
+        // Pin: when bg-agents are registered, the timeout payload
+        // must include `bg_agents_in_flight` (count) plus a
+        // `bg_agents` array with one entry per non-terminal task.
+        // Without these the model has no signal to differentiate
+        // "timed out, work in progress" from "timed out, nothing
+        // running" — see #1338 Issue #3 for the diagnosis.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        // Two in-flight bg-agents at the top-level scope. We don't
+        // care about the senders here — letting them drop is fine,
+        // the registry entries persist until explicitly drained.
+        let (_id_a, _tx_a) = bg_agents.register_test("explore", "find usages of Foo");
+        let (_id_b, _tx_b) = bg_agents.register_test("verify", "check tests pass");
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+
+        assert_eq!(payload["timed_out"], true);
+        assert_eq!(
+            payload["bg_agents_in_flight"], 2,
+            "in-flight count must reflect the two registered tasks; got: {payload}"
+        );
+        let entries = payload["bg_agents"].as_array().expect("bg_agents array");
+        assert_eq!(
+            entries.len(),
+            2,
+            "per-task summary length mismatch: {payload}"
+        );
+        // Pin the per-entry shape so a future renamer doesn't
+        // silently change the contract the model relies on.
+        for entry in entries {
+            assert!(entry.get("task_id").and_then(|v| v.as_u64()).is_some());
+            assert!(entry.get("agent_name").and_then(|v| v.as_str()).is_some());
+            assert!(entry.get("status").and_then(|v| v.as_str()).is_some());
+            assert!(entry.get("age_secs").and_then(|v| v.as_u64()).is_some());
+        }
+        // Hint must reference the in-flight count (so the model
+        // sees a concrete number, not just a generic nudge).
+        let hint = payload["hint"].as_str().expect("hint string");
+        assert!(
+            hint.contains("2"),
+            "hint must mention the in-flight count; got: {hint}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_payload_zero_in_flight_when_no_bg_agents() {
+        // Pin: registry attached but empty → in_flight=0, empty
+        // array, hint suggests proceeding solo. Inverted form of
+        // the previous test; both shapes are part of the contract.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(payload["timed_out"], true);
+        assert_eq!(payload["bg_agents_in_flight"], 0);
+        assert!(payload["bg_agents"].as_array().unwrap().is_empty());
+        let hint = payload["hint"].as_str().unwrap();
+        assert!(
+            hint.to_lowercase().contains("no background") || hint.to_lowercase().contains("no bg"),
+            "hint must call out the empty-queue case so the model proceeds solo; got: {hint}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_payload_falls_back_when_no_registry_attached() {
+        // Pin: when `ctx.bg_agents` is `None` (standalone-`ToolRegistry`
+        // tests, or any caller that hasn't wired `set_bg_agents`),
+        // the payload must fall back to the legacy minimal
+        // `{message, timed_out}` shape — keys for the rich payload
+        // must not appear at all (so the model can rely on their
+        // absence to detect 'no signal available').
+        let (reg, _mb) = fresh_registry_with_root();
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_registry(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
+        );
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(payload["timed_out"], true);
+        assert_eq!(payload["message"], "Wait timed out.");
+        assert!(
+            payload.get("bg_agents_in_flight").is_none(),
+            "fallback payload must not include rich-payload keys; got: {payload}"
+        );
+        assert!(payload.get("bg_agents").is_none());
+        assert!(payload.get("hint").is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_payload_terminal_bg_agents_excluded() {
+        // Pin: a bg-agent that has Completed/Errored is no longer
+        // 'in flight' and must not appear in the timeout payload.
+        // Reporting it would mislead the model into waiting for
+        // something already done.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (_id_running, _tx_r) = bg_agents.register_test("explore", "still working");
+        let (_id_done, _tx_d, status_tx, _cancel) =
+            bg_agents.register_test_with_status("verify", "already done", None);
+        // Drive the second task to a terminal state.
+        status_tx
+            .send(crate::child_agent::AgentStatus::Completed {
+                summary: "all good".to_string(),
+            })
+            .unwrap();
+
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(
+            payload["bg_agents_in_flight"], 1,
+            "terminal bg-agents must be excluded; got: {payload}"
+        );
+        let names: Vec<&str> = payload["bg_agents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["agent_name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["explore"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_payload_scoped_to_caller_spawner() {
+        // Pin: a sub-agent that calls WaitForMail must only see ITS
+        // OWN child bg-agents — not its siblings'. Mirrors the
+        // scoping rules of `ListBackgroundTasks` / Model E in #996.
+        // Without this a sub-agent would learn about other agents'
+        // work, which is both a leak and a source of confusion.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        // Caller is sub-agent with id=42. Its child has spawner=Some(42).
+        // A sibling agent's child has spawner=Some(99) — must be hidden.
+        let (_id_mine, _tx_mine, _, _) =
+            bg_agents.register_test_with_status("mine", "my work", Some(42));
+        let (_id_sibling, _tx_sib, _, _) =
+            bg_agents.register_test_with_status("sibling", "not mine", Some(99));
+        let (_id_top, _tx_top, _, _) =
+            bg_agents.register_test_with_status("top", "top-level", None);
+
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let mut ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+        ctx.caller_spawner = Some(42);
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        let names: Vec<&str> = payload["bg_agents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["agent_name"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["mine"],
+            "sub-agent caller must only see its own children; got: {payload}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn success_payload_remains_minimal_on_mail_arrival() {
+        // Pin: the rich payload is timeout-path-only. The success
+        // path stays as `{message, timed_out: false}` because there's
+        // nothing useful to add (the next iteration drains the
+        // mailbox; bg-agent state is irrelevant). Inverted regression
+        // for the timeout enrichment.
+        let (reg, mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (_id, _tx) = bg_agents.register_test("explore", "work");
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        // Pre-publish mail so the wait completes immediately.
+        mb.send(sample_mail());
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(payload["timed_out"], false);
+        assert_eq!(payload["message"], "Wait completed.");
+        assert!(
+            payload.get("bg_agents_in_flight").is_none(),
+            "success payload must NOT include rich-payload keys; got: {payload}"
+        );
+        assert!(payload.get("bg_agents").is_none());
+        assert!(payload.get("hint").is_none());
     }
 }

--- a/koda-test-utils/src/env.rs
+++ b/koda-test-utils/src/env.rs
@@ -142,6 +142,12 @@ impl EnvBuilder {
         );
         tools.set_mailbox_registry(Arc::clone(&mailbox_registry));
 
+        // #1338 Issue #3: mirror `KodaSession::new` — hand the
+        // bg-agent registry to the tool layer so `WaitForMail`'s
+        // timeout payload sees in-flight bg-agents in tests too.
+        let bg_agents = koda_core::child_agent::new_shared();
+        tools.set_bg_agents(Arc::clone(&bg_agents));
+
         Env {
             _tmp: tmp,
             root,
@@ -150,7 +156,7 @@ impl EnvBuilder {
             config,
             tools,
             trust: self.trust,
-            bg_agents: koda_core::child_agent::new_shared(),
+            bg_agents,
             _mailbox_rx: Arc::new(tokio::sync::Mutex::new(mailbox_rx)),
         }
     }


### PR DESCRIPTION
## Summary

When `WaitForMail` times out, the model used to receive only:
```json
{"message": "Wait timed out.", "timed_out": true}
```

That's not enough signal: the model can't tell whether (a) bg-agents are still working (so wait again with a shorter timeout / do useful concurrent work), or (b) nothing was ever queued (so just proceed solo). The observed recovery loop was *'timeout → re-explore manually → re-wait → timeout again'* — burning real wall-clock for no gain.

This PR enriches the timeout payload with:

- `bg_agents_in_flight`: count of caller-scoped non-terminal sub-agents
- `bg_agents`: per-task summary `[{task_id, agent_name, status, age_secs}]`
- `hint`: prose recommendation tailored to `in_flight==0` vs `>0`

The success payload (mail arrived) stays minimal — there's nothing useful to add when the next iteration will drain the mailbox anyway.

## Wiring

- Add `ToolExecCtx::bg_agents` (`Option<&Arc<ChildAgentRegistry>>`), mirroring the `mailbox_registry` slot. Borrowed, not owned, so the per-call dispatch path doesn't pay an `Arc::clone` for tools that don't need it.
- Add `ToolRegistry::set_bg_agents` / `bg_agents()` following the exact shape of the `mailbox_registry` setter (interior mutability, poison tolerance, snapshot-once-per-dispatch in `execute()`).
- Wire `set_bg_agents` from `KodaSession::new` and `koda_test_utils::Env`.

## Scoping (correctness)

- Uses `ChildAgentRegistry::snapshot_for_caller(caller_spawner)` so a sub-agent only sees its own children, not its siblings'. Mirrors `ListBackgroundTasks` / Model E in #996.
- Terminal entries (`Completed`/`Errored`/`Cancelled`) are filtered out — reporting them would mislead the model into waiting for work that's already done.

## Backward compat

- When `ctx.bg_agents` is `None` (standalone-`ToolRegistry` tests, any caller that doesn't wire `set_bg_agents`), the payload falls back to the legacy minimal `{message, timed_out}` shape. Pinned by a new test.

## Tool description

Updated to document the new payload keys so the model knows to read `bg_agents_in_flight` + `hint` on timeout. The original `SendMessage` use case + anti-pattern guidance are preserved (regression test pins this).

## Tests

6 new unit tests in `wait_for_mail`:
- `timeout_payload_includes_bg_agents_in_flight` — happy path, count + array shape + hint mentions count
- `timeout_payload_zero_in_flight_when_no_bg_agents` — registry attached but empty
- `timeout_payload_falls_back_when_no_registry_attached` — legacy minimal shape preserved
- `timeout_payload_terminal_bg_agents_excluded` — Completed tasks filtered out
- `timeout_payload_scoped_to_caller_spawner` — sub-agent only sees own children
- `success_payload_remains_minimal_on_mail_arrival` — inverted regression

**Test results:** 16/16 `wait_for_mail` tests pass; 1389/1389 `koda-core` lib tests pass; clippy clean across workspace; `cargo fmt --all` clean.

## Files changed

```
 koda-core/src/session.rs             |  11 +-
 koda-core/src/tools/mod.rs           |  35 +++
 koda-core/src/tools/send_message.rs  |   2 +
 koda-core/src/tools/tool_trait.rs    |  15 ++
 koda-core/src/tools/wait_for_mail.rs | 485 ++++++++++++++++++++++++++++++++-
 koda-test-utils/src/env.rs           |   8 +-
```
