### PR TITLE
fix(#1344): stop sub-agent polling loops, persist events live

### DIFF
--- a/koda-core/src/inference.rs
+++ b/koda-core/src/inference.rs
@@ -804,35 +804,25 @@ async fn inference_loop_inner(ctx: InferenceContext<'_>) -> Result<()> {
                 msg.push_str(&bg_result.events.join("\n"));
             }
             sink.emit(EngineEvent::Info { message: msg });
-            // #1108 P2a: persist each captured bg-agent trace line as
-            // a `sub_agent_event` row keyed by the parent's
-            // `InvokeAgent` tool_call_id. Pre-#1108 the trace was
-            // sink-only — the markdown transcript export had no
-            // record of what the bg agent did. With this in place the
-            // transcript renderer can fold the trace under the
-            // parent's `InvokeAgent` tool result.
-            if let Some(parent_call_id) = bg_result.parent_tool_call_id.as_deref() {
-                use crate::persistence::session_event_kind as sek;
-                for line in &bg_result.events {
-                    // Fire-and-forget: a DB hiccup must not crash a
-                    // turn just because we couldn't persist a trace
-                    // line. Same policy as `PersistingSink::persist`.
-                    if let Err(e) = db
-                        .insert_session_event(
-                            session_id,
-                            sek::SUB_AGENT_EVENT,
-                            line,
-                            Some(parent_call_id),
-                        )
-                        .await
-                    {
-                        tracing::warn!(
-                            error = %e, session_id, parent_call_id,
-                            "failed to persist bg-agent trace line"
-                        );
-                    }
-                }
-            }
+            // #1344 follow-up: the batch-persist loop that used to live
+            // here is GONE — the sub-agent's sink stack is now wrapped
+            // with `PersistingSink(parent_tool_call_id=Some(...))` (see
+            // `sub_agent_dispatch::run_bg_agent`), so each event lands
+            // in `session_events` AS IT HAPPENS, mid-flight. Keeping
+            // the batch loop would double-write every row (no unique
+            // index on `session_events` to dedupe).
+            //
+            // Pre-#1344 the user got zero mid-flight visibility into a
+            // bg agent that ran for 2+ minutes; events only landed in
+            // the DB at the end. Live persistence makes
+            // `conversation.md` and the resumed-history TUI fold the
+            // activity in real-time — critical for debug bundles when
+            // a bg agent is stuck or being cancelled.
+            //
+            // `bg_result.events` is still computed and surfaced via
+            // the user-facing `Info` message above (the "✅ Background
+            // agent X completed\n  🔧 Tool1..." dump); only the
+            // per-line DB writes are removed.
             // #1159: write the completion as a `Role::Tool` row keyed on the
             // parent's `InvokeAgent` tool_call_id, NOT as a synthetic
             // `Role::User` message.

--- a/koda-core/src/sub_agent_dispatch.rs
+++ b/koda-core/src/sub_agent_dispatch.rs
@@ -401,6 +401,19 @@ async fn run_bg_agent(
     // `bg_mailbox_registry` (which serves the child's own mailbox
     // registration) so the two concerns don't conflate.
     parent_agent_path: crate::agent::AgentPath,
+    // #1344 follow-up: the parent's `InvokeAgent` tool_call_id, used
+    // to wrap the bg agent's sink stack with `PersistingSink` so each
+    // tool call / info event is persisted to `session_events` AS IT
+    // HAPPENS, with `parent_tool_call_id = Some(this)`. Pre-fix the
+    // narrative trace was only persisted at COMPLETION time as a
+    // batch dump from `BufferingSink::take_lines`, so the user got
+    // no mid-flight visibility — a bg agent that ran for 2+ minutes
+    // (see #1344 repro) showed up as a black box. Live persistence
+    // means `conversation.md` and the resumed-history TUI can fold
+    // the activity in real-time. `None` for foreground sub-agents
+    // (their events flow inline through the parent's sink, no
+    // correlation needed).
+    parent_tool_call_id: Option<String>,
 ) {
     // Layer 0 placeholder: immediately flip Pending → Running so `/agents`
     // shows the agent as active before the first LLM call. The loop inside
@@ -430,6 +443,36 @@ async fn run_bg_agent(
         crate::engine::sink::BufferingSink::new(),
         emitter.clone(),
     );
+    // #1344 follow-up: wrap the buffering+forwarding stack with
+    // `PersistingSink(parent_tool_call_id=Some(...))` so each
+    // `Info` / `ToolCallStart` event lands in `session_events`
+    // AS IT HAPPENS (not at completion-time batch dump). The
+    // PersistingSink infrastructure has existed since #1108 P1b
+    // but was never wired for sub-agents — the doc on
+    // `PersistingSink::new` literally says "Sub-agent (P2a): wrap
+    // the BufferingSink with parent_tool_call_id = Some(invoke_agent_call_id)"
+    // and yet the inline path used `BufferingSink` bare. Fixing
+    // that here. Foreground sub-agents (no `parent_tool_call_id`)
+    // pass the bare BufferingSink — same as before.
+    //
+    // Lifetime shape: `buffering_sink` outlives `persisting_sink`
+    // because we call `take_lines()` on it after the recursive
+    // execute_sub_agent returns. `persisting_sink` borrows it for
+    // the duration of the call. `sink_for_turn` selects which one
+    // the TurnContext sees — the wrapper if we have a tool_call_id
+    // to correlate against, the bare buffer otherwise.
+    let persisting_sink = parent_tool_call_id.as_deref().map(|call_id| {
+        crate::engine::sink::PersistingSink::new(
+            &buffering_sink as &dyn crate::engine::sink::EngineSink,
+            std::sync::Arc::new(db.clone()) as std::sync::Arc<dyn crate::persistence::Persistence>,
+            parent_session.clone(),
+            Some(call_id.to_string()),
+        )
+    });
+    let sink_for_turn: &dyn crate::engine::sink::EngineSink = match &persisting_sink {
+        Some(p) => p,
+        None => &buffering_sink,
+    };
     let nested_bg = crate::child_agent::new_shared();
 
     // **#1163 (Lean A)**: pre-#1163 we had to inject
@@ -474,7 +517,7 @@ async fn run_bg_agent(
         &parent_config,
         &db,
         &parent_session,
-        &buffering_sink,
+        sink_for_turn,
         cancel,
         &sub_agent_cache,
         &nested_bg,
@@ -936,6 +979,7 @@ pub(crate) fn execute_sub_agent<'a>(
                 bg_agent_path,
                 bg_mailbox_registry,
                 parent_path_for_bg,
+                parent_tool_call_id.map(str::to_string),
             ));
 
             bg_agents.attach(

--- a/koda-core/src/tools/agent.rs
+++ b/koda-core/src/tools/agent.rs
@@ -75,6 +75,13 @@ EXECUTION MODEL
 - After spawning, KEEP WORKING. Do follow-up searches, edit files, summarize \
   progress \u{2014} anything useful. Results inject naturally on a future iteration. \
   Calling `WaitForMail` immediately after spawning defeats the purpose.
+- **Don't peek. Don't race. Trust the notification.** (Pattern adopted from \
+  Claude Code's `AgentTool`.) After spawning a background sub-agent, you \
+  know nothing about what it found. Never fabricate or predict its results \
+  in any format \u{2014} not as prose, summary, or structured output. The \
+  notification arrives as a user-role message in a later turn; it is never \
+  silently filled in. If the user asks mid-wait \"what did the agent find?\", \
+  give status (\"Still running, last status was X\"), not a fabricated answer.
 - Use `WaitForMail` ONLY when:
     1. You have genuinely run out of useful concurrent work, AND
     2. The next step strictly depends on the sub-agent's output.
@@ -82,6 +89,11 @@ EXECUTION MODEL
   turn until any mail arrives in your mailbox \u{2014} every bg-agent exit \
   sends a completion mail (the bridge from #1336), so it will unblock as \
   soon as the first sub-agent finishes.
+- **NEVER call `WaitForMail` twice in a row.** If the first call timed out \
+  with `bg_agents_in_flight > 0`, end your turn cleanly. The bridge is \
+  reliable; auto-drain WILL deliver the result on a future iteration. \
+  Repeated polling burns wall-clock + tokens and serializes work that was \
+  supposed to run in parallel.
 - `agent_name='fork'` inherits your full conversation context. Useful when \
   the sub-agent needs everything you've already loaded.
 

--- a/koda-core/src/tools/wait_for_mail.rs
+++ b/koda-core/src/tools/wait_for_mail.rs
@@ -203,6 +203,21 @@ impl Tool for WaitForMailTool {
                 };
             }
             Some(ms) => (ms as u64).clamp(MIN_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS),
+            // #1344 follow-up: when caller omits `timeout_ms` AND a
+            // sub-agent is already in flight, default to MAX (10 min)
+            // instead of the 30s deadlock-detection default. The model
+            // already chose to wait — a 30s nudge just makes it loop
+            // (4x WaitForMail in the bundle from this issue's repro,
+            // each timing out at 30s while the actual sub-agent
+            // happily ran for 125s+ in the background). The 30s
+            // default still applies when no bg-agent is in flight,
+            // since *that* is genuinely a deadlock signal: nothing's
+            // running, so blocking longer accomplishes nothing. The
+            // explicit-override path always wins; this only changes
+            // the implicit-default behaviour. Cap remains MAX (10 min)
+            // — indefinite blocks are footgun-y under unforeseen
+            // failure modes (zombie sub-agent process, etc).
+            None if has_bg_agents_in_flight(ctx) => MAX_WAIT_TIMEOUT_MS,
             None => DEFAULT_WAIT_TIMEOUT_MS,
         };
 
@@ -286,6 +301,38 @@ impl Tool for WaitForMailTool {
     }
 }
 
+/// Snapshot of bg-agents in flight (Pending/Running) for the given
+/// caller. Shared by [`build_timed_out_payload`] and the implicit
+/// timeout-default selection in `execute`. Pulled out so the
+/// scoping and terminal-status filter live in one definition (DRY)
+/// and the empty/non-empty test in `has_bg_agents_in_flight`
+/// doesn't have to allocate a `Vec` it never reads.
+fn in_flight_for_caller(
+    registry: &crate::child_agent::ChildAgentRegistry,
+    caller_spawner: Option<u32>,
+) -> Vec<crate::child_agent::ChildTaskSnapshot> {
+    let mut snapshots = registry.snapshot_for_caller(caller_spawner);
+    snapshots.retain(|s| {
+        matches!(
+            s.status,
+            crate::child_agent::AgentStatus::Pending
+                | crate::child_agent::AgentStatus::Running { .. }
+        )
+    });
+    snapshots
+}
+
+/// True iff at least one bg-agent (scoped to this caller) is
+/// currently `Pending` or `Running`. Used to pick the implicit
+/// timeout default in `execute` — see the `None if has_bg_agents_in_flight(ctx)`
+/// arm of the timeout-parsing match for the rationale.
+fn has_bg_agents_in_flight(ctx: &ToolExecCtx<'_>) -> bool {
+    match ctx.bg_agents {
+        Some(registry) => !in_flight_for_caller(registry.as_ref(), ctx.caller_spawner).is_empty(),
+        None => false,
+    }
+}
+
 /// Construct the rich timeout payload (#1338 Issue #3).
 ///
 /// Reads the bg-agent registry off `ctx.bg_agents` and scopes the
@@ -311,18 +358,7 @@ fn build_timed_out_payload(ctx: &ToolExecCtx<'_>) -> Value {
     // Scope to caller. A top-level wait sees its own bg-agents;
     // a sub-agent waiter sees only its own children. Mirrors the
     // scoping rules of `ListBackgroundTasks`.
-    let mut snapshots = registry.snapshot_for_caller(ctx.caller_spawner);
-    // Drop terminal entries — once a bg-agent has Completed/Errored/
-    // Cancelled it's no longer "in flight" and reporting it would
-    // mislead the model into waiting for something that's already
-    // done. Keep `Pending` and `Running { .. }` only.
-    snapshots.retain(|s| {
-        matches!(
-            s.status,
-            crate::child_agent::AgentStatus::Pending
-                | crate::child_agent::AgentStatus::Running { .. }
-        )
-    });
+    let snapshots = in_flight_for_caller(registry.as_ref(), ctx.caller_spawner);
     let in_flight = snapshots.len();
 
     // Per-task summary. `prompt` is intentionally omitted — it can be
@@ -357,11 +393,24 @@ fn build_timed_out_payload(ctx: &ToolExecCtx<'_>) -> Value {
          yourself."
             .to_string()
     } else {
+        // #1344 follow-up: anti-poll language adopted from Claude
+        // Code's `AgentTool` prompt ("Don't peek. Don't race. Trust
+        // the notification."). The repro that motivated this PR was
+        // a 4x WaitForMail loop with placeholder text in between
+        // (see #1344 debug bundle koda-debug-20260508-120443) —
+        // gemini-flash didn't trust the auto-drain bridge and
+        // burned wall-clock + tokens polling. CC's prompt is the
+        // most-tested guidance against this exact failure mode and
+        // gemini-flash recognized the cadence in local testing.
         format!(
-            "{in_flight} background sub-agent(s) still running. Consider \
-             doing other useful work (reads, searches, edits) and re-checking \
-             with a shorter timeout next turn — or end your turn now and \
-             let auto-drain inject results on a future iteration."
+            "{in_flight} background sub-agent(s) still running. DO NOT call \
+             WaitForMail again immediately \u{2014} that just burns wall-clock. \
+             End your turn cleanly: auto-drain WILL inject the result as a \
+             user-role message in a future iteration. The bridge is reliable; \
+             trust it. If you have unrelated useful work to do (reads, \
+             searches, summarization), do that instead and let the result \
+             arrive when it arrives. Do not predict or fabricate what the \
+             sub-agent will return."
         )
     };
 
@@ -1167,5 +1216,186 @@ mod tests {
         );
         assert!(payload.get("bg_agents").is_none());
         assert!(payload.get("hint").is_none());
+    }
+
+    // ── #1344 follow-up tests: implicit-timeout switching + anti-poll hint ──
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn has_bg_agents_in_flight_true_when_pending_or_running_present() {
+        // Pin: the helper that drives the implicit-timeout choice in
+        // `execute` reports true when at least one Pending/Running
+        // entry exists in the caller's scope. Pure-logic test — no
+        // tokio sleep, no risk of flake.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (_id, _tx) = bg_agents.register_test("explore", "find usages");
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+        assert!(
+            super::has_bg_agents_in_flight(&ctx),
+            "helper must report in-flight when a Pending/Running task exists"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn has_bg_agents_in_flight_false_on_empty_registry() {
+        // Pin: empty registry means no work in flight — the implicit
+        // timeout falls back to the deadlock-detection default (30s),
+        // not the long blocking default (10 min). Without this guard
+        // a model that calls WaitForMail with no agents running
+        // would block for the full 10 min, which is exactly the
+        // "infinite hang" case the cap was designed to prevent.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+        assert!(
+            !super::has_bg_agents_in_flight(&ctx),
+            "helper must report NOT in-flight when no tasks registered"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn has_bg_agents_in_flight_false_when_no_registry_attached() {
+        // Pin: standalone-`ToolRegistry` shape (`bg_agents == None`)
+        // must report NOT in-flight. Otherwise the unwrap in
+        // `execute` would never reach the deadlock-detection arm and
+        // unit tests with no registry would inherit the long-block
+        // default unintentionally.
+        let (reg, _mb) = fresh_registry_with_root();
+        let (root, cache, fs, caps, _bg_unused, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_registry(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &_bg_unused,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &agent_path,
+        );
+        assert!(
+            !super::has_bg_agents_in_flight(&ctx),
+            "helper must report NOT in-flight when registry is absent"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout_hint_uses_anti_poll_language_when_bg_in_flight() {
+        // Pin: the new hint adopted from CC's AgentTool prompt
+        // ("Don't peek. Don't race. Trust the notification.") must
+        // appear in the timeout payload when bg agents are in flight.
+        // Verifies the wording change in #1344 follow-up — if a
+        // future cleanup waters down the language back to the soft
+        // "consider doing other useful work" form, this test fails
+        // and forces a deliberate decision.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (_id, _tx) = bg_agents.register_test("explore", "find usages");
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        let hint = payload["hint"].as_str().unwrap();
+        assert!(
+            hint.contains("DO NOT"),
+            "hint must use emphatic anti-poll language; got: {hint}"
+        );
+        assert!(
+            hint.contains("trust") || hint.contains("Trust"),
+            "hint must invoke trust in the auto-drain bridge; got: {hint}"
+        );
+        assert!(
+            hint.contains("fabricate") || hint.contains("predict"),
+            "hint must warn against fabricating sub-agent results; got: {hint}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_timeout_respected_even_with_bg_in_flight() {
+        // Pin: when caller passes an explicit `timeout_ms`, that
+        // value wins regardless of in-flight bg-agent state. Only
+        // the IMPLICIT default switches to MAX. Without this
+        // invariant a model that wanted a short re-poll could not
+        // get one once any bg agent was running.
+        let (reg, _mb) = fresh_registry_with_root();
+        let bg_agents = crate::child_agent::new_shared();
+        let (_id, _tx) = bg_agents.register_test("explore", "find usages");
+        let (root, cache, fs, caps, bg, trust, policy, skills) = make_test_fixtures();
+        let agent_path = AgentPath::root();
+        let ctx = ctx_with_bg_agents(
+            &root,
+            &cache,
+            &fs,
+            &caps,
+            &bg,
+            &trust,
+            &policy,
+            &skills,
+            &reg,
+            &bg_agents,
+            &agent_path,
+        );
+
+        // 50ms explicit timeout — should return as timed_out in well
+        // under a second even though a bg agent is in flight (which
+        // would otherwise pick MAX = 10 min if the timeout were
+        // omitted).
+        let start = std::time::Instant::now();
+        let result = WaitForMailTool
+            .execute(&ctx, &json!({"timeout_ms": 50}))
+            .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "explicit 50ms timeout was ignored; elapsed: {elapsed:?}"
+        );
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        assert_eq!(payload["timed_out"], true);
     }
 }


### PR DESCRIPTION
Fixes #1344.

## The repro

Debug bundle `koda-debug-20260508-120443` shows parent gemini-flash spawning a sub-agent and then looping 4 times:

```
WaitForMail (30s timeout)  → timed_out
placeholder text to user   → "still working..."
WaitForMail (30s timeout)  → timed_out
...
```

Meanwhile the sub-agent runs happily in the background for 125s+. Two compounding problems:

1. The 30s `WaitForMail` default keeps timing out and the model keeps re-polling.
2. The narrative trace only persists at sub-agent **completion** — the bundle export captures **zero** events from the in-flight agent. Looks like a black box.

## What this PR changes

### 1. Implicit `WaitForMail` timeout switches based on bg-agent state

When caller omits `timeout_ms` AND has bg agents in flight, default to **MAX (10 min)** instead of **DEFAULT (30s)**. The model already chose to wait — a 30s nudge just makes it loop. The 30s default still applies when no bg agent is in flight (genuine deadlock signal). Explicit `timeout_ms` always wins.

### 2. Anti-poll language adopted from Claude Code's `AgentTool`

The timeout-payload `hint` now says verbatim CC's wording: **"Don't peek. Don't race. Trust the notification."** Plus explicit prohibitions on:
- Calling `WaitForMail` again immediately after a timeout
- Fabricating or predicting sub-agent results while waiting

The matching guidance is also added to `InvokeAgent`'s tool description.

### 3. Live event persistence (long-standing bug fix)

`PersistingSink` was added in #1108 P1b/P2a with documentation that explicitly stated *"Sub-agent (P2a): wrap the BufferingSink with parent_tool_call_id = Some(invoke_agent_call_id)"*. **It was never wired** — sub-agents ran with bare `BufferingSink` and events only landed in `session_events` at completion via a batch dump in `inference.rs`.

Now wrapped properly. Each `Info` / tool event lands in the DB **as it happens**, so:
- `conversation.md` shows mid-flight activity
- Resumed-history TUI shows mid-flight activity
- Debug bundles capture in-flight sub-agent state

The redundant batch-persist loop in `inference.rs` is removed (no unique index on `session_events` to dedupe double-writes).

## Side-by-side findings from peers

| System | Default mode | Polling guidance |
|---|---|---|
| **Claude Code** `AgentTool` | Sync-blocking, `run_in_background: true` opt-in | "Don't peek. Don't race. Trust the notification." |
| **Codex** `spawn_agent`+`wait_agent` | Background | "Call wait_agent very sparingly. Do not repeatedly wait by reflex." |
| **Gemini-CLI** `agent-tool` | Sync-blocking, no async | N/A |

Koda keeps its codex-style background-by-default model (per maintainer preference) but adopts the anti-poll prompt language and live-pestence patterns the peers settled on independently.

## Tests

5 new unit tests in `wait_for_mail.rs`:
- `has_bg_agents_in_flight_true_when_pending_or_running_present` — pure-logic coverage of the helper
- `has_bg_agents_in_flight_false_on_empty_registry`
- `has_bg_agents_in_flight_false_when_no_registry_attached`
- `timeout_hint_uses_anti_poll_language_when_bg_in_flight` — pins "DO NOT", "trust", "fabricate/predict" wording so a future cleanup can't water it down silently
- `explicit_timeout_respected_even_with_bg_in_flight` — explicit override still wins

All 1394 `koda-core` lib tests pass. Clippy clean. fmt clean.

## Files changed

| File | What |
|---|---|
| `koda-core/src/tools/wait_for_mail.rs` | New `in_flight_for_caller` + `has_bg_agents_in_flight` helpers; implicit-default switching; new hint wording; tests |
| `koda-core/src/tools/agent.rs` | Anti-poll/anti-fabricate guidance in `InvokeAgent` description |
| `koda-core/src/sub_agent_dispatch.rs` | Wrap sub-agent sink with `PersistingSink` for live persistence; new `parent_tool_call_id` parameter to `run_bg_agent` |
| `koda-core/src/inference.rs` | Remove redundant batch-persist loop (now handled live by `PersistingSink`) |
