### PR TITLE
feat(peers): sync script + manifest for cross-reference repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,14 @@ docs/book/
 # Python bytecode (scripts/ contains a few helper scripts)
 __pycache__/
 *.pyc
+
+# peers/ — local symlinks + clones to reference projects (Codex, Claude
+# Code, Gemini CLI, Zed) used during koda development. The meta-files
+# (manifest, sync script, README) are checked in so contributors
+# can run `./peers/sync.sh` on a fresh laptop; the symlinks and
+# clones stay strictly local. See peers/README.md for the design.
+peers/*
+!peers/.gitkeep
+!peers/README.md
+!peers/peers.txt
+!peers/sync.sh

--- a/peers/README.md
+++ b/peers/README.md
@@ -1,0 +1,91 @@
+# `peers/` — cross-reference repos for koda development
+
+This directory holds **symlinks to sibling clones of peer projects** we
+study while building koda — Claude Code, Codex, Gemini CLI, and Zed.
+
+## Why this exists, in one paragraph
+
+When we design a feature (mailbox plumbing, sub-agent dispatch, TUI
+event loop, etc.) we constantly pattern-match against how the same
+problem is solved in those four projects. Having their source one
+`rg peers/codex/codex-rs/ ...` away — without leaving the repo, without
+GitHub round-trips, with full IDE jump-to-definition — turns hours of
+context-switching into seconds.
+
+## Why **not** git submodules
+
+Submodules **pin to specific commits**. We want **always-at-HEAD**
+reference material. A submodule-based design means either:
+
+- Every peer bump becomes a noisy "chore: bump peers" commit in koda's
+  history, OR
+- Submodules drift stale and the whole point is defeated.
+
+Submodules also force-clone gigabytes onto every contributor (zed alone
+is huge) and publish a `.gitmodules` file that misleadingly declares
+codex/zed as koda dependencies. They aren't — they're reference
+material for koda's authors, with zero runtime relationship to koda.
+
+The sync-script approach below sidesteps all of that.
+
+## Layout
+
+```
+peers/
+├── README.md          ← checked in (this file)
+├── peers.txt          ← checked in (manifest: name + git URL)
+├── sync.sh            ← checked in (clone-or-update + symlink)
+├── .gitkeep           ← checked in (keeps the dir present)
+└── <name>/            ← gitignored (symlink to ../../<name>)
+```
+
+Each entry in `peers.txt` becomes:
+
+1. A clone at `../<name>` (sibling of the koda repo)
+2. A symlink `peers/<name>` → `../../<name>`
+
+The clones live OUTSIDE the koda working tree so they never count
+against koda's clone size, never trigger `cargo`/`npm`/IDE indexers
+that walk the workspace, and can be `git pull`-ed independently.
+
+## Daily usage
+
+```sh
+./peers/sync.sh
+```
+
+That's it. The script is **idempotent and serves as both first-time
+setup and ongoing sync** — same as `npm install`, `brew install`,
+`cargo update`, and `terraform apply`. One verb, one command, always
+correct:
+
+- Missing clone → `git clone` it into `../<name>`
+- Missing symlink → create `peers/<name>` → `../../<name>`
+- Existing clone, clean tree → fast-forward to upstream HEAD
+- Existing clone, dirty tree → skip the update (never touches your WIP)
+- Diverged from upstream → skip the update (your problem to resolve)
+
+Run it on a fresh laptop to set everything up. Run it weekly to
+refresh. Same command, same mental model, no second script to
+remember.
+
+## Adding or removing a peer
+
+**Add:** append a line to `peers.txt`, run `./peers/sync.sh`.
+
+**Remove:** delete the line from `peers.txt`, then `rm peers/<name>` to
+drop the symlink. The clone at `../<name>` is left in place — it's
+your local checkout, the script doesn't presume to delete it.
+
+## When this design might break down
+
+- If we ever need a peer **at a known-good commit** (e.g. for a
+  reproducible benchmark comparison), submodules become the right
+  call for that *specific* peer. Add it as a real submodule under a
+  different path (e.g. `bench/refs/`); leave `peers/` for the
+  always-at-HEAD reference workflow.
+- If a peer changes hosting (GitHub → GitLab, rename, etc.), update
+  the URL in `peers.txt` and rerun sync. Existing clones won't
+  auto-rewrite their `origin` remote — you'd need to `git remote
+  set-url origin <new>` in `../<name>` manually, or just delete the
+  clone and let sync re-clone fresh.

--- a/peers/peers.txt
+++ b/peers/peers.txt
@@ -1,0 +1,14 @@
+# Peer projects manifest.
+#
+# Format: <name><whitespace><git URL>
+# Lines starting with # are ignored. Blank lines OK.
+#
+# Each entry is cloned into ../<name> (sibling of this repo) by
+# peers/sync.sh, which then symlinks peers/<name> -> ../../<name>.
+# This keeps koda's clone footprint tiny while making peer source
+# always reachable from inside the repo for grep/rg/IDE jump-to-def.
+
+codex            https://github.com/openai/codex.git
+claude_code_src  https://github.com/ponponon/claude_code_src.git
+gemini-cli       https://github.com/google-gemini/gemini-cli.git
+zed              https://github.com/zed-industries/zed.git

--- a/peers/sync.sh
+++ b/peers/sync.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Sync peer reference repos for koda development.
+#
+# Reads peers/peers.txt — each entry becomes:
+#   1. A clone at ../<name>          (sibling of this repo)
+#   2. A symlink peers/<name>        (-> ../../<name>)
+#
+# Idempotent — safe to run on every checkout, every week, every time.
+# Doubles as first-time setup on a new machine: missing clones get
+# created, existing clones get fast-forwarded. One verb (sync), one
+# command, always correct — same shape as `npm install`, `brew install`,
+# `cargo update`, `terraform apply`.
+#
+# Why we fight this hard with `--tags --force --prune`:
+#   Several peers (codex's rusty-v8, zed's release tags) retag in place.
+#   `git pull --ff-only` aborts the merge silently when fetch rejects
+#   tag rewrites — HEAD never moves and you don't notice. `--force`
+#   accepts the rewrites; these are read-only mirrors so local tag
+#   state isn't precious.
+#
+# Why we never auto-stash dirty trees:
+#   These clones are YOUR working copies. If you've made local changes
+#   in ../codex while patching a bug, we will not silently move HEAD
+#   out from under you. We skip and warn.
+#
+# Why we use --ff-only and bail on divergence:
+#   Same reason. Diverged history means you've done something
+#   intentional in the peer; auto-merging it would be presumptuous.
+
+set -euo pipefail
+
+# ── Locate ourselves ─────────────────────────────────────────────────
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_parent="$(cd "$script_dir/.." && pwd)"
+parent_dir="$(cd "$repo_parent/.." && pwd)"
+manifest="$script_dir/peers.txt"
+
+if [[ ! -f "$manifest" ]]; then
+  echo "❌ Missing manifest: $manifest" >&2
+  exit 1
+fi
+
+# ── Per-peer state for the summary table ────────────────────────────
+summary=()
+record() { summary+=("$1"); }
+
+# ── Worker: sync one peer (clone if missing, fast-forward if present) ──────
+process_peer() {
+  local name="$1" url="$2"
+  local clone_path="$parent_dir/$name"
+  local link_path="$script_dir/$name"
+
+  printf '\n━━ %s ━━\n' "$name"
+
+  # Step 1: ensure the clone exists.
+  if [[ ! -d "$clone_path/.git" ]]; then
+    if [[ -e "$clone_path" ]]; then
+      echo "  ❌ $clone_path exists but isn't a git repo — investigate manually"
+      record "$(printf '%-20s  ERROR (path collision)' "$name")"
+      return
+    fi
+    echo "  📥 cloning $url → $clone_path"
+    if ! git clone "$url" "$clone_path"; then
+      record "$(printf '%-20s  ERROR (clone failed)' "$name")"
+      return
+    fi
+  else
+    # Step 2a: existing clone — fast-forward to upstream HEAD.
+    update_existing_clone "$name" "$clone_path" || {
+      # update_existing_clone records its own summary line on failure.
+      ensure_symlink "$name" "$link_path" "$clone_path"
+      return
+    }
+  fi
+
+  # Step 2b: ensure the symlink exists and points where it should.
+  ensure_symlink "$name" "$link_path" "$clone_path"
+
+  # Step 3: emit summary line for the up-to-date case.
+  record_status "$name" "$clone_path"
+}
+
+# Fast-forward an existing clone to its upstream HEAD. Returns non-zero
+# on any condition that left HEAD unmoved (dirty, diverged, fetch
+# error) — caller still creates the symlink but skips the OK-summary.
+update_existing_clone() {
+  local name="$1" clone_path="$2"
+  local prev_head; prev_head=$(git -C "$clone_path" rev-parse HEAD)
+
+  # Refuse to touch a dirty tree.
+  if ! git -C "$clone_path" diff --quiet \
+     || ! git -C "$clone_path" diff --cached --quiet; then
+    echo "  ⚠️  dirty working tree in $clone_path — leaving alone"
+    record "$(printf '%-20s  SKIPPED (dirty)' "$name")"
+    return 1
+  fi
+
+  # `--tags --force --prune` accepts retagged remotes; mirrors aren't
+  # precious about local tag state.
+  if ! git -C "$clone_path" fetch --tags --force --prune origin 2>&1 | tail -3; then
+    record "$(printf '%-20s  ERROR (fetch failed)' "$name")"
+    return 1
+  fi
+
+  # Bail if no upstream is set on the current branch (detached HEAD,
+  # custom branch, etc.) — leave HEAD where the user put it.
+  if ! git -C "$clone_path" rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+    echo "  ⚠️  no upstream tracking branch — leaving alone"
+    record "$(printf '%-20s  SKIPPED (no upstream)' "$name")"
+    return 1
+  fi
+
+  # Fast-forward only. Diverged history is the user's problem.
+  if ! git -C "$clone_path" merge --ff-only '@{u}' 2>&1 | tail -3; then
+    record "$(printf '%-20s  SKIPPED (non-ff)' "$name")"
+    return 1
+  fi
+
+  local new_head; new_head=$(git -C "$clone_path" rev-parse HEAD)
+  if [[ "$prev_head" == "$new_head" ]]; then
+    echo "  ✓ already up to date"
+  else
+    local n; n=$(git -C "$clone_path" rev-list --count "$prev_head..$new_head")
+    echo "  ⬆️  fast-forwarded $n commit(s)"
+  fi
+}
+
+# Create or repair the symlink at peers/<name>. Idempotent.
+# Uses a relative target so the symlink survives moves of the koda repo.
+ensure_symlink() {
+  local name="$1" link_path="$2" clone_path="$3"
+  local rel_target="../../$name"
+
+  if [[ -L "$link_path" ]]; then
+    local current; current=$(readlink "$link_path")
+    if [[ "$current" == "$rel_target" ]]; then
+      return 0
+    fi
+    echo "  🔗 fixing symlink ($current → $rel_target)"
+  elif [[ -e "$link_path" ]]; then
+    echo "  ❌ $link_path exists but isn't a symlink — investigate manually"
+    record "$(printf '%-20s  ERROR (link path occupied)' "$name")"
+    return 1
+  else
+    echo "  🔗 creating symlink $link_path → $rel_target"
+  fi
+
+  ln -snf "$rel_target" "$link_path"
+}
+
+record_status() {
+  local name="$1" clone_path="$2"
+  local branch; branch=$(git -C "$clone_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
+  local ab; ab=$(git -C "$clone_path" rev-list --left-right --count HEAD...@\{u\} 2>/dev/null | tr '\t' '/' || echo '?/?')
+  local last; last=$(git -C "$clone_path" log -1 --format='%cr  %s' 2>/dev/null | cut -c1-60)
+  record "$(printf '%-20s  %-10s  ahead/behind=%-6s  %s' "$name" "$branch" "$ab" "$last")"
+}
+
+# ── Main loop ────────────────────────────────────────────────────────
+while IFS=$' \t' read -r name url _rest; do
+  # Skip blanks and comments.
+  [[ -z "${name:-}" ]] && continue
+  [[ "${name:0:1}" == "#" ]] && continue
+  if [[ -z "${url:-}" ]]; then
+    echo "⚠️  manifest line missing URL: $name" >&2
+    continue
+  fi
+  process_peer "$name" "$url"
+done < "$manifest"
+
+# ── Summary ──────────────────────────────────────────────────────────
+printf '\n━━ summary ━━\n'
+for line in "${summary[@]}"; do
+  printf '%s\n' "$line"
+done


### PR DESCRIPTION
## What

Adds a checked-in sync convention so reference clones of **Codex**, **Claude Code**, **Gemini CLI**, and **Zed** can be set up on any machine with one command:

```sh
./peers/sync.sh
```

The script is idempotent and serves as both first-time setup and ongoing sync — same shape as `npm install`, `brew install`, `cargo update`, `terraform apply`. **One verb, one command, always correct:**

- Missing clone → `git clone` into `../<name>`
- Missing symlink → create `peers/<name>` → `../../<name>`
- Existing clone, clean tree → fast-forward to upstream HEAD
- Existing clone, dirty tree → skip the update (never touches your WIP)
- Diverged from upstream → skip the update (your problem to resolve)

## Why

We constantly pattern-match koda's design against how the same problem is solved in those four projects (mailbox plumbing, sub-agent dispatch, TUI event loops, etc.). Having their source one `rg peers/codex/codex-rs/ ...` away — without leaving the repo, without GitHub round-trips, with full IDE jump-to-definition — turns hours of context-switching into seconds.

Until today this was a single-user setup with un-tracked symlinks pointing at `../codex` etc. New machines (and future-me on a fresh laptop) had no way to reproduce it. This PR makes the convention reproducible without imposing anything on contributors who don't want it.

## Why **not** git submodules

I considered this and rejected it. Submodules **pin to specific commits**, but we want **always-at-HEAD** reference material:

| What we want | What submodules give us |
|---|---|
| Always at latest HEAD | Pinned to a specific commit; bumping = noisy "chore: bump peers" commits |
| Zero cost for koda installation | `git clone --recurse-submodules` pulls **gigabytes** (zed alone is huge) |
| Personal reference, not part of koda | `.gitmodules` publicly declares codex/zed as koda dependencies — they aren't |
| Update independently of koda commits | The whole point of submodules is that they DON'T |

Plus the usual submodule footguns (detached HEAD on update, "submodule is dirty" warnings, `--recurse-submodules` flag everyone forgets).

## Layout

```
peers/
├── README.md          ← checked in (explains the design)
├── peers.txt          ← checked in (manifest: name + git URL)
├── sync.sh            ← checked in (clone-or-update + symlink)
├── .gitkeep           ← checked in (keeps the dir present)
└── <name>/            ← gitignored (symlink to ../../<name>)
```

The clones live **outside** the koda working tree so they never count against koda's clone size, never trigger `cargo`/`npm`/IDE indexers that walk the workspace, and can be `git pull`-ed independently.

The `.gitignore` flips from `peers/` to `peers/*` with an allowlist for the four meta-files. Adding a new peer is one line in `peers.txt` + a re-run of `sync.sh` — no script edits needed.

## Tested locally

- Sync on existing clones → no-op + fast-forwards as expected (`zed` picked up 2 fresh upstream commits during the test run)
- Sync with deliberately-missing symlink → recreates it
- `shellcheck peers/sync.sh` → clean (exit 0)
- `git status` after staging → only the four meta-files appear; symlinks invisible
- Pre-push clippy hook → passed

## Naming note

Earlier draft of this PR called the script `bootstrap.sh`, but "bootstrap" implies *one-time setup* — misleading for a script meant to be re-run weekly. Renamed to `sync.sh` to match its actual usage pattern (the create-if-missing semantics are bundled in for free, same way `npm install` doesn't *only* install).

## Backstory

This came out of the #1349 debugging session — pulling and updating the four reference repos by hand to compare implementations was painful enough that "let's formalize this" became obvious. The original quick-and-dirty version (symlinks + a local `sync.sh`) is what's being upgraded into a checked-in, machine-portable form here.
